### PR TITLE
fix(context_compressor): off-by-one in tail protection for short conversations

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -538,7 +538,7 @@ class ContextCompressor(ContextEngine):
             # Token-budget approach: walk backward accumulating tokens
             accumulated = 0
             boundary = len(result)
-            min_protect = min(protect_tail_count, len(result) - 1)
+            min_protect = min(protect_tail_count, len(result))
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 raw_content = msg.get("content") or ""

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1119,6 +1119,34 @@ class TestTokenBudgetTailProtection:
         # At least one old tool result should have been pruned
         assert pruned >= 1
 
+    def test_prune_short_conv_protects_entire_tail(self, budget_compressor):
+        """Regression guard for PR #17025.
+
+        When ``len(messages) <= protect_tail_count`` and a token budget is
+        also set, every message must be protected. The previous code used
+        ``min(protect_tail_count, len(result) - 1)`` which capped the floor
+        one below the full length, leaving the oldest message eligible for
+        pruning.
+        """
+        c = budget_compressor
+        # 4 messages, protect_tail_count=4 -- nothing should be pruned.
+        # Oldest message is a large tool result; on the buggy path it falls
+        # outside the protected window and gets summarized.
+        messages = [
+            {"role": "tool", "content": "x" * 5000, "tool_call_id": "c0"},
+            {"role": "assistant", "content": "ack"},
+            {"role": "user", "content": "recent"},
+            {"role": "assistant", "content": "reply"},
+        ]
+        result, pruned = c._prune_old_tool_results(
+            messages,
+            protect_tail_count=4,
+            protect_tail_tokens=1_000_000,  # budget large enough to protect all
+        )
+        assert pruned == 0
+        # Tool result at index 0 must be preserved verbatim
+        assert result[0]["content"] == "x" * 5000
+
     def test_prune_without_token_budget_uses_message_count(self, budget_compressor):
         """Without protect_tail_tokens, falls back to message-count behavior."""
         c = budget_compressor


### PR DESCRIPTION
Salvage of #17025 (@0z1-ghb) onto current main, with a regression test added.

## Summary
In `_prune_old_tool_results`, the token-budget branch computed `min_protect = min(protect_tail_count, len(result) - 1)`. When a conversation had `<= protect_tail_count` messages, the `- 1` dropped the floor by one — leaving the oldest message eligible for summarization. With `protect_tail_count=3` and 3 messages, only 2 were protected.

## Changes
- `agent/context_compressor.py`: `len(result) - 1` → `len(result)` (contributor commit, @0z1-ghb)
- `tests/agent/test_context_compressor.py`: `test_prune_short_conv_protects_entire_tail` — 4-message convo, `protect_tail_count=4`, asserts `pruned == 0` and tool content preserved verbatim

## Validation
|  | Buggy formula | Fixed formula |
|---|---|---|
| new regression test | FAIL (pruned=1, tool summarized) | PASS (pruned=0) |
| `TestTokenBudgetTailProtection` (11 tests) | — | PASS |
| `test_context_compressor.py` full (65 tests) | — | PASS |

Closes #17025.