### PR TITLE
fix(session_search): order recent mode by last activity (SQL-level chain walk)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -933,6 +933,7 @@ class SessionDB:
         offset: int = 0,
         include_children: bool = False,
         project_compression_tips: bool = True,
+        order_by_last_active: bool = False,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -952,6 +953,11 @@ class SessionDB:
         compressed continuations from being invisible to users while keeping
         delegate subagents and branches hidden. Pass ``False`` to return the
         raw root rows (useful for admin/debug UIs).
+
+        Pass ``order_by_last_active=True`` to sort by most-recent activity
+        instead of original conversation start time. This is computed after
+        compression-tip projection so "recent sessions" surfaces the live tip
+        of a compressed conversation in the correct slot.
         """
         where_clauses = []
         params = []
@@ -979,6 +985,15 @@ class SessionDB:
             params.extend(exclude_sources)
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        order_sql = (
+            "ORDER BY last_active DESC, s.started_at DESC, s.id DESC"
+            if order_by_last_active
+            else "ORDER BY s.started_at DESC"
+        )
+        limit_sql = ""
+        if not order_by_last_active:
+            limit_sql = "LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
         query = f"""
             SELECT s.*,
                 COALESCE(
@@ -994,10 +1009,9 @@ class SessionDB:
                 ) AS last_active
             FROM sessions s
             {where_sql}
-            ORDER BY s.started_at DESC
-            LIMIT ? OFFSET ?
+            {order_sql}
+            {limit_sql}
         """
-        params.extend([limit, offset])
         with self._lock:
             cursor = self._conn.execute(query, params)
             rows = cursor.fetchall()
@@ -1046,6 +1060,17 @@ class SessionDB:
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
+
+        if order_by_last_active:
+            sessions.sort(
+                key=lambda s: (
+                    s.get("last_active") or s.get("started_at") or 0,
+                    s.get("started_at") or 0,
+                    s.get("id") or "",
+                ),
+                reverse=True,
+            )
+            sessions = sessions[offset:offset + limit]
 
         return sessions
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -955,9 +955,12 @@ class SessionDB:
         raw root rows (useful for admin/debug UIs).
 
         Pass ``order_by_last_active=True`` to sort by most-recent activity
-        instead of original conversation start time. This is computed after
-        compression-tip projection so "recent sessions" surfaces the live tip
-        of a compressed conversation in the correct slot.
+        instead of original conversation start time. For compression chains,
+        the "most-recent activity" is taken from the live tip (not the root),
+        so an old conversation that was compressed and continued recently
+        surfaces in the correct slot. Ordering is computed at SQL level via
+        a recursive CTE that walks compression-continuation edges, so LIMIT
+        and OFFSET still apply efficiently.
         """
         where_clauses = []
         params = []
@@ -985,33 +988,80 @@ class SessionDB:
             params.extend(exclude_sources)
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
-        order_sql = (
-            "ORDER BY last_active DESC, s.started_at DESC, s.id DESC"
-            if order_by_last_active
-            else "ORDER BY s.started_at DESC"
-        )
-        limit_sql = ""
-        if not order_by_last_active:
-            limit_sql = "LIMIT ? OFFSET ?"
+        if order_by_last_active:
+            # Compute effective_last_active by walking each surfaced session's
+            # compression-continuation chain forward in SQL and taking the MAX
+            # timestamp across the chain. This lets us ORDER BY + LIMIT at SQL
+            # level instead of fetching every row and sorting in Python, while
+            # still surfacing old compression roots whose live tip is fresh.
+            #
+            # The CTE seeds from rows the outer WHERE admits (roots + branch
+            # children), then recursively joins forward through
+            # compression-continuation edges using the same criteria as
+            # get_compression_tip (parent.end_reason='compression' AND
+            # child.started_at >= parent.ended_at).
+            query = f"""
+                WITH RECURSIVE chain(root_id, cur_id) AS (
+                    SELECT s.id, s.id FROM sessions s {where_sql}
+                    UNION ALL
+                    SELECT c.root_id, child.id
+                    FROM chain c
+                    JOIN sessions parent ON parent.id = c.cur_id
+                    JOIN sessions child ON child.parent_session_id = c.cur_id
+                    WHERE parent.end_reason = 'compression'
+                      AND child.started_at >= parent.ended_at
+                ),
+                chain_max AS (
+                    SELECT
+                        root_id,
+                        MAX(COALESCE(
+                            (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = cur_id),
+                            (SELECT started_at FROM sessions ss WHERE ss.id = cur_id)
+                        )) AS effective_last_active
+                    FROM chain
+                    GROUP BY root_id
+                )
+                SELECT s.*,
+                    COALESCE(
+                        (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                         FROM messages m
+                         WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                         ORDER BY m.timestamp, m.id LIMIT 1),
+                        ''
+                    ) AS _preview_raw,
+                    COALESCE(
+                        (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
+                        s.started_at
+                    ) AS last_active,
+                    COALESCE(cm.effective_last_active, s.started_at) AS _effective_last_active
+                FROM sessions s
+                LEFT JOIN chain_max cm ON cm.root_id = s.id
+                {where_sql}
+                ORDER BY _effective_last_active DESC, s.started_at DESC, s.id DESC
+                LIMIT ? OFFSET ?
+            """
+            # WHERE params apply twice (CTE seed + outer select).
+            params = params + params + [limit, offset]
+        else:
+            query = f"""
+                SELECT s.*,
+                    COALESCE(
+                        (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                         FROM messages m
+                         WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                         ORDER BY m.timestamp, m.id LIMIT 1),
+                        ''
+                    ) AS _preview_raw,
+                    COALESCE(
+                        (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
+                        s.started_at
+                    ) AS last_active
+                FROM sessions s
+                {where_sql}
+                ORDER BY s.started_at DESC
+                LIMIT ? OFFSET ?
+            """
             params.extend([limit, offset])
