### PR TITLE
fix(hindsight): complete recall tool methods

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -118,7 +118,7 @@ Available in `hybrid` and `tools` memory modes:
 | Tool | Description |
 |------|-------------|
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Retrieve memories. Defaults to semantic/entity-graph recall; supports optional `method` (`recall`, `list`, `entity`) plus per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, `tag_groups`, and exact-match `metadata` filters. `method="list"` also supports `limit`/`offset`; `method="entity"` supports `max_entity_tokens`. |
+| `hindsight_recall` | Retrieve memories. Defaults to semantic/entity-graph recall; supports optional `method` (`recall`, `list`, `entity`) plus per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, and exact-match `metadata` filters. `tag_groups` is passed through for `recall`/`entity`; `method="list"` uses the public list API and supports `limit`/`offset`; `method="entity"` supports `max_entity_tokens`. |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
 
 ## Environment Variables

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -118,7 +118,7 @@ Available in `hybrid` and `tools` memory modes:
 | Tool | Description |
 |------|-------------|
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
+| `hindsight_recall` | Retrieve memories. Defaults to semantic/entity-graph recall; supports optional `method` (`recall`, `list`, `entity`) plus per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, `tag_groups`, and exact-match `metadata` filters. `method="list"` also supports `limit`/`offset`; `method="entity"` supports `max_entity_tokens`. |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
 
 ## Environment Variables

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -121,6 +121,32 @@ Available in `hybrid` and `tools` memory modes:
 | `hindsight_recall` | Retrieve memories. Defaults to semantic/entity-graph recall; supports optional `method` (`recall`, `list`, `entity`) plus per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, and exact-match `metadata` filters. `tag_groups` is passed through for `recall`/`entity`; `method="list"` uses the public list API and supports `limit`/`offset`; `method="entity"` supports `max_entity_tokens`. |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
 
+### `hindsight_recall` controls
+
+`hindsight_recall` defaults to `method="recall"`, which uses Hindsight's normal semantic/entity-graph recall. Unknown `method` values fall back to this default behavior.
+
+Supported methods:
+
+| Method | Behavior |
+|--------|----------|
+| `recall` | Ranked semantic/entity-graph recall. |
+| `list` | Raw memory listing through Hindsight's public `client.memory.list_memories(...)` API. Supports `limit` and `offset`. |
+| `entity` | Recall with entity observations formatted from the current Hindsight entity response shape. Supports `max_entity_tokens`. |
+
+Per-call controls:
+
+| Argument | Applies to | Description |
+|----------|------------|-------------|
+| `budget` | `recall`, `entity` | Recall budget override: `low`, `mid`, or `high`. Invalid values use the configured default. |
+| `max_tokens` | `recall`, `entity` | Token cap for recalled memory results. Invalid values use the configured default. |
+| `types` | all methods | Fact type filter: `world`, `experience`, or `observation`. Invalid values use configured `recall_types`. |
+| `tags` | all methods | Tag filter. Untagged list items are excluded when tags are explicitly configured or provided. |
+| `tags_match` | all methods | Tag matching mode: `any`, `all`, `any_strict`, or `all_strict`. |
+| `tag_groups` | `recall`, `entity` | Advanced Hindsight tag groups passed through to recall. The public list API does not accept tag groups. |
+| `metadata` | all methods | Exact key/value metadata filter applied to returned memories. Entity output is narrowed to metadata-scoped result entities. |
+| `limit` / `offset` | `list` | Pagination controls for raw list retrieval. `limit` is capped at 200 and `offset` is never negative. |
+| `max_entity_tokens` | `entity` | Token budget for entity observations. Invalid values use the default entity budget. |
+
 ## Environment Variables
 
 | Variable | Description |

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1770,9 +1770,11 @@ class HindsightMemoryProvider(MemoryProvider):
                 return tool_error("Missing required parameter: query")
             method = str(args.get("method") or "recall").strip()
             if method not in _VALID_RECALL_METHODS:
-                return tool_error(
-                    "Invalid recall method. Expected one of: recall, list, entity"
+                logger.debug(
+                    "Tool hindsight_recall: invalid method %r; falling back to recall",
+                    method,
                 )
+                method = "recall"
             try:
                 if method == "list":
                     return self._handle_recall_list(args, query)

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -53,6 +53,9 @@ _MIN_CLIENT_VERSION = "0.4.22"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 _VALID_BUDGETS = {"low", "mid", "high"}
+_VALID_RECALL_METHODS = {"recall", "list", "entity"}
+_VALID_RECALL_TYPES = {"world", "experience", "observation"}
+_VALID_TAG_MATCH_MODES = {"any", "all", "any_strict", "all_strict"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -73,7 +76,9 @@ def _parse_int_setting(value: Any, default: int) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
-        logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
+        logger.warning(
+            "Invalid integer Hindsight setting %r; using default %s", value, default
+        )
         return default
 
 
@@ -150,7 +155,10 @@ RETAIN_SCHEMA = {
         "type": "object",
         "properties": {
             "content": {"type": "string", "description": "The information to store."},
-            "context": {"type": "string", "description": "Short label (e.g. 'user preference', 'project decision')."},
+            "context": {
+                "type": "string",
+                "description": "Short label (e.g. 'user preference', 'project decision').",
+            },
             "tags": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -171,6 +179,68 @@ RECALL_SCHEMA = {
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "What to search for."},
+            "method": {
+                "type": "string",
+                "enum": ["recall", "list", "entity"],
+                "description": (
+                    "Retrieval strategy: semantic recall, keyword/list search, "
+                    "or recall with entity observations."
+                ),
+            },
+            "budget": {
+                "type": "string",
+                "enum": ["low", "mid", "high"],
+                "description": "Optional per-call recall thoroughness override.",
+            },
+            "max_tokens": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional per-call maximum token budget for recall results.",
+            },
+            "types": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["world", "experience", "observation"],
+                },
+                "description": "Optional per-call fact type filter.",
+            },
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional per-call tag filter. Falls back to configured recall_tags.",
+            },
+            "tags_match": {
+                "type": "string",
+                "enum": ["any", "all", "any_strict", "all_strict"],
+                "description": "Tag matching mode for tags.",
+            },
+            "tag_groups": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Advanced Hindsight tag-group filter passed through to recall.",
+            },
+            "metadata": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": "Exact metadata key/value post-filter applied to returned memories.",
+            },
+            "max_entity_tokens": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum token budget for entity observations when method='entity'.",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 200,
+                "description": "Maximum items to fetch when method='list'.",
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Pagination offset when method='list'.",
+            },
         },
         "required": ["query"],
     },
@@ -195,6 +265,7 @@ REFLECT_SCHEMA = {
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
+
 
 def _load_config() -> dict:
     """Load config from profile-scoped path, legacy path, or env vars.
@@ -225,12 +296,18 @@ def _load_config() -> dict:
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
         "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
-        "timeout": _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
-        "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
+        "timeout": _parse_int_setting(
+            os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT
+        ),
+        "idle_timeout": _parse_int_setting(
+            os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT
+        ),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
-        "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
+        "retain_assistant_prefix": os.environ.get(
+            "HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"
+        ),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -278,9 +355,190 @@ def _normalize_retain_tags(value: Any) -> List[str]:
     return normalized
 
 
+def _get_value(obj: Any, key: str, default: Any = None) -> Any:
+    """Return a field from dict-like, pydantic, or attribute-style objects."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    value = getattr(obj, key, default)
+    if value is not default:
+        return value
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            data = model_dump()
+        except Exception:
+            data = None
+        if isinstance(data, dict):
+            return data.get(key, default)
+    to_dict = getattr(obj, "to_dict", None)
+    if callable(to_dict):
+        try:
+            data = to_dict()
+        except Exception:
+            data = None
+        if isinstance(data, dict):
+            return data.get(key, default)
+    return default
+
+
+def _normalize_recall_types(value: Any) -> list[str] | None:
+    """Normalize and validate Hindsight recall result type filters."""
+    result = [
+        item for item in _normalize_retain_tags(value) if item in _VALID_RECALL_TYPES
+    ]
+    return result or None
+
+
+def _normalize_tag_match(value: Any, default: str = "any") -> str:
+    mode = str(value or default).strip()
+    return mode if mode in _VALID_TAG_MATCH_MODES else default
+
+
+def _normalize_metadata_filter(value: Any) -> dict[str, str] | None:
+    """Normalize an exact-match metadata filter from dict or JSON object string."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except Exception:
+            return None
+    if not isinstance(value, dict):
+        return None
+    result = {
+        str(key).strip(): str(val)
+        for key, val in value.items()
+        if str(key).strip() and val is not None
+    }
+    return result or None
+
+
+def _extract_memory_text(item: Any) -> str:
+    """Best-effort extraction of display text from recall/list result objects."""
+    for key in ("text", "content", "observation", "summary"):
+        value = _get_value(item, key)
+        if value:
+            return str(value).strip()
+    return ""
+
+
+def _item_tags(item: Any) -> list[str]:
+    return _normalize_retain_tags(_get_value(item, "tags"))
+
+
+def _item_type(item: Any) -> str:
+    return str(_get_value(item, "type", "") or "").strip()
+
+
+def _item_metadata(item: Any) -> dict[str, Any]:
+    metadata = _get_value(item, "metadata", {})
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _matches_type_filter(item: Any, types: list[str] | None) -> bool:
+    if not types:
+        return True
+    item_type = _item_type(item)
+    return bool(item_type and item_type in types)
+
+
+def _matches_tag_filter(item: Any, tags: list[str] | None, tags_match: str) -> bool:
+    if not tags:
+        return True
+    item_tags = _item_tags(item)
+    if not item_tags:
+        return tags_match in {"any", "all"}
+    if tags_match in {"all", "all_strict"}:
+        return all(tag in item_tags for tag in tags)
+    return any(tag in item_tags for tag in tags)
+
+
+def _matches_metadata_filter(item: Any, metadata_filter: dict[str, str] | None) -> bool:
+    if not metadata_filter:
+        return True
+    metadata = _item_metadata(item)
+    return all(
+        str(metadata.get(key)) == expected for key, expected in metadata_filter.items()
+    )
+
+
+def _filter_memory_items(
+    items: list[Any],
+    *,
+    types: list[str] | None = None,
+    tags: list[str] | None = None,
+    tags_match: str = "any",
+    metadata: dict[str, str] | None = None,
+) -> list[Any]:
+    return [
+        item
+        for item in items
+        if _matches_type_filter(item, types)
+        and _matches_tag_filter(item, tags, tags_match)
+        and _matches_metadata_filter(item, metadata)
+    ]
+
+
+def _format_memory_lines(items: list[Any]) -> list[str]:
+    lines = []
+    for index, item in enumerate(items, 1):
+        text = _extract_memory_text(item)
+        if text:
+            lines.append(f"{index}. {text}")
+    return lines
+
+
+def _entity_items(entities: Any) -> list[tuple[str | None, Any]]:
+    if not entities:
+        return []
+    if isinstance(entities, dict):
+        return [(str(key), value) for key, value in entities.items()]
+    return [(None, entity) for entity in entities]
+
+
+def _format_entity_lines(entities: Any) -> list[str]:
+    lines: list[str] = []
+    for index, (entity_key, entity) in enumerate(_entity_items(entities), 1):
+        name = (
+            _get_value(entity, "canonical_name")
+            or _get_value(entity, "label")
+            or _get_value(entity, "name")
+            or _get_value(entity, "entity_id")
+            or entity_key
+            or "unknown"
+        )
+        entity_type = _get_value(entity, "type") or _get_value(entity, "kind") or ""
+        prefix = f"[{entity_type}] " if entity_type else ""
+        lines.append(f"{index}. {prefix}{name}")
+        observations = _get_value(entity, "observations", None)
+        if observations is None:
+            observation = _get_value(entity, "observation", None)
+            observations = [observation] if observation else []
+        for observation in observations or []:
+            text = _extract_memory_text(observation)
+            if text:
+                lines.append(f"   - {text}")
+    return lines
+
+
+def _bounded_int(
+    value: Any, default: int, *, minimum: int = 1, maximum: int | None = None
+) -> int:
+    parsed = _parse_int_setting(value, default)
+    if parsed < minimum:
+        return default
+    if maximum is not None and parsed > maximum:
+        return maximum
+    return parsed
+
+
 def _utc_timestamp() -> str:
     """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
 
 
 def _embedded_profile_name(config: dict[str, Any]) -> str:
@@ -303,7 +561,9 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
-def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
+def _build_embedded_profile_env(
+    config: dict[str, Any], *, llm_api_key: str | None = None
+) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
     if current_key is None:
@@ -315,10 +575,16 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
-    current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    current_base_url = config.get("llm_base_url") or os.environ.get(
+        "HINDSIGHT_API_LLM_BASE_URL", ""
+    )
 
     # The embedded daemon expects OpenAI wire format for these providers.
-    daemon_provider = "openai" if current_provider in ("openai_compatible", "openrouter") else current_provider
+    daemon_provider = (
+        "openai"
+        if current_provider in ("openai_compatible", "openrouter")
+        else current_provider
+    )
 
     env_values = {
         "HINDSIGHT_API_LLM_PROVIDER": str(daemon_provider),
@@ -344,10 +610,17 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 def _embedded_profile_env_path(config: dict[str, Any]):
     from pathlib import Path
 
-    return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
+    return (
+        Path.home()
+        / ".hindsight"
+        / "profiles"
+        / f"{_embedded_profile_name(config)}.env"
+    )
 
 
-def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
+def _materialize_embedded_profile_env(
+    config: dict[str, Any], *, llm_api_key: str | None = None
+):
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
@@ -357,6 +630,7 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
         encoding="utf-8",
     )
     return profile_env
+
 
 def _sanitize_bank_segment(value: str) -> str:
     """Sanitize a bank_id_template placeholder value.
@@ -402,8 +676,12 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
     try:
         rendered = template.format(**sanitized)
     except (KeyError, IndexError) as exc:
-        logger.warning("Invalid bank_id_template %r: %s — using fallback %r",
-                       template, exc, fallback)
+        logger.warning(
+            "Invalid bank_id_template %r: %s — using fallback %r",
+            template,
+            exc,
+            fallback,
+        )
         return fallback
     while "--" in rendered:
         rendered = rendered.replace("--", "-")
@@ -416,6 +694,7 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
+
 
 class HindsightMemoryProvider(MemoryProvider):
     """Hindsight long-term memory with knowledge graph and multi-strategy retrieval."""
@@ -508,7 +787,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 or cfg.get("api_key")
                 or os.environ.get("HINDSIGHT_API_KEY", "")
             )
-            has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
+            has_url = bool(
+                cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", "")
+            )
             return has_key or has_url
         except Exception:
             return False
@@ -517,6 +798,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Write config to $HERMES_HOME/hindsight/config.json."""
         import json
         from pathlib import Path
+
         config_dir = Path(hermes_home) / "hindsight"
         config_dir.mkdir(parents=True, exist_ok=True)
         config_path = config_dir / "config.json"
@@ -543,7 +825,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         print("\n  Configuring Hindsight memory:\n")
 
-        existing_config = self._config if isinstance(self._config, dict) else _load_config()
+        existing_config = (
+            self._config if isinstance(self._config, dict) else _load_config()
+        )
         if not isinstance(existing_config, dict):
             existing_config = {}
 
@@ -551,11 +835,16 @@ class HindsightMemoryProvider(MemoryProvider):
         mode_values = ["cloud", "local_embedded", "local_external"]
         mode_items = [
             ("Cloud", "Hindsight Cloud API (lightweight, just needs an API key)"),
-            ("Local Embedded", "Run Hindsight locally (downloads ~200MB, needs LLM key)"),
+            (
+                "Local Embedded",
+                "Run Hindsight locally (downloads ~200MB, needs LLM key)",
+            ),
             ("Local External", "Connect to an existing Hindsight instance"),
         ]
         existing_mode = existing_config.get("mode")
-        mode_default_idx = mode_values.index(existing_mode) if existing_mode in mode_values else 0
+        mode_default_idx = (
+            mode_values.index(existing_mode) if existing_mode in mode_values else 0
+        )
         mode_idx = _curses_select("  Select mode", mode_items, default=mode_default_idx)
         mode = mode_values[mode_idx]
 
@@ -577,18 +866,35 @@ class HindsightMemoryProvider(MemoryProvider):
         print("\n  Checking dependencies...")
         uv_path = shutil.which("uv")
         if not uv_path:
-            print("  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh")
-            print(f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
+            print(
+                "  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh"
+            )
+            print(
+                f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}"
+            )
         else:
             try:
                 subprocess.run(
-                    [uv_path, "pip", "install", "--python", sys.executable, "--quiet", "--upgrade"] + deps_to_install,
-                    check=True, timeout=120, capture_output=True,
+                    [
+                        uv_path,
+                        "pip",
+                        "install",
+                        "--python",
+                        sys.executable,
+                        "--quiet",
+                        "--upgrade",
+                    ]
+                    + deps_to_install,
+                    check=True,
+                    timeout=120,
+                    capture_output=True,
                 )
                 print("  ✓ Dependencies up to date")
             except Exception as e:
                 print(f"  ⚠ Install failed: {e}")
-                print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
+                print(
+                    f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}"
+                )
 
         # Step 3: Mode-specific config
         if mode == "cloud":
@@ -598,11 +904,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 masked = f"...{existing_key[-4:]}" if len(existing_key) > 4 else "set"
                 sys.stdout.write(f"  API key (current: {masked}, blank to keep): ")
                 sys.stdout.flush()
-                api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+                api_key = (
+                    getpass.getpass(prompt="")
+                    if sys.stdin.isatty()
+                    else sys.stdin.readline().strip()
+                )
             else:
                 sys.stdout.write("  API key: ")
                 sys.stdout.flush()
-                api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+                api_key = (
+                    getpass.getpass(prompt="")
+                    if sys.stdin.isatty()
+                    else sys.stdin.readline().strip()
+                )
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
@@ -616,7 +930,11 @@ class HindsightMemoryProvider(MemoryProvider):
 
             sys.stdout.write("  API key (optional, blank to skip): ")
             sys.stdout.flush()
-            api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+            api_key = (
+                getpass.getpass(prompt="")
+                if sys.stdin.isatty()
+                else sys.stdin.readline().strip()
+            )
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
@@ -627,8 +945,14 @@ class HindsightMemoryProvider(MemoryProvider):
                 for p in providers_list
             ]
             existing_llm_provider = provider_config.get("llm_provider")
-            llm_default_idx = providers_list.index(existing_llm_provider) if existing_llm_provider in providers_list else 0
-            llm_idx = _curses_select("  Select LLM provider", llm_items, default=llm_default_idx)
+            llm_default_idx = (
+                providers_list.index(existing_llm_provider)
+                if existing_llm_provider in providers_list
+                else 0
+            )
+            llm_idx = _curses_select(
+                "  Select LLM provider", llm_items, default=llm_default_idx
+            )
             llm_provider = providers_list[llm_idx]
 
             provider_config["llm_provider"] = llm_provider
@@ -645,14 +969,20 @@ class HindsightMemoryProvider(MemoryProvider):
             elif llm_provider == "openrouter":
                 provider_config["llm_base_url"] = "https://openrouter.ai/api/v1"
 
-            provider_default_model = _PROVIDER_DEFAULT_MODELS.get(llm_provider, "gpt-4o-mini")
+            provider_default_model = _PROVIDER_DEFAULT_MODELS.get(
+                llm_provider, "gpt-4o-mini"
+            )
             current_model = provider_config.get("llm_model") or provider_default_model
             val = input(f"  LLM model [{current_model}]: ").strip()
             provider_config["llm_model"] = val or current_model
 
             sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
-            llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+            llm_key = (
+                getpass.getpass(prompt="")
+                if sys.stdin.isatty()
+                else sys.stdin.readline().strip()
+            )
             if llm_key:
                 env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
             else:
