### PR TITLE
fix(teams): post-merge fixes and doc improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       # - TEAMS_CLIENT_SECRET=${TEAMS_CLIENT_SECRET}
       # - TEAMS_TENANT_ID=${TEAMS_TENANT_ID}
       # - TEAMS_ALLOWED_USERS=${TEAMS_ALLOWED_USERS}
-      # - TEAMS_PORT=3978
+      # - TEAMS_PORT=${TEAMS_PORT:-3978}
     command: ["gateway", "run"]
 
   dashboard:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -38,6 +38,7 @@ except ImportError:
 
 try:
     from microsoft_teams.apps import App, ActivityContext
+    from microsoft_teams.common.http.client import ClientOptions
     from microsoft_teams.api import MessageActivity, ConversationReference
     from microsoft_teams.api.activities.typing import TypingActivityInput
     from microsoft_teams.api.activities.invoke.adaptive_card import AdaptiveCardInvokeActivity
@@ -57,6 +58,7 @@ try:
     TEAMS_SDK_AVAILABLE = True
 except ImportError:
     TEAMS_SDK_AVAILABLE = False
+    ClientOptions = None  # type: ignore[assignment,misc]
     App = None  # type: ignore[assignment,misc]
     ActivityContext = None  # type: ignore[assignment,misc]
     MessageActivity = None  # type: ignore[assignment,misc]
@@ -208,6 +210,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 client_secret=self._client_secret,
                 tenant_id=self._tenant_id,
                 http_server_adapter=_AiohttpBridgeAdapter(aiohttp_app),
+                client=ClientOptions(headers={"User-Agent": "Hermes"}),
             )
 
             # Register message handler before initialize()

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -37,9 +37,9 @@ teams status --verbose
 
 ---
 
-## Step 2: Expose Port 3978
+## Step 2: Expose the Webhook Port
 
-Teams cannot deliver messages to `localhost`. For local development, use any tunnel tool to get a public HTTPS URL:
+Teams cannot deliver messages to `localhost`. For local development, use any tunnel tool to get a public HTTPS URL. The default port is `3978` — change it with `TEAMS_PORT` if needed.
 
 ```bash
 # devtunnel (Microsoft)
@@ -95,7 +95,7 @@ TEAMS_ALLOWED_USERS=<your-aad-object-id>
 HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d gateway
 ```
 
-This starts the gateway and maps port 3978 on your host to the container. Check that it's running:
+This starts the gateway. The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
 
 ```bash
 curl http://localhost:3978/health   # should return: ok
@@ -129,6 +129,7 @@ The `teamsAppId` was printed by `teams app create` in Step 3. After installing, 
 | `TEAMS_CLIENT_SECRET` | Azure AD client secret |
 | `TEAMS_TENANT_ID` | Azure AD tenant ID |
 | `TEAMS_ALLOWED_USERS` | Comma-separated AAD object IDs allowed to use the bot |
+| `TEAMS_ALLOW_ALL_USERS` | Set `true` to skip the allowlist and allow anyone |
 | `TEAMS_HOME_CHANNEL` | Conversation ID for cron/proactive message delivery |
 | `TEAMS_HOME_CHANNEL_NAME` | Display name for the home channel |
 | `TEAMS_PORT` | Webhook port (default: `3978`) |
@@ -181,7 +182,7 @@ If you've already created the bot and just need to update the endpoint:
 teams app update --id <teamsAppId> --endpoint "https://your-domain.com/api/messages"
 ```
 
-Make sure port 3978 (or your configured `TEAMS_PORT`) is reachable from the internet and that your TLS certificate is valid — Teams rejects self-signed certificates.
+Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from the internet and that your TLS certificate is valid — Teams rejects self-signed certificates.
 
 ---
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -111,13 +111,7 @@ Look for:
 
 ## Step 6: Install the App in Teams
 
-Open the **Install in Teams** link printed by `teams app create` in Step 3:
-
-```
-https://teams.microsoft.com/l/app/<teamsAppId>?installAppPackage=true&appTenantId=<tenantId>
-```
-
-After installing, open Microsoft Teams and send a direct message to your bot — it's ready.
+Open the **Install in Teams** link printed by `teams app create` in Step 3. After installing, open Microsoft Teams and send a direct message to your bot — it's ready.
 
 ---
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -13,8 +13,10 @@ Connect Hermes Agent to Microsoft Teams as a bot. Unlike Slack's Socket Mode, Te
 | Context | Behavior |
 |---------|----------|
 | **Personal chat (DM)** | Bot responds to every message. No @mention needed. |
