### PR TITLE
fix(agent): reset fallback index when activation never succeeded (#16677)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7624,6 +7624,15 @@ class AIAgent:
         ``gateway/run.py``), so this restoration IS needed there too.
         """
         if not self._fallback_activated:
+            # _try_activate_fallback() advances _fallback_index *before* the
+            # activation can fail.  When every entry fails to resolve (e.g.
+            # exhausted credential pool, unconfigured provider) the recursion
+            # walks the index to len(chain) without ever flipping
+            # _fallback_activated.  Without this reset, the next turn's
+            # _try_activate_fallback() short-circuits at the bounds check and
+            # the caller emits "trying fallback..." then aborts immediately.
+            # See #16677.
+            self._fallback_index = 0
             return False
 
         if getattr(self, "_rate_limited_until", 0) > time.monotonic():

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -168,6 +168,46 @@ class TestRestorePrimaryRuntime:
 
         assert agent._fallback_index == 0  # reset for next turn
 
+    def test_resets_fallback_index_after_failed_activation(self):
+        """Regression for #16677: when every fallback entry fails to resolve,
+        _try_activate_fallback() walks _fallback_index to len(chain) without
+        ever flipping _fallback_activated. _restore_primary_runtime() at the
+        top of the next turn must still reset the index, otherwise
+        subsequent fallback attempts short-circuit at the bounds check
+        and the caller emits "trying fallback..." then aborts immediately.
+        """
+        agent = _make_agent(
+            fallback_model=[{"provider": "openrouter", "model": "google/gemini-2.0-flash-001"}],
+        )
+
+        # Turn 1: fallback resolution returns None (e.g. exhausted credential
+        # pool, unconfigured provider). Activation never succeeds.
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(None, None),
+        ):
+            assert agent._try_activate_fallback() is False
+
+        assert agent._fallback_index == 1
+        assert agent._fallback_activated is False
+
+        # Start of turn 2: run_conversation() calls _restore_primary_runtime().
+        # The early-return branch (not _fallback_activated) must still reset
+        # the chain pointer so subsequent activations can attempt the chain.
+        assert agent._restore_primary_runtime() is False
+        assert agent._fallback_index == 0
+
+        # Turn 2: fallback would now resolve fine. Activation must succeed
+        # instead of short-circuiting at the bounds check.
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_resolve(), "google/gemini-2.0-flash-001"),
+        ):
+            assert agent._try_activate_fallback() is True
+        assert agent._fallback_activated is True
+        assert agent.model == "google/gemini-2.0-flash-001"
+        assert agent.provider == "openrouter"
+
     def test_restores_compressor_state(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},


### PR DESCRIPTION
Closes #16677.

`_try_activate_fallback()` increments `_fallback_index` before activation can fail. When every entry fails to resolve (exhausted credential pool, unconfigured provider, etc.), the recursion walks the index to `len(chain)` without ever flipping `_fallback_activated`. `_restore_primary_runtime()` then early-returned without resetting the index, so the next turn's `_try_activate_fallback()` short-circuits at the bounds check — the user sees `⚠️ trying fallback...` followed by an immediate abort, with no swap on the wire.

The fix is one line: reset `_fallback_index = 0` in the early-return branch so the chain is attempt-able again next turn.

I reproduced the bug deterministically against the real `run_agent.py` code paths (single-entry chain, mocked `resolve_provider_client` returning `(None, None)` to simulate the exhausted-pool case): turn 1 leaves `_fallback_index = 1` / `_fallback_activated = False`, the next turn's `_restore_primary_runtime()` doesn't reset, and even a now-resolvable fallback short-circuits at the bounds check. With the patch, the same script swaps to the fallback on turn 2 as expected.

Tested:
- New regression test `test_resets_fallback_index_after_failed_activation` in `tests/run_agent/test_primary_runtime_restore.py`. Fails without the patch (third assertion), passes with it.
- Full `tests/run_agent/` suite: 1182 passed, 9 skipped, no regressions.

Note: this only fixes the credential-pool-exhausted / unconfigured-fallback class of #16677. The reporter also describes a separate `auxiliary.vision.provider: auto` resolving to a 16K-context model — that path doesn't apply the `MINIMUM_CONTEXT_LENGTH` floor and deserves its own ticket. Their `status=75/TEMPFAIL` "crash loop" framing is downstream of this same fallback-never-fires bug (75 is the intentional graceful-restart code in `gateway/restart.py`, not a 429 exit).