### PR TITLE
fix(gateway): pass user args to exec-type quick_commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4925,6 +4925,9 @@ class GatewayRunner:
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        user_args = event.get_command_args().strip()
+                        if user_args:
+                            exec_cmd = f"{exec_cmd} {user_args}"
                         try:
                             proc = await asyncio.create_subprocess_shell(
                                 exec_cmd,


### PR DESCRIPTION
Exec-type quick_commands currently ignore any arguments the user passes after the command name.

For example, if a user configures:

```yaml
quick_commands:
  greet:
    type: exec
    command: echo Hello
```

And sends `/greet World`, the expected output is `Hello World`, but the gateway drops `World` and only runs `echo Hello`, producing `Hello`.

### Root cause
`gateway/run.py` calls `asyncio.create_subprocess_shell(exec_cmd)` with only the base command from config, ignoring `event.get_command_args()`.

### Fix
Append user args to `exec_cmd` before spawning the subprocess (+3 lines).