### PR TITLE
fix(discord_tool): key capability cache by token instead of single global

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -696,6 +696,38 @@ class TestCapabilityDetection:
         _detect_capabilities("tok", force=True)
         assert mock_req.call_count == 2
 
+    @patch("tools.discord_tool._discord_request")
+    def test_cache_is_keyed_by_token(self, mock_req):
+        """Regression: token A's capabilities must not leak to token B.
+
+        Before the fix, the cache was a single module-global dict. The first
+        call populated it and every subsequent call — regardless of token —
+        returned the same cached value, producing wrong schema gating for
+        rotated or multi-token deployments.
+        """
+        def _per_token_flags(method, path, token, **_kwargs):
+            # token A: both intents; token B: neither.
+            if token == "tok_a":
+                return {"flags": (1 << 14) | (1 << 18)}
+            return {"flags": 0}
+
+        mock_req.side_effect = _per_token_flags
+
+        caps_a = _detect_capabilities("tok_a")
+        caps_b = _detect_capabilities("tok_b")
+
+        assert caps_a["has_members_intent"] is True
+        assert caps_a["has_message_content"] is True
+        assert caps_b["has_members_intent"] is False
+        assert caps_b["has_message_content"] is False
+        # Each token should hit the endpoint exactly once.
+        assert mock_req.call_count == 2
+
+        # Re-requesting either token serves from its own cache entry.
+        _detect_capabilities("tok_a")
+        _detect_capabilities("tok_b")
+        assert mock_req.call_count == 2
+
 
 # ---------------------------------------------------------------------------
 # Config allowlist

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -132,7 +132,7 @@ def _channel_type_name(type_id: int) -> str:
 # ---------------------------------------------------------------------------
 
 # Module-level cache so the app/me endpoint is hit at most once per process.
-_capability_cache: Optional[Dict[str, Any]] = None
+_capability_cache: Dict[str, Dict[str, Any]] = {}
 
 
 def _detect_capabilities(token: str, *, force: bool = False) -> Dict[str, Any]:
@@ -148,8 +148,8 @@ def _detect_capabilities(token: str, *, force: bool = False) -> Dict[str, Any]:
     Cached in a module-global. Pass ``force=True`` to re-fetch.
     """
     global _capability_cache
-    if _capability_cache is not None and not force:
-        return _capability_cache
+    if token in _capability_cache and not force:
+        return _capability_cache[token]
 
     caps: Dict[str, Any] = {
         "has_members_intent": True,
@@ -172,14 +172,14 @@ def _detect_capabilities(token: str, *, force: bool = False) -> Dict[str, Any]:
             "Discord capability detection failed (%s); exposing all actions.", exc,
         )
 
-    _capability_cache = caps
+    _capability_cache[token] = caps
     return caps
 
 
 def _reset_capability_cache() -> None:
     """Test hook: clear the detection cache."""
     global _capability_cache
-    _capability_cache = None
+    _capability_cache = {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Discord capability detection now caches per-token, so token rotation or multi-token usage no longer returns token A's cached capabilities for token B.

## Root cause
`_capability_cache` was a single module-level dict populated on first call. Any subsequent `_detect_capabilities(token)` returned that dict regardless of which token was passed — producing wrong schema gating (members/message-content intent flags) when more than one token flowed through the module.

## Changes
- `tools/discord_tool.py`: `_capability_cache` → `Dict[str, Dict[str, Any]]`; lookup/write/reset updated to key on token.
- `tests/tools/test_discord_tool.py`: new regression test `test_cache_is_keyed_by_token` — confirms token A (intents on) and token B (intents off) stay isolated and each hits the endpoint exactly once.

## Validation
`scripts/run_tests.sh tests/tools/test_discord_tool.py` — 88 passed (was 87).

Salvaged from #16688 by @sprmn24. The original PR mixed in two unrelated commits which are being split into their own PRs.