### PR TITLE
feat(honcho): HONCHO_SESSION env var for per-launch session pinning

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -374,7 +375,18 @@ class HonchoMemoryProvider(MemoryProvider):
             or session_id
             or "hermes-default"
         )
-        logger.debug("Honcho session key resolved: %s", self._session_key)
+        # Distinguish env-var-derived sessions for operator debugging.
+        # Reconstruct the env-derived value and compare to the resolved key —
+        # `sessions[cwd]` (manual map, line 548) wins silently and would
+        # otherwise produce a misleading "via env var" line.
+        env_raw = os.environ.get("HONCHO_SESSION", "")
+        env_sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', env_raw).strip('-')
+        prefix = f"{cfg.peer_name}-" if cfg.session_peer_prefix and cfg.peer_name else ""
+        env_resolved = f"{prefix}{env_sanitized}" if env_sanitized else None
+        if env_resolved and self._session_key == env_resolved:
+            logger.debug("Honcho session resolved via HONCHO_SESSION env var: %s", self._session_key)
+        else:
+            logger.debug("Honcho session key resolved: %s", self._session_key)
 
         # Create session eagerly
         session = self._manager.get_or_create(self._session_key)

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -606,10 +606,11 @@ class HonchoClientConfig:
           1. Manual directory override from sessions map
           2. Hermes session title (from /title command)
           3. Gateway session key (stable per-chat identifier from gateway platforms)
