### PR TITLE
fix(model_metadata): parse_context_limit_from_error matches underscore short form

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -816,7 +816,7 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     # Pattern: look for numbers near context-related keywords
     patterns = [
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
-        r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
+        r'context[\s_]*(?:length|size|window)[\w]*\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
         r'>\s*(\d{4,})\s*(?:max|limit|token)',  # "250000 tokens > 200000 maximum"
         r'(\d{4,})\s*(?:max(?:imum)?)\b',  # "200000 maximum"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -904,6 +904,11 @@ class TestParseContextLimitFromError:
         msg = "context_length_exceeded: maximum context length is 131072"
         assert parse_context_limit_from_error(msg) == 131072
 
+    def test_context_length_exceeded_short_form(self):
+        """Underscore short form 'context_length_exceeded: N' (#17983)."""
+        msg = "context_length_exceeded: 131072"
+        assert parse_context_limit_from_error(msg) == 131072
+
     def test_context_size_exceeded(self):
         msg = "Maximum context size 65536 exceeded"
         assert parse_context_limit_from_error(msg) == 65536


### PR DESCRIPTION
## Problem

Fixes #17983

`parse_context_limit_from_error` in `agent/model_metadata.py` advertises `"context_length_exceeded: 131072"` as a supported format in its docstring, but actually returned `None` for that input.

Two regex patterns failed:
- Pattern 1 had no `max`/`limit` keyword to anchor on
- Pattern 2 used `\s*` between `context` and `length` (so `_` did not match) and required an `is`/`of`/`:` connector immediately after the keyword (so `length_exceeded:` did not match either)

## Fix

Widen pattern 2 in `parse_context_limit_from_error`:
- `\s*` → `[\s_]*` between `context` and `(length|size|window)` to accept underscore separators
- `[\w]*` after the keyword to allow trailing text like `_exceeded`

This accepts the underscore short form while keeping every existing negative case rejected. The adversarial string `"context window exceeds limit (2013)"` continues to return `None`.

## Before vs After

| Input | Before | After |
|---|---|---|
| `"context_length_exceeded: 131072"` | `None` | `131072` |
| `"maximum context length is 32768 tokens"` | `32768` | `32768` (unchanged) |
| `"Maximum context size 32768 exceeded"` | `32768` | `32768` (unchanged) |
| `"context window exceeds limit (2013)"` | `None` | `None` (unchanged) |

## Tests

- `tests/agent/test_model_metadata.py` — added `test_context_length_exceeded_short_form` verifying the underscore short form is now parsed correctly
