### PR TITLE
fix(gateway): preserve assistant metadata when branching sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8794,8 +8794,12 @@ class GatewayRunner:
                     tool_name=msg.get("tool_name") or msg.get("name"),
                     tool_calls=msg.get("tool_calls"),
                     tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
                     reasoning=msg.get("reasoning"),
                     reasoning_content=msg.get("reasoning_content"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
+                    codex_message_items=msg.get("codex_message_items"),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1464,8 +1464,8 @@ class SessionDB:
             placeholders = ",".join("?" for _ in session_ids)
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
-                "reasoning, reasoning_content, reasoning_details, codex_reasoning_items, "
-                "codex_message_items "
+                "finish_reason, reasoning, reasoning_content, reasoning_details, "
+                "codex_reasoning_items, codex_message_items "
                 f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY timestamp, id",
                 tuple(session_ids),
             ).fetchall()
@@ -1490,6 +1490,8 @@ class SessionDB:
             # that replay reasoning (OpenRouter, OpenAI, Nous) receive
             # coherent multi-turn reasoning context.
             if row["role"] == "assistant":
+                if row["finish_reason"]:
+                    msg["finish_reason"] = row["finish_reason"]
                 if row["reasoning"]:
                     msg["reasoning"] = row["reasoning"]
                 if row["reasoning_content"] is not None:

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -173,6 +173,38 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     assert other_key in runner._update_prompt_pending
 
 
+@pytest.mark.asyncio
+async def test_branch_preserves_persisted_assistant_metadata():
+    runner, _session_key = _make_branch_runner()
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "world",
+            "finish_reason": "stop",
+            "reasoning": "thinking",
+            "reasoning_content": "provider scratchpad",
+            "reasoning_details": [{"type": "summary", "text": "step"}],
+            "codex_reasoning_items": [{"id": "r1", "type": "reasoning"}],
+            "codex_message_items": [{"id": "m1", "type": "message"}],
+        },
+    ]
+
+    result = await runner._handle_branch_command(_make_event("/branch"))
+
+    assert "Branched to" in result
+    append_calls = runner._session_db.append_message.call_args_list
+    assert len(append_calls) == 2
+    assistant_kwargs = append_calls[1].kwargs
+    assert assistant_kwargs["role"] == "assistant"
+    assert assistant_kwargs["finish_reason"] == "stop"
+    assert assistant_kwargs["reasoning"] == "thinking"
+    assert assistant_kwargs["reasoning_content"] == "provider scratchpad"
+    assert assistant_kwargs["reasoning_details"] == [{"type": "summary", "text": "step"}]
+    assert assistant_kwargs["codex_reasoning_items"] == [{"id": "r1", "type": "reasoning"}]
+    assert assistant_kwargs["codex_message_items"] == [{"id": "m1", "type": "message"}]
+
+
 def test_clear_session_boundary_security_state_is_scoped():
     """The helper must wipe only the target session's approval/yolo state.
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -399,6 +399,27 @@ class TestMessageStorage:
         assert msg["reasoning"] == "Thinking about what to say"
         assert msg["reasoning_details"] == details
 
+    def test_finish_reason_restored_by_get_messages_as_conversation(self, db):
+        """finish_reason on assistant messages must survive conversation replay.
+
+        Without this, /branch copies and other transcript round-trips silently
+        drop the provider's stop signal.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="Done",
+            finish_reason="tool_calls",
+        )
+        db.append_message("s1", role="user", content="next")
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0]["role"] == "assistant"
+        assert conv[0]["finish_reason"] == "tool_calls"
+        # Non-assistant rows should not have a finish_reason key added.
+        assert "finish_reason" not in conv[1]
+
     def test_reasoning_content_persisted_and_restored(self, db):
         """reasoning_content must survive session replay as its own field."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
Salvage of #16446 onto current main, plus follow-up fix for the nit raised in review.

## Summary
`/branch` now produces a faithful copy of the parent transcript — assistant metadata that was previously dropped (finish_reason, reasoning_details, codex_reasoning_items, codex_message_items) is forwarded to the new session's `append_message()` calls.

## Changes
- **gateway/run.py** — `_handle_branch_command` now forwards `finish_reason`, `reasoning_details`, `codex_reasoning_items`, `codex_message_items` to `append_message()` alongside the existing `reasoning`/`reasoning_content` fields. (@simbam99's commit, preserved verbatim.)
- **hermes_state.py** — `get_messages_as_conversation()` now SELECTs `finish_reason` and restores it onto assistant rows. Without this, the SQLite-backed replay path would have dropped `finish_reason` before `/branch` even saw it, making the #16446 change a no-op for SQLite sessions.
- **tests/gateway/test_session_boundary_security_state.py** — @simbam99's regression test locks the branch-forwarding behaviour in.
- **tests/test_hermes_state.py** — new round-trip test locks in `finish_reason` restoration through `get_messages_as_conversation`.

## Validation
`scripts/run_tests.sh tests/test_hermes_state.py tests/gateway/test_session_boundary_security_state.py tests/cli/test_branch_command.py` → 226 passed.

Closes #16446.