### PR TITLE
Add shared-home skill locking

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -588,7 +588,12 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _skills_manifest_cache_token(manifest: dict[str, list[int]]) -> tuple:
+    """Return a hashable token for cache keys."""
+    return tuple(sorted((path, tuple(values)) for path, values in manifest.items()))
+
+
+def _load_skills_snapshot(skills_dir: Path, manifest: dict[str, list[int]] | None = None) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -601,7 +606,8 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    expected_manifest = manifest if manifest is not None else _build_skills_manifest(skills_dir)
+    if snapshot.get("manifest") != expected_manifest:
         return None
     return snapshot
 
@@ -733,6 +739,8 @@ def build_skills_system_prompt(
     if not skills_dir.exists() and not external_dirs:
         return ""
 
+    local_manifest = _build_skills_manifest(skills_dir) if skills_dir.exists() else {}
+
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
@@ -750,6 +758,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        _skills_manifest_cache_token(local_manifest),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -758,7 +767,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, manifest=local_manifest)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -827,7 +836,7 @@ def build_skills_system_prompt(
 
         _write_skills_snapshot(
             skills_dir,
-            _build_skills_manifest(skills_dir),
+            local_manifest,
             skill_entries,
             category_descriptions,
         )

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -372,6 +372,28 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_rebuilds_prompt_when_local_skill_tree_changes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        first_skill = tmp_path / "skills" / "tools" / "first-skill"
+        first_skill.mkdir(parents=True)
+        (first_skill / "SKILL.md").write_text(
+            "---\nname: first-skill\ndescription: First skill\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "first-skill" in first
+        assert "second-skill" not in first
+
+        second_skill = tmp_path / "skills" / "tools" / "second-skill"
+        second_skill.mkdir(parents=True)
+        (second_skill / "SKILL.md").write_text(
+            "---\nname: second-skill\ndescription: Second skill\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "first-skill" in second
+        assert "second-skill" in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)
@@ -1086,6 +1108,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -44,6 +44,7 @@ from typing import Dict, Any, Optional, Tuple
 
 from utils import atomic_replace
 from hermes_cli.config import cfg_get
+from tools.skills_lock import skills_write_lock
 
 logger = logging.getLogger(__name__)
 
@@ -705,40 +706,41 @@ def skill_manage(
 
     Returns JSON string with results.
     """
-    if action == "create":
-        if not content:
-            return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
+    with skills_write_lock():
+        if action == "create":
+            if not content:
+                return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
+            result = _create_skill(name, content, category)
 
-    elif action == "edit":
-        if not content:
-            return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
-        result = _edit_skill(name, content)
+        elif action == "edit":
+            if not content:
+                return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
+            result = _edit_skill(name, content)
 
-    elif action == "patch":
-        if not old_string:
-            return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
-        if new_string is None:
-            return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
-        result = _patch_skill(name, old_string, new_string, file_path, replace_all)
+        elif action == "patch":
+            if not old_string:
+                return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
+            if new_string is None:
+                return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
+            result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
-    elif action == "delete":
-        result = _delete_skill(name)
+        elif action == "delete":
+            result = _delete_skill(name)
 
-    elif action == "write_file":
-        if not file_path:
-            return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
-        if file_content is None:
-            return tool_error("file_content is required for 'write_file'.", success=False)
-        result = _write_file(name, file_path, file_content)
+        elif action == "write_file":
+            if not file_path:
+                return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+            if file_content is None:
+                return tool_error("file_content is required for 'write_file'.", success=False)
+            result = _write_file(name, file_path, file_content)
 
-    elif action == "remove_file":
-        if not file_path:
-            return tool_error("file_path is required for 'remove_file'.", success=False)
-        result = _remove_file(name, file_path)
+        elif action == "remove_file":
+            if not file_path:
+                return tool_error("file_path is required for 'remove_file'.", success=False)
+            result = _remove_file(name, file_path)
 
-    else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+        else:
+            result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
 
     if result.get("success"):
         try:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
+from tools.skills_lock import skills_write_lock
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse, urlunparse
 
@@ -2692,27 +2693,28 @@ def ensure_hub_dirs() -> None:
 
 def quarantine_bundle(bundle: SkillBundle) -> Path:
     """Write a skill bundle to the quarantine directory for scanning."""
-    ensure_hub_dirs()
-    skill_name = _validate_skill_name(bundle.name)
-    validated_files: List[Tuple[str, Union[str, bytes]]] = []
-    for rel_path, file_content in bundle.files.items():
-        safe_rel_path = _validate_bundle_rel_path(rel_path)
-        validated_files.append((safe_rel_path, file_content))
+    with skills_write_lock():
+        ensure_hub_dirs()
+        skill_name = _validate_skill_name(bundle.name)
+        validated_files: List[Tuple[str, Union[str, bytes]]] = []
+        for rel_path, file_content in bundle.files.items():
+            safe_rel_path = _validate_bundle_rel_path(rel_path)
+            validated_files.append((safe_rel_path, file_content))
 
-    dest = QUARANTINE_DIR / skill_name
-    if dest.exists():
-        shutil.rmtree(dest)
-    dest.mkdir(parents=True)
+        dest = QUARANTINE_DIR / skill_name
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.mkdir(parents=True)
 
-    for rel_path, file_content in validated_files:
-        file_dest = dest.joinpath(*rel_path.split("/"))
-        file_dest.parent.mkdir(parents=True, exist_ok=True)
-        if isinstance(file_content, bytes):
-            file_dest.write_bytes(file_content)
-        else:
-            file_dest.write_text(file_content, encoding="utf-8")
+        for rel_path, file_content in validated_files:
+            file_dest = dest.joinpath(*rel_path.split("/"))
+            file_dest.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(file_content, bytes):
+                file_dest.write_bytes(file_content)
+            else:
+                file_dest.write_text(file_content, encoding="utf-8")
 
-    return dest
+        return dest
 
 
 def install_from_quarantine(
@@ -2723,78 +2725,80 @@ def install_from_quarantine(
     scan_result: ScanResult,
 ) -> Path:
     """Move a scanned skill from quarantine into the skills directory."""
-    safe_skill_name = _validate_skill_name(skill_name)
-    safe_category = _validate_category_name(category) if category else ""
-    quarantine_resolved = quarantine_path.resolve()
-    quarantine_root = QUARANTINE_DIR.resolve()
-    if not quarantine_resolved.is_relative_to(quarantine_root):
-        raise ValueError(f"Unsafe quarantine path: {quarantine_path}")
+    with skills_write_lock():
+        safe_skill_name = _validate_skill_name(skill_name)
+        safe_category = _validate_category_name(category) if category else ""
+        quarantine_resolved = quarantine_path.resolve()
+        quarantine_root = QUARANTINE_DIR.resolve()
+        if not quarantine_resolved.is_relative_to(quarantine_root):
+            raise ValueError(f"Unsafe quarantine path: {quarantine_path}")
 
-    if safe_category:
-        install_dir = SKILLS_DIR / safe_category / safe_skill_name
-    else:
-        install_dir = SKILLS_DIR / safe_skill_name
+        if safe_category:
+            install_dir = SKILLS_DIR / safe_category / safe_skill_name
+        else:
+            install_dir = SKILLS_DIR / safe_skill_name
 
-    if install_dir.exists():
-        shutil.rmtree(install_dir)
+        if install_dir.exists():
+            shutil.rmtree(install_dir)
 
-    # Warn (but don't block) if SKILL.md is very large
-    skill_md = quarantine_path / "SKILL.md"
-    if skill_md.exists():
-        try:
-            skill_size = skill_md.stat().st_size
-            if skill_size > 100_000:
-                logger.warning(
-                    "Skill '%s' has a large SKILL.md (%s chars). "
-                    "Large skills consume significant context when loaded. "
-                    "Consider asking the author to split it into smaller files.",
-                    safe_skill_name,
-                    f"{skill_size:,}",
-                )
-        except OSError:
-            pass
+        # Warn (but don't block) if SKILL.md is very large
+        skill_md = quarantine_path / "SKILL.md"
+        if skill_md.exists():
+            try:
+                skill_size = skill_md.stat().st_size
+                if skill_size > 100_000:
+                    logger.warning(
+                        "Skill '%s' has a large SKILL.md (%s chars). "
+                        "Large skills consume significant context when loaded. "
+                        "Consider asking the author to split it into smaller files.",
+                        safe_skill_name,
+                        f"{skill_size:,}",
+                    )
+            except OSError:
+                pass
 
-    install_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(quarantine_path), str(install_dir))
+        install_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(quarantine_path), str(install_dir))
 
-    # Record in lock file
-    lock = HubLockFile()
-    lock.record_install(
-        name=safe_skill_name,
-        source=bundle.source,
-        identifier=bundle.identifier,
-        trust_level=bundle.trust_level,
-        scan_verdict=scan_result.verdict,
-        skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
-        files=list(bundle.files.keys()),
-        metadata=bundle.metadata,
-    )
+        # Record in lock file
+        lock = HubLockFile()
+        lock.record_install(
+            name=safe_skill_name,
+            source=bundle.source,
+            identifier=bundle.identifier,
+            trust_level=bundle.trust_level,
+            scan_verdict=scan_result.verdict,
+            skill_hash=content_hash(install_dir),
+            install_path=str(install_dir.relative_to(SKILLS_DIR)),
+            files=list(bundle.files.keys()),
+            metadata=bundle.metadata,
+        )
 
-    append_audit_log(
-        "INSTALL", safe_skill_name, bundle.source,
-        bundle.trust_level, scan_result.verdict,
-        content_hash(install_dir),
-    )
+        append_audit_log(
+            "INSTALL", safe_skill_name, bundle.source,
+            bundle.trust_level, scan_result.verdict,
+            content_hash(install_dir),
+        )
 
-    return install_dir
+        return install_dir
 
 
 def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
-    lock = HubLockFile()
-    entry = lock.get_installed(skill_name)
-    if not entry:
-        return False, f"'{skill_name}' is not a hub-installed skill (may be a builtin)"
+    with skills_write_lock():
+        lock = HubLockFile()
+        entry = lock.get_installed(skill_name)
+        if not entry:
+            return False, f"'{skill_name}' is not a hub-installed skill (may be a builtin)"
 
-    install_path = SKILLS_DIR / entry["install_path"]
-    if install_path.exists():
-        shutil.rmtree(install_path)
+        install_path = SKILLS_DIR / entry["install_path"]
+        if install_path.exists():
+            shutil.rmtree(install_path)
 
-    lock.record_uninstall(skill_name)
-    append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")
+        lock.record_uninstall(skill_name)
+        append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")
 
-    return True, f"Uninstalled '{skill_name}' from {entry['install_path']}"
+        return True, f"Uninstalled '{skill_name}' from {entry['install_path']}"
 
 
 def bundle_content_hash(bundle: SkillBundle) -> str:

--- a/tools/skills_lock.py
+++ b/tools/skills_lock.py
@@ -1,0 +1,73 @@
+"""Shared skill-tree locking helpers.
+
+Hermes can run multiple processes against the same ``$HERMES_HOME``.  Any code
+path that mutates ``$HERMES_HOME/skills`` must take this lock so skill edits,
+bundled skill syncs, and hub installs do not interleave.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import threading
+from typing import Iterator, TextIO
+
+from hermes_constants import get_hermes_home
+
+try:  # pragma: no cover - exercised on Unix, fallback keeps Windows usable
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+
+_thread_state = threading.local()
+_process_fallback_lock = threading.RLock()
+
+
+def skills_lock_path() -> Path:
+    """Return the configured cross-process skills lock path."""
+    override = os.getenv("HERMES_SKILLS_LOCK_PATH", "").strip()
+    if override:
+        return Path(override)
+    return get_hermes_home() / ".locks" / "skills.lock"
+
+
+@contextmanager
+def skills_write_lock(lock_path: Path | None = None) -> Iterator[None]:
+    """Take the shared skills write lock.
+
+    The lock is re-entrant within a thread so high-level operations can call
+    lower-level helpers that also take the lock without deadlocking.
+    """
+    depth = int(getattr(_thread_state, "skills_lock_depth", 0) or 0)
+    if depth > 0:
+        _thread_state.skills_lock_depth = depth + 1
+        try:
+            yield
+        finally:
+            _thread_state.skills_lock_depth = depth
+        return
+
+    path = lock_path or skills_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lock_file: TextIO | None = None
+    try:
+        lock_file = path.open("a+", encoding="utf-8")
+        if fcntl is None:
+            _process_fallback_lock.acquire()
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        _thread_state.skills_lock_depth = 1
+        yield
+    finally:
+        _thread_state.skills_lock_depth = 0
+        try:
+            if lock_file is not None and fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            elif fcntl is None:
+                _process_fallback_lock.release()
+        finally:
+            if lock_file is not None:
+                lock_file.close()

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Tuple
 from utils import atomic_replace
+from tools.skills_lock import skills_write_lock
 
 logger = logging.getLogger(__name__)
 
@@ -182,6 +183,11 @@ def sync_skills(quiet: bool = False) -> dict:
         dict with keys: copied (list), updated (list), skipped (int),
                         user_modified (list), cleaned (list), total_bundled (int)
     """
+    with skills_write_lock():
+        return _sync_skills_unlocked(quiet=quiet)
+
+
+def _sync_skills_unlocked(quiet: bool = False) -> dict:
     bundled_dir = _get_bundled_dir()
     if not bundled_dir.exists():
         return {
@@ -342,6 +348,11 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
           - message: human-readable description
           - synced: dict from sync_skills() if a sync was triggered, else None
     """
+    with skills_write_lock():
+        return _reset_bundled_skill_unlocked(name=name, restore=restore)
+
+
+def _reset_bundled_skill_unlocked(name: str, restore: bool = False) -> dict:
     manifest = _read_manifest()
     bundled_dir = _get_bundled_dir()
     bundled_skills = _discover_bundled_skills(bundled_dir)


### PR DESCRIPTION
## Summary
- add a cross-process skills write lock under /.locks/skills.lock
- take the lock around skill_manage, bundled skill sync/reset, and skill hub install/uninstall mutations
- include the local skills manifest in the in-process prompt cache key so sibling processes see shared skill edits without restart

## Tests
- uv run --python /opt/homebrew/bin/python3.12 --with pytest --with pytest-xdist pytest -o addopts='' tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt::test_rebuilds_prompt_when_local_skill_tree_changes tests/tools/test_skills_sync.py::TestSyncSkills::test_fresh_install_copies_all