### PR TITLE
fix(gateway): /sethome on Matrix and Email now persists across restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -232,6 +232,16 @@ def _ensure_ssl_certs() -> None:
             os.environ["SSL_CERT_FILE"] = candidate
             return
 
+def _home_target_env_var(platform_name: str) -> str:
+    """Return the configured home-target env var for a platform."""
+    from cron.scheduler import _HOME_TARGET_ENV_VARS
+
+    return _HOME_TARGET_ENV_VARS.get(
+        platform_name.lower(),
+        f"{platform_name.upper()}_HOME_CHANNEL",
+    )
+
+
 _ensure_ssl_certs()
 
 # Add parent directory to path
@@ -5758,7 +5768,7 @@ class GatewayRunner:
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
-            env_key = f"{platform_name.upper()}_HOME_CHANNEL"
+            env_key = _home_target_env_var(platform_name)
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -7453,16 +7463,16 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
-        
-        env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-        
+
+        env_key = _home_target_env_var(platform_name)
+
         # Save to .env so it persists across restarts
         try:
             from hermes_cli.config import save_env_value
             save_env_value(env_key, str(chat_id))
         except Exception as e:
             return f"Failed to save home channel: {e}"
-        
+
         return (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,6 +41,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "m@mobrienv.dev": "mikeyobrien",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "leone.parise@gmail.com": "leoneparise",
     "teknium@nousresearch.com": "teknium1",

--- a/tests/gateway/test_home_target_env_var.py
+++ b/tests/gateway/test_home_target_env_var.py
@@ -1,0 +1,36 @@
+"""Regression tests for /sethome env-var resolution.
+
+The `/sethome` command writes to a platform's home-target env var. Two platforms
+don't follow the `{PLATFORM}_HOME_CHANNEL` convention: matrix uses
+`MATRIX_HOME_ROOM` and email uses `EMAIL_HOME_ADDRESS`. Before PR #12698
+`/sethome` hardcoded the `_HOME_CHANNEL` suffix, so Matrix and Email saves went
+to env vars nothing read on startup — the home channel appeared to set
+successfully but was lost on every new gateway session.
+"""
+
+from gateway.run import _home_target_env_var
+
+
+def test_matrix_home_target_env_var_uses_home_room():
+    assert _home_target_env_var("matrix") == "MATRIX_HOME_ROOM"
+
+
+def test_email_home_target_env_var_uses_home_address():
+    assert _home_target_env_var("email") == "EMAIL_HOME_ADDRESS"
+
+
+def test_telegram_home_target_env_var_uses_home_channel():
+    assert _home_target_env_var("telegram") == "TELEGRAM_HOME_CHANNEL"
+
+
+def test_discord_home_target_env_var_uses_home_channel():
+    assert _home_target_env_var("discord") == "DISCORD_HOME_CHANNEL"
+
+
+def test_unknown_platform_home_target_env_var_falls_back_to_home_channel():
+    assert _home_target_env_var("custom") == "CUSTOM_HOME_CHANNEL"
+
+
+def test_case_insensitive_platform_name():
+    assert _home_target_env_var("MATRIX") == "MATRIX_HOME_ROOM"
+    assert _home_target_env_var("Email") == "EMAIL_HOME_ADDRESS"


### PR DESCRIPTION
## Summary

`/sethome` on Matrix and Email now persists across gateway restarts.

Root cause: `_handle_set_home_command` hardcoded `{PLATFORM}_HOME_CHANNEL` as the env-var name, but two platforms don't follow that convention — Matrix reads `MATRIX_HOME_ROOM` (gateway/config.py:1177) and Email reads `EMAIL_HOME_ADDRESS` (gateway/config.py:1210). On those platforms, `/sethome` wrote to an env var nothing read on startup, so users had to re-run it every new session.

## Changes

- `gateway/run.py`: add `_home_target_env_var()` helper backed by `cron.scheduler._HOME_TARGET_ENV_VARS` (single source of truth), with `{PLATFORM}_HOME_CHANNEL` fallback for unknown platforms. Wired into both `/sethome` and the first-run onboarding "no home channel" warning so they agree on the env-var name.
- `tests/gateway/test_home_target_env_var.py`: regression coverage for Matrix (HOME_ROOM), Email (HOME_ADDRESS), Telegram/Discord (HOME_CHANNEL convention), unknown-platform fallback, case-insensitive lookup.
- `scripts/release.py`: add @mikeyobrien to AUTHOR_MAP.

## Validation

| | Before | After |
|---|---|---|
| `/sethome` on Matrix writes | `MATRIX_HOME_CHANNEL` (dead) | `MATRIX_HOME_ROOM` (read by loader) |
| `/sethome` on Email writes | `EMAIL_HOME_CHANNEL` (dead) | `EMAIL_HOME_ADDRESS` (read by loader) |
| `/sethome` on Telegram/Discord/etc. | `*_HOME_CHANNEL` | `*_HOME_CHANNEL` (unchanged) |
| Persists across restart | no on Matrix/Email | yes |

E2E verified: real `save_env_value()` write + `.env` inspection + `gateway/config.py` loader path. Targeted pytest: 6/6 new cases pass, 247/247 matrix + cron cases still pass (3 pre-existing `TestSilentDelivery` failures on clean main are unrelated).

Salvaged from #12698 by @mikeyobrien — widened the contributor's regression test to also cover email and the convention platforms. Original PR touched the pre-#16900 YAML write path; this version is rebased onto the current `save_env_value()` path.

Closes the contributor's issue and supersedes #18154 (which patched the cron reader to align with the bug instead of fixing the bug at the write site).

Co-authored-by: Mikey O'Brien <m@mobrienv.dev>