-        query = f"""
-            SELECT s.*,
-                COALESCE(
-                    (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
-                     FROM messages m
-                     WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp, m.id LIMIT 1),
-                    ''
-                ) AS _preview_raw,
-                COALESCE(
-                    (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),
-                    s.started_at
-                ) AS last_active
-            FROM sessions s
-            {where_sql}
-            {order_sql}
-            {limit_sql}
-        """
         with self._lock:
             cursor = self._conn.execute(query, params)
             rows = cursor.fetchall()
@@ -1025,6 +1075,8 @@ class SessionDB:
                 s["preview"] = text + ("..." if len(raw) > 60 else "")
             else:
                 s["preview"] = ""
+            # Drop the internal ordering column so callers see a clean dict.
+            s.pop("_effective_last_active", None)
             sessions.append(s)
 
         # Project compression roots forward to their tips. Each row whose
@@ -1060,17 +1112,6 @@ class SessionDB:
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
-
-        if order_by_last_active:
-            sessions.sort(
-                key=lambda s: (
-                    s.get("last_active") or s.get("started_at") or 0,
-                    s.get("started_at") or 0,
-                    s.get("id") or "",
-                ),
-                reverse=True,
-            )
-            sessions = sessions[offset:offset + limit]
 
         return sessions
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1752,6 +1752,64 @@ class TestListSessionsRich:
             s["id"] for s in db.list_sessions_rich(limit=5, order_by_last_active=True)
         ] == ["old", "new"]
 
+    def test_order_by_last_active_uses_compression_tip_activity(self, db):
+        """A compression root whose tip was touched recently must rank above
+        a newer uncompressed session, even when that tip activity lives in a
+        different row and the outer LIMIT could otherwise cut it.
+
+        This is the case that forced SQL-level chain walking: a naive "cap
+        the SQL fetch at limit*K" optimization would drop the old root off
+        the SQL page before post-projection could promote it.
+        """
+        t0 = 1709500000.0
+        db.create_session("root1", "cli")
+        with db._lock:
+            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root1"))
+            db._conn.execute(
+                "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+                (t0 + 100, "compression", "root1"),
+            )
+        db.append_message("root1", "user", "old ask")
+
+        # Continuation tip created after root ended; last activity much later.
+        db.create_session("tip1", "cli", parent_session_id="root1")
+        with db._lock:
+            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "tip1"))
+        db.append_message("tip1", "user", "latest message")
+
+        # Bunch of newer, uncompressed sessions — fresher start_at but older
+        # last activity than the tip. Explicitly pin message timestamps so
+        # they don't pick up wall-clock from append_message.
+        for i in range(5):
+            sid = f"newer{i}"
+            db.create_session(sid, "cli")
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE sessions SET started_at=? WHERE id=?",
+                    (t0 + 500 + i, sid),
+                )
+            db.append_message(sid, "user", f"msg {i}")
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE messages SET timestamp=? WHERE session_id=? AND content=?",
+                    (t0 + 500 + i, sid, f"msg {i}"),
+                )
+
+        # Tip activity timestamp is the latest thing in the DB.
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=? AND content=?",
+                (t0 + 10_000, "tip1", "latest message"),
+            )
+            db._conn.commit()
+
+        # limit=1 is the stress test: the old root must win the single slot.
+        top = db.list_sessions_rich(limit=1, order_by_last_active=True)
+        assert len(top) == 1
+        # Projection surfaces the tip's id in the root's slot.
+        assert top[0]["id"] == "tip1"
+        assert top[0]["_lineage_root_id"] == "root1"
+
     def test_rich_list_includes_title(self, db):
         db.create_session("s1", "cli")
         db.set_session_title("s1", "refactoring auth")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1719,6 +1719,39 @@ class TestListSessionsRich:
         # No messages, so last_active falls back to started_at
         assert sessions[0]["last_active"] == sessions[0]["started_at"]
 
