### PR TITLE
fix(api-server): use session-scoped task IDs for tool isolation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2351,10 +2351,11 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
+            effective_task_id = session_id or str(uuid.uuid4())
             result = agent.run_conversation(
                 user_message=user_message,
                 conversation_history=conversation_history,
-                task_id="default",
+                task_id=effective_task_id,
             )
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
@@ -2551,10 +2552,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 self._active_run_agents[run_id] = agent
                 def _run_sync():
+                    effective_task_id = session_id or run_id
                     r = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
-                        task_id="default",
+                        task_id=effective_task_id,
                     )
                     u = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -333,6 +333,36 @@ def auth_adapter():
 
 
 # ---------------------------------------------------------------------------
+# Adapter internals
+# ---------------------------------------------------------------------------
+
+
+class TestAgentExecution:
+    @pytest.mark.asyncio
+    async def test_run_agent_uses_session_id_as_task_id(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+            )
+
+        assert result == {"final_response": "ok"}
+        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        mock_agent.run_conversation.assert_called_once_with(
+            user_message="hello",
+            conversation_history=[],
+            task_id="session-123",
+        )
+
+
+# ---------------------------------------------------------------------------
 # /health endpoint
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -253,10 +253,7 @@ class TestRunStatus:
                     await asyncio.sleep(0.05)
 
                 mock_agent.run_conversation.assert_called_once()
-                # task_id stays "default" so the Runs API shares one sandbox
-                # container with CLI/gateway; session_id is surfaced in status
-                # for external UIs to correlate runs with their own session IDs.
-                assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "default"
+                assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "space-session"
                 assert status["session_id"] == "space-session"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Salvage of #17567 by @hharry11 onto current `main` (222 commits ahead of the original branch).

## Summary
API server's `run_conversation(task_id=…)` now uses the session identity the API server already tracks, instead of a hardcoded `"default"`. This matches what the regular gateway (gateway/run.py:12129) has always done and gives concurrent API sessions their own browser sessions, file-state tracking, and process registries.

## Why the "shared Docker sandbox" invariant is not broken
The earlier decision in #17085 kept `task_id="default"` to preserve the shared-container model. That invariant is actually enforced one layer below: `tools/terminal_tool.py:_resolve_container_task_id()` collapses any `task_id` back to `"default"` unless `register_task_env_overrides()` was called (RL/benchmark paths only). So session-scoped task IDs still land on the shared container — the guarantee holds.

## Changes
- `gateway/platforms/api_server.py`: `_run_agent` uses `session_id or uuid4`; `/v1/runs` path uses `session_id or run_id`.
- Regression test: `test_run_agent_uses_session_id_as_task_id`.
- Updated `test_status_reflects_explicit_session_id` to assert the new behavior.

## Validation
`scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py` → 144 passed.

Closes #17567.