### PR TITLE
fix(gateway): load WhatsApp home channel from env overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1051,7 +1051,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.WHATSAPP not in config.platforms:
             config.platforms[Platform.WHATSAPP] = PlatformConfig()
         config.platforms[Platform.WHATSAPP].enabled = True
-    
+    whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
+    if whatsapp_home and Platform.WHATSAPP in config.platforms:
+        config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id=whatsapp_home,
+            name=os.getenv("WHATSAPP_HOME_CHANNEL_NAME", "Home"),
+        )
+
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -456,6 +456,15 @@ class TestHomeChannelEnvOverrides:
                 ("C123", "Ops"),
             ),
             (
+                Platform.WHATSAPP,
+                PlatformConfig(enabled=True),
+                {
+                    "WHATSAPP_HOME_CHANNEL": "1234567890@lid",
+                    "WHATSAPP_HOME_CHANNEL_NAME": "Owner DM",
+                },
+                ("1234567890@lid", "Owner DM"),
+            ),
+            (
                 Platform.SIGNAL,
                 PlatformConfig(
                     enabled=True,


### PR DESCRIPTION
Salvage of #17449 (@Yukipukii1) onto current main.

## Summary
WhatsApp was the lone messaging platform that silently ignored its home-channel env vars. Setting `WHATSAPP_ENABLED=true` + `WHATSAPP_HOME_CHANNEL=...` would enable the adapter but leave `config.get_home_channel(Platform.WHATSAPP)` returning `None`.

## Changes
- `gateway/config.py`: map `WHATSAPP_HOME_CHANNEL` / `WHATSAPP_HOME_CHANNEL_NAME` into `PlatformConfig.home_channel`, matching the Telegram/Discord/Slack/Signal/Mattermost/Matrix/... template
- `tests/gateway/test_config.py`: parametrized regression case

## Validation
- `tests/gateway/test_config.py` — 33/33 passed
- Verified WhatsApp was the only messaging platform missing this env override on current main

Closes #17449. Contributor authorship preserved via cherry-pick + rebase-merge.