### PR TITLE
feat(gateway): add busy_ack_enabled config option to suppress ack messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1963,6 +1963,14 @@ class GatewayRunner:
             except Exception:
                 pass  # don't let interrupt failure block the ack
 
+        # Check if busy ack is disabled — skip sending but still process the input.
+        # Placed before debounce so we don't stamp a "last ack" timestamp that was
+        # never actually delivered.
+        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
+        if not busy_ack_enabled:
+            logger.debug("Busy ack suppressed for session %s", session_key)
+            return True  # input still processed, just no ack sent
+
         # Debounce: only send an acknowledgment once every 30 seconds per session
         # to avoid spamming the user when they send multiple messages quickly
         _BUSY_ACK_COOLDOWN = 30
@@ -1972,12 +1980,6 @@ class GatewayRunner:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
         self._busy_ack_ts[session_key] = now
-
-        # Check if busy ack is disabled — skip sending but still process the input
-        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
-        if not busy_ack_enabled:
-            logger.debug("Busy ack suppressed for session %s", session_key)
-            return True  # input still processed, just no ack sent
 
         # Build a status-rich acknowledgment
         status_parts = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -381,6 +381,8 @@ if _config_path.exists():
         if _display_cfg and isinstance(_display_cfg, dict):
             if "busy_input_mode" in _display_cfg and "HERMES_GATEWAY_BUSY_INPUT_MODE" not in os.environ:
                 os.environ["HERMES_GATEWAY_BUSY_INPUT_MODE"] = str(_display_cfg["busy_input_mode"])
+            if "busy_ack_enabled" in _display_cfg and "HERMES_GATEWAY_BUSY_ACK_ENABLED" not in os.environ:
+                os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_display_cfg["busy_ack_enabled"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         # HERMES_TIMEZONE from .env takes precedence (already in os.environ).
         _tz_cfg = _cfg.get("timezone", "")
@@ -1970,6 +1972,12 @@ class GatewayRunner:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
         self._busy_ack_ts[session_key] = now
+
+        # Check if busy ack is disabled — skip sending but still process the input
+        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
+        if not busy_ack_enabled:
+            logger.debug("Busy ack suppressed for session %s", session_key)
+            return True  # input still processed, just no ack sent
 
         # Build a status-rich acknowledgment
         status_parts = []

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -169,6 +169,7 @@ AUTHOR_MAP = {
     "sir_even@icloud.com": "sirEven",
     "36056348+sirEven@users.noreply.github.com": "sirEven",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
+    "jezzahehn@gmail.com": "JezzaHehn",
     "254021826+dodo-reach@users.noreply.github.com": "dodo-reach",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "270082434+crayfish-ai@users.noreply.github.com": "crayfish-ai",

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -406,6 +406,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_RESTART_DRAIN_TIMEOUT` | Gateway: seconds to wait for active runs to drain on `/restart` before forcing the restart (default: `900`). |
 | `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` | Per-platform connect timeout during gateway startup (seconds). |
 | `HERMES_GATEWAY_BUSY_INPUT_MODE` | Default gateway busy-input behavior: `queue`, `steer`, or `interrupt`. Can be overridden per chat with `/busy`. |
+| `HERMES_GATEWAY_BUSY_ACK_ENABLED` | Whether the gateway sends an acknowledgment message (⚡/⏳/⏩) when a user sends input while the agent is busy (default: `true`). Set to `false` to suppress these messages entirely — the input is still queued/steered/interrupts as normal, only the chat reply is silenced. Bridged from `display.busy_ack_enabled` in `config.yaml`. |
 | `HERMES_CRON_TIMEOUT` | Inactivity timeout for cron job agent runs in seconds (default: `600`). The agent can run indefinitely while actively calling tools or receiving stream tokens — this only triggers when idle. Set to `0` for unlimited. |
 | `HERMES_CRON_SCRIPT_TIMEOUT` | Timeout for pre-run scripts attached to cron jobs in seconds (default: `120`). Override for scripts that need longer execution (e.g., randomized delays for anti-bot timing). Also configurable via `cron.script_timeout_seconds` in `config.yaml`. |
 | `HERMES_CRON_MAX_PARALLEL` | Max cron jobs run in parallel per tick (default: `4`). |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -232,9 +232,12 @@ By default, messaging a busy agent interrupts it. Two other modes are available:
 ```yaml
 display:
   busy_input_mode: steer   # or queue, or interrupt (default)
+  busy_ack_enabled: true   # set to false to suppress the ⚡/⏳/⏩ chat reply entirely
 ```
 
 The first time you message a busy agent on any platform, Hermes appends a one-line reminder to the busy-ack explaining the knob (`"💡 First-time tip — …"`). The reminder fires once per install — a flag under `onboarding.seen.busy_input_prompt` latches it. Delete that key to see the tip again.
+
+If you find the busy-ack noisy — especially with voice input or rapid-fire messages — set `display.busy_ack_enabled: false`. Your input is still queued/steered/interrupts as normal, only the chat reply is silenced.
 
 ## Tool Progress Notifications
 


### PR DESCRIPTION
Salvage of #17491 by @JezzaHehn onto current main, plus a timestamp-placement nit and docs.

## Summary
Users can now set `display.busy_ack_enabled: false` in config.yaml to silence the ⚡/⏳/⏩ gateway reply that fires when a user sends input while the agent is busy. The input is still queued/steered/interrupts as normal — only the chat reply is suppressed. Fixes #17457.

## Changes
- `gateway/run.py`: bridge `display.busy_ack_enabled` → `HERMES_GATEWAY_BUSY_ACK_ENABLED` at startup; early-return guard in `_handle_active_session_busy_message()` placed above the debounce cooldown so no `_busy_ack_ts` timestamp is stamped when no ack was sent.
- `website/docs/reference/environment-variables.md`: document `HERMES_GATEWAY_BUSY_ACK_ENABLED`.
- `website/docs/user-guide/messaging/index.md`: document `display.busy_ack_enabled` alongside `busy_input_mode`.
- `scripts/release.py`: add `jezzahehn@gmail.com` → `JezzaHehn` to AUTHOR_MAP.

## Validation
| scenario | return | sends | stamps ts | input queued |
|---|---|---|---|---|
| default (no env) | True | 1 | yes | yes |
| `true` | True | 1 | yes | yes |
| `false` | True | **0** | **no** | **yes** |
| `FALSE` (case) | True | 0 | no | yes |

22/22 gateway busy-input tests pass on `scripts/run_tests.sh tests/gateway/ -k busy`.

Closes #17457.
Original PR: #17491 by @JezzaHehn — authorship preserved via rebase-merge.

Co-authored-by: Jezza Hehn <jezzahehn@gmail.com>