### PR TITLE
fix(docker): expose hermes in volume local bin

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -64,7 +64,15 @@ source "${INSTALL_DIR}/.venv/bin/activate"
 # The "home/" subdirectory is a per-profile HOME for subprocesses (git,
 # ssh, gh, npm …).  Without it those tools write to /root which is
 # ephemeral and shared across profiles.  See issue #4426.
-mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,home}
+# The ".local/bin" directory is on the image PATH so later
+# `docker compose exec ... bash` sessions can find the hermes launcher even
+# though they do not run this entrypoint or activate the venv first.
+mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,home} "$HERMES_HOME/.local/bin"
+
+hermes_launcher="$HERMES_HOME/.local/bin/hermes"
+if [ ! -e "$hermes_launcher" ] || [ -L "$hermes_launcher" ]; then
+    ln -sfn "${INSTALL_DIR}/.venv/bin/hermes" "$hermes_launcher"
+fi
 
 # .env
 if [ ! -f "$HERMES_HOME/.env" ]; then

--- a/tests/tools/test_docker_entrypoint.py
+++ b/tests/tools/test_docker_entrypoint.py
@@ -1,0 +1,32 @@
+"""Contract tests for Docker entrypoint volume bootstrapping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+
+
+@pytest.fixture(scope="module")
+def entrypoint_text() -> str:
+    if not ENTRYPOINT.exists():
+        pytest.skip("Docker entrypoint script not present in this checkout")
+    return ENTRYPOINT.read_text()
+
+
+def test_entrypoint_exposes_hermes_on_volume_local_bin(entrypoint_text: str):
+    """Fresh Docker volumes must make `hermes` available to later exec shells.
+
+    The image PATH includes ``$HERMES_HOME/.local/bin`` so that commands run via
+    ``docker compose exec ... bash`` can find user-local launchers.  A fresh
+    mounted volume starts empty, so the entrypoint must create that directory
+    and install a ``hermes`` launcher there; otherwise `which hermes` returns
+    nothing in later Docker terminal sessions even though the app started.
+    """
+    assert '"$HERMES_HOME/.local/bin"' in entrypoint_text
+    assert '"$HERMES_HOME/.local/bin/hermes"' in entrypoint_text
+    assert '"${INSTALL_DIR}/.venv/bin/hermes"' in entrypoint_text


### PR DESCRIPTION
## Summary
- create `$HERMES_HOME/.local/bin` during Docker entrypoint bootstrap
- install a `hermes` launcher symlink to the image venv so later `docker compose exec ... bash` sessions can resolve `hermes`
- add a Docker entrypoint contract test for the fresh-volume launcher path

## Root cause
The Docker image adds `/opt/data/.local/bin` to `PATH`, but a fresh mounted Docker volume starts without that directory or a `hermes` launcher. The container startup path works because the entrypoint activates `/opt/hermes/.venv`, but later terminal sessions entered with `docker compose exec` do not rerun the entrypoint activation, so `which hermes` can return nothing.

## Fix
During entrypoint volume bootstrap, create `$HERMES_HOME/.local/bin` and populate `$HERMES_HOME/.local/bin/hermes` as a symlink to `${INSTALL_DIR}/.venv/bin/hermes`, while preserving any existing non-symlink user-provided launcher.

## Regression coverage
Added `tests/tools/test_docker_entrypoint.py` to assert the entrypoint creates the volume-local bin directory and launcher pointing at the packaged venv `hermes` executable.

## Testing
- `scripts/run_tests.sh tests/tools/test_docker_entrypoint.py -q` (RED before fix)
- `scripts/run_tests.sh tests/tools/test_docker_entrypoint.py tests/tools/test_dockerfile_pid1_reaping.py -q` (GREEN: 7 passed)
- `bash -n docker/entrypoint.sh`

Closes #18184