@@ -671,12 +1001,18 @@ class HindsightMemoryProvider(MemoryProvider):
         # Read existing timeout from config if present, otherwise use default.
         # Preserve explicit 0 values instead of treating them as blank.
         existing_timeout = provider_config.get("timeout")
-        timeout_val = existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
+        timeout_val = (
+            existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
+        )
         provider_config["timeout"] = timeout_val
         env_writes["HINDSIGHT_TIMEOUT"] = str(timeout_val)
         if mode == "local_embedded":
             existing_idle_timeout = provider_config.get("idle_timeout")
-            idle_timeout_val = existing_idle_timeout if existing_idle_timeout is not None else _DEFAULT_IDLE_TIMEOUT
+            idle_timeout_val = (
+                existing_idle_timeout
+                if existing_idle_timeout is not None
+                else _DEFAULT_IDLE_TIMEOUT
+            )
             provider_config["idle_timeout"] = idle_timeout_val
             env_writes["HINDSIGHT_IDLE_TIMEOUT"] = str(idle_timeout_val)
         config["memory"]["provider"] = "hindsight"
@@ -693,7 +1029,11 @@ class HindsightMemoryProvider(MemoryProvider):
             updated_keys = set()
             new_lines = []
             for line in existing_lines:
-                key_match = line.split("=", 1)[0].strip() if "=" in line and not line.startswith("#") else None
+                key_match = (
+                    line.split("=", 1)[0].strip()
+                    if "=" in line and not line.startswith("#")
+                    else None
+                )
                 if key_match and key_match in env_writes:
                     new_lines.append(f"{key_match}={env_writes[key_match]}")
                     updated_keys.add(key_match)
@@ -708,15 +1048,21 @@ class HindsightMemoryProvider(MemoryProvider):
             materialized_config = dict(provider_config)
             config_path = Path(hermes_home) / "hindsight" / "config.json"
             try:
-                materialized_config = json.loads(config_path.read_text(encoding="utf-8"))
+                materialized_config = json.loads(
+                    config_path.read_text(encoding="utf-8")
+                )
             except Exception:
                 pass
 
             llm_api_key = env_writes.get("HINDSIGHT_LLM_API_KEY", "")
             if not llm_api_key:
-                llm_api_key = _load_simple_env(Path(hermes_home) / ".env").get("HINDSIGHT_LLM_API_KEY", "")
+                llm_api_key = _load_simple_env(Path(hermes_home) / ".env").get(
+                    "HINDSIGHT_LLM_API_KEY", ""
+                )
             if not llm_api_key:
