### PR TITLE
Prefer config max turns in gateway agents

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -727,7 +727,12 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway platforms), falling back to the hermes-api-server default.
         """
         from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
+        from gateway.run import (
+            _resolve_runtime_agent_kwargs,
+            _resolve_gateway_model,
+            _load_gateway_config,
+            _resolve_gateway_max_iterations,
+        )
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
@@ -736,7 +741,7 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
-        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        max_iterations = _resolve_gateway_max_iterations(user_config)
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -718,6 +718,49 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _coerce_positive_int(value: Any) -> Optional[int]:
+    """Return a positive int for config/env values, otherwise None."""
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _resolve_gateway_max_iterations(config: dict | None = None, default: int = 90) -> int:
+    """Resolve gateway agent max iterations from config before legacy env.
+
+    ``agent.max_turns`` in config.yaml is the current source of truth.  Older
+    deployments may still have ``HERMES_MAX_ITERATIONS`` in .env; keep that as
+    a fallback only so a stale env value cannot silently override config.yaml
+    after the long-lived gateway reloads .env between messages.
+    """
+    cfg = config if config is not None else _load_gateway_config()
+    candidates: list[Any] = []
+    if isinstance(cfg, dict):
+        agent_cfg = cfg.get("agent") or {}
+        if isinstance(agent_cfg, dict):
+            candidates.extend([
+                agent_cfg.get("max_turns"),
+                agent_cfg.get("max_iterations"),
+            ])
+        candidates.extend([
+            cfg.get("max_turns"),
+            cfg.get("max_iterations"),
+        ])
+    candidates.append(os.getenv("HERMES_MAX_ITERATIONS"))
+
+    for candidate in candidates:
+        value = _coerce_positive_int(candidate)
+        if value is not None:
+            return value
+    return default
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -7976,7 +8019,7 @@ class GatewayRunner:
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = _resolve_gateway_max_iterations(user_config)
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -11567,9 +11610,6 @@ class GatewayRunner:
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
-
-            # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
@@ -11592,6 +11632,8 @@ class GatewayRunner:
                 load_dotenv(_env_path, override=True, encoding="latin-1")
             except Exception:
                 pass
+
+            max_iterations = _resolve_gateway_max_iterations(user_config)
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(

--- a/tests/gateway/test_gateway_max_iterations.py
+++ b/tests/gateway/test_gateway_max_iterations.py
@@ -1,0 +1,29 @@
+"""Gateway max-iteration resolution tests."""
+
+from gateway.run import _resolve_gateway_max_iterations
+
+
+def test_gateway_max_iterations_prefers_agent_max_turns_over_legacy_env(monkeypatch):
+    """config.yaml agent.max_turns is the source of truth for gateway agents."""
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "200")
+
+    value = _resolve_gateway_max_iterations({"agent": {"max_turns": 600}})
+
+    assert value == 600
+
+
+def test_gateway_max_iterations_uses_legacy_env_when_config_missing(monkeypatch):
+    """Keep old env-only deployments working when config has no max_turns."""
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "200")
+
+    value = _resolve_gateway_max_iterations({})
+
+    assert value == 200
+
+
+def test_gateway_max_iterations_ignores_invalid_values(monkeypatch):
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "not-an-int")
+
+    value = _resolve_gateway_max_iterations({"agent": {"max_turns": ""}}, default=90)
+
+    assert value == 90


### PR DESCRIPTION
## Summary
- Resolve gateway agent max iterations from `agent.max_turns` in config.yaml before legacy `HERMES_MAX_ITERATIONS`.
- Prevent a long-lived gateway from falling back to stale `.env` values after reloading credentials between messages.
- Apply the same resolver to API Server agent creation.

## Test Plan
- `python -m pytest tests/gateway/test_gateway_max_iterations.py tests/gateway/test_proxy_mode.py -q`
- `python -m py_compile gateway/run.py gateway/platforms/api_server.py`
- `git diff --check`