-| **Group chat** | Bot responds to every message in the chat. |
-| **Channel** | Bot only responds when @mentioned (Teams delivers @mentions as regular messages with `<at>BotName</at>` tags, which Hermes strips automatically). |
+| **Group chat** | Bot only responds when @mentioned. |
+| **Channel** | Bot only responds when @mentioned. |
+
+Teams delivers @mentions as regular messages with `<at>BotName</at>` tags, which Hermes strips automatically before processing.
 
 ---
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -68,7 +68,7 @@ teams app create \
   --endpoint "https://<your-tunnel-url>/api/messages"
 ```
 
-The CLI outputs your `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID`. Save them — you'll need all three.
+The CLI outputs your `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID`, plus an install link for Step 6. Save the client secret — it won't be shown again.
 
 ---
 
@@ -111,11 +111,13 @@ Look for:
 
 ## Step 6: Install the App in Teams
 
-```bash
-teams app install --id <teamsAppId>
+Open the **Install in Teams** link printed by `teams app create` in Step 3:
+
+```
+https://teams.microsoft.com/l/app/<teamsAppId>?installAppPackage=true&appTenantId=<tenantId>
 ```
 
-The `teamsAppId` was printed by `teams app create` in Step 3. After installing, open Microsoft Teams and send a direct message to your bot — it's ready.
+After installing, open Microsoft Teams and send a direct message to your bot — it's ready.
 
 ---
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -111,7 +111,11 @@ Look for:
 
 ## Step 6: Install the App in Teams
 
-Open the **Install in Teams** link printed by `teams app create` in Step 3 — it opens directly in the Teams client. After installing, send a direct message to your bot — it's ready.
+```bash
+teams app get <teamsAppId> --install-link
+```
+
+Open the printed link in your browser — it opens directly in the Teams client. After installing, send a direct message to your bot — it's ready.
 
 ---
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -44,14 +44,14 @@ Teams cannot deliver messages to `localhost`. For local development, use any tun
 ```bash
 # devtunnel (Microsoft)
 devtunnel create hermes-bot --allow-anonymous
-devtunnel port create hermes-bot -p 3978 --protocol https
+devtunnel port create hermes-bot -p 3978 --protocol https  # replace 3978 with TEAMS_PORT if changed
 devtunnel host hermes-bot
 
 # ngrok
-ngrok http 3978
+ngrok http 3978  # replace 3978 with TEAMS_PORT if changed
 
 # cloudflared
-cloudflared tunnel --url http://localhost:3978
+cloudflared tunnel --url http://localhost:3978  # replace 3978 with TEAMS_PORT if changed
 ```
 
 Copy the `https://` URL from the output — you'll use it in the next step. Leave the tunnel running while developing.

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -111,7 +111,7 @@ Look for:
 
 ## Step 6: Install the App in Teams
 
-Open the **Install in Teams** link printed by `teams app create` in Step 3. After installing, open Microsoft Teams and send a direct message to your bot — it's ready.
+Open the **Install in Teams** link printed by `teams app create` in Step 3 — it opens directly in the Teams client. After installing, send a direct message to your bot — it's ready.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up fixes to the Teams adapter after it landed in main.

- **`feat(teams): set User-Agent to Hermes`** — uses the new `client` option in `microsoft-teams-apps` 2.0.0 to set `User-Agent: Hermes` on all outgoing requests
- **`fix(teams): pipe TEAMS_PORT through docker-compose`** — was hardcoded to `3978`, now uses `${TEAMS_PORT:-3978}`
- **`docs(teams): fix group chat behavior`** — group chats require @mention, not respond-to-all
- **`docs(teams): fix port references`** — reference `TEAMS_PORT` instead of hardcoding `3978`; add missing `TEAMS_ALLOW_ALL_USERS` to config table
- **`docs(teams): fix CLI install steps`** — remove `@preview` confusion (keep it), update Step 6 to use `teams app get --install-link`, note client secret won't be shown again

## Test plan

- [ ] `User-Agent: Hermes` appears in outgoing Teams API requests
- [ ] `TEAMS_PORT` set in `.env` is respected by docker-compose
- [ ] Docs steps work end-to-end with the Teams CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)