### PR TITLE
feat(line): LINE Messaging API platform adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, LINE, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -66,7 +66,7 @@ hermes doctor       # Diagnose any issues
 
 ## CLI vs Messaging Quick Reference
 
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
+Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, LINE, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
 
 | Action | CLI | Messaging platforms |
 |---------|-----|---------------------|
@@ -93,7 +93,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, LINE, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -385,6 +385,14 @@ PLATFORM_HINTS = {
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be sent as attachments."
     ),
+    "line": (
+        "You are on LINE Messaging. "
+        "LINE does not render Markdown — use plain text only. "
+        "Messages are limited to 5000 characters; split long responses into multiple messages. "
+        "Replies go through the Reply API and are only possible within the current conversation turn. "
+        "Images can be sent via HTTPS URL (send_image); local file upload is not supported. "
+        "Voice and document delivery are not supported."
+    ),
     "slack": (
         "You are in a Slack workspace communicating with your user. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -75,7 +75,7 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
-    "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
+    "line", "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
     "qqbot", "yuanbao",
 })
@@ -88,6 +88,7 @@ _HOME_TARGET_ENV_VARS = {
     "discord": "DISCORD_HOME_CHANNEL",
     "slack": "SLACK_HOME_CHANNEL",
     "signal": "SIGNAL_HOME_CHANNEL",
+    "line": "LINE_HOME_CHANNEL",
     "mattermost": "MATTERMOST_HOME_CHANNEL",
     "sms": "SMS_HOME_CHANNEL",
     "email": "EMAIL_HOME_ADDRESS",

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -78,6 +78,7 @@ class Platform(Enum):
     WEIXIN = "weixin"
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
+    LINE = "line"
     YUANBAO = "yuanbao"
     @classmethod
     def _missing_(cls, value):
@@ -347,6 +348,10 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
         (cfg.extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID"))
         and (cfg.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
     ),
+    # LINE uses a single channel access token — generic config.token check
+    # at line 422 already accepts this, but a bespoke entry documents the
+    # auth model explicitly and keeps the builtin-coverage guard happy.
+    Platform.LINE: lambda cfg: bool(cfg.token),
 }
 
 
@@ -990,7 +995,29 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
-    
+
+    # LINE (auto-enable on access token alone — channel secret is only
+    # required for the inbound webhook receiver path. Outbound-only
+    # setups (send_message(target="line:U…") and cron home-channel
+    # Push deliveries) work on token + home channel without a secret.
+    # The receiver path refuses inbound webhooks when secret is missing
+    # — signature verification fails — so an unset secret cleanly
+    # disables incoming traffic without disabling outbound.
+    line_token = os.getenv("LINE_CHANNEL_ACCESS_TOKEN")
+    if line_token:
+        if Platform.LINE not in config.platforms:
+            config.platforms[Platform.LINE] = PlatformConfig()
+        config.platforms[Platform.LINE].enabled = True
+        config.platforms[Platform.LINE].token = line_token
+
+    line_home = os.getenv("LINE_HOME_CHANNEL")
+    if line_home and Platform.LINE in config.platforms:
+        config.platforms[Platform.LINE].home_channel = HomeChannel(
+            platform=Platform.LINE,
+            chat_id=line_home,
+            name=os.getenv("LINE_HOME_CHANNEL_NAME", "Home"),
+        )
+
     # Telegram
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:

--- a/gateway/platforms/__init__.py
+++ b/gateway/platforms/__init__.py
@@ -9,6 +9,7 @@ Each adapter handles:
 """
 
 from .base import BasePlatformAdapter, MessageEvent, SendResult
+from .line import LineAdapter
 from .qqbot import QQAdapter
 from .yuanbao import YuanbaoAdapter
 
@@ -16,6 +17,7 @@ __all__ = [
     "BasePlatformAdapter",
     "MessageEvent",
     "SendResult",
+    "LineAdapter",
     "QQAdapter",
     "YuanbaoAdapter",
 ]

--- a/gateway/platforms/line.py
+++ b/gateway/platforms/line.py
@@ -1,0 +1,1214 @@
+"""LineAdapter — Hermes platform adapter for LINE Messaging API.
+
+This adapter delegates control flow to BasePlatformAdapter.handle_message()
+so LINE traffic gets the same queue/interrupt/bypass/photo-burst behavior
+as Telegram/Discord/Signal/Matrix.
+
+Three hooks are overridden for LINE-specific behavior:
+
+  * ``send()`` — smart routing: cached reply_token (free Reply API) when
+    valid; Push API fallback (metered) when expired or a Quick Reply
+    postback button is pending delivery.
+  * ``_keep_typing()`` — shows LINE's loading indicator (DM only) and at
+    the ``slow_response_threshold`` mark (default 45s) sends a Quick Reply
+    postback button so the user can fetch the response later via a fresh
+    reply_token instead of paying for a Push API delivery.
+  * ``_handle_postback`` (LINE-specific) — when the user taps the button,
+    retrieves the cached response (PENDING/READY/DELIVERED/ERROR) and
+    delivers via the postback's fresh reply_token.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import enum
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+# aiohttp lives in the [messaging] optional extra; guard the top-level import
+# so the module is importable when only core deps are installed. The factory
+# in gateway/run.py uses check_line_requirements() to gate adapter creation.
+try:
+    import aiohttp  # noqa: F401
+    from aiohttp import web
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    aiohttp = None  # type: ignore[assignment]
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.helpers import MessageDeduplicator, strip_markdown
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    coerce_plaintext_gateway_command,
+)
+from gateway.session import SessionSource
+
+logger = logging.getLogger(__name__)
+
+
+def check_line_requirements() -> bool:
+    """Check if LINE adapter dependencies (httpx, aiohttp) are available."""
+    return AIOHTTP_AVAILABLE  # httpx is a core dep — only aiohttp can be missing
+
+
+LINE_REPLY_URL = "https://api.line.me/v2/bot/message/reply"
+LINE_LOADING_URL = "https://api.line.me/v2/bot/chat/loading/start"
+LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push"
+
+# Defaults for the slow-LLM Quick Reply notice strings. Per-instance overrides
+# come from env vars at __init__ time so tests can monkeypatch and operators
+# can customize without restarting the module.
+DEFAULT_PENDING_REPLY_TEXT = "🤔 Still thinking, please wait. Tap below to fetch the answer when ready."
+DEFAULT_EXPIRED_REPLY_TEXT = "Response expired — please ask again."
+DEFAULT_ALREADY_DELIVERED_TEXT = "Already replied ✅"
+DEFAULT_SHOW_RESPONSE_BUTTON_LABEL = "📋 Show response"
+DEFAULT_INTERRUPTED_TEXT = "⚡ This run was interrupted by a newer message — see the latest reply above."
+
+# Known prefixes for system messages that base/run.py emit during an active
+# session (interrupt-ack, queue-ack, steer-ack). When `_pending_buttons[chat]`
+# is armed waiting for the agent's final response, these system messages must
+# bypass the cache — otherwise the orphan button would resolve to the wrong
+# content and the user would never see the system message as a bubble.
+_SYSTEM_MESSAGE_PREFIXES = ("⚡ Interrupting", "⏳ Queued", "⏩ Steered")
+
+# Match Markdown links — same shape as helpers._RE_LINK but we rewrite
+# (preserving the URL) rather than discard.
+_RE_MARKDOWN_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _strip_markdown_for_line(text: str) -> str:
+    """Strip Markdown for LINE plain-text bubbles, preserving link URLs.
+
+    The shared ``strip_markdown`` discards URLs entirely (``[label](url)``
+    → ``label``) — fine for SMS-style platforms with no link auto-detection,
+    useless for LINE which auto-linkifies bare URLs in text. We rewrite
+    ``[label](url)`` to ``label (url)`` first so the URL survives as
+    tappable plain text, then delegate to the shared helper for the rest
+    (bold, italic, code, headings).
+    """
+    text = _RE_MARKDOWN_LINK.sub(r"\1 (\2)", text)
+    return strip_markdown(text)
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature + payload parsing
+# ---------------------------------------------------------------------------
+# Spec: https://developers.line.biz/en/reference/messaging-api/#signature-validation
+
+
+def _scrub_token(text: str) -> str:
+    """Best-effort scrubbing of Bearer tokens before they hit logs / SendResult."""
+    return re.sub(r"Bearer\s+\S+", "Bearer <redacted>", text)
+
+
+def verify_signature(body: bytes, signature: str, channel_secret: str) -> bool:
+    """Constant-time compare LINE's X-Line-Signature header against an HMAC-SHA256
+    of the raw body using the channel secret.
+
+    Returns False (rejecting the webhook) when ``channel_secret`` is empty —
+    operators running in outbound-only mode get 401 on every inbound webhook,
+    cleanly disabling incoming traffic without breaking sends.
+    """
+    if not signature or not channel_secret:
+        return False
+    expected = base64.b64encode(
+        hmac.new(channel_secret.encode("utf-8"), body, hashlib.sha256).digest()
+    ).decode()
+    return hmac.compare_digest(expected, signature)
+
+
+def parse_events(body: bytes) -> List[Dict[str, Any]]:
+    """Parse a LINE webhook body into the raw events list. Returns [] on no events."""
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    return payload.get("events", []) or []
+
+
+# ---------------------------------------------------------------------------
+# Source allowlist (three-allowlist model: users, groups, rooms)
+# ---------------------------------------------------------------------------
+
+
+def is_allowed(event: Dict[str, Any], cfg: Dict[str, List[str]]) -> bool:
+    """Return True if the event's source is in the appropriate allowlist.
+
+    cfg expected shape:
+        {"users": ["U..."], "groups": ["C..."], "rooms": ["R..."]}
+
+    The debug-only ``allow_all_users`` escape hatch is resolved by the
+    adapter (``self._allow_all_sources``) and short-circuited at the
+    call site — kept out of this helper so it stays pure.
+    """
+    source = event.get("source") or {}
+    if not isinstance(source, dict):
+        return False
+    src_type = source.get("type")
+    if src_type == "user":
+        return source.get("userId") in cfg.get("users", [])
+    if src_type == "group":
+        return source.get("groupId") in cfg.get("groups", [])
+    if src_type == "room":
+        return source.get("roomId") in cfg.get("rooms", [])
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Cache state machine — used for slow-LLM Quick Reply postback retrieval
+# ---------------------------------------------------------------------------
+# When the LLM is slow (> slow_response_threshold), the adapter sends a
+# Quick Reply postback button using the original reply_token (free), then
+# stashes the response here for the user to fetch by tapping the button.
+# The postback callback gets a fresh reply_token and uses it to deliver
+# the cached payload.
+#
+# State machine:
+#     PENDING   → button sent, LLM still running
+#     READY     → LLM done, response cached, waiting for postback tap
+#     DELIVERED → response sent via postback's fresh reply_token
+#     ERROR     → LLM raised; cached error text waiting to be shown
+#
+# Two TTLs:
+#     - ttl_seconds (default 1h) for READY/DELIVERED/ERROR (by updated_at)
+#     - pending_ttl_seconds (default 24h) for PENDING (ceiling, by created_at)
+
+
+class State(enum.Enum):
+    PENDING = "pending"
+    READY = "ready"
+    DELIVERED = "delivered"
+    ERROR = "error"
+
+
+@dataclass
+class CacheEntry:
+    state: State
+    payload: Any = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+
+class RequestCache:
+    """In-memory ``Dict[request_id, CacheEntry]`` with TTL pruning.
+
+    Not thread-safe — relies on cooperative single-event-loop scheduling.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: int = 3600,
+        pending_ttl_seconds: int = 86400,
+    ) -> None:
+        self._entries: Dict[str, CacheEntry] = {}
+        self._ttl = ttl_seconds
+        self._pending_ttl = pending_ttl_seconds
+
+    def register_pending(self) -> str:
+        rid = str(uuid.uuid4())
+        self._entries[rid] = CacheEntry(state=State.PENDING)
+        return rid
+
+    def get(self, request_id: str) -> Optional[CacheEntry]:
+        return self._entries.get(request_id)
+
+    def set_ready(self, request_id: str, payload: Any) -> None:
+        entry = self._entries.get(request_id)
+        if entry is None or entry.state is not State.PENDING:
+            return
+        entry.state = State.READY
+        entry.payload = payload
+        entry.updated_at = time.time()
+
+    def set_error(self, request_id: str, message: str) -> None:
+        entry = self._entries.get(request_id)
+        if entry is None or entry.state is not State.PENDING:
+            return
+        entry.state = State.ERROR
+        entry.payload = message
+        entry.updated_at = time.time()
+
+    def mark_delivered(self, request_id: str) -> None:
+        entry = self._entries.get(request_id)
+        if entry is None or entry.state not in (State.READY, State.ERROR):
+            return
+        entry.state = State.DELIVERED
+        entry.updated_at = time.time()
+
+    def prune(self) -> int:
+        now = time.time()
+        removed = 0
+        for rid in list(self._entries.keys()):
+            entry = self._entries[rid]
+            if entry.state is State.PENDING:
+                if now - entry.created_at > self._pending_ttl:
+                    del self._entries[rid]
+                    removed += 1
+            else:
+                if now - entry.updated_at > self._ttl:
+                    del self._entries[rid]
+                    removed += 1
+        return removed
+
+
+# ---------------------------------------------------------------------------
+# LINE Reply / Push API client
+# ---------------------------------------------------------------------------
+
+
+class LineReplyClient:
+    """Thin wrapper around LINE Messaging API HTTP endpoints."""
+
+    def __init__(self, channel_access_token: str, timeout: float = 10.0) -> None:
+        self._token = channel_access_token
+        self._headers = {
+            "Authorization": f"Bearer {channel_access_token}",
+            "Content-Type": "application/json",
+        }
+        self._timeout = timeout
+
+    async def reply(self, reply_token: str, messages: List[Dict[str, Any]]) -> None:
+        """Reply API — single-use, ~60s window. Raises on non-2xx."""
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            r = await client.post(
+                LINE_REPLY_URL,
+                headers=self._headers,
+                json={"replyToken": reply_token, "messages": messages},
+            )
+            r.raise_for_status()
+
+    async def push(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Push API — metered, no token. Raises on non-2xx."""
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            r = await client.post(
+                LINE_PUSH_URL,
+                headers=self._headers,
+                json={"to": chat_id, "messages": messages},
+            )
+            r.raise_for_status()
+
+    async def show_loading(self, chat_id: str, seconds: int = 60) -> None:
+        """Loading indicator — DM only. Auto-stops when the bot replies.
+        seconds is the fallback fade timer (LINE max 60). Best-effort: errors
+        are swallowed since the indicator is purely visual feedback."""
+        if not chat_id or not chat_id.startswith("U"):
+            return  # LINE only supports loading indicator for 1-on-1 user chats
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                await client.post(
+                    LINE_LOADING_URL,
+                    headers=self._headers,
+                    json={"chatId": chat_id, "loadingSeconds": seconds},
+                )
+        except Exception as exc:
+            logger.debug("LINE loading indicator failed (chat=%s): %s", chat_id, exc)
+
+
+def build_postback_button_message(
+    text: str, button_label: str, request_id: str
+) -> Dict[str, Any]:
+    """Build a LINE Template Buttons message with a single postback action.
+
+    Uses Template Buttons rather than Quick Reply because Quick Reply chips
+    are TRANSIENT — LINE clients dismiss them when the user sends another
+    message or when any subsequent bot message arrives. Template Button
+    bubbles are PERSISTENT and stay tappable from chat history indefinitely,
+    which is essential for the slow-LLM postback-fetch UX (the user must be
+    able to tap the button at any time before TTL expiry, even if other
+    messages have come and gone in between).
+
+    Limits: Template Buttons text capped at 160 chars (LINE constraint).
+
+    See ``tests/gateway/test_line_reply.py`` for the message-shape contract
+    and ``tests/gateway/test_line_send_routing.py`` for the system-message
+    cache-bypass contract.
+    """
+    truncated_text = text if len(text) <= 160 else text[:157] + "..."
+    # altText capped at 400 chars by LINE — exceeding rejects the whole
+    # message with a 400 from the API.
+    alt_text = text if len(text) <= 400 else text[:397] + "..."
+    return {
+        "type": "template",
+        "altText": alt_text,
+        "template": {
+            "type": "buttons",
+            "text": truncated_text,
+            "actions": [
+                {
+                    "type": "postback",
+                    "label": button_label,
+                    "data": json.dumps(
+                        {"action": "show_response", "request_id": request_id}
+                    ),
+                    "displayText": button_label,
+                }
+            ],
+        },
+    }
+
+
+
+
+# ---------------------------------------------------------------------------
+# LineAdapter
+# ---------------------------------------------------------------------------
+
+
+def _csv_env(name: str) -> List[str]:
+    """Parse a comma-separated env var into a stripped, non-empty list."""
+    raw = os.environ.get(name, "").strip()
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _csv_or_extra(extra: Dict[str, Any], extra_key: str, env_key: str) -> List[str]:
+    """Resolve a CSV-or-list setting from PlatformConfig.extra first, then
+    a comma-separated env var. Returns a stripped, non-empty list."""
+    raw = extra.get(extra_key)
+    if isinstance(raw, list):
+        return [str(x).strip() for x in raw if str(x).strip()]
+    if isinstance(raw, str) and raw.strip():
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    return _csv_env(env_key)
+
+
+def _bool_env(name: str) -> bool:
+    return os.environ.get(name, "").lower() in ("true", "1", "yes")
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce a YAML/extra value to bool with truthy-string semantics.
+    Avoids ``bool("false") == True`` which is the naive trap."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes")
+    return bool(value)
+
+
+class LineAdapter(BasePlatformAdapter):
+    """LINE Messaging API adapter, fully integrated with BasePlatformAdapter.
+
+    Inherits queue/interrupt/bypass/photo-burst behavior from base via
+    ``handle_message()``. Overrides ``send()``, ``_keep_typing()``, and
+    adds ``_handle_postback`` to handle LINE's reply-token semantics and
+    the slow-LLM Quick Reply fallback.
+    """
+
+    MAX_MESSAGE_LENGTH = 5000  # LINE per-message hard limit
+    # LINE Messaging API has no edit/update endpoint — every send is final.
+    # Setting False disables token streaming (run.py:10495) so the user
+    # doesn't receive a partial-then-final duplicate. Matches the
+    # bluebubbles / weixin / qqbot convention for non-editable platforms.
+    SUPPORTS_MESSAGE_EDITING = False
+    # LINE's documented webhook body cap is ~1 MB; reject larger payloads
+    # before reading them into memory (defends against hostile traffic
+    # to the public webhook URL).
+    _MAX_WEBHOOK_BYTES = 1 * 1024 * 1024
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.LINE)
+        # Settings honor PlatformConfig.extra (YAML) first, then LINE_* env
+        # var, then default — matches bluebubbles/signal/mattermost peer
+        # convention. Channel secret is optional: outbound-only mode rejects
+        # every inbound webhook (401) when empty, cleanly disabling incoming
+        # traffic without breaking sends.
+        extra = config.extra or {}
+        self._channel_access_token: str = config.token or ""
+        self._channel_secret: str = (
+            extra.get("channel_secret") or os.getenv("LINE_CHANNEL_SECRET", "")
+        )
+        self._allowed_users: List[str] = _csv_or_extra(extra, "allowed_users", "LINE_ALLOWED_USERS")
+        self._allowed_groups: List[str] = _csv_or_extra(extra, "allowed_groups", "LINE_ALLOWED_GROUPS")
+        self._allowed_rooms: List[str] = _csv_or_extra(extra, "allowed_rooms", "LINE_ALLOWED_ROOMS")
+        self._free_response_groups: List[str] = _csv_or_extra(
+            extra, "free_response_groups", "LINE_FREE_RESPONSE_GROUPS"
+        )
+        self._free_response_rooms: List[str] = _csv_or_extra(
+            extra, "free_response_rooms", "LINE_FREE_RESPONSE_ROOMS"
+        )
+        # LINE's reply token is documented as valid for ~60 seconds. 45s
+        # default leaves a 15s safety margin for the Quick Reply button
+        # to land before the token expires.
+        self._slow_response_threshold: float = float(
+            extra.get("slow_response_threshold")
+            or os.getenv("LINE_SLOW_RESPONSE_THRESHOLD", "45")
+        )
+        self._cache_ttl: int = int(
+            extra.get("cache_ttl") or os.getenv("LINE_CACHE_TTL", "3600")
+        )
+        self._require_mention: bool = _coerce_bool(
+            extra.get("require_mention"), _bool_env("LINE_REQUIRE_MENTION")
+        )
+        # Resolved at connect() time via GET /v2/bot/info; extra/env override
+        # for tests/offline use.
+        self._bot_display_name: str = str(
+            extra.get("bot_display_name") or os.getenv("LINE_BOT_DISPLAY_NAME", "") or ""
+        ).strip()
+        self._pending_reply_text: str = (
+            extra.get("pending_text")
+            or os.getenv("LINE_PENDING_TEXT")
+            or DEFAULT_PENDING_REPLY_TEXT
+        )
+        self._expired_reply_text: str = (
+            extra.get("expired_text")
+            or os.getenv("LINE_EXPIRED_TEXT")
+            or DEFAULT_EXPIRED_REPLY_TEXT
+        )
+        self._already_delivered_text: str = (
+            extra.get("delivered_text")
+            or os.getenv("LINE_DELIVERED_TEXT")
+            or DEFAULT_ALREADY_DELIVERED_TEXT
+        )
+        self._show_response_button_label: str = (
+            extra.get("button_label")
+            or os.getenv("LINE_BUTTON_LABEL")
+            or DEFAULT_SHOW_RESPONSE_BUTTON_LABEL
+        )
+        self._interrupted_text: str = (
+            extra.get("interrupted_text")
+            or os.getenv("LINE_INTERRUPTED_TEXT")
+            or DEFAULT_INTERRUPTED_TEXT
+        )
+        # Debug-only escape hatch — bypass all three allowlists.
+        # Mirrors DISCORD_ALLOW_ALL_USERS; honors extra-then-env-then-default.
+        self._allow_all_sources: bool = _coerce_bool(
+            extra.get("allow_all_users"),
+            os.environ.get("LINE_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes"),
+        )
+
+        self._reply = LineReplyClient(channel_access_token=self._channel_access_token)
+        self._cache = RequestCache(ttl_seconds=self._cache_ttl)
+        self._dedup = MessageDeduplicator()
+        # chat_id → (reply_token, expires_at). Reply tokens are single-use
+        # and ~60s lived. We cache the most recent one per chat so send()
+        # can use it for free Reply API delivery; expired/consumed tokens
+        # fall back to Push API. Pruned opportunistically in _handle_http.
+        self._reply_tokens: Dict[str, Tuple[str, float]] = {}
+        # chat_id → request_id. Set by _keep_typing when it sends a slow-LLM
+        # Quick Reply postback button. send() consults this to avoid Push API:
+        # if a button is pending, the response is cached for postback retrieval
+        # instead of pushed.
+        self._pending_buttons: Dict[str, str] = {}
+        # Annotated as Any because aiohttp is an optional [messaging] extra —
+        # the module imports cleanly when it's absent (web=None, AIOHTTP_AVAILABLE=False)
+        # and the factory in gateway/run.py guards instantiation. Matches the
+        # peer pattern for adapters with conditional aiohttp imports.
+        self._runner: Optional[Any] = None
+
+    # -----------------------------------------------------------------------
+    # connect / disconnect — webhook server lifecycle + platform lock
+    # -----------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Acquire platform lock, fetch bot info, start webhook listener."""
+        if not self._acquire_platform_lock(
+            "line-channel-token",
+            self._channel_access_token,
+            "LINE channel access token",
+        ):
+            return False
+        # Lock acquired — release on any failure between here and end of connect.
+        try:
+            # Resolve bot info BEFORE accepting webhooks so the mention gate
+            # never has a cold-start window with bot_display_name unresolved.
+            await self._fetch_bot_info()
+            # Operator footgun: free_response_* IDs not in the allowlist are
+            # silently dropped before the free-response check fires.
+            unreachable_groups = set(self._free_response_groups) - set(self._allowed_groups)
+            unreachable_rooms = set(self._free_response_rooms) - set(self._allowed_rooms)
+            if unreachable_groups:
+                logger.warning(
+                    "[%s] free_response_groups contains IDs not in LINE_ALLOWED_GROUPS — "
+                    "messages will be silently dropped at the allowlist: %s",
+                    self.name, sorted(unreachable_groups),
+                )
+            if unreachable_rooms:
+                logger.warning(
+                    "[%s] free_response_rooms contains IDs not in LINE_ALLOWED_ROOMS — "
+                    "messages will be silently dropped at the allowlist: %s",
+                    self.name, sorted(unreachable_rooms),
+                )
+            app = web.Application()
+            self.register_routes(app)
+            extra = self.config.extra or {}
+            port = int(
+                extra.get("webhook_port")
+                or os.getenv("LINE_WEBHOOK_PORT", "8646")
+            )
+            runner = web.AppRunner(app)
+            await runner.setup()
+            try:
+                site = web.TCPSite(runner, "0.0.0.0", port)
+                await site.start()
+            except Exception:
+                await runner.cleanup()
+                raise
+            self._runner = runner
+            logger.info("[%s] webhook listening on :%d/line/webhook", self.name, port)
+        except Exception:
+            self._release_platform_lock()
+            raise
+        self._mark_connected()
+        return True
+
+    async def disconnect(self) -> None:
+        await self.cancel_background_tasks()
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            finally:
+                self._runner = None
+        self._release_platform_lock()
+        self._mark_disconnected()
+
+    def register_routes(self, app: web.Application) -> None:
+        """Register webhook routes on the provided aiohttp.web.Application."""
+        app.router.add_post("/line/webhook", self._handle_http)
+        app.router.add_get("/line/webhook/health", self._handle_health)
+
+    async def _fetch_bot_info(self) -> None:
+        """Resolve bot display name from /v2/bot/info. Best-effort — failure
+        leaves bot_display_name empty and the mention gate falls back to
+        fail-closed behavior (drops all group/room messages with a warning).
+        Skipped when require_mention=False or operator already set the name."""
+        if not self._require_mention or self._bot_display_name:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                r = await client.get(
+                    "https://api.line.me/v2/bot/info",
+                    headers={"Authorization": f"Bearer {self._channel_access_token}"},
+                )
+                r.raise_for_status()
+                name = (r.json() or {}).get("displayName", "").strip()
+                if not name:
+                    logger.warning(
+                        "[%s] /v2/bot/info returned empty displayName — set "
+                        "LINE_BOT_DISPLAY_NAME manually for group mention gating to work.",
+                        self.name,
+                    )
+                    return
+                self._bot_display_name = name
+                logger.info("[%s] bot display name resolved: %r", self.name, name)
+        except Exception:
+            logger.warning(
+                "[%s] Failed to fetch LINE bot info — set LINE_BOT_DISPLAY_NAME manually "
+                "if you want group mention gating to work.",
+                self.name,
+                exc_info=True,
+            )
+
+    # -----------------------------------------------------------------------
+    # HTTP handlers
+    # -----------------------------------------------------------------------
+
+    async def _handle_http(self, request: web.Request) -> web.Response:
+        """LINE webhook entry. Verifies signature, deduplicates, dispatches
+        each event to the right handler. Returns 200 immediately to satisfy
+        LINE's retry semantics."""
+        if request.content_length and request.content_length > self._MAX_WEBHOOK_BYTES:
+            return web.json_response({"error": "payload too large"}, status=413)
+        body = await request.read()
+        signature = request.headers.get("X-Line-Signature", "")
+        if not verify_signature(body, signature, self._channel_secret):
+            return web.json_response({"error": "invalid signature"}, status=401)
+
+        events = parse_events(body)
+        # Opportunistic pruning (cheap; once per webhook). Trims expired
+        # cache entries AND expired/consumed reply_tokens so neither dict
+        # grows unbounded over the lifetime of a chatty deployment.
+        self._cache.prune()
+        now = time.time()
+        self._reply_tokens = {
+            k: v for k, v in self._reply_tokens.items() if v[1] > now
+        }
+
+        for event in events:
+            event_id = event.get("webhookEventId")
+            if event_id and self._dedup.is_duplicate(event_id):
+                continue
+            try:
+                await self._dispatch_event(event)
+            except Exception:
+                logger.exception("[%s] dispatch failure for event=%r", self.name, event_id)
+
+        return web.Response(status=200)
+
+    async def _handle_health(self, _request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok", "platform": "line"})
+
+    # -----------------------------------------------------------------------
+    # Event dispatch — message vs postback
+    # -----------------------------------------------------------------------
+
+    async def _dispatch_event(self, event: Dict[str, Any]) -> None:
+        evt_type = event.get("type")
+        if evt_type == "postback":
+            await self._handle_postback(event)
+            return
+        if evt_type != "message":
+            logger.debug("[%s] ignoring non-message non-postback event type=%r", self.name, evt_type)
+            return
+
+        msg = event.get("message", {})
+        if msg.get("type") != "text":
+            logger.debug("[%s] ignoring non-text message type=%s", self.name, msg.get("type"))
+            return
+
+        cfg = {
+            "users": self._allowed_users,
+            "groups": self._allowed_groups,
+            "rooms": self._allowed_rooms,
+        }
+        if not self._allow_all_sources and not is_allowed(event, cfg):
+            src = event.get("source", {}) or {}
+            logger.info(
+                "[%s] drop unauthorised src_type=%s user=%s group=%s room=%s",
+                self.name,
+                src.get("type"),
+                src.get("userId"),
+                src.get("groupId"),
+                src.get("roomId"),
+            )
+            return
+
+        # Mention gate (group/room only).
+        text = msg.get("text", "")
+        source = event.get("source", {}) or {}
+        src_type = source.get("type")
+        free_response = (
+            (src_type == "group"
+             and source.get("groupId") in self._free_response_groups)
+            or (src_type == "room"
+                and source.get("roomId") in self._free_response_rooms)
+        )
+        if src_type in ("group", "room") and self._require_mention and not free_response:
+            if not self._bot_display_name:
+                # Fail-closed: gate is configured but bot name unresolved.
+                logger.warning(
+                    "[%s] require_mention=True but bot_display_name is empty — "
+                    "dropping group/room message",
+                    self.name,
+                )
+                return
+            trigger = f"@{self._bot_display_name}"
+            if trigger not in text:
+                logger.info(
+                    "[%s] group message not addressed to bot — silent drop (trigger=%r)",
+                    self.name,
+                    trigger,
+                )
+                return
+            # Strip the mention prefix and surrounding whitespace before dispatch.
+            text = re.sub(re.escape(trigger), "", text, count=1).strip()
+            if not text:
+                logger.info("[%s] mention-only message — silent drop", self.name)
+                return
+
+        # Register the reply_token for this chat. send() will consume it for
+        # free Reply API delivery if still valid; expired tokens fall back to
+        # Push API. ~55s expiry leaves a safety margin under LINE's 60s window.
+        chat_id = (
+            source.get("groupId")
+            or source.get("roomId")
+            or source.get("userId")
+            or ""
+        )
+        reply_token = event.get("replyToken")
+        if chat_id and reply_token:
+            self._reply_tokens[chat_id] = (reply_token, time.time() + 55)
+
+        # Build MessageEvent and hand off to base.handle_message — this is
+        # where queue / interrupt / bypass / photo-burst behavior lives.
+        msg_event = self._build_message_event(event, text)
+        coerce_plaintext_gateway_command(msg_event)
+        # Base spawns a task; we don't await full agent completion here so
+        # the webhook response goes back to LINE within the retry budget.
+        await self.handle_message(msg_event)
+
+    def _build_message_event(self, event: Dict[str, Any], text: str) -> MessageEvent:
+        source = event.get("source", {}) or {}
+        src_type = source.get("type")
+        chat_type = {"user": "dm", "group": "group", "room": "room"}.get(src_type, "unknown")
+        chat_id = (
+            source.get("groupId")
+            or source.get("roomId")
+            or source.get("userId")
+            or "unknown"
+        )
+        user_id = source.get("userId")
+        session_source = SessionSource(
+            platform=Platform.LINE,
+            chat_id=str(chat_id),
+            chat_type=chat_type,
+            user_id=str(user_id) if user_id else None,
+        )
+        return MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=session_source,
+            message_id=(event.get("message") or {}).get("id"),
+            raw_message={"line_event": event},
+        )
+
+    # -----------------------------------------------------------------------
+    # Postback handler
+    # -----------------------------------------------------------------------
+
+    async def _handle_postback(self, event: Dict[str, Any]) -> None:
+        """User tapped the slow-LLM Quick Reply button. Look up the cached
+        response and deliver via the postback's fresh reply_token."""
+        reply_token = event.get("replyToken")
+        if not reply_token:
+            logger.info("[%s] postback without replyToken: source=%s", self.name, event.get("source"))
+            return
+        try:
+            payload = json.loads((event.get("postback") or {}).get("data", "{}"))
+            if not isinstance(payload, dict):
+                payload = {}
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.get("action") != "show_response":
+            # Not the slow-LLM Quick Reply button — could be a future
+            # postback feature (different action). Log so operators can
+            # observe orphan postbacks without surfacing as errors.
+            logger.debug(
+                "[%s] postback with unrecognised action=%r — ignoring",
+                self.name,
+                payload.get("action"),
+            )
+            return
+
+        request_id = payload.get("request_id")
+        # Defensive: postback ``data`` is opaque attacker-controlled JSON
+        # (signature-verified, but operators-of-the-channel could craft
+        # nonsense). Accept only string request_ids — RequestCache.get()
+        # expects str.
+        entry = self._cache.get(request_id) if isinstance(request_id, str) else None
+
+        if entry is None:
+            logger.info(
+                "[%s] postback request_id=%s not found (expired or never cached)",
+                self.name, request_id,
+            )
+            await self._reply.reply(
+                reply_token, [{"type": "text", "text": self._expired_reply_text}]
+            )
+            return
+
+        if entry.state is State.PENDING:
+            # LLM still running — re-arm the same button on the new reply_token.
+            logger.debug(
+                "[%s] postback re-arm: request_id=%s still PENDING",
+                self.name, request_id,
+            )
+            msg = build_postback_button_message(
+                text=self._pending_reply_text,
+                button_label=self._show_response_button_label,
+                request_id=request_id,
+            )
+            await self._reply.reply(reply_token, [msg])
+            return
+
+        if entry.state is State.READY:
+            await self._reply.reply(
+                reply_token, self._build_reply_messages(entry.payload)
+            )
+            self._cache.mark_delivered(request_id)
+            logger.info(
+                "[%s] postback delivered cached response: request_id=%s payload=%d chars",
+                self.name, request_id, len(entry.payload or ""),
+            )
+            return
+
+        if entry.state is State.DELIVERED:
+            logger.info(
+                "[%s] postback duplicate tap: request_id=%s already DELIVERED",
+                self.name, request_id,
+            )
+            await self._reply.reply(
+                reply_token, [{"type": "text", "text": self._already_delivered_text}]
+            )
+            return
+
+        if entry.state is State.ERROR:
+            logger.info(
+                "[%s] postback delivered cached ERROR: request_id=%s",
+                self.name, request_id,
+            )
+            await self._reply.reply(reply_token, self._build_reply_messages(entry.payload))
+            self._cache.mark_delivered(request_id)
+            return
+
+        # Defensive: state added in the future but not handled here. Log
+        # rather than silently fall through.
+        logger.warning(
+            "[%s] postback hit unknown cache state=%r request_id=%s",
+            self.name, entry.state, request_id,
+        )
+
+    # -----------------------------------------------------------------------
+    # Override: send() — smart Reply API vs Push API routing
+    # -----------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Deliver a response to LINE.
+
+        Routing:
+          1. If a slow-LLM Quick Reply button is pending for this chat, cache
+             the response under the button's request_id and skip Push (the
+             user will tap the button to fetch via fresh reply_token).
+          2. Else if a fresh reply_token is cached, use Reply API (free).
+          3. Else fall back to Push API (metered).
+
+        Multi-send within a single turn (rare — base usually calls send()
+        once per agent response): the first call consumes the
+        ``_pending_buttons`` slot and caches the payload; subsequent calls
+        for the same chat fall through to step 2/3 and deliver immediately.
+        Operators see this in the log via the "second send for chat" line."""
+        # 1. Pending Quick Reply button — cache for postback retrieval.
+        # If multiple send() calls land for the same chat within one turn
+        # (rare; base.handle_message normally calls send() once), only the
+        # FIRST one populates the cache slot — subsequent sends fall
+        # through to Reply/Push routing below and deliver immediately.
+        # That's the intended ordering: streaming intermediate messages go
+        # via the still-valid token (or Push) while the final answer waits
+        # for the user's postback tap.
+        # Skip cache for known system messages (interrupt-ack, queue-ack, etc.)
+        # so they reach the user as visible bubbles instead of being swallowed
+        # into the orphan postback slot. Brittle but tolerable: the prefixes
+        # are centrally defined in run.py and rarely changed; a regression
+        # test pins the contract.
+        is_system_message = isinstance(content, str) and content.startswith(
+            _SYSTEM_MESSAGE_PREFIXES
+        )
+        if not is_system_message:
+            request_id = self._pending_buttons.pop(chat_id, None)
+            if request_id is not None:
+                self._cache.set_ready(request_id, content)
+                logger.info(
+                    "[%s] cached response for pending postback (chat=%s request_id=%s)",
+                    self.name, chat_id, request_id,
+                )
+                return SendResult(success=True, message_id=request_id)
+
+        # 2. Reply API if we still have a valid reply_token.
+        token_entry = self._reply_tokens.get(chat_id)
+        if token_entry is not None:
+            token, expires_at = token_entry
+            if time.time() < expires_at:
+                try:
+                    messages = self._build_reply_messages(content)
+                    await self._reply.reply(token, messages)
+                    # Single-use — drop after success.
+                    self._reply_tokens.pop(chat_id, None)
+                    return SendResult(success=True)
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] Reply API failed (chat=%s) — falling back to Push: %s",
+                        self.name, chat_id, _scrub_token(str(exc)),
+                    )
+                    self._reply_tokens.pop(chat_id, None)
+
+        # 3. Push API fallback (cron deliveries, expired tokens, etc.)
+        return await self._push(chat_id, content)
+
+    async def _push(self, chat_id: str, content: str) -> SendResult:
+        """Push API delivery — metered. Always extracts media URLs to native
+        image bubbles via _build_reply_messages."""
+        if not self._channel_access_token:
+            return SendResult(success=False, error="LINE: channel access token not set")
+        try:
+            messages = self._build_reply_messages(content)
+            await self._reply.push(chat_id, messages)
+            return SendResult(success=True)
+        except Exception as exc:
+            scrubbed = _scrub_token(str(exc))
+            logger.warning("[%s] push failed chat_id=%s: %s", self.name, chat_id, scrubbed)
+            return SendResult(success=False, error=scrubbed)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an image. LINE requires HTTPS image URLs and rejects local
+        file paths — non-HTTPS URLs degrade to text-with-link delivery.
+
+        Same routing as ``send()``: prefer free Reply API when a fresh
+        reply_token is cached, fall back to Push API otherwise."""
+        if not image_url.startswith("https://"):
+            text = f"{caption}\n{image_url}" if caption else image_url
+            return await self.send(chat_id, text)
+        if not self._channel_access_token:
+            return SendResult(success=False, error="LINE: channel access token not set")
+        messages: List[Dict[str, Any]] = [
+            {
+                "type": "image",
+                "originalContentUrl": image_url,
+                "previewImageUrl": image_url,
+            }
+        ]
+        if caption:
+            messages.extend(self._chunk_text(caption)[:4])  # 1 image + max 4 text = 5
+
+        # Route through reply_token first (free) when available, else Push.
+        token_entry = self._reply_tokens.get(chat_id)
+        if token_entry is not None:
+            token, expires_at = token_entry
+            if time.time() < expires_at:
+                try:
+                    await self._reply.reply(token, messages)
+                    self._reply_tokens.pop(chat_id, None)
+                    return SendResult(success=True)
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] image Reply API failed (chat=%s) — falling back to Push: %s",
+                        self.name, chat_id, _scrub_token(str(exc)),
+                    )
+                    self._reply_tokens.pop(chat_id, None)
+        try:
+            await self._reply.push(chat_id, messages)
+            return SendResult(success=True)
+        except Exception as exc:
+            scrubbed = _scrub_token(str(exc))
+            return SendResult(success=False, error=scrubbed)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """LINE has no native local file upload — fall back to a clear text
+        notice so the operator knows to host the file at an HTTPS URL."""
+        logger.warning(
+            "[%s] send_image_file unsupported (LINE requires HTTPS URL): chat=%s path=%s",
+            self.name, chat_id, image_path,
+        )
+        return SendResult(
+            success=False,
+            error=(
+                "LINE Messaging API does not accept local file uploads — "
+                "host the image at an HTTPS URL and use send_image() instead. "
+                f"Skipped: {image_path}"
+            ),
+        )
+
+    # -----------------------------------------------------------------------
+    # Override: _keep_typing — show loading indicator + slow-LLM Quick Reply
+    # -----------------------------------------------------------------------
+
+    async def _keep_typing(
+        self,
+        chat_id: str,
+        interval: float = 2.0,
+        metadata: Optional[Dict[str, Any]] = None,
+        stop_event: Optional[asyncio.Event] = None,
+    ) -> None:
+        """LINE-specific typing indicator + slow-LLM Quick Reply orchestration.
+
+        Behavior:
+          1. Show LINE loading indicator (DM only — LINE limit). LINE
+             auto-stops the indicator when the bot replies, so we max it
+             out at 60s (LINE's documented cap).
+          2. Wait up to ``slow_response_threshold_seconds`` for the agent
+             to finish (signaled by ``stop_event``).
+          3. If agent finishes within threshold: return — send() will
+             deliver via the still-valid reply_token (free).
+          4. If threshold elapses with agent still running: send Quick
+             Reply postback button via the original reply_token (free) and
+             register the chat in ``_pending_buttons`` so send() caches the
+             eventual response for postback retrieval instead of Push.
+        """
+        registered_request_id: Optional[str] = None
+        try:
+            # 1. Show loading indicator (best-effort, DM only). LINE's loading
+            # indicator is one-shot by API design — it auto-stops when the bot
+            # replies, so unlike Telegram/Discord we don't need a periodic
+            # refresh loop. The 60s ceiling is LINE's documented maximum.
+            await self._reply.show_loading(chat_id, seconds=60)
+
+            if stop_event is None:
+                return  # No stop signal → no slow-LLM watcher possible.
+
+            threshold = self._slow_response_threshold
+
+            # 2. Wait for agent done OR threshold elapse.
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=threshold)
+                return  # Agent done within threshold — fast path.
+            except asyncio.TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                # Agent run was cancelled (interrupt or shutdown) — exit
+                # quietly without spamming a "button delivery failed" warning.
+                raise
+
+            # 3. Threshold elapsed — try to send postback button.
+            token_entry = self._reply_tokens.get(chat_id)
+            if token_entry is None:
+                # No reply_token cached — agent must have been triggered without
+                # an inbound webhook (e.g. cron). Nothing to do; send() will Push.
+                return
+            token, expires_at = token_entry
+            if time.time() >= expires_at:
+                return  # Already expired — send() will Push when agent finishes.
+
+            request_id = self._cache.register_pending()
+            msg = build_postback_button_message(
+                text=self._pending_reply_text,
+                button_label=self._show_response_button_label,
+                request_id=request_id,
+            )
+            try:
+                await self._reply.reply(token, [msg])
+                # Token consumed by the button — mark it gone so send() doesn't
+                # try to reuse it. Register the pending button so send() routes
+                # the eventual response into the cache instead of Push.
+                self._reply_tokens.pop(chat_id, None)
+                self._pending_buttons[chat_id] = request_id
+                registered_request_id = request_id
+                logger.info(
+                    "[%s] slow-LLM postback button sent for chat=%s after %.1fs (request_id=%s)",
+                    self.name, chat_id, threshold, request_id,
+                )
+            except asyncio.CancelledError:
+                raise
+
+            # 4. Stay alive until base cancels us (agent finished/interrupted).
+            # Without this await the task exits immediately and the finally
+            # block's orphan-cleanup would race the agent's send() — every
+            # successful turn would mis-mark the cache ERROR before the
+            # response could land. The wait_for-with-timeout pattern lets
+            # ``stop_event`` short-circuit on interrupt without busy-looping.
+            try:
+                await stop_event.wait()
+            except asyncio.CancelledError:
+                raise
+        except Exception as exc:
+            logger.warning(
+                "[%s] failed to send slow-LLM postback button for chat=%s: %s",
+                self.name, chat_id, _scrub_token(str(exc)),
+            )
+        finally:
+            # Mirror BasePlatformAdapter._keep_typing's cleanup contract.
+            # LINE has no continuous send_typing loop, but pause-state set
+            # membership must still be cleared on exit so future invocations
+            # don't see a stale pause.
+            self._typing_paused.discard(chat_id)
+            # Orphan-cleanup: if we registered a postback slot but the agent
+            # was cancelled (interrupt/shutdown) before send() consumed it,
+            # the cache entry is stuck in PENDING. Resolve to ERROR so the
+            # persistent button — when tapped — shows "interrupted" instead
+            # of looping in "still thinking → re-arm → still thinking".
+            if (
+                registered_request_id is not None
+                and self._pending_buttons.get(chat_id) == registered_request_id
+            ):
+                entry = self._cache.get(registered_request_id)
+                if entry is not None and entry.state is State.PENDING:
+                    self._cache.set_error(registered_request_id, self._interrupted_text)
+                    logger.info(
+                        "[%s] orphan postback marked ERROR (chat=%s request_id=%s) — agent run was cancelled",
+                        self.name, chat_id, registered_request_id,
+                    )
+                self._pending_buttons.pop(chat_id, None)
+
+    # -----------------------------------------------------------------------
+    # Helpers — text chunking + media extraction
+    # -----------------------------------------------------------------------
+
+    @classmethod
+    def _build_reply_messages(cls, text: str) -> List[Dict[str, Any]]:
+        """Build a LINE messages array, extracting Markdown/HTML image URLs
+        into native image bubbles before chunking the remaining text. LINE
+        accepts up to 5 message objects per Reply/Push call. Markdown syntax
+        in the remaining text is stripped (LINE renders text bubbles as
+        plain — see ``format_message``)."""
+        images, cleaned = BasePlatformAdapter.extract_images(text)
+        cleaned = _strip_markdown_for_line(cleaned) if cleaned else cleaned
+        messages: List[Dict[str, Any]] = []
+        max_image_msgs = 4 if cleaned.strip() else 5
+        for url, _alt in images[:max_image_msgs]:
+            if url.startswith("https://"):
+                messages.append({
+                    "type": "image",
+                    "originalContentUrl": url,
+                    "previewImageUrl": url,
+                })
+        text_budget = 5 - len(messages)
+        if cleaned.strip() and text_budget > 0:
+            messages.extend(cls._chunk_text(cleaned)[:text_budget])
+        if not messages:  # Defensive — never empty.
+            messages = cls._chunk_text(_strip_markdown_for_line(text))[:5]
+        return messages
+
+    @staticmethod
+    def _chunk_text(text: str) -> List[Dict[str, Any]]:
+        """Chunk by Python string length into 5000-char segments; truncate
+        beyond 5 chunks (25k chars) with a clear suffix on the final chunk."""
+        if not text:
+            return [{"type": "text", "text": ""}]
+        max_len = LineAdapter.MAX_MESSAGE_LENGTH
+        all_chunks = [text[i:i + max_len] for i in range(0, len(text), max_len)]
+        truncated = len(all_chunks) > 5
+        chunks = all_chunks[:5]
+        if truncated:
+            suffix = "\n… (truncated)"
+            last = chunks[-1]
+            if len(last) + len(suffix) > max_len:
+                last = last[: max_len - len(suffix)]
+            chunks[-1] = last + suffix
+        return [{"type": "text", "text": chunk} for chunk in chunks]
+
+    def format_message(self, content: str) -> str:
+        """LINE renders text as plain — Markdown syntax leaks into the bubble.
+        Strips Markdown but preserves link URLs via ``_strip_markdown_for_line``
+        so citations stay tappable (LINE auto-linkifies bare URLs)."""
+        return _strip_markdown_for_line(content)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Resolve chat metadata. Uses the LINE chat-id prefix to infer the
+        chat type (U → dm, C/R → group). Returns the contract-defined keys
+        ``{"name", "type", "chat_id"}`` shared across all platform adapters.
+
+        LINE's "room" source is a multi-user chat without a stable group
+        identity (typically a temporary multi-person conversation); we map
+        it to ``"group"`` so downstream introspection treats it like any
+        other multi-party chat. The original prefix is preserved in
+        ``chat_id`` for callers that need to distinguish."""
+        prefix = chat_id[:1] if chat_id else ""
+        chat_type = {"U": "dm", "C": "group", "R": "group"}.get(prefix, "unknown")
+        return {"name": chat_id, "type": chat_type, "chat_id": chat_id}
+

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -38,7 +38,6 @@ from typing import Dict, Optional, Any, List
 # gateway is a long-running daemon, so its boot cost matters less than
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
-from hermes_cli.config import cfg_get
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -292,8 +291,6 @@ if _config_path.exists():
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
-                "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-                "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }
@@ -306,10 +303,6 @@ if _config_path.exists():
                     # Only bridge explicit absolute paths from config.yaml.
                     if _cfg_key == "cwd" and str(_val) in (".", "auto", "cwd"):
                         continue
-                    # Expand shell tilde in cwd so subprocess.Popen never
-                    # receives a literal "~/" which the kernel rejects.
-                    if _cfg_key == "cwd" and isinstance(_val, str):
-                        _val = os.path.expanduser(_val)
                     if isinstance(_val, list):
                         os.environ[_env_var] = json.dumps(_val)
                     else:
@@ -1614,7 +1607,7 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                return (cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+                return (cfg.get("agent", {}).get("system_prompt", "") or "").strip()
         except Exception:
             pass
         return ""
@@ -1635,7 +1628,7 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                effort = str(cfg_get(cfg, "agent", "reasoning_effort", default="") or "").strip()
+                effort = str(cfg.get("agent", {}).get("reasoning_effort", "") or "").strip()
         except Exception:
             pass
         result = parse_reasoning_effort(effort)
@@ -1718,7 +1711,7 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                raw = str(cfg_get(cfg, "agent", "service_tier", default="") or "").strip()
+                raw = str(cfg.get("agent", {}).get("service_tier", "") or "").strip()
         except Exception:
             pass
 
@@ -1739,7 +1732,7 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                return bool(cfg_get(cfg, "display", "show_reasoning", default=False))
+                return bool(cfg.get("display", {}).get("show_reasoning", False))
         except Exception:
             pass
         return False
@@ -1755,7 +1748,7 @@ class GatewayRunner:
                 if cfg_path.exists():
                     with open(cfg_path, encoding="utf-8") as _f:
                         cfg = _y.safe_load(_f) or {}
-                    mode = str(cfg_get(cfg, "display", "busy_input_mode", default="") or "").strip().lower()
+                    mode = str(cfg.get("display", {}).get("busy_input_mode", "") or "").strip().lower()
             except Exception:
                 pass
         if mode == "queue":
@@ -1775,7 +1768,7 @@ class GatewayRunner:
                 if cfg_path.exists():
                     with open(cfg_path, encoding="utf-8") as _f:
                         cfg = _y.safe_load(_f) or {}
-                    raw = str(cfg_get(cfg, "agent", "restart_drain_timeout", default="") or "").strip()
+                    raw = str(cfg.get("agent", {}).get("restart_drain_timeout", "") or "").strip()
             except Exception:
                 pass
         value = parse_restart_drain_timeout(raw)
@@ -1808,7 +1801,7 @@ class GatewayRunner:
                 if cfg_path.exists():
                     with open(cfg_path, encoding="utf-8") as _f:
                         cfg = _y.safe_load(_f) or {}
-                    raw = cfg_get(cfg, "display", "background_process_notifications")
+                    raw = cfg.get("display", {}).get("background_process_notifications")
                     if raw is False:
                         mode = "off"
                     elif raw not in (None, ""):
@@ -2405,6 +2398,9 @@ class GatewayRunner:
             "BLUEBUBBLES_ALLOWED_USERS",
             "QQ_ALLOWED_USERS",
             "YUANBAO_ALLOWED_USERS",
+            "LINE_ALLOWED_USERS",
+            "LINE_ALLOWED_GROUPS",
+            "LINE_ALLOWED_ROOMS",
             "GATEWAY_ALLOWED_USERS",
         )
         _builtin_allow_all_vars = (
@@ -2420,6 +2416,7 @@ class GatewayRunner:
             "BLUEBUBBLES_ALLOW_ALL_USERS",
             "QQ_ALLOW_ALL_USERS",
             "YUANBAO_ALLOW_ALL_USERS",
+            "LINE_ALLOW_ALL_USERS",
         )
         # Also pick up plugin-registered platforms — each entry can declare
         # its own allowed_users_env / allow_all_env, so the warning stays
@@ -2487,7 +2484,6 @@ class GatewayRunner:
 
         # Discover and load event hooks
         self.hooks.discover_and_load()
-
         
         # Recover background processes from checkpoint (crash recovery)
         try:
@@ -3878,6 +3874,19 @@ class GatewayRunner:
                 return None
             return YuanbaoAdapter(config)
 
+        elif platform == Platform.LINE:
+            from gateway.platforms.line import (
+                LineAdapter,
+                check_line_requirements,
+            )
+            if not check_line_requirements():
+                logger.warning("LINE: Dependencies not available (httpx/aiohttp missing)")
+                return None
+            if not config.token:
+                logger.warning("LINE: LINE_CHANNEL_ACCESS_TOKEN must be set")
+                return None
+            return LineAdapter(config)
+
         return None
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
@@ -3896,6 +3905,16 @@ class GatewayRunner:
         # Webhook events are authenticated via HMAC signature validation in
         # the adapter itself — no user allowlist applies.
         if source.platform in (Platform.HOMEASSISTANT, Platform.WEBHOOK):
+            return True
+
+        # LINE: HMAC-verified webhook events for group/room sources have
+        # already been authorized by the adapter's own three-allowlist
+        # check (LINE_ALLOWED_GROUPS / LINE_ALLOWED_ROOMS) before dispatch.
+        # The DM path (chat_type="dm") still flows through LINE_ALLOWED_USERS
+        # below — only group and room sources skip the per-user check, since
+        # LINE groups have no stable per-member allowlist concept and the
+        # group/room id is the meaningful authorization handle.
+        if source.platform == Platform.LINE and source.chat_type in {"group", "room"}:
             return True
 
         user_id = source.user_id
@@ -3920,6 +3939,7 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
+            Platform.LINE: "LINE_ALLOWED_USERS",
         }
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
@@ -3946,6 +3966,7 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
+            Platform.LINE: "LINE_ALLOW_ALL_USERS",
         }
 
         # Plugin platforms: check the registry for auth env var names
@@ -4131,6 +4152,7 @@ class GatewayRunner:
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
+                Platform.LINE:     "LINE_ALLOWED_USERS",
             }
             platform_group_env_map = {
                 Platform.TELEGRAM: (
@@ -7266,7 +7288,7 @@ class GatewayRunner:
 
         try:
             config = _load_gateway_config()
-            personalities = cfg_get(config, "agent", "personalities", default={})
+            personalities = config.get("agent", {}).get("personalities", {}) if config else {}
         except Exception:
             config = {}
             personalities = {}
@@ -8292,7 +8314,7 @@ class GatewayRunner:
         # --- check config gate ------------------------------------------------
         try:
             user_config = _load_gateway_config()
-            gate_enabled = cfg_get(user_config, "display", "tool_progress_command", default=False)
+            gate_enabled = user_config.get("display", {}).get("tool_progress_command", False)
         except Exception:
             gate_enabled = False
 
@@ -9383,7 +9405,7 @@ class GatewayRunner:
         Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
         Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
-        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL,
+        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LINE, Platform.LOCAL,
     })
 
     async def _handle_debug_command(self, event: MessageEvent) -> str:
@@ -11219,7 +11241,7 @@ class GatewayRunner:
                             tool_progress_hint_gateway,
                         )
                         _cfg = _load_gateway_config()
-                        gate_on = bool(cfg_get(_cfg, "display", "tool_progress_command", default=False))
+                        gate_on = bool(_cfg.get("display", {}).get("tool_progress_command", False))
                         if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
                             long_tool_hint_fired[0] = True
                             progress_queue.put(tool_progress_hint_gateway())
@@ -11377,20 +11399,6 @@ class GatewayRunner:
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
-                    elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
-                        # Content bubble just landed on the platform — close off
-                        # the current tool-progress bubble so the next tool
-                        # starts a fresh bubble below the content. Without this,
-                        # tool lines keep editing the ORIGINAL progress message
-                        # above the new content, making the chat appear out of
-                        # order. Mirrors GatewayStreamConsumer.on_segment_break
-                        # on the content side. (Issue: tool + content
-                        # linearization regression after PR #7885.)
-                        progress_msg_id = None
-                        progress_lines = []
-                        last_progress_msg[0] = None
-                        repeat_count[0] = 0
-                        continue
                     else:
                         msg = raw
                         progress_lines.append(msg)
@@ -11460,24 +11468,6 @@ class GatewayRunner:
                                 _, base_msg, count = raw
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                            elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
-                                # Content-bubble marker during drain: close off
-                                # the current progress bubble and start a fresh
-                                # one for any tool lines that arrived after.
-                                if can_edit and progress_lines and progress_msg_id:
-                                    _pending_text = "\n".join(progress_lines)
-                                    try:
-                                        await adapter.edit_message(
-                                            chat_id=source.chat_id,
-                                            message_id=progress_msg_id,
-                                            content=_pending_text,
-                                        )
-                                    except Exception:
-                                        pass
-                                progress_msg_id = None
-                                progress_lines = []
-                                last_progress_msg[0] = None
-                                repeat_count[0] = 0
                             else:
                                 progress_lines.append(raw)
                         except Exception:
@@ -11683,11 +11673,6 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
-                            on_new_message=(
-                                (lambda: progress_queue.put(("__reset__",)))
-                                if progress_queue is not None
-                                else None
-                            ),
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:
@@ -12906,7 +12891,6 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
-    CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
@@ -12957,21 +12941,6 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
                     )
             except Exception as e:
                 logger.debug("Paste sweep error: %s", e)
-
-        # Curator — piggy-back on the existing cron ticker so long-running
-        # gateways get weekly skill maintenance without needing restarts.
-        # maybe_run_curator() is internally gated by config.interval_hours
-        # (7 days by default), so CURATOR_EVERY is just the poll rate — the
-        # real work only fires once per config interval.
-        if tick_count % CURATOR_EVERY == 0:
-            try:
-                from agent.curator import maybe_run_curator
-                maybe_run_curator(
-                    idle_for_seconds=float("inf"),
-                    on_summary=lambda msg: logger.info("curator: %s", msg),
-                )
-            except Exception as e:
-                logger.debug("Curator tick error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -98,6 +98,7 @@ def _configured_platforms() -> list[str]:
     """Return list of configured messaging platform names."""
     checks = {
         "telegram": "TELEGRAM_BOT_TOKEN",
+        "line": "LINE_CHANNEL_ACCESS_TOKEN",
         "discord": "DISCORD_BOT_TOKEN",
         "slack": "SLACK_BOT_TOKEN",
         "whatsapp": "WHATSAPP_ENABLED",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2406,6 +2406,35 @@ _PLATFORMS = [
         ],
     },
     {
+        "key": "line",
+        "label": "LINE",
+        "emoji": "💬",
+        "token_var": "LINE_CHANNEL_ACCESS_TOKEN",
+        "setup_instructions": [
+            "1. Create a LINE Official Account: https://www.linebiz.com/jp-en/manual/OfficialAccountManager/registration/",
+            "2. Open https://developers.line.biz/console/ → select your channel",
+            "3. Messaging API tab → Channel access token → Issue (long-lived)",
+            "4. Basic settings tab → Channel secret",
+            "5. Find your LINE user ID: Basic settings → 'Your user ID' (starts with 'U')",
+            "6. Webhook URL will be set later, after the gateway starts (uses LINE_WEBHOOK_PORT, default 8645)",
+        ],
+        "vars": [
+            {"name": "LINE_CHANNEL_ACCESS_TOKEN", "prompt": "Channel access token", "password": True,
+             "help": "Paste the long-lived access token from step 3 above."},
+            {"name": "LINE_CHANNEL_SECRET", "prompt": "Channel secret", "password": True,
+             "help": "Paste the secret from step 4 above."},
+            {"name": "LINE_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated)", "password": False,
+             "is_allowlist": True,
+             "help": "Paste your user ID from step 5 above. All three allowlists default-deny — empty list = no access."},
+            {"name": "LINE_ALLOWED_GROUPS", "prompt": "Allowed group IDs (comma-separated, leave empty)", "password": False,
+             "help": "LINE group IDs start with 'C'. Discover by adding the bot to a group, sending a message, then checking 'line.drop' log entries."},
+            {"name": "LINE_ALLOWED_ROOMS", "prompt": "Allowed room IDs (comma-separated, leave empty)", "password": False,
+             "help": "LINE room IDs start with 'R'."},
+            {"name": "LINE_HOME_CHANNEL", "prompt": "Home channel ID (for cron/notifications, or empty to set later with /set-home)", "password": False,
+             "help": "For DMs, this is your user ID. Set later by typing /set-home in chat."},
+        ],
+    },
+    {
         "key": "discord",
         "label": "Discord",
         "emoji": "💬",
@@ -3677,6 +3706,12 @@ def _setup_qqbot():
     print()
     print_success("🐧 QQ Bot configured!")
     print_info(f"  App ID: {credentials['app_id']}")
+
+
+def _setup_line():
+    """Interactive setup for LINE Messaging API."""
+    line_platform = next(p for p in _PLATFORMS if p["key"] == "line")
+    _setup_standard_platform(line_platform)
 
 
 def _setup_signal():

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -21,6 +21,7 @@ class PlatformInfo(NamedTuple):
 PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("cli",            PlatformInfo(label="🖥️  CLI",            default_toolset="hermes-cli")),
     ("telegram",       PlatformInfo(label="📱 Telegram",        default_toolset="hermes-telegram")),
+    ("line",           PlatformInfo(label="💬 LINE",            default_toolset="hermes-line")),
     ("discord",        PlatformInfo(label="💬 Discord",         default_toolset="hermes-discord")),
     ("slack",          PlatformInfo(label="💼 Slack",           default_toolset="hermes-slack")),
     ("whatsapp",       PlatformInfo(label="📱 WhatsApp",        default_toolset="hermes-whatsapp")),

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -28,15 +28,12 @@ def check_mark(ok: bool) -> str:
     return color("✗", Colors.RED)
 
 def redact_key(key: str) -> str:
-    """Redact an API key for display.
-
-    Thin wrapper over :func:`agent.redact.mask_secret`. Preserves the
-    "(not set)" placeholder in dim color to match ``hermes config``'s
-    output (previously this variant was missing the DIM color —
-    consolidated via PR that also introduced ``mask_secret``).
-    """
-    from agent.redact import mask_secret
-    return mask_secret(key, empty=color("(not set)", Colors.DIM))
+    """Redact an API key for display."""
+    if not key:
+        return "(not set)"
+    if len(key) < 12:
+        return "***"
+    return key[:4] + "..." + key[-4:]
 
 
 def _format_iso_timestamp(value) -> str:
@@ -369,6 +366,7 @@ def show_status(args):
 
     platforms = {
         "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
+        "LINE": ("LINE_CHANNEL_ACCESS_TOKEN", "LINE_HOME_CHANNEL"),
         "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
         "WhatsApp": ("WHATSAPP_ENABLED", None),
         "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
@@ -388,18 +386,26 @@ def show_status(args):
     for name, (token_var, home_var) in platforms.items():
         token = os.getenv(token_var, "")
         has_token = bool(token)
-        
+
         home_channel = ""
         if home_var:
             home_channel = os.getenv(home_var, "")
         # Back-compat: QQBot home channel was renamed from QQ_HOME_CHANNEL to QQBOT_HOME_CHANNEL
         if not home_channel and home_var == "QQBOT_HOME_CHANNEL":
             home_channel = os.getenv("QQ_HOME_CHANNEL", "")
-        
+
         status = "configured" if has_token else "not configured"
+        # LINE works in two modes: outbound-only (token alone — Push API for
+        # send_message + cron) or full duplex (token + secret — adds inbound
+        # webhook receiver). Reflect which mode is active so operators know.
+        if name == "LINE" and has_token:
+            if os.getenv("LINE_CHANNEL_SECRET", ""):
+                status = "configured (full duplex: send + receive)"
+            else:
+                status = "configured (outbound-only — set LINE_CHANNEL_SECRET to enable inbound)"
         if home_channel:
             status += f" (home: {home_channel})"
-        
+
         print(f"  {name:<12}  {check_mark(has_token)} {status}")
 
     # Plugin-registered platforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-aiohttp>=1.1.0,<2", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff", "respx>=0.21,<1"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -343,3 +343,94 @@ def pytest_configure(config):
             + _GUARD_HINT
         )
 
+# ---------------------------------------------------------------------------
+# LINE adapter shared helpers
+# ---------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+
+from gateway.config import PlatformConfig as _PlatformConfig  # noqa: E402
+from gateway.platforms.line import LineAdapter as _LineAdapter  # noqa: E402
+
+
+def make_line_platform_config(token: str = "t") -> _PlatformConfig:
+    """Build a PlatformConfig for LineAdapter — matches the shape produced
+    by gateway/run.py's adapter factory. LINE-specific options come from
+    env vars at adapter __init__ time, so tests should monkeypatch the
+    LINE_* vars BEFORE constructing the adapter."""
+    return _PlatformConfig(enabled=True, token=token)
+
+
+@pytest.fixture
+def line_lock_noop(monkeypatch):
+    """Stub the per-credential platform lock for LINE connect()/disconnect().
+
+    Without this, multiple ``connect()`` calls in the same test process
+    contend on a real file lock keyed by ``channel_access_token="t"`` —
+    the default credential used by LINE fixtures — and every test after
+    the first fails with ``Failed to acquire lock``. The lock is a real
+    production safety mechanism (mirrors Telegram/Discord); we stub it
+    inside the test process via the same pattern test_telegram_conflict
+    uses when it needs to exercise the failure branch.
+
+    Opt-in only — request this fixture in tests that exercise
+    connect()/disconnect(). Peer convention (test_telegram, test_discord)
+    favors explicit opt-in over autouse to avoid silently neutering
+    unrelated tests."""
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+
+@pytest_asyncio.fixture
+async def make_line_adapter(monkeypatch):
+    """Factory fixture for building a LineAdapter with custom env-driven
+    settings. Sets LINE_* env vars then constructs the adapter so the v2
+    PlatformConfig + os.environ pattern is exercised end-to-end.
+
+    Usage::
+
+        adapter = make_line_adapter(
+            LINE_ALLOWED_GROUPS="C1",
+            LINE_REQUIRE_MENTION="true",
+            LINE_BOT_DISPLAY_NAME="小茉",
+        )
+    """
+    adapters = []
+
+    def _factory(**env_overrides):
+        defaults = {
+            "LINE_CHANNEL_ACCESS_TOKEN": "t",
+            "LINE_CHANNEL_SECRET": "s",
+            "LINE_ALLOWED_USERS": "U1",
+            "LINE_SLOW_RESPONSE_THRESHOLD": "50",
+        }
+        defaults.update(env_overrides)
+        for key, value in defaults.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, str(value))
+        adapter = _LineAdapter(make_line_platform_config(token=defaults["LINE_CHANNEL_ACCESS_TOKEN"]))
+        adapters.append(adapter)
+        return adapter
+
+    yield _factory
+
+    for a in adapters:
+        await a.disconnect()
+
+
+def line_sign(secret: str, body: bytes) -> str:
+    """Build a LINE-format X-Line-Signature header for a body using the channel secret."""
+    import base64 as _base64
+    import hashlib as _hashlib
+    import hmac as _hmac
+    digest = _hmac.new(secret.encode(), body, _hashlib.sha256).digest()
+    return _base64.b64encode(digest).decode()

--- a/tests/gateway/test_line_allowlist.py
+++ b/tests/gateway/test_line_allowlist.py
@@ -1,0 +1,76 @@
+"""Tests for the LINE source allowlist (user / group / room filtering)."""
+import pytest
+
+from gateway.platforms.line import is_allowed
+
+
+@pytest.mark.parametrize(
+    "cfg, user_id, expected",
+    [
+        ({"users": ["U1", "U2"], "groups": [], "rooms": []}, "U1", True),
+        ({"users": ["U1"], "groups": [], "rooms": []}, "U999", False),
+    ],
+    ids=["in_list", "not_in_list"],
+)
+def test_is_allowed_user(cfg, user_id, expected):
+    event = {"source": {"type": "user", "userId": user_id}}
+    assert is_allowed(event, cfg) is expected
+
+
+def test_group_in_allowlist():
+    cfg = {"users": [], "groups": ["Cabc"], "rooms": []}
+    event = {"source": {"type": "group", "groupId": "Cabc", "userId": "U1"}}
+    assert is_allowed(event, cfg) is True
+
+
+def test_room_in_allowlist():
+    cfg = {"users": [], "groups": [], "rooms": ["Rxyz"]}
+    event = {"source": {"type": "room", "roomId": "Rxyz", "userId": "U1"}}
+    assert is_allowed(event, cfg) is True
+
+
+def test_unknown_source_type_denied():
+    cfg = {"users": [], "groups": [], "rooms": []}
+    event = {"source": {"type": "weird", "id": "?"}}
+    assert is_allowed(event, cfg) is False
+
+
+def test_empty_allowlists_deny_all():
+    cfg = {"users": [], "groups": [], "rooms": []}
+    for src in [{"type": "user", "userId": "U1"},
+                {"type": "group", "groupId": "C1", "userId": "U1"},
+                {"type": "room", "roomId": "R1", "userId": "U1"}]:
+        assert is_allowed({"source": src}, cfg) is False
+
+
+def test_source_type_present_but_id_missing_denied():
+    cfg = {"users": ["U1"], "groups": ["C1"], "rooms": ["R1"]}
+    assert is_allowed({"source": {"type": "user"}}, cfg) is False
+    assert is_allowed({"source": {"type": "group"}}, cfg) is False
+    assert is_allowed({"source": {"type": "room"}}, cfg) is False
+
+
+def test_missing_source_key_denied():
+    cfg = {"users": ["U1"], "groups": [], "rooms": []}
+    assert is_allowed({}, cfg) is False
+
+
+def test_allow_all_users_env_resolved_in_adapter(monkeypatch):
+    """LINE_ALLOW_ALL_USERS=true resolves to _allow_all_sources=True at __init__
+    (debug-only escape hatch — bypass enforced at the dispatch call site)."""
+    from gateway.platforms.line import LineAdapter
+    from tests.gateway.conftest import make_line_platform_config
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_ALLOW_ALL_USERS", "true")
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    assert adapter._allow_all_sources is True
+
+
+def test_allow_all_users_env_unset_resolves_false(monkeypatch):
+    """When LINE_ALLOW_ALL_USERS is unset/false, the bypass is disabled."""
+    from gateway.platforms.line import LineAdapter
+    from tests.gateway.conftest import make_line_platform_config
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.delenv("LINE_ALLOW_ALL_USERS", raising=False)
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    assert adapter._allow_all_sources is False

--- a/tests/gateway/test_line_bot_info.py
+++ b/tests/gateway/test_line_bot_info.py
@@ -1,0 +1,87 @@
+"""Tests for _fetch_bot_info — auto-resolves bot display name at connect()."""
+import logging
+
+import pytest
+import respx
+from httpx import Response
+
+from gateway.platforms.line import LineAdapter
+from tests.gateway.conftest import make_line_platform_config
+
+
+def _adapter(require_mention=True, bot_display_name=""):
+    """Build a LineAdapter with require_mention/bot_display_name from env
+    (v2 reads LINE_* env vars at __init__). Process-wide os.environ is OK
+    here because each test calls this fresh and overwrites the previous."""
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "t"
+    os.environ["LINE_CHANNEL_SECRET"] = "s"
+    os.environ["LINE_REQUIRE_MENTION"] = "true" if require_mention else "false"
+    os.environ["LINE_BOT_DISPLAY_NAME"] = bot_display_name
+    return LineAdapter(make_line_platform_config(token="t"))
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_bot_info_resolves_display_name():
+    """When require_mention=True and no manual override, /v2/bot/info is called."""
+    respx.get("https://api.line.me/v2/bot/info").mock(
+        return_value=Response(200, json={"displayName": "小茉", "userId": "Ubot"})
+    )
+    adapter = _adapter(require_mention=True, bot_display_name="")
+    await adapter._fetch_bot_info()
+    assert adapter._bot_display_name == "小茉"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_bot_info_skipped_when_require_mention_disabled():
+    """No HTTP call when require_mention=False."""
+    route = respx.get("https://api.line.me/v2/bot/info").mock(
+        return_value=Response(200, json={"displayName": "小茉"})
+    )
+    adapter = _adapter(require_mention=False, bot_display_name="")
+    await adapter._fetch_bot_info()
+    assert not route.called
+    assert adapter._bot_display_name == ""
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_bot_info_skipped_when_manual_override_set():
+    """No HTTP call when LINE_BOT_DISPLAY_NAME is explicitly set."""
+    route = respx.get("https://api.line.me/v2/bot/info").mock(
+        return_value=Response(200, json={"displayName": "Auto"})
+    )
+    adapter = _adapter(require_mention=True, bot_display_name="Manual")
+    await adapter._fetch_bot_info()
+    assert not route.called
+    assert adapter._bot_display_name == "Manual"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_bot_info_empty_display_name_treated_as_failure(caplog):
+    """When LINE returns 200 but displayName is empty, log warning and leave name unset."""
+    respx.get("https://api.line.me/v2/bot/info").mock(
+        return_value=Response(200, json={"displayName": "", "userId": "Ubot"})
+    )
+    adapter = _adapter(require_mention=True, bot_display_name="")
+    with caplog.at_level(logging.WARNING, logger="gateway.platforms.line"):
+        await adapter._fetch_bot_info()
+    assert adapter._bot_display_name == ""
+    assert any("empty displayName" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_bot_info_http_failure_logs_warning(caplog):
+    """LINE API failure is non-fatal — display name stays empty, warning logged."""
+    respx.get("https://api.line.me/v2/bot/info").mock(
+        return_value=Response(401, json={"message": "Unauthorized"})
+    )
+    adapter = _adapter(require_mention=True, bot_display_name="")
+    with caplog.at_level(logging.WARNING, logger="gateway.platforms.line"):
+        await adapter._fetch_bot_info()
+    assert adapter._bot_display_name == ""
+    assert any("Failed to fetch LINE bot info" in r.message for r in caplog.records)

--- a/tests/gateway/test_line_cache.py
+++ b/tests/gateway/test_line_cache.py
@@ -1,0 +1,137 @@
+"""Tests for the LINE request cache state machine (PENDING → READY → DELIVERED / ERROR)."""
+import time
+
+import pytest
+
+from gateway.platforms.line import (
+    RequestCache,
+    State,
+)
+
+
+def test_register_pending_returns_uuid():
+    cache = RequestCache(ttl_seconds=3600)
+    rid = cache.register_pending()
+    assert isinstance(rid, str)
+    entry = cache.get(rid)
+    assert entry is not None
+    assert entry.state is State.PENDING
+
+
+def test_set_ready_transitions_state():
+    cache = RequestCache(ttl_seconds=3600)
+    rid = cache.register_pending()
+    cache.set_ready(rid, "the answer")
+    entry = cache.get(rid)
+    assert entry.state is State.READY
+    assert entry.payload == "the answer"
+
+
+@pytest.mark.parametrize("method", ["set_ready", "set_error"], ids=["set_ready", "set_error"])
+def test_cache_unknown_id_noop(method):
+    """Both transition methods must silently ignore unknown request_ids
+    (otherwise a postback for an evicted entry would crash the handler)."""
+    cache = RequestCache(ttl_seconds=3600)
+    getattr(cache, method)("not-a-real-id", "ignored")  # must not raise
+
+
+def test_mark_delivered_transitions_state():
+    cache = RequestCache(ttl_seconds=3600)
+    rid = cache.register_pending()
+    cache.set_ready(rid, "x")
+    cache.mark_delivered(rid)
+    entry = cache.get(rid)
+    assert entry.state is State.DELIVERED
+
+
+def test_prune_removes_only_old_ready_and_delivered(monkeypatch):
+    cache = RequestCache(ttl_seconds=10)  # default pending_ttl=86400
+    rid_pending = cache.register_pending()
+    rid_old_ready = cache.register_pending()
+    cache.set_ready(rid_old_ready, "stale")
+    rid_old_delivered = cache.register_pending()
+    cache.set_ready(rid_old_delivered, "x")
+    cache.mark_delivered(rid_old_delivered)
+
+    # Backdate the two terminal entries
+    now = time.time()
+    cache._entries[rid_old_ready].updated_at = now - 11
+    cache._entries[rid_old_delivered].updated_at = now - 11
+    # Backdate PENDING's created_at past the regular TTL (10s) but well
+    # under the ceiling TTL (default 86400s) — proves the regular TTL
+    # does NOT apply to PENDING.
+    cache._entries[rid_pending].created_at = now - 11
+
+    cache.prune()
+
+    assert cache.get(rid_pending) is not None  # PENDING not pruned via terminal TTL
+    assert cache.get(rid_old_ready) is None
+    assert cache.get(rid_old_delivered) is None
+
+
+def test_prune_keeps_recent_entries():
+    cache = RequestCache(ttl_seconds=3600)
+    rid = cache.register_pending()
+    cache.set_ready(rid, "x")
+    cache.prune()
+    assert cache.get(rid) is not None
+
+
+def test_set_error_transitions_state():
+    cache = RequestCache(ttl_seconds=3600)
+    rid = cache.register_pending()
+    cache.set_error(rid, "boom")
+    entry = cache.get(rid)
+    assert entry.state is State.ERROR
+    assert entry.payload == "boom"
+
+
+def test_prune_removes_old_error_entries():
+    cache = RequestCache(ttl_seconds=10)
+    rid = cache.register_pending()
+    cache.set_error(rid, "boom")
+    cache._entries[rid].updated_at = time.time() - 11
+    cache.prune()
+    assert cache.get(rid) is None
+
+
+def test_prune_removes_old_pending_via_ceiling_ttl():
+    cache = RequestCache(ttl_seconds=10, pending_ttl_seconds=20)
+    rid = cache.register_pending()
+    # Backdate created_at past the ceiling TTL
+    cache._entries[rid].created_at = time.time() - 25
+
+    cache.prune()
+
+    assert cache.get(rid) is None
+
+
+# ---- State-machine guard tests ----
+
+def test_set_ready_after_delivered_is_noop():
+    """set_ready on a DELIVERED entry must not roll the state back."""
+    cache = RequestCache()
+    rid = cache.register_pending()
+    cache.set_ready(rid, "first")
+    cache.mark_delivered(rid)
+    cache.set_ready(rid, "second")
+    entry = cache.get(rid)
+    assert entry.state is State.DELIVERED
+    assert entry.payload == "first"
+
+
+def test_set_error_after_delivered_is_noop():
+    cache = RequestCache()
+    rid = cache.register_pending()
+    cache.set_ready(rid, "ok")
+    cache.mark_delivered(rid)
+    cache.set_error(rid, "late error")
+    assert cache.get(rid).state is State.DELIVERED
+
+
+def test_mark_delivered_on_pending_is_noop():
+    """Marking a still-PENDING entry delivered must be a no-op."""
+    cache = RequestCache()
+    rid = cache.register_pending()
+    cache.mark_delivered(rid)
+    assert cache.get(rid).state is State.PENDING

--- a/tests/gateway/test_line_config.py
+++ b/tests/gateway/test_line_config.py
@@ -1,0 +1,76 @@
+"""Tests for LineAdapter env-var configuration loading + global integration checks."""
+import pytest
+
+from gateway.platforms.line import LineAdapter
+from tests.gateway.conftest import make_line_platform_config
+
+
+def test_init_parses_csv_allowlists(monkeypatch):
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_ALLOWED_USERS", "U1,U2")
+    monkeypatch.setenv("LINE_ALLOWED_GROUPS", "C1")
+    monkeypatch.setenv("LINE_ALLOWED_ROOMS", "")
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    assert adapter._allowed_users == ["U1", "U2"]
+    assert adapter._allowed_groups == ["C1"]
+    assert adapter._allowed_rooms == []
+
+
+def test_init_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_ALLOWED_USERS", " U1 , U2 , ")
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    assert adapter._allowed_users == ["U1", "U2"]
+
+
+def test_init_no_secret_yields_outbound_only(monkeypatch):
+    """Outbound-only mode: LINE_CHANNEL_ACCESS_TOKEN alone is enough for
+    Push API + cron deliveries; webhook receiver returns 401 on every
+    inbound (verify_signature rejects when secret is empty)."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    assert adapter._channel_access_token == "t"
+    assert adapter._channel_secret == ""
+
+
+def test_init_reads_optional_overrides(monkeypatch):
+    """All optional env overrides should round-trip through __init__."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_SLOW_RESPONSE_THRESHOLD", "30")
+    monkeypatch.setenv("LINE_CACHE_TTL", "7200")
+    monkeypatch.setenv("LINE_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("LINE_BOT_DISPLAY_NAME", "Samantha")
+    monkeypatch.setenv("LINE_FREE_RESPONSE_GROUPS", "Caaa,Cbbb")
+    monkeypatch.setenv("LINE_FREE_RESPONSE_ROOMS", "R111")
+
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+
+    assert adapter._slow_response_threshold == 30.0
+    assert adapter._cache_ttl == 7200
+    assert adapter._require_mention is True
+    assert adapter._bot_display_name == "Samantha"
+    assert adapter._free_response_groups == ["Caaa", "Cbbb"]
+    assert adapter._free_response_rooms == ["R111"]
+
+
+def test_init_defaults_when_overrides_missing(monkeypatch):
+    """__init__ applies sensible defaults when optional overrides are unset."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    for key in ("LINE_SLOW_RESPONSE_THRESHOLD", "LINE_CACHE_TTL",
+                "LINE_REQUIRE_MENTION", "LINE_BOT_DISPLAY_NAME",
+                "LINE_FREE_RESPONSE_GROUPS", "LINE_FREE_RESPONSE_ROOMS"):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+
+    assert adapter._slow_response_threshold == 45.0  # documented LINE token margin
+    assert adapter._cache_ttl == 3600
+    assert adapter._require_mention is False
+    assert adapter._bot_display_name == ""
+    assert adapter._free_response_groups == []
+    assert adapter._free_response_rooms == []

