### PR TITLE
fix(config): coerce quoted-boolean config gates consistently

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1742,7 +1742,10 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                return bool(cfg_get(cfg, "display", "show_reasoning", default=False))
+                return is_truthy_value(
+                    cfg_get(cfg, "display", "show_reasoning"),
+                    default=False,
+                )
         except Exception:
             pass
         return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8351,7 +8351,10 @@ class GatewayRunner:
         # --- check config gate ------------------------------------------------
         try:
             user_config = _load_gateway_config()
-            gate_enabled = cfg_get(user_config, "display", "tool_progress_command", default=False)
+            gate_enabled = is_truthy_value(
+                cfg_get(user_config, "display", "tool_progress_command"),
+                default=False,
+            )
         except Exception:
             gate_enabled = False
 
@@ -11298,7 +11301,10 @@ class GatewayRunner:
                             tool_progress_hint_gateway,
                         )
                         _cfg = _load_gateway_config()
-                        gate_on = bool(cfg_get(_cfg, "display", "tool_progress_command", default=False))
+                        gate_on = is_truthy_value(
+                            cfg_get(_cfg, "display", "tool_progress_command"),
+                            default=False,
+                        )
                         if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
                             long_tool_hint_fired[0] = True
                             progress_queue.put(tool_progress_hint_gateway())

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -19,6 +19,8 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from utils import is_truthy_value
+
 # prompt_toolkit is an optional CLI dependency — only needed for
 # SlashCommandCompleter and SlashCommandAutoSuggest.  Gateway and test
 # environments that lack it must still be able to import this module
@@ -371,7 +373,7 @@ def _resolve_config_gates() -> set[str]:
             else:
                 val = None
                 break
-        if val:
+        if is_truthy_value(val, default=False):
             result.add(cmd.name)
     return result
 

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -407,3 +407,44 @@ class TestReasoningCommand:
         assert result["final_response"] == "ok"
         assert _CapturingAgent.last_init is not None
         assert "homeassistant" in set(_CapturingAgent.last_init["enabled_toolsets"])
+
+
+class TestLoadShowReasoningCoercion:
+    """Regression: display.show_reasoning must be coerced, not bool()'d."""
+
+    def _load_with_config(self, tmp_path, monkeypatch, yaml_body: str) -> bool:
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        return gateway_run.GatewayRunner._load_show_reasoning()
+
+    def test_quoted_false_is_false(self, tmp_path, monkeypatch):
+        assert self._load_with_config(
+            tmp_path, monkeypatch,
+            'display:\n  show_reasoning: "false"\n',
+        ) is False
+
+    def test_quoted_off_is_false(self, tmp_path, monkeypatch):
+        assert self._load_with_config(
+            tmp_path, monkeypatch,
+            'display:\n  show_reasoning: "off"\n',
+        ) is False
+
+    def test_quoted_true_is_true(self, tmp_path, monkeypatch):
+        assert self._load_with_config(
+            tmp_path, monkeypatch,
+            'display:\n  show_reasoning: "true"\n',
+        ) is True
+
+    def test_bare_true_is_true(self, tmp_path, monkeypatch):
+        assert self._load_with_config(
+            tmp_path, monkeypatch,
+            'display:\n  show_reasoning: true\n',
+        ) is True
+
+    def test_missing_is_false(self, tmp_path, monkeypatch):
+        assert self._load_with_config(
+            tmp_path, monkeypatch,
+            'display: {}\n',
+        ) is False

--- a/tests/gateway/test_verbose_command.py
+++ b/tests/gateway/test_verbose_command.py
@@ -86,6 +86,25 @@ class TestVerboseCommand:
         assert saved["display"]["platforms"]["telegram"]["tool_progress"] == "verbose"
 
     @pytest.mark.asyncio
