### PR TITLE
feat(terminal): expose session context to local subprocesses

### DIFF
--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -116,6 +116,45 @@ class TestMakeRunEnvHomeInjection:
 
         assert result["HOME"] == "/home/user"
 
+    def test_injects_gateway_session_context(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/user")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        for key in (
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_THREAD_ID",
+            "HERMES_SESSION_USER_ID",
+            "HERMES_SESSION_USER_NAME",
+            "HERMES_SESSION_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.environments.local import _make_run_env
+
+        tokens = set_session_vars(
+            platform="discord",
+            chat_id="1493236260880519238",
+            chat_name="Home",
+            thread_id="1499608576682102925",
+            user_id="123456789",
+            user_name="cristo",
+            session_key="discord:1493236260880519238:1499608576682102925",
+        )
+        try:
+            result = _make_run_env({})
+        finally:
+            clear_session_vars(tokens)
+
+        assert result["HERMES_SESSION_PLATFORM"] == "discord"
+        assert result["HERMES_SESSION_CHAT_ID"] == "1493236260880519238"
+        assert result["HERMES_SESSION_CHAT_NAME"] == "Home"
+        assert result["HERMES_SESSION_THREAD_ID"] == "1499608576682102925"
+        assert result["HERMES_SESSION_USER_ID"] == "123456789"
+        assert result["HERMES_SESSION_USER_NAME"] == "cristo"
+        assert result["HERMES_SESSION_KEY"] == "discord:1493236260880519238:1499608576682102925"
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_subprocess_env() injection

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -194,6 +194,10 @@ def _make_run_env(env: dict) -> dict:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
+    try:
+        from gateway.session_context import get_session_env as _get_session_env
+    except Exception:
+        _get_session_env = None
 
     merged = dict(os.environ | env)
     run_env = {}
@@ -214,6 +218,20 @@ def _make_run_env(env: dict) -> dict:
     _profile_home = get_subprocess_home()
     if _profile_home:
         run_env["HOME"] = _profile_home
+
+    if _get_session_env is not None:
+        for name in (
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_THREAD_ID",
+            "HERMES_SESSION_USER_ID",
+            "HERMES_SESSION_USER_NAME",
+            "HERMES_SESSION_KEY",
+        ):
+            value = _get_session_env(name, "")
+            if value:
+                run_env[name] = value
 
     return run_env
 


### PR DESCRIPTION
## Summary
- forward `HERMES_SESSION_*` context into local subprocess environments built by `_make_run_env()`
- let shell/Python/Node subprocesses access gateway session metadata without importing Python helpers directly
- add a regression test covering session-context injection via `set_session_vars()`

## Why
Hermes already tracks gateway session context in `gateway.session_context`, and multiple tools read it directly. But local subprocesses launched through the terminal environment did not inherit that context, which made hooks and external scripts blind to the active platform/chat/thread/user/session.

Passing the values through environment variables gives non-Python subprocesses a simple cross-process interface.

## Test Plan
- `source ~/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_subprocess_home_isolation.py tests/gateway/test_session_env.py -q`