+    def test_order_by_last_active_surfaces_recently_touched_older_session_first(self, db):
+        t0 = 1709500000.0
+        db.create_session("old", "cli")
+        db.create_session("new", "cli")
+
+        with db._lock:
+            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "old"))
+            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 10, "new"))
+
+        db.append_message("old", "user", "old first")
+        db.append_message("new", "user", "new first")
+        db.append_message("old", "assistant", "old touched later")
+
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=? AND role=? AND content=?",
+                (t0 + 1, "old", "user", "old first"),
+            )
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=? AND role=? AND content=?",
+                (t0 + 11, "new", "user", "new first"),
+            )
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=? AND role=? AND content=?",
+                (t0 + 20, "old", "assistant", "old touched later"),
+            )
+            db._conn.commit()
+
+        assert [s["id"] for s in db.list_sessions_rich(limit=5)] == ["new", "old"]
+        assert [
+            s["id"] for s in db.list_sessions_rich(limit=5, order_by_last_active=True)
+        ] == ["old", "new"]
+
     def test_rich_list_includes_title(self, db):
         db.create_session("s1", "cli")
         db.set_session_title("s1", "refactoring auth")

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -242,6 +242,21 @@ class TestSessionSearchConcurrency:
 
 
 class TestRecentSessionListing:
+    def test_recent_mode_requests_last_active_ordering(self):
+        from unittest.mock import MagicMock
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        result = json.loads(_list_recent_sessions(mock_db, limit=5))
+
+        assert result["success"] is True
+        mock_db.list_sessions_rich.assert_called_once_with(
+            limit=10,
+            exclude_sources=["tool"],
+            order_by_last_active=True,
+        )
+
     def test_current_child_session_excludes_root_lineage_even_when_child_id_is_longer(self):
         from unittest.mock import MagicMock
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -266,7 +266,11 @@ _HIDDEN_SESSION_SOURCES = ("tool",)
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
-        sessions = db.list_sessions_rich(limit=limit + 5, exclude_sources=list(_HIDDEN_SESSION_SOURCES))  # fetch extra to skip current
+        sessions = db.list_sessions_rich(
+            limit=limit + 5,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            order_by_last_active=True,
+        )  # fetch extra to skip current
 
         # Resolve current session lineage to exclude it
         current_root = None


### PR DESCRIPTION
Recent mode in `session_search` now ranks conversations by actual last activity, with compression continuations pulling their root to the top.

Salvages #17988 by @simbam99 onto current main and replaces the post-fetch Python re-sort with a SQL-level recursive CTE so the fix stays correct without dropping LIMIT/OFFSET.

## Changes
- `hermes_state.py`: `list_sessions_rich(order_by_last_active=True)` now uses a recursive CTE over sessions + compression-continuation edges to compute `effective_last_active = MAX(message timestamp across the chain)` per root, then `ORDER BY _effective_last_active DESC LIMIT ? OFFSET ?`. Chain walk criteria match `get_compression_tip` (parent.end_reason='compression' AND child.started_at >= parent.ended_at).
- `tools/session_search_tool.py`: `_list_recent_sessions()` passes `order_by_last_active=True`.
- Tests: contributor's two regression tests + one additional compression-chain test at `limit=1` (stress case that pins the correctness property a bounded-oversample approach would break).

## Why the CTE, not the contributor's Python re-sort
The original PR dropped `LIMIT`/`OFFSET` from SQL and re-sorted the full result set in Python after compression-tip projection. Correct, but O(N) per call — `session_search` recent mode is called on every no-query invocation, and users with thousands of sessions would fetch every row. A naive "oversample at SQL level" shortcut doesn't work either: an old compression root whose tip was touched yesterday has its root's `last_active` stuck at (say) a year ago, so it falls off any bounded SQL page. Computing effective_last_active at SQL level solves both.

## Validation
- `./scripts/run_tests.sh tests/test_hermes_state.py tests/tools/test_session_search.py` — 237 passed.
- E2E: isolated SessionDB with one compressed-and-continued root (tip last_active = t0+10000) + six newer idle sessions (last_active ∈ t0+500..t0+505). `_list_recent_sessions(limit=3)` returns `['tip1', 'idle5', 'idle4']` — tip correctly surfaces at rank 1.

Closes #17988.