+    async def test_quoted_false_keeps_command_disabled(self, tmp_path, monkeypatch):
+        """Quoted false must not enable the /verbose gateway command."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            'display:\n  tool_progress_command: "false"\n  tool_progress: all\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_verbose_command(_make_event())
+
+        assert "not enabled" in result.lower()
+        assert "tool_progress_command" in result
+
+    @pytest.mark.asyncio
     async def test_cycles_through_all_modes(self, tmp_path, monkeypatch):
         """Calling /verbose repeatedly cycles through all four modes."""
         hermes_home = tmp_path / "hermes"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -405,6 +405,21 @@ class TestGatewayConfigGate:
         joined = "\n".join(lines)
         assert "`/verbose" in joined
 
+    def test_config_gate_quoted_false_stays_disabled_everywhere(self, tmp_path, monkeypatch):
+        """Quoted false must not enable config-gated gateway commands."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text('display:\n  tool_progress_command: "false"\n')
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        lines = gateway_help_lines()
+        joined = "\n".join(lines)
+        names = {name for name, _ in telegram_bot_commands()}
+        mapping = slack_subcommand_map()
+
+        assert "`/verbose" not in joined
+        assert "verbose" not in names
+        assert "verbose" not in mapping
+
     def test_config_gate_excluded_from_telegram_when_off(self, tmp_path, monkeypatch):
         config_file = tmp_path / "config.yaml"
         config_file.write_text("display:\n  tool_progress_command: false\n")

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -567,6 +567,26 @@ class TestSecurityScanGate:
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
             assert _guard_agent_created_enabled() is False
 
+    def test_guard_flag_quoted_false_stays_disabled(self):
+        """Quoted 'false' from YAML edits must not enable the guard."""
+        from tools.skill_manager_tool import _guard_agent_created_enabled
+
+        for quoted in ("false", "False", "0", "no", "off"):
+            with patch("hermes_cli.config.load_config",
+                       return_value={"skills": {"guard_agent_created": quoted}}):
+                assert _guard_agent_created_enabled() is False, \
+                    f"guard_agent_created={quoted!r} must coerce to False"
+
+    def test_guard_flag_quoted_true_enables(self):
+        """Quoted truthy strings must enable the guard."""
+        from tools.skill_manager_tool import _guard_agent_created_enabled
+
+        for quoted in ("true", "True", "1", "yes", "on"):
+            with patch("hermes_cli.config.load_config",
+                       return_value={"skills": {"guard_agent_created": quoted}}):
+                assert _guard_agent_created_enabled() is True, \
+                    f"guard_agent_created={quoted!r} must coerce to True"
+
 
 # ---------------------------------------------------------------------------
 # External skills directories (skills.external_dirs) — mutations in place

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
 from typing import Dict, Any, Optional, Tuple
 
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,10 @@ def _guard_agent_created_enabled() -> bool:
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
-        return bool(cfg_get(cfg, "skills", "guard_agent_created", default=False))
+        return is_truthy_value(
+            cfg_get(cfg, "skills", "guard_agent_created"),
+            default=False,
+        )
     except Exception:
         return False
 


### PR DESCRIPTION
Salvages #16528 onto current main and widens the fix to two sibling sites with the same bug class.

## Summary
Quoted YAML booleans (`display.tool_progress_command: "false"`) were slipping through as truthy because `if val:` and `bool(val)` treat any non-empty string as true. Every call site that reads a user-writable bool config now routes through `utils.is_truthy_value`.

## Root cause
`bool("false") == True`. YAML writes from manual edits, env-expanded values, or CLI `hermes config set` can all produce string values where a bool is expected.

## Changes
- **@johnncenae's commit (aacba845)** — the original PR #16528, reshaped onto current main's `cfg_get(...)` helper:
  - `hermes_cli/commands.py` `_resolve_config_gates`
  - `gateway/run.py` `_handle_verbose_command`
  - `gateway/run.py` onboarding `progress_callback` gate
  - Regression tests in `tests/gateway/test_verbose_command.py` and `tests/hermes_cli/test_commands.py`
- **Sibling-site widening (75de6c51)**:
  - `gateway/run.py` `_load_show_reasoning` — same bug for `display.show_reasoning`
  - `tools/skill_manager_tool.py` `_guard_agent_created_enabled` — same bug for `skills.guard_agent_created`
  - Regression tests for both

## Validation
- `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/gateway/test_reasoning_command.py tests/gateway/test_verbose_command.py tests/hermes_cli/test_commands.py` → 232 passed
- E2E: wrote real config files with `"false"`/`"true"`/bare-bool values, called `_guard_agent_created_enabled()` and the `show_reasoning` path end-to-end — all coerced correctly.

Closes #16528.
Credit to @johnncenae for the original diagnosis and fix.