### PR TITLE
fix: route media files to Feishu send_message pipeline

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -588,11 +588,26 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu: native media attachment support via running gateway adapter ---
+    if _feishu_available and platform == Platform.FEISHU and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig, chat_id, chunk,
+                thread_id=thread_id,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -600,7 +615,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary

The Feishu adapter (feishu.py) already fully supports send_image_file, send_document, and send_video. The _send_feishu() function accepts media_files parameter and iterates over them correctly. However, the routing layer in _send_to_platform() silently dropped media_files for Feishu.

## Changes

### 1. Added Feishu chunked-send media block (lines 591-604)
Matching the Telegram/Discord/Yuanbao pattern: chunks the message, passes media_files on the last chunk only, returns early when media is present.

### 2. Updated non-media fallback error message (line 610)
Added feishu to the supported platforms list in the error text.

### 3. Updated media-omitted warning text (line 618)
Added feishu to the supported platforms list in the warning text.

## Behavior Change

Before: send_message with MEDIA: to Feishu returned error
After: send_message with MEDIA: to Feishu delivers native image bubble

## Test

Sent a PNG image via send_message with MEDIA: prefix to Feishu DM:
- Image delivered as native image bubble ✅
- Previously returned "MEDIA delivery not supported" error — no longer occurs ✅

## Related

Fixes: #10136, #17418
Related: #6421, #10392, #12461
Closes: #18161