### PR TITLE
fix(status): add NVIDIA_API_KEY to hermes status API keys display

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -125,6 +125,7 @@ def show_status(args):
     keys = {
         "OpenRouter": "OPENROUTER_API_KEY",
         "OpenAI": "OPENAI_API_KEY",
+        "NVIDIA": "NVIDIA_API_KEY",
         "Z.AI/GLM": "GLM_API_KEY",
         "Kimi": "KIMI_API_KEY",
         "StepFun Step Plan": "STEPFUN_API_KEY",


### PR DESCRIPTION
Closes #16082. Salvaged from #18067 (@Feranmi10, commit authorship preserved).

`hermes status` listed provider API keys under the ◆ API Keys section but `NVIDIA_API_KEY` was absent. Users on NVIDIA NIM had no way to verify their key from status output.

## Changes
- `hermes_cli/status.py`: add `"NVIDIA": "NVIDIA_API_KEY"` to the keys dict.

## Why not merge #18067 directly
#18067 also included ~25 lines of unrelated custom_providers fallback changes in `agent/auxiliary_client.py` and `run_agent.py` that duplicate the same author's PR #17827 and overlap with #15756. Scoping this PR down to just the NVIDIA status fix; the fallback work can be handled separately via #17827 / #15756.