### PR TITLE
fix(gateway): return numeric analytics totals

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2703,14 +2703,14 @@ async def get_usage_analytics(days: int = 30):
         cutoff = time.time() - (days * 86400)
         cur = db._conn.execute("""
             SELECT date(started_at, 'unixepoch') as day,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as api_calls
             FROM sessions WHERE started_at > ?
             GROUP BY day ORDER BY day
         """, (cutoff,))
@@ -2718,25 +2718,25 @@ async def get_usage_analytics(days: int = 30):
 
         cur2 = db._conn.execute("""
             SELECT model,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL
-            GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            GROUP BY model ORDER BY COALESCE(SUM(input_tokens), 0) + COALESCE(SUM(output_tokens), 0) DESC
         """, (cutoff,))
         by_model = [dict(r) for r in cur2.fetchall()]
 
         cur3 = db._conn.execute("""
-            SELECT SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
+            SELECT COALESCE(SUM(input_tokens), 0) as total_input,
+                   COALESCE(SUM(output_tokens), 0) as total_output,
+                   COALESCE(SUM(cache_read_tokens), 0) as total_cache_read,
+                   COALESCE(SUM(reasoning_tokens), 0) as total_reasoning,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as total_api_calls
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
@@ -2778,20 +2778,20 @@ async def get_models_analytics(days: int = 30):
         cur = db._conn.execute("""
             SELECT model,
                    billing_provider,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls,
-                   SUM(tool_call_count) as tool_calls,
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as api_calls,
+                   COALESCE(SUM(tool_call_count), 0) as tool_calls,
                    MAX(started_at) as last_used_at,
-                   AVG(input_tokens + output_tokens) as avg_tokens_per_session
+                   AVG(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) as avg_tokens_per_session
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
             GROUP BY model, billing_provider
-            ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            ORDER BY COALESCE(SUM(input_tokens), 0) + COALESCE(SUM(output_tokens), 0) DESC
         """, (cutoff,))
         rows = [dict(r) for r in cur.fetchall()]
 
@@ -2834,14 +2834,14 @@ async def get_models_analytics(days: int = 30):
 
         totals_cur = db._conn.execute("""
             SELECT COUNT(DISTINCT model) as distinct_models,
-                   SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
+                   COALESCE(SUM(input_tokens), 0) as total_input,
+                   COALESCE(SUM(output_tokens), 0) as total_output,
+                   COALESCE(SUM(cache_read_tokens), 0) as total_cache_read,
+                   COALESCE(SUM(reasoning_tokens), 0) as total_reasoning,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
+                   COALESCE(SUM(COALESCE(api_call_count, 0)), 0) as total_api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
         """, (cutoff,))
         totals = dict(totals_cur.fetchone())

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -962,6 +962,11 @@ class TestNewEndpoints:
         assert isinstance(data["daily"], list)
         assert "total_sessions" in data["totals"]
         assert "total_api_calls" in data["totals"]
+        assert data["totals"]["total_input"] == 0
+        assert data["totals"]["total_output"] == 0
+        assert data["totals"]["total_cache_read"] == 0
+        assert data["totals"]["total_reasoning"] == 0
+        assert data["totals"]["total_api_calls"] == 0
         assert data["skills"] == {
             "summary": {
                 "total_skill_loads": 0,
@@ -970,6 +975,23 @@ class TestNewEndpoints:
                 "distinct_skills_used": 0,
             },
             "top_skills": [],
+        }
+
+    def test_analytics_models_empty_totals_are_numeric(self):
+        resp = self.client.get("/api/analytics/models?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["models"] == []
+        assert data["totals"] == {
+            "distinct_models": 0,
+            "total_input": 0,
+            "total_output": 0,
+            "total_cache_read": 0,
+            "total_reasoning": 0,
+            "total_estimated_cost": 0,
+            "total_actual_cost": 0,
+            "total_sessions": 0,
+            "total_api_calls": 0,
         }
 
     def test_analytics_usage_includes_skill_breakdown(self):


### PR DESCRIPTION
## Summary
- Return numeric zeroes instead of `null` for empty analytics aggregate totals.
- Cover empty model analytics totals with a regression test.

## Related Issue
- No linked GitHub issue; found during local dashboard/API review.

## Type of Change
- Bug fix
- Tests

## Test Plan
- Tested on macOS 26.4.1.
- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh` against the analytics empty-total regression test in `tests/hermes_cli/test_web_server.py` (passed as part of 8 focused endpoint tests).
- Full local `tests/hermes_cli/test_web_server.py` run is currently blocked by 3 unrelated `TestPtyWebSocket` failures in this macOS temp environment; non-PTY coverage passed.
