### PR TITLE
fix(mcp): honor stdio server workdir config

### DIFF
--- a/skills/mcp/native-mcp/SKILL.md
+++ b/skills/mcp/native-mcp/SKILL.md
@@ -93,6 +93,7 @@ mcp_servers:
 |-------------------|--------|---------|---------------------------------------------------|
 | `command`         | string | --      | Executable to run (stdio transport, required)     |
 | `args`            | list   | `[]`    | Arguments passed to the command                   |
+| `workdir` / `cwd` | string | --      | Working directory used to spawn a stdio server    |
 | `env`             | dict   | `{}`    | Extra environment variables for the subprocess    |
 | `url`             | string | --      | Server URL (HTTP transport, required)             |
 | `headers`         | dict   | `{}`    | HTTP headers sent with every request              |

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -839,6 +839,90 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_workdir_is_passed_to_stdio_server_parameters(self):
+        """Stdio MCP servers can run from a configured working directory."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, \
+                 p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                await server.start({
+                    "command": "python",
+                    "args": ["-m", "mcp_server.server"],
+                    "workdir": "/srv/knowledge-rag",
+                })
+
+                assert mock_params.call_args.kwargs["cwd"] == "/srv/knowledge-rag"
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
+    def test_cwd_alias_is_used_when_workdir_absent(self):
+        """The shorter cwd alias is honored for stdio MCP servers."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, \
+                 p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                await server.start({
+                    "command": "python",
+                    "args": ["-m", "mcp_server.server"],
+                    "cwd": "/srv/alias",
+                })
+
+                assert mock_params.call_args.kwargs["cwd"] == "/srv/alias"
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
+    def test_workdir_takes_precedence_over_cwd_alias(self):
+        """workdir is the documented spelling when both cwd aliases are present."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, \
+                 p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                await server.start({
+                    "command": "python",
+                    "workdir": "/srv/workdir",
+                    "cwd": "/srv/cwd",
+                })
+
+                assert mock_params.call_args.kwargs["cwd"] == "/srv/workdir"
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
     def test_shutdown_signals_task_exit(self):
         """shutdown() signals the event and waits for task completion."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1065,6 +1065,9 @@ class MCPServerTask:
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
+        cwd = config.get("workdir")
+        if cwd is None:
+            cwd = config.get("cwd")
 
         if not command:
             raise ValueError(
@@ -1086,6 +1089,7 @@ class MCPServerTask:
             command=command,
             args=args,
             env=safe_env if safe_env else None,
+            cwd=cwd,
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -99,6 +99,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 |---|---|---|
 | `command` | string | Executable for a stdio MCP server |
 | `args` | list | Arguments for the stdio server |
+| `workdir` / `cwd` | string | Working directory used when spawning a stdio server |
 | `env` | mapping | Environment variables passed to the stdio server |
 | `url` | string | HTTP MCP endpoint |
 | `headers` | mapping | HTTP headers for remote servers |

--- a/website/docs/user-guide/skills/bundled/mcp/mcp-native-mcp.md
+++ b/website/docs/user-guide/skills/bundled/mcp/mcp-native-mcp.md
@@ -111,6 +111,7 @@ mcp_servers:
 |-------------------|--------|---------|---------------------------------------------------|
 | `command`         | string | --      | Executable to run (stdio transport, required)     |
 | `args`            | list   | `[]`    | Arguments passed to the command                   |
+| `workdir` / `cwd` | string | --      | Working directory used to spawn a stdio server    |
 | `env`             | dict   | `{}`    | Extra environment variables for the subprocess    |
 | `url`             | string | --      | Server URL (HTTP transport, required)             |
 | `headers`         | dict   | `{}`    | HTTP headers sent with every request              |


### PR DESCRIPTION
Fixes #5467.

## Summary

Hermes now honors `workdir` / `cwd` for stdio MCP servers by passing the configured directory through to the MCP SDK's `StdioServerParameters.cwd`.

This lets servers launched with cwd-dependent commands, such as:

```yaml
mcp_servers:
  knowledge_rag:
    command: /path/to/venv/bin/python
    args: ["-m", "mcp_server.server"]
    workdir: /path/to/knowledge-rag
```

start from the configured project directory instead of silently inheriting Hermes' own launch directory.

## Root Cause

The MCP config schema and docs exposed `workdir`-style configuration, but `_run_stdio()` only read `command`, `args`, and `env` before constructing `StdioServerParameters`. Any configured working directory was ignored, so cwd-sensitive stdio servers failed at startup with unhelpful connection errors.

## Fix

- Read `workdir` from stdio server config.
- Fall back to the `cwd` alias when `workdir` is absent.
- Pass the resolved value to `StdioServerParameters(cwd=...)`.
- Document the stdio working-directory option in MCP docs and the bundled MCP skill docs.

## Tests

Added regression coverage for:

- `workdir` being passed through to `StdioServerParameters.cwd`
- `cwd` alias support
- `workdir` taking precedence when both spellings are present

```text
./.venv/bin/python -m pytest tests/tools/test_mcp_tool.py -q
185 passed, 8 warnings
```
