### PR TITLE
fix(acp): honor model.custom_provider in runtime resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -500,7 +500,21 @@ def _resolve_named_custom_runtime(
             "requested_provider": requested_provider,
         }
 
-    custom_provider = _get_named_custom_provider(requested_provider)
+    # When provider="custom" and model.custom_provider names a specific entry in
+    # custom_providers:, look up that entry rather than falling through to the
+    # bare-"custom" guard in _get_named_custom_provider() which returns None for
+    # the literal string "custom".
+    # This fixes ACP sessions: hermes chat --tui resolves correctly because cli.py
+    # reads model.custom_provider directly, but _make_agent() only sees the top-level
+    # config_provider ("custom") and never the custom_provider sub-key.
+    _lookup_provider = requested_provider
+    if requested_norm == "custom":
+        _model_cfg = _get_model_config()
+        _named = str(_model_cfg.get("custom_provider") or "").strip()
+        if _named and _named.lower() != "custom":
+            _lookup_provider = _named
+
+    custom_provider = _get_named_custom_provider(_lookup_provider)
     if not custom_provider:
         return None
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2233,3 +2233,54 @@ def test_minimax_oauth_runtime_uses_inference_base_url(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="minimax-oauth")
 
     assert MINIMAX_OAUTH_CN_INFERENCE.rstrip("/") in resolved["base_url"]
+
+
+def test_resolve_runtime_provider_custom_with_named_custom_provider(monkeypatch):
+    """When provider='custom' + model.custom_provider names a custom_providers entry,
+    the resolved base_url must use that entry's base_url — NOT the OpenRouter URL.
+
+    Regression for ACP bug: _make_agent() passes config_provider='custom' to
+    resolve_runtime_provider(); _get_named_custom_provider() guarded against bare
+    'custom' and returned None, causing fallthrough to OPENROUTER_BASE_URL in
+    _resolve_openrouter_runtime().
+    """
+    _fake_config = {
+        "model": {
+            "default": "route-llm",
+            "provider": "custom",
+            "custom_provider": "abacus-proxy",
+        },
+        "custom_providers": [
+            {
+                "name": "abacus-proxy",
+                "base_url": "http://localhost:8003/v1",
+                "api_key": "anything",
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "default": "route-llm",
+            "provider": "custom",
+            "custom_provider": "abacus-proxy",
+        },
+    )
+    # _get_named_custom_provider calls load_config() via the name imported into
+    # runtime_provider's namespace, so patch it there (not in hermes_cli.config).
+    monkeypatch.setattr(rp, "load_config", lambda: _fake_config)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["base_url"] == "http://localhost:8003/v1", (
+        f"Expected localhost:8003/v1 but got {resolved['base_url']!r} — "
+        "custom_provider lookup not working"
+    )
+    assert resolved["base_url"] != rp.OPENROUTER_BASE_URL
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["api_key"] == "anything"
+


### PR DESCRIPTION
## What does this PR do?

`hermes acp` ignored `model.custom_provider` in `config.yaml` when `provider: custom`, falling back to OpenRouter's URL regardless of the matching `custom_providers` entry. The TUI (`hermes chat --tui`) handled this correctly; ACP did not, breaking any VS Code extension or other ACP client trying to use a custom OpenAI-compatible endpoint.

This patches the runtime resolver to look up the named entry in `custom_providers` when `provider == "custom"` and `custom_provider` is set, using that entry's `base_url` and `api_key`. Falls back to existing OpenRouter behavior when no match is found.

## Related Issue

No prior issue filed — discovered while configuring the joaompfp.hermes-ai-agent VS Code extension to use a local OpenAI-compatible proxy. Happy to file a tracking issue if maintainers prefer.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — added lookup of `custom_provider` against the `custom_providers:` array in `_resolve_named_custom_runtime`; uses the matched entry's `base_url` and `api_key` when found, falls back to existing OpenRouter behavior otherwise.
- `tests/hermes_cli/test_runtime_provider_resolution.py` — added a test verifying that ACP runtime resolution with `provider: custom` + matching `custom_provider` returns the configured `base_url` rather than the OpenRouter fallback.

## How to Test

1. Configure `~/.hermes/config.yaml`:

```yaml
model:
  default: route-llm
  provider: custom
  custom_provider: my-server
custom_providers:
  - name: my-server
    base_url: http://localhost:8003/v1
    api_key: anything
```

2. Launch any ACP client (e.g., the VS Code extension `joaompfp.hermes-ai-agent` with `hermes.path` pointing at this branch's binary).
3. Send any prompt.
4. Check the resulting session's `model_config`:

```bash
sqlite3 ~/.hermes/state.db \
  "SELECT model_config FROM sessions ORDER BY started_at DESC LIMIT 1;" | jq .
```

Before this fix: `"base_url": "https://openrouter.ai/api/v1"` (wrong)
After this fix: `"base_url": "http://localhost:8003/v1"` (correct)

The new test in `test_runtime_provider_resolution.py` covers this case automatically.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run pytest and the runtime-resolution suite passes (108/108)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no documentation changes
- [x] N/A — no schema changes
- [x] N/A — no architecture changes
- [x] Cross-platform safe — pure Python, no platform-specific calls
- [x] N/A — no tool description changes

## Screenshots / Logs

Before fix:

```json
{"provider": "custom", "base_url": "https://openrouter.ai/api/v1", ...}
```

After fix:

```json
{"provider": "custom", "base_url": "http://localhost:8003/v1", ...}
```

End-to-end verified: VS Code extension → ACP → resolver → local proxy → upstream → response. Proxy logs show `status=200`.