-                llm_api_key = _load_simple_env(_embedded_profile_env_path(materialized_config)).get(
+                llm_api_key = _load_simple_env(
+                    _embedded_profile_env_path(materialized_config)
+                ).get(
                     "HINDSIGHT_API_LLM_API_KEY",
                     "",
                 )
@@ -733,41 +1079,199 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def get_config_schema(self):
         return [
-            {"key": "mode", "description": "Connection mode", "default": "cloud", "choices": ["cloud", "local_embedded", "local_external"]},
+            {
+                "key": "mode",
+                "description": "Connection mode",
+                "default": "cloud",
+                "choices": ["cloud", "local_embedded", "local_external"],
+            },
             # Cloud mode
-            {"key": "api_url", "description": "Hindsight Cloud API URL", "default": _DEFAULT_API_URL, "when": {"mode": "cloud"}},
-            {"key": "api_key", "description": "Hindsight Cloud API key", "secret": True, "env_var": "HINDSIGHT_API_KEY", "url": "https://ui.hindsight.vectorize.io", "when": {"mode": "cloud"}},
+            {
+                "key": "api_url",
+                "description": "Hindsight Cloud API URL",
+                "default": _DEFAULT_API_URL,
+                "when": {"mode": "cloud"},
+            },
+            {
+                "key": "api_key",
+                "description": "Hindsight Cloud API key",
+                "secret": True,
+                "env_var": "HINDSIGHT_API_KEY",
+                "url": "https://ui.hindsight.vectorize.io",
+                "when": {"mode": "cloud"},
+            },
             # Local external mode
-            {"key": "api_url", "description": "Hindsight API URL", "default": _DEFAULT_LOCAL_URL, "when": {"mode": "local_external"}},
-            {"key": "api_key", "description": "API key (optional)", "secret": True, "env_var": "HINDSIGHT_API_KEY", "when": {"mode": "local_external"}},
+            {
+                "key": "api_url",
+                "description": "Hindsight API URL",
+                "default": _DEFAULT_LOCAL_URL,
+                "when": {"mode": "local_external"},
+            },
+            {
+                "key": "api_key",
+                "description": "API key (optional)",
+                "secret": True,
+                "env_var": "HINDSIGHT_API_KEY",
+                "when": {"mode": "local_external"},
+            },
             # Local embedded mode
-            {"key": "llm_provider", "description": "LLM provider", "default": "openai", "choices": ["openai", "anthropic", "gemini", "groq", "openrouter", "minimax", "ollama", "lmstudio", "openai_compatible"], "when": {"mode": "local_embedded"}},
-            {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
-            {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
-            {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
-            {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
-            {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
-            {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
-            {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
-            {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
-            {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
-            {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
-            {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
-            {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
-            {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
-            {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
-            {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
-            {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
-            {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
-            {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
-            {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
-            {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
-            {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
-            {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
-            {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
-            {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
-            {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
+            {
+                "key": "llm_provider",
+                "description": "LLM provider",
+                "default": "openai",
+                "choices": [
+                    "openai",
+                    "anthropic",
+                    "gemini",
+                    "groq",
+                    "openrouter",
+                    "minimax",
+                    "ollama",
+                    "lmstudio",
+                    "openai_compatible",
+                ],
+                "when": {"mode": "local_embedded"},
+            },
+            {
+                "key": "llm_base_url",
+                "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)",
+                "default": "",
+                "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"},
+            },
+            {
+                "key": "llm_api_key",
+                "description": "LLM API key (optional for openai_compatible)",
+                "secret": True,
+                "env_var": "HINDSIGHT_LLM_API_KEY",
+                "when": {"mode": "local_embedded"},
+            },
+            {
+                "key": "llm_model",
+                "description": "LLM model",
+                "default": "gpt-4o-mini",
+                "default_from": {
+                    "field": "llm_provider",
+                    "map": _PROVIDER_DEFAULT_MODELS,
+                },
+                "when": {"mode": "local_embedded"},
+            },
+            {
+                "key": "bank_id",
+                "description": "Memory bank name (static fallback when bank_id_template is unset)",
+                "default": "hermes",
+            },
+            {
+                "key": "bank_id_template",
+                "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}",
+                "default": "",
+            },
+            {
+                "key": "bank_mission",
+                "description": "Mission/purpose description for the memory bank",
+            },
+            {
+                "key": "bank_retain_mission",
+                "description": "Custom extraction prompt for memory retention",
+            },
+            {
+                "key": "recall_budget",
+                "description": "Recall thoroughness",
+                "default": "mid",
+                "choices": ["low", "mid", "high"],
+            },
+            {
+                "key": "memory_mode",
+                "description": "Memory integration mode",
+                "default": "hybrid",
+                "choices": ["hybrid", "context", "tools"],
+            },
+            {
+                "key": "recall_prefetch_method",
+                "description": "Auto-recall method",
+                "default": "recall",
+                "choices": ["recall", "reflect"],
+            },
+            {
+                "key": "retain_tags",
+                "description": "Default tags applied to retained memories (comma-separated)",
+                "default": "",
+            },
+            {
+                "key": "retain_source",
+                "description": "Metadata source value attached to retained memories",
+                "default": "",
+            },
+            {
+                "key": "retain_user_prefix",
+                "description": "Label used before user turns in retained transcripts",
+                "default": "User",
+            },
+            {
+                "key": "retain_assistant_prefix",
+                "description": "Label used before assistant turns in retained transcripts",
+                "default": "Assistant",
+            },
+            {
+                "key": "recall_tags",
+                "description": "Tags to filter when searching memories (comma-separated)",
+                "default": "",
+            },
+            {
+                "key": "recall_tags_match",
+                "description": "Tag matching mode for recall",
+                "default": "any",
+                "choices": ["any", "all", "any_strict", "all_strict"],
+            },
+            {
+                "key": "auto_recall",
+                "description": "Automatically recall memories before each turn",
+                "default": True,
+            },
+            {
+                "key": "auto_retain",
+                "description": "Automatically retain conversation turns",
+                "default": True,
+            },
+            {
+                "key": "retain_every_n_turns",
+                "description": "Retain every N turns (1 = every turn)",
+                "default": 1,
+            },
+            {
+                "key": "retain_async",
+                "description": "Process retain asynchronously on the Hindsight server",
+                "default": True,
+            },
+            {
+                "key": "retain_context",
+                "description": "Context label for retained memories",
+                "default": "conversation between Hermes Agent and the User",
+            },
+            {
+                "key": "recall_max_tokens",
+                "description": "Maximum tokens for recall results",
+                "default": 4096,
+            },
+            {
+                "key": "recall_max_input_chars",
+                "description": "Maximum input query length for auto-recall",
+                "default": 800,
+            },
+            {
+                "key": "recall_prompt_preamble",
+                "description": "Custom preamble for recalled memories in context",
+            },
+            {
+                "key": "timeout",
+                "description": "API request timeout in seconds",
+                "default": _DEFAULT_TIMEOUT,
+            },
+            {
+                "key": "idle_timeout",
+                "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)",
+                "default": _DEFAULT_IDLE_TIMEOUT,
+                "when": {"mode": "local_embedded"},
+            },
         ]
 
     def _get_client(self):
@@ -781,16 +1285,22 @@ class HindsightMemoryProvider(MemoryProvider):
                         + (f": {reason}" if reason else "")
                     )
                 from hindsight import HindsightEmbedded
+
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in ("openai_compatible", "openrouter"):
                     llm_provider = "openai"
-                logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
-                             self._config.get("profile", "hermes"), llm_provider)
+                logger.debug(
+                    "Creating HindsightEmbedded client (profile=%s, provider=%s)",
+                    self._config.get("profile", "hermes"),
+                    llm_provider,
+                )
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=self._config.get("llmApiKey")
+                    or self._config.get("llm_api_key")
+                    or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:
@@ -806,12 +1316,17 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 from hindsight_client import Hindsight
+
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
                     kwargs["api_key"] = self._api_key
-                logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
-                             self._api_url, bool(self._api_key), kwargs["timeout"])
+                logger.debug(
+                    "Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
+                    self._api_url,
+                    bool(self._api_key),
+                    kwargs["timeout"],
+                )
                 self._client = Hindsight(**kwargs)
         return self._client
 
@@ -934,27 +1449,50 @@ class HindsightMemoryProvider(MemoryProvider):
         try:
             from importlib.metadata import version as pkg_version
             from packaging.version import Version
+
             installed = pkg_version("hindsight-client")
             if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
+                logger.warning(
+                    "hindsight-client %s is outdated (need >=%s), attempting upgrade...",
+                    installed,
+                    _MIN_CLIENT_VERSION,
+                )
                 import shutil
                 import subprocess
                 import sys
+
                 uv_path = shutil.which("uv")
                 if uv_path:
                     try:
                         subprocess.run(
-                            [uv_path, "pip", "install", "--python", sys.executable,
-                             "--quiet", "--upgrade", f"hindsight-client>={_MIN_CLIENT_VERSION}"],
-                            check=True, timeout=120, capture_output=True,
+                            [
+                                uv_path,
+                                "pip",
+                                "install",
+                                "--python",
+                                sys.executable,
+                                "--quiet",
+                                "--upgrade",
+                                f"hindsight-client>={_MIN_CLIENT_VERSION}",
+                            ],
+                            check=True,
+                            timeout=120,
+                            capture_output=True,
                         )
-                        logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
+                        logger.info(
+                            "hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION
+                        )
                     except Exception as e:
-                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                       e, _MIN_CLIENT_VERSION)
+                        logger.warning(
+                            "Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
+                            e,
+                            _MIN_CLIENT_VERSION,
+                        )
                 else:
-                    logger.warning("uv not found. Run: pip install 'hindsight-client>=%s'", _MIN_CLIENT_VERSION)
+                    logger.warning(
+                        "uv not found. Run: pip install 'hindsight-client>=%s'",
+                        _MIN_CLIENT_VERSION,
+                    )
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
@@ -973,11 +1511,15 @@ class HindsightMemoryProvider(MemoryProvider):
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
-            self._config.get("timeout") if self._config.get("timeout") is not None else os.environ.get("HINDSIGHT_TIMEOUT"),
+            self._config.get("timeout")
+            if self._config.get("timeout") is not None
+            else os.environ.get("HINDSIGHT_TIMEOUT"),
             _DEFAULT_TIMEOUT,
         )
         self._idle_timeout = _parse_int_setting(
-            self._config.get("idle_timeout") if self._config.get("idle_timeout") is not None else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
+            self._config.get("idle_timeout")
+            if self._config.get("idle_timeout") is not None
+            else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
             _DEFAULT_IDLE_TIMEOUT,
         )
         # "local" is a legacy alias for "local_embedded"
@@ -992,9 +1534,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
-        default_url = _DEFAULT_LOCAL_URL if self._mode in ("local_embedded", "local_external") else _DEFAULT_API_URL
-        self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
+        self._api_key = (
+            self._config.get("apiKey")
+            or self._config.get("api_key")
+            or os.environ.get("HINDSIGHT_API_KEY", "")
+        )
+        default_url = (
+            _DEFAULT_LOCAL_URL
+            if self._mode in ("local_embedded", "local_external")
+            else _DEFAULT_API_URL
+        )
+        self._api_url = self._config.get("api_url") or os.environ.get(
+            "HINDSIGHT_API_URL", default_url
+        )
         self._llm_base_url = self._config.get("llm_base_url", "")
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
@@ -1009,14 +1561,24 @@ class HindsightMemoryProvider(MemoryProvider):
             user=self._user_id,
             session=self._session_id,
         )
-        budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
+        budget = (
+            self._config.get("recall_budget")
+            or self._config.get("budget")
+            or banks.get("budget", "mid")
+        )
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
         memory_mode = self._config.get("memory_mode", "hybrid")
-        self._memory_mode = memory_mode if memory_mode in ("context", "tools", "hybrid") else "hybrid"
+        self._memory_mode = (
+            memory_mode if memory_mode in ("context", "tools", "hybrid") else "hybrid"
+        )
 
-        prefetch_method = self._config.get("recall_prefetch_method") or self._config.get("prefetch_method", "recall")
-        self._prefetch_method = prefetch_method if prefetch_method in ("recall", "reflect") else "recall"
+        prefetch_method = self._config.get(
+            "recall_prefetch_method"
+        ) or self._config.get("prefetch_method", "recall")
+        self._prefetch_method = (
+            prefetch_method if prefetch_method in ("recall", "reflect") else "recall"
+        )
 
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
@@ -1028,55 +1590,101 @@ class HindsightMemoryProvider(MemoryProvider):
             or os.environ.get("HINDSIGHT_RETAIN_TAGS", "")
         )
         self._tags = self._retain_tags or None
-        self._recall_tags = self._config.get("recall_tags") or None
-        self._recall_tags_match = self._config.get("recall_tags_match", "any")
+        self._recall_tags = (
+            _normalize_retain_tags(self._config.get("recall_tags")) or None
+        )
+        self._recall_tags_match = _normalize_tag_match(
+            self._config.get("recall_tags_match"), "any"
+        )
         self._retain_source = str(
-            self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
+            self._config.get("retain_source")
+            or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
         ).strip()
-        self._retain_user_prefix = str(
-            self._config.get("retain_user_prefix") or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")
-        ).strip() or "User"
-        self._retain_assistant_prefix = str(
-            self._config.get("retain_assistant_prefix") or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
-        ).strip() or "Assistant"
+        self._retain_user_prefix = (
+            str(
+                self._config.get("retain_user_prefix")
+                or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")
+            ).strip()
+            or "User"
+        )
+        self._retain_assistant_prefix = (
+            str(
+                self._config.get("retain_assistant_prefix")
+                or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
+            ).strip()
+            or "Assistant"
+        )
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
-        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
-        self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
+        self._retain_every_n_turns = max(
+            1, int(self._config.get("retain_every_n_turns", 1))
+        )
+        self._retain_context = self._config.get(
+            "retain_context", "conversation between Hermes Agent and the User"
+        )
 
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
-        self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
-        self._recall_types = self._config.get("recall_types") or None
+        self._recall_max_tokens = _bounded_int(
+            self._config.get("recall_max_tokens", 4096), 4096
+        )
+        self._recall_types = _normalize_recall_types(self._config.get("recall_types"))
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
-        self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_max_input_chars = int(
+            self._config.get("recall_max_input_chars", 800)
+        )
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
         try:
             from importlib.metadata import version as pkg_version
+
             _client_version = pkg_version("hindsight-client")
         except Exception:
             pass
-        logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
-                     self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method, _client_version)
+        logger.info(
+            "Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
+            self._mode,
+            self._api_url,
+            self._bank_id,
+            self._budget,
+            self._memory_mode,
+            self._prefetch_method,
+            _client_version,
+        )
         if self._bank_id_template:
-            logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
-                         self._bank_id_template, self._agent_identity, self._agent_workspace,
-                         self._platform, self._user_id, self._bank_id)
-        logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
-                     self._auto_retain, self._auto_recall, self._retain_every_n_turns,
-                     self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
-                     self._tags, self._recall_tags)
+            logger.debug(
+                "Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
+                self._bank_id_template,
+                self._agent_identity,
+                self._agent_workspace,
+                self._platform,
+                self._user_id,
+                self._bank_id,
+            )
+        logger.debug(
+            "Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
+            "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+            self._auto_retain,
+            self._auto_recall,
+            self._retain_every_n_turns,
+            self._retain_async,
+            self._retain_context,
+            self._recall_max_tokens,
+            self._recall_max_input_chars,
+            self._tags,
+            self._recall_tags,
+        )
 
         # For local mode, start the embedded daemon in the background so it
         # doesn't block the chat. Redirect stdout/stderr to a log file to
         # prevent rich startup output from spamming the terminal.
         if self._mode == "local_embedded":
+
             def _start_daemon():
                 import traceback
+
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
@@ -1086,7 +1694,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     # would capture output from other threads.
                     import hindsight_embed.daemon_embed_manager as dem
                     from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a"), force_terminal=False)
+
+                    dem.console = Console(
+                        file=open(log_path, "a"), force_terminal=False
+                    )
 
                     client = self._get_client()
                     profile = self._config.get("profile", "hermes")
@@ -1114,7 +1725,9 @@ class HindsightMemoryProvider(MemoryProvider):
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
                         traceback.print_exc(file=f)
 
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = threading.Thread(
+                target=_start_daemon, daemon=True, name="hindsight-daemon-start"
+            )
             t.start()
 
     def system_prompt_block(self) -> str:
@@ -1169,40 +1782,64 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         # Truncate query to max chars
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
+            query = query[: self._recall_max_input_chars]
 
         def _run():
             try:
                 if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                    logger.debug(
+                        "Prefetch: calling reflect (bank=%s, query_len=%d)",
+                        self._bank_id,
+                        len(query),
+                    )
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.areflect(
+                            bank_id=self._bank_id, query=query, budget=self._budget
+                        )
+                    )
                     text = resp.text or ""
                 else:
                     recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
+                        "bank_id": self._bank_id,
+                        "query": query,
+                        "budget": self._budget,
+                        "max_tokens": self._recall_max_tokens,
                     }
                     if self._recall_tags:
                         recall_kwargs["tags"] = self._recall_tags
                         recall_kwargs["tags_match"] = self._recall_tags_match
                     if self._recall_types:
                         recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+                    logger.debug(
+                        "Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                        self._bank_id,
+                        len(query),
+                        self._budget,
+                    )
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.arecall(**recall_kwargs)
+                    )
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = (
+                        "\n".join(f"- {r.text}" for r in resp.results if r.text)
+                        if resp.results
+                        else ""
+                    )
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
             except Exception as e:
                 logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
 
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="hindsight-prefetch"
+        )
         self._prefetch_thread.start()
 
-    def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
+    def _build_turn_messages(
+        self, user_content: str, assistant_content: str
+    ) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
         return [
             {
@@ -1258,7 +1895,8 @@ class HindsightMemoryProvider(MemoryProvider):
         kwargs: Dict[str, Any] = {
             "bank_id": self._bank_id,
             "content": content,
-            "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
+            "metadata": metadata
+            or self._build_metadata(message_count=1, turn_index=self._turn_index),
         }
         if context is not None:
             kwargs["context"] = context
@@ -1274,7 +1912,9 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["tags"] = merged_tags
         return kwargs
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(
+        self, user_content: str, assistant_content: str, *, session_id: str = ""
+    ) -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
         The actual aretain_batch runs on a single long-lived writer thread
@@ -1292,18 +1932,31 @@ class HindsightMemoryProvider(MemoryProvider):
         if session_id:
             self._session_id = str(session_id).strip()
 
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
+        turn = json.dumps(
+            self._build_turn_messages(user_content, assistant_content),
+            ensure_ascii=False,
+        )
         self._session_turns.append(turn)
         self._turn_counter += 1
         self._turn_index = self._turn_counter
 
         if self._turn_counter % self._retain_every_n_turns != 0:
-            logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
-                         self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
+            logger.debug(
+                "sync_turn: buffered turn %d (will retain at turn %d)",
+                self._turn_counter,
+                self._turn_counter
+                + (
+                    self._retain_every_n_turns
+                    - self._turn_counter % self._retain_every_n_turns
+                ),
+            )
             return
 
-        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
-                     len(self._session_turns), sum(len(t) for t in self._session_turns))
+        logger.debug(
+            "sync_turn: retaining %d turns, total session content %d chars",
+            len(self._session_turns),
+            sum(len(t) for t in self._session_turns),
+        )
         content = "[" + ",".join(self._session_turns) + "]"
 
         lineage_tags: list[str] = []
@@ -1333,8 +1986,14 @@ class HindsightMemoryProvider(MemoryProvider):
             )
             item.pop("bank_id", None)
             item.pop("retain_async", None)
-            logger.debug("Hindsight retain: bank=%s, doc=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, retain_async_flag, len(content), num_turns)
+            logger.debug(
+                "Hindsight retain: bank=%s, doc=%s, async=%s, content_len=%d, num_turns=%d",
+                bank_id,
+                document_id,
+                retain_async_flag,
+                len(content),
+                num_turns,
+            )
             self._run_hindsight_operation(
                 lambda client: client.aretain_batch(
                     bank_id=bank_id,
@@ -1354,6 +2013,148 @@ class HindsightMemoryProvider(MemoryProvider):
             return []
         return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
 
+    def _build_tool_recall_kwargs(
+        self,
+        args: dict[str, Any],
+        query: str,
+        *,
+        default_types: list[str] | None = None,
+    ) -> tuple[dict[str, Any], dict[str, str] | None, list[str] | None, str]:
+        """Build validated kwargs for Hindsight recall-like tool calls."""
+        budget = (
+            args.get("budget") if args.get("budget") in _VALID_BUDGETS else self._budget
+        )
+        max_tokens = _bounded_int(args.get("max_tokens"), self._recall_max_tokens)
+        types = _normalize_recall_types(args.get("types")) if "types" in args else None
+        if not types:
+            types = self._recall_types or default_types
+
+        raw_tags = args.get("tags") if isinstance(args.get("tags"), list) else None
+        tags = _normalize_retain_tags(raw_tags) if raw_tags is not None else None
+        if not tags:
+            tags = self._recall_tags
+        tags_match = _normalize_tag_match(
+            args.get("tags_match"), self._recall_tags_match
+        )
+
+        recall_kwargs: dict[str, Any] = {
+            "bank_id": self._bank_id,
+            "query": query,
+            "budget": budget,
+            "max_tokens": max_tokens,
+        }
+        if types:
+            recall_kwargs["types"] = types
+        if tags:
+            recall_kwargs["tags"] = tags
+            recall_kwargs["tags_match"] = tags_match
+        if isinstance(args.get("tag_groups"), list):
+            recall_kwargs["tag_groups"] = args["tag_groups"]
+
+        metadata_filter = _normalize_metadata_filter(args.get("metadata"))
+        return recall_kwargs, metadata_filter, tags, tags_match
+
+    def _handle_recall_search(self, args: dict[str, Any], query: str) -> str:
+        recall_kwargs, metadata_filter, _, _ = self._build_tool_recall_kwargs(
+            args, query
+        )
+        logger.debug(
+            "Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
+            self._bank_id,
+            len(query),
+            recall_kwargs["budget"],
+        )
+        resp = self._run_hindsight_operation(
+            lambda client: client.arecall(**recall_kwargs)
+        )
+        results = list(getattr(resp, "results", None) or [])
+        results = _filter_memory_items(results, metadata=metadata_filter)
+        logger.debug("Tool hindsight_recall: %d results", len(results))
+        lines = _format_memory_lines(results)
+        if not lines:
+            return json.dumps({"result": "No relevant memories found."})
+        return json.dumps({"result": "\n".join(lines)})
+
+    def _handle_recall_list(self, args: dict[str, Any], query: str) -> str:
+        _, metadata_filter, tags, tags_match = self._build_tool_recall_kwargs(
+            args, query
+        )
+        types = (
+            _normalize_recall_types(args.get("types"))
+            if "types" in args
+            else self._recall_types
+        )
+        limit = _bounded_int(args.get("limit"), 50, minimum=1, maximum=200)
+        offset = _bounded_int(args.get("offset"), 0, minimum=0)
+        server_type = types[0] if types and len(types) == 1 else None
+        list_kwargs = {
+            "bank_id": self._bank_id,
+            "type": server_type,
+            "q": query,
+            "limit": limit,
+            "offset": offset,
+            "_request_timeout": self._timeout,
+        }
+        resp = self._run_hindsight_operation(
+            lambda client: client.memory.list_memories(**list_kwargs)
+        )
+        items = list(getattr(resp, "items", None) or [])
+        items = _filter_memory_items(
+            items,
+            types=types,
+            tags=tags,
+            tags_match=tags_match,
+            metadata=metadata_filter,
+        )
+        lines = _format_memory_lines(items)
+        if not lines:
+            return json.dumps(
+                {
+                    "result": "No matching memories found.",
+                    "total": getattr(resp, "total", 0),
+                    "returned": 0,
+                }
+            )
+        return json.dumps(
+            {
+                "result": "\n".join(lines),
+                "total": getattr(resp, "total", len(items)),
+                "returned": len(lines),
+                "limit": getattr(resp, "limit", limit),
+                "offset": getattr(resp, "offset", offset),
+            }
+        )
+
+    def _handle_recall_entity(self, args: dict[str, Any], query: str) -> str:
+        recall_kwargs, metadata_filter, _, _ = self._build_tool_recall_kwargs(
+            args,
+            query,
+            default_types=["world"],
+        )
+        recall_kwargs["include_entities"] = True
+        recall_kwargs["max_entity_tokens"] = _bounded_int(
+            args.get("max_entity_tokens"), 2000
+        )
+        resp = self._run_hindsight_operation(
+            lambda client: client.arecall(**recall_kwargs)
+        )
+        results = list(getattr(resp, "results", None) or [])
+        results = _filter_memory_items(results, metadata=metadata_filter)
+        entities = getattr(resp, "entities", None)
+        if metadata_filter and not results:
+            entities = None
+
+        sections: list[str] = []
+        memory_lines = _format_memory_lines(results)
+        if memory_lines:
+            sections.append("Memories:\n" + "\n".join(memory_lines))
+        entity_lines = _format_entity_lines(entities)
+        if entity_lines:
+            sections.append("Entities:\n" + "\n".join(entity_lines))
+        if not sections:
+            return json.dumps({"result": "No relevant memories found."})
+        return json.dumps({"result": "\n\n".join(sections)})
+
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
             content = args.get("content", "")
@@ -1366,9 +2167,15 @@ class HindsightMemoryProvider(MemoryProvider):
                     context=context,
                     tags=args.get("tags"),
                 )
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
-                self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
+                    self._bank_id,
+                    len(content),
+                    context,
+                )
+                self._run_hindsight_operation(
+                    lambda client: client.aretain(**retain_kwargs)
+                )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
@@ -1379,25 +2186,17 @@ class HindsightMemoryProvider(MemoryProvider):
             query = args.get("query", "")
             if not query:
                 return tool_error("Missing required parameter: query")
+            method = str(args.get("method") or "recall").strip()
+            if method not in _VALID_RECALL_METHODS:
+                return tool_error(
+                    "Invalid recall method. Expected one of: recall, list, entity"
+                )
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
-                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
-                logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
-                    return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                if method == "list":
+                    return self._handle_recall_list(args, query)
+                if method == "entity":
+                    return self._handle_recall_entity(args, query)
+                return self._handle_recall_search(args, query)
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")
@@ -1407,15 +2206,23 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
+                logger.debug(
+                    "Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
+                    self._bank_id,
+                    len(query),
+                    self._budget,
+                )
                 resp = self._run_hindsight_operation(
                     lambda client: client.areflect(
                         bank_id=self._bank_id, query=query, budget=self._budget
                     )
                 )
-                logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
-                return json.dumps({"result": resp.text or "No relevant memories found."})
+                logger.debug(
+                    "Tool hindsight_reflect: response_len=%d", len(resp.text or "")
+                )
+                return json.dumps(
+                    {"result": resp.text or "No relevant memories found."}
+                )
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
@@ -1497,7 +2304,9 @@ class HindsightMemoryProvider(MemoryProvider):
                     item.pop("retain_async", None)
                     logger.debug(
                         "Hindsight flush-on-switch: bank=%s, doc=%s, num_turns=%d",
-                        self._bank_id, old_document_id, len(old_turns),
+                        self._bank_id,
+                        old_document_id,
+                        len(old_turns),
                     )
                     self._run_hindsight_operation(
                         lambda client: client.aretain_batch(
@@ -1508,7 +2317,9 @@ class HindsightMemoryProvider(MemoryProvider):
                         )
                     )
                 except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
+                    logger.warning(
+                        "Hindsight flush-on-switch failed: %s", e, exc_info=True
+                    )
 
             # Route the flush through the same writer queue sync_turn
             # uses. That serializes it behind any still-queued retains
@@ -1539,11 +2350,16 @@ class HindsightMemoryProvider(MemoryProvider):
         self._turn_index = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
-            self._session_id, self._parent_session_id, reset, self._document_id,
+            self._session_id,
+            self._parent_session_id,
+            reset,
+            self._document_id,
         )
 
     def shutdown(self) -> None:
-        logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
+        logger.debug(
+            "Hindsight shutdown: stopping writer + waiting for background threads"
+        )
         # Stop accepting new retain jobs first so anyone still calling
         # sync_turn() during teardown is dropped, not enqueued.
         self._shutting_down.set()

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -435,7 +435,7 @@ def _matches_tag_filter(item: Any, tags: list[str] | None, tags_match: str) -> b
         return True
     item_tags = _item_tags(item)
     if not item_tags:
-        return tags_match in {"any", "all"}
+        return False
     if tags_match in {"all", "all_strict"}:
         return all(tag in item_tags for tag in tags)
     return any(tag in item_tags for tag in tags)
@@ -445,7 +445,7 @@ def _matches_metadata_filter(item: Any, metadata_filter: dict[str, str] | None) 
     if not metadata_filter:
         return True
     metadata = _item_metadata(item)
-    return all(str(metadata.get(key)) == expected for key, expected in metadata_filter.items())
+    return all(key in metadata and str(metadata[key]) == expected for key, expected in metadata_filter.items())
 
 
 def _filter_memory_items(

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -76,9 +76,7 @@ def _parse_int_setting(value: Any, default: int) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
-        logger.warning(
-            "Invalid integer Hindsight setting %r; using default %s", value, default
-        )
+        logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
 
 
@@ -155,10 +153,7 @@ RETAIN_SCHEMA = {
         "type": "object",
         "properties": {
             "content": {"type": "string", "description": "The information to store."},
-            "context": {
-                "type": "string",
-                "description": "Short label (e.g. 'user preference', 'project decision').",
-            },
+            "context": {"type": "string", "description": "Short label (e.g. 'user preference', 'project decision')."},
             "tags": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -199,10 +194,7 @@ RECALL_SCHEMA = {
             },
             "types": {
                 "type": "array",
-                "items": {
-                    "type": "string",
-                    "enum": ["world", "experience", "observation"],
-                },
+                "items": {"type": "string", "enum": ["world", "experience", "observation"]},
                 "description": "Optional per-call fact type filter.",
             },
             "tags": {
@@ -266,7 +258,6 @@ REFLECT_SCHEMA = {
 # Config
 # ---------------------------------------------------------------------------
 
-
 def _load_config() -> dict:
     """Load config from profile-scoped path, legacy path, or env vars.
 
@@ -296,18 +287,12 @@ def _load_config() -> dict:
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
         "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
-        "timeout": _parse_int_setting(
-            os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT
-        ),
-        "idle_timeout": _parse_int_setting(
-            os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT
-        ),
+        "timeout": _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
+        "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
-        "retain_assistant_prefix": os.environ.get(
-            "HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"
-        ),
+        "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -385,9 +370,7 @@ def _get_value(obj: Any, key: str, default: Any = None) -> Any:
 
 def _normalize_recall_types(value: Any) -> list[str] | None:
     """Normalize and validate Hindsight recall result type filters."""
-    result = [
-        item for item in _normalize_retain_tags(value) if item in _VALID_RECALL_TYPES
-    ]
+    result = [item for item in _normalize_retain_tags(value) if item in _VALID_RECALL_TYPES]
     return result or None
 
 
@@ -427,7 +410,12 @@ def _item_tags(item: Any) -> list[str]:
 
 
 def _item_type(item: Any) -> str:
-    return str(_get_value(item, "type", "") or "").strip()
+    return str(
+        _get_value(item, "type", None)
+        or _get_value(item, "fact_type", None)
+        or _get_value(item, "factType", "")
+        or ""
+    ).strip()
 
 
 def _item_metadata(item: Any) -> dict[str, Any]:
@@ -457,9 +445,7 @@ def _matches_metadata_filter(item: Any, metadata_filter: dict[str, str] | None) 
     if not metadata_filter:
         return True
     metadata = _item_metadata(item)
-    return all(
-        str(metadata.get(key)) == expected for key, expected in metadata_filter.items()
-    )
+    return all(str(metadata.get(key)) == expected for key, expected in metadata_filter.items())
 
 
 def _filter_memory_items(
@@ -521,9 +507,40 @@ def _format_entity_lines(entities: Any) -> list[str]:
     return lines
 
 
-def _bounded_int(
-    value: Any, default: int, *, minimum: int = 1, maximum: int | None = None
-) -> int:
+def _result_entity_ids(items: list[Any]) -> set[str]:
+    """Return entity ids referenced by recall results."""
+    entity_ids: set[str] = set()
+    for item in items:
+        raw_entities = _get_value(item, "entities", None)
+        if isinstance(raw_entities, str):
+            raw_entities = [raw_entities]
+        if isinstance(raw_entities, (list, tuple, set)):
+            entity_ids.update(str(entity_id) for entity_id in raw_entities if entity_id)
+    return entity_ids
+
+
+def _filter_entities_by_ids(entities: Any, allowed_ids: set[str]) -> Any:
+    """Restrict entity payloads to ids referenced by already-filtered memories."""
+    if not entities or not allowed_ids:
+        return None
+    if isinstance(entities, dict):
+        filtered: dict[str, Any] = {}
+        for key, entity in entities.items():
+            entity_id = str(_get_value(entity, "entity_id", key) or key)
+            key_id = str(key)
+            if key_id in allowed_ids or entity_id in allowed_ids:
+                filtered[key] = entity
+        return filtered or None
+
+    filtered_entities = []
+    for entity in entities:
+        entity_id = str(_get_value(entity, "entity_id", "") or "")
+        if entity_id in allowed_ids:
+            filtered_entities.append(entity)
+    return filtered_entities or None
+
+
+def _bounded_int(value: Any, default: int, *, minimum: int = 1, maximum: int | None = None) -> int:
     parsed = _parse_int_setting(value, default)
     if parsed < minimum:
         return default
@@ -534,11 +551,7 @@ def _bounded_int(
 
 def _utc_timestamp() -> str:
     """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
-    return (
-        datetime.now(timezone.utc)
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _embedded_profile_name(config: dict[str, Any]) -> str:
@@ -561,9 +574,7 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
-def _build_embedded_profile_env(
-    config: dict[str, Any], *, llm_api_key: str | None = None
-) -> dict[str, str]:
+def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
     if current_key is None:
@@ -575,16 +586,10 @@ def _build_embedded_profile_env(
 
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
-    current_base_url = config.get("llm_base_url") or os.environ.get(
-        "HINDSIGHT_API_LLM_BASE_URL", ""
-    )
+    current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
 
     # The embedded daemon expects OpenAI wire format for these providers.
-    daemon_provider = (
-        "openai"
-        if current_provider in ("openai_compatible", "openrouter")
-        else current_provider
-    )
+    daemon_provider = "openai" if current_provider in ("openai_compatible", "openrouter") else current_provider
 
     env_values = {
         "HINDSIGHT_API_LLM_PROVIDER": str(daemon_provider),
@@ -610,17 +615,10 @@ def _build_embedded_profile_env(
 def _embedded_profile_env_path(config: dict[str, Any]):
     from pathlib import Path
 
-    return (
-        Path.home()
-        / ".hindsight"
-        / "profiles"
-        / f"{_embedded_profile_name(config)}.env"
-    )
+    return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
 
 
-def _materialize_embedded_profile_env(
-    config: dict[str, Any], *, llm_api_key: str | None = None
-):
+def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
@@ -630,7 +628,6 @@ def _materialize_embedded_profile_env(
         encoding="utf-8",
     )
     return profile_env
-
 
 def _sanitize_bank_segment(value: str) -> str:
     """Sanitize a bank_id_template placeholder value.
@@ -676,12 +673,8 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
     try:
         rendered = template.format(**sanitized)
     except (KeyError, IndexError) as exc:
-        logger.warning(
-            "Invalid bank_id_template %r: %s — using fallback %r",
-            template,
-            exc,
-            fallback,
-        )
+        logger.warning("Invalid bank_id_template %r: %s — using fallback %r",
+                       template, exc, fallback)
         return fallback
     while "--" in rendered:
         rendered = rendered.replace("--", "-")
@@ -694,7 +687,6 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
-
 
 class HindsightMemoryProvider(MemoryProvider):
     """Hindsight long-term memory with knowledge graph and multi-strategy retrieval."""
@@ -787,9 +779,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 or cfg.get("api_key")
                 or os.environ.get("HINDSIGHT_API_KEY", "")
             )
-            has_url = bool(
-                cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", "")
-            )
+            has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
             return has_key or has_url
         except Exception:
             return False
@@ -798,7 +788,6 @@ class HindsightMemoryProvider(MemoryProvider):
         """Write config to $HERMES_HOME/hindsight/config.json."""
         import json
         from pathlib import Path
-
         config_dir = Path(hermes_home) / "hindsight"
         config_dir.mkdir(parents=True, exist_ok=True)
         config_path = config_dir / "config.json"
@@ -825,9 +814,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         print("\n  Configuring Hindsight memory:\n")
 
-        existing_config = (
-            self._config if isinstance(self._config, dict) else _load_config()
-        )
+        existing_config = self._config if isinstance(self._config, dict) else _load_config()
         if not isinstance(existing_config, dict):
             existing_config = {}
 
@@ -835,16 +822,11 @@ class HindsightMemoryProvider(MemoryProvider):
         mode_values = ["cloud", "local_embedded", "local_external"]
         mode_items = [
             ("Cloud", "Hindsight Cloud API (lightweight, just needs an API key)"),
-            (
-                "Local Embedded",
-                "Run Hindsight locally (downloads ~200MB, needs LLM key)",
-            ),
+            ("Local Embedded", "Run Hindsight locally (downloads ~200MB, needs LLM key)"),
             ("Local External", "Connect to an existing Hindsight instance"),
         ]
         existing_mode = existing_config.get("mode")
-        mode_default_idx = (
-            mode_values.index(existing_mode) if existing_mode in mode_values else 0
-        )
+        mode_default_idx = mode_values.index(existing_mode) if existing_mode in mode_values else 0
         mode_idx = _curses_select("  Select mode", mode_items, default=mode_default_idx)
         mode = mode_values[mode_idx]
 
@@ -866,35 +848,18 @@ class HindsightMemoryProvider(MemoryProvider):
         print("\n  Checking dependencies...")
         uv_path = shutil.which("uv")
         if not uv_path:
-            print(
-                "  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh"
-            )
-            print(
-                f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}"
-            )
+            print("  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh")
+            print(f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
         else:
             try:
                 subprocess.run(
-                    [
-                        uv_path,
-                        "pip",
-                        "install",
-                        "--python",
-                        sys.executable,
-                        "--quiet",
-                        "--upgrade",
-                    ]
-                    + deps_to_install,
-                    check=True,
-                    timeout=120,
-                    capture_output=True,
+                    [uv_path, "pip", "install", "--python", sys.executable, "--quiet", "--upgrade"] + deps_to_install,
+                    check=True, timeout=120, capture_output=True,
                 )
                 print("  ✓ Dependencies up to date")
             except Exception as e:
                 print(f"  ⚠ Install failed: {e}")
-                print(
-                    f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}"
-                )
+                print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
 
         # Step 3: Mode-specific config
         if mode == "cloud":
@@ -904,19 +869,11 @@ class HindsightMemoryProvider(MemoryProvider):
                 masked = f"...{existing_key[-4:]}" if len(existing_key) > 4 else "set"
                 sys.stdout.write(f"  API key (current: {masked}, blank to keep): ")
                 sys.stdout.flush()
-                api_key = (
-                    getpass.getpass(prompt="")
-                    if sys.stdin.isatty()
-                    else sys.stdin.readline().strip()
-                )
+                api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             else:
                 sys.stdout.write("  API key: ")
                 sys.stdout.flush()
-                api_key = (
-                    getpass.getpass(prompt="")
-                    if sys.stdin.isatty()
-                    else sys.stdin.readline().strip()
-                )
+                api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
@@ -930,11 +887,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
             sys.stdout.write("  API key (optional, blank to skip): ")
             sys.stdout.flush()
-            api_key = (
-                getpass.getpass(prompt="")
-                if sys.stdin.isatty()
-                else sys.stdin.readline().strip()
-            )
+            api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
@@ -945,14 +898,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 for p in providers_list
             ]
             existing_llm_provider = provider_config.get("llm_provider")
-            llm_default_idx = (
-                providers_list.index(existing_llm_provider)
-                if existing_llm_provider in providers_list
-                else 0
-            )
-            llm_idx = _curses_select(
-                "  Select LLM provider", llm_items, default=llm_default_idx
-            )
+            llm_default_idx = providers_list.index(existing_llm_provider) if existing_llm_provider in providers_list else 0
+            llm_idx = _curses_select("  Select LLM provider", llm_items, default=llm_default_idx)
             llm_provider = providers_list[llm_idx]
 
             provider_config["llm_provider"] = llm_provider
@@ -969,20 +916,14 @@ class HindsightMemoryProvider(MemoryProvider):
             elif llm_provider == "openrouter":
                 provider_config["llm_base_url"] = "https://openrouter.ai/api/v1"
 
-            provider_default_model = _PROVIDER_DEFAULT_MODELS.get(
-                llm_provider, "gpt-4o-mini"
-            )
+            provider_default_model = _PROVIDER_DEFAULT_MODELS.get(llm_provider, "gpt-4o-mini")
             current_model = provider_config.get("llm_model") or provider_default_model
             val = input(f"  LLM model [{current_model}]: ").strip()
             provider_config["llm_model"] = val or current_model
 
             sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
-            llm_key = (
-                getpass.getpass(prompt="")
-                if sys.stdin.isatty()
-                else sys.stdin.readline().strip()
-            )
+            llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             if llm_key:
                 env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
             else:
@@ -1001,18 +942,12 @@ class HindsightMemoryProvider(MemoryProvider):
         # Read existing timeout from config if present, otherwise use default.
         # Preserve explicit 0 values instead of treating them as blank.
         existing_timeout = provider_config.get("timeout")
-        timeout_val = (
-            existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
-        )
+        timeout_val = existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
         provider_config["timeout"] = timeout_val
         env_writes["HINDSIGHT_TIMEOUT"] = str(timeout_val)
         if mode == "local_embedded":
             existing_idle_timeout = provider_config.get("idle_timeout")
-            idle_timeout_val = (
-                existing_idle_timeout
-                if existing_idle_timeout is not None
-                else _DEFAULT_IDLE_TIMEOUT
-            )
+            idle_timeout_val = existing_idle_timeout if existing_idle_timeout is not None else _DEFAULT_IDLE_TIMEOUT
             provider_config["idle_timeout"] = idle_timeout_val
             env_writes["HINDSIGHT_IDLE_TIMEOUT"] = str(idle_timeout_val)
         config["memory"]["provider"] = "hindsight"
@@ -1029,11 +964,7 @@ class HindsightMemoryProvider(MemoryProvider):
             updated_keys = set()
             new_lines = []
             for line in existing_lines:
-                key_match = (
-                    line.split("=", 1)[0].strip()
-                    if "=" in line and not line.startswith("#")
-                    else None
-                )
+                key_match = line.split("=", 1)[0].strip() if "=" in line and not line.startswith("#") else None
                 if key_match and key_match in env_writes:
                     new_lines.append(f"{key_match}={env_writes[key_match]}")
                     updated_keys.add(key_match)
@@ -1048,21 +979,15 @@ class HindsightMemoryProvider(MemoryProvider):
             materialized_config = dict(provider_config)
             config_path = Path(hermes_home) / "hindsight" / "config.json"
             try:
-                materialized_config = json.loads(
-                    config_path.read_text(encoding="utf-8")
-                )
+                materialized_config = json.loads(config_path.read_text(encoding="utf-8"))
             except Exception:
                 pass
 
             llm_api_key = env_writes.get("HINDSIGHT_LLM_API_KEY", "")
             if not llm_api_key:
-                llm_api_key = _load_simple_env(Path(hermes_home) / ".env").get(
-                    "HINDSIGHT_LLM_API_KEY", ""
-                )
+                llm_api_key = _load_simple_env(Path(hermes_home) / ".env").get("HINDSIGHT_LLM_API_KEY", "")
             if not llm_api_key:
-                llm_api_key = _load_simple_env(
-                    _embedded_profile_env_path(materialized_config)
-                ).get(
+                llm_api_key = _load_simple_env(_embedded_profile_env_path(materialized_config)).get(
                     "HINDSIGHT_API_LLM_API_KEY",
                     "",
                 )
@@ -1079,199 +1004,41 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def get_config_schema(self):
         return [
-            {
-                "key": "mode",
-                "description": "Connection mode",
-                "default": "cloud",
-                "choices": ["cloud", "local_embedded", "local_external"],
-            },
+            {"key": "mode", "description": "Connection mode", "default": "cloud", "choices": ["cloud", "local_embedded", "local_external"]},
             # Cloud mode
-            {
-                "key": "api_url",
-                "description": "Hindsight Cloud API URL",
-                "default": _DEFAULT_API_URL,
-                "when": {"mode": "cloud"},
-            },
-            {
-                "key": "api_key",
-                "description": "Hindsight Cloud API key",
-                "secret": True,
-                "env_var": "HINDSIGHT_API_KEY",
-                "url": "https://ui.hindsight.vectorize.io",
-                "when": {"mode": "cloud"},
-            },
+            {"key": "api_url", "description": "Hindsight Cloud API URL", "default": _DEFAULT_API_URL, "when": {"mode": "cloud"}},
+            {"key": "api_key", "description": "Hindsight Cloud API key", "secret": True, "env_var": "HINDSIGHT_API_KEY", "url": "https://ui.hindsight.vectorize.io", "when": {"mode": "cloud"}},
             # Local external mode
-            {
-                "key": "api_url",
-                "description": "Hindsight API URL",
-                "default": _DEFAULT_LOCAL_URL,
-                "when": {"mode": "local_external"},
-            },
-            {
-                "key": "api_key",
-                "description": "API key (optional)",
-                "secret": True,
-                "env_var": "HINDSIGHT_API_KEY",
-                "when": {"mode": "local_external"},
-            },
+            {"key": "api_url", "description": "Hindsight API URL", "default": _DEFAULT_LOCAL_URL, "when": {"mode": "local_external"}},
+            {"key": "api_key", "description": "API key (optional)", "secret": True, "env_var": "HINDSIGHT_API_KEY", "when": {"mode": "local_external"}},
             # Local embedded mode
-            {
-                "key": "llm_provider",
-                "description": "LLM provider",
-                "default": "openai",
-                "choices": [
-                    "openai",
-                    "anthropic",
-                    "gemini",
-                    "groq",
-                    "openrouter",
-                    "minimax",
-                    "ollama",
-                    "lmstudio",
-                    "openai_compatible",
-                ],
-                "when": {"mode": "local_embedded"},
-            },
-            {
-                "key": "llm_base_url",
-                "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)",
-                "default": "",
-                "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"},
-            },
-            {
-                "key": "llm_api_key",
-                "description": "LLM API key (optional for openai_compatible)",
-                "secret": True,
-                "env_var": "HINDSIGHT_LLM_API_KEY",
-                "when": {"mode": "local_embedded"},
-            },
-            {
-                "key": "llm_model",
-                "description": "LLM model",
-                "default": "gpt-4o-mini",
-                "default_from": {
-                    "field": "llm_provider",
-                    "map": _PROVIDER_DEFAULT_MODELS,
-                },
-                "when": {"mode": "local_embedded"},
-            },
-            {
-                "key": "bank_id",
-                "description": "Memory bank name (static fallback when bank_id_template is unset)",
-                "default": "hermes",
-            },
-            {
-                "key": "bank_id_template",
-                "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}",
-                "default": "",
-            },
-            {
-                "key": "bank_mission",
-                "description": "Mission/purpose description for the memory bank",
-            },
-            {
-                "key": "bank_retain_mission",
-                "description": "Custom extraction prompt for memory retention",
-            },
-            {
-                "key": "recall_budget",
-                "description": "Recall thoroughness",
-                "default": "mid",
-                "choices": ["low", "mid", "high"],
-            },
-            {
-                "key": "memory_mode",
-                "description": "Memory integration mode",
-                "default": "hybrid",
-                "choices": ["hybrid", "context", "tools"],
-            },
-            {
-                "key": "recall_prefetch_method",
-                "description": "Auto-recall method",
-                "default": "recall",
-                "choices": ["recall", "reflect"],
-            },
-            {
-                "key": "retain_tags",
-                "description": "Default tags applied to retained memories (comma-separated)",
-                "default": "",
-            },
-            {
-                "key": "retain_source",
-                "description": "Metadata source value attached to retained memories",
-                "default": "",
-            },
-            {
-                "key": "retain_user_prefix",
-                "description": "Label used before user turns in retained transcripts",
-                "default": "User",
-            },
-            {
-                "key": "retain_assistant_prefix",
-                "description": "Label used before assistant turns in retained transcripts",
-                "default": "Assistant",
-            },
-            {
-                "key": "recall_tags",
-                "description": "Tags to filter when searching memories (comma-separated)",
-                "default": "",
-            },
-            {
-                "key": "recall_tags_match",
-                "description": "Tag matching mode for recall",
-                "default": "any",
-                "choices": ["any", "all", "any_strict", "all_strict"],
-            },
-            {
-                "key": "auto_recall",
-                "description": "Automatically recall memories before each turn",
-                "default": True,
-            },
-            {
-                "key": "auto_retain",
-                "description": "Automatically retain conversation turns",
-                "default": True,
-            },
-            {
-                "key": "retain_every_n_turns",
-                "description": "Retain every N turns (1 = every turn)",
-                "default": 1,
-            },
-            {
-                "key": "retain_async",
-                "description": "Process retain asynchronously on the Hindsight server",
-                "default": True,
-            },
-            {
-                "key": "retain_context",
-                "description": "Context label for retained memories",
-                "default": "conversation between Hermes Agent and the User",
-            },
-            {
-                "key": "recall_max_tokens",
-                "description": "Maximum tokens for recall results",
-                "default": 4096,
-            },
-            {
-                "key": "recall_max_input_chars",
-                "description": "Maximum input query length for auto-recall",
-                "default": 800,
-            },
-            {
-                "key": "recall_prompt_preamble",
-                "description": "Custom preamble for recalled memories in context",
-            },
-            {
-                "key": "timeout",
-                "description": "API request timeout in seconds",
-                "default": _DEFAULT_TIMEOUT,
-            },
-            {
-                "key": "idle_timeout",
-                "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)",
-                "default": _DEFAULT_IDLE_TIMEOUT,
-                "when": {"mode": "local_embedded"},
-            },
+            {"key": "llm_provider", "description": "LLM provider", "default": "openai", "choices": ["openai", "anthropic", "gemini", "groq", "openrouter", "minimax", "ollama", "lmstudio", "openai_compatible"], "when": {"mode": "local_embedded"}},
+            {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
+            {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
+            {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
+            {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
+            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
+            {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
+            {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
+            {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
+            {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
+            {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
+            {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
+            {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
+            {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
+            {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
+            {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
+            {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
+            {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
+            {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
+            {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
+            {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
+            {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
+            {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
+            {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
+            {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
+            {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
         ]
 
     def _get_client(self):
@@ -1285,22 +1052,16 @@ class HindsightMemoryProvider(MemoryProvider):
                         + (f": {reason}" if reason else "")
                     )
                 from hindsight import HindsightEmbedded
-
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in ("openai_compatible", "openrouter"):
                     llm_provider = "openai"
-                logger.debug(
-                    "Creating HindsightEmbedded client (profile=%s, provider=%s)",
-                    self._config.get("profile", "hermes"),
-                    llm_provider,
-                )
+                logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
+                             self._config.get("profile", "hermes"), llm_provider)
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey")
-                    or self._config.get("llm_api_key")
-                    or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:
@@ -1316,17 +1077,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 from hindsight_client import Hindsight
-
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
                     kwargs["api_key"] = self._api_key
-                logger.debug(
-                    "Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
-                    self._api_url,
-                    bool(self._api_key),
-                    kwargs["timeout"],
-                )
+                logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
+                             self._api_url, bool(self._api_key), kwargs["timeout"])
                 self._client = Hindsight(**kwargs)
         return self._client
 
@@ -1449,50 +1205,27 @@ class HindsightMemoryProvider(MemoryProvider):
         try:
             from importlib.metadata import version as pkg_version
             from packaging.version import Version
-
             installed = pkg_version("hindsight-client")
             if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning(
-                    "hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                    installed,
-                    _MIN_CLIENT_VERSION,
-                )
+                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
+                               installed, _MIN_CLIENT_VERSION)
                 import shutil
                 import subprocess
                 import sys
-
                 uv_path = shutil.which("uv")
                 if uv_path:
                     try:
                         subprocess.run(
-                            [
-                                uv_path,
-                                "pip",
-                                "install",
-                                "--python",
-                                sys.executable,
-                                "--quiet",
-                                "--upgrade",
-                                f"hindsight-client>={_MIN_CLIENT_VERSION}",
-                            ],
-                            check=True,
-                            timeout=120,
-                            capture_output=True,
+                            [uv_path, "pip", "install", "--python", sys.executable,
+                             "--quiet", "--upgrade", f"hindsight-client>={_MIN_CLIENT_VERSION}"],
+                            check=True, timeout=120, capture_output=True,
                         )
-                        logger.info(
-                            "hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION
-                        )
+                        logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
                     except Exception as e:
-                        logger.warning(
-                            "Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                            e,
-                            _MIN_CLIENT_VERSION,
-                        )
+                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
+                                       e, _MIN_CLIENT_VERSION)
                 else:
-                    logger.warning(
-                        "uv not found. Run: pip install 'hindsight-client>=%s'",
-                        _MIN_CLIENT_VERSION,
-                    )
+                    logger.warning("uv not found. Run: pip install 'hindsight-client>=%s'", _MIN_CLIENT_VERSION)
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
@@ -1511,15 +1244,11 @@ class HindsightMemoryProvider(MemoryProvider):
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
-            self._config.get("timeout")
-            if self._config.get("timeout") is not None
-            else os.environ.get("HINDSIGHT_TIMEOUT"),
+            self._config.get("timeout") if self._config.get("timeout") is not None else os.environ.get("HINDSIGHT_TIMEOUT"),
             _DEFAULT_TIMEOUT,
         )
         self._idle_timeout = _parse_int_setting(
-            self._config.get("idle_timeout")
-            if self._config.get("idle_timeout") is not None
-            else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
+            self._config.get("idle_timeout") if self._config.get("idle_timeout") is not None else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
             _DEFAULT_IDLE_TIMEOUT,
         )
         # "local" is a legacy alias for "local_embedded"
@@ -1534,19 +1263,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = (
-            self._config.get("apiKey")
-            or self._config.get("api_key")
-            or os.environ.get("HINDSIGHT_API_KEY", "")
-        )
-        default_url = (
-            _DEFAULT_LOCAL_URL
-            if self._mode in ("local_embedded", "local_external")
-            else _DEFAULT_API_URL
-        )
-        self._api_url = self._config.get("api_url") or os.environ.get(
-            "HINDSIGHT_API_URL", default_url
-        )
+        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
+        default_url = _DEFAULT_LOCAL_URL if self._mode in ("local_embedded", "local_external") else _DEFAULT_API_URL
+        self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
         self._llm_base_url = self._config.get("llm_base_url", "")
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
@@ -1561,24 +1280,14 @@ class HindsightMemoryProvider(MemoryProvider):
             user=self._user_id,
             session=self._session_id,
         )
-        budget = (
-            self._config.get("recall_budget")
-            or self._config.get("budget")
-            or banks.get("budget", "mid")
-        )
+        budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
         memory_mode = self._config.get("memory_mode", "hybrid")
-        self._memory_mode = (
-            memory_mode if memory_mode in ("context", "tools", "hybrid") else "hybrid"
-        )
+        self._memory_mode = memory_mode if memory_mode in ("context", "tools", "hybrid") else "hybrid"
 
-        prefetch_method = self._config.get(
-            "recall_prefetch_method"
-        ) or self._config.get("prefetch_method", "recall")
-        self._prefetch_method = (
-            prefetch_method if prefetch_method in ("recall", "reflect") else "recall"
-        )
+        prefetch_method = self._config.get("recall_prefetch_method") or self._config.get("prefetch_method", "recall")
+        self._prefetch_method = prefetch_method if prefetch_method in ("recall", "reflect") else "recall"
 
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
@@ -1590,101 +1299,55 @@ class HindsightMemoryProvider(MemoryProvider):
             or os.environ.get("HINDSIGHT_RETAIN_TAGS", "")
         )
         self._tags = self._retain_tags or None
-        self._recall_tags = (
-            _normalize_retain_tags(self._config.get("recall_tags")) or None
-        )
-        self._recall_tags_match = _normalize_tag_match(
-            self._config.get("recall_tags_match"), "any"
-        )
+        self._recall_tags = _normalize_retain_tags(self._config.get("recall_tags")) or None
+        self._recall_tags_match = _normalize_tag_match(self._config.get("recall_tags_match"), "any")
         self._retain_source = str(
-            self._config.get("retain_source")
-            or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
+            self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
         ).strip()
-        self._retain_user_prefix = (
-            str(
-                self._config.get("retain_user_prefix")
-                or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")
-            ).strip()
-            or "User"
-        )
-        self._retain_assistant_prefix = (
-            str(
-                self._config.get("retain_assistant_prefix")
-                or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
-            ).strip()
-            or "Assistant"
-        )
+        self._retain_user_prefix = str(
+            self._config.get("retain_user_prefix") or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")
+        ).strip() or "User"
+        self._retain_assistant_prefix = str(
+            self._config.get("retain_assistant_prefix") or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
+        ).strip() or "Assistant"
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
-        self._retain_every_n_turns = max(
-            1, int(self._config.get("retain_every_n_turns", 1))
-        )
-        self._retain_context = self._config.get(
-            "retain_context", "conversation between Hermes Agent and the User"
-        )
+        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
+        self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
-        self._recall_max_tokens = _bounded_int(
-            self._config.get("recall_max_tokens", 4096), 4096
-        )
+        self._recall_max_tokens = _bounded_int(self._config.get("recall_max_tokens", 4096), 4096)
         self._recall_types = _normalize_recall_types(self._config.get("recall_types"))
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
-        self._recall_max_input_chars = int(
-            self._config.get("recall_max_input_chars", 800)
-        )
+        self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
         try:
             from importlib.metadata import version as pkg_version
-
             _client_version = pkg_version("hindsight-client")
         except Exception:
             pass
-        logger.info(
-            "Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
-            self._mode,
-            self._api_url,
-            self._bank_id,
-            self._budget,
-            self._memory_mode,
-            self._prefetch_method,
-            _client_version,
-        )
+        logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
+                     self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method, _client_version)
         if self._bank_id_template:
-            logger.debug(
-                "Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
-                self._bank_id_template,
-                self._agent_identity,
-                self._agent_workspace,
-                self._platform,
-                self._user_id,
-                self._bank_id,
-            )
-        logger.debug(
-            "Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-            "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
-            self._auto_retain,
-            self._auto_recall,
-            self._retain_every_n_turns,
-            self._retain_async,
-            self._retain_context,
-            self._recall_max_tokens,
-            self._recall_max_input_chars,
-            self._tags,
-            self._recall_tags,
-        )
+            logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
+                         self._bank_id_template, self._agent_identity, self._agent_workspace,
+                         self._platform, self._user_id, self._bank_id)
+        logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
+                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+                     self._auto_retain, self._auto_recall, self._retain_every_n_turns,
+                     self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
+                     self._tags, self._recall_tags)
 
         # For local mode, start the embedded daemon in the background so it
         # doesn't block the chat. Redirect stdout/stderr to a log file to
         # prevent rich startup output from spamming the terminal.
         if self._mode == "local_embedded":
-
             def _start_daemon():
                 import traceback
-
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
@@ -1694,10 +1357,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     # would capture output from other threads.
                     import hindsight_embed.daemon_embed_manager as dem
                     from rich.console import Console
-
-                    dem.console = Console(
-                        file=open(log_path, "a"), force_terminal=False
-                    )
+                    dem.console = Console(file=open(log_path, "a"), force_terminal=False)
 
                     client = self._get_client()
                     profile = self._config.get("profile", "hermes")
@@ -1725,9 +1385,7 @@ class HindsightMemoryProvider(MemoryProvider):
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
                         traceback.print_exc(file=f)
 
-            t = threading.Thread(
-                target=_start_daemon, daemon=True, name="hindsight-daemon-start"
-            )
+            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()
 
     def system_prompt_block(self) -> str:
@@ -1782,64 +1440,40 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         # Truncate query to max chars
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[: self._recall_max_input_chars]
+            query = query[:self._recall_max_input_chars]
 
         def _run():
             try:
                 if self._prefetch_method == "reflect":
-                    logger.debug(
-                        "Prefetch: calling reflect (bank=%s, query_len=%d)",
-                        self._bank_id,
-                        len(query),
-                    )
-                    resp = self._run_hindsight_operation(
-                        lambda client: client.areflect(
-                            bank_id=self._bank_id, query=query, budget=self._budget
-                        )
-                    )
+                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
+                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
                     text = resp.text or ""
                 else:
                     recall_kwargs: dict = {
-                        "bank_id": self._bank_id,
-                        "query": query,
-                        "budget": self._budget,
-                        "max_tokens": self._recall_max_tokens,
+                        "bank_id": self._bank_id, "query": query,
+                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
                     }
                     if self._recall_tags:
                         recall_kwargs["tags"] = self._recall_tags
                         recall_kwargs["tags_match"] = self._recall_tags_match
                     if self._recall_types:
                         recall_kwargs["types"] = self._recall_types
-                    logger.debug(
-                        "Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                        self._bank_id,
-                        len(query),
-                        self._budget,
-                    )
-                    resp = self._run_hindsight_operation(
-                        lambda client: client.arecall(**recall_kwargs)
-                    )
+                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                                 self._bank_id, len(query), self._budget)
+                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = (
-                        "\n".join(f"- {r.text}" for r in resp.results if r.text)
-                        if resp.results
-                        else ""
-                    )
+                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
             except Exception as e:
                 logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
 
-        self._prefetch_thread = threading.Thread(
-            target=_run, daemon=True, name="hindsight-prefetch"
-        )
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
-    def _build_turn_messages(
-        self, user_content: str, assistant_content: str
-    ) -> List[Dict[str, str]]:
+    def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
         return [
             {
@@ -1895,8 +1529,7 @@ class HindsightMemoryProvider(MemoryProvider):
         kwargs: Dict[str, Any] = {
             "bank_id": self._bank_id,
             "content": content,
-            "metadata": metadata
-            or self._build_metadata(message_count=1, turn_index=self._turn_index),
+            "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
         }
         if context is not None:
             kwargs["context"] = context
@@ -1912,9 +1545,7 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["tags"] = merged_tags
         return kwargs
 
-    def sync_turn(
-        self, user_content: str, assistant_content: str, *, session_id: str = ""
-    ) -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
         The actual aretain_batch runs on a single long-lived writer thread
@@ -1932,31 +1563,18 @@ class HindsightMemoryProvider(MemoryProvider):
         if session_id:
             self._session_id = str(session_id).strip()
 
-        turn = json.dumps(
-            self._build_turn_messages(user_content, assistant_content),
-            ensure_ascii=False,
-        )
+        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
         self._session_turns.append(turn)
         self._turn_counter += 1
         self._turn_index = self._turn_counter
 
         if self._turn_counter % self._retain_every_n_turns != 0:
-            logger.debug(
-                "sync_turn: buffered turn %d (will retain at turn %d)",
-                self._turn_counter,
-                self._turn_counter
-                + (
-                    self._retain_every_n_turns
-                    - self._turn_counter % self._retain_every_n_turns
-                ),
-            )
+            logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
+                         self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
             return
 
-        logger.debug(
-            "sync_turn: retaining %d turns, total session content %d chars",
-            len(self._session_turns),
-            sum(len(t) for t in self._session_turns),
-        )
+        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
+                     len(self._session_turns), sum(len(t) for t in self._session_turns))
         content = "[" + ",".join(self._session_turns) + "]"
 
         lineage_tags: list[str] = []
@@ -1986,14 +1604,8 @@ class HindsightMemoryProvider(MemoryProvider):
             )
             item.pop("bank_id", None)
             item.pop("retain_async", None)
-            logger.debug(
-                "Hindsight retain: bank=%s, doc=%s, async=%s, content_len=%d, num_turns=%d",
-                bank_id,
-                document_id,
-                retain_async_flag,
-                len(content),
-                num_turns,
-            )
+            logger.debug("Hindsight retain: bank=%s, doc=%s, async=%s, content_len=%d, num_turns=%d",
+                         bank_id, document_id, retain_async_flag, len(content), num_turns)
             self._run_hindsight_operation(
                 lambda client: client.aretain_batch(
                     bank_id=bank_id,
@@ -2021,9 +1633,7 @@ class HindsightMemoryProvider(MemoryProvider):
         default_types: list[str] | None = None,
     ) -> tuple[dict[str, Any], dict[str, str] | None, list[str] | None, str]:
         """Build validated kwargs for Hindsight recall-like tool calls."""
-        budget = (
-            args.get("budget") if args.get("budget") in _VALID_BUDGETS else self._budget
-        )
+        budget = args.get("budget") if args.get("budget") in _VALID_BUDGETS else self._budget
         max_tokens = _bounded_int(args.get("max_tokens"), self._recall_max_tokens)
         types = _normalize_recall_types(args.get("types")) if "types" in args else None
         if not types:
@@ -2033,9 +1643,7 @@ class HindsightMemoryProvider(MemoryProvider):
         tags = _normalize_retain_tags(raw_tags) if raw_tags is not None else None
         if not tags:
             tags = self._recall_tags
-        tags_match = _normalize_tag_match(
-            args.get("tags_match"), self._recall_tags_match
-        )
+        tags_match = _normalize_tag_match(args.get("tags_match"), self._recall_tags_match)
 
         recall_kwargs: dict[str, Any] = {
             "bank_id": self._bank_id,
@@ -2055,18 +1663,14 @@ class HindsightMemoryProvider(MemoryProvider):
         return recall_kwargs, metadata_filter, tags, tags_match
 
     def _handle_recall_search(self, args: dict[str, Any], query: str) -> str:
-        recall_kwargs, metadata_filter, _, _ = self._build_tool_recall_kwargs(
-            args, query
-        )
+        recall_kwargs, metadata_filter, _, _ = self._build_tool_recall_kwargs(args, query)
         logger.debug(
             "Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
             self._bank_id,
             len(query),
             recall_kwargs["budget"],
         )
-        resp = self._run_hindsight_operation(
-            lambda client: client.arecall(**recall_kwargs)
-        )
+        resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
         results = list(getattr(resp, "results", None) or [])
         results = _filter_memory_items(results, metadata=metadata_filter)
         logger.debug("Tool hindsight_recall: %d results", len(results))
@@ -2076,14 +1680,8 @@ class HindsightMemoryProvider(MemoryProvider):
         return json.dumps({"result": "\n".join(lines)})
 
     def _handle_recall_list(self, args: dict[str, Any], query: str) -> str:
-        _, metadata_filter, tags, tags_match = self._build_tool_recall_kwargs(
-            args, query
-        )
-        types = (
-            _normalize_recall_types(args.get("types"))
-            if "types" in args
-            else self._recall_types
-        )
+        recall_kwargs, metadata_filter, tags, tags_match = self._build_tool_recall_kwargs(args, query)
+        types = recall_kwargs.get("types")
         limit = _bounded_int(args.get("limit"), 50, minimum=1, maximum=200)
         offset = _bounded_int(args.get("offset"), 0, minimum=0)
         server_type = types[0] if types and len(types) == 1 else None
@@ -2108,13 +1706,7 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         lines = _format_memory_lines(items)
         if not lines:
-            return json.dumps(
-                {
-                    "result": "No matching memories found.",
-                    "total": getattr(resp, "total", 0),
-                    "returned": 0,
-                }
-            )
+            return json.dumps({"result": "No matching memories found.", "total": getattr(resp, "total", 0), "returned": 0})
         return json.dumps(
             {
                 "result": "\n".join(lines),
@@ -2132,17 +1724,13 @@ class HindsightMemoryProvider(MemoryProvider):
             default_types=["world"],
         )
         recall_kwargs["include_entities"] = True
-        recall_kwargs["max_entity_tokens"] = _bounded_int(
-            args.get("max_entity_tokens"), 2000
-        )
-        resp = self._run_hindsight_operation(
-            lambda client: client.arecall(**recall_kwargs)
-        )
+        recall_kwargs["max_entity_tokens"] = _bounded_int(args.get("max_entity_tokens"), 2000)
+        resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
         results = list(getattr(resp, "results", None) or [])
         results = _filter_memory_items(results, metadata=metadata_filter)
         entities = getattr(resp, "entities", None)
-        if metadata_filter and not results:
-            entities = None
+        if metadata_filter:
+            entities = _filter_entities_by_ids(entities, _result_entity_ids(results))
 
         sections: list[str] = []
         memory_lines = _format_memory_lines(results)
@@ -2167,15 +1755,9 @@ class HindsightMemoryProvider(MemoryProvider):
                     context=context,
                     tags=args.get("tags"),
                 )
-                logger.debug(
-                    "Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                    self._bank_id,
-                    len(content),
-                    context,
-                )
-                self._run_hindsight_operation(
-                    lambda client: client.aretain(**retain_kwargs)
-                )
+                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
+                             self._bank_id, len(content), context)
+                self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
@@ -2206,23 +1788,15 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                logger.debug(
-                    "Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
-                    self._bank_id,
-                    len(query),
-                    self._budget,
-                )
+                logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
+                             self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(
                     lambda client: client.areflect(
                         bank_id=self._bank_id, query=query, budget=self._budget
                     )
                 )
-                logger.debug(
-                    "Tool hindsight_reflect: response_len=%d", len(resp.text or "")
-                )
-                return json.dumps(
-                    {"result": resp.text or "No relevant memories found."}
-                )
+                logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
+                return json.dumps({"result": resp.text or "No relevant memories found."})
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
@@ -2304,9 +1878,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     item.pop("retain_async", None)
                     logger.debug(
                         "Hindsight flush-on-switch: bank=%s, doc=%s, num_turns=%d",
-                        self._bank_id,
-                        old_document_id,
-                        len(old_turns),
+                        self._bank_id, old_document_id, len(old_turns),
                     )
                     self._run_hindsight_operation(
                         lambda client: client.aretain_batch(
@@ -2317,9 +1889,7 @@ class HindsightMemoryProvider(MemoryProvider):
                         )
                     )
                 except Exception as e:
-                    logger.warning(
-                        "Hindsight flush-on-switch failed: %s", e, exc_info=True
-                    )
+                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
 
             # Route the flush through the same writer queue sync_turn
             # uses. That serializes it behind any still-queued retains
@@ -2350,16 +1920,11 @@ class HindsightMemoryProvider(MemoryProvider):
         self._turn_index = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
-            self._session_id,
-            self._parent_session_id,
-            reset,
-            self._document_id,
+            self._session_id, self._parent_session_id, reset, self._document_id,
         )
 
     def shutdown(self) -> None:
-        logger.debug(
-            "Hindsight shutdown: stopping writer + waiting for background threads"
-        )
+        logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
         # Stop accepting new retain jobs first so anyone still calling
         # sync_turn() during teardown is dropped, not enqueued.
         self._shutting_down.set()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -614,6 +614,28 @@ class TestToolHandlers:
         assert "Keyword Memory 2" not in result["result"]
         assert result["returned"] == 1
 
+    def test_recall_list_method_excludes_untagged_items_when_filtering_tags(self, provider_with_config):
+        p = provider_with_config(recall_tags=["tag1"])
+        p._client.memory.list_memories.return_value = SimpleNamespace(
+            items=[
+                {"text": "Tagged memory", "fact_type": "world", "tags": ["tag1"]},
+                {"text": "Wrong-tag memory", "fact_type": "world", "tags": ["tag2"]},
+                {"text": "Untagged memory", "fact_type": "world"},
+            ],
+            total=3,
+            limit=50,
+            offset=0,
+        )
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "keyword", "method": "list"}
+        ))
+
+        assert "Tagged memory" in result["result"]
+        assert "Wrong-tag memory" not in result["result"]
+        assert "Untagged memory" not in result["result"]
+        assert result["returned"] == 1
+
     def test_recall_list_method_applies_metadata_filter(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_recall",
@@ -623,6 +645,35 @@ class TestToolHandlers:
         assert "Keyword Memory 1" not in result["result"]
         assert "Keyword Memory 2" in result["result"]
         assert result["returned"] == 1
+
+    def test_recall_list_method_metadata_filter_requires_present_key(self, provider):
+        provider._client.memory.list_memories.return_value = SimpleNamespace(
+            items=[
+                {"text": "Missing tenant", "metadata": {}},
+                {"text": "Matching tenant", "metadata": {"tenant": "alpha"}},
+            ],
+            total=2,
+            limit=50,
+            offset=0,
+        )
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "keyword", "method": "list", "metadata": {"tenant": "alpha"}},
+        ))
+
+        assert "Matching tenant" in result["result"]
+        assert "Missing tenant" not in result["result"]
+        assert result["returned"] == 1
+
+    def test_recall_list_method_ignores_invalid_metadata_filter(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "keyword", "method": "list", "metadata": "not-json"},
+        ))
+
+        assert "Keyword Memory 1" in result["result"]
+        assert "Keyword Memory 2" in result["result"]
 
     def test_recall_list_method_passes_pagination_controls(self, provider):
         provider.handle_tool_call(
@@ -754,16 +805,12 @@ class TestToolHandlers:
         assert "Beta Entity" not in result["result"]
         assert "Beta observation" not in result["result"]
 
-    def test_recall_entity_method_handles_current_client_models(self, provider):
-        from hindsight_client_api.models.entity_observation_response import (
-            EntityObservationResponse,
-        )
-        from hindsight_client_api.models.entity_state_response import EntityStateResponse
-        from hindsight_client_api.models.recall_result import RecallResult
-
+    def test_recall_entity_method_handles_current_client_model_shape(self, provider):
+        # Mirrors the fields exposed by current hindsight_client_api models without
+        # importing the optional Hindsight client package in the repo test suite.
         provider._client.arecall.return_value = SimpleNamespace(
             results=[
-                RecallResult(
+                SimpleNamespace(
                     id="r1",
                     text="Model-backed memory",
                     type="world",
@@ -772,12 +819,10 @@ class TestToolHandlers:
                 )
             ],
             entities={
-                "ent-model": EntityStateResponse(
+                "ent-model": SimpleNamespace(
                     entity_id="ent-model",
                     canonical_name="Model Entity",
-                    observations=[
-                        EntityObservationResponse(text="Model observation", mentioned_at=None)
-                    ],
+                    observations=[SimpleNamespace(text="Model observation", mentioned_at=None)],
                 )
             },
         )

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -35,25 +35,17 @@ from plugins.memory.hindsight import (
 def _clean_env(monkeypatch):
     """Ensure no stale env vars leak between tests."""
     for key in (
-        "HINDSIGHT_API_KEY",
-        "HINDSIGHT_API_URL",
-        "HINDSIGHT_BANK_ID",
-        "HINDSIGHT_BUDGET",
-        "HINDSIGHT_MODE",
-        "HINDSIGHT_TIMEOUT",
-        "HINDSIGHT_IDLE_TIMEOUT",
-        "HINDSIGHT_LLM_API_KEY",
-        "HINDSIGHT_RETAIN_TAGS",
-        "HINDSIGHT_RETAIN_SOURCE",
-        "HINDSIGHT_RETAIN_USER_PREFIX",
-        "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
+        "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
+        "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
+        "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
         monkeypatch.delenv(key, raising=False)
 
 
 def _make_mock_client():
     """Create a mock Hindsight client with async methods."""
-
     async def _aretain(
         bank_id,
         content,
@@ -78,7 +70,9 @@ def _make_mock_client():
             ]
         )
     )
-    client.areflect = AsyncMock(return_value=SimpleNamespace(text="Synthesized answer"))
+    client.areflect = AsyncMock(
+        return_value=SimpleNamespace(text="Synthesized answer")
+    )
     client.memory = MagicMock()
     client.memory.list_memories = AsyncMock(
         return_value=SimpleNamespace(
@@ -86,14 +80,14 @@ def _make_mock_client():
                 {
                     "id": "m1",
                     "text": "Keyword Memory 1",
-                    "type": "world",
+                    "fact_type": "world",
                     "tags": ["tag1"],
                     "metadata": {"tenant": "alpha"},
                 },
                 {
                     "id": "m2",
                     "content": "Keyword Memory 2",
-                    "type": "experience",
+                    "fact_type": "experience",
                     "tags": ["tag2"],
                     "metadata": {"tenant": "beta"},
                 },
@@ -131,7 +125,9 @@ def provider(tmp_path, monkeypatch):
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config))
 
-    monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+    )
 
     p = HindsightMemoryProvider()
     p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
@@ -142,7 +138,6 @@ def provider(tmp_path, monkeypatch):
 @pytest.fixture()
 def provider_with_config(tmp_path, monkeypatch):
     """Create a provider factory that accepts custom config overrides."""
-
     def _make(**overrides):
         config = {
             "mode": "cloud",
@@ -162,19 +157,14 @@ def provider_with_config(tmp_path, monkeypatch):
         )
 
         p = HindsightMemoryProvider()
-        p.initialize(
-            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
-        )
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
         p._client = _make_mock_client()
         return p
-
     return _make
 
 
 def test_normalize_retain_tags_accepts_csv_and_dedupes():
-    assert _normalize_retain_tags(
-        "agent:fakeassistantname, source_system:hermes-agent, agent:fakeassistantname"
-    ) == [
+    assert _normalize_retain_tags("agent:fakeassistantname, source_system:hermes-agent, agent:fakeassistantname") == [
         "agent:fakeassistantname",
         "source_system:hermes-agent",
     ]
@@ -182,10 +172,7 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 
 def test_normalize_retain_tags_accepts_json_array_string():
     value = json.dumps(["agent:fakeassistantname", "source_system:hermes-agent"])
-    assert _normalize_retain_tags(value) == [
-        "agent:fakeassistantname",
-        "source_system:hermes-agent",
-    ]
+    assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
 
 
 # ---------------------------------------------------------------------------
@@ -246,9 +233,7 @@ class TestConfig:
         assert provider._recall_tags is None
         assert provider._bank_mission == ""
         assert provider._bank_retain_mission is None
-        assert (
-            provider._retain_context == "conversation between Hermes Agent and the User"
-        )
+        assert provider._retain_context == "conversation between Hermes Agent and the User"
 
     def test_custom_config_values(self, provider_with_config):
         p = provider_with_config(
@@ -304,25 +289,21 @@ class TestConfig:
         assert cfg["banks"]["hermes"]["budget"] == "high"
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
-        env = _build_embedded_profile_env(
-            {
-                "llm_provider": "openai",
-                "llm_model": "gpt-4o-mini",
-                "idle_timeout": 0,
-            }
-        )
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "idle_timeout": 0,
+        })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
 
     def test_embedded_profile_env_includes_idle_timeout_from_env(self, monkeypatch):
         monkeypatch.setenv("HINDSIGHT_IDLE_TIMEOUT", "42")
 
-        env = _build_embedded_profile_env(
-            {
-                "llm_provider": "openai",
-                "llm_model": "gpt-4o-mini",
-            }
-        )
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
@@ -333,14 +314,8 @@ class TestConfig:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
 
-        monkeypatch.setitem(
-            sys.modules,
-            "hindsight",
-            SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded),
-        )
-        monkeypatch.setattr(
-            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
-        )
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
@@ -367,19 +342,13 @@ class TestPostSetup:
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr(
-            "hermes_cli.memory_setup._curses_select",
-            lambda *args, **kwargs: next(selections),
-        )
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
         saved_configs = []
-        monkeypatch.setattr(
-            "hermes_cli.config.save_config",
-            lambda cfg: saved_configs.append(cfg.copy()),
-        )
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
 
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})
@@ -400,19 +369,14 @@ class TestPostSetup:
             "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n"
         )
 
-    def test_local_embedded_setup_respects_existing_profile_name(
-        self, tmp_path, monkeypatch
-    ):
+    def test_local_embedded_setup_respects_existing_profile_name(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr(
-            "hermes_cli.memory_setup._curses_select",
-            lambda *args, **kwargs: next(selections),
-        )
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -428,19 +392,14 @@ class TestPostSetup:
         assert coder_env.exists()
         assert not hermes_env.exists()
 
-    def test_local_embedded_setup_preserves_existing_key_when_input_left_blank(
-        self, tmp_path, monkeypatch
-    ):
+    def test_local_embedded_setup_preserves_existing_key_when_input_left_blank(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr(
-            "hermes_cli.memory_setup._curses_select",
-            lambda *args, **kwargs: next(selections),
-        )
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -458,17 +417,14 @@ class TestPostSetup:
         assert profile_env.exists()
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
 
-    def test_local_embedded_setup_blank_inputs_preserve_existing_config(
-        self, tmp_path, monkeypatch
-    ):
+
+    def test_local_embedded_setup_blank_inputs_preserve_existing_config(self, tmp_path, monkeypatch):
         """Pressing Enter through setup should keep existing Hindsight values."""
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
-        monkeypatch.setattr(
-            "plugins.memory.hindsight.get_hermes_home", lambda: hermes_home
-        )
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: hermes_home)
 
         existing_config = {
             "mode": "local_embedded",
@@ -488,10 +444,7 @@ class TestPostSetup:
 
         # Simulate pressing Enter at the mode and LLM-provider pickers, which
         # should select their current values, and pressing Enter at text prompts.
-        monkeypatch.setattr(
-            "hermes_cli.memory_setup._curses_select",
-            lambda *args, **kwargs: kwargs.get("default", 0),
-        )
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: kwargs.get("default", 0))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -513,6 +466,7 @@ class TestPostSetup:
         assert saved["timeout"] == 120
 
 
+
 # ---------------------------------------------------------------------------
 # Tool handler tests
 # ---------------------------------------------------------------------------
@@ -520,11 +474,9 @@ class TestPostSetup:
 
 class TestToolHandlers:
     def test_retain_success(self, provider):
-        result = json.loads(
-            provider.handle_tool_call(
-                "hindsight_retain", {"content": "user likes dark mode"}
-            )
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "user likes dark mode"}
+        ))
         assert result["result"] == "Memory stored successfully."
         provider._client.aretain.assert_called_once()
         call_kwargs = provider._client.aretain.call_args.kwargs
@@ -552,13 +504,15 @@ class TestToolHandlers:
         assert "tags" not in call_kwargs
 
     def test_retain_missing_content(self, provider):
-        result = json.loads(provider.handle_tool_call("hindsight_retain", {}))
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {}
+        ))
         assert "error" in result
 
     def test_recall_success(self, provider):
-        result = json.loads(
-            provider.handle_tool_call("hindsight_recall", {"query": "dark mode"})
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "dark mode"}
+        ))
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
 
@@ -617,22 +571,16 @@ class TestToolHandlers:
         assert call_kwargs["tags_match"] == "all"
 
     def test_recall_rejects_unknown_method(self, provider):
-        result = json.loads(
-            provider.handle_tool_call(
-                "hindsight_recall", {"query": "test", "method": "unknown"}
-            )
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test", "method": "unknown"}
+        ))
         assert "error" in result
         provider._client.arecall.assert_not_called()
 
-    def test_recall_list_method_uses_public_memory_api_and_formats_items(
-        self, provider
-    ):
-        result = json.loads(
-            provider.handle_tool_call(
-                "hindsight_recall", {"query": "keyword", "method": "list"}
-            )
-        )
+    def test_recall_list_method_uses_public_memory_api_and_formats_items(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "keyword", "method": "list"}
+        ))
 
         provider._client.memory.list_memories.assert_called_once_with(
             bank_id="test-bank",
@@ -648,19 +596,15 @@ class TestToolHandlers:
         assert result["total"] == 2
         provider._client.arecall.assert_not_called()
 
-    def test_recall_list_method_applies_configured_type_and_tag_filters(
-        self, provider_with_config
-    ):
+    def test_recall_list_method_applies_configured_type_and_tag_filters(self, provider_with_config):
         p = provider_with_config(
             recall_types=["world", "experience"],
             recall_tags=["tag1"],
             recall_tags_match="all_strict",
         )
-        result = json.loads(
-            p.handle_tool_call(
-                "hindsight_recall", {"query": "keyword", "method": "list"}
-            )
-        )
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "keyword", "method": "list"}
+        ))
 
         call_kwargs = p._client.memory.list_memories.call_args.kwargs
         assert call_kwargs["q"] == "keyword"
@@ -671,16 +615,36 @@ class TestToolHandlers:
         assert result["returned"] == 1
 
     def test_recall_list_method_applies_metadata_filter(self, provider):
-        result = json.loads(
-            provider.handle_tool_call(
-                "hindsight_recall",
-                {"query": "keyword", "method": "list", "metadata": {"tenant": "beta"}},
-            )
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "keyword", "method": "list", "metadata": {"tenant": "beta"}},
+        ))
 
         assert "Keyword Memory 1" not in result["result"]
         assert "Keyword Memory 2" in result["result"]
         assert result["returned"] == 1
+
+    def test_recall_list_method_passes_pagination_controls(self, provider):
+        provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "keyword", "method": "list", "limit": 25, "offset": 10},
+        )
+
+        call_kwargs = provider._client.memory.list_memories.call_args.kwargs
+        assert call_kwargs["limit"] == 25
+        assert call_kwargs["offset"] == 10
+
+    def test_recall_list_method_invalid_types_fall_back_to_config(self, provider_with_config):
+        p = provider_with_config(recall_types=["world"])
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall",
+            {"query": "keyword", "method": "list", "types": ["invalid"]},
+        ))
+
+        call_kwargs = p._client.memory.list_memories.call_args.kwargs
+        assert call_kwargs["type"] == "world"
+        assert "Keyword Memory 1" in result["result"]
+        assert "Keyword Memory 2" not in result["result"]
 
     def test_recall_method_applies_metadata_filter_to_returned_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(
@@ -689,18 +653,14 @@ class TestToolHandlers:
                 SimpleNamespace(text="Beta memory", metadata={"tenant": "beta"}),
             ]
         )
-        result = json.loads(
-            provider.handle_tool_call(
-                "hindsight_recall", {"query": "tenant", "metadata": {"tenant": "alpha"}}
-            )
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "tenant", "metadata": {"tenant": "alpha"}}
+        ))
 
         assert "Alpha memory" in result["result"]
         assert "Beta memory" not in result["result"]
 
-    def test_recall_entity_method_formats_entity_dict_response(
-        self, provider_with_config
-    ):
+    def test_recall_entity_method_formats_entity_dict_response(self, provider_with_config):
         p = provider_with_config(recall_tags=["configured"], recall_tags_match="all")
         p._client.arecall.return_value = SimpleNamespace(
             results=[SimpleNamespace(text="Related memory")],
@@ -709,21 +669,16 @@ class TestToolHandlers:
                     entity_id="ent-1",
                     canonical_name="Alice Example",
                     observations=[
-                        SimpleNamespace(
-                            text="Alice is Bob's mother.",
-                            mentioned_at="2026-04-30T10:00:00Z",
-                        ),
+                        SimpleNamespace(text="Alice is Bob's mother.", mentioned_at="2026-04-30T10:00:00Z"),
                         {"text": "Alice works at ExampleCo."},
                     ],
                 )
             },
         )
 
-        result = json.loads(
-            p.handle_tool_call(
-                "hindsight_recall", {"query": "who is Alice?", "method": "entity"}
-            )
-        )
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "who is Alice?", "method": "entity"}
+        ))
         call_kwargs = p._client.arecall.call_args.kwargs
         assert call_kwargs["include_entities"] is True
         assert call_kwargs["max_entity_tokens"] == 2000
@@ -735,9 +690,7 @@ class TestToolHandlers:
         assert "Alice is Bob's mother." in result["result"]
         assert "Alice works at ExampleCo." in result["result"]
 
-    def test_recall_entity_method_allows_per_call_type_and_budget_overrides(
-        self, provider_with_config
-    ):
+    def test_recall_entity_method_allows_per_call_type_and_budget_overrides(self, provider_with_config):
         p = provider_with_config(recall_types=["experience"], recall_max_tokens=2048)
         p.handle_tool_call(
             "hindsight_recall",
@@ -747,6 +700,7 @@ class TestToolHandlers:
                 "budget": "low",
                 "max_tokens": 512,
                 "types": ["observation"],
+                "max_entity_tokens": 512,
             },
         )
 
@@ -754,6 +708,92 @@ class TestToolHandlers:
         assert call_kwargs["budget"] == "low"
         assert call_kwargs["max_tokens"] == 512
         assert call_kwargs["types"] == ["observation"]
+        assert call_kwargs["max_entity_tokens"] == 512
+
+    def test_recall_entity_method_filters_entities_to_metadata_scoped_results(self, provider):
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Alpha memory",
+                    metadata={"tenant": "alpha"},
+                    entities=["ent-alpha"],
+                ),
+                SimpleNamespace(
+                    text="Beta memory",
+                    metadata={"tenant": "beta"},
+                    entities=["ent-beta"],
+                ),
+            ],
+            entities={
+                "ent-alpha": SimpleNamespace(
+                    entity_id="ent-alpha",
+                    canonical_name="Alpha Entity",
+                    observations=[SimpleNamespace(text="Alpha observation")],
+                ),
+                "ent-beta": SimpleNamespace(
+                    entity_id="ent-beta",
+                    canonical_name="Beta Entity",
+                    observations=[SimpleNamespace(text="Beta observation")],
+                ),
+            },
+        )
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {
+                "query": "tenant",
+                "method": "entity",
+                "metadata": {"tenant": "alpha"},
+            },
+        ))
+
+        assert "Alpha memory" in result["result"]
+        assert "Alpha Entity" in result["result"]
+        assert "Alpha observation" in result["result"]
+        assert "Beta memory" not in result["result"]
+        assert "Beta Entity" not in result["result"]
+        assert "Beta observation" not in result["result"]
+
+    def test_recall_entity_method_handles_current_client_models(self, provider):
+        from hindsight_client_api.models.entity_observation_response import (
+            EntityObservationResponse,
+        )
+        from hindsight_client_api.models.entity_state_response import EntityStateResponse
+        from hindsight_client_api.models.recall_result import RecallResult
+
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                RecallResult(
+                    id="r1",
+                    text="Model-backed memory",
+                    type="world",
+                    metadata={"tenant": "alpha"},
+                    entities=["ent-model"],
+                )
+            ],
+            entities={
+                "ent-model": EntityStateResponse(
+                    entity_id="ent-model",
+                    canonical_name="Model Entity",
+                    observations=[
+                        EntityObservationResponse(text="Model observation", mentioned_at=None)
+                    ],
+                )
+            },
+        )
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {
+                "query": "tenant",
+                "method": "entity",
+                "metadata": {"tenant": "alpha"},
+            },
+        ))
+
+        assert "Model-backed memory" in result["result"]
+        assert "Model Entity" in result["result"]
+        assert "Model observation" in result["result"]
 
     def test_recall_passes_tags(self, provider_with_config):
         p = provider_with_config(recall_tags=["tag1"], recall_tags_match="all")
@@ -770,51 +810,53 @@ class TestToolHandlers:
 
     def test_recall_no_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(results=[])
-        result = json.loads(
-            provider.handle_tool_call("hindsight_recall", {"query": "test"})
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
         assert result["result"] == "No relevant memories found."
 
     def test_recall_missing_query(self, provider):
-        result = json.loads(provider.handle_tool_call("hindsight_recall", {}))
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {}
+        ))
         assert "error" in result
 
     def test_reflect_success(self, provider):
-        result = json.loads(
-            provider.handle_tool_call("hindsight_reflect", {"query": "summarize"})
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
         assert result["result"] == "Synthesized answer"
 
     def test_reflect_missing_query(self, provider):
-        result = json.loads(provider.handle_tool_call("hindsight_reflect", {}))
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {}
+        ))
         assert "error" in result
 
     def test_unknown_tool(self, provider):
-        result = json.loads(provider.handle_tool_call("hindsight_unknown", {}))
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_unknown", {}
+        ))
         assert "error" in result
 
     def test_retain_error_handling(self, provider):
         provider._client.aretain.side_effect = RuntimeError("connection failed")
-        result = json.loads(
-            provider.handle_tool_call("hindsight_retain", {"content": "test"})
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "test"}
+        ))
         assert "error" in result
         assert "connection failed" in result["error"]
 
     def test_recall_error_handling(self, provider):
         provider._client.arecall.side_effect = RuntimeError("timeout")
-        result = json.loads(
-            provider.handle_tool_call("hindsight_recall", {"query": "test"})
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
         assert "error" in result
 
-    def test_local_embedded_recall_reconnects_after_idle_shutdown(
-        self, provider, monkeypatch
-    ):
+    def test_local_embedded_recall_reconnects_after_idle_shutdown(self, provider, monkeypatch):
         first_client = _make_mock_client()
-        first_client.arecall.side_effect = RuntimeError(
-            "Cannot connect to host 127.0.0.1:8888"
-        )
+        first_client.arecall.side_effect = RuntimeError("Cannot connect to host 127.0.0.1:8888")
         second_client = _make_mock_client()
         second_client.arecall.return_value = SimpleNamespace(
             results=[SimpleNamespace(text="Recovered memory")]
@@ -825,9 +867,9 @@ class TestToolHandlers:
         provider._client = first_client
         monkeypatch.setattr(provider, "_get_client", lambda: next(clients))
 
-        result = json.loads(
-            provider.handle_tool_call("hindsight_recall", {"query": "test"})
-        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
 
         assert result["result"] == "1. Recovered memory"
         assert provider._client is second_client
@@ -963,14 +1005,8 @@ class TestSyncTurn:
         assert item["metadata"]["agent_identity"] == "fakeassistantname"
         assert item["metadata"]["turn_index"] == "1"
         assert item["metadata"]["message_count"] == "2"
-        assert re.fullmatch(
-            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00",
-            content[0][0]["timestamp"],
-        )
-        assert re.fullmatch(
-            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z",
-            item["metadata"]["retained_at"],
-        )
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00", content[0][0]["timestamp"])
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", item["metadata"]["retained_at"])
 
     def test_sync_turn_skipped_when_auto_retain_off(self, provider_with_config):
         p = provider_with_config(auto_retain=False)
@@ -996,10 +1032,7 @@ class TestSyncTurn:
         assert call_kwargs["document_id"].startswith("test-session-")
         assert call_kwargs["retain_async"] is True
         assert len(call_kwargs["items"]) == 1
-        assert (
-            call_kwargs["items"][0]["context"]
-            == "conversation between Hermes Agent and the User"
-        )
+        assert call_kwargs["items"][0]["context"] == "conversation between Hermes Agent and the User"
 
     def test_sync_turn_custom_context(self, provider_with_config):
         p = provider_with_config(retain_context="my-agent")
@@ -1067,24 +1100,17 @@ class TestSyncTurn:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr(
-            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-        )
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
         p1 = HindsightMemoryProvider()
-        p1.initialize(
-            session_id="resumed-session", hermes_home=str(tmp_path), platform="cli"
-        )
+        p1.initialize(session_id="resumed-session", hermes_home=str(tmp_path), platform="cli")
 
         # Sleep just enough that the microsecond timestamp differs
         import time
-
         time.sleep(0.001)
 
         p2 = HindsightMemoryProvider()
-        p2.initialize(
-            session_id="resumed-session", hermes_home=str(tmp_path), platform="cli"
-        )
+        p2.initialize(session_id="resumed-session", hermes_home=str(tmp_path), platform="cli")
 
         # Same session, but each process gets its own document_id
         assert p1._document_id != p2._document_id
@@ -1104,9 +1130,7 @@ class TestSyncTurn:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr(
-            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-        )
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1389,32 +1413,15 @@ class TestConfigSchema:
         schema = provider.get_config_schema()
         keys = {f["key"] for f in schema}
         expected_keys = {
-            "mode",
-            "api_url",
-            "api_key",
-            "llm_provider",
-            "llm_api_key",
-            "llm_model",
-            "bank_id",
-            "bank_id_template",
-            "bank_mission",
-            "bank_retain_mission",
-            "recall_budget",
-            "memory_mode",
-            "recall_prefetch_method",
-            "retain_tags",
-            "retain_source",
-            "retain_user_prefix",
-            "retain_assistant_prefix",
-            "recall_tags",
-            "recall_tags_match",
-            "auto_recall",
-            "auto_retain",
-            "retain_every_n_turns",
-            "retain_async",
-            "retain_context",
-            "recall_max_tokens",
-            "recall_max_input_chars",
+            "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
+            "llm_model", "bank_id", "bank_id_template", "bank_mission", "bank_retain_mission",
+            "recall_budget", "memory_mode", "recall_prefetch_method",
+            "retain_tags", "retain_source",
+            "retain_user_prefix", "retain_assistant_prefix",
+            "recall_tags", "recall_tags_match",
+            "auto_recall", "auto_retain",
+            "retain_every_n_turns", "retain_async", "retain_context",
+            "recall_max_tokens", "recall_max_input_chars",
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"
@@ -1440,18 +1447,15 @@ class TestBankIdTemplate:
         assert _sanitize_bank_segment(None) == ""
 
     def test_resolve_empty_template_uses_fallback(self):
-        result = _resolve_bank_id_template("", fallback="hermes", profile="coder")
+        result = _resolve_bank_id_template(
+            "", fallback="hermes", profile="coder"
+        )
         assert result == "hermes"
 
     def test_resolve_with_profile(self):
         result = _resolve_bank_id_template(
-            "hermes-{profile}",
-            fallback="hermes",
-            profile="coder",
-            workspace="",
-            platform="",
-            user="",
-            session="",
+            "hermes-{profile}", fallback="hermes",
+            profile="coder", workspace="", platform="", user="", session="",
         )
         assert result == "hermes-coder"
 
@@ -1459,74 +1463,47 @@ class TestBankIdTemplate:
         result = _resolve_bank_id_template(
             "{workspace}-{profile}-{platform}",
             fallback="hermes",
-            profile="coder",
-            workspace="myorg",
-            platform="cli",
-            user="",
-            session="",
+            profile="coder", workspace="myorg", platform="cli",
+            user="", session="",
         )
         assert result == "myorg-coder-cli"
 
     def test_resolve_collapses_empty_placeholders(self):
         # When user is empty, "hermes-{user}" becomes "hermes-" -> trimmed to "hermes"
         result = _resolve_bank_id_template(
-            "hermes-{user}",
-            fallback="default",
-            profile="",
-            workspace="",
-            platform="",
-            user="",
-            session="",
+            "hermes-{user}", fallback="default",
+            profile="", workspace="", platform="", user="", session="",
         )
         assert result == "hermes"
 
     def test_resolve_collapses_double_dashes(self):
         # Two empty placeholders with a dash between them should collapse
         result = _resolve_bank_id_template(
-            "{workspace}-{profile}-{user}",
-            fallback="fallback",
-            profile="coder",
-            workspace="",
-            platform="",
-            user="",
-            session="",
+            "{workspace}-{profile}-{user}", fallback="fallback",
+            profile="coder", workspace="", platform="", user="", session="",
         )
         assert result == "coder"
 
     def test_resolve_empty_rendered_falls_back(self):
         result = _resolve_bank_id_template(
-            "{user}-{profile}",
-            fallback="fallback",
-            profile="",
-            workspace="",
-            platform="",
-            user="",
-            session="",
+            "{user}-{profile}", fallback="fallback",
+            profile="", workspace="", platform="", user="", session="",
         )
         assert result == "fallback"
 
     def test_resolve_sanitizes_placeholder_values(self):
         result = _resolve_bank_id_template(
-            "user-{user}",
-            fallback="hermes",
-            profile="",
-            workspace="",
-            platform="",
-            user="josh@example.com",
-            session="",
+            "user-{user}", fallback="hermes",
+            profile="", workspace="", platform="",
+            user="josh@example.com", session="",
         )
         assert result == "user-josh-example-com"
 
     def test_resolve_invalid_template_returns_fallback(self):
         # Unknown placeholder should fall back without raising
         result = _resolve_bank_id_template(
-            "hermes-{unknown}",
-            fallback="hermes",
-            profile="",
-            workspace="",
-            platform="",
-            user="",
-            session="",
+            "hermes-{unknown}", fallback="hermes",
+            profile="", workspace="", platform="", user="", session="",
         )
         assert result == "hermes"
 
@@ -1541,9 +1518,7 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr(
-            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-        )
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1566,9 +1541,7 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr(
-            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-        )
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1579,9 +1552,7 @@ class TestBankIdTemplate:
         )
         assert p._bank_id == "my-static-bank"
 
-    def test_provider_template_with_missing_profile_falls_back(
-        self, tmp_path, monkeypatch
-    ):
+    def test_provider_template_with_missing_profile_falls_back(self, tmp_path, monkeypatch):
         config = {
             "mode": "cloud",
             "apiKey": "k",
@@ -1592,9 +1563,7 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr(
-            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-        )
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
         p = HindsightMemoryProvider()
         # No agent_identity passed — template renders to "hermes-" which collapses to "hermes"
@@ -1641,14 +1610,10 @@ class TestAvailability:
     def test_available_with_snake_case_api_key_in_config(self, tmp_path, monkeypatch):
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(
-            json.dumps(
-                {
-                    "mode": "cloud",
-                    "api_key": "***",
-                }
-            )
-        )
+        config_path.write_text(json.dumps({
+            "mode": "cloud",
+            "api_key": "***",
+        }))
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path,
@@ -1658,9 +1623,7 @@ class TestAvailability:
 
         assert p.is_available()
 
-    def test_local_mode_unavailable_when_runtime_import_fails(
-        self, tmp_path, monkeypatch
-    ):
+    def test_local_mode_unavailable_when_runtime_import_fails(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path / "nonexistent",
@@ -1679,9 +1642,7 @@ class TestAvailability:
         p = HindsightMemoryProvider()
         assert not p.is_available()
 
-    def test_initialize_disables_local_mode_when_runtime_import_fails(
-        self, tmp_path, monkeypatch
-    ):
+    def test_initialize_disables_local_mode_when_runtime_import_fails(self, tmp_path, monkeypatch):
         config = {"mode": "local_embedded"}
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1699,9 +1660,7 @@ class TestAvailability:
         )
 
         p = HindsightMemoryProvider()
-        p.initialize(
-            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
-        )
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
         assert p._mode == "disabled"
 
 
@@ -1776,9 +1735,7 @@ class TestSharedEventLoopLifecycle:
 
 
 class TestShutdown:
-    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(
-        self, provider
-    ):
+    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
         inner_client = _make_mock_client()
         embedded = MagicMock()
         embedded._client = inner_client
@@ -1793,3 +1750,4 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
+

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -570,12 +570,14 @@ class TestToolHandlers:
         assert call_kwargs["tags"] == ["configured"]
         assert call_kwargs["tags_match"] == "all"
 
-    def test_recall_rejects_unknown_method(self, provider):
+    def test_recall_invalid_method_falls_back_to_default_recall(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_recall", {"query": "test", "method": "unknown"}
         ))
-        assert "error" in result
-        provider._client.arecall.assert_not_called()
+        assert "Memory 1" in result["result"]
+        assert "Memory 2" in result["result"]
+        provider._client.arecall.assert_called_once()
+        provider._client.memory.list_memories.assert_not_called()
 
     def test_recall_list_method_uses_public_memory_api_and_formats_items(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -697,6 +699,38 @@ class TestToolHandlers:
         assert "Keyword Memory 1" in result["result"]
         assert "Keyword Memory 2" not in result["result"]
 
+    def test_recall_list_method_filters_type_field_variants(self, provider_with_config):
+        p = provider_with_config(recall_types=["observation"])
+        p._client.memory.list_memories.return_value = SimpleNamespace(
+            items=[
+                {"text": "World-only memory", "type": "world"},
+                {"text": "Experience-only memory", "fact_type": "experience"},
+                {"text": "Observation-only memory", "factType": "observation"},
+            ],
+            total=3,
+            limit=50,
+            offset=0,
+        )
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "keyword", "method": "list"}
+        ))
+
+        assert "Observation-only memory" in result["result"]
+        assert "World-only memory" not in result["result"]
+        assert "Experience-only memory" not in result["result"]
+        assert result["returned"] == 1
+
+    def test_recall_list_method_bounds_invalid_pagination_controls(self, provider):
+        provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "keyword", "method": "list", "limit": 500, "offset": -10},
+        )
+
+        call_kwargs = provider._client.memory.list_memories.call_args.kwargs
+        assert call_kwargs["limit"] == 200
+        assert call_kwargs["offset"] == 0
+
     def test_recall_method_applies_metadata_filter_to_returned_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(
             results=[
@@ -760,6 +794,15 @@ class TestToolHandlers:
         assert call_kwargs["max_tokens"] == 512
         assert call_kwargs["types"] == ["observation"]
         assert call_kwargs["max_entity_tokens"] == 512
+
+    def test_recall_entity_method_invalid_entity_budget_falls_back_to_default(self, provider):
+        provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "relationship", "method": "entity", "max_entity_tokens": -1},
+        )
+
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["max_entity_tokens"] == 2000
 
     def test_recall_entity_method_filters_entities_to_metadata_scoped_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(
@@ -1795,4 +1838,3 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
-

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -35,17 +35,25 @@ from plugins.memory.hindsight import (
 def _clean_env(monkeypatch):
     """Ensure no stale env vars leak between tests."""
     for key in (
-        "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
-        "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
-        "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
-        "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
-        "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_API_KEY",
+        "HINDSIGHT_API_URL",
+        "HINDSIGHT_BANK_ID",
+        "HINDSIGHT_BUDGET",
+        "HINDSIGHT_MODE",
+        "HINDSIGHT_TIMEOUT",
+        "HINDSIGHT_IDLE_TIMEOUT",
+        "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_RETAIN_TAGS",
+        "HINDSIGHT_RETAIN_SOURCE",
+        "HINDSIGHT_RETAIN_USER_PREFIX",
+        "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
         monkeypatch.delenv(key, raising=False)
 
 
 def _make_mock_client():
     """Create a mock Hindsight client with async methods."""
+
     async def _aretain(
         bank_id,
         content,
@@ -70,8 +78,30 @@ def _make_mock_client():
             ]
         )
     )
-    client.areflect = AsyncMock(
-        return_value=SimpleNamespace(text="Synthesized answer")
+    client.areflect = AsyncMock(return_value=SimpleNamespace(text="Synthesized answer"))
+    client.memory = MagicMock()
+    client.memory.list_memories = AsyncMock(
+        return_value=SimpleNamespace(
+            items=[
+                {
+                    "id": "m1",
+                    "text": "Keyword Memory 1",
+                    "type": "world",
+                    "tags": ["tag1"],
+                    "metadata": {"tenant": "alpha"},
+                },
+                {
+                    "id": "m2",
+                    "content": "Keyword Memory 2",
+                    "type": "experience",
+                    "tags": ["tag2"],
+                    "metadata": {"tenant": "beta"},
+                },
+            ],
+            total=2,
+            limit=50,
+            offset=0,
+        )
     )
     client.aretain_batch = AsyncMock()
     client.aclose = AsyncMock()
@@ -101,9 +131,7 @@ def provider(tmp_path, monkeypatch):
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config))
 
-    monkeypatch.setattr(
-        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-    )
+    monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
     p = HindsightMemoryProvider()
     p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
@@ -114,6 +142,7 @@ def provider(tmp_path, monkeypatch):
 @pytest.fixture()
 def provider_with_config(tmp_path, monkeypatch):
     """Create a provider factory that accepts custom config overrides."""
+
     def _make(**overrides):
         config = {
             "mode": "cloud",
@@ -133,14 +162,19 @@ def provider_with_config(tmp_path, monkeypatch):
         )
 
         p = HindsightMemoryProvider()
-        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        p.initialize(
+            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
+        )
         p._client = _make_mock_client()
         return p
+
     return _make
 
 
 def test_normalize_retain_tags_accepts_csv_and_dedupes():
-    assert _normalize_retain_tags("agent:fakeassistantname, source_system:hermes-agent, agent:fakeassistantname") == [
+    assert _normalize_retain_tags(
+        "agent:fakeassistantname, source_system:hermes-agent, agent:fakeassistantname"
+    ) == [
         "agent:fakeassistantname",
         "source_system:hermes-agent",
     ]
@@ -148,7 +182,10 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 
 def test_normalize_retain_tags_accepts_json_array_string():
     value = json.dumps(["agent:fakeassistantname", "source_system:hermes-agent"])
-    assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
+    assert _normalize_retain_tags(value) == [
+        "agent:fakeassistantname",
+        "source_system:hermes-agent",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -163,9 +200,19 @@ class TestSchemas:
         assert "tags" in RETAIN_SCHEMA["parameters"]["properties"]
         assert "content" in RETAIN_SCHEMA["parameters"]["required"]
 
-    def test_recall_schema_has_query(self):
+    def test_recall_schema_has_query_and_optional_controls(self):
         assert RECALL_SCHEMA["name"] == "hindsight_recall"
-        assert "query" in RECALL_SCHEMA["parameters"]["properties"]
+        props = RECALL_SCHEMA["parameters"]["properties"]
+        assert "query" in props
+        assert props["method"]["enum"] == ["recall", "list", "entity"]
+        assert props["budget"]["enum"] == ["low", "mid", "high"]
+        assert "max_tokens" in props
+        assert props["types"]["items"]["enum"] == ["world", "experience", "observation"]
+        assert "tags" in props
+        assert props["tags_match"]["enum"] == ["any", "all", "any_strict", "all_strict"]
+        assert "tag_groups" in props
+        assert "metadata" in props
+        assert "max_entity_tokens" in props
         assert "query" in RECALL_SCHEMA["parameters"]["required"]
 
     def test_reflect_schema_has_query(self):
@@ -199,7 +246,9 @@ class TestConfig:
         assert provider._recall_tags is None
         assert provider._bank_mission == ""
         assert provider._bank_retain_mission is None
-        assert provider._retain_context == "conversation between Hermes Agent and the User"
+        assert (
+            provider._retain_context == "conversation between Hermes Agent and the User"
+        )
 
     def test_custom_config_values(self, provider_with_config):
         p = provider_with_config(
@@ -255,21 +304,25 @@ class TestConfig:
         assert cfg["banks"]["hermes"]["budget"] == "high"
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
-        env = _build_embedded_profile_env({
-            "llm_provider": "openai",
-            "llm_model": "gpt-4o-mini",
-            "idle_timeout": 0,
-        })
+        env = _build_embedded_profile_env(
+            {
+                "llm_provider": "openai",
+                "llm_model": "gpt-4o-mini",
+                "idle_timeout": 0,
+            }
+        )
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
 
     def test_embedded_profile_env_includes_idle_timeout_from_env(self, monkeypatch):
         monkeypatch.setenv("HINDSIGHT_IDLE_TIMEOUT", "42")
 
-        env = _build_embedded_profile_env({
-            "llm_provider": "openai",
-            "llm_model": "gpt-4o-mini",
-        })
+        env = _build_embedded_profile_env(
+            {
+                "llm_provider": "openai",
+                "llm_model": "gpt-4o-mini",
+            }
+        )
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
@@ -280,8 +333,14 @@ class TestConfig:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
 
-        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
-        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight",
+            SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
@@ -308,13 +367,19 @@ class TestPostSetup:
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
         saved_configs = []
-        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
+        monkeypatch.setattr(
+            "hermes_cli.config.save_config",
+            lambda cfg: saved_configs.append(cfg.copy()),
+        )
 
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})
@@ -335,14 +400,19 @@ class TestPostSetup:
             "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n"
         )
 
-    def test_local_embedded_setup_respects_existing_profile_name(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_respects_existing_profile_name(
+        self, tmp_path, monkeypatch
+    ):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -358,14 +428,19 @@ class TestPostSetup:
         assert coder_env.exists()
         assert not hermes_env.exists()
 
-    def test_local_embedded_setup_preserves_existing_key_when_input_left_blank(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_preserves_existing_key_when_input_left_blank(
+        self, tmp_path, monkeypatch
+    ):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -383,14 +458,17 @@ class TestPostSetup:
         assert profile_env.exists()
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
 
-
-    def test_local_embedded_setup_blank_inputs_preserve_existing_config(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_blank_inputs_preserve_existing_config(
+        self, tmp_path, monkeypatch
+    ):
         """Pressing Enter through setup should keep existing Hindsight values."""
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: hermes_home
+        )
 
         existing_config = {
             "mode": "local_embedded",
@@ -410,7 +488,10 @@ class TestPostSetup:
 
         # Simulate pressing Enter at the mode and LLM-provider pickers, which
         # should select their current values, and pressing Enter at text prompts.
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: kwargs.get("default", 0))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: kwargs.get("default", 0),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -432,7 +513,6 @@ class TestPostSetup:
         assert saved["timeout"] == 120
 
 
-
 # ---------------------------------------------------------------------------
 # Tool handler tests
 # ---------------------------------------------------------------------------
@@ -440,9 +520,11 @@ class TestPostSetup:
 
 class TestToolHandlers:
     def test_retain_success(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_retain", {"content": "user likes dark mode"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call(
+                "hindsight_retain", {"content": "user likes dark mode"}
+            )
+        )
         assert result["result"] == "Memory stored successfully."
         provider._client.aretain.assert_called_once()
         call_kwargs = provider._client.aretain.call_args.kwargs
@@ -470,15 +552,13 @@ class TestToolHandlers:
         assert "tags" not in call_kwargs
 
     def test_retain_missing_content(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_retain", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_retain", {}))
         assert "error" in result
 
     def test_recall_success(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "dark mode"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "dark mode"})
+        )
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
 
@@ -487,6 +567,193 @@ class TestToolHandlers:
         p.handle_tool_call("hindsight_recall", {"query": "test"})
         call_kwargs = p._client.arecall.call_args.kwargs
         assert call_kwargs["max_tokens"] == 2048
+
+    def test_recall_accepts_per_call_controls(self, provider_with_config):
+        p = provider_with_config(recall_tags=["configured"], recall_tags_match="all")
+        p.handle_tool_call(
+            "hindsight_recall",
+            {
+                "query": "test",
+                "budget": "high",
+                "max_tokens": 12288,
+                "types": ["world"],
+                "tags": ["override"],
+                "tags_match": "all_strict",
+                "tag_groups": [{"tags": ["grouped"], "match": "all"}],
+            },
+        )
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["budget"] == "high"
+        assert call_kwargs["max_tokens"] == 12288
+        assert call_kwargs["types"] == ["world"]
+        assert call_kwargs["tags"] == ["override"]
+        assert call_kwargs["tags_match"] == "all_strict"
+        assert call_kwargs["tag_groups"] == [{"tags": ["grouped"], "match": "all"}]
+
+    def test_recall_invalid_controls_fall_back_to_config(self, provider_with_config):
+        p = provider_with_config(
+            recall_budget="mid",
+            recall_max_tokens=2048,
+            recall_types=["experience"],
+            recall_tags=["configured"],
+            recall_tags_match="all",
+        )
+        p.handle_tool_call(
+            "hindsight_recall",
+            {
+                "query": "test",
+                "budget": "ultra",
+                "max_tokens": "not-an-int",
+                "types": ["family"],
+                "tags": "not-a-list",
+                "tags_match": "invalid",
+            },
+        )
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["budget"] == "mid"
+        assert call_kwargs["max_tokens"] == 2048
+        assert call_kwargs["types"] == ["experience"]
+        assert call_kwargs["tags"] == ["configured"]
+        assert call_kwargs["tags_match"] == "all"
+
+    def test_recall_rejects_unknown_method(self, provider):
+        result = json.loads(
+            provider.handle_tool_call(
+                "hindsight_recall", {"query": "test", "method": "unknown"}
+            )
+        )
+        assert "error" in result
+        provider._client.arecall.assert_not_called()
+
+    def test_recall_list_method_uses_public_memory_api_and_formats_items(
+        self, provider
+    ):
+        result = json.loads(
+            provider.handle_tool_call(
+                "hindsight_recall", {"query": "keyword", "method": "list"}
+            )
+        )
+
+        provider._client.memory.list_memories.assert_called_once_with(
+            bank_id="test-bank",
+            type=None,
+            q="keyword",
+            limit=50,
+            offset=0,
+            _request_timeout=120,
+        )
+        assert "Keyword Memory 1" in result["result"]
+        assert "Keyword Memory 2" in result["result"]
+        assert "{'id':" not in result["result"]
+        assert result["total"] == 2
+        provider._client.arecall.assert_not_called()
+
+    def test_recall_list_method_applies_configured_type_and_tag_filters(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            recall_types=["world", "experience"],
+            recall_tags=["tag1"],
+            recall_tags_match="all_strict",
+        )
+        result = json.loads(
+            p.handle_tool_call(
+                "hindsight_recall", {"query": "keyword", "method": "list"}
+            )
+        )
+
+        call_kwargs = p._client.memory.list_memories.call_args.kwargs
+        assert call_kwargs["q"] == "keyword"
+        assert call_kwargs["type"] is None
+        assert call_kwargs["_request_timeout"] == 120
+        assert "Keyword Memory 1" in result["result"]
+        assert "Keyword Memory 2" not in result["result"]
+        assert result["returned"] == 1
+
+    def test_recall_list_method_applies_metadata_filter(self, provider):
+        result = json.loads(
+            provider.handle_tool_call(
+                "hindsight_recall",
+                {"query": "keyword", "method": "list", "metadata": {"tenant": "beta"}},
+            )
+        )
+
+        assert "Keyword Memory 1" not in result["result"]
+        assert "Keyword Memory 2" in result["result"]
+        assert result["returned"] == 1
+
+    def test_recall_method_applies_metadata_filter_to_returned_results(self, provider):
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(text="Alpha memory", metadata={"tenant": "alpha"}),
+                SimpleNamespace(text="Beta memory", metadata={"tenant": "beta"}),
+            ]
+        )
+        result = json.loads(
+            provider.handle_tool_call(
+                "hindsight_recall", {"query": "tenant", "metadata": {"tenant": "alpha"}}
+            )
+        )
+
+        assert "Alpha memory" in result["result"]
+        assert "Beta memory" not in result["result"]
+
+    def test_recall_entity_method_formats_entity_dict_response(
+        self, provider_with_config
+    ):
+        p = provider_with_config(recall_tags=["configured"], recall_tags_match="all")
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[SimpleNamespace(text="Related memory")],
+            entities={
+                "ent-1": SimpleNamespace(
+                    entity_id="ent-1",
+                    canonical_name="Alice Example",
+                    observations=[
+                        SimpleNamespace(
+                            text="Alice is Bob's mother.",
+                            mentioned_at="2026-04-30T10:00:00Z",
+                        ),
+                        {"text": "Alice works at ExampleCo."},
+                    ],
+                )
+            },
+        )
+
+        result = json.loads(
+            p.handle_tool_call(
+                "hindsight_recall", {"query": "who is Alice?", "method": "entity"}
+            )
+        )
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["include_entities"] is True
+        assert call_kwargs["max_entity_tokens"] == 2000
+        assert call_kwargs["types"] == ["world"]
+        assert call_kwargs["tags"] == ["configured"]
+        assert call_kwargs["tags_match"] == "all"
+        assert "Related memory" in result["result"]
+        assert "Alice Example" in result["result"]
+        assert "Alice is Bob's mother." in result["result"]
+        assert "Alice works at ExampleCo." in result["result"]
+
+    def test_recall_entity_method_allows_per_call_type_and_budget_overrides(
+        self, provider_with_config
+    ):
+        p = provider_with_config(recall_types=["experience"], recall_max_tokens=2048)
+        p.handle_tool_call(
+            "hindsight_recall",
+            {
+                "query": "relationship",
+                "method": "entity",
+                "budget": "low",
+                "max_tokens": 512,
+                "types": ["observation"],
+            },
+        )
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["budget"] == "low"
+        assert call_kwargs["max_tokens"] == 512
+        assert call_kwargs["types"] == ["observation"]
 
     def test_recall_passes_tags(self, provider_with_config):
         p = provider_with_config(recall_tags=["tag1"], recall_tags_match="all")
@@ -503,53 +770,51 @@ class TestToolHandlers:
 
     def test_recall_no_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(results=[])
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "test"})
+        )
         assert result["result"] == "No relevant memories found."
 
     def test_recall_missing_query(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_recall", {}))
         assert "error" in result
 
     def test_reflect_success(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_reflect", {"query": "summarize"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_reflect", {"query": "summarize"})
+        )
         assert result["result"] == "Synthesized answer"
 
     def test_reflect_missing_query(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_reflect", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_reflect", {}))
         assert "error" in result
 
     def test_unknown_tool(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_unknown", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_unknown", {}))
         assert "error" in result
 
     def test_retain_error_handling(self, provider):
         provider._client.aretain.side_effect = RuntimeError("connection failed")
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_retain", {"content": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_retain", {"content": "test"})
+        )
         assert "error" in result
         assert "connection failed" in result["error"]
 
     def test_recall_error_handling(self, provider):
         provider._client.arecall.side_effect = RuntimeError("timeout")
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "test"})
+        )
         assert "error" in result
 
-    def test_local_embedded_recall_reconnects_after_idle_shutdown(self, provider, monkeypatch):
+    def test_local_embedded_recall_reconnects_after_idle_shutdown(
+        self, provider, monkeypatch
+    ):
         first_client = _make_mock_client()
-        first_client.arecall.side_effect = RuntimeError("Cannot connect to host 127.0.0.1:8888")
+        first_client.arecall.side_effect = RuntimeError(
+            "Cannot connect to host 127.0.0.1:8888"
+        )
         second_client = _make_mock_client()
         second_client.arecall.return_value = SimpleNamespace(
             results=[SimpleNamespace(text="Recovered memory")]
@@ -560,9 +825,9 @@ class TestToolHandlers:
         provider._client = first_client
         monkeypatch.setattr(provider, "_get_client", lambda: next(clients))
 
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "test"})
+        )
 
         assert result["result"] == "1. Recovered memory"
         assert provider._client is second_client
@@ -698,8 +963,14 @@ class TestSyncTurn:
         assert item["metadata"]["agent_identity"] == "fakeassistantname"
         assert item["metadata"]["turn_index"] == "1"
         assert item["metadata"]["message_count"] == "2"
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00", content[0][0]["timestamp"])
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", item["metadata"]["retained_at"])
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00",
+            content[0][0]["timestamp"],
+        )
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z",
+            item["metadata"]["retained_at"],
+        )
 
     def test_sync_turn_skipped_when_auto_retain_off(self, provider_with_config):
         p = provider_with_config(auto_retain=False)
@@ -725,7 +996,10 @@ class TestSyncTurn:
         assert call_kwargs["document_id"].startswith("test-session-")
         assert call_kwargs["retain_async"] is True
         assert len(call_kwargs["items"]) == 1
-        assert call_kwargs["items"][0]["context"] == "conversation between Hermes Agent and the User"
+        assert (
+            call_kwargs["items"][0]["context"]
+            == "conversation between Hermes Agent and the User"
+        )
 
     def test_sync_turn_custom_context(self, provider_with_config):
         p = provider_with_config(retain_context="my-agent")
@@ -793,17 +1067,24 @@ class TestSyncTurn:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p1 = HindsightMemoryProvider()
-        p1.initialize(session_id="resumed-session", hermes_home=str(tmp_path), platform="cli")
+        p1.initialize(
+            session_id="resumed-session", hermes_home=str(tmp_path), platform="cli"
+        )
 
         # Sleep just enough that the microsecond timestamp differs
         import time
+
         time.sleep(0.001)
 
         p2 = HindsightMemoryProvider()
-        p2.initialize(session_id="resumed-session", hermes_home=str(tmp_path), platform="cli")
+        p2.initialize(
+            session_id="resumed-session", hermes_home=str(tmp_path), platform="cli"
+        )
 
         # Same session, but each process gets its own document_id
         assert p1._document_id != p2._document_id
@@ -823,7 +1104,9 @@ class TestSyncTurn:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -994,7 +1277,6 @@ class TestSessionSwitchBufferFlush:
         old session to settle before clearing _prefetch_result, otherwise
         the thread can race and re-populate the field after the clear."""
         import threading
-        import time as _time
 
         gate = threading.Event()
         finished = threading.Event()
@@ -1107,15 +1389,32 @@ class TestConfigSchema:
         schema = provider.get_config_schema()
         keys = {f["key"] for f in schema}
         expected_keys = {
-            "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
-            "llm_model", "bank_id", "bank_id_template", "bank_mission", "bank_retain_mission",
-            "recall_budget", "memory_mode", "recall_prefetch_method",
-            "retain_tags", "retain_source",
-            "retain_user_prefix", "retain_assistant_prefix",
-            "recall_tags", "recall_tags_match",
-            "auto_recall", "auto_retain",
-            "retain_every_n_turns", "retain_async", "retain_context",
-            "recall_max_tokens", "recall_max_input_chars",
+            "mode",
+            "api_url",
+            "api_key",
+            "llm_provider",
+            "llm_api_key",
+            "llm_model",
+            "bank_id",
+            "bank_id_template",
+            "bank_mission",
+            "bank_retain_mission",
+            "recall_budget",
+            "memory_mode",
+            "recall_prefetch_method",
+            "retain_tags",
+            "retain_source",
+            "retain_user_prefix",
+            "retain_assistant_prefix",
+            "recall_tags",
+            "recall_tags_match",
+            "auto_recall",
+            "auto_retain",
+            "retain_every_n_turns",
+            "retain_async",
+            "retain_context",
+            "recall_max_tokens",
+            "recall_max_input_chars",
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"
@@ -1141,15 +1440,18 @@ class TestBankIdTemplate:
         assert _sanitize_bank_segment(None) == ""
 
     def test_resolve_empty_template_uses_fallback(self):
-        result = _resolve_bank_id_template(
-            "", fallback="hermes", profile="coder"
-        )
+        result = _resolve_bank_id_template("", fallback="hermes", profile="coder")
         assert result == "hermes"
 
     def test_resolve_with_profile(self):
         result = _resolve_bank_id_template(
-            "hermes-{profile}", fallback="hermes",
-            profile="coder", workspace="", platform="", user="", session="",
+            "hermes-{profile}",
+            fallback="hermes",
+            profile="coder",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "hermes-coder"
 
@@ -1157,47 +1459,74 @@ class TestBankIdTemplate:
         result = _resolve_bank_id_template(
             "{workspace}-{profile}-{platform}",
             fallback="hermes",
-            profile="coder", workspace="myorg", platform="cli",
-            user="", session="",
+            profile="coder",
+            workspace="myorg",
+            platform="cli",
+            user="",
+            session="",
         )
         assert result == "myorg-coder-cli"
 
     def test_resolve_collapses_empty_placeholders(self):
         # When user is empty, "hermes-{user}" becomes "hermes-" -> trimmed to "hermes"
         result = _resolve_bank_id_template(
-            "hermes-{user}", fallback="default",
-            profile="", workspace="", platform="", user="", session="",
+            "hermes-{user}",
+            fallback="default",
+            profile="",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "hermes"
 
     def test_resolve_collapses_double_dashes(self):
         # Two empty placeholders with a dash between them should collapse
         result = _resolve_bank_id_template(
-            "{workspace}-{profile}-{user}", fallback="fallback",
-            profile="coder", workspace="", platform="", user="", session="",
+            "{workspace}-{profile}-{user}",
+            fallback="fallback",
+            profile="coder",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "coder"
 
     def test_resolve_empty_rendered_falls_back(self):
         result = _resolve_bank_id_template(
-            "{user}-{profile}", fallback="fallback",
-            profile="", workspace="", platform="", user="", session="",
+            "{user}-{profile}",
+            fallback="fallback",
+            profile="",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "fallback"
 
     def test_resolve_sanitizes_placeholder_values(self):
         result = _resolve_bank_id_template(
-            "user-{user}", fallback="hermes",
-            profile="", workspace="", platform="",
-            user="josh@example.com", session="",
+            "user-{user}",
+            fallback="hermes",
+            profile="",
+            workspace="",
+            platform="",
+            user="josh@example.com",
+            session="",
         )
         assert result == "user-josh-example-com"
 
     def test_resolve_invalid_template_returns_fallback(self):
         # Unknown placeholder should fall back without raising
         result = _resolve_bank_id_template(
-            "hermes-{unknown}", fallback="hermes",
-            profile="", workspace="", platform="", user="", session="",
+            "hermes-{unknown}",
+            fallback="hermes",
+            profile="",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "hermes"
 
@@ -1212,7 +1541,9 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1235,7 +1566,9 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1246,7 +1579,9 @@ class TestBankIdTemplate:
         )
         assert p._bank_id == "my-static-bank"
 
-    def test_provider_template_with_missing_profile_falls_back(self, tmp_path, monkeypatch):
+    def test_provider_template_with_missing_profile_falls_back(
+        self, tmp_path, monkeypatch
+    ):
         config = {
             "mode": "cloud",
             "apiKey": "k",
@@ -1257,7 +1592,9 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         # No agent_identity passed — template renders to "hermes-" which collapses to "hermes"
@@ -1304,10 +1641,14 @@ class TestAvailability:
     def test_available_with_snake_case_api_key_in_config(self, tmp_path, monkeypatch):
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(json.dumps({
-            "mode": "cloud",
-            "api_key": "***",
-        }))
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mode": "cloud",
+                    "api_key": "***",
+                }
+            )
+        )
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path,
@@ -1317,7 +1658,9 @@ class TestAvailability:
 
         assert p.is_available()
 
-    def test_local_mode_unavailable_when_runtime_import_fails(self, tmp_path, monkeypatch):
+    def test_local_mode_unavailable_when_runtime_import_fails(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path / "nonexistent",
@@ -1336,7 +1679,9 @@ class TestAvailability:
         p = HindsightMemoryProvider()
         assert not p.is_available()
 
-    def test_initialize_disables_local_mode_when_runtime_import_fails(self, tmp_path, monkeypatch):
+    def test_initialize_disables_local_mode_when_runtime_import_fails(
+        self, tmp_path, monkeypatch
+    ):
         config = {"mode": "local_embedded"}
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1354,7 +1699,9 @@ class TestAvailability:
         )
 
         p = HindsightMemoryProvider()
-        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        p.initialize(
+            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
+        )
         assert p._mode == "disabled"
 
 
@@ -1429,7 +1776,9 @@ class TestSharedEventLoopLifecycle:
 
 
 class TestShutdown:
-    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
+    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(
+        self, provider
+    ):
         inner_client = _make_mock_client()
         embedded = MagicMock()
         embedded._client = inner_client
@@ -1444,4 +1793,3 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
-

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -334,7 +334,7 @@ Long-term memory with knowledge graph, entity resolution, and multi-strategy ret
 | **Data storage** | Hindsight Cloud or local embedded PostgreSQL |
 | **Cost** | Hindsight pricing (cloud) or free (local) |
 
-**Tools:** `hindsight_retain` (store with entity extraction), `hindsight_recall` (multi-strategy search), `hindsight_reflect` (cross-memory synthesis)
+**Tools:** `hindsight_retain` (store with entity extraction), `hindsight_recall` (default semantic/entity-graph recall, plus optional `method="list"` for raw memory listing and `method="entity"` for entity context), `hindsight_reflect` (cross-memory synthesis)
 
 **Setup:**
 ```bash
@@ -365,6 +365,10 @@ The setup wizard installs dependencies automatically and only installs what's ne
 | `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
 | `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
 | `recall_tags` | — | Tags to filter on recall |
+| `recall_tags_match` | `any` | Tag matching mode: `any`, `all`, `any_strict`, or `all_strict` |
+| `recall_max_tokens` | `4096` | Default token cap for recall results |
+
+`hindsight_recall` also accepts per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, `metadata`, and `tag_groups` controls. `method="list"` uses Hindsight's public memory-list API and supports `limit`/`offset`; because that list API does not accept tag groups, `tag_groups` only applies to the default recall/entity paths.
 
 See [plugin README](https://github.com/NousResearch/hermes-agent/blob/main/plugins/memory/hindsight/README.md) for the full configuration reference.
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -368,7 +368,7 @@ The setup wizard installs dependencies automatically and only installs what's ne
 | `recall_tags_match` | `any` | Tag matching mode: `any`, `all`, `any_strict`, or `all_strict` |
 | `recall_max_tokens` | `4096` | Default token cap for recall results |
 
-`hindsight_recall` also accepts per-call `budget`, `max_tokens`, `types`, `tags`, `tags_match`, `metadata`, and `tag_groups` controls. `method="list"` uses Hindsight's public memory-list API and supports `limit`/`offset`; because that list API does not accept tag groups, `tag_groups` only applies to the default recall/entity paths.
+`hindsight_recall` defaults to semantic/entity-graph recall and accepts `method="recall"`, `method="list"`, or `method="entity"`. Unknown method values fall back to the default recall path. Per-call controls include `budget`, `max_tokens`, `types`, `tags`, `tags_match`, exact-match `metadata`, and `tag_groups`. `method="list"` uses Hindsight's public memory-list API, supports `limit`/`offset`, and filters returned items by type, tag, and metadata. Because the public list API does not accept tag groups, `tag_groups` applies only to the default recall/entity paths. `method="entity"` formats entity names and observations from Hindsight's current entity response shape and supports `max_entity_tokens`.
 
 See [plugin README](https://github.com/NousResearch/hermes-agent/blob/main/plugins/memory/hindsight/README.md) for the full configuration reference.
 


### PR DESCRIPTION
## Summary

- Completes `hindsight_recall` support for `method="recall"`, `method="list"`, and `method="entity"`.
- Adds validated per-call controls for `budget`, `max_tokens`, `types`, `tags`, `tags_match`, `tag_groups`, metadata filtering, list pagination, and entity token budget.
- Uses the current provider operation wrapper and the public Hindsight `client.memory.list_memories(...)` API.
- Fixes entity formatting for the current Hindsight client model shape and narrows scoped list/entity output so unrelated or untagged results do not leak through filtered calls.
- Falls back to default recall for unknown `method` values, matching existing tolerant control handling.
- Updates the Hindsight plugin README and user-facing memory-provider docs.

## Investigation

- Current `main` uses `_run_hindsight_operation(...)` for Hindsight calls, so this keeps recall/list/entity behavior inside that provider operation wrapper.
- Raw/list retrieval uses the public `client.memory.list_memories(...)` path instead of private client internals.
- Current Hindsight entity responses expose `RecallResponse.entities` as a mapping of entity ids to entity state objects with `entity_id`, `canonical_name`, and `observations`; entity output now formats those fields directly.
- Metadata, tag, and type filters are applied after retrieval where the public API cannot express the full filter, including exact metadata scoping and exclusion of untagged list items when tags are requested.
- List item type detection accepts `type`, `fact_type`, and `factType` so current and older response shapes filter consistently.
- Invalid per-call controls fall back to configured defaults or safe bounds instead of breaking recall.

## Validation

- `python3 -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` -> passed
- `HERMES_HOME=/tmp/hermes-pr18268-provider PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o addopts=` -> 110 passed
- `HERMES_HOME=/tmp/hermes-pr18268-memory PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/plugins/memory -q -o addopts=` -> 156 passed
- `python3 -m ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` -> passed
- `git diff --check` -> passed
- `HERMES_HOME=/tmp/hermes-pr18268-full PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/ -q` -> blocked before collection because this local environment lacks `pytest-xdist` for the repo default `-n auto`.
- `HERMES_HOME=/tmp/hermes-pr18268-full PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/ -q -o addopts=` -> 29 collection errors, 4 skipped; errors are missing local optional/dev dependencies (`acp`, `fire`).
- Baseline comparison: the same full-suite command on clean `origin/main` also reports 29 collection errors and 4 skipped for the same missing dependencies, so this PR does not introduce those local full-suite failures.

## Notes / Caveats

- Live PR head after this update: `8040bd900714855407972f66fb5bc1c2662af7f6`.
- The PR branch is mergeable but still diverged from current `main` (`ahead_by=4`, `behind_by=34` at verification time).
- This PR does not modify workflow files. If maintainers require the branch to be updated onto current `main`, an owner/maintainer token with workflow scope may be needed because upstream `main` has workflow-file changes.
