### PR TITLE
fix(session_search): truncate TOOL rows with None tool_name

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -82,11 +82,15 @@ def _format_conversation(messages: List[Dict[str, Any]]) -> str:
         content = msg.get("content") or ""
         tool_name = msg.get("tool_name")
 
-        if role == "TOOL" and tool_name:
-            # Truncate long tool outputs
+        if role == "TOOL":
+            # Truncate long tool outputs regardless of whether tool_name is set —
+            # stored sessions sometimes have tool_name=None, and without this
+            # guard those rows render as untruncated [TOOL]: <huge-blob>, drowning
+            # out actual conversation content during summarization.
             if len(content) > 500:
                 content = content[:250] + "\n...[truncated]...\n" + content[-250:]
-            parts.append(f"[TOOL:{tool_name}]: {content}")
+            header = f"[TOOL:{tool_name}]" if tool_name else "[TOOL]"
+            parts.append(f"{header}: {content}")
         elif role == "ASSISTANT":
             # Include tool call names if present
             tool_calls = msg.get("tool_calls")


### PR DESCRIPTION
## Summary
Truncate `[TOOL]` rows during session_search summarization even when `tool_name` is `None`. Previously those rows fell through to the generic branch and rendered as untruncated blobs, drowning out actual conversation content.

## Changes
- `tools/session_search_tool.py` `_format_conversation()`: drop the `and tool_name` guard; render `[TOOL]` (no name) when tool_name is absent; always apply the 500-char truncation.

## Validation
`py_compile` clean. One-line behavioral change, same truncation threshold and slicing already used for named-tool rows.

## Credit
Bug originally reported by @toaiclaw-a11y in #2579 (closed as otherwise stale — the rest of that PR's truncation logic has been superseded by `_truncate_around_matches` centering on query matches). Preserving credit via `Co-authored-by:` on the commit.
