### PR TITLE
Fallback immediately on provider content-policy blocks

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -44,9 +44,10 @@ class FailoverReason(enum.Enum):
     payload_too_large = "payload_too_large"  # 413 — compress payload
     image_too_large = "image_too_large"   # Native image part exceeds provider's per-image limit — shrink and retry
 
-    # Model
+    # Model / provider policy
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator (e.g. OpenRouter) blocked the only endpoint due to account data/privacy policy
+    content_policy_blocked = "content_policy_blocked"  # Provider safety policy blocked this prompt; don't retry unchanged prompt
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
@@ -233,6 +234,16 @@ _PROVIDER_POLICY_BLOCKED_PATTERNS = [
     "no endpoints available matching your guardrail",
     "no endpoints available matching your data policy",
     "no endpoints found matching your data policy",
+]
+
+# Provider content-policy / safety-filter blocks.  These are deterministic
+# policy decisions for the unchanged request, not transient transport/server
+# failures.  Retrying them several times wastes time and produces the noisy
+# "Max retries ... trying fallback" status; the agent should switch to a
+# configured fallback immediately (or surface the policy block if none exists).
+_CONTENT_POLICY_BLOCKED_PATTERNS = [
+    "flagged for possible cybersecurity risk",
+    "trusted access for cyber",
 ]
 
 # Auth patterns (non-status-code signals)
@@ -423,6 +434,17 @@ def classify_api_error(
         return ClassifiedError(**defaults)
 
     # ── 1. Provider-specific patterns (highest priority) ────────────
+
+    # Provider content-policy/safety-filter block (message may arrive without
+    # an HTTP status from provider SDKs).  This must run before normal status
+    # classification so a 400 policy block doesn't become a format_error and
+    # a status-less policy block doesn't become retryable unknown.
+    if any(p in error_msg for p in _CONTENT_POLICY_BLOCKED_PATTERNS):
+        return _result(
+            FailoverReason.content_policy_blocked,
+            retryable=False,
+            should_fallback=True,
+        )
 
     # Anthropic thinking block signature invalid (400).
     # Don't gate on provider — OpenRouter proxies Anthropic errors, so the

--- a/run_agent.py
+++ b/run_agent.py
@@ -12405,7 +12405,10 @@ class AIAgent:
                     if is_client_error:
                         # Try fallback before aborting — a different provider
                         # may not have the same issue (rate limit, auth, etc.)
-                        self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                        if classified.reason == FailoverReason.content_policy_blocked:
+                            self._emit_status("⚠️ Provider content policy blocked this request — trying fallback...")
+                        else:
+                            self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                         if self._try_activate_fallback():
                             retry_count = 0
                             compression_attempts = 0
@@ -12415,10 +12418,16 @@ class AIAgent:
                             self._dump_api_request_debug(
                                 api_kwargs, reason="non_retryable_client_error", error=api_error,
                             )
-                        self._emit_status(
-                            f"❌ Non-retryable error (HTTP {status_code}): "
-                            f"{self._summarize_api_error(api_error)}"
-                        )
+                        if classified.reason == FailoverReason.content_policy_blocked:
+                            self._emit_status(
+                                f"❌ Provider content policy blocked this request: "
+                                f"{self._summarize_api_error(api_error)}"
+                            )
+                        else:
+                            self._emit_status(
+                                f"❌ Non-retryable error (HTTP {status_code}): "
+                                f"{self._summarize_api_error(api_error)}"
+                            )
                         self._vprint(f"{self.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                         self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                         self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -56,7 +56,7 @@ class TestFailoverReason:
             "overloaded", "server_error", "timeout",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
-            "provider_policy_blocked",
+            "provider_policy_blocked", "content_policy_blocked",
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "unknown",
@@ -362,6 +362,33 @@ class TestClassifyApiError:
         )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.model_not_found
+        assert result.should_fallback is True
+
+    # ── Provider content-policy block ──
+
+    def test_message_only_cyber_content_policy_blocked(self):
+        # OpenAI Codex can return this without an HTTP status. Retrying the
+        # same prompt three times only repeats the same policy decision, so it
+        # should jump directly to fallback instead of emitting "Max retries".
+        e = Exception(
+            "This content was flagged for possible cybersecurity risk. If this "
+            "seems wrong, try rephrasing your request. To get authorized for "
+            "security work, join the Trusted Access for Cyber program."
+        )
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.5")
+        assert result.reason == FailoverReason.content_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.should_compress is False
+
+    def test_status_code_cyber_content_policy_blocked(self):
+        e = MockAPIError(
+            "This content was flagged for possible cybersecurity risk",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.5")
+        assert result.reason == FailoverReason.content_policy_blocked
+        assert result.retryable is False
         assert result.should_fallback is True
 
     # ── Payload too large ──


### PR DESCRIPTION
## Summary
- classify provider content-policy blocks (including OpenAI Codex cybersecurity-risk messages) as non-retryable
- activate fallback immediately instead of retrying the same blocked prompt until `Max retries`
- add regression coverage for status-less and 400 content-policy block messages

## Verification
- `python -m pytest tests/agent/test_error_classifier.py tests/run_agent/test_primary_runtime_restore.py -q`
- `python -m py_compile agent/error_classifier.py run_agent.py`