### PR TITLE
fix(tui,state): image paths with spaces + sqlite multimodal content binding

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1154,6 +1154,48 @@ class SessionDB:
     # Message storage
     # =========================================================================
 
+    # Sentinel prefix used to distinguish JSON-encoded structured content
+    # (multimodal messages: lists of parts like text + image_url) from plain
+    # string content. The NUL byte is not legal in normal text, so this
+    # cannot collide with real user content.
+    _CONTENT_JSON_PREFIX = "\x00json:"
+
+    @classmethod
+    def _encode_content(cls, content: Any) -> Any:
+        """Serialize structured (list/dict) message content for sqlite.
+
+        sqlite3 can only bind ``str``, ``bytes``, ``int``, ``float``, and ``None``
+        to query parameters. Multimodal messages have ``content`` as a list of
+        parts (``[{"type": "text", ...}, {"type": "image_url", ...}]``), which
+        raises ``ProgrammingError: Error binding parameter N: type 'list' is
+        not supported`` when bound directly.
+
+        Returns the value unchanged when it's already a safe scalar, or a
+        sentinel-prefixed JSON string for lists/dicts. Paired with
+        :meth:`_decode_content` on read.
+        """
+        if content is None or isinstance(content, (str, bytes, int, float)):
+            return content
+        try:
+            return cls._CONTENT_JSON_PREFIX + json.dumps(content)
+        except (TypeError, ValueError):
+            # Last-resort fallback: stringify so persistence never fails.
+            return str(content)
+
+    @classmethod
+    def _decode_content(cls, content: Any) -> Any:
+        """Reverse :meth:`_encode_content`; returns scalars unchanged."""
+        if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
+            try:
+                return json.loads(content[len(cls._CONTENT_JSON_PREFIX):])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Failed to decode JSON-encoded message content; "
+                    "returning raw string"
+                )
+                return content
+        return content
+
     def append_message(
         self,
         session_id: str,
@@ -1190,6 +1232,9 @@ class SessionDB:
             if codex_message_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
+        # cannot bind list/dict parameters directly.
+        stored_content = self._encode_content(content)
 
         # Pre-compute tool call count
         num_tool_calls = 0
@@ -1206,7 +1251,7 @@ class SessionDB:
                 (
                     session_id,
                     role,
-                    content,
+                    stored_content,
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
@@ -1289,7 +1334,7 @@ class SessionDB:
                     (
                         session_id,
                         role,
-                        msg.get("content"),
+                        self._encode_content(msg.get("content")),
                         msg.get("tool_call_id"),
                         tool_calls_json,
                         msg.get("tool_name"),
@@ -1328,6 +1373,8 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
+            if "content" in msg:
+                msg["content"] = self._decode_content(msg["content"])
             if msg.get("tool_calls"):
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
@@ -1425,7 +1472,7 @@ class SessionDB:
 
         messages = []
         for row in rows:
-            content = row["content"]
+            content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
@@ -1810,10 +1857,26 @@ class SessionDB:
                            )""",
                         (match["id"], match["id"]),
                     )
-                    context_msgs = [
-                        {"role": r["role"], "content": (r["content"] or "")[:200]}
-                        for r in ctx_cursor.fetchall()
-                    ]
+                    context_msgs = []
+                    for r in ctx_cursor.fetchall():
+                        raw = r["content"]
+                        decoded = self._decode_content(raw)
+                        # Multimodal context: render a compact text-only
+                        # summary for search previews.
+                        if isinstance(decoded, list):
+                            text_parts = [
+                                p.get("text", "") for p in decoded
+                                if isinstance(p, dict) and p.get("type") == "text"
+                            ]
+                            text = " ".join(t for t in text_parts if t).strip()
+                            preview = text or "[multimodal content]"
+                        elif isinstance(decoded, str):
+                            preview = decoded
+                        else:
+                            preview = ""
+                        context_msgs.append(
+                            {"role": r["role"], "content": preview[:200]}
+                        )
                 match["context"] = context_msgs
             except Exception:
                 match["context"] = []

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1243,7 +1243,7 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
 
-    def test_db_rewrite_is_atomic_on_insert_failure(self, tmp_path):
+    def test_db_rewrite_is_atomic_on_insert_failure(self, tmp_path, monkeypatch):
         from hermes_state import SessionDB
 
         db = SessionDB(db_path=tmp_path / "test.db")
@@ -1258,16 +1258,27 @@ class TestRewriteTranscriptPreservesReasoning:
         store._db = db
         store._loaded = True
 
+        # Force the second insert inside replace_messages to fail, simulating
+        # any storage-layer error that might abort a multi-row rewrite.
+        real_encode = SessionDB._encode_content
+        calls = {"n": 0}
+
+        def flaky_encode(cls, content):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("simulated storage failure")
+            return real_encode.__func__(cls, content)
+
+        monkeypatch.setattr(SessionDB, "_encode_content", classmethod(flaky_encode))
+
         replacement = [
             {"role": "user", "content": "after user"},
-            {
-                "role": "assistant",
-                "content": {"not": "sqlite-bindable but JSONL-safe"},
-            },
+            {"role": "assistant", "content": "after assistant"},
         ]
 
         store.rewrite_transcript(session_id, replacement)
 
+        # The rewrite must roll back atomically — original messages preserved.
         after = db.get_messages_as_conversation(session_id)
         assert [msg["content"] for msg in after] == [
             "before user",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -212,6 +212,82 @@ class TestMessageStorage:
         messages = db.get_messages("s1")
         assert messages[0]["tool_calls"] == tool_calls
 
+    def test_multimodal_list_content_round_trip(self, db):
+        """Multimodal ``content`` (list of parts) must survive the SQLite
+        round-trip.  sqlite3 cannot bind Python lists directly, so the DB
+        layer JSON-encodes structured content on write and decodes on read.
+
+        Regression test for the "Error binding parameter 3: type 'list' is
+        not supported" crash users hit when pasting screenshots into the
+        TUI (issue #17522).
+        """
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "describe this screenshot"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KG..."},
+            },
+        ]
+
+        # Write must not raise
+        db.append_message("s1", role="user", content=content)
+
+        # get_messages decodes back to the original list
+        msgs = db.get_messages("s1")
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == content
+
+        # get_messages_as_conversation decodes back to the original list
+        conv = db.get_messages_as_conversation("s1")
+        assert len(conv) == 1
+        assert conv[0] == {"role": "user", "content": content}
+
+    def test_dict_content_round_trip(self, db):
+        """Dict-shaped content (e.g. provider wrappers) also round-trips."""
+        db.create_session(session_id="s1", source="cli")
+        content = {"parts": [{"text": "hi"}]}
+
+        db.append_message("s1", role="user", content=content)
+        msgs = db.get_messages("s1")
+        assert msgs[0]["content"] == content
+
+    def test_string_content_unchanged_by_encoding(self, db):
+        """Plain strings must not be wrapped — FTS search and legacy
+        consumers depend on raw-string storage for text content.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="plain text")
+
+        # Peek at the raw column to confirm no encoding was applied
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT content FROM messages WHERE session_id = ?", ("s1",)
+            ).fetchone()
+        assert row["content"] == "plain text"
+
+    def test_replace_messages_handles_multimodal_content(self, db):
+        """`replace_messages` (used by /retry, /undo, /compress) must also
+        handle list content without crashing."""
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "look at this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+        ]
+
+        db.replace_messages(
+            "s1",
+            [
+                {"role": "user", "content": content},
+                {"role": "assistant", "content": "I see a screenshot."},
+            ],
+        )
+
+        msgs = db.get_messages("s1")
+        assert len(msgs) == 2
+        assert msgs[0]["content"] == content
+        assert msgs[1]["content"] == "I see a screenshot."
+
     def test_get_messages_as_conversation(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="Hello")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1923,6 +1923,55 @@ def test_input_detect_drop_attaches_image(monkeypatch):
     assert resp["result"]["text"] == "[User attached image: cat.png]"
 
 
+def test_input_detect_drop_path_with_spaces(tmp_path):
+    """input.detect_drop correctly handles image paths containing spaces."""
+    # Create a minimal PNG file with a space in its name
+    img = tmp_path / "screenshot with spaces.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")  # valid PNG header
+
+    server._sessions["sid"] = _session()
+
+    resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "input.detect_drop",
+            "params": {"session_id": "sid", "text": str(img)},
+        }
+    )
+
+    assert resp["result"]["matched"] is True
+    assert resp["result"]["is_image"] is True
+    assert resp["result"]["path"] == str(img)
+    assert resp["result"]["text"] == f"[User attached image: {img.name}]"
+    # Verify attachment was recorded in the session
+    assert len(server._sessions["sid"]["attached_images"]) == 1
+    assert server._sessions["sid"]["attached_images"][0] == str(img)
+
+
+def test_input_detect_drop_path_with_spaces_and_remainder(tmp_path):
+    """input.detect_drop splits remainder when path contains spaces."""
+    img = tmp_path / "photo with space.jpg"
+    img.write_bytes(b"\xff\xd8\xff" + b"fakejpeg")  # minimal-ish JPEG header
+
+    server._sessions["sid"] = _session()
+
+    user_input = f"{img} describe this image"
+    resp = server.handle_request(
+        {
+            "id": "3",
+            "method": "input.detect_drop",
+            "params": {"session_id": "sid", "text": user_input},
+        }
+    )
+
+    assert resp["result"]["matched"] is True
+    assert resp["result"]["is_image"] is True
+    assert resp["result"]["path"] == str(img)
+    # Remainder becomes the text sent to the model
+    assert resp["result"]["text"] == "describe this image"
+    assert server._sessions["sid"]["attached_images"][0] == str(img)
+
+
 def test_rollback_restore_resolves_number_and_file_path():
     calls = {}
 

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -126,13 +126,9 @@ export function useSubmission(opts: UseSubmissionOptions) {
         return sys('session not ready yet')
       }
 