--- a/tests/gateway/test_line_http_endpoint.py
+++ b/tests/gateway/test_line_http_endpoint.py
@@ -1,0 +1,140 @@
+"""HTTP endpoint tests for LineAdapter — POST /line/webhook + HMAC validation."""
+import json
+
+import pytest
+from aiohttp import web
+
+from gateway.platforms.line import LineAdapter
+from tests.gateway.conftest import line_sign as _sign, make_line_platform_config
+
+
+@pytest.fixture
+def line_adapter(monkeypatch):
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_ALLOWED_USERS", "U1")
+    return LineAdapter(make_line_platform_config(token="t"))
+
+
+@pytest.fixture
+def app(line_adapter):
+    app = web.Application()
+    line_adapter.register_routes(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_post_with_valid_signature_returns_200(aiohttp_client, app):
+    client = await aiohttp_client(app)
+    body = json.dumps({"events": [], "destination": "U1"}).encode()
+    sig = _sign("s", body)
+    resp = await client.post("/line/webhook", data=body, headers={"X-Line-Signature": sig})
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_post_with_invalid_signature_returns_401(aiohttp_client, app):
+    client = await aiohttp_client(app)
+    body = json.dumps({"events": []}).encode()
+    resp = await client.post("/line/webhook", data=body, headers={"X-Line-Signature": "bad"})
+    assert resp.status == 401
+
+
+@pytest.mark.asyncio
+async def test_post_with_missing_signature_returns_401(aiohttp_client, app):
+    client = await aiohttp_client(app)
+    body = json.dumps({"events": []}).encode()
+    resp = await client.post("/line/webhook", data=body)
+    assert resp.status == 401
+
+
+@pytest.mark.asyncio
+async def test_get_returns_405(aiohttp_client, app):
+    client = await aiohttp_client(app)
+    resp = await client.get("/line/webhook")
+    assert resp.status == 405
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_returns_ok(aiohttp_client, app):
+    client = await aiohttp_client(app)
+    resp = await client.get("/line/webhook/health")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == {"status": "ok", "platform": "line"}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_webhook_event_id_is_dropped(aiohttp_client, line_adapter, app):
+    """Second delivery of the same webhookEventId must be silently deduplicated."""
+    client = await aiohttp_client(app)
+    body = json.dumps({
+        "events": [{
+            "type": "message",
+            "webhookEventId": "wh-evt-001",
+            "replyToken": "rt",
+            "source": {"type": "user", "userId": "U1"},
+            "timestamp": 1,
+            "message": {"id": "m1", "type": "text", "text": "hello"},
+        }],
+        "destination": "U1",
+    }).encode()
+    sig = _sign("s", body)
+    headers = {"X-Line-Signature": sig}
+
+    dispatched: list[dict] = []
+    original = line_adapter._dispatch_event
+
+    async def _counting_dispatch(event):
+        dispatched.append(event)
+        await original(event)
+
+    line_adapter._dispatch_event = _counting_dispatch
+
+    await client.post("/line/webhook", data=body, headers=headers)
+    await client.post("/line/webhook", data=body, headers=headers)
+
+    assert len(dispatched) == 1, "duplicate webhookEventId must be dropped on second delivery"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_delivery_of_same_event_id_dispatches_once(
+    aiohttp_client, line_adapter, app
+):
+    """Concurrent re-delivery of the same webhookEventId must still dedupe.
+    Documents the at-most-once contract under cooperative single-loop scheduling —
+    if dedup ever moves out of the synchronous webhook path, this test will catch it."""
+    import asyncio
+
+    client = await aiohttp_client(app)
+    body = json.dumps({
+        "events": [{
+            "type": "message",
+            "webhookEventId": "wh-evt-concurrent",
+            "replyToken": "rt",
+            "source": {"type": "user", "userId": "U1"},
+            "timestamp": 1,
+            "message": {"id": "m1", "type": "text", "text": "hello"},
+        }],
+        "destination": "U1",
+    }).encode()
+    sig = _sign("s", body)
+    headers = {"X-Line-Signature": sig}
+
+    dispatched: list[dict] = []
+    original = line_adapter._dispatch_event
+
+    async def _counting_dispatch(event):
+        dispatched.append(event)
+        await original(event)
+
+    line_adapter._dispatch_event = _counting_dispatch
+
+    await asyncio.gather(
+        client.post("/line/webhook", data=body, headers=headers),
+        client.post("/line/webhook", data=body, headers=headers),
+    )
+
+    assert len(dispatched) == 1, (
+        "concurrent webhookEventId deliveries must dedupe to a single dispatch"
+    )

--- a/tests/gateway/test_line_reply.py
+++ b/tests/gateway/test_line_reply.py
@@ -1,0 +1,117 @@
+"""Tests for LineReplyClient — reply, postback button, and loading indicator calls."""
+import json
+
+import pytest
+import respx
+from httpx import Response
+
+from gateway.platforms.line import (
+    LineReplyClient,
+    _strip_markdown_for_line,
+    build_postback_button_message,
+    DEFAULT_PENDING_REPLY_TEXT as PENDING_REPLY_TEXT,
+    DEFAULT_EXPIRED_REPLY_TEXT as EXPIRED_REPLY_TEXT,
+    DEFAULT_ALREADY_DELIVERED_TEXT as ALREADY_DELIVERED_TEXT,
+)
+
+
+def test_strip_markdown_for_line_preserves_link_urls():
+    """LINE auto-linkifies bare URLs, so [label](url) must rewrite to
+    'label (url)' before the shared strip_markdown drops the URL.
+    Without this, citations would lose their tappable links."""
+    out = _strip_markdown_for_line(
+        "See **the docs** at [LINE Developers](https://developers.line.biz)."
+    )
+    # Bold stripped, link rewritten with URL preserved as bare text.
+    assert "**" not in out
+    assert "[LINE Developers]" not in out
+    assert "LINE Developers" in out
+    assert "https://developers.line.biz" in out
+
+
+def test_strip_markdown_for_line_strips_other_markdown():
+    """Headings, bold, italic, code spans all collapse to plain text."""
+    out = _strip_markdown_for_line(
+        "# Heading\n\n**bold** and *italic* and `code`"
+    )
+    for marker in ("#", "**", "*", "`"):
+        assert marker not in out
+    for word in ("Heading", "bold", "italic", "code"):
+        assert word in out
+
+
+def test_build_postback_button_message_carries_request_id():
+    msg = build_postback_button_message(
+        text=PENDING_REPLY_TEXT,
+        button_label="📋 Show response",
+        request_id="rid-123",
+    )
+    # Template Buttons message — persistent (Quick Reply chips would be
+    # transient; see build_postback_button_message docstring).
+    assert msg["type"] == "template"
+    assert msg["template"]["type"] == "buttons"
+    assert msg["altText"] == PENDING_REPLY_TEXT
+    actions = msg["template"]["actions"]
+    assert len(actions) == 1
+    action = actions[0]
+    assert action["type"] == "postback"
+    payload = json.loads(action["data"])
+    assert payload["action"] == "show_response"
+    assert payload["request_id"] == "rid-123"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_reply_sends_post_to_line():
+    route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    client = LineReplyClient(channel_access_token="test-token")
+    await client.reply("rt-1", [{"type": "text", "text": "hello"}])
+    assert route.called
+    sent = json.loads(route.calls.last.request.content)
+    assert sent["replyToken"] == "rt-1"
+    assert sent["messages"][0]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_show_loading_suppressed_for_group_id():
+    """show_loading() must skip the HTTP call for group/room IDs (LINE limitation)."""
+    route = respx.post("https://api.line.me/v2/bot/chat/loading/start").mock(
+        return_value=Response(200, json={})
+    )
+    client = LineReplyClient(channel_access_token="t")
+    await client.show_loading("C_group_id_starts_with_C")
+    await client.show_loading("R_room_id_starts_with_R")
+    await client.show_loading("")
+    assert not route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_show_loading_fires_for_user_id():
+    """show_loading() must POST for U-prefixed IDs (DM users) — guards against
+    inverted prefix check that would silently disable the typing indicator."""
+    route = respx.post("https://api.line.me/v2/bot/chat/loading/start").mock(
+        return_value=Response(200, json={})
+    )
+    client = LineReplyClient(channel_access_token="t")
+    await client.show_loading("U_user_id")
+    assert route.called
+    body = json.loads(route.calls.last.request.content)
+    assert body["chatId"] == "U_user_id"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_reply_raises_on_non_2xx():
+    """LineReplyClient.reply() must surface LINE API errors via raise_for_status —
+    documented contract; silently swallowing non-2xx would mask expired reply tokens."""
+    import httpx
+    respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(400, json={"message": "Invalid reply token"})
+    )
+    client = LineReplyClient(channel_access_token="t")
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.reply("expired-token", [{"type": "text", "text": "hi"}])

