### PR TITLE
fix(mcp): recognise 'Session terminated' as transport session expiry

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -46,6 +46,16 @@ def test_is_session_expired_detects_session_not_found():
     assert _is_session_expired_error(RuntimeError("Unknown session: abc123")) is True
 
 
+def test_is_session_expired_detects_session_terminated():
+    """MCP SDK streamable-http server sends ``Session terminated`` (code 32600)
+    when a client POSTs to a session ID that no longer exists (#18069)."""
+    from tools.mcp_tool import _is_session_expired_error
+    assert _is_session_expired_error(
+        RuntimeError("McpError(ErrorData(code=32600, message='Session terminated'))")
+    ) is True
+    assert _is_session_expired_error(RuntimeError("Session terminated")) is True
+
+
 def test_is_session_expired_is_case_insensitive():
     """Match uses lower-cased comparison so servers that emit the
     message in different cases (SDK formatter quirks) still trigger."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1666,6 +1666,7 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "expired session",
     "session expired",
     "session not found",
+    "session terminated",
     "unknown session",
 )
 


### PR DESCRIPTION
## Problem

Fixes #18069

When a streamable-http MCP server restarts (or its session is garbage-collected due to idle TTL, pod rotation, etc.), the MCP SDK sends:

```
McpError(ErrorData(code=32600, message="Session terminated"))
```

This error was **not** included in `_SESSION_EXPIRED_MARKERS`, so it fell through to the generic tool-failure path with no recovery. Every subsequent call on the affected MCP server would fail until the gateway was manually restarted — even though the transport layer had already reconnected with a fresh session ID.

## Fix

Add `"session terminated"` to `_SESSION_EXPIRED_MARKERS` in `tools/mcp_tool.py` so the error is routed through the existing reconnect-and-retry flow introduced in #13383.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| MCP server sends `Session terminated` (code 32600) | Generic tool error, no recovery | Reconnect + retry via existing flow |
| Existing markers (`expired session`, etc.) | Reconnect + retry | Unchanged |

## Tests

- `tests/tools/test_mcp_tool_session_expired.py` — added `test_is_session_expired_detects_session_terminated` with 2 assertions:
  - Full McpError string: `"McpError(ErrorData(code=32600, message='Session terminated'))"` → detected
  - Bare message: `"Session terminated"` → detected
