### PR TITLE
fix(gateway): /status reads token totals from SessionDB (regression of #1465)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6550,11 +6550,17 @@ class GatewayRunner:
         queue_depth = self._queue_depth(session_key, adapter=adapter)
 
         title = None
+        token_totals = None
         if self._session_db:
             try:
                 title = self._session_db.get_session_title(session_entry.session_id)
+                token_totals = self._session_db.get_session_token_totals(session_entry.session_id)
             except Exception:
                 title = None
+                token_totals = None
+
+        # Use SessionDB token totals for authoritative count; fall back to session_store
+        total_tokens = token_totals["total_tokens"] if token_totals else session_entry.total_tokens
 
         lines = [
             "📊 **Hermes Gateway Status**",
@@ -6566,7 +6572,7 @@ class GatewayRunner:
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
+            f"**Tokens:** {total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
         ])
         if queue_depth:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -704,6 +704,46 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_session_token_totals(self, session_id: str) -> Dict[str, int]:
+        """Get token totals for a session from SessionDB.
+
+        Returns a dict with input_tokens, output_tokens, cache_read_tokens,
+        cache_write_tokens, reasoning_tokens, and total_tokens (sum of all).
+        Returns zeros for all fields if the session is not found.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                """SELECT input_tokens, output_tokens, cache_read_tokens,
+                          cache_write_tokens, reasoning_tokens
+                   FROM sessions WHERE id = ?""",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if row:
+            totals = {
+                "input_tokens": row["input_tokens"] or 0,
+                "output_tokens": row["output_tokens"] or 0,
+                "cache_read_tokens": row["cache_read_tokens"] or 0,
+                "cache_write_tokens": row["cache_write_tokens"] or 0,
+                "reasoning_tokens": row["reasoning_tokens"] or 0,
+            }
+            totals["total_tokens"] = (
+                totals["input_tokens"]
+                + totals["output_tokens"]
+                + totals["cache_read_tokens"]
+                + totals["cache_write_tokens"]
+                + totals["reasoning_tokens"]
+            )
+            return totals
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+            "total_tokens": 0,
+        }
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -704,12 +704,12 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def get_session_token_totals(self, session_id: str) -> Dict[str, int]:
+    def get_session_token_totals(self, session_id: str) -> Optional[Dict[str, int]]:
         """Get token totals for a session from SessionDB.
 
         Returns a dict with input_tokens, output_tokens, cache_read_tokens,
         cache_write_tokens, reasoning_tokens, and total_tokens (sum of all).
-        Returns zeros for all fields if the session is not found.
+        Returns None if the session is not found.
         """
         with self._lock:
             cursor = self._conn.execute(
@@ -735,14 +735,7 @@ class SessionDB:
                 + totals["reasoning_tokens"]
             )
             return totals
-        return {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_tokens": 0,
-            "cache_write_tokens": 0,
-            "reasoning_tokens": 0,
-            "total_tokens": 0,
-        }
+        return None
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -55,6 +55,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner._pending_approvals = {}
     runner._session_db = MagicMock()
     runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session_token_totals.return_value = None
     runner._reasoning_config = None
     runner._provider_routing = {}
     runner._fallback_model = None
@@ -111,6 +112,51 @@ async def test_status_command_includes_session_title_when_present():
 
     assert "**Session ID:** `sess-1`" in result
     assert "**Title:** My titled session" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_sessiondb_token_totals():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session_token_totals.return_value = {
+        "input_tokens": 100,
+        "output_tokens": 200,
+        "cache_read_tokens": 10,
+        "cache_write_tokens": 5,
+        "reasoning_tokens": 6,
+        "total_tokens": 3210,
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 3,210" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_falls_back_when_sessiondb_row_missing():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session_token_totals.return_value = None
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 321" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -128,6 +128,30 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
 
+    def test_get_session_token_totals_sums_all_columns(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_token_counts(
+            "s1",
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_tokens=3,
+            cache_write_tokens=4,
+            reasoning_tokens=5,
+        )
+
+        totals = db.get_session_token_totals("s1")
+        assert totals == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "cache_read_tokens": 3,
+            "cache_write_tokens": 4,
+            "reasoning_tokens": 5,
+            "total_tokens": 42,
+        }
+
+    def test_get_session_token_totals_returns_none_for_missing_session(self, db):
+        assert db.get_session_token_totals("missing") is None
+
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -130,13 +130,14 @@ class TestSessionLifecycle:
 
     def test_get_session_token_totals_sums_all_columns(self, db):
         db.create_session(session_id="s1", source="cli")
-        db.set_token_counts(
+        db.update_token_counts(
             "s1",
             input_tokens=10,
             output_tokens=20,
             cache_read_tokens=3,
             cache_write_tokens=4,
             reasoning_tokens=5,
+            absolute=True,
         )
 
         totals = db.get_session_token_totals("s1")


### PR DESCRIPTION
Make `/status` read token totals from SQLite (the authoritative store `run_agent.py` already writes per API call), so `Tokens:` stops showing stale zeros after #1465 regressed.

Salvaged from #5989 by @Tranquil-Flow. Closes #5960. Supersedes competing PRs #5989 #11088 #13820 #17158 (partial), #12565 (totals portion; the callback_generation snapshot bug in #12565 is a real but separate fix).

## Architecture note
Two camps in the open PRs: (A) read from SQLite at display time, (B) mirror totals into SessionStore on every turn. (A) wins — `run_agent.py` already writes to SQLite per API call (see L11502), SessionStore's `total_tokens` is vestigial (no production reader). Teaching `/status` to read the authoritative store means no drift, no double bookkeeping, and naturally covers CLI/cron/delegated sessions too.

## Changes
- `hermes_state.py`: add `SessionDB.get_session_token_totals(session_id)` returning `{input, output, cache_read, cache_write, reasoning, total}` or `None`.
- `gateway/run.py`: `_handle_status_command` prefers the SQLite totals, falls back to `session_entry.total_tokens` on missing row or exception.
- Tests: SessionDB unit tests + `/status` prefers-SQLite and fallback-on-missing-row tests.
- Follow-up: swap `set_token_counts` (nonexistent) for `update_token_counts(absolute=True)` in one test.

## Validation
| | Before | After |
|---|---|---|
| `/status` mid-session | Tokens: 0 (from stale `session_entry`) | Tokens: 1,856,650 (live SQLite) |
| SQLite row missing | Tokens: 0 | Tokens: `session_entry.total_tokens` (fallback) |
| SessionDB raises | n/a | fallback (no /status crash) |

Targeted tests: `tests/gateway/test_status_command.py` + `tests/test_hermes_state.py` — **215/215 passing**.

E2E verified with real SessionDB + real SQLite + real `_handle_status_command`: two simulated API-call `update_token_counts` deltas (150k in, 5k out, 1.7M cache-read, 150 cache-write, 1.5k reasoning) round-trip correctly via `get_session_token_totals`, and `/status` reports the cumulative 1,856,650 instead of the stale `session_entry.total_tokens=999`.

## Credit
- @Tranquil-Flow (#5989) — primary implementation, preserved as 2 commits with their authorship (rebase-merge to preserve).
- @JezzaHehn (#17158) — surfaced that the regression is still live on v0.11.0.
- @rustyorb (#11088), @wgd753 (#13820), @Oxidane-bot (#12565) — independently identified the same bug. #12565's callback-generation-snapshot fix should land separately.