### PR TITLE
fix(update): don't crash hermes update if skill config scan fails

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2437,7 +2437,17 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
     except Exception:
         return []
 
-    all_vars = discover_all_skill_config_vars()
+    try:
+        all_vars = discover_all_skill_config_vars()
+    except Exception as e:
+        # A malformed SKILL.md, unreadable external skill dir, or similar
+        # should never break `hermes update`.  Skill-config prompting is a
+        # post-migration nicety, not a blocker.
+        import logging
+        logging.getLogger(__name__).debug(
+            "discover_all_skill_config_vars failed: %s", e
+        )
+        return []
     if not all_vars:
         return []
 


### PR DESCRIPTION
## Summary
`hermes update` no longer crashes after a successful config migration if the optional skill-config scan raises.

Reported by @FlockonUS — his update migrated config 11 → 17 successfully, then crashed at `agent/skill_utils.py:340` in `get_disabled_skill_names()`, leaving him with a half-finished update.

Root cause: `get_missing_skill_config_vars` (hermes_cli/config.py) guarded the *import* of `discover_all_skill_config_vars` in a try/except but not the *call*. Any runtime exception inside the skill scan (malformed SKILL.md, unreadable external skills dir, etc.) propagated up through `migrate_config` and aborted `hermes update`.

## Changes
- `hermes_cli/config.py`: wrap `discover_all_skill_config_vars()` in try/except, return `[]` on failure, log at debug.

## Validation
E2E with a worktree-imported `get_missing_skill_config_vars` against an isolated `HERMES_HOME`:

| | Before | After |
|---|---|---|
| `discover_all_skill_config_vars` raises | propagates, kills `hermes update` | returns `[]`, update continues |
| normal path | works | works (unchanged) |