### PR TITLE
fix: prefer ~/.hermes/.env over os.environ when seeding credential pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import random
 import threading
 import time
@@ -13,7 +14,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
-from hermes_cli.config import get_env_value
+from hermes_cli.config import get_env_value, load_env
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
@@ -1380,6 +1381,16 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
 def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
+
+    # Prefer ~/.hermes/.env over os.environ — the user's config file is the
+    # authoritative source for Hermes credentials. Stale env vars from parent
+    # processes (Codex CLI, test scripts, etc.) should not override deliberate
+    # changes to the .env file.
+    def _get_env_prefer_dotenv(key: str) -> str:
+        env_file = load_env()
+        val = env_file.get(key) or os.environ.get(key) or ""
+        return val.strip()
+
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it
     # won't be re-seeded from the user's shell environment or ~/.hermes/.env.
@@ -1391,8 +1402,8 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         def _is_source_suppressed(_p, _s):  # type: ignore[misc]
             return False
     if provider == "openrouter":
-        # Check both os.environ and ~/.hermes/.env file
-        token = (get_env_value("OPENROUTER_API_KEY") or "").strip()
+        # Prefer ~/.hermes/.env over os.environ
+        token = _get_env_prefer_dotenv("OPENROUTER_API_KEY")
         if token:
             source = "env:OPENROUTER_API_KEY"
             if _is_source_suppressed(provider, source):
@@ -1418,7 +1429,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip().rstrip("/")
+        env_url = _get_env_prefer_dotenv(pconfig.base_url_env_var).rstrip("/")
 
     env_vars = list(pconfig.api_key_env_vars)
     if provider == "anthropic":
@@ -1429,8 +1440,8 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         ]
 
     for env_var in env_vars:
-        # Check both os.environ and ~/.hermes/.env file
-        token = (get_env_value(env_var) or "").strip()
+        # Prefer ~/.hermes/.env over os.environ
+        token = _get_env_prefer_dotenv(env_var)
         if not token:
             continue
         source = f"env:{env_var}"


### PR DESCRIPTION
## Summary

When `_seed_from_env()` reads API keys to populate the credential pool in `auth.json`, it was using `get_env_value()` which prefers `os.environ` over `~/.hermes/.env`. This means stale env vars inherited from parent shell processes (Codex CLI, test scripts, etc.) can shadow deliberate changes to the `.env` file.

If a parent process exported `OPENROUTER_API_KEY=test-key-fresh` and the user later updates `.env` with a valid key, restarting Hermes still picks up the stale `os.environ` value, writes it back to `auth.json`, and all OpenRouter API calls silently fail with 401.

## Changes

1. Added a local helper `_get_env_prefer_dotenv()` in `_seed_from_env()` that reads from `~/.hermes/.env` (via `load_env()`) first, then falls back to `os.environ`
2. Replaced all 3 `get_env_value()` call sites in `_seed_from_env()` with the new helper
3. Added `import os` and `load_env` imports

## Root Cause

`get_env_value()` in `hermes_cli/config.py` checks `os.environ` FIRST, then falls back to the `.env` file:

```python
def get_env_value(key: str) -> Optional[str]:
    if key in os.environ:
        return os.environ[key]  # <-- takes priority over .env!
    env_vars = load_env()
    return env_vars.get(key)
```

This is a reasonable default for most call sites (runtime config), but for `_seed_from_env()` — which populates the persistent credential cache — the `.env` file should be authoritative. The credential cache already persists the snapshot, so the env var is only relevant during seeding; using a potentially stale `os.environ` value here defeats the purpose of the persistent cache.

## Additional Discovery

During testing, another source of stale keys was identified: **Hermes profile `.env` files** at `~/.hermes/profiles/<name>/.env`. These are created by `hermes profile create --clone` which copies the main `.env` at creation time. If the main `.env` had a test/stale key at that point, the profile retains it even after the main `.env` is updated. This is a separate concern from the `os.environ` priority issue, but users should be aware that profile `.env` files may also need manual sync when rotating keys.

## Test Plan

- [x] Syntax verification: `python3 -c "import py_compile; py_compile.compile('agent/credential_pool.py', doraise=True)"`
- [ ] Manual: set a key in `.env`, export a different value in shell, restart Hermes → should use `.env` value
- [ ] Existing credential pool tests should pass

## Related Issues

Closes #18254