### PR TITLE
fix(tui): preserve raw LF for Shift+Enter newline

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from 'vitest'
 import { INITIAL_STATE, parseMultipleKeypresses } from './parse-keypress.js'
 import { PASTE_END, PASTE_START } from './termio/csi.js'
 
+describe('return key raw byte preservation', () => {
+  it('preserves CR for plain Enter', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, '\r')
+
+    expect(key).toMatchObject({ kind: 'key', name: 'return', raw: '\r', sequence: '\r' })
+  })
+
+  it('preserves LF so TextInput can treat Shift+Enter/Ctrl+J as newline', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, '\n')
+
+    expect(key).toMatchObject({ kind: 'key', name: 'return', raw: '\n', sequence: '\n' })
+  })
+})
+
 describe('parseMultipleKeypresses bracketed paste recovery', () => {
   it('emits empty bracketed pastes when the terminal sends both markers', () => {
     const [keys, state] = parseMultipleKeypresses(INITIAL_STATE, PASTE_START + PASTE_END)

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -805,7 +805,6 @@ function parseKeypress(s: string = ''): ParsedKey {
   }
 
   if (s === '\r' || s === '\n') {
-    key.raw = undefined
     key.name = 'return'
   } else if (s === '\t') {
     key.name = 'tab'

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -761,7 +761,12 @@ export function TextInput({
       }
 
       if (k.return) {
-        if (k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
+        // Some terminal stacks (notably Warp/tmux on macOS) distinguish
+        // plain Enter from Shift+Enter/Ctrl+J by raw byte only:
+        //   Enter -> CR (\r, 13), Shift+Enter/Ctrl+J -> LF (\n, 10)
+        // Ink marks both as `key.return`, so preserve the raw LF distinction
+        // before falling through to the normal CR-submit path.
+        if (eventRaw === '\n' || k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
           flushParentChange()
           commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
         } else {


### PR DESCRIPTION
## Summary

Fixes TUI multiline input for terminal stacks that distinguish plain Enter and Shift+Enter by raw CR/LF bytes.

The TUI `TextInput` already checks `event.keypress.raw === '\n'` to insert a newline, but `hermes-ink` was clearing `raw` for both `\r` and `\n` when normalizing them to `key.return`. This meant LF from Shift+Enter/Ctrl+J could no longer be distinguished from CR from Enter, so it submitted instead of inserting a newline.

This PR preserves `keypress.raw` for CR/LF and adds regression coverage.

Fixes #18228

## Test Plan

- [x] `npm --prefix ui-tui test -- parse-keypress.test.ts --run`
- [x] `npm --prefix ui-tui run build`
- [x] Manual verification: on macOS Warp/tmux, Enter sends CR (`13`) and Shift+Enter sends LF (`10`); after the fix, Shift+Enter inserts a newline and Enter submits.
