### PR TITLE
fix(terminal): skip sudo prompt when local NOPASSWD sudo works

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -94,6 +94,8 @@ AUTHOR_MAP = {
     "130918800+devorun@users.noreply.github.com": "devorun",
     "surat.s@itm.kmutnb.ac.th": "beesrsj2500",
     "beesr@bee.localdomain": "beesrsj2500",
+    "mind-dragon@nous.research": "Mind-Dragon",
+    "juntingpublic@gmail.com": "JustinUssuri",
     "mtf201013@gmail.com": "ma-pony",
     "sonoyuncudmr@gmail.com": "Sonoyunchu",
     "43525405+yatesjalex@users.noreply.github.com": "yatesjalex",

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -104,6 +104,57 @@ def test_cached_sudo_password_isolated_by_session_key(monkeypatch):
     assert terminal_tool._get_cached_sudo_password() == "alpha-pass"
 
 
+def test_passwordless_sudo_skips_interactive_prompt_and_rewrite(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError(
+            "interactive sudo prompt should not run when sudo -n already works"
+        )
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: True, raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo whoami")
+
+    assert transformed == "sudo whoami"
+    assert sudo_stdin is None
+
+
+def test_passwordless_sudo_probe_rechecks_local_terminal(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    calls = []
+
+    class Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return Result(0 if len(calls) == 1 else 1)
+
+    monkeypatch.setattr(terminal_tool.subprocess, "run", fake_run)
+
+    assert terminal_tool._sudo_nopasswd_works() is True
+    assert terminal_tool._sudo_nopasswd_works() is False
+    assert len(calls) == 2
+    assert calls[0][0] == ["sudo", "-n", "true"]
+    assert calls[1][0] == ["sudo", "-n", "true"]
+
+
+def test_passwordless_sudo_probe_is_disabled_for_nonlocal_terminal_env(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    def _fail_run(*_args, **_kwargs):
+        raise AssertionError("host sudo probe must not run for non-local terminal envs")
+
+    monkeypatch.setattr(terminal_tool.subprocess, "run", _fail_run)
+
+    assert terminal_tool._sudo_nopasswd_works() is False
+
+
 def test_validate_workdir_allows_windows_drive_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project") is None
     assert terminal_tool._validate_workdir("C:/Users/Alice/project") is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -620,6 +620,32 @@ def _rewrite_real_sudo_invocations(command: str) -> tuple[str, bool]:
     return "".join(out), found
 
 
+def _sudo_nopasswd_works() -> bool:
+    """Return True when local sudo currently works without prompting.
+
+    Only probes for the `local` terminal backend; Docker/SSH/Modal/etc. must
+    not inherit the host's sudo state. Re-probes every call (no process-level
+    cache) so an expired sudo timestamp cannot make a later command silently
+    block waiting for a password.
+    """
+    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    if terminal_env != "local":
+        return False
+
+    try:
+        probe = subprocess.run(
+            ["sudo", "-n", "true"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+            check=False,
+        )
+        return probe.returncode == 0
+    except Exception:
+        return False
+
+
 def _rewrite_compound_background(command: str) -> str:
     """Wrap `A && B &` (or `A || B &`) to `A && { B & }` at depth 0.
 
@@ -832,6 +858,15 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         if has_configured_password
         else _get_cached_sudo_password()
     )
+
+    # Local hosts with sudoers NOPASSWD should not be forced through the
+    # interactive Hermes password prompt or the sudo -S password-pipe path.
+    # Scoped to the local terminal backend so Docker/SSH/Modal/etc. can't
+    # inherit host sudo state. Re-probes every call (no process-lifetime
+    # cache) so an expired sudo timestamp doesn't make a later command block
+    # silently without Hermes prompting.
+    if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
+        return command, None
 
     if not has_configured_password and not sudo_password and os.getenv("HERMES_INTERACTIVE"):
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)


### PR DESCRIPTION
Salvage of #16631 (@Mind-Dragon) + co-credit to #7760 (@JustinUssuri) for the original atomic fix.

## Summary
Hermes no longer prompts for a sudo password inside interactive sessions on hosts where sudoers NOPASSWD is already configured.

## Changes
- `tools/terminal_tool.py`: add `_sudo_nopasswd_works()` probe (local-terminal-only, re-probes every call, 3s timeout). `_transform_sudo_command()` returns the command unchanged with no stdin password when the probe succeeds and no `SUDO_PASSWORD` / cached password is present.
- `tests/tools/test_terminal_tool.py`: three new regression tests covering the skip-prompt path, the reprobe-every-call behavior, and the non-local backend gate.
- `scripts/release.py`: map `mind-dragon@nous.research` and `juntingpublic@gmail.com` so CI's AUTHOR_MAP check passes.

## Why this is a salvage PR
- #16631 was stale against current `main` (conflicted on the recently-merged session-scoped sudo password cache).
- #7760 is the original atomic fix by @JustinUssuri for the same behavior, opened ~6 months earlier. It is currently CONFLICTING with no branch-update access, so that author cannot rebase it.
- This PR reimplements the fix on current `main` with both authors credited: Mind-Dragon as commit author (for the rebased implementation and the local-terminal scoping improvement) and JustinUssuri as `Co-authored-by:` (for the original idea).

## Validation
- Targeted suite: `scripts/run_tests.sh tests/tools/test_terminal_tool.py` — 14 passed
- `py_compile` on `tools/terminal_tool.py` — ok
- E2E check with real imports and mocked subprocess: NOPASSWD skip works, Docker gate rejects probe

## After merge
Close #16631 and #7760 with credit to both contributors.