-          4. per-session strategy — Hermes session_id ({timestamp}_{hex})
-          5. per-repo strategy — git repo root directory name
-          6. per-directory strategy — directory basename
-          7. global strategy — workspace name
+          4. HONCHO_SESSION env var (launch-time operator pin, below gateway for daemon safety)
+          5. per-session strategy — Hermes session_id ({timestamp}_{hex})
+          6. per-repo strategy — git repo root directory name
+          7. per-directory strategy — directory basename
+          8. global strategy — workspace name
         """
         import re
 
@@ -638,6 +639,17 @@ class HonchoClientConfig:
             sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', gateway_session_key).strip('-')
             if sanitized:
                 return self._enforce_session_id_limit(sanitized, gateway_session_key)
+
+        # HONCHO_SESSION env var: launch-time operator pin. Sits BELOW
+        # gateway_session_key so a process-wide env on the daemon does not
+        # collapse multi-chat isolation. For non-gateway launches (CLI/REPL),
+        # this is the primary launch-time session pin.
+        env_session = os.environ.get("HONCHO_SESSION", "")
+        sanitized_env = re.sub(r'[^a-zA-Z0-9_-]+', '-', env_session).strip('-')
+        if sanitized_env:
+            if self.session_peer_prefix and self.peer_name:
+                return f"{self.peer_name}-{sanitized_env}"
+            return sanitized_env
 
         # per-session: inherit Hermes session_id (new Honcho session each run)
         if self.session_strategy == "per-session" and session_id:

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -891,3 +891,74 @@ class TestDialecticDepthParsing:
         }))
         config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.dialectic_depth_levels == ["low", "high"]
+
+
+class TestResolveSessionNameEnvVar:
+    """Tests for HONCHO_SESSION env var pin in resolve_session_name.
+
+    Priority: below gateway_session_key (so daemon multi-chat isolation
+    survives a process-wide env), above session_strategy. Critical safety
+    invariant: the gateway-wins case in test_gateway_wins_over_env_var.
+    """
+
+    def test_env_var_returns_value_no_peer_prefix(self):
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=False)
+        with patch.dict(os.environ, {"HONCHO_SESSION": "foo"}, clear=False):
+            assert config.resolve_session_name(cwd="/tmp/x") == "foo"
+
+    def test_env_var_with_peer_prefix(self):
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=True)
+        with patch.dict(os.environ, {"HONCHO_SESSION": "foo"}, clear=False):
+            assert config.resolve_session_name(cwd="/tmp/x") == "op-foo"
+
+    def test_gateway_wins_over_env_var(self):
+        """DAEMON-SAFETY INVARIANT — do not let this test regress.
+
+        If env var beats gateway_session_key, a process-wide HONCHO_SESSION on
+        the systemd unit collapses all gateway chats into one Honcho session.
+        """
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=False)
+        with patch.dict(os.environ, {"HONCHO_SESSION": "from-env"}, clear=False):
+            result = config.resolve_session_name(
+                cwd="/tmp/x",
+                gateway_session_key="agent:main:telegram:dm:42",
+            )
+        assert result == "agent-main-telegram-dm-42"
+
+    def test_title_wins_over_env_var(self):
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=True)
+        with patch.dict(os.environ, {"HONCHO_SESSION": "from-env"}, clear=False):
+            result = config.resolve_session_name(cwd="/tmp/x", session_title="from-title")
+        assert result == "op-from-title"
+
+    def test_env_var_sanitization_preserves_casing(self):
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=False)
+        with patch.dict(os.environ, {"HONCHO_SESSION": "Foo.Bar!"}, clear=False):
+            assert config.resolve_session_name(cwd="/tmp/x") == "Foo-Bar"
+
+    def test_env_var_sanitizes_to_empty_falls_through(self):
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=False)
+        with patch.dict(os.environ, {"HONCHO_SESSION": "---"}, clear=False):
+            result = config.resolve_session_name(cwd="/tmp/myproj")
+        assert result == "myproj"  # per-directory basename fallback
+
+    def test_env_var_unset_preserves_existing_behavior(self, monkeypatch):
+        """Env-unset path stays compatible with existing per-directory strategy.
+        Use monkeypatch.delenv (not patch.dict(clear=True)) so PATH/HOME and
+        other unrelated env stays intact — important if any callee shells out."""
+        config = HonchoClientConfig(session_strategy="per-directory", peer_name="op", session_peer_prefix=False)
+        monkeypatch.delenv("HONCHO_SESSION", raising=False)
+        result = config.resolve_session_name(cwd="/tmp/myproj")
+        assert result == "myproj"
+
+    def test_manual_sessions_map_wins_over_env_var(self):
+        """Manual override at line 549 is the FIRST check; env var is below
+        gateway_session_key. Manual map should still win."""
+        config = HonchoClientConfig(
+            session_strategy="per-directory",
+            peer_name="op",
+            session_peer_prefix=False,
+            sessions={"/tmp/x": "from-manual-map"},
+        )
+        with patch.dict(os.environ, {"HONCHO_SESSION": "from-env"}, clear=False):
+            assert config.resolve_session_name(cwd="/tmp/x") == "from-manual-map"


### PR DESCRIPTION
## What

Adds a `HONCHO_SESSION` env var that pins the Honcho session name for the launch. `resolve_session_name` reads `HONCHO_SESSION` after the gateway-session-key check and before the strategy fallback, returning the sanitized value (peer-prefixed when `session_peer_prefix=True`).

## Why

Today the only operator-facing session-pin signal is `/title` (set post-launch, persisted in the SQLite session DB). Operators who launch hermes from per-project wrappers want to pin the session at launch without `/title`-ing every session. Mirrors how operator-written values are sanitized elsewhere in the same function (`session_title` at `client.py:555`, `gateway_session_key` at `client.py:567`) — same regex (`[^a-zA-Z0-9_-]+ → -`, then strip leading/trailing dashes), case-preserving.

## Daemon-safety invariant

The env var sits **below** `gateway_session_key` in priority. Tested by `TestResolveSessionNameEnvVar.test_gateway_wins_over_env_var`. Without that ordering, a process-wide `HONCHO_SESSION` on a gateway systemd unit would collapse all gateway chats into one Honcho session — the test guards against the regression.

For non-gateway launches (CLI / REPL), the env var becomes the primary launch-time session pin.

## How to test

```bash
HONCHO_SESSION=test-foo hermes -q "hello"
```

Then check `~/.hermes/logs/` (or stderr if debug logging is enabled) for:

```
Honcho session resolved via HONCHO_SESSION env var: <peer>-test-foo
```

With `session_peer_prefix=False` (the default in `client.py:283`): `Honcho session resolved via HONCHO_SESSION env var: test-foo`.

The plugin's `__init__.py` now reconstructs the env-derived value and compares it to the resolved session key before logging the env-var-derived line — so manual `sessions[cwd]` overrides (which preempt env silently) don't false-positive in the logs.

## Cross-platform

`os.environ.get` is OS-agnostic. No `termios` / `fcntl` / `signal` / process-management changes. macOS verified locally.

## Tests

`tests/honcho_plugin/test_client.py::TestResolveSessionNameEnvVar` — 8 cases:

- env-set returns value (with and without `session_peer_prefix`)
- gateway wins (daemon-safety invariant)
- `/title` wins
- sanitization preserves casing (`Foo.Bar!` → `Foo-Bar`)
- sanitize-to-empty falls through (`---` → per-directory basename)
- env-unset preserves existing behavior (uses `monkeypatch.delenv`, not `patch.dict(clear=True)`, so PATH/HOME stay intact)
- manual `sessions[cwd]` still wins (unchanged)

Run: `pytest tests/honcho_plugin/test_client.py -v`. All pre-existing tests still pass (77 passed, 3 skipped, 0 fails).

## Scope

Plugin-only change. Wrapper / launcher changes that export the env var live downstream in operator tooling, not in this PR. Docstring on `resolve_session_name` updated from 7 numbered steps to 8.