### PR TITLE
chore(release): map AllardQuek email for AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -498,6 +498,7 @@ AUTHOR_MAP = {
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "harryplusplus@gmail.com": "harryplusplus",
     "anthhub@163.com": "anthhub",
+    "allard.quek@singtel.com": "AllardQuek",
     "shenuu@gmail.com": "shenuu",
     "xiayh17@gmail.com": "xiayh0107",
     "zhujianxyz@gmail.com": "opriz",


### PR DESCRIPTION
Adds `allard.quek@singtel.com` → `AllardQuek` so the release-notes author resolver can attribute #17232 correctly.

Follow-up to the merge of #17232.