### PR TITLE
fix(gateway): add image types to SUPPORTED_DOCUMENT_TYPES

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -783,6 +783,11 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
 }
 
 


### PR DESCRIPTION
When users send images as documents on messaging platforms (Telegram, Discord, etc.), they get "Unsupported document type '.png'" error and the image data is lost.

This fix adds `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif` to `SUPPORTED_DOCUMENT_TYPES` so images sent as documents are properly cached and available in the conversation context.

The existing download, cache, and injection logic already handles these types — only the type dictionary needed updating.