### PR TITLE
fix(gateway): preserve document type when merging queued events

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1034,6 +1034,11 @@ def merge_pending_message_event(
                     existing.text = event.text
             if existing_is_photo or incoming_is_photo:
                 existing.message_type = MessageType.PHOTO
+            elif (
+                getattr(existing, "message_type", None) == MessageType.TEXT
+                and event.message_type != MessageType.TEXT
+            ):
+                existing.message_type = event.message_type
             return
 
         if (

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -226,6 +226,39 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
     assert merged.media_types == ["image/png"]
 
 
+def test_merge_pending_message_event_promotes_document_followups_over_text():
+    pending = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+
+    text_event = MessageEvent(
+        text="please review this",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    document_event = MessageEvent(
+        text="",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=["/tmp/report.pdf"],
+        media_types=["application/pdf"],
+    )
+
+    merge_pending_message_event(pending, session_key, text_event, merge_text=True)
+    merge_pending_message_event(pending, session_key, document_event, merge_text=True)
+
+    merged = pending[session_key]
+    assert merged.message_type == MessageType.DOCUMENT
+    assert merged.text == "please review this"
+    assert merged.media_urls == ["/tmp/report.pdf"]
+    assert merged.media_types == ["application/pdf"]
+
+
 @pytest.mark.asyncio
 async def test_recent_telegram_text_followup_is_queued_without_interrupt():
     runner = _make_runner()


### PR DESCRIPTION
Salvage of #16589 by @hharry11 onto current main.

## Summary
Cherry-picked on top of current main (branch was 621 commits behind). Clean pick, no conflicts, authorship preserved.

## What the fix does
In `merge_pending_message_event`, when a queued TEXT event absorbs an incoming non-text media event (DOCUMENT, AUDIO, VIDEO), promote the merged event's `message_type` to the incoming type. Existing PHOTO precedence is untouched.

## Why it matters
Session busy → user sends text → user sends a PDF/audio/video. The queued event kept `message_type=TEXT` even after inheriting the document's `media_urls`/`media_types`. Downstream `gateway/run.py:5157` gates document content-injection on `message_type == DOCUMENT`, so the agent received only a bare file path with no context note.

## Validation
- Targeted suite: `tests/gateway/test_session_race_guard.py` 17/17 pass (includes new regression test)
- Live E2E against real imports (isolated HERMES_HOME): 8/8 scenarios pass
  - text → doc: promoted to DOCUMENT, text+media preserved, downstream handler fires
  - text → photo: stays PHOTO (precedence unchanged)
  - text → text: burst merge preserved
  - text → audio, text → video: fix generalizes correctly
  - photo → photo album, doc → doc burst, empty → doc: all baseline paths intact

Closes #16589.