### PR TITLE
fix(email): guard IMAP FETCH response against non-bytes payloads

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -362,7 +362,24 @@ class EmailAdapter(BasePlatformAdapter):
                     if status != "OK":
                         continue
 
-                    raw_email = msg_data[0][1]
+                    # Guard against malformed FETCH responses where the
+                    # body slot is an int, plain bytes, or None instead
+                    # of the expected (header, body) tuple (#12498, #18106).
+                    try:
+                        raw_email = msg_data[0][1]
+                    except (IndexError, TypeError):
+                        logger.warning(
+                            "[Email] Malformed IMAP FETCH response for UID %s: %r",
+                            uid, msg_data,
+                        )
+                        continue
+                    if not isinstance(raw_email, (bytes, bytearray)):
+                        logger.warning(
+                            "[Email] IMAP FETCH returned non-bytes payload for UID %s "
+                            "(type=%s); skipping",
+                            uid, type(raw_email).__name__,
+                        )
+                        continue
                     msg = email_lib.message_from_bytes(raw_email)
 
                     sender_raw = msg.get("From", "")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1046,5 +1046,50 @@ class TestImapConnectionCleanup(unittest.TestCase):
         mock_imap.logout.assert_called_once()
 
 
+class TestFetchMalformedResponse(unittest.TestCase):
+    """Guard against malformed IMAP FETCH responses (#12498, #18106)."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "test@example.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "993",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+        }):
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_fetch_skips_int_payload(self):
+        """msg_data[0] is bytes → indexing yields int → guard skips."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.uid.side_effect = [
+            ("OK", [b"1"]),           # search
+            ("OK", [b"abcdef"]),      # fetch — msg_data[0] is bytes, [1] is int
+        ]
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+
+    def test_fetch_skips_none_payload(self):
+        """msg_data[0] is None → TypeError on [1] → guard skips."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.uid.side_effect = [
+            ("OK", [b"1"]),      # search
+            ("OK", [None]),      # fetch — msg_data[0] is None
+        ]
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Fixes #12498
Fixes #18106

Some IMAP servers return malformed `FETCH` responses where the body slot is an `int`, plain `bytes`, or `None` instead of the expected `(header, body)` tuple. Accessing `msg_data[0][1]` then either raises `IndexError`/`TypeError`, or returns an int (indexing `bytes` yields an int in Python 3), which only surfaces later as:

```
ERROR gateway.platforms.email: [Email] IMAP fetch error: 'int' object has no attribute 'decode'
```

The exception kills the inner loop iteration and is caught by the outer `try/except` at the bottom of `_fetch_new_messages`, so the **entire polling pass returns empty** — no messages are dispatched for that tick.

Observed on iCloud (OVH IMAP) and reported independently in two issues.

## Fix

Add a two-stage guard around the fetch response, inside the per-UID loop in `_fetch_new_messages`:

1. `try/except (IndexError, TypeError)` around `msg_data[0][1]` access
2. `isinstance(raw_email, (bytes, bytearray))` check before `message_from_bytes`

In both branches, log a warning with the offending UID and `continue` to the next message rather than bailing on the entire poll pass.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| `msg_data[0]` is bytes (indexing yields int) | `'int' object has no attribute 'decode'`, entire poll fails | Warning logged, message skipped, rest of inbox processed |
| `msg_data[0]` is None | `TypeError`, entire poll fails | Warning logged, message skipped, rest of inbox processed |
| Normal `(header, body)` tuple | Parses OK | Unchanged |

## Tests

- `tests/gateway/test_email.py` — added `TestFetchMalformedResponse` with 2 tests:
  - `test_fetch_skips_int_payload`: `msg_data = [b"abcdef"]` → `msg_data[0][1]` is int → guard skips
  - `test_fetch_skips_none_payload`: `msg_data = [None]` → `TypeError` → guard skips
