### PR TITLE
fix(tui_gateway): guard env var parsing against invalid values at import

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -125,9 +125,11 @@ _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
-_SLASH_WORKER_TIMEOUT_S = max(
-    5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45)
-)
+try:
+    _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
+except (ValueError, TypeError):
+    _slash_timeout = 45.0
+_SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
@@ -153,8 +155,12 @@ _LONG_HANDLERS = frozenset(
     }
 )
 
+try:
+    _rpc_pool_workers = max(2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or "4"))
+except (ValueError, TypeError):
+    _rpc_pool_workers = 4
 _pool = concurrent.futures.ThreadPoolExecutor(
-    max_workers=max(2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS", "4") or 4)),
+    max_workers=_rpc_pool_workers,
     thread_name_prefix="tui-rpc",
 )
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))


### PR DESCRIPTION
Garbage values in `HERMES_TUI_SLASH_TIMEOUT_S` or `HERMES_TUI_RPC_POOL_WORKERS` no longer crash TUI gateway import — they fall back to 45.0s / 4 workers instead of raising `ValueError` with no error surfaced.

Salvaged from #17168 by @sprmn24 — the tui_gateway slice. The honcho-specific changes from that PR will follow in a separate PR.

## Changes
- `tui_gateway/server.py`: wrap `float()`/`int()` env parses in try/except with safe fallbacks

## Validation
E2E tested import with 8 env scenarios (garbage timeout, garbage workers, both garbage, empty, valid overrides, below-min clamps, unset). All 8 succeed; the 4 garbage cases previously crashed import.

| Env | Before | After |
|---|---|---|
| `HERMES_TUI_SLASH_TIMEOUT_S=abc` | ValueError at import | 45.0 (fallback) |
| `HERMES_TUI_RPC_POOL_WORKERS=bad` | ValueError at import | 4 (fallback) |
| `HERMES_TUI_SLASH_TIMEOUT_S=30` | 30.0 | 30.0 (unchanged) |
| `HERMES_TUI_RPC_POOL_WORKERS=8` | 8 | 8 (unchanged) |

Closes #17168 (salvage).