-      // Plain prompts are the common path and should not pay an extra RPC
-      // before prompt.submit. File-drop detection still runs for absolute,
-      // tilde, file://, and explicit relative paths.
-      if (!looksLikeSlashCommand(text) && !/(?:^|\s)(?:file:\/\/|~\/|\.?\.\/|\/)[^\s]+/.test(text)) {
-        return startSubmit(text, expand(text), showUserMessage)
-      }
-
+      // Always ask the backend whether this looks like a file drop.
+      // The backend's _detect_file_drop handles paths with spaces, quotes,
+      // Windows drive letters, and escaped characters correctly.
       gw.request<InputDetectDropResponse>('input.detect_drop', { session_id: sid, text })
         .then(r => {
           if (!r?.matched) {


### PR DESCRIPTION
Closes #17522 — fixes both issues reported: paths-with-spaces in TUI image attachment AND the "Error binding parameter N: type 'list' is not supported" sqlite crash when pasting screenshots.

## Changes

**1. TUI drop detection** (`ui-tui/src/app/useSubmission.ts`, `tests/test_tui_gateway_server.py`) — salvaged from @0xharryriddle's #17523:
- Remove the frontend regex gate; always delegate to the backend's `_detect_file_drop`, which already handles spaces, quotes, Windows drive letters, and `file://` URIs.
- Adds two round-trip tests for paths with spaces (with and without trailing remainder).

**2. SQLite multimodal content** (`hermes_state.py`, `tests/test_hermes_state.py`, `tests/gateway/test_session.py`):
- `sqlite3` refuses to bind Python lists/dicts as query parameters. Multimodal messages (`[{"type": "text", ...}, {"type": "image_url", ...}]`) raised `ProgrammingError: Error binding parameter 3: type 'list' is not supported` in `append_message` and `replace_messages`.
- In the CLI/TUI this surfaced as a visible crash. In the gateway it was silently swallowed by a bare `except` in `append_to_transcript`, causing multimodal turns to be lost from the transcript.
- New `_encode_content` / `_decode_content` helpers wrap structured content as `"\x00json:" + json.dumps(...)` on write and unwrap on read. Plain strings are untouched, so FTS search, legacy JSONL transcripts, and every existing caller are unaffected.
- Applied to `append_message`, `replace_messages`, `get_messages`, `get_messages_as_conversation`, and `search_messages` context previews (multimodal previews render text-part summary instead of the raw JSON).

## Validation

| | Before | After |
|---|---|---|
| `/tmp/Screenshot 2026-04-29.png describe` | path truncated at first space; no attachment | path recognized; image attached; remainder becomes prompt |
| Paste screenshot → multimodal round-trip | sqlite crash in CLI, silent transcript loss in gateway | persists and restores round-trip unchanged |
| `tests/test_hermes_state.py` + `tests/test_tui_gateway_server.py` + `tests/gateway/test_session.py` + `tests/run_agent/test_860_dedup.py` + `tests/run_agent/test_413_compression.py` + `tests/run_agent/test_compression_persistence.py` + `tests/hermes_state/` + `tests/acp/` | — | 646 / 646 passing |

Targeted new coverage: `test_multimodal_list_content_round_trip`, `test_dict_content_round_trip`, `test_string_content_unchanged_by_encoding`, `test_replace_messages_handles_multimodal_content`, plus the two TUI detect-drop tests from #17523.

## Credit

Cherry-picked PR #17523 by @0xharryriddle with authorship preserved via rebase-merge (first commit). The second issue in #17522 (sqlite list-binding) was beyond the original PR's scope; added here as a follow-up so #17522 closes cleanly.