--- a/tests/gateway/test_line_runner_integration.py
+++ b/tests/gateway/test_line_runner_integration.py
@@ -1,0 +1,62 @@
+"""Verify LINE integration points exist in the gateway runner and cron scheduler.
+
+Guards against Platform.LINE being accidentally omitted from authorization
+maps (which would silently drop every incoming LINE message) and from the
+cron scheduler's platform_map (which would silently ignore deliver='line').
+"""
+import inspect
+
+from gateway.run import GatewayRunner
+
+
+def test_line_in_authorization_maps():
+    """Source-text guard: the platform_env_map / platform_allow_all_map dicts
+    inside ``_is_user_authorized`` are method-local (rebuilt per call), so we
+    can't import them as data. Asserting on the source literal text is a
+    pragmatic regression guard that catches the most likely failure mode —
+    forgetting to add ``Platform.LINE`` to one of the maps when the rest of
+    the wiring is in place. A full behavioural test would require building a
+    GatewayConfig + GatewayRunner + MessageEvent fixture, an order of
+    magnitude more setup for the same coverage."""
+    src = inspect.getsource(GatewayRunner._is_user_authorized)
+    assert "Platform.LINE" in src, (
+        "Platform.LINE missing from GatewayRunner._is_user_authorized — "
+        "every LINE message will fail authorization"
+    )
+    assert "LINE_ALLOWED_USERS" in src
+    assert "LINE_ALLOW_ALL_USERS" in src
+
+
+def test_line_in_cron_known_delivery_platforms():
+    """'line' must be in _KNOWN_DELIVERY_PLATFORMS or bare deliver='line' is silently dropped."""
+    from cron.scheduler import _KNOWN_DELIVERY_PLATFORMS
+    assert "line" in _KNOWN_DELIVERY_PLATFORMS, (
+        "'line' missing from _KNOWN_DELIVERY_PLATFORMS — "
+        "cronjob(deliver='line') using a home channel will produce no delivery"
+    )
+
+
+def test_line_in_cron_home_target_env_vars():
+    """LINE_HOME_CHANNEL must be registered so hermes setup-configured home channels work."""
+    from cron.scheduler import _HOME_TARGET_ENV_VARS
+    assert "line" in _HOME_TARGET_ENV_VARS, (
+        "'line' missing from _HOME_TARGET_ENV_VARS — "
+        "LINE_HOME_CHANNEL is unreachable for cron home-channel delivery"
+    )
+    assert _HOME_TARGET_ENV_VARS["line"] == "LINE_HOME_CHANNEL"
+
+
+def test_line_group_room_chat_type_bypasses_user_allowlist_in_runner():
+    """LINE group/room chat_type sources must be auto-authorized at the gateway
+    layer because the LINE adapter's own LINE_ALLOWED_GROUPS/ROOMS check
+    already validated them before dispatch.
+
+    Regression guard: a previous version of this PR only registered
+    LINE_ALLOWED_USERS in `_is_user_authorized`'s `platform_env_map`, which
+    meant group/room messages were rejected at the gateway layer even when
+    the LINE adapter passed them."""
+    src = inspect.getsource(GatewayRunner._is_user_authorized)
+    assert "Platform.LINE" in src and 'chat_type in {"group", "room"}' in src, (
+        "_is_user_authorized must short-circuit LINE group/room sources — "
+        "otherwise LINE_ALLOWED_GROUPS/ROOMS messages get gateway-level rejection"
+    )

