### PR TITLE
fix(tools): strictly subtract agent.disabled_toolsets in CLI + gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,8 +15,8 @@ Usage:
 
 import logging
 import os
-import platform
 import shutil
+import sys
 import json
 import re
 import concurrent.futures

--- a/cli.py
+++ b/cli.py
@@ -15,9 +15,8 @@ Usage:
 
 import logging
 import os
-import re
+import platform
 import shutil
-import sys
 import json
 import re
 import concurrent.futures
@@ -599,6 +598,7 @@ def load_cli_config() -> Dict[str, Any]:
 
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
+
 
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
@@ -2118,6 +2118,8 @@ class HermesCLI:
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
+        self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
+
         if toolsets and "all" not in toolsets and "*" not in toolsets:
             # Validate each toolset — MCP server names are resolved via
             # live registry aliases (registered during discover_mcp_tools),
@@ -3568,6 +3570,7 @@ class HermesCLI:
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
                 ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7978,6 +7978,8 @@ class GatewayRunner:
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            agent_cfg = user_config.get("agent") or {}
+            disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
@@ -7994,6 +7996,7 @@ class GatewayRunner:
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
@@ -10352,6 +10355,7 @@ class GatewayRunner:
         ("compression", "threshold"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("agent", "disabled_toolsets"),
     )
 
     @classmethod
@@ -11135,6 +11139,8 @@ class GatewayRunner:
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        agent_cfg_local = user_config.get("agent") or {}
+        disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -11763,6 +11769,7 @@ class GatewayRunner:
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,
                     prefill_messages=self._prefill_messages or None,
                     reasoning_config=reasoning_config,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -457,6 +457,7 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        "disabled_toolsets": [],
     },
     
     "terminal": {

--- a/model_tools.py
+++ b/model_tools.py
@@ -23,8 +23,6 @@ Public API (signatures preserved from the original 2,400-line version):
 import json
 import asyncio
 import logging
-import os
-import sys
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
@@ -367,7 +365,7 @@ def _compute_tool_definitions(
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
-    # stripped out. See issue #15291.
+    # stripped out. See issue #17309.
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):

--- a/model_tools.py
+++ b/model_tools.py
@@ -23,6 +23,8 @@ Public API (signatures preserved from the original 2,400-line version):
 import json
 import asyncio
 import logging
+import os
+import sys
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
@@ -356,12 +358,17 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
-
-    elif disabled_toolsets:
+    else:
+        # Default: start with everything
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
+    # Always apply disabled toolsets as a subtraction step at the end.
+    # This ensures that even if a composite toolset (like hermes-cli)
+    # is enabled, any tools belonging to a disabled toolset are strictly
+    # stripped out. See issue #15291.
+    if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
@@ -376,10 +383,6 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
-    else:
-        from toolsets import get_all_toolsets
-        for ts_name in get_all_toolsets():
-            tools_to_include.update(resolve_toolset(ts_name))
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     "aludwin+gh@gmail.com": "adamludwin",
     "2093036+exiao@users.noreply.github.com": "exiao",
     "rylen.anil@gmail.com": "rylena",
+    "godnanijatin@gmail.com": "jatingodnani",
     "14046872+tmimmanuel@users.noreply.github.com": "tmimmanuel",
     "revar@users.noreply.github.com": "revaraver",
     # Matrix parity salvage batch (April 2026)


### PR DESCRIPTION
## Summary
`agent.disabled_toolsets` in config.yaml now strictly overrides the enabled toolset list in both CLI and gateway, even when a composite toolset (`browser`, `hermes-cli`, `hermes-telegram`, etc.) pulls the tool in implicitly. Salvages #17343 and widens the fix to the gateway.

Closes #17309.

## Root cause
Two separate gaps:
1. `model_tools._compute_tool_definitions` used `if enabled / elif disabled / else all` — disabled toolsets were silently ignored whenever enabled was set.
2. Neither CLI nor gateway passed `disabled_toolsets` to `AIAgent`. `_get_platform_tools` subtracted by **toolset name**, so `web` in `disabled_toolsets` didn't remove `web_search` when it rode in on `browser`.

## Changes
- **model_tools.py** (@jatingodnani): two-phase resolution — collect enabled first, then unconditionally `difference_update` by disabled toolsets.
- **cli.py** (@jatingodnani): read `agent.disabled_toolsets` from config and pass to `AIAgent` at init.
- **hermes_cli/config.py** (@jatingodnani): register `disabled_toolsets: []` in `DEFAULT_CONFIG`.
- **gateway/run.py** (follow-up): apply `disabled_toolsets` at both user-facing `AIAgent(`...)` sites (main message loop + single-turn path). Compression hygiene agents with fixed `enabled_toolsets=["memory"]` left alone. Add `(agent, disabled_toolsets)` to `_CACHE_BUSTING_CONFIG_KEYS` so edits invalidate the cached agent on next message.
- **cli.py / model_tools.py** (follow-up cleanup): drop unused `import platform` / `import os, sys` left over from #17343's import churn; fix stale `#15291` comment ref to `#17309`.

## Validation

| Scenario | main | this PR |
|---|---|---|
| CLI: enabled=`[browser]`, disabled=`[web]`, Firecrawl key set | `web_search` present | `web_search` absent |
| Gateway (Telegram): platform_toolsets=`[browser,terminal,file]`, agent.disabled_toolsets=`[web]` | `web_search` present | `web_search` absent |
| Sanity: enabled=`[web]` alone | works | works |
| Sanity: enabled=`[browser]`, disabled=`None` | `web_search` present (browser includes it) | same |
| Legacy: `disabled_toolsets` only, no enabled | web_search absent | same |

Targeted tests: `tests/` with `-k "toolset or disabled or tool_definitions or platform_tools"` → 382 passed. `-k "agent_config_signature or cache_busting or cached_agent"` → 7 passed.

---

Credit to @jatingodnani for the original fix in #17343. His substantive commit is preserved via cherry-pick; gateway widening and small cleanups are on top.