### PR TITLE
fix(acp): run /steer as a regular prompt on idle sessions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -669,24 +669,38 @@ class HermesACPAgent(acp.Agent):
         if not has_content:
             return PromptResponse(stop_reason="end_turn")
 
-        # Zed currently interrupts an active ACP request before delivering a
-        # follow-up slash command. If that follow-up is /steer, there may be no
-        # live AIAgent left to steer by the time this method runs. Salvage that
-        # UX by replaying the interrupted prompt with the steer text attached as
-        # explicit correction/guidance.
+        # /steer on an idle session has no in-flight tool call to inject into.
+        # Rewrite it so the payload runs as a normal user prompt, matching the
+        # gateway's behavior (gateway/run.py ~L4898). Two sub-cases:
+        #   1. Zed-interrupt salvage — a prior prompt was cancelled by the
+        #      client right before /steer arrived; replay it with the steer
+        #      text attached as explicit correction/guidance so the user's
+        #      in-flight work isn't lost.
+        #   2. Plain idle — no prior work to salvage; just run the steer
+        #      payload as a regular prompt. Without this, _cmd_steer would
+        #      silently append to state.queued_prompts and respond with
+        #      "No active turn — queued for the next turn", which looks like
+        #      /queue even though the user never typed /queue.
         if isinstance(user_content, str) and user_text.startswith("/steer"):
             steer_text = user_text.split(maxsplit=1)[1].strip() if len(user_text.split(maxsplit=1)) > 1 else ""
             interrupted_prompt = ""
+            rewrite_idle = False
             with state.runtime_lock:
-                if not state.is_running and steer_text and state.interrupted_prompt_text:
-                    interrupted_prompt = state.interrupted_prompt_text
-                    state.interrupted_prompt_text = ""
+                if not state.is_running and steer_text:
+                    if state.interrupted_prompt_text:
+                        interrupted_prompt = state.interrupted_prompt_text
+                        state.interrupted_prompt_text = ""
+                    else:
+                        rewrite_idle = True
             if interrupted_prompt:
                 user_text = (
                     f"{interrupted_prompt}\n\n"
                     f"User correction/guidance after interrupt: {steer_text}"
                 )
                 user_content = user_text
+            elif rewrite_idle:
+                user_text = steer_text
+                user_content = steer_text
 
         # Intercept slash commands — handle locally without calling the LLM.
         # Slash commands are text-only; if the client included images/resources,

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -100,6 +100,26 @@ async def test_acp_steer_after_zed_interrupt_replays_interrupted_prompt_with_gui
 
 
 @pytest.mark.asyncio
+async def test_acp_steer_on_idle_session_runs_as_regular_prompt():
+    # /steer on an idle session (no running turn, nothing to salvage) should
+    # run the steer payload as a normal user prompt — NOT silently append it
+    # to state.queued_prompts. Without this, users on Zed / other ACP clients
+    # see their /steer turn into "queued for the next turn" when they never
+    # typed /queue. Matches gateway/run.py ~L4898 idle-/steer behavior.
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/steer summarize the README")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.steers == []
+    assert fake.runs == ["summarize the README"]
+    assert state.queued_prompts == []
+
+
+@pytest.mark.asyncio
 async def test_acp_queue_slash_command_adds_next_turn_without_running_now():
     acp_agent, state, fake, _conn = make_agent_and_state()
 


### PR DESCRIPTION
## Summary
`/steer <text>` on an idle ACP session now runs the payload as a normal user prompt instead of silently appending to the queue.

Before: @EddyLeeKhane (and anyone on Zed / other ACP clients) typed `/steer foo` with no active turn, got back "No active turn — queued for the next turn" — looks like /queue even though they never typed /queue.

## Changes
- `acp_adapter/server.py`: extend the existing `/steer` salvage block so that when the session is idle and there's nothing interrupted to replay, we rewrite `user_text` to the steer payload and fall through to the normal prompt path. Matches `gateway/run.py` ~L4898.
- `tests/acp_adapter/test_acp_commands.py`: regression test covering the idle-steer case.

## Validation
```
scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py -v
5 passed in 1.43s
```

| /steer input | Before | After |
|---|---|---|
| running turn | inject mid-run (ok) | inject mid-run (unchanged) |
| idle + interrupted prompt | replay + guidance (ok) | replay + guidance (unchanged) |
| idle + nothing to salvage | append to `queued_prompts` | run payload as a regular prompt |

## Reported by
@EddyLeeKhane (x.com)