--- a/tests/gateway/test_line_runner_smoke.py
+++ b/tests/gateway/test_line_runner_smoke.py
@@ -1,0 +1,72 @@
+"""Smoke tests for LineAdapter connect/disconnect lifecycle and route registration."""
+import logging
+
+import pytest
+from aiohttp import web
+
+from gateway.platforms.line import LineAdapter
+from tests.gateway.conftest import make_line_platform_config
+
+
+@pytest.mark.asyncio
+async def test_connect_starts_standalone_server(monkeypatch, line_lock_noop):
+    """connect() spins up its own aiohttp listener and tracks the runner."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_WEBHOOK_PORT", "0")  # let OS pick free port
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    try:
+        result = await adapter.connect()
+        assert result is True
+        assert adapter._runner is not None
+        assert adapter.is_connected is True
+    finally:
+        await adapter.disconnect()
+        assert adapter.is_connected is False
+
+
+def test_register_routes_exposes_webhook_and_health_endpoints(monkeypatch):
+    """register_routes() injects the LINE webhook + health endpoints
+    on a caller-owned aiohttp app — used by tests and reusable for
+    future shared-app integration."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    app = web.Application()
+    adapter.register_routes(app)
+    routes = [r.resource.canonical for r in app.router.routes()]
+    assert "/line/webhook" in routes
+    assert "/line/webhook/health" in routes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind, allow_env, free_env, allow_id, free_id",
+    [
+        ("groups", "LINE_ALLOWED_GROUPS", "LINE_FREE_RESPONSE_GROUPS", "Callowed", "Cunreachable"),
+        ("rooms", "LINE_ALLOWED_ROOMS", "LINE_FREE_RESPONSE_ROOMS", "Rallowed", "Runreachable"),
+    ],
+    ids=["groups", "rooms"],
+)
+async def test_connect_warns_unreachable_free_response(
+    kind, allow_env, free_env, allow_id, free_id, caplog, monkeypatch, line_lock_noop
+):
+    """Operator footgun: free_response_<kind> contains an ID missing from
+    allowed_<kind> → allowlist drops the message before free-response fires.
+    connect() must log a WARNING so operators catch the misconfiguration."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv(allow_env, allow_id)
+    monkeypatch.setenv(free_env, f"{free_id},{allow_id}")
+    monkeypatch.setenv("LINE_WEBHOOK_PORT", "0")
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    try:
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.line"):
+            await adapter.connect()
+    finally:
+        await adapter.disconnect()
+    expected_setting = f"free_response_{kind}"
+    assert any(
+        free_id in r.message and expected_setting in r.message
+        for r in caplog.records
+    )

--- a/tests/gateway/test_line_send_message.py
+++ b/tests/gateway/test_line_send_message.py
@@ -1,0 +1,194 @@
+"""Tests for LINE send_message tool routing."""
+from tests.gateway.conftest import make_line_platform_config
+import json
+
+import pytest
+import respx
+from httpx import Response
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_line_posts_to_push_api():
+    """_send_line() must POST to LINE Push API with correct headers."""
+    from tools.send_message_tool import _send_line
+
+    route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+
+    class _FakePConfig:
+        token = "test-token"
+
+    result = await _send_line(_FakePConfig(), "U123456789", "hello from cron")
+    assert route.called
+    body = json.loads(route.calls.last.request.content)
+    assert body["to"] == "U123456789"
+    assert body["messages"][0]["text"] == "hello from cron"
+    assert route.calls.last.request.headers["Authorization"] == "Bearer test-token"
+    assert result.get("success") is True
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_line_returns_error_without_token():
+    """_send_line() must return an error dict when no token is configured."""
+    from tools.send_message_tool import _send_line
+
+    class _NullConfig:
+        token = ""
+
+    result = await _send_line(_NullConfig(), "U123", "hi")
+    assert "error" in result
+    assert "LINE" in result["error"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_adapter_send_image_https_url():
+    """send_image() with HTTPS URL sends an image message via Push API."""
+    from gateway.platforms.line import LineAdapter
+    from gateway.platforms.base import SendResult
+
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "tok"
+    os.environ["LINE_CHANNEL_SECRET"] = "sec"
+    os.environ["LINE_ALLOWED_USERS"] = "U1"
+    adapter = LineAdapter(make_line_platform_config(token="tok"))
+
+    route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+
+    result = await adapter.send_image("U1", "https://example.com/img.png", caption="hi")
+    assert isinstance(result, SendResult)
+    assert result.success
+    body = json.loads(route.calls.last.request.content)
+    assert body["to"] == "U1"
+    assert body["messages"][0]["type"] == "image"
+    assert body["messages"][0]["originalContentUrl"] == "https://example.com/img.png"
+    # Caption arrives as a second text message
+    assert body["messages"][1]["type"] == "text"
+    assert body["messages"][1]["text"] == "hi"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_adapter_send_image_http_url_falls_back_to_text():
+    """send_image() with non-HTTPS URL degrades to a Push API text message."""
+    from gateway.platforms.line import LineAdapter
+    from gateway.platforms.base import SendResult
+
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "tok"
+    os.environ["LINE_CHANNEL_SECRET"] = "sec"
+    os.environ["LINE_ALLOWED_USERS"] = "U1"
+    adapter = LineAdapter(make_line_platform_config(token="tok"))
+
+    route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+
+    result = await adapter.send_image("U1", "http://example.com/img.png")
+    assert isinstance(result, SendResult)
+    assert result.success
+    body = json.loads(route.calls.last.request.content)
+    # Non-HTTPS → text fallback, not image message
+    assert body["messages"][0]["type"] == "text"
+    assert "http://example.com/img.png" in body["messages"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_send_image_file_returns_unsupported():
+    """send_image_file() returns a non-fatal error — LINE has no local file upload."""
+    from gateway.platforms.line import LineAdapter
+    from gateway.platforms.base import SendResult
+
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "tok"
+    os.environ["LINE_CHANNEL_SECRET"] = "sec"
+    os.environ["LINE_ALLOWED_USERS"] = ""
+    adapter = LineAdapter(make_line_platform_config(token="tok"))
+    result = await adapter.send_image_file("U1", "/tmp/img.png", caption="cap")
+    assert isinstance(result, SendResult)
+    assert not result.success
+    assert result.error and "HTTPS" in result.error
+
+
+def test_build_reply_messages_extracts_markdown_image():
+    """Agent output with ![alt](url) must yield a native LINE image message,
+    not raw text. Regression guard: previously
+    self._chunk_text(answer) sent the raw markdown to LINE which displayed
+    it as text instead of an image bubble."""
+    from gateway.platforms.line import LineAdapter
+
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "t"
+    os.environ["LINE_CHANNEL_SECRET"] = "s"
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    msgs = adapter._build_reply_messages(
+        "Here is the chart:\n![chart](https://example.com/chart.png)\nDone."
+    )
+    image_msgs = [m for m in msgs if m.get("type") == "image"]
+    text_msgs = [m for m in msgs if m.get("type") == "text"]
+    assert len(image_msgs) == 1
+    assert image_msgs[0]["originalContentUrl"] == "https://example.com/chart.png"
+    assert any("chart" in m.get("text", "") and "https://example.com" not in m.get("text", "")
+               for m in text_msgs)
+
+
+def test_build_reply_messages_caps_at_5_total():
+    """LINE rejects > 5 messages per Reply/Push call. The builder must
+    keep the total at or below 5 even when an agent dumps many images."""
+    from gateway.platforms.line import LineAdapter
+
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "t"
+    os.environ["LINE_CHANNEL_SECRET"] = "s"
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    text = "\n".join(f"![img{i}](https://example.com/img{i}.png)" for i in range(10))
+    text += "\nFinal text after all images."
+    msgs = adapter._build_reply_messages(text)
+    assert len(msgs) <= 5
+
+
+def test_build_reply_messages_falls_back_to_text_for_non_https():
+    """LINE rejects non-HTTPS image URLs — those should stay in the cleaned
+    text rather than producing an image message LINE will reject."""
+    from gateway.platforms.line import LineAdapter
+
+    import os
+    os.environ["LINE_CHANNEL_ACCESS_TOKEN"] = "t"
+    os.environ["LINE_CHANNEL_SECRET"] = "s"
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    msgs = adapter._build_reply_messages(
+        "![local](http://localhost/img.png)\nResponse text."
+    )
+    image_msgs = [m for m in msgs if m.get("type") == "image"]
+    assert len(image_msgs) == 0
+    # Cleaned text still goes through (markdown extracted but no image
+    # message emitted because URL was non-HTTPS).
+    assert any(m.get("type") == "text" for m in msgs)
+
+
+def test_parse_target_ref_recognizes_line_chat_id_prefixes():
+    """`send_message(target="line:U1234...")` etc. must be parsed as an
+    explicit chat_id, not handed to the channel-name resolver."""
+    from tools.send_message_tool import _parse_target_ref
+
+    chat_id, thread_id, is_explicit = _parse_target_ref("line", "U1234567890abcdef1234567890abcdef")
+    assert chat_id == "U1234567890abcdef1234567890abcdef"
+    assert thread_id is None
+    assert is_explicit is True
+
+    chat_id, _, is_explicit = _parse_target_ref("line", "Cabcdef0123456789abcdef0123456789")
+    assert chat_id == "Cabcdef0123456789abcdef0123456789"
+    assert is_explicit is True
+
+    chat_id, _, is_explicit = _parse_target_ref("line", "Rabcdef0123456789abcdef0123456789")
+    assert chat_id == "Rabcdef0123456789abcdef0123456789"
+    assert is_explicit is True
+
+    # Non-LINE-prefixed strings fall through to channel-name resolution
+    chat_id, _, is_explicit = _parse_target_ref("line", "team-channel-name")
+    assert is_explicit is False

--- a/tests/gateway/test_line_send_routing.py
+++ b/tests/gateway/test_line_send_routing.py
@@ -1,0 +1,330 @@
+"""LineAdapter send() routing + _keep_typing slow-LLM Quick Reply tests:
+
+- ``send()`` smart routing (Reply API when token valid, Push fallback)
+- ``send()`` pending-button cache (slow-LLM Quick Reply outcome)
+- ``_keep_typing`` override (loading indicator + Quick Reply at threshold)
+"""
+import asyncio
+import json
+import time
+
+import pytest
+import respx
+from httpx import Response
+
+from gateway.platforms.line import LineAdapter, State
+from tests.gateway.conftest import make_line_platform_config
+
+
+def _adapter(monkeypatch, threshold: float = 45.0):
+    """Build a LineAdapter for routing/keep-typing tests. Uses monkeypatch
+    so env vars auto-restore (avoids cross-test pollution under xdist)."""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_ALLOWED_USERS", "U1")
+    monkeypatch.setenv("LINE_SLOW_RESPONSE_THRESHOLD", str(threshold))
+    return LineAdapter(make_line_platform_config(token="t"))
+
+
+# ---------------------------------------------------------------------------
+# send() routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_uses_reply_api_when_token_valid(monkeypatch):
+    """A cached, fresh reply_token must be consumed via the Reply API,
+    avoiding Push API charges entirely."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    adapter._reply_tokens["U1"] = ("rt-fresh", time.time() + 30)
+    result = await adapter.send("U1", "hello")
+    assert result.success is True
+    assert reply_route.called
+    assert not push_route.called
+    # Reply token is single-use — must be consumed after success.
+    assert "U1" not in adapter._reply_tokens
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_falls_back_to_push_when_token_expired(monkeypatch):
+    """An expired reply_token must trigger Push API fallback so cron and
+    operator-initiated deliveries still reach the user."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    # Expired token (1s ago)
+    adapter._reply_tokens["U1"] = ("rt-stale", time.time() - 1)
+    result = await adapter.send("U1", "hello")
+    assert result.success is True
+    assert not reply_route.called
+    assert push_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_falls_back_to_push_when_no_reply_token(monkeypatch):
+    """No reply_token in cache (e.g. cron delivery) → Push API."""
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    result = await adapter.send("U_CRON_TARGET", "Cronjob Response: ...")
+    assert result.success is True
+    assert push_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_falls_back_to_push_when_reply_api_raises(monkeypatch):
+    """If Reply API returns non-2xx (e.g. token already consumed by
+    a race), send() must fall back to Push so the user still gets the
+    message instead of a silent loss."""
+    respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(400, json={"message": "Invalid reply token"})
+    )
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    adapter._reply_tokens["U1"] = ("rt-bad", time.time() + 30)
+    result = await adapter.send("U1", "hello")
+    assert result.success is True
+    assert push_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_with_pending_button_caches_response_instead_of_push(monkeypatch):
+    """When _keep_typing has already sent a slow-LLM Quick Reply button,
+    send() must cache the response under the button's request_id (READY)
+    and NOT invoke Push API — the user will fetch via postback tap."""
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    # Simulate _keep_typing having just sent a Quick Reply button.
+    request_id = adapter._cache.register_pending()
+    adapter._pending_buttons["U1"] = request_id
+
+    result = await adapter.send("U1", "the slow answer")
+    assert result.success is True
+    assert result.message_id == request_id
+    assert not push_route.called
+    entry = adapter._cache.get(request_id)
+    assert entry.state is State.READY
+    assert entry.payload == "the slow answer"
+    # Pending button slot is freed once cached so a second turn doesn't
+    # accidentally inherit it.
+    assert "U1" not in adapter._pending_buttons
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_does_not_cache_system_messages_into_pending_button(monkeypatch):
+    """System messages from base/run.py (interrupt-ack, queue-ack, steer-ack)
+    must NOT consume the pending-button slot — otherwise the orphan button
+    would resolve to the wrong content and the user would never see the
+    system message as a visible bubble.
+
+    Regression for the cache-corruption bug observed during interrupt:
+    busy-ack ('⚡ Interrupting current task...') was being silently swallowed
+    into the pending-button cache, leaving the user with no feedback."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    # Simulate _keep_typing having armed a button.
+    request_id = adapter._cache.register_pending()
+    adapter._pending_buttons["U1"] = request_id
+    # AND a fresh reply_token from the interrupting message's webhook.
+    adapter._reply_tokens["U1"] = ("rt-new", time.time() + 30)
+
+    result = await adapter.send(
+        "U1", "⚡ Interrupting current task. I'll respond shortly."
+    )
+
+    assert result.success is True
+    # Routed via Reply API (the interrupting message's fresh token), NOT
+    # cached into the orphan slot.
+    assert reply_route.called
+    assert not push_route.called
+    # Cache entry untouched — still PENDING, waiting for the actual agent
+    # response (or the orphan-cleanup in _keep_typing's finally block).
+    entry = adapter._cache.get(request_id)
+    assert entry.state is State.PENDING
+    # Pending-button slot also untouched.
+    assert adapter._pending_buttons["U1"] == request_id
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_send_extracts_markdown_image_to_native_bubble(monkeypatch):
+    """Reply API delivery must extract ``![alt](https://...)`` markdown
+    into a native LINE image message instead of sending raw text — same
+    as v1's _build_reply_messages behavior."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch)
+    adapter._reply_tokens["U1"] = ("rt-fresh", time.time() + 30)
+    await adapter.send(
+        "U1",
+        "Here is the chart:\n![chart](https://example.com/chart.png)\nDone.",
+    )
+    sent = json.loads(reply_route.calls.last.request.content)
+    image_msgs = [m for m in sent["messages"] if m.get("type") == "image"]
+    assert len(image_msgs) == 1
+    assert image_msgs[0]["originalContentUrl"] == "https://example.com/chart.png"
+
+
+# ---------------------------------------------------------------------------
+# _keep_typing override — slow-LLM Quick Reply
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_keep_typing_returns_quickly_when_agent_finishes_under_threshold(monkeypatch):
+    """If stop_event fires before the slow-response threshold elapses,
+    _keep_typing must NOT send a Quick Reply button — the response will
+    be auto-delivered via reply_token in the normal send() path."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    loading_route = respx.post("https://api.line.me/v2/bot/chat/loading/start").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch, threshold=10.0)
+    adapter._reply_tokens["U1"] = ("rt-fresh", time.time() + 30)
+
+    stop_event = asyncio.Event()
+    # Signal "agent finished" almost immediately.
+    asyncio.get_event_loop().call_soon(stop_event.set)
+
+    await adapter._keep_typing("U1", stop_event=stop_event)
+
+    # No Quick Reply button sent — token still cached for send() to use.
+    assert not reply_route.called
+    assert "U1" in adapter._reply_tokens
+    assert "U1" not in adapter._pending_buttons
+    # Loading indicator was triggered (DM only).
+    assert loading_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_keep_typing_sends_quick_reply_button_when_threshold_elapses(monkeypatch):
+    """At the threshold mark with the agent still running, _keep_typing
+    must consume the cached reply_token to send a Quick Reply postback
+    button, register the pending-button slot, and free the reply_token."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    respx.post("https://api.line.me/v2/bot/chat/loading/start").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch, threshold=0.05)  # 50ms threshold for fast test
+    adapter._reply_tokens["U1"] = ("rt-fresh", time.time() + 30)
+
+    stop_event = asyncio.Event()  # never set — simulates LLM still running
+
+    async def _keep_typing_in_background():
+        await adapter._keep_typing("U1", stop_event=stop_event)
+
+    keep_task = asyncio.create_task(_keep_typing_in_background())
+    # Poll respx until the postback button POST lands (or timeout).
+    # Standard pattern in other adapter tests for awaiting async-spawned
+    # side effects.
+    deadline = time.time() + 2.0
+    while not reply_route.called and time.time() < deadline:
+        await asyncio.sleep(0.02)
+
+    stop_event.set()
+    await keep_task
+
+    # Button POST landed with the right shape.
+    assert reply_route.called
+    sent = json.loads(reply_route.calls.last.request.content)
+    # Template Buttons message — persistent postback (not Quick Reply chip).
+    template_msg = sent["messages"][0]
+    assert template_msg["type"] == "template"
+    action = template_msg["template"]["actions"][0]
+    payload = json.loads(action["data"])
+    assert payload["action"] == "show_response"
+    request_id = payload["request_id"]
+    # Reply token consumed by the button.
+    assert "U1" not in adapter._reply_tokens
+
+    # _keep_typing finished without a send() — orphan cleanup transitioned
+    # the cache PENDING → ERROR (with interrupted-text) and popped the
+    # pending-button slot. Tapping the persistent button later will surface
+    # the interrupted message instead of looping in "still thinking".
+    assert "U1" not in adapter._pending_buttons
+    entry = adapter._cache.get(request_id)
+    assert entry is not None
+    assert entry.state is State.ERROR
+    assert "interrupted" in entry.payload.lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_keep_typing_no_token_no_button(monkeypatch):
+    """If no reply_token is cached for the chat (e.g. cron-triggered run),
+    _keep_typing must NOT send a Quick Reply button — there's nothing
+    to send it on, and Push API would defeat the purpose."""
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    respx.post("https://api.line.me/v2/bot/chat/loading/start").mock(
+        return_value=Response(200, json={})
+    )
+    adapter = _adapter(monkeypatch, threshold=0.05)
+    # No reply_token registered — simulates cron path or stale chat.
+    stop_event = asyncio.Event()  # never set
+
+    async def runner():
+        await adapter._keep_typing("U_NO_TOKEN", stop_event=stop_event)
+
+    task = asyncio.create_task(runner())
+    await asyncio.sleep(0.15)  # past threshold
+    stop_event.set()
+    await task
+    assert not reply_route.called
+    assert "U_NO_TOKEN" not in adapter._pending_buttons
+
+
+# ---------------------------------------------------------------------------
+# Outbound-only mode (no LINE_CHANNEL_SECRET)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_outbound_only_mode_can_push_with_no_secret(monkeypatch):
+    """LINE_CHANNEL_ACCESS_TOKEN alone (no secret) must allow Push API
+    deliveries — needed for setups that send notifications but don't
+    receive webhooks (cron-only, broadcast bots, etc.)."""
+    push_route = respx.post("https://api.line.me/v2/bot/message/push").mock(
+        return_value=Response(200, json={})
+    )
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+    result = await adapter.send("U_HOME", "scheduled notice")
+    assert result.success is True
+    assert push_route.called

--- a/tests/gateway/test_line_slow_llm_e2e.py
+++ b/tests/gateway/test_line_slow_llm_e2e.py
@@ -1,0 +1,124 @@
+"""End-to-end integration test for the slow-LLM postback flow.
+
+Drives `_dispatch_event → handle_message → _keep_typing → send → cache →
+_handle_postback` as a single sequence, with the LLM stubbed via a slow
+``_message_handler`` and the LINE API mocked via respx. Catches wiring gaps
+between BasePlatformAdapter and the LineAdapter overrides — the kind of
+production-only race that unit tests with hand-injected ``stop_event`` miss.
+"""
+import asyncio
+import json
+import time
+
+import pytest
+import respx
+from httpx import Response
+
+from gateway.platforms.line import LineAdapter, State
+from tests.gateway.conftest import make_line_platform_config
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_slow_llm_postback_full_round_trip(monkeypatch):
+    """Full slow-LLM round trip without manually injecting any internals.
+
+    Sequence simulated:
+      1. Webhook delivers an inbound message → _dispatch_event runs.
+      2. base.handle_message spawns _keep_typing (real) AND a slow stubbed
+         message handler (~0.3s) to force the threshold (0.1s) to elapse.
+      3. _keep_typing sends the postback button via Reply API (mocked) and
+         arms _pending_buttons.
+      4. Slow handler returns its response → base calls send() → cached as
+         READY under the button's request_id.
+      5. Postback webhook (the user "tap") delivers the cached response via
+         a fresh reply_token (mocked).
+
+    Asserts every observable boundary: button POST shape, cache transitions,
+    pending-button slot freed, postback delivery payload.
+    """
+    reply_route = respx.post("https://api.line.me/v2/bot/message/reply").mock(
+        return_value=Response(200, json={})
+    )
+    respx.post("https://api.line.me/v2/bot/chat/loading/start").mock(
+        return_value=Response(200, json={})
+    )
+
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_ALLOWED_USERS", "U_e2e")
+    monkeypatch.setenv("LINE_SLOW_RESPONSE_THRESHOLD", "0.1")
+    adapter = LineAdapter(make_line_platform_config(token="t"))
+
+    final_response = "the final agent answer (cached for postback retrieval)"
+
+    async def slow_handler(event):
+        # Long enough to force threshold elapse (0.1s) so the button arms.
+        await asyncio.sleep(0.4)
+        return final_response
+
+    adapter._message_handler = slow_handler
+
+    inbound_event = {
+        "type": "message",
+        "replyToken": "rt-original",
+        "source": {"type": "user", "userId": "U_e2e"},
+        "timestamp": int(time.time() * 1000),
+        "message": {"id": "m-1", "type": "text", "text": "slow prompt"},
+    }
+    # Drive the dispatch path. handle_message spawns _process_message_background
+    # as a fire-and-forget task; await it explicitly so the slow handler +
+    # _keep_typing + send() fully unwind before we assert.
+    await adapter._dispatch_event(inbound_event)
+    background_tasks = list(adapter._session_tasks.values())
+    assert background_tasks, "handle_message should have spawned a background task"
+    await asyncio.gather(*background_tasks, return_exceptions=True)
+
+    # Button POST landed with Template Buttons + show_response postback.
+    assert reply_route.called
+    button_call = next(
+        c for c in reply_route.calls
+        if json.loads(c.request.content)["replyToken"] == "rt-original"
+    )
+    button_body = json.loads(button_call.request.content)
+    template_msg = button_body["messages"][0]
+    assert template_msg["type"] == "template"
+    assert template_msg["template"]["type"] == "buttons"
+    action = template_msg["template"]["actions"][0]
+    payload = json.loads(action["data"])
+    assert payload["action"] == "show_response"
+    request_id = payload["request_id"]
+
+    # send() (called by base after the slow handler returned) cached the
+    # final response READY under the button's request_id and freed the slot.
+    entry = adapter._cache.get(request_id)
+    assert entry is not None
+    assert entry.state is State.READY
+    assert entry.payload == final_response
+    assert "U_e2e" not in adapter._pending_buttons
+
+    # Now simulate the user tapping the button.
+    postback_event = {
+        "type": "postback",
+        "replyToken": "rt-postback-fresh",
+        "source": {"type": "user", "userId": "U_e2e"},
+        "timestamp": int(time.time() * 1000),
+        "postback": {"data": json.dumps({"action": "show_response", "request_id": request_id})},
+    }
+    await adapter._dispatch_event(postback_event)
+
+    # Postback delivered the cached payload via the fresh reply_token.
+    postback_call = next(
+        c for c in reply_route.calls
+        if json.loads(c.request.content)["replyToken"] == "rt-postback-fresh"
+    )
+    postback_body = json.loads(postback_call.request.content)
+    delivered_text = postback_body["messages"][0]["text"]
+    assert delivered_text == final_response
+
+    # Cache transitioned READY → DELIVERED (so a duplicate tap surfaces
+    # "already replied" instead of re-delivering).
+    entry = adapter._cache.get(request_id)
+    assert entry.state is State.DELIVERED
+
+    await adapter.disconnect()

--- a/tests/gateway/test_line_webhook.py
+++ b/tests/gateway/test_line_webhook.py
@@ -1,0 +1,62 @@
+"""Tests for LINE webhook signature verification and payload parsing."""
+import json
+
+import pytest
+
+from gateway.platforms.line import verify_signature, parse_events
+from tests.gateway.conftest import line_sign as _sign
+
+
+@pytest.mark.parametrize(
+    "body, signed, secret, expected",
+    [
+        # Valid signature on a normal payload.
+        (b'{"events":[]}', True, "test_secret", True),
+        # Valid signature on empty body — boundary case.
+        (b"", True, "test_secret", True),
+        # Invalid signature — must be rejected.
+        (b'{"events":[]}', False, "test_secret", False),
+        # Empty signature on empty body — must be rejected.
+        (b"", False, "test_secret", False),
+        # Outbound-only mode (LINE_CHANNEL_SECRET unset) — every inbound
+        # rejected so the gateway can't accept un-verifiable traffic.
+        (b'{"events": []}', False, "", False),
+    ],
+    ids=["valid", "valid_empty_body", "invalid_sig", "empty_sig_empty_body", "outbound_only_no_secret"],
+)
+def test_verify_signature_edge_cases(body, signed, secret, expected):
+    sig = _sign(secret, body) if signed and secret else "not-the-real-signature" if not signed else "any-sig"
+    assert verify_signature(body, sig, secret) is expected
+
+
+def test_parse_events_returns_empty_for_no_events():
+    body = json.dumps({"destination": "U1", "events": []}).encode()
+    assert parse_events(body) == []
+
+
+def test_parse_events_extracts_message_event():
+    payload = {
+        "destination": "U1",
+        "events": [
+            {
+                "type": "message",
+                "replyToken": "rt-1",
+                "source": {"type": "user", "userId": "Uabc"},
+                "timestamp": 1234567890,
+                "message": {"id": "m1", "type": "text", "text": "hi"},
+            }
+        ],
+    }
+    body = json.dumps(payload).encode()
+    events = parse_events(body)
+    assert len(events) == 1
+    assert events[0]["type"] == "message"
+    assert events[0]["source"]["userId"] == "Uabc"
+
+
+def test_parse_events_returns_empty_for_malformed_json():
+    assert parse_events(b"not json") == []
+
+
+def test_parse_events_returns_empty_for_non_dict_payload():
+    assert parse_events(b"[1,2,3]") == []

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -500,7 +500,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering', 'sms:+15551234567'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
+                "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering', 'line:U1234567890abcdef', 'sms:+15551234567'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
             },
             "skills": {
                 "type": "array",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -132,7 +132,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'line:U1234567890abcdef', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -347,6 +347,12 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit
     if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
         return target_ref, None, True
+    # LINE chat IDs are prefix-distinguished: U=DM, C=group, R=room. Treat
+    # any target starting with one of these prefixes as an explicit chat_id
+    # so `send_message(target="line:U1234...")` bypasses the channel-name
+    # lookup that would otherwise reject it (codex review #6 P1).
+    if platform_name == "line" and target_ref[:1] in ("U", "C", "R"):
+        return target_ref, None, True
     return None, None, False
 
 
@@ -462,6 +468,13 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     except ImportError:
         _feishu_available = False
 
+    # LINE adapter import is optional (requires httpx + aiohttp — both core deps)
+    try:
+        from gateway.platforms.line import LineAdapter as _LineAdapter
+        _line_available = True
+    except ImportError:
+        _line_available = False
+
     media_files = media_files or []
 
     if platform == Platform.SLACK and message:
@@ -479,6 +492,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     }
     if _feishu_available:
         _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH
+    if _line_available:
+        _MAX_LENGTHS[Platform.LINE] = _LineAdapter.MAX_MESSAGE_LENGTH
 
     # Check plugin registry for max_message_length
     if platform not in _MAX_LENGTHS:
@@ -633,6 +648,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_qqbot(pconfig, chat_id, chunk)
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
+        elif platform == Platform.LINE:
+            result = await _send_line(pconfig, chat_id, chunk)
         else:
             # Plugin platform — route through the gateway's live adapter
             # if available, otherwise report the error.
@@ -1633,6 +1650,49 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
         }
     except Exception as e:
         return _error(f"Feishu send failed: {e}")
+
+
+async def _send_line(pconfig, chat_id, message):
+    """Send a message to a LINE user/group via Push API.
+
+    Uses Push API (not Reply API) because send_message/cron runs outside
+    a webhook handler and has no reply token. Push API costs a message
+    credit on LINE's paid plan.
+
+    Requires LINE_CHANNEL_ACCESS_TOKEN in pconfig.token.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return _error("LINE send requires httpx. Run: pip install httpx")
+
+    token = pconfig.token or ""
+    if not token:
+        return _error("LINE: LINE_CHANNEL_ACCESS_TOKEN not configured.")
+
+    # Reuse adapter's media-extracting builder so cron/send_message bodies
+    # with Markdown image URLs render as native LINE image bubbles instead
+    # of raw text (codex review #4 P2). Falls back to plain chunking when
+    # no images are present.
+    from gateway.platforms.line import LINE_PUSH_URL, LineAdapter as _LineAdapter
+    messages = _LineAdapter._build_reply_messages(message)
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                LINE_PUSH_URL,
+                json={"to": chat_id, "messages": messages},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            resp.raise_for_status()
+            return {"success": True, "platform": "line", "chat_id": chat_id}
+    except Exception as exc:
+        scrubbed = _sanitize_error_text(str(exc))
+        logger.warning("line: push send failed chat_id=%s: %s", chat_id, scrubbed)
+        return _error(f"LINE push failed: {scrubbed}")
 
 
 def _check_send_message():

