### PR TITLE
fix(cli): coerce tls insecure flag safely in auth state (#17826)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -43,7 +43,7 @@ import yaml
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -2480,8 +2480,8 @@ def _resolve_verify(
     tls_state = tls_state if isinstance(tls_state, dict) else {}
 
     effective_insecure = (
-        bool(insecure) if insecure is not None
-        else bool(tls_state.get("insecure", False))
+        is_truthy_value(insecure, default=False) if insecure is not None
+        else is_truthy_value(tls_state.get("insecure", False), default=False)
     )
     effective_ca = (
         ca_bundle

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -77,10 +77,12 @@ class TestResolveVerifyFallback:
         assert result is False
 
     def test_string_false_in_auth_state_does_not_disable_tls_verify(self):
+        import ssl
         from hermes_cli.auth import _resolve_verify
 
         result = _resolve_verify(auth_state={"tls": {"insecure": "false"}})
-        assert result is True
+        assert result is not False
+        assert result is True or isinstance(result, ssl.SSLContext)
 
     def test_string_true_in_auth_state_disables_tls_verify(self):
         from hermes_cli.auth import _resolve_verify

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -76,6 +76,18 @@ class TestResolveVerifyFallback:
         )
         assert result is False
 
+    def test_string_false_in_auth_state_does_not_disable_tls_verify(self):
+        from hermes_cli.auth import _resolve_verify
+
+        result = _resolve_verify(auth_state={"tls": {"insecure": "false"}})
+        assert result is True
+
+    def test_string_true_in_auth_state_disables_tls_verify(self):
+        from hermes_cli.auth import _resolve_verify
+
+        result = _resolve_verify(auth_state={"tls": {"insecure": "true"}})
+        assert result is False
+
     def test_no_ca_bundle_returns_true(self, monkeypatch):
         from hermes_cli.auth import _resolve_verify
 


### PR DESCRIPTION
Salvage of #17826 by @johnncenae onto current main.

## Summary
TLS verify no longer silently disables when `auth.tls.insecure` is stored as the string `"false"`. Previously `bool("false") == True` → cert verification off.

## Change
- `hermes_cli/auth.py::_resolve_verify()` now routes `insecure` through the shared `is_truthy_value()` helper in `utils.py`.
- Two regression tests: string `"false"` keeps verify on; string `"true"` still disables.

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_auth_nous_provider.py` → 30/30 passed.

Closes #17826.