### PR TITLE
fix: guard openai import in stream error handlers (Option A)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7054,8 +7054,11 @@ class AIAgent:
                             )
                             _is_sse_conn_err_preview = False
                             if not _is_timeout and not _is_conn_err:
-                                from openai import APIError as _APIError
-                                if isinstance(e, _APIError) and not getattr(e, "status_code", None):
+                                try:
+                                    from openai import APIError as _APIError
+                                except ImportError:
+                                    _APIError = None
+                                if _APIError is not None and isinstance(e, _APIError) and not getattr(e, "status_code", None):
                                     _err_lower_preview = str(e).lower()
                                     _SSE_PREVIEW_PHRASES = (
                                         "connection lost",
@@ -7163,8 +7166,11 @@ class AIAgent:
                         # APIStatusError (4xx/5xx) always has one.
                         _is_sse_conn_err = False
                         if not _is_timeout and not _is_conn_err:
-                            from openai import APIError as _APIError
-                            if isinstance(e, _APIError) and not getattr(e, "status_code", None):
+                            try:
+                                from openai import APIError as _APIError
+                            except ImportError:
+                                _APIError = None
+                            if _APIError is not None and isinstance(e, _APIError) and not getattr(e, "status_code", None):
                                 _err_lower_sse = str(e).lower()
                                 _SSE_CONN_PHRASES = (
                                     "connection lost",


### PR DESCRIPTION
## Fix: guard openai import in stream error handlers (Option A)

**Corresponds to:** [nesquena/hermes-webui PR #1383](https://github.com/nesquena/hermes-webui/pull/1383)

### Problem

Two sites in `run_agent.py` unconditionally execute `from openai import APIError as _APIError` inside exception handlers. When `openai` is not installed (e.g. inside the WebUI server process venv), this raises `ModuleNotFoundError` / `ImportError` inside an already-crashing handler — tearing down a daemon thread while it holds `_ENV_LOCK`, causing a deadlock that exhausts the httpx connection pool (EMFILE/ENFILE on `/proc/self/fd`).

### Fix (Option A)

Both sites now use `try/except ImportError`:

    try:
        from openai import APIError as _APIError
    except ImportError:
        _APIError = None
    if _APIError is not None and isinstance(e, _APIError) and not getattr(e, "status_code", None):
        ...

The subsequent `isinstance()` check gates the openai-specific logic on `_APIError is not None`, so the handler degrades gracefully when openai is absent rather than crashing with an unhandled `ImportError`.

### Sites patched

- `run_agent.py ~line 7057` — SSE preview stream retry gate
- `run_agent.py ~line 7166` — SSE error event detection (OpenRouter proxy errors)

### Note

The [hermes-webui PR #1383](https://github.com/nesquena/hermes-webui/pull/1383) added `openai` and `httpx` to `requirements.txt` as a workaround. This PR lands the correct fix in the layer where the bug actually lives. As noted in that PR's discussion: the WebUI's requirements contract is intentionally minimal, and the real fix belongs in hermes-agent's exception handlers.