### PR TITLE
test(skill_utils): regression tests for non-dict metadata in extract_skill_conditions

### DIFF
--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,0 +1,58 @@
+"""Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
+
+from agent.skill_utils import extract_skill_conditions
+
+
+def test_metadata_as_dict_with_hermes():
+    """Normal case: metadata is a dict containing hermes keys."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "fallback_for_toolsets": ["toolset_a"],
+                "requires_toolsets": ["toolset_b"],
+                "fallback_for_tools": ["tool_x"],
+                "requires_tools": ["tool_y"],
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["fallback_for_toolsets"] == ["toolset_a"]
+    assert result["requires_toolsets"] == ["toolset_b"]
+    assert result["fallback_for_tools"] == ["tool_x"]
+    assert result["requires_tools"] == ["tool_y"]
+
+
+def test_metadata_as_string_does_not_crash():
+    """Bug case: metadata is a non-dict truthy value (e.g. a YAML string)."""
+    frontmatter = {"metadata": "some text"}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_metadata_as_none():
+    """metadata key is present but set to null/None."""
+    frontmatter = {"metadata": None}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_metadata_missing_entirely():
+    """metadata key is absent from frontmatter."""
+    frontmatter = {"name": "my-skill", "description": "Does stuff."}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }


### PR DESCRIPTION
## Summary
Locks in the existing `isinstance(metadata, dict)` guard in `extract_skill_conditions()` so a future refactor cannot silently regress it back to `frontmatter.get("metadata") or {}` — which crashes on skills whose frontmatter has `metadata:` as a plain string or any other non-dict value.

## Coverage added
- `metadata` as a valid nested dict with `hermes:` keys
- `metadata` as a string (malformed YAML) — the regression case
- `metadata` as `None`
- `metadata` key absent

## Validation
`scripts/run_tests.sh tests/agent/test_skill_utils.py` — 4 passed.

Mutation-verified: removing the `isinstance(metadata, dict)` guard causes `test_metadata_as_string_does_not_crash` to fail with `AttributeError: 'str' object has no attribute 'get'`.

Salvaged from #16688 by @sprmn24. The original PR bundled this with two unrelated changes; splitting into separate PRs for clean review.