### PR TITLE
fix(cron): align matrix home env var with /sethome conventio

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -83,7 +83,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
 # Platforms that support a configured cron/notification home target, mapped to
 # the environment variable used by gateway setup/runtime config.
 _HOME_TARGET_ENV_VARS = {
-    "matrix": "MATRIX_HOME_ROOM",
+    "matrix": "MATRIX_HOME_CHANNEL",
     "telegram": "TELEGRAM_HOME_CHANNEL",
     "discord": "DISCORD_HOME_CHANNEL",
     "slack": "SLACK_HOME_CHANNEL",
@@ -105,6 +105,7 @@ _HOME_TARGET_ENV_VARS = {
 # old name before the rename keep working until they migrate.
 _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
+    "MATRIX_HOME_CHANNEL": "MATRIX_HOME_ROOM",
 }
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run


### PR DESCRIPTION
The cron delivery scheduler reads `MATRIX_HOME_ROOM` for the matrix home channel, but the `/sethome` command handler in `gateway/run.py` writes `{platform.upper()}_HOME_CHANNEL` — i.e. `MATRIX_HOME_CHANNEL`. All other 14 platforms in `_HOME_TARGET_ENV_VARS` use the unified `_HOME_CHANNEL` suffix; only Matrix is the outlier on `_HOME_ROOM`.

Effect: a Matrix cron job with `deliver: "origin"` and `origin: null` falls through to the home-channel fallback which checks `MATRIX_HOME_ROOM` — but that env var is never set by `/sethome`, so the fallback returns nothing and delivery is silently dropped.

This patch:

1. Renames the matrix entry in `_HOME_TARGET_ENV_VARS` to `MATRIX_HOME_CHANNEL`, matching what `/sethome` writes and aligning with the other platforms.
2. Adds `MATRIX_HOME_CHANNEL → MATRIX_HOME_ROOM` to `_LEGACY_HOME_TARGET_ENV_VARS` so any existing deployments that manually set `MATRIX_HOME_ROOM` continue to work via the legacy fallback path.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

