### PR TITLE
fix(curator): preserve last_report_path in state

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -55,6 +55,7 @@ def _default_state() -> Dict[str, Any]:
         "last_run_at": None,
         "last_run_duration_seconds": None,
         "last_run_summary": None,
+        "last_report_path": None,
         "paused": False,
         "run_count": 0,
     }

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -363,6 +363,19 @@ def test_state_atomic_write_no_tmp_leftovers(curator_env):
         assert not p.name.startswith(".curator_state_"), f"tmp leftover: {p.name}"
 
 
+def test_state_preserves_last_report_path(curator_env):
+    c = curator_env["curator"]
+    c.save_state({
+        "last_run_at": "2026-04-30T12:00:00+00:00",
+        "last_run_summary": "ok",
+        "last_report_path": "/tmp/curator-report",
+        "paused": False,
+        "run_count": 1,
+    })
+    state = c.load_state()
+    assert state["last_report_path"] == "/tmp/curator-report"
+
+
 def test_curator_review_prompt_has_invariants():
     """Core invariants must be in the review prompt text."""
     from agent.curator import CURATOR_REVIEW_PROMPT


### PR DESCRIPTION
Salvages #18058 by @Yukipukii1 onto current main.

## Summary
`hermes curator status` now shows the last report path instead of always showing none. Root cause: curator wrote `last_report_path` into state but `load_state()` only preserved keys present in `_default_state()`, silently dropping it on the next read.

## Changes
- `agent/curator.py`: add `last_report_path` to `_default_state()`
- `tests/agent/test_curator.py`: regression test for save → load round-trip

## Validation
- `scripts/run_tests.sh tests/agent/test_curator.py` → 39 passed
- E2E: save with `last_report_path` set → load → field preserved (previously dropped)

Authored by @Yukipukii1 (commit authorship preserved). Closes #18058.