### PR TITLE
fix(mcp): make sampling tools capability opt-in

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -998,6 +998,7 @@ platform_toolsets:
 #       max_rpm: 10             # max requests per minute
 #       allowed_models: []      # model whitelist (empty = all)
 #       max_tool_rounds: 5      # tool loop limit (0 = disable)
+#       expose_client_tools: false # advertise extended sampling.tools capability
 #       log_level: "info"       # audit verbosity
 
 # =============================================================================

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -429,6 +429,7 @@
                   timeout = mkOption { type = types.nullOr types.int; default = null; description = "LLM call timeout in seconds."; };
                   max_rpm = mkOption { type = types.nullOr types.int; default = null; description = "Max requests per minute."; };
                   max_tool_rounds = mkOption { type = types.nullOr types.int; default = null; description = "Max tool-use rounds per sampling request."; };
+                  expose_client_tools = mkOption { type = types.bool; default = false; description = "Advertise the extended sampling.tools client capability."; };
                   allowed_models = mkOption { type = types.listOf types.str; default = [ ]; description = "Models the server is allowed to request."; };
                   log_level = mkOption {
                     type = types.nullOr (types.enum [ "debug" "info" "warning" ]);
@@ -638,7 +639,7 @@
           // lib.optionalAttrs (srv.sampling != null) {
             sampling = lib.filterAttrs (_: v: v != null && v != [ ]) {
               inherit (srv.sampling) enabled model max_tokens_cap timeout max_rpm
-                max_tool_rounds allowed_models log_level;
+                max_tool_rounds expose_client_tools allowed_models log_level;
             };
           }
         ) cfg.mcpServers;

--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -328,10 +328,11 @@ mcp_servers:
       max_rpm: 10             # max requests per minute
       allowed_models: []      # model whitelist (empty = all)
       max_tool_rounds: 5      # tool loop limit (0 = disable)
+      expose_client_tools: false # advertise extended sampling.tools capability
       log_level: "info"       # audit verbosity
 ```
 
-Servers can also include `tools` in sampling requests for multi-turn tool-augmented workflows. The `max_tool_rounds` config prevents infinite tool loops. Per-server audit metrics (requests, errors, tokens, tool use count) are tracked via `get_mcp_status()`.
+Servers can also include `tools` in sampling requests for multi-turn tool-augmented workflows. The `max_tool_rounds` config prevents infinite tool loops. Hermes does not advertise the extended `sampling.tools` client capability unless `expose_client_tools: true` is set, because some strict MCP servers reject unknown sampling sub-capabilities during initialization. Most servers only need normal sampling; enable `expose_client_tools` only for servers that explicitly support sampling tool callbacks. Per-server audit metrics (requests, errors, tokens, tool use count) are tracked via `get_mcp_status()`.
 
 Disable sampling for untrusted servers with `sampling: { enabled: false }`.
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2701,12 +2701,14 @@ class _CompatType:
 
 try:
     from mcp.types import (
+        ClientCapabilities,
         CreateMessageResult,
         ErrorData,
         SamplingCapability,
         TextContent,
     )
 except ImportError:
+    ClientCapabilities = _CompatType
     CreateMessageResult = _CompatType
     ErrorData = _CompatType
     SamplingCapability = _CompatType
@@ -3504,6 +3506,25 @@ class TestMetricsTracking:
 # ---------------------------------------------------------------------------
 
 class TestSessionKwargs:
+    @staticmethod
+    def _capability_payload(capability):
+        if hasattr(capability, "model_dump"):
+            return capability.model_dump(exclude_none=True)
+        return {
+            key: (
+                TestSessionKwargs._capability_payload(value)
+                if hasattr(value, "__dict__")
+                else value
+            )
+            for key, value in vars(capability).items()
+            if value is not None
+        }
+
+    @classmethod
+    def _client_capability_payload(cls, sampling_capability):
+        capabilities = ClientCapabilities(sampling=sampling_capability)
+        return cls._capability_payload(capabilities)
+
     def test_returns_correct_keys(self):
         handler = SamplingHandler("sk", {})
         kwargs = handler.session_kwargs()
@@ -3516,7 +3537,42 @@ class TestSessionKwargs:
         kwargs = handler.session_kwargs()
         cap = kwargs["sampling_capabilities"]
         assert isinstance(cap, SamplingCapability)
+        assert cap.tools is None
+        assert "tools" not in self._capability_payload(cap)
+        assert self._client_capability_payload(cap) == {"sampling": {}}
+
+    def test_sampling_tools_capability_is_opt_in(self):
+        handler = SamplingHandler("sk3", {"expose_client_tools": True})
+        kwargs = handler.session_kwargs()
+        cap = kwargs["sampling_capabilities"]
         assert isinstance(cap.tools, SamplingToolsCapability)
+        assert "tools" in self._capability_payload(cap)
+        assert self._client_capability_payload(cap) == {"sampling": {"tools": {}}}
+
+    @pytest.mark.parametrize(
+        "raw_value, expected",
+        [
+            (False, False),
+            ("false", False),
+            ("0", False),
+            ("off", False),
+            (True, True),
+            ("true", True),
+            ("1", True),
+            ("yes", True),
+        ],
+    )
+    def test_sampling_tools_capability_parses_bool_flags(self, raw_value, expected):
+        handler = SamplingHandler("sk4", {"expose_client_tools": raw_value})
+        cap = handler.session_kwargs()["sampling_capabilities"]
+        payload = self._capability_payload(cap)
+
+        if expected:
+            assert isinstance(cap.tools, SamplingToolsCapability)
+            assert "tools" in payload
+        else:
+            assert cap.tools is None
+            assert "tools" not in payload
 
 
 # ---------------------------------------------------------------------------
@@ -3531,7 +3587,7 @@ class TestMCPServerTaskSamplingIntegration:
         server = MCPServerTask("int_test")
         config = {
             "command": "fake",
-            "sampling": {"enabled": True, "max_rpm": 5},
+            "sampling": {"enabled": True, "max_rpm": 5, "expose_client_tools": True},
         }
         # We only need to test the setup logic, not the actual connection.
         # Calling run() would attempt a real connection, so we test the
@@ -3547,6 +3603,7 @@ class TestMCPServerTaskSamplingIntegration:
         assert isinstance(server._sampling, SamplingHandler)
         assert server._sampling.server_name == "int_test"
         assert server._sampling.max_rpm == 5
+        assert server._sampling.expose_client_tools is True
 
     def test_sampling_handler_none_when_disabled(self):
         """MCPServerTask._sampling is None when sampling is disabled."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -57,6 +57,7 @@ Example config::
           max_rpm: 10                # max requests per minute
           allowed_models: []         # model whitelist (empty = all)
           max_tool_rounds: 5         # tool loop limit (0 = disable)
+          expose_client_tools: false # advertise extended sampling.tools capability
           log_level: "info"          # audit verbosity
 
 Features:
@@ -107,6 +108,8 @@ from typing import Callable
 from datetime import datetime
 from typing import Any, Coroutine, Dict, List, Optional
 from urllib.parse import urlparse
+
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1136,6 +1139,9 @@ class SamplingHandler:
         )
         self.model_override = config.get("model")
         self.allowed_models = config.get("allowed_models", [])
+        self.expose_client_tools = is_truthy_value(
+            config.get("expose_client_tools"), default=False
+        )
 
         _log_levels = {"debug": logging.DEBUG, "info": logging.INFO, "warning": logging.WARNING}
         self.audit_level = _log_levels.get(
@@ -1341,11 +1347,14 @@ class SamplingHandler:
 
     def session_kwargs(self) -> dict:
         """Return kwargs to pass to ClientSession for sampling support."""
+        sampling_capabilities = (
+            SamplingCapability(tools=SamplingToolsCapability())
+            if self.expose_client_tools
+            else SamplingCapability()
+        )
         return {
             "sampling_callback": self,
-            "sampling_capabilities": SamplingCapability(
-                tools=SamplingToolsCapability(),
-            ),
+            "sampling_capabilities": sampling_capabilities,
         }
 
     # -- Main callback -------------------------------------------------------

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -681,10 +681,11 @@ mcp_servers:
       max_rpm: 10              # Rate limit: max requests per minute (default: 10)
       max_tool_rounds: 5       # Max tool-use rounds in sampling loops (default: 5)
       allowed_models: []       # Allowlist of model names the server may request (empty = any)
+      expose_client_tools: false # Advertise extended sampling.tools capability
       log_level: "info"        # Audit log level: debug, info, or warning (default: info)
 ```
 
-The sampling handler includes a sliding-window rate limiter, per-request timeouts, and tool-loop depth limits to prevent runaway usage. Metrics (request count, errors, tokens used) are tracked per server instance.
+The sampling handler includes a sliding-window rate limiter, per-request timeouts, and tool-loop depth limits to prevent runaway usage. Hermes does not advertise the extended `sampling.tools` client capability unless `expose_client_tools: true` is set, because some strict MCP servers reject unknown sampling sub-capabilities during initialization. Most servers only need normal sampling; enable `expose_client_tools` only for servers that explicitly support sampling tool callbacks. Metrics (request count, errors, tokens used) are tracked per server instance.
 
 To disable sampling for a specific server:
 


### PR DESCRIPTION
Fixes #5468.

## Summary

Hermes still enables MCP sampling by default, but no longer advertises the extended `sampling.tools` client capability unless a server explicitly opts in with:

```yaml
mcp_servers:
  my_server:
    sampling:
      expose_client_tools: true
```

This keeps normal `sampling/createMessage` callbacks available while avoiding initialize failures on strict MCP servers that reject unknown `sampling.tools` fields.

## Root Cause

Hermes previously advertised:

```python
SamplingCapability(tools=SamplingToolsCapability())
```

for every MCP server with sampling enabled. Some strict Java/Jackson MCP servers reject the `tools` sub-capability during the initialize handshake because they do not recognize that extension field.

## Fix

- Default sampling capabilities now serialize as:

```json
{"sampling": {}}
```

- Servers that opt in with `sampling.expose_client_tools: true` retain the old extended capability:

```json
{"sampling": {"tools": {}}}
```

- `sampling.enabled: false` still disables sampling entirely.
- Server-provided sampling request tools are still handled at runtime.

## Tests

- Added serialization regression coverage for the initialize capability payload.
- Added boolean parsing coverage for `expose_client_tools`.
- Verified existing server-provided sampling tools still flow through.

```text
./.venv/bin/python -m pytest tests/tools/test_mcp_tool.py -q
191 passed, 8 warnings
```
