### PR TITLE
fix(cli): guard interactive chat without tty

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,6 +77,19 @@ from hermes_cli.banner import _format_context_length, format_banner_version_labe
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
 
+def _require_interactive_stdin_tty() -> None:
+    """Fail fast before prompt_toolkit tries to attach to non-TTY stdin."""
+    if not sys.stdin.isatty():
+        print(
+            "Error: interactive Hermes requires a terminal on stdin.\n"
+            "Run `hermes` directly in a terminal, use `hermes </dev/tty` "
+            "when a wrapper has redirected stdin, or use `hermes -z \"...\"` "
+            "for non-interactive prompts.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_constants import get_hermes_home, display_hermes_home
@@ -9617,6 +9630,8 @@ class HermesCLI:
 
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
+        _require_interactive_stdin_tty()
+
         # Push the entire TUI to the bottom of the terminal so the banner,
         # responses, and prompt all appear pinned to the bottom — empty
         # space stays above, not below.  This prints enough blank lines to
@@ -11597,10 +11612,6 @@ def main(
     """
     global _active_worktree
 
-    # Signal to terminal_tool that we're in interactive mode
-    # This enables interactive sudo password prompts with timeout
-    os.environ["HERMES_INTERACTIVE"] = "1"
-    
     # Handle gateway mode (messaging + cron)
     if gateway:
         import asyncio
@@ -11608,6 +11619,17 @@ def main(
         print("Starting Hermes Gateway (messaging platforms)...")
         asyncio.run(start_gateway())
         return
+
+    # Handle query shorthand before deciding whether this is an interactive
+    # prompt-toolkit launch. Single-query/list modes are intentionally usable
+    # with piped or redirected stdin.
+    query = query or q
+    if not (query or image or list_tools or list_toolsets):
+        _require_interactive_stdin_tty()
+
+    # Signal to terminal_tool that we're in interactive mode
+    # This enables interactive sudo password prompts with timeout
+    os.environ["HERMES_INTERACTIVE"] = "1"
 
     # Skip worktree for list commands (they exit immediately)
     if not list_tools and not list_toolsets:
@@ -11632,9 +11654,6 @@ def main(
                 return
     else:
         wt_info = None
-    
-    # Handle query shorthand
-    query = query or q
     
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -83,6 +83,19 @@ def _require_tty(command_name: str) -> None:
         sys.exit(1)
 
 
+def _require_chat_tty() -> None:
+    """Exit cleanly when interactive chat is launched without a real stdin TTY."""
+    if not sys.stdin.isatty():
+        print(
+            "Error: interactive Hermes requires a terminal on stdin.\n"
+            "Run `hermes` directly in a terminal, use `hermes </dev/tty` "
+            "when a wrapper has redirected stdin, or use `hermes -z \"...\"` "
+            "for non-interactive prompts.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -1193,6 +1206,7 @@ def _launch_tui(
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1"
+    single_query = bool(getattr(args, "query", None) or getattr(args, "image", None))
 
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)
@@ -1259,6 +1273,9 @@ def cmd_chat(args):
         print()
         print("You can run 'hermes setup' at any time to configure.")
         sys.exit(1)
+
+    if not single_query:
+        _require_chat_tty()
 
     # Start update check in background (runs while other init happens)
     try:

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -5,6 +5,8 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -158,6 +160,28 @@ class TestSingleQueryState:
         assert cli._voice_tts_done.is_set()
         assert hasattr(cli, "_interrupt_queue")
         assert hasattr(cli, "_pending_input")
+
+
+class TestNonTTYInteractiveLaunch:
+    def test_direct_cli_main_requires_tty_before_initializing_cli(self, capsys):
+        """Direct `python cli.py` should fail clearly instead of crashing prompt_toolkit."""
+        import cli as cli_mod
+
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch.object(
+                cli_mod,
+                "HermesCLI",
+                side_effect=AssertionError("HermesCLI should not initialize"),
+            ),
+        ):
+            mock_stdin.isatty.return_value = False
+            with pytest.raises(SystemExit) as exc:
+                cli_mod.main()
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "interactive Hermes requires a terminal on stdin" in err
 
 
 class TestHistoryDisplay:

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -1,7 +1,9 @@
 """Tests for non-interactive setup and first-run headless behavior."""
 
 from argparse import Namespace
-from unittest.mock import MagicMock, patch
+import sys
+import types
+from unittest.mock import patch
 
 import pytest
 from hermes_cli.config import DEFAULT_CONFIG, load_config, save_config
@@ -143,6 +145,61 @@ class TestNonInteractiveSetup:
         mock_setup.assert_not_called()
         out = capsys.readouterr().out
         assert "hermes config set model.provider custom" in out
+
+    def test_chat_headless_with_configured_provider_exits_before_cli_startup(
+        self, monkeypatch, capsys
+    ):
+        """Bare `hermes` should not let prompt_toolkit crash on non-TTY stdin."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args()
+        fake_cli_module = types.ModuleType("cli")
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            monkeypatch.setitem(sys.modules, "cli", fake_cli_module)
+
+            with pytest.raises(SystemExit) as exc:
+                cmd_chat(args)
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "interactive Hermes requires a terminal on stdin" in err
+        assert "hermes -z" in err
+
+    def test_chat_single_query_remains_allowed_without_tty(self, monkeypatch):
+        """Scripted `hermes chat -q` should still work with redirected stdin."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args(query="hello", quiet=True)
+        captured = {}
+
+        fake_cli_module = types.ModuleType("cli")
+
+        def fake_cli_main(**kwargs):
+            captured.update(kwargs)
+
+        fake_cli_module.main = fake_cli_main
+
+        fake_skills_sync = types.ModuleType("tools.skills_sync")
+        fake_skills_sync.sync_skills = lambda quiet=True: None
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("hermes_cli.banner.prefetch_update_check"),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            monkeypatch.setitem(sys.modules, "cli", fake_cli_module)
+            monkeypatch.setitem(sys.modules, "tools.skills_sync", fake_skills_sync)
+
+            cmd_chat(args)
+
+        assert captured["query"] == "hello"
+        assert captured["quiet"] is True
 
     def test_main_accepts_tts_setup_section(self, monkeypatch):
         """`hermes setup tts` should parse and dispatch like other setup sections."""

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -25,6 +25,7 @@ def main_mod(monkeypatch):
     import hermes_cli.main as mod
 
     monkeypatch.setattr(mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     return mod
 
 


### PR DESCRIPTION
## Summary
- add an early stdin TTY guard for interactive `hermes` / `hermes chat` launches
- keep scripted modes such as `hermes -z ...` and `hermes chat -q ...` usable with redirected stdin
- add regression coverage for configured-provider headless launch and direct `python cli.py` entrypoints

## Root Cause
Interactive classic chat could be launched with stdin redirected or closed. Hermes printed a prompt_toolkit warning, then still allowed prompt_toolkit to attach to fd 0, which can crash on macOS/uv Python with `KeyError: 0 is not registered` followed by `OSError: [Errno 22] Invalid argument`.

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_tui_resume_flow.py tests/cli/test_cli_init.py`
- smoke: non-TTY `hermes chat` exits with a clear error and no traceback
- smoke: real-PTY `hermes chat` still opens and exits cleanly

## Platform
Tested on macOS with uv-managed Python 3.11.13.