### PR TITLE
fix(yuanbao): enforce owner identity check on group slash commands

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1896,10 +1896,12 @@ class OwnerCommandMiddleware(InboundMiddleware):
         if cmd not in cls.ALLOWLIST:
             return None, None, False
 
-        # Sender identity check: bot owner <-> push.from_account == push.bot_owner_id
-        # owner_id = (push or {}).get("bot_owner_id") or ""
-        # is_owner = bool(owner_id) and owner_id == from_account
-        is_owner = True
+        # Sender identity check: bot owner <-> push.from_account == push.bot_owner_id.
+        # The allowlisted commands (/approve, /deny, /stop, /reset, ...) are
+        # privileged — leaking them to non-owners lets any group member approve
+        # a dangerous tool call, kill the owner's task, or wipe session state.
+        owner_id = str((push or {}).get("bot_owner_id") or "").strip()
+        is_owner = bool(owner_id) and owner_id == from_account
         return cmd, cmd_line, is_owner
 
     async def handle(self, ctx: InboundContext, next_fn) -> None:


### PR DESCRIPTION
## Summary
- The bot-owner identity check inside `OwnerCommandMiddleware._detect_owner_command` in `gateway/platforms/yuanbao.py` was commented out and replaced with a hardcoded `is_owner = True`. As a result, **any** group member could trigger the allowlisted privileged commands (`/approve`, `/deny`, `/stop`, `/reset`, `/retry`, `/undo`, `/new`, `/background`, `/bg`, `/btw`, `/queue`, `/q`) on a Yuanbao group bot.
- The most severe case is `/approve` and `/deny`: when the bot is mid-turn waiting for the owner to confirm a dangerous tool call (terminal, write_file, send_message, etc.), a non-owner in the group could approve or reject it. The other commands let arbitrary group members kill the owner's running task or reset/wipe the owner's session state.
- The `is_owner=True` flag also feeds two downstream effects in the same file: `GroupAtGuardMiddleware` skips the `@bot` mention requirement, and `GroupAttributionMiddleware` strips the `[nickname|user_id]` attribution prefix. So the runner sees the slash command as if the owner had typed it directly — there's no salvaging the policy after this point.

## Fix
Re-enable the documented identity check that the existing comments describe: `push.from_account == push.bot_owner_id`. `bot_owner_id` is already extracted from the inbound payload in `DecodeMiddleware` (line 1138), so no plumbing change is needed.

```python
owner_id = str((push or {}).get("bot_owner_id") or "").strip()
is_owner = bool(owner_id) and owner_id == from_account
```

When `bot_owner_id` is missing or doesn't match the sender, `_detect_owner_command` returns `(cmd, cmd_line, False)` and `OwnerCommandMiddleware.handle` already rejects with the existing `"⚠️ {cmd} is only available to the creator in private chat mode"` notice.

## Test plan
- [x] `python3 -m py_compile gateway/platforms/yuanbao.py` — passes.
- [x] `uv run pytest tests/test_yuanbao_pipeline.py` — all 94 tests pass (no existing test asserted on the bypass behaviour, so nothing was relying on it).
- [ ] Manual verification on a real Yuanbao group bot that:
  - the owner can still issue `/approve`, `/stop`, etc. without `@bot`
  - a non-owner sending `/approve` in the same group is rejected with the existing creator-only notice and does not advance an awaiting approval prompt