### PR TITLE
fix(discord): close old client before reconnect to prevent zombie websockets

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -613,6 +613,21 @@ class DiscordAdapter(BasePlatformAdapter):
             # so LLM output or echoed user content can't ping the whole
             # server; override per DISCORD_ALLOW_MENTION_* env vars or the
             # discord.allow_mentions.* block in config.yaml.
+
+            # Close any existing client to prevent zombie websocket connections
+            # on reconnect (see #18187). Without this, the old client remains
+            # connected to Discord gateway and both fire on_message, causing
+            # double responses.
+            if self._client is not None:
+                try:
+                    if not self._client.is_closed():
+                        await self._client.close()
+                except Exception:
+                    logger.debug("[%s] Failed to close previous Discord client", self.name)
+                finally:
+                    self._client = None
+                    self._ready_event.clear()
+
             self._client = commands.Bot(
                 command_prefix="!",  # Not really used, we handle raw messages
                 intents=intents,


### PR DESCRIPTION
## Summary

Fixes #18187 — Discord adapter creates zombie websocket connection on reconnect, causing double responses.

## Problem

When `DiscordAdapter.connect()` is called during a reconnect cycle (e.g. gateway restart), it unconditionally creates a new `commands.Bot` client without closing the previous one. The old client's websocket remains connected to Discord's gateway, so **both** clients fire `on_message` for every incoming event — resulting in double responses with different wording.

The existing `MessageDeduplicator` cannot prevent this because the two websockets deliver events independently, and the two `on_message` coroutines race on the dedup check.

## Fix

Before creating a new `Bot` instance in `connect()`, check if a previous client exists and close it:

```python
if self._client is not None:
    try:
        if not self._client.is_closed():
            await self._client.close()
    except Exception:
        logger.debug("[%s] Failed to close previous Discord client", self.name)
    finally:
        self._client = None
        self._ready_event.clear()
```

This ensures only one Discord websocket connection is ever active for the adapter.

## Scope

- **1 file changed**: `gateway/platforms/discord.py` (+15 lines)
- All 375 Discord-related tests pass

## Testing

```bash
python -m pytest tests/tools/test_discord_tool.py tests/gateway/ -k discord
# 375 passed, 1 skipped
```