### PR TITLE
feat(skin): pass spinner, tool_emojis, and status bar colors to TUI

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -724,14 +724,28 @@ def resolve_skin() -> dict:
 
         init_skin_from_config(_load_cfg())
         skin = get_active_skin()
+        colors = skin.colors or {}
+        branding = skin.branding or {}
         return {
             "name": skin.name,
-            "colors": skin.colors,
-            "branding": skin.branding,
+            "colors": colors,
+            "branding": branding,
             "banner_logo": skin.banner_logo,
             "banner_hero": skin.banner_hero,
             "tool_prefix": skin.tool_prefix,
-            "help_header": (skin.branding or {}).get("help_header", ""),
+            "help_header": branding.get("help_header", ""),
+            "spinner": skin.spinner,
+            "tool_emojis": skin.tool_emojis,
+            # Pass status bar colors explicitly so the TUI can use
+            # dedicated status_bar_* keys rather than repurposing ui_ok/ui_warn.
+            "status_bar_bg": colors.get("status_bar_bg", ""),
+            "status_bar_text": colors.get("status_bar_text", ""),
+            "status_bar_strong": colors.get("status_bar_strong", ""),
+            "status_bar_dim": colors.get("status_bar_dim", ""),
+            "status_bar_good": colors.get("status_bar_good", ""),
+            "status_bar_warn": colors.get("status_bar_warn", ""),
+            "status_bar_bad": colors.get("status_bar_bad", ""),
+            "status_bar_critical": colors.get("status_bar_critical", ""),
         }
     except Exception:
         return {}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -7,6 +7,16 @@ export interface GatewaySkin {
   colors?: Record<string, string>
   help_header?: string
   tool_prefix?: string
+  spinner?: Record<string, unknown>
+  tool_emojis?: Record<string, string>
+  status_bar_bg?: string
+  status_bar_text?: string
+  status_bar_strong?: string
+  status_bar_dim?: string
+  status_bar_good?: string
+  status_bar_warn?: string
+  status_bar_bad?: string
+  status_bar_critical?: string
 }
 
 export interface GatewayCompletionItem {

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -542,12 +542,12 @@ export function fromSkin(
       sessionLabel: c('session_label') ?? muted,
       sessionBorder: c('session_border') ?? muted,
 
-      statusBg: d.color.statusBg,
-      statusFg: d.color.statusFg,
-      statusGood: c('ui_ok') ?? d.color.statusGood,
-      statusWarn: c('ui_warn') ?? d.color.statusWarn,
-      statusBad: d.color.statusBad,
-      statusCritical: d.color.statusCritical,
+      statusBg: c('status_bar_bg') ?? d.color.statusBg,
+      statusFg: c('status_bar_text') ?? d.color.statusFg,
+      statusGood: c('status_bar_good') ?? c('ui_ok') ?? d.color.statusGood,
+      statusWarn: c('status_bar_warn') ?? c('ui_warn') ?? d.color.statusWarn,
+      statusBad: c('status_bar_bad') ?? d.color.statusBad,
+      statusCritical: c('status_bar_critical') ?? d.color.statusCritical,
       selectionBg: c('selection_bg') ?? d.color.selectionBg,
 
       diffAdded: d.color.diffAdded,


### PR DESCRIPTION
## Summary

Completes the Python to TUI skin data pipeline by passing `spinner`, `tool_emojis`, and all 8 `status_bar_*` color fields through `resolve_skin()` and mapping them properly in `fromSkin()`.

## Changes

### `tui_gateway/server.py`
- `resolve_skin()` now sends `spinner`, `tool_emojis`, `status_bar_bg`, `status_bar_text`, `status_bar_strong`, `status_bar_dim`, `status_bar_good`, `status_bar_warn`, `status_bar_bad`, `status_bar_critical`
- Wrapped `colors`/`branding` with `or {}` for safety before `.get()` calls

### `ui-tui/src/gatewayTypes.ts`
- Added `spinner`, `tool_emojis`, and all 8 `status_bar_*` fields to `GatewaySkin`

### `ui-tui/src/theme.ts`
- `fromSkin()` now reads `status_bar_bg`/`status_bar_text` instead of hardcoded default colors for `statusBg`/`statusFg`
- `statusGood`/`statusWarn` look up `status_bar_good`/`status_bar_warn` first, then fall back to `ui_ok`/`ui_warn`, then default colors
- `statusBad`/`statusCritical` look up `status_bar_bad`/`status_bar_critical` before falling back to defaults

## Backward Compatibility

All new fields are optional. Skins that don't set them continue to work identically -- every value falls through to the same defaults as before.

## Refs

Closes #17977
