### PR TITLE
test(ci): stabilize Teams and Kanban dashboard mocks

### DIFF
--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -32,6 +32,9 @@ def _ensure_teams_mock():
     microsoft_teams_api_activities_invoke_adaptive_card = types.ModuleType(
         "microsoft_teams.api.activities.invoke.adaptive_card"
     )
+    microsoft_teams_common = types.ModuleType("microsoft_teams.common")
+    microsoft_teams_common_http = types.ModuleType("microsoft_teams.common.http")
+    microsoft_teams_common_http_client = types.ModuleType("microsoft_teams.common.http.client")
     microsoft_teams_api_models = types.ModuleType("microsoft_teams.api.models")
     microsoft_teams_api_models_adaptive_card = types.ModuleType("microsoft_teams.api.models.adaptive_card")
     microsoft_teams_api_models_invoke_response = types.ModuleType("microsoft_teams.api.models.invoke_response")
@@ -76,6 +79,7 @@ def _ensure_teams_mock():
 
     microsoft_teams_apps.App = MockApp
     microsoft_teams_apps.ActivityContext = MagicMock
+    microsoft_teams_common_http_client.ClientOptions = MagicMock
 
     # MessageActivity mock
     microsoft_teams_api.MessageActivity = MagicMock
@@ -143,6 +147,9 @@ def _ensure_teams_mock():
         "microsoft_teams.api.activities.typing": microsoft_teams_api_activities_typing,
         "microsoft_teams.api.activities.invoke": microsoft_teams_api_activities_invoke,
         "microsoft_teams.api.activities.invoke.adaptive_card": microsoft_teams_api_activities_invoke_adaptive_card,
+        "microsoft_teams.common": microsoft_teams_common,
+        "microsoft_teams.common.http": microsoft_teams_common_http,
+        "microsoft_teams.common.http.client": microsoft_teams_common_http_client,
         "microsoft_teams.api.models": microsoft_teams_api_models,
         "microsoft_teams.api.models.adaptive_card": microsoft_teams_api_models_adaptive_card,
         "microsoft_teams.api.models.invoke_response": microsoft_teams_api_models_invoke_response,

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -478,9 +478,11 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     kb.init_db()
 
     # Stub web_server so _check_ws_token has a token to compare against.
+    import hermes_cli
     import types
     stub = types.SimpleNamespace(_SESSION_TOKEN="secret-xyz")
     monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
 
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")


### PR DESCRIPTION
## What does this PR do?

Restores two test mocks that are breaking the shared `Tests / test` check on current `main`.

1. Microsoft Teams adapter tests did not mock `microsoft_teams.common.http.client.ClientOptions`, which the adapter imports. The import fell into the adapter's `ImportError` fallback, left `TypingActivityInput` as `None`, and made `send_typing()` swallow an exception before `mock_app.send` was awaited.
2. Kanban dashboard websocket auth tests patched `sys.modules["hermes_cli.web_server"]` but not the cached `hermes_cli.web_server` package attribute. After `tests/hermes_cli/test_web_server.py` imports the real module in the same worker, `_check_ws_token()` resolves the stale package attribute and rejects the supposedly valid websocket token.

This is test-only. It aligns the mocks with the production import and auth lookup paths.

## Related Issue

Fixes current main CI failures observed in Tests runs 25200177148 and 25200549436.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_teams.py`
  - Mock `microsoft_teams.common`, `microsoft_teams.common.http`, and `microsoft_teams.common.http.client`.
  - Provide `ClientOptions` in the Teams SDK mock before loading the adapter.
- `tests/plugins/test_kanban_dashboard_plugin.py`
  - Patch both `sys.modules["hermes_cli.web_server"]` and the `hermes_cli.web_server` package attribute.
  - Keep the accepted websocket token path exercising the same token value as the stub.

## How to Test

1. Reproduce the Teams failure on current `origin/main`:
   - `python -m pytest tests/gateway/test_teams.py::TestTeamsSend::test_send_typing -q --tb=short -o addopts=''`
2. Reproduce the Kanban package-attribute leak:
   - `python -m pytest tests/hermes_cli/test_web_server.py tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required -q --tb=short -o addopts=''`
3. Validate the focused suites after this patch:
   - `python -m compileall -q tests/gateway/test_teams.py tests/plugins/test_kanban_dashboard_plugin.py`
   - `python -m pytest tests/hermes_cli/test_web_server.py tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required -q --tb=short -o addopts=''`
   - `python -m pytest tests/gateway/test_teams.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_local_interrupt_cleanup.py -q --tb=short -o addopts=''`

## Validation Status

Focused local validation passes:

```text
tests/hermes_cli/test_web_server.py + Kanban websocket regression:
138 passed, 143 warnings in 2.86s

Teams + Kanban plugin + local interrupt cleanup focused suites:
78 passed, 64 warnings in 2.00s
```

Notes:

- Before the Teams mock patch, `test_send_typing` failed deterministically with `Expected send to have been awaited once. Awaited 0 times.`
- Before the Kanban package-attribute patch, the Kanban websocket test passed alone but failed after `tests/hermes_cli/test_web_server.py` imported `hermes_cli.web_server`.
- The separate current-main `tests/tools/test_local_interrupt_cleanup.py::test_wait_for_process_kills_subprocess_on_keyboardinterrupt` failure from run 25200177148 still passes locally in the focused suite above, so this PR only changes deterministic mock regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A

## Screenshots / Logs

Current main Teams failure:

```text
FAILED tests/gateway/test_teams.py::TestTeamsSend::test_send_typing - AssertionError: Expected send to have been awaited once. Awaited 0 times.
```

PR run Kanban failure before the second patch:

```text
FAILED tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required - starlette.websockets.WebSocketDisconnect
```