--- a/toolsets.py
+++ b/toolsets.py
@@ -369,7 +369,13 @@ TOOLSETS = {
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },
-    
+
+    "hermes-line": {
+        "description": "LINE bot toolset - full access for personal use (terminal has safety checks)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-discord": {
         "description": "Discord bot toolset - full access (terminal has safety checks via dangerous command approval)",
         "tools": _HERMES_CORE_TOOLS + [
@@ -497,7 +503,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-line", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
     }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-17T16:49:45.944715922Z"
+exclude-newer = "2026-04-24T00:04:46.511909Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -154,6 +154,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
+]
+
+[[package]]
+name = "aiohttp-socks"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "python-socks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
 ]
 
 [[package]]
@@ -1760,6 +1773,77 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.194.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/ab/e83af0eb043e4ccc49571ca7a6a49984e9d00f4e9e6e6f1238d60bc84dce/google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023", size = 14443469, upload-time = "2026-04-08T23:07:35.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/34/5a624e49f179aa5b0cb87b2ce8093960299030ff40423bfbde09360eb908/google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717", size = 15016514, upload-time = "2026-04-08T23:07:33.093Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1870,10 +1954,11 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "croniter" },
     { name = "edge-tts" },
     { name = "exa-py" },
     { name = "fal-client" },
@@ -1900,11 +1985,11 @@ acp = [
 all = [
     { name = "agent-client-protocol" },
     { name = "aiohttp" },
+    { name = "aiohttp-socks", marker = "sys_platform == 'linux'" },
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
     { name = "alibabacloud-dingtalk" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
     { name = "boto3" },
-    { name = "croniter" },
     { name = "daytona" },
     { name = "debugpy" },
     { name = "dingtalk-stream" },
@@ -1912,6 +1997,9 @@ all = [
     { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "faster-whisper" },
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
     { name = "markdown", marker = "sys_platform == 'linux'" },
@@ -1922,11 +2010,13 @@ all = [
     { name = "numpy" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "pytest" },
+    { name = "pytest-aiohttp" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "qrcode" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "simple-term-menu" },
     { name = "slack-bolt" },
@@ -1942,9 +2032,6 @@ bedrock = [
 cli = [
     { name = "simple-term-menu" },
 ]
-cron = [
-    { name = "croniter" },
-]
 daytona = [
     { name = "daytona" },
 ]
@@ -1952,8 +2039,10 @@ dev = [
     { name = "debugpy" },
     { name = "mcp" },
     { name = "pytest" },
+    { name = "pytest-aiohttp" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1966,6 +2055,11 @@ feishu = [
     { name = "lark-oapi" },
     { name = "qrcode" },
 ]
+google = [
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
+]
 homeassistant = [
     { name = "aiohttp" },
 ]
@@ -1973,6 +2067,7 @@ honcho = [
     { name = "honcho-ai" },
 ]
 matrix = [
+    { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "markdown" },
@@ -2015,7 +2110,6 @@ sms = [
 ]
 termux = [
     { name = "agent-client-protocol" },
-    { name = "croniter" },
     { name = "honcho-ai" },
     { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
@@ -2048,13 +2142,14 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = ">=3.9.0,<4" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = ">=3.13.3,<4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = ">=3.9.0,<4" },
+    { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = ">=0.10,<1" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = ">=0.20" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = ">=2.0.0" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = ">=0.29" },
     { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
-    { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
+    { name = "croniter", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
     { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = ">=0.20,<1" },
@@ -2068,6 +2163,9 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
+    { name = "google-api-python-client", marker = "extra == 'google'", specifier = ">=2.100,<3" },
+    { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = ">=0.2,<1" },
+    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.0,<2" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
@@ -2079,6 +2177,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["dev"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["dingtalk"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["google"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
@@ -2114,6 +2213,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2,<10" },
+    { name = "pytest-aiohttp", marker = "extra == 'dev'", specifier = ">=1.1.0,<2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
@@ -2125,6 +2225,7 @@ requires-dist = [
     { name = "qrcode", marker = "extra == 'feishu'", specifier = ">=7.0,<8" },
     { name = "qrcode", marker = "extra == 'messaging'", specifier = ">=7.0,<8" },
     { name = "requests", specifier = ">=2.33.0,<3" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21,<1" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
@@ -2142,7 +2243,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "vercel", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "vercel", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "google", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2242,6 +2343,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -3284,6 +3397,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "obstore"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3862,6 +3984,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3933,6 +4067,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -4203,6 +4358,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-aiohttp"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4b/d326890c153f2c4ce1bf45d07683c08c10a1766058a22934620bc6ac6592/pytest_aiohttp-1.1.0.tar.gz", hash = "sha256:147de8cb164f3fc9d7196967f109ab3c0b93ea3463ab50631e56438eab7b5adc", size = 12842, upload-time = "2025-01-23T12:44:04.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/0f/e6af71c02e0f1098eaf7d2dbf3ffdf0a69fc1e0ef174f96af05cef161f1b/pytest_aiohttp-1.1.0-py3-none-any.whl", hash = "sha256:f39a11693a0dce08dd6c542d241e199dd8047a6e6596b2bcfa60d373f143456d", size = 8932, upload-time = "2025-01-23T12:44:03.27Z" },
+]
+
+[[package]]
 name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4273,6 +4442,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/56/652349f97dc2ce6d1aed43481d179c775f565e68796517836406fb7794c7/python_olm-3.2.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16bbb209d43d62135450696526ed0a811150e9de9df32ed91542bf9434e79030", size = 293671, upload-time = "2023-11-28T19:25:21.525Z" },
     { url = "https://files.pythonhosted.org/packages/39/ee/1e15304ac67d3a7ebecbcac417d6479abb7186aad73c6a035647938eaa8e/python_olm-3.2.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45e76b3f5060a5cf8451140d6c7e3b438f972ff432b6f39d0ca2c7f2296509bb", size = 301030, upload-time = "2023-11-28T19:25:26.634Z" },
     { url = "https://files.pythonhosted.org/packages/79/93/f6729f10149305262194774d6c8b438c0b084740cf239f48ab97b4df02fa/python_olm-3.2.16-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10a5e68a2f4b5a2bfa5fdb5dbfa22396a551730df6c4a572235acaa96e997d3f", size = 297000, upload-time = "2023-11-28T19:25:31.045Z" },
+]
+
+[[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
 ]
 
 [[package]]
@@ -4536,6 +4714,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4545,6 +4736,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]
@@ -5275,6 +5478,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5347,7 +5559,7 @@ wheels = [
 
 [[package]]
 name = "vercel"
-version = "0.5.7"
+version = "0.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -5358,14 +5570,14 @@ dependencies = [
     { name = "vercel-workers", marker = "python_full_version >= '3.12'" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/68/a671ebc656afbb5e25fb88c681b61511cc13670ea771c87b2f711782022b/vercel-0.5.7.tar.gz", hash = "sha256:8070ea1b33962adfed98498f9273f24ea2066a20c74d38643d479d8280801c6e", size = 118597, upload-time = "2026-04-15T17:58:20.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/e8/59c0373534fec6863699a39bc3abd0e1e50824f982da4adbf33103eb69dd/vercel-0.5.8.tar.gz", hash = "sha256:ea5eaae26def728da908c25a0bfc5329f166d5919f4ae20a799ff421b0219693", size = 122292, upload-time = "2026-04-22T20:33:36.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/2e/bacf1ccc0ec95464a68398e64bf5e36f859cd51f3e379623f103802f85f1/vercel-0.5.7-py3-none-any.whl", hash = "sha256:90eb2689c34e403db2170fec3eb47e1a91092c200d91baf4b4501fb3e2a44d28", size = 139698, upload-time = "2026-04-15T17:58:18.945Z" },
+    { url = "https://files.pythonhosted.org/packages/88/12/15d1866b15343d3589139d26db71e3faddb3b288561f8217024b1e0efc84/vercel-0.5.8-py3-none-any.whl", hash = "sha256:2add201ef2e25fb35dbf9f71a9e6f5184901155ecd1ffad4e6e98d8c13927b62", size = 142455, upload-time = "2026-04-22T20:33:35.322Z" },
 ]
 
 [[package]]
 name = "vercel-workers"
-version = "0.0.16"
+version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.12'" },
@@ -5373,9 +5585,9 @@ dependencies = [
     { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
     { name = "vercel", marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/d8/17ba256fceff42be231ca8ff0567dcf2da54ee8de633e949fa08b9403b1f/vercel_workers-0.0.16.tar.gz", hash = "sha256:38df45dbf42fbae39ffa0e419f0908bf1beb047e38fc5ddd0a479feac340fb8c", size = 51615, upload-time = "2026-04-13T21:23:27.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/f0/afb62b021d50dec5334c89220f69df39b29092c657a459664ee6b079c1cf/vercel_workers-0.0.17.tar.gz", hash = "sha256:c9d39fc8f2860b1c304b42b7ef6351a12be9c9b41cc1c98269ac20b2645143be", size = 53109, upload-time = "2026-04-17T22:34:41.12Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/3a/0137d5b157845e1d41a70130d8dce8ba15d8712f34619693cda04ecb8f02/vercel_workers-0.0.16-py3-none-any.whl", hash = "sha256:542be839e46e236a68cc308695ccc3c970d76de72c978d7f416cc6ce09688896", size = 50141, upload-time = "2026-04-13T21:23:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bf/62e66b8f06f697f776afc90f2647cbea02ac180fb629043f5b63fc9f0b2e/vercel_workers-0.0.17-py3-none-any.whl", hash = "sha256:ee5da143bf67fda3857f3b3a46dcb6067564d488a643cb52b995c86c04bc4168", size = 51677, upload-time = "2026-04-17T22:34:42.16Z" },
 ]
 
 [[package]]

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -232,6 +232,26 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all`. Matches the Discord pattern. |
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
+| `LINE_CHANNEL_ACCESS_TOKEN` | LINE Messaging API channel access token (long-lived, from Developers Console) |
+| `LINE_CHANNEL_SECRET` | LINE channel secret used to verify webhook signatures (HMAC-SHA256) |
+| `LINE_ALLOWED_USERS` | Comma-separated `U`-prefixed LINE user IDs allowed to chat with the bot via DM |
+| `LINE_ALLOWED_GROUPS` | Comma-separated `C`-prefixed LINE group IDs allowed to use the bot |
+| `LINE_ALLOWED_ROOMS` | Comma-separated `R`-prefixed LINE room IDs allowed to use the bot |
+| `LINE_ALLOW_ALL_USERS` | Bypass all source allowlists — users, groups, AND rooms (NOT recommended for production; default: `false`) |
+| `LINE_HOME_CHANNEL` | Default LINE chat ID for cron delivery and notifications |
+| `LINE_HOME_CHANNEL_NAME` | Display name for the LINE home channel (default: `Home`) |
+| `LINE_WEBHOOK_PORT` | Local listen port for the LINE webhook server (default: `8646`) |
+| `LINE_REQUIRE_MENTION` | Require @mention in groups/rooms before responding (default: `false`) |
+| `LINE_BOT_DISPLAY_NAME` | Manual override for the bot's display name (auto-fetched from `/v2/bot/info` if empty) |
+| `LINE_FREE_RESPONSE_GROUPS` | Comma-separated group IDs that bypass the mention gate (must also be in `LINE_ALLOWED_GROUPS`) |
+| `LINE_FREE_RESPONSE_ROOMS` | Comma-separated room IDs that bypass the mention gate (must also be in `LINE_ALLOWED_ROOMS`) |
+| `LINE_SLOW_RESPONSE_THRESHOLD` | Seconds before showing the postback button when the LLM is slow (default: `45`) |
+| `LINE_CACHE_TTL` | Seconds to cache the LLM response for postback retrieval (default: `3600`) |
+| `LINE_PENDING_TEXT` | Text shown alongside the postback button while the response is pending |
+| `LINE_DELIVERED_TEXT` | Reply text when a user taps the button after the response was already delivered |
+| `LINE_EXPIRED_TEXT` | Reply text when the cached response has expired |
+| `LINE_INTERRUPTED_TEXT` | Reply text when the orphan postback button is tapped after the agent run was cancelled (e.g. via `/stop`) |
+| `LINE_BUTTON_LABEL` | Label on the postback button (default: `📋 Show response`) |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_ALLOWED_ROLES` | Comma-separated Discord role IDs allowed to use the bot (OR with `DISCORD_ALLOWED_USERS`). Auto-enables the Members intent. Useful when moderation teams churn — role grants propagate automatically. |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, LINE, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, LINE, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/docs/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/docs/guides/use-voice-mode-with-hermes).
 
@@ -15,6 +15,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | Platform | Voice | Images | Files | Threads | Reactions | Typing | Streaming |
 |----------|:-----:|:------:|:-----:|:-------:|:---------:|:------:|:---------:|
 | Telegram | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
+| LINE | — | URL only | URL only | — | — | DM only | — |
 | Discord | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
@@ -42,6 +43,7 @@ flowchart TB
     subgraph Gateway["Hermes Gateway"]
         subgraph Adapters["Platform adapters"]
             tg[Telegram]
+            ln[LINE]
             dc[Discord]
             wa[WhatsApp]
             sl[Slack]
@@ -69,6 +71,7 @@ flowchart TB
     end
 
     tg --> store
+    ln --> store
     dc --> store
     wa --> store
     sl --> store
@@ -179,6 +182,7 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 ```bash
 # Restrict to specific users (recommended):
 TELEGRAM_ALLOWED_USERS=123456789,987654321
+LINE_ALLOWED_USERS=U1234567890abcdef1234567890abcdef
 DISCORD_ALLOWED_USERS=123456789012345678
 SIGNAL_ALLOWED_USERS=+155****4567,+155****6543
 SMS_ALLOWED_USERS=+155****4567,+155****6543
@@ -373,6 +377,7 @@ Each platform has its own toolset:
 |----------|---------|--------------|
 | CLI | `hermes-cli` | Full access |
 | Telegram | `hermes-telegram` | Full tools including terminal |
+| LINE | `hermes-line` | Full tools including terminal (no local file uploads — LINE accepts media via HTTPS URL only) |
 | Discord | `hermes-discord` | Full tools including terminal |
 | WhatsApp | `hermes-whatsapp` | Full tools including terminal |
 | Slack | `hermes-slack` | Full tools including terminal |
@@ -396,6 +401,7 @@ Each platform has its own toolset:
 ## Next Steps
 
 - [Telegram Setup](telegram.md)
+- [LINE Setup](line.md)
 - [Discord Setup](discord.md)
 - [Slack Setup](slack.md)
 - [WhatsApp Setup](whatsapp.md)

--- a/website/docs/user-guide/messaging/line.md
+++ b/website/docs/user-guide/messaging/line.md
@@ -1,0 +1,362 @@
+---
+sidebar_position: 2
+title: "LINE"
+description: "Set up Hermes Agent as a LINE Messaging API bot"
+---
+
+# LINE Setup
+
+Hermes Agent integrates with [LINE](https://line.me/) as a full-featured Messaging API bot. Once connected, you can chat with your agent on iOS, Android, or desktop LINE clients, use it in groups and rooms, and receive scheduled task results. The integration uses LINE's official [Messaging API](https://developers.line.biz/en/services/messaging-api/) — webhook delivery, Reply API for free responses, and Push API for outbound messages.
+
+LINE has two API quirks the adapter handles transparently:
+
+- **Reply tokens are single-use and short-lived.** If the LLM takes longer than ~45 seconds, the reply token may expire before the answer is ready. The adapter automatically falls back to a persistent Template Buttons postback message — the user taps it to fetch the queued response, avoiding the cost of a Push API message.
+- **Group/room source types are distinct from user source.** LINE separates `user` (DM), `group` (multi-user chat with full IDs), and `room` (multi-user chat without IDs). The adapter uses three independent allowlists so you can grant access at any level.
+
+## Step 1: Create a LINE Official Account
+
+LINE bots run on top of an Official Account (formerly "LINE@"). Create one at [LINE Official Account Manager](https://manager.line.biz/):
+
+1. Sign in with your personal LINE account
+2. Click **Create** → fill in the account name, category, and region
+3. Accept the terms — your Official Account is provisioned immediately
+
+## Step 2: Provision a Messaging API Channel
+
+Open the [LINE Developers Console](https://developers.line.biz/console/) and do the following:
+
+1. Select (or create) a **Provider** — this is the legal entity owning the bot
+2. Inside the Provider, click **Create a Messaging API channel**
+3. Link the channel to the Official Account from Step 1
+4. Fill in the channel name, description, and icon
+
+Once the channel exists, you'll find two tabs you need:
+
+| Tab | What you need |
+|-----|--------------|
+| **Basic settings** | **Channel secret** (used to verify webhook signatures) and **Your user ID** (starts with `U`) |
+| **Messaging API** | **Channel access token** — click **Issue** to generate a long-lived token |
+
+:::warning
+Treat the **Channel access token** like a password. Anyone with it can send messages as your bot. If it leaks, click **Reissue** in the same tab — old tokens are revoked immediately.
+:::
+
+## Step 3: Disable LINE's Default Auto-Replies
+
+By default, every Messaging API channel ships with three auto-reply behaviors that interfere with bot operation. Disable all three:
+
+1. In the **Messaging API** tab of your channel, click **Edit** next to **LINE Official Account features**
+2. In the response settings page that opens, set:
+   - **Greeting message** → Disabled
+   - **Auto-reply** → Disabled
+   - **Webhook** → Enabled
+
+If you skip this, your bot will reply twice to every message — once from the auto-responder, once from Hermes.
+
+## Step 4: Find Your User ID
+
+Hermes uses LINE user IDs (which start with `U`) to control who can chat with the bot.
+
+1. Open the [LINE Developers Console](https://developers.line.biz/console/) → your channel → **Basic settings** tab
+2. Scroll down to find **Your user ID** — copy the value (it looks like `U1234567890abcdef1234567890abcdef`)
+
+This is the user ID of the LINE account you signed in with. Save it for the next step.
+
+:::tip
+To find another user's ID without console access, add the bot to a chat with them, send any message, and check the gateway logs for a `line: drop` entry containing the unrecognized user ID.
+:::
+
+## Step 5: Configure Hermes
+
+### Option A: Interactive Setup (Recommended)
+
+```bash
+hermes gateway setup
+```
+
+Select **LINE** when prompted. The wizard asks for your channel access token, channel secret, and allowed user IDs, then writes everything to `~/.hermes/.env`.
+
+### Option B: Manual Configuration
+
+Add the following to `~/.hermes/.env`:
+
+```bash
+LINE_CHANNEL_ACCESS_TOKEN=YOUR_LONG_LIVED_TOKEN
+LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
+LINE_ALLOWED_USERS=U1234567890abcdef1234567890abcdef    # comma-separated for multiple users
+```
+
+### Start the Gateway
+
+```bash
+hermes gateway
+```
+
+The gateway starts an HTTP listener on `LINE_WEBHOOK_PORT` (default `8646`). The next step is exposing it to LINE.
+
+## Step 6: Set the Webhook URL
+
+LINE pushes incoming events to a public HTTPS URL. The adapter exposes them at `/line/webhook`.
+
+### Local development with a tunnel
+
+For local testing, expose port 8646 with a tunneling service such as [ngrok](https://ngrok.com/) or [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/):
+
+```bash
+ngrok http 8646
+# copy the https://....ngrok-free.app URL
+```
+
+### Cloud deployment
+
+Use your platform's public HTTPS URL (Fly.io, Railway, Render, etc.). Make sure the inbound HTTPS port routes traffic to `LINE_WEBHOOK_PORT` inside the container.
+
+### Register the URL with LINE
+
+1. In the LINE Developers Console → your channel → **Messaging API** tab
+2. Set **Webhook URL** to `https://YOUR-PUBLIC-HOST/line/webhook`
+3. Click **Verify** — LINE sends a probe request and reports success/failure
+4. Toggle **Use webhook** ON
+
+If verification fails, check that:
+
+- The gateway is running and reachable from the public internet
+- The URL ends with `/line/webhook` (the adapter does not respond at `/`)
+- TLS is valid — LINE rejects self-signed certificates
+
+You can health-check the webhook endpoint at `GET /line/webhook/health` — it returns `{"status": "ok", "platform": "line"}`.
+
+## Group and Room Chats
+
+LINE has two kinds of multi-user chats, with different ID semantics:
+
+| Source type | Prefix | What it represents | Allowlist env var |
+|-------------|--------|---------------------|--------------------|
+| `user` | `U` | DM with a single user | `LINE_ALLOWED_USERS` |
+| `group` | `C` | Group chat with stable IDs | `LINE_ALLOWED_GROUPS` |
+| `room` | `R` | Multi-user chat without persistent group ID | `LINE_ALLOWED_ROOMS` |
+
+All three allowlists default-deny — an empty list means no access at that source type. To allow the bot to respond in a group, you must add its `C`-prefixed ID to `LINE_ALLOWED_GROUPS`.
+
+### How to discover a group/room ID
+
+Group and room IDs aren't exposed in the LINE app. Discover them this way:
+
+1. Add the bot to the group/room
+2. Send any message
+3. Check `hermes gateway` logs for a `line: drop unauthorised` entry — the dropped event includes the source IDs broken out by type
+
+```
+line: drop unauthorised src_type=group user=U1234... group=Cabcdef0123456789... room=None
+```
+
+For a group, copy the value of `group=`. For a room, copy `room=`. Add it to the appropriate allowlist:
+
+```bash
+LINE_ALLOWED_GROUPS=Cabcdef0123456789...
+```
+
+Restart the gateway to pick up the new value.
+
+## Mention Gate (Quiet Mode in Groups)
+
+By default, in any allowed group/room, the bot responds to every message. To make the bot only respond when explicitly addressed, enable the mention gate:
+
+```bash
+LINE_REQUIRE_MENTION=true
+```
+
+With this set, group/room messages are accepted only if they:
+
+- Mention the bot by display name (e.g., `@小茉 hello`)
+- The bot's display name is auto-fetched from LINE's `/v2/bot/info` endpoint at startup. You can override it manually with `LINE_BOT_DISPLAY_NAME=YourBotName`.
+
+:::warning Fail-closed behavior
+If `LINE_REQUIRE_MENTION=true` is set but the bot's display name is empty (auto-fetch failed and no manual override), the gate **drops every group message** and emits an operator warning in the logs. This is intentional fail-closed behavior — the gate must have something to match against, or it can't enforce the rule. Set `LINE_BOT_DISPLAY_NAME` explicitly if your bot doesn't have a discoverable display name.
+:::
+
+DM messages always bypass the mention gate.
+
+### Free-Response Groups and Rooms
+
+You may want certain groups/rooms to bypass the mention gate even when it's enabled globally — for example, a private team channel where you want every message answered:
+
+```bash
+LINE_FREE_RESPONSE_GROUPS=Cprivateteam0123...
+LINE_FREE_RESPONSE_ROOMS=Rresearchroom0123...
+```
+
+Each ID listed here must also appear in the corresponding allowlist (`LINE_ALLOWED_GROUPS` / `LINE_ALLOWED_ROOMS`). The gateway logs a warning at startup if a free-response ID is missing from the allowlist — otherwise the message would be dropped before the free-response check runs.
+
+## Slow-LLM Postback Fallback
+
+LINE's reply token expires after approximately 60 seconds (LINE's documented limit) and is single-use. If the LLM takes longer than the threshold (default 45 seconds, leaving a 15-second safety margin), the reply token may already be invalid by the time the answer is ready.
+
+Rather than burning a Push API call (which is metered), the adapter sends a **Template Buttons postback message** at the threshold:
+
+1. User sends a message — the adapter starts the LLM and shows a loading indicator.
+2. At ~45 seconds, the adapter posts a card with a "📋 Show response" button.
+3. When the LLM finishes, the answer is cached under the button's `request_id`.
+4. The user taps the button — LINE delivers a postback event with a fresh reply token, and the adapter sends the cached answer using the new token.
+
+The button is implemented as a **Template Buttons** message rather than a Quick Reply chip because Quick Reply chips are dismissed by the LINE client the moment any new message arrives in the chat (user or bot). Template Buttons stay tappable from chat history indefinitely — required for the postback to remain reachable in real conversations.
+
+Tune the threshold and cache TTL:
+
+```bash
+LINE_SLOW_RESPONSE_THRESHOLD=45     # seconds before showing the button (default: 45)
+LINE_CACHE_TTL=3600                 # how long to keep the cached answer (default: 1 hour)
+```
+
+You can also customize the button labels and notice texts:
+
+```bash
+LINE_BUTTON_LABEL="📋 Show response"
+LINE_PENDING_TEXT="Working on it — tap when you're ready to see the answer"
+LINE_DELIVERED_TEXT="✓ Response already delivered earlier in this thread"
+LINE_EXPIRED_TEXT="The cached response has expired. Please ask again."
+LINE_INTERRUPTED_TEXT="⚡ This run was interrupted by a newer message — see the latest reply above."
+```
+
+### Recommended display config
+
+LINE's metered Reply API conflicts with Hermes' default streaming chatter: every "⏳ Still working..." or "好，先上網搜一下..." message emitted before the slow-LLM threshold consumes the single-use reply token and bypasses the postback fallback for that turn. For deployments that prioritize cost-efficiency over live progress updates, suppress both:
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  interim_assistant_messages: false   # global — agent's pre-tool-call acks (e.g. "好的，我來查...")
+  platforms:
+    line:
+      tool_progress: off              # per-platform — Hermes' "⏳ Still working" updates
+```
+
+`tool_progress` honors per-platform overrides via `display.platforms.line.tool_progress`. `interim_assistant_messages` is currently global only — setting it under `display.platforms.line` has no effect (`gateway/run.py:10058` reads the top-level value). Setting the global to `false` affects all chat platforms.
+
+With both off, the adapter stays silent until either the threshold elapses (button appears) or the LLM finishes (response delivered via the original reply token).
+
+### Interrupt semantics
+
+Hermes' default `busy_input_mode` is `interrupt` — when a user sends a follow-up while the agent is still running, the gateway **steers** the same agent rather than killing it. The agent sees both messages and emits a combined response; the postback button (still tappable thanks to Template Buttons) delivers the combined response. To truly cancel the run instead, send `/stop` — the orphan postback then resolves to `LINE_INTERRUPTED_TEXT` when tapped.
+
+## Home Channel
+
+The home channel is where Hermes delivers cron job results, cross-platform notifications, and `send_message` calls that don't specify a chat. Configure it in `~/.hermes/.env`:
+
+```bash
+LINE_HOME_CHANNEL=U1234567890abcdef...
+LINE_HOME_CHANNEL_NAME="My Notes"      # optional friendly label
+```
+
+For DMs, this is your user ID. For a group/room home channel, use the `C`/`R` ID — and make sure it's also in the corresponding allowlist.
+
+You can also set this from inside the chat by typing `/sethome` in any allowed chat with the bot.
+
+## Sending Files
+
+LINE's Messaging API only accepts media via **public HTTPS URLs** — it cannot upload local file bytes. This is a LINE platform constraint, not a Hermes limitation.
+
+The adapter handles this gracefully:
+
+- **Images via HTTPS URL** → sent successfully
+- **Local file path** → the adapter logs a warning and skips the attachment, but text content still delivers
+
+If you need to send images generated locally, you have a few options:
+
+- Host the file on a public URL (S3, R2, GitHub Pages, etc.) and pass the URL
+- Forward through a service that uploads to a CDN, then pass the resulting URL
+
+This constraint also applies to documents, video, and voice attachments — none can be uploaded directly via the Messaging API.
+
+## Token Length Limits
+
+Each LINE message is capped at **5000 characters** (LINE's documented limit). The adapter chunks longer responses by Python string length into up to 5 message objects (5000 chars each — LINE caps a single Push or Reply call to 5 messages).
+
+Responses longer than **25,000 characters** are truncated. The final chunk is appended with `… (truncated)` so you know the answer was cut off. If a response includes one image and many text segments, only the first 4 text segments after the image are sent (the rest are silently dropped).
+
+## Inbound Non-Text Messages
+
+The adapter only responds to **text messages**. Inbound stickers, images, voice notes, location shares, and file uploads are silently ignored — you get no reply and no error. This is by design (LINE's inbound media model is more complex than a simple text channel and the agent is text-only). If you send a sticker and get no response, that's why.
+
+## Smart Send Routing
+
+The adapter uses **Reply API by default, Push API as fallback**. When a message comes in, the adapter caches the inbound `replyToken` (~55s safety window). Outbound responses then route as follows:
+
+1. **Reply API** (free) — used when a fresh `replyToken` is cached for the chat. Single-use; consumed on success.
+2. **Push API** (metered) — used when the `replyToken` has expired, was already consumed, or the response originates outside an inbound webhook (cron jobs, `send_message` tool calls, home-channel notifications).
+3. **Slow-LLM postback cache** — when the LLM is taking longer than `LINE_SLOW_RESPONSE_THRESHOLD` (default 45s), the adapter sends a postback button using the still-valid `replyToken`, then caches the eventual response so the user can fetch it via the postback (no Push charge).
+
+This means `self.send()` calls from the base session pipeline (compaction notices, tool approval prompts, etc.) DO get delivered — they use Push API when no `replyToken` is available. **Operators on LINE's free tier should monitor Push quota usage**, especially for chatty agent behaviors like long tool chains.
+
+To minimize Push usage:
+- Keep responses fast (under 45s) so Reply API handles them
+- Use a tool-restricted toolset for LINE if you don't need terminal/code execution (set `default_toolset` for the LINE platform in `~/.hermes/config.yaml`)
+
+## Known Limitations
+
+### Typing indicator is DM-only
+
+LINE's loading indicator API only supports `user` source types (DMs). For groups and rooms, the adapter skips the indicator silently — you'll see a small delay before the response with no "typing" feedback.
+
+### In-memory cache (no persistence across restarts)
+
+The slow-LLM Quick Reply cache lives in memory only — there's no Redis backend. If the gateway restarts while a slow LLM is computing and a postback button is already in the user's chat, tapping the button will show `LINE_EXPIRED_TEXT` because the cache entry was lost. PENDING entries are kept for up to 24 hours (non-configurable) before the prune sweep removes them; READY/DELIVERED/ERROR entries follow `LINE_CACHE_TTL`.
+
+### Mention-stripping in groups
+
+When the mention gate accepts a group message, the bot's display-name prefix (e.g., `@小茉 `) is **stripped from the text** before passing it to the LLM. So a message like `@小茉 hello` reaches the agent as just `hello` — useful for cleanliness, but means the agent doesn't see its own name in the prompt context. A message containing **only** the mention with no body text after stripping is silently dropped.
+
+### Local-file media uploads not supported
+
+LINE Messaging API does not accept local file uploads for `send_image_file()` / `send_voice()` / `send_document()` — only HTTPS URLs work. Cron jobs that emit `MEDIA:/local/path/img.png` payloads will fail at delivery. **Workaround:** host the file at a public HTTPS URL and emit `![alt](https://...)` markdown — the adapter's reply builder extracts that as a native image bubble (works in both inbound replies and cron deliveries).
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Webhook verification fails | Ensure the URL is HTTPS, publicly reachable, ends with `/line/webhook`, and TLS is valid (no self-signed certs). |
+| Bot responds twice to every message | LINE's auto-responder is enabled. Disable greeting, auto-reply, and group auto-reply in the **LINE Official Account features** settings (Step 3). |
+| Bot responds to nothing | Check that `LINE_ALLOWED_USERS` contains your user ID (the one from console **Basic settings** → **Your user ID**, not your LINE display name). |
+| Group messages dropped | Add the group's `C`-prefixed ID to `LINE_ALLOWED_GROUPS`. Discover it via the `line: drop` log entry after sending a message in the group. |
+| Bot ignores group messages even when allowed | If `LINE_REQUIRE_MENTION=true`, the message must mention the bot by display name. Either drop the requirement, set `LINE_BOT_DISPLAY_NAME` explicitly, or add the group to `LINE_FREE_RESPONSE_GROUPS`. |
+| `Failed to fetch LINE bot info` warning | The auto-name-fetch failed (usually a token problem). The bot still works for DMs. Set `LINE_BOT_DISPLAY_NAME` manually if you need group mention gating. |
+| postback button doesn't appear | Check that the LLM is actually slow enough to trigger it (default threshold is 45s). Lower `LINE_SLOW_RESPONSE_THRESHOLD` to test. |
+| `401 Unauthorized` returned to LINE (gateway logs) | `LINE_CHANNEL_SECRET` is wrong — the gateway returns 401 from `/line/webhook` when HMAC verification fails. Copy the secret again from **Basic settings** (it's distinct from the access token). |
+| Reply/Push API failures in logs | Channel access token is invalid or revoked. Reissue it from the **Messaging API** tab and update `LINE_CHANNEL_ACCESS_TOKEN`. |
+
+## Security
+
+:::warning
+All three LINE allowlists default-deny. An empty `LINE_ALLOWED_USERS` means no users can chat with the bot via DM. Always set this explicitly.
+:::
+
+The `LINE_ALLOW_ALL_USERS=true` override exists for low-trust testing only — never enable it on a production bot, especially one with terminal access.
+
+Webhook signatures are verified using HMAC-SHA256 with constant-time comparison. Requests with missing or invalid signatures return `401` and are not dispatched to the agent.
+
+For more details, see the [Security documentation](/user-guide/security). You can also use [DM pairing](/user-guide/messaging#dm-pairing-alternative-to-allowlists) for a more dynamic approach to user authorization.
+
+## Reference: Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | — | Long-lived channel access token |
+| `LINE_CHANNEL_SECRET` | Yes | — | Channel secret for HMAC signature verification |
+| `LINE_ALLOWED_USERS` | Yes | — | Comma-separated list of `U`-prefixed user IDs; default-deny — an empty list means no DM access |
+| `LINE_ALLOWED_GROUPS` | No | — | Comma-separated list of `C`-prefixed group IDs |
+| `LINE_ALLOWED_ROOMS` | No | — | Comma-separated list of `R`-prefixed room IDs |
+| `LINE_ALLOW_ALL_USERS` | No | `false` | If `true`, bypass all source allowlists (users, groups, AND rooms) — NOT recommended for production |
+| `LINE_HOME_CHANNEL` | No | — | Where cron results and notifications are delivered |
+| `LINE_HOME_CHANNEL_NAME` | No | `Home` | Friendly label for the home channel |
+| `LINE_WEBHOOK_PORT` | No | `8646` | Local port for the webhook listener |
+| `LINE_REQUIRE_MENTION` | No | `false` | Require @mention in groups/rooms |
+| `LINE_BOT_DISPLAY_NAME` | No | auto-fetched | Manual override of bot's display name for the mention gate |
+| `LINE_FREE_RESPONSE_GROUPS` | No | — | Groups that bypass the mention gate (must also be in `LINE_ALLOWED_GROUPS`) |
+| `LINE_FREE_RESPONSE_ROOMS` | No | — | Rooms that bypass the mention gate (must also be in `LINE_ALLOWED_ROOMS`) |
+| `LINE_SLOW_RESPONSE_THRESHOLD` | No | `45` | Seconds before showing the postback button |
+| `LINE_CACHE_TTL` | No | `3600` | Seconds to cache the response for postback retrieval |
+| `LINE_PENDING_TEXT` | No | (built-in) | Text shown when the slow-response button appears |
+| `LINE_DELIVERED_TEXT` | No | (built-in) | Reply when a user taps the button after delivery |
+| `LINE_EXPIRED_TEXT` | No | (built-in) | Reply when the cache TTL has elapsed |
+| `LINE_INTERRUPTED_TEXT` | No | (built-in) | Reply when an orphan button is tapped after `/stop` |
+| `LINE_BUTTON_LABEL` | No | `📋 Show response` | Label on the postback button |


### PR DESCRIPTION
Closes #6081. Relates to #16611.

Adds a LINE Messaging API platform adapter (`gateway/platforms/line.py`) integrated with `BasePlatformAdapter` so LINE traffic gets the same queue / interrupt / bypass / photo-burst behavior as Telegram, Discord, Signal, Matrix.

## Summary

LINE uses single-use reply_tokens (~60s validity) — slow LLM responses normally force a paid Push API call once the token expires. This adapter caches the response under a persistent postback button (Template Buttons message); the user taps it to fetch the answer via a fresh reply_token (free). When `/stop` cancels the run, the orphan resolves to a clear "interrupted" message. Three-allowlist gating (users / groups / rooms) with mention gate and free-response escape hatch covers production deployment. Inbound non-text messages (images, stickers, audio) are currently dropped at the dispatch boundary; native multimodal handling is a planned follow-up.

## Changes

| File | What |
|------|------|
| `gateway/platforms/line.py` | `LineAdapter` — HMAC-SHA256 webhook verify, 1MB body cap, dedup, Reply API + Push fallback routing, slow-LLM postback cache state machine, format_message with URL-preserving Markdown strip |
| `gateway/run.py` | LINE adapter factory + group/room allowlist bypass + `LINE_*` env vars in `_builtin_allowed_vars` |
| `gateway/config.py` | `Platform.LINE` enum + `_PLATFORM_CONNECTED_CHECKERS` entry |
| `gateway/platforms/__init__.py` | LINE registration |
| `tools/send_message_tool.py` | `_send_line` for cron / outbound Push deliveries |
| `cron/scheduler.py`, `tools/cronjob_tools.py`, `agent/prompt_builder.py`, `hermes_cli/{gateway,platforms,status,dump}.py` | LINE wiring |
| `tests/gateway/test_line_*.py` (12 files) | 85 tests (signature, allowlist, cache, postback, send routing, e2e) |
| `website/docs/user-guide/messaging/line.md` + `website/docs/reference/environment-variables.md` | Setup guide + `LINE_*` reference |
| `README.md` | LINE added to supported-platforms lists |

No new runtime deps (uses core `httpx` + `aiohttp` from `[messaging]`). Adds `respx` and `pytest-aiohttp` to `[dev]`.

## Design

**Slow-LLM postback fallback.** When `_keep_typing` detects the LLM running past `LINE_SLOW_RESPONSE_THRESHOLD` (default 45s, leaving 15s reply_token margin), the adapter consumes the cached reply_token to send a Template Buttons postback message and registers a `_pending_buttons[chat_id]` slot. The agent's response is then cached READY under the request_id instead of being pushed. The user's tap delivers a fresh reply_token via webhook → cached payload sent free. State machine: PENDING → READY → DELIVERED, plus ERROR for cancelled runs (orphan PENDING resolves to `LINE_INTERRUPTED_TEXT` after `/stop` so the persistent button doesn't loop).

**Template Buttons over Quick Reply chips.** Quick Reply chips are dismissed by the LINE client the moment any new message arrives in the chat — the postback would be unreachable in real conversations. Template Buttons stay tappable from chat history.

**System-message guard.** `send()` detects known prefixes from base/run.py (`⚡ Interrupting`, `⏳ Queued`, `⏩ Steered`) and routes them past the postback cache so busy-acks reach the user as visible bubbles instead of being swallowed into the orphan slot.

## Setup

Minimum `~/.hermes/.env` to bring LINE online:

\`\`\`bash
LINE_CHANNEL_ACCESS_TOKEN=YOUR_LONG_LIVED_TOKEN
LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
LINE_ALLOWED_USERS=U1234567890abcdef...
\`\`\`

Then `hermes gateway` (or `hermes gateway setup` for the interactive wizard). Webhook listens on `:8646/line/webhook` by default. Recommended display config to make the slow-LLM postback fire reliably (suppresses chatter that would consume the reply_token before the threshold):

\`\`\`yaml
# ~/.hermes/config.yaml
display:
  interim_assistant_messages: false
  platforms:
    line:
      tool_progress: off
\`\`\`

Full setup walkthrough in `website/docs/user-guide/messaging/line.md`.

## Validation

\`\`\`
pytest tests/gateway/test_line_*.py — 85 passed
pytest tests/gateway/test_platform_connected_checkers.py — all passed
pytest tests/gateway/ — full suite (4,319 passed; 12 pre-existing failures unrelated to LINE — verified against pristine upstream/main)
\`\`\`

Tested on macOS 26.2 (Darwin 25.2.0), Python 3.11.6, against a live LINE Official Account: Reply API delivery, slow-LLM postback round trip (button at threshold → tap → cached delivery via fresh reply_token), `/stop` true-cancel + orphan resolution, interrupt-as-steer combined response, Markdown with URL preservation.

3 logical commits on top of `e5dad4ac5`.