### PR TITLE
fix(tui): refresh usage on tool completion

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -328,6 +328,42 @@ def test_status_callback_accepts_single_message_argument():
     )
 
 
+def test_tool_complete_includes_live_usage_snapshot(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_input_tokens=120,
+        session_output_tokens=30,
+        session_total_tokens=150,
+        session_api_calls=2,
+        context_compressor=types.SimpleNamespace(
+            context_length=1000,
+            last_prompt_tokens=250,
+            compression_count=0,
+        ),
+    )
+    server._sessions["sid"] = {
+        "agent": agent,
+        "edit_snapshots": {},
+        "tool_started_at": {},
+        "tool_progress_mode": "compact",
+    }
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: True)
+
+    try:
+        with patch("tui_gateway.server._emit") as emit:
+            server._on_tool_complete("sid", "tool-1", "read_file", {}, "ok")
+    finally:
+        server._sessions.pop("sid", None)
+
+    emit.assert_called_once()
+    event, sid, payload = emit.call_args.args
+    assert event == "tool.complete"
+    assert sid == "sid"
+    assert payload["usage"]["context_used"] == 250
+    assert payload["usage"]["context_max"] == 1000
+    assert payload["usage"]["total"] == 150
+
+
 def test_resolve_model_uses_inference_model_env(monkeypatch):
     monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", " anthropic/claude-sonnet-4.6\n")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1479,6 +1479,9 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     if session is not None:
         snapshot = session.setdefault("edit_snapshots", {}).pop(tool_call_id, None)
         started_at = session.setdefault("tool_started_at", {}).pop(tool_call_id, None)
+        agent = session.get("agent")
+        if agent is not None:
+            payload["usage"] = _get_usage(agent)
     duration_s = time.time() - started_at if started_at else None
     if duration_s is not None:
         payload["duration_s"] = duration_s

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -4,7 +4,7 @@ import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
-import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -57,6 +57,25 @@ describe('createGatewayEventHandler', () => {
     resetTurnState()
     turnController.fullReset()
     patchUiState({ showReasoning: true })
+  })
+
+  it('updates usage from mid-turn tool completion events', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchUiState({ usage: { context_max: 1000, context_used: 100, total: 100 } })
+
+    onEvent({
+      payload: {
+        name: 'read_file',
+        summary: 'read file',
+        tool_id: 'tool-1',
+        usage: { context_max: 1000, context_percent: 25, context_used: 250, total: 250 }
+      },
+      type: 'tool.complete'
+    } as any)
+
+    expect(getUiState().usage).toMatchObject({ context_max: 1000, context_percent: 25, context_used: 250, total: 250 })
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -12,7 +12,7 @@ import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatToolCall, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
-import type { Msg, SubagentProgress } from '../types.js'
+import type { Msg, SubagentProgress, Usage } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
@@ -23,6 +23,12 @@ import { getUiState, patchUiState } from './uiStore.js'
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
+
+const patchUsage = (usage?: Usage) => {
+  if (usage) {
+    patchUiState(state => ({ ...state, usage: { ...state.usage, ...usage } }))
+  }
+}
 
 const applySkin = (s: GatewaySkin) =>
   patchUiState({
@@ -257,6 +263,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'thinking.delta': {
         const text = ev.payload?.text
 
+        patchUsage(ev.payload?.usage)
+
         if (text !== undefined) {
           const value = String(text)
           scheduleThinkingStatus(value || statusFromBusy())
@@ -418,6 +426,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'reasoning.delta':
+        patchUsage(ev.payload?.usage)
+
         if (ev.payload?.text) {
           turnController.recordReasoningDelta(ev.payload.text)
         }
@@ -449,6 +459,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'tool.complete': {
+        patchUsage(ev.payload?.usage)
+
         const inlineDiffText =
           ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
 
@@ -632,9 +644,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus('ready')
 
-        if (ev.payload?.usage) {
-          patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
-        }
+        patchUsage(ev.payload?.usage)
 
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -446,7 +446,7 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
-  | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
+  | { payload?: { text?: string; usage?: Usage }; session_id?: string; type: 'thinking.delta' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }
   | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }
   | { payload?: { state?: 'idle' | 'listening' | 'transcribing' }; session_id?: string; type: 'voice.status' }
@@ -463,7 +463,7 @@ export type GatewayEvent =
       type: 'gateway.start_timeout'
     }
   | { payload?: { preview?: string }; session_id?: string; type: 'gateway.protocol_error' }
-  | { payload?: { text?: string }; session_id?: string; type: 'reasoning.delta' | 'reasoning.available' }
+  | { payload?: { text?: string; usage?: Usage }; session_id?: string; type: 'reasoning.delta' | 'reasoning.available' }
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {
@@ -480,6 +480,7 @@ export type GatewayEvent =
         summary?: string
         tool_id: string
         todos?: unknown[]
+        usage?: Usage
       }
       session_id?: string
       type: 'tool.complete'


### PR DESCRIPTION
## What does this PR do?

- Add live usage snapshots to TUI `tool.complete` events.
- Let the TUI frontend merge usage from mid-turn `tool.complete` / reasoning events instead of waiting only for `message.complete`.
- Cover both the gateway payload and frontend state update paths with regressions.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A