### PR TITLE
fix: preserve DeepSeek V4 signed thinking blocks on /anthropic endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1657,8 +1657,11 @@ def convert_messages_to_anthropic(
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
                     continue
-                if b.get("signature") or b.get("data"):
-                    # Anthropic-signed block — upstream can't validate, strip
+                if b.get("type") == "redacted_thinking" and b.get("data"):
+                    # Anthropic redacted_thinking payload — upstream can't validate, strip
+                    continue
+                if b.get("signature") and b.get("type") != "thinking":
+                    # Signed block that isn't a normal thinking block — strip
                     continue
                 # Unsigned thinking (synthesised from reasoning_content) —
                 # keep it: the upstream needs it for message-history validation.

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -439,6 +439,19 @@ def classify_api_error(
             should_compress=False,
         )
 
+    # DeepSeek V4 /anthropic: missing thinking blocks on replay.
+    # Error: "The `content[].thinking` in the thinking mode must be passed back to the API."
+    if (
+        status_code == 400
+        and "thinking" in error_msg
+        and "must be passed back" in error_msg
+    ):
+        return _result(
+            FailoverReason.thinking_signature,
+            retryable=True,
+            should_compress=False,
+        )
+
     # Anthropic long-context tier gate (429 "extra usage" + "long context")
     if (
         status_code == 429


### PR DESCRIPTION
## Summary

DeepSeek V4 with the `/anthropic` endpoint signs its own thinking blocks with a `signature` field. The current `_preserve_unsigned_thinking` path in the Anthropic adapter strips **all** blocks that carry a `signature` or `data` field, which was designed for Anthropic's proprietary `redacted_thinking` payloads but now incorrectly strips DeepSeek's legitimate signed `thinking` blocks too. DeepSeek then rejects the next request with HTTP 400 because thinking blocks must round-trip.

Additionally, the error classifier only catches the `thinking_signature` failover reason when both `"signature"` and `"thinking"` appear in the error message. DeepSeek's actual error (`"The content[].thinking in the thinking mode must be passed back to the API."`) contains `"thinking"` but not `"signature"`, so the appropriate failover/retry logic never triggers.

## Changes

**`agent/anthropic_adapter.py`**
- Restrict the stripping logic to only remove Anthropic's `redacted_thinking` blocks (which carry opaque `data` payloads) and signed blocks that are not normal `thinking` type. This preserves DeepSeek V4's own signed thinking blocks (which have `signature` but `type="thinking"`).

**`agent/error_classifier.py`**
- Add a second pattern match for DeepSeek's specific error message format (`status 400` + `"thinking"` + `"must be passed back"`), mapping it to `FailoverReason.thinking_signature` so the existing retry/failover path handles it correctly.

## Testing

- All 262 existing tests in `test_anthropic_adapter.py` and `test_error_classifier.py` pass.
- `py_compile` and `ruff check` clean for both files.

Closes #17992
