### PR TITLE
fix(cli): allow custom Nous model on free tier

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2507,13 +2507,10 @@ def _model_flow_nous(config, current_model="", args=None):
         pass
 
     if free_tier and not model_ids:
-        print("No free models currently available.")
-        if unavailable_models:
-            from hermes_cli.auth import DEFAULT_NOUS_PORTAL_URL
-
-            _url = (_nous_portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
-            print(f"Upgrade at {_url} to access paid models.")
-        return
+        print(
+            "No free curated models currently available — "
+            "use \"Enter custom model name\" for models available to your account."
+        )
 
     print(
         f'Showing {len(model_ids)} curated models — use "Enter custom model name" for others.'

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -114,6 +114,62 @@ def test_setup_keep_current_config_provider_uses_provider_specific_model_menu(
     assert reloaded["model"]["provider"] == "zai"
 
 
+def test_nous_free_tier_with_only_paid_curated_models_still_allows_custom_model(
+    tmp_path, monkeypatch
+):
+    """Free-tier Nous accounts must still be able to enter a custom model.
+
+    Portal credit balances can make non-curated models usable even when every
+    curated model is marked paid. The menu should still offer the custom-model
+    path instead of returning at the upgrade banner.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    selected = []
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_provider_auth_state",
+        lambda provider: {
+            "access_token": "token",
+            "portal_base_url": "https://portal.example.com",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_nous_runtime_credentials",
+        lambda **kwargs: {"base_url": "https://inference.example.com/v1"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.get_curated_nous_model_ids",
+        lambda: ["paid/curated-model"],
+    )
+    monkeypatch.setattr("hermes_cli.models.get_pricing_for_provider", lambda provider: {})
+    monkeypatch.setattr("hermes_cli.models.check_nous_free_tier", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.models.partition_nous_models_by_tier",
+        lambda model_ids, pricing, free_tier: ([], list(model_ids)),
+    )
+
+    def fake_prompt(model_ids, **kwargs):
+        selected.append({"model_ids": model_ids, "unavailable": kwargs.get("unavailable_models")})
+        return "custom/free-credit-model"
+
+    monkeypatch.setattr("hermes_cli.auth._prompt_model_selection", fake_prompt)
+    monkeypatch.setattr("hermes_cli.nous_subscription.prompt_enable_tool_gateway", lambda config: set())
+
+    from hermes_cli.config import load_config
+    from hermes_cli.main import _model_flow_nous
+
+    cfg = load_config()
+    _model_flow_nous(cfg)
+
+    assert selected == [{"model_ids": [], "unavailable": ["paid/curated-model"]}]
+    reloaded = load_config()
+    assert reloaded["model"]["provider"] == "nous"
+    assert reloaded["model"]["default"] == "custom/free-credit-model"
+    assert reloaded["model"]["base_url"] == "https://inference.example.com/v1"
+
+
 def test_setup_same_provider_rotation_strategy_saved_for_multi_credential_pool(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

- Keeps the Nous Portal model picker open when a free-tier account has no free curated models
- Allows users to enter a custom Nous model name instead of exiting at the upgrade message
- Adds regression coverage for the free-tier/all-curated-paid path

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A