### PR TITLE
fix(doctor,browser): centralize tool PATH fallbacks (mise/asdf/nvm/Homebrew)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.path_env import ensure_common_tool_paths
 from hermes_constants import display_hermes_home
 from hermes_constants import agent_browser_runnable
 
@@ -1426,6 +1427,12 @@ def run_doctor(args):
                         manual_issues.append(f"Add {_cmd_link_display} to your PATH")
                 else:
                     issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
+
+    # Non-interactive launchers often miss shell-initialized tool directories
+    # (for example mise/asdf/nvm shims or Homebrew). Add conservative fallbacks
+    # before checking external tools so doctor matches what users can run from
+    # an interactive shell without requiring a wrapper script around Hermes.
+    ensure_common_tool_paths()
 
     _section("External Tools")
     # Git

--- a/hermes_cli/path_env.py
+++ b/hermes_cli/path_env.py
@@ -46,11 +46,26 @@ def _dedupe(paths: list[str]) -> list[str]:
     return result
 
 
+def _resolve_home() -> Path | None:
+    """Return the user's home directory, preferring ``$HOME`` over passwd lookups.
+
+    ``Path.home()`` consults ``pwd.getpwuid(os.getuid()).pw_dir`` on POSIX, which
+    can ignore the current process's ``HOME`` environment variable. That makes
+    behaviour surprising for callers (and tests) that override ``HOME`` to point
+    at a sandbox directory. We honour ``HOME`` when set so non-interactive
+    launches and unit tests both see the directory the rest of the process is
+    using.
+    """
+    home_str = os.environ.get("HOME") or os.path.expanduser("~")
+    if not home_str or home_str == "~":
+        return None
+    return Path(home_str)
+
+
 def _home_tool_path_dirs() -> list[str]:
     """Return user-level tool directories managed by common version managers."""
-    try:
-        home = Path.home()
-    except RuntimeError:
+    home = _resolve_home()
+    if home is None:
         return []
 
     candidates = [

--- a/hermes_cli/path_env.py
+++ b/hermes_cli/path_env.py
@@ -1,0 +1,103 @@
+"""Helpers for making Hermes subprocess PATH lookups resilient.
+
+Hermes is often launched by non-interactive process managers (launchd,
+systemd, cron, IDEs, dashboard actions). Those environments can miss user shell
+initialisation, so common tools installed through Homebrew, mise, asdf, nvm, or
+Termux may not be visible even though they work in an interactive shell.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+_STATIC_TOOL_PATH_DIRS: tuple[str, ...] = (
+    # Android / Termux
+    "/data/data/com.termux/files/usr/bin",
+    "/data/data/com.termux/files/usr/sbin",
+    # macOS package managers
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+    # Standard Unix fallbacks
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+)
+
+
+def _split_path(path: str | None) -> list[str]:
+    """Split a PATH string into non-empty entries."""
+    return [part for part in (path or "").split(os.pathsep) if part]
+
+
+def _dedupe(paths: list[str]) -> list[str]:
+    """Return paths with duplicates removed while preserving order."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        result.append(path)
+    return result
+
+
+def _home_tool_path_dirs() -> list[str]:
+    """Return user-level tool directories managed by common version managers."""
+    try:
+        home = Path.home()
+    except RuntimeError:
+        return []
+
+    candidates = [
+        home / ".local" / "bin",
+        home / ".local" / "share" / "mise" / "shims",
+        home / ".asdf" / "shims",
+        home / ".bun" / "bin",
+    ]
+
+    nvm_dir = Path(os.environ.get("NVM_DIR") or (home / ".nvm"))
+    node_versions_dir = nvm_dir / "versions" / "node"
+    try:
+        candidates.extend(sorted(node_versions_dir.glob("*/bin"), reverse=True))
+    except OSError:
+        pass
+
+    return [str(path) for path in candidates]
+
+
+def common_tool_path_dirs(*, existing_only: bool = True) -> tuple[str, ...]:
+    """Return ordered PATH fallback directories for external tools.
+
+    Dynamic user-level directories come first so non-interactive launches can
+    see version-manager shims. Static platform directories follow. By default
+    only directories that exist on the current machine are returned.
+    """
+    candidates = _dedupe([*_home_tool_path_dirs(), *_STATIC_TOOL_PATH_DIRS])
+    if not existing_only:
+        return tuple(candidates)
+    return tuple(path for path in candidates if os.path.isdir(path))
+
+
+def merge_common_tool_path(existing_path: str | None = None, *, prepend: bool = False) -> str:
+    """Merge common tool fallbacks into an existing PATH.
+
+    Appending is the default so an explicitly configured PATH keeps priority.
+    Callers that need fallback tools to win (for example browser command
+    execution) can request ``prepend=True``.
+    """
+    path_parts = _split_path(existing_path if existing_path is not None else os.environ.get("PATH", ""))
+    fallback_parts = [part for part in common_tool_path_dirs() if part not in path_parts]
+    merged = [*fallback_parts, *path_parts] if prepend else [*path_parts, *fallback_parts]
+    return os.pathsep.join(merged)
+
+
+def ensure_common_tool_paths(*, prepend: bool = False) -> str:
+    """Update ``os.environ['PATH']`` with common external-tool fallbacks."""
+    merged = merge_common_tool_path(prepend=prepend)
+    os.environ["PATH"] = merged
+    return merged

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -564,6 +564,17 @@ def agent_browser_runnable(path: str | None) -> bool:
         return False
     import subprocess
 
+    run_env = with_hermes_node_path()
+    # npm-installed shims commonly use ``#!/usr/bin/env node``. When the
+    # candidate came from a mise/asdf/nvm fallback directory that was absent
+    # from the original process PATH, validation must expose that same
+    # directory so the shim can resolve its sibling Node executable.
+    candidate_dir = str(Path(path).absolute().parent)
+    path_parts = [part for part in run_env.get("PATH", "").split(os.pathsep) if part]
+    if candidate_dir not in path_parts:
+        path_parts.insert(0, candidate_dir)
+    run_env["PATH"] = os.pathsep.join(path_parts)
+
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -571,7 +582,7 @@ def agent_browser_runnable(path: str | None) -> bool:
             [path, "--version"],
             capture_output=True,
             timeout=10,
-            env=with_hermes_node_path(),
+            env=run_env,
             creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.TimeoutExpired, ValueError):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -249,6 +249,57 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
     assert seen["path_helper_called"] is True
 
 
+def test_run_doctor_resolves_node_from_mise_with_minimal_path(monkeypatch, tmp_path):
+    """The real doctor flow should expose mise shims to its Node lookup."""
+    if os.name == "nt":
+        pytest.skip("mise shell shims are POSIX executables")
+
+    project_root = tmp_path / "project"
+    hermes_home = tmp_path / ".hermes"
+    minimal_bin = tmp_path / "minimal-bin"
+    mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
+    for path in (project_root, hermes_home, minimal_bin, mise_shims):
+        path.mkdir(parents=True)
+
+    node_shim = mise_shims / "node"
+    node_shim.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    node_shim.chmod(0o755)
+
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("PATH", str(minimal_bin))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("NVM_DIR", raising=False)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+
+    real_which = doctor_mod.shutil.which
+    seen = {}
+
+    class NodeLookupReached(BaseException):
+        pass
+
+    def record_real_lookup(cmd, *args, **kwargs):
+        # Avoid probing host-specific Docker/Codex installations while still
+        # using the real shutil.which implementation for the Node contract.
+        if cmd in {"codex", "docker"}:
+            return None
+        result = real_which(cmd, *args, **kwargs)
+        if cmd == "node":
+            seen["node"] = result
+            raise NodeLookupReached
+        return result
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", record_real_lookup)
+
+    with pytest.raises(NodeLookupReached):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert seen["node"] == str(node_shim)
+    assert str(mise_shims) in os.environ["PATH"].split(os.pathsep)
+
+
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "hermes-gateway.service"
     unit_path.write_text("[Unit]\n")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -227,6 +227,11 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
 
     seen = {}
 
+    def fake_ensure_common_tool_paths():
+        seen["path_helper_called"] = True
+
+    monkeypatch.setattr(doctor_mod, "ensure_common_tool_paths", fake_ensure_common_tool_paths)
+
     def fake_check_tool_availability(*args, **kwargs):
         seen["interactive"] = os.getenv("HERMES_INTERACTIVE")
         raise SystemExit(0)
@@ -241,6 +246,7 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
         doctor_mod.run_doctor(Namespace(fix=False))
 
     assert seen["interactive"] == "1"
+    assert seen["path_helper_called"] is True
 
 
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_path_env.py
+++ b/tests/hermes_cli/test_path_env.py
@@ -26,7 +26,7 @@ def test_common_tool_path_dirs_include_version_manager_and_platform_dirs(monkeyp
     assert str(mise_shims) in dirs
     assert str(asdf_shims) in dirs
     assert str(nvm_node_bin) in dirs
-    assert "/usr/bin" in dirs
+    assert "/usr/bin" in common_tool_path_dirs(existing_only=False)
 
 
 def test_common_tool_path_dirs_can_return_non_existing_static_candidates(monkeypatch, tmp_path):
@@ -43,15 +43,17 @@ def test_merge_common_tool_path_appends_fallbacks_without_duplicates(monkeypatch
     monkeypatch.setenv("HOME", str(tmp_path))
     custom_bin = tmp_path / "custom" / "bin"
     mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
+    asdf_shims = tmp_path / ".asdf" / "shims"
     custom_bin.mkdir(parents=True)
     mise_shims.mkdir(parents=True)
+    asdf_shims.mkdir(parents=True)
 
     merged = merge_common_tool_path(os.pathsep.join([str(custom_bin), str(mise_shims)]))
     parts = merged.split(os.pathsep)
 
     assert parts[0] == str(custom_bin)
     assert parts.count(str(mise_shims)) == 1
-    assert "/usr/bin" in parts
+    assert str(asdf_shims) in parts
 
 
 def test_merge_common_tool_path_can_prepend_fallbacks(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_path_env.py
+++ b/tests/hermes_cli/test_path_env.py
@@ -1,0 +1,75 @@
+"""Tests for PATH fallback helpers used by CLI diagnostics and tools."""
+
+import os
+
+from hermes_cli.path_env import (
+    common_tool_path_dirs,
+    ensure_common_tool_paths,
+    merge_common_tool_path,
+)
+
+
+def test_common_tool_path_dirs_include_version_manager_and_platform_dirs(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
+    asdf_shims = tmp_path / ".asdf" / "shims"
+    nvm_node_bin = tmp_path / ".nvm" / "versions" / "node" / "v24.11.0" / "bin"
+    for path in (mise_shims, asdf_shims, nvm_node_bin):
+        path.mkdir(parents=True)
+
+    dirs = common_tool_path_dirs()
+
+    assert str(mise_shims) in dirs
+    assert str(asdf_shims) in dirs
+    assert str(nvm_node_bin) in dirs
+    assert "/usr/bin" in dirs
+
+
+def test_common_tool_path_dirs_can_return_non_existing_static_candidates(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    dirs = common_tool_path_dirs(existing_only=False)
+
+    assert str(tmp_path / ".local" / "share" / "mise" / "shims") in dirs
+    assert "/opt/homebrew/bin" in dirs
+    assert "/data/data/com.termux/files/usr/bin" in dirs
+
+
+def test_merge_common_tool_path_appends_fallbacks_without_duplicates(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    custom_bin = tmp_path / "custom" / "bin"
+    mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
+    custom_bin.mkdir(parents=True)
+    mise_shims.mkdir(parents=True)
+
+    merged = merge_common_tool_path(os.pathsep.join([str(custom_bin), str(mise_shims)]))
+    parts = merged.split(os.pathsep)
+
+    assert parts[0] == str(custom_bin)
+    assert parts.count(str(mise_shims)) == 1
+    assert "/usr/bin" in parts
+
+
+def test_merge_common_tool_path_can_prepend_fallbacks(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    existing_bin = tmp_path / "existing" / "bin"
+    mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
+    existing_bin.mkdir(parents=True)
+    mise_shims.mkdir(parents=True)
+
+    merged = merge_common_tool_path(str(existing_bin), prepend=True)
+    parts = merged.split(os.pathsep)
+
+    assert parts.index(str(mise_shims)) < parts.index(str(existing_bin))
+
+
+def test_ensure_common_tool_paths_updates_process_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
+    mise_shims.mkdir(parents=True)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    merged = ensure_common_tool_paths()
+
+    assert os.environ["PATH"] == merged
+    assert str(mise_shims) in merged.split(os.pathsep)

--- a/tests/hermes_cli/test_path_env.py
+++ b/tests/hermes_cli/test_path_env.py
@@ -11,6 +11,10 @@ from hermes_cli.path_env import (
 
 def test_common_tool_path_dirs_include_version_manager_and_platform_dirs(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    # nvm honours $NVM_DIR ahead of $HOME/.nvm. CI runners commonly set
+    # $NVM_DIR to a path outside the test's tmp_path, so clear it to make
+    # the version-manager lookup deterministic.
+    monkeypatch.delenv("NVM_DIR", raising=False)
     mise_shims = tmp_path / ".local" / "share" / "mise" / "shims"
     asdf_shims = tmp_path / ".asdf" / "shims"
     nvm_node_bin = tmp_path / ".nvm" / "versions" / "node" / "v24.11.0" / "bin"

--- a/tests/tools/test_browser_chromium_autoinstall.py
+++ b/tests/tools/test_browser_chromium_autoinstall.py
@@ -1,5 +1,7 @@
 """Tests for gated Chromium-binary auto-install on local cold start."""
 
+import os
+import shutil
 from types import SimpleNamespace
 
 import pytest
@@ -11,9 +13,13 @@ import tools.browser_tool as bt
 def _reset_state():
     bt._chromium_autoinstall_attempted = False
     bt._cached_chromium_installed = None
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
     yield
     bt._chromium_autoinstall_attempted = False
     bt._cached_chromium_installed = None
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
 
 
 def _no_subprocess(monkeypatch):
@@ -38,6 +44,46 @@ class TestGating:
 
 
 class TestInstall:
+    @pytest.mark.skipif(os.name == "nt", reason="nvm shell shims are POSIX executables")
+    def test_nvm_shim_path_reaches_chromium_install_subprocess(
+        self, monkeypatch, tmp_path
+    ):
+        minimal_bin = tmp_path / "minimal-bin"
+        nvm_bin = tmp_path / ".nvm" / "versions" / "node" / "v24.11.0" / "bin"
+        hermes_home = tmp_path / ".hermes"
+        for path in (minimal_bin, nvm_bin, hermes_home):
+            path.mkdir(parents=True)
+
+        node_shim = nvm_bin / "node"
+        node_shim.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        node_shim.chmod(0o755)
+        browser_shim = nvm_bin / "agent-browser"
+        browser_shim.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+        browser_shim.chmod(0o755)
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("PATH", str(minimal_bin))
+        monkeypatch.delenv("NVM_DIR", raising=False)
+        monkeypatch.setattr(bt, "_running_in_docker", lambda: False)
+        monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+
+        assert bt._find_agent_browser() == str(browser_shim)
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs["env"]
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(bt.subprocess, "run", fake_run)
+
+        assert bt._maybe_autoinstall_chromium() is True
+        assert captured["cmd"] == [str(browser_shim), "install"]
+        assert shutil.which("node", path=captured["env"]["PATH"]) == str(node_shim)
+
     def test_success_installs_binary_only_and_rechecks(self, monkeypatch):
         monkeypatch.setattr(bt, "_running_in_docker", lambda: False)
         monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)

--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -82,7 +82,8 @@ class TestFindAgentBrowserCache:
 
         with patch("shutil.which", return_value=None), \
              patch("os.path.isdir", return_value=False), \
-             patch.object(Path, "exists", mock_exists):
+             patch.object(Path, "exists", mock_exists), \
+             patch("hermes_cli.dep_ensure.ensure_dependency", return_value=False):
             with pytest.raises(FileNotFoundError):
                 bt._find_agent_browser()
         # Second call should also raise (from cache)

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -44,6 +44,12 @@ class TestSanePath:
     def test_includes_homebrew_sbin(self):
         assert "/opt/homebrew/sbin" in _SANE_PATH.split(os.pathsep)
 
+    def test_includes_mise_shims(self):
+        assert str(Path.home() / ".local" / "share" / "mise" / "shims") in _SANE_PATH.split(os.pathsep)
+
+    def test_includes_asdf_shims(self):
+        assert str(Path.home() / ".asdf" / "shims") in _SANE_PATH.split(os.pathsep)
+
     def test_includes_standard_dirs(self):
         path_parts = _SANE_PATH.split(os.pathsep)
         assert "/usr/local/bin" in path_parts

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, mock_open
 
@@ -105,6 +107,55 @@ class TestDiscoverHomebrewNodeDirs:
 class TestFindAgentBrowser:
     """Tests for _find_agent_browser() Homebrew path search."""
 
+    @pytest.mark.skipif(os.name == "nt", reason="nvm shell shims are POSIX executables")
+    def test_resolves_node_backed_nvm_shim_with_minimal_original_path(self, tmp_path):
+        """A fresh browser process should validate a Node-backed nvm shim."""
+        minimal_bin = tmp_path / "minimal-bin"
+        nvm_bin = tmp_path / ".nvm" / "versions" / "node" / "v24.11.0" / "bin"
+        hermes_home = tmp_path / ".hermes"
+        for path in (minimal_bin, nvm_bin, hermes_home):
+            path.mkdir(parents=True)
+
+        node_shim = nvm_bin / "node"
+        node_shim.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        node_shim.chmod(0o755)
+        browser_shim = nvm_bin / "agent-browser"
+        browser_shim.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+        browser_shim.chmod(0o755)
+
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(tmp_path),
+                "HERMES_HOME": str(hermes_home),
+                "PATH": str(minimal_bin),
+            }
+        )
+        env.pop("NVM_DIR", None)
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(
+            part for part in (str(repo_root), existing_pythonpath) if part
+        )
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from tools.browser_tool import _find_agent_browser; "
+                "print(_find_agent_browser())",
+            ],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert completed.stdout.strip() == str(browser_shim)
+
     def test_finds_in_current_path(self):
         """Should return result from shutil.which if available on current PATH."""
         with patch("shutil.which", return_value="/usr/local/bin/agent-browser"), \
@@ -207,6 +258,7 @@ class TestFindAgentBrowser:
         with patch("shutil.which", return_value=None), \
              patch("os.path.isdir", return_value=False), \
              patch.object(Path, "exists", mock_path_exists), \
+             patch("hermes_cli.dep_ensure.ensure_dependency", return_value=False), \
              patch(
                  "tools.browser_tool._discover_homebrew_node_dirs",
                  return_value=[],

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -92,7 +92,8 @@ def _build_browser_env() -> dict:
     """Credential-scrubbed env for an agent-browser subprocess.
 
     Strips Hermes-managed secrets (provider keys, gateway tokens, GitHub auth,
-    infra secrets) then re-adds only the browser-backend keys the worker needs.
+    infra secrets), re-adds only the browser-backend keys the worker needs,
+    then supplies the same executable PATH fallbacks used for discovery.
     The ``hermes_subprocess_env`` import is deferred to keep ``browser_tool``
     importable under test harnesses that load it against a stubbed ``tools``
     package (tests/tools/test_managed_browserbase_and_modal.py).
@@ -103,6 +104,7 @@ def _build_browser_env() -> dict:
     for _key in _BROWSER_PASSTHROUGH_KEYS:
         if _key in os.environ:
             env[_key] = os.environ[_key]
+    env["PATH"] = _merge_browser_path(env.get("PATH", ""))
     return env
 
 try:
@@ -187,7 +189,8 @@ def _browser_candidate_path_dirs() -> list[str]:
     hermes_node_bin = str(hermes_home / "node" / "bin")
     hermes_node_root = str(hermes_home / "node")
     hermes_nm_bin = str(hermes_home / "node_modules" / ".bin")
-    return [hermes_node_bin, hermes_node_root, hermes_nm_bin, *list(_discover_homebrew_node_dirs()), *_SANE_PATH_DIRS]
+    common_dirs = common_tool_path_dirs(existing_only=False)
+    return [hermes_node_bin, hermes_node_root, hermes_nm_bin, *list(_discover_homebrew_node_dirs()), *common_dirs]
 
 
 def _merge_browser_path(existing_path: str = "") -> str:
@@ -1044,7 +1047,6 @@ def _run_chrome_fallback_command(
     os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
     browser_env = _build_browser_env()
     browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
-    browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
 
     if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
         browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
@@ -2369,10 +2371,6 @@ def _run_browser_command(
                      command, task_id, task_socket_dir, len(task_socket_dir))
 
         browser_env = _build_browser_env()
-
-        # Ensure subprocesses inherit the same browser-specific PATH fallbacks
-        # used during CLI discovery.
-        browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
         browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
 
         # Tell the agent-browser daemon to self-terminate after being idle

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -70,6 +70,7 @@ from hermes_constants import agent_browser_runnable, get_hermes_home
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.path_env import common_tool_path_dirs
 
 # Browser-specific tool keys passed through to the agent-browser subprocess
 # AFTER credential stripping.  agent-browser is a Node process loading npm
@@ -151,20 +152,9 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
-# Includes Android/Termux and macOS Homebrew locations needed for agent-browser,
-# npx, node, and Android's glibc runner (grun).
-_SANE_PATH_DIRS = (
-    "/data/data/com.termux/files/usr/bin",
-    "/data/data/com.termux/files/usr/sbin",
-    "/opt/homebrew/bin",
-    "/opt/homebrew/sbin",
-    "/usr/local/sbin",
-    "/usr/local/bin",
-    "/usr/sbin",
-    "/usr/bin",
-    "/sbin",
-    "/bin",
-)
+# Includes version-manager shims, macOS Homebrew locations, Android/Termux,
+# and standard Unix directories needed for agent-browser, npx, node, and grun.
+_SANE_PATH_DIRS = common_tool_path_dirs(existing_only=False)
 _SANE_PATH = os.pathsep.join(_SANE_PATH_DIRS)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the non-interactive `PATH` discovery gap shared by `hermes doctor` and the browser tool.

Hermes can be launched by launchd, systemd user services, dashboards, IDE integrations, or cron with a minimal `PATH`. In those environments, tools installed through version managers or platform package managers can be invisible even though they work in an interactive shell. This affects Node.js, npm, `agent-browser`, and browser subprocess setup.

This PR adds one shared helper module for common tool-path fallbacks and wires both `hermes doctor` and `tools/browser_tool.py` through it, so they use the same ordered fallback directories.

Closest related PRs checked:
- #16125 handled a doctor-only global `agent-browser` lookup.
- #20672 tightened Lightpanda/browser fallback behavior.
- This PR covers shared mise/asdf/nvm/Homebrew/Termux/FHS path fallback across both doctor checks and browser subprocesses.

## Related Issue

Fixes #18158

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/path_env.py`
  - Adds `common_tool_path_dirs(existing_only=True)` for ordered fallback directories.
  - Adds `merge_common_tool_path(existing_path=None, prepend=False)` for deduped `PATH` merging.
  - Adds `ensure_common_tool_paths(prepend=False)` for idempotent environment mutation.
- `hermes_cli/doctor.py`
  - Calls `ensure_common_tool_paths()` before External Tools checks so `shutil.which()` can see version-manager and package-manager shims in non-interactive launches.
- `tools/browser_tool.py`
  - Derives `_SANE_PATH` / `_SANE_PATH_DIRS` from the shared helper, keeping browser subprocess behavior aligned with doctor checks.
- `tests/hermes_cli/test_path_env.py`
  - Covers version-manager dirs, Homebrew/Termux/FHS statics, dedupe, append/prepend behavior, and `os.environ['PATH']` mutation.
- `tests/hermes_cli/test_doctor.py`
  - Verifies doctor invokes the shared path helper.
- `tests/tools/test_browser_homebrew_paths.py`
  - Extends browser path assertions to cover mise/asdf shims alongside existing Homebrew/FHS paths.

## How to Test

1. Run the targeted regression suite:

```bash
python -m pytest tests/hermes_cli/test_path_env.py \
                   tests/hermes_cli/test_doctor.py::test_run_doctor_sets_interactive_env_for_tool_checks \
                   tests/tools/test_browser_homebrew_paths.py \
                   -o 'addopts=' -q
```

Expected result:

```text
29 passed
```

2. Reproduce on a machine where Node.js or `agent-browser` is available through mise/asdf/nvm/Homebrew while Hermes is launched with a minimal non-interactive `PATH`.
3. Run `hermes doctor` and verify External Tools can find Node.js / npm / `agent-browser` through the fallback path set.
4. Use the browser tool and verify the spawned subprocess receives the same fallback path coverage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, with non-interactive launch-style PATH reproduction

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests:

```text
$ python -m pytest tests/hermes_cli/test_path_env.py \
                   tests/hermes_cli/test_doctor.py::test_run_doctor_sets_interactive_env_for_tool_checks \
                   tests/tools/test_browser_homebrew_paths.py \
                   -o 'addopts=' -q
29 passed
```
