### PR TITLE
fix(paths): route achievements plugin + profile-tui through HERMES_HOME

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -18,6 +18,7 @@ for reinstall when scopes/commands change.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -128,7 +129,7 @@ def slack_manifest_command(args) -> int:
 
                 target = Path(get_hermes_home()) / "slack-manifest.json"
             except Exception:
-                target = Path.home() / ".hermes" / "slack-manifest.json"
+                target = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")) / "slack-manifest.json"
         else:
             target = Path(write_target).expanduser()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -2960,7 +2960,7 @@ class Migrator:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Migrate OpenClaw user state into Hermes Agent.")
     parser.add_argument("--source", default=str(Path.home() / ".openclaw"), help="OpenClaw home directory")
-    parser.add_argument("--target", default=str(Path.home() / ".hermes"), help="Hermes home directory")
+    parser.add_argument("--target", default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"), help="Hermes home directory")
     parser.add_argument(
         "--workspace-target",
         help="Optional workspace root where the workspace instructions file should be copied",

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -13,6 +13,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 try:
+    from hermes_constants import get_hermes_home
+except ImportError:
+    import os as _os
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        val = (_os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
+
+try:
     from fastapi import APIRouter
 except Exception:  # Allows local unit tests without dashboard dependencies.
     class APIRouter:  # type: ignore
@@ -135,15 +143,15 @@ ACHIEVEMENTS: List[Dict[str, Any]] = [
 
 
 def state_path() -> Path:
-    return Path.home() / ".hermes" / "plugins" / "hermes-achievements" / "state.json"
+    return get_hermes_home() / "plugins" / "hermes-achievements" / "state.json"
 
 
 def snapshot_path() -> Path:
-    return Path.home() / ".hermes" / "plugins" / "hermes-achievements" / "scan_snapshot.json"
+    return get_hermes_home() / "plugins" / "hermes-achievements" / "scan_snapshot.json"
 
 
 def checkpoint_path() -> Path:
-    return Path.home() / ".hermes" / "plugins" / "hermes-achievements" / "scan_checkpoint.json"
+    return get_hermes_home() / "plugins" / "hermes-achievements" / "scan_checkpoint.json"
 
 
 def load_state() -> Dict[str, Any]:

--- a/scripts/profile-tui.py
+++ b/scripts/profile-tui.py
@@ -35,10 +35,18 @@ import time
 from pathlib import Path
 from typing import Any
 
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+try:
+    from hermes_constants import get_hermes_home
+except ImportError:
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        val = (os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
 
 DEFAULT_TUI_DIR = Path(os.environ.get("HERMES_TUI_DIR", "/home/bb/hermes-agent/ui-tui"))
-DEFAULT_LOG = Path(os.environ.get("HERMES_PERF_LOG", str(Path.home() / ".hermes" / "perf.log")))
-DEFAULT_STATE_DB = Path.home() / ".hermes" / "state.db"
+DEFAULT_LOG = Path(os.environ.get("HERMES_PERF_LOG", str(get_hermes_home() / "perf.log")))
+DEFAULT_STATE_DB = get_hermes_home() / "state.db"
 
 # Keystroke escape sequences.  Matches what xterm/VT220 send when the
 # terminal has bracketed-paste disabled and the key-repeat handler fires.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -506,6 +506,7 @@ AUTHOR_MAP = {
     "hubin_ll@qq.com": "LLQWQ",
     "memosr_email@gmail.com": "memosr",
     "jperlow@gmail.com": "perlowja",
+    "jasonpette1783@gmail.com": "web-dev0521",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "harryplusplus@gmail.com": "harryplusplus",
     "anthhub@163.com": "anthhub",


### PR DESCRIPTION
## Summary

Four callsites that hardcoded `Path.home() / ".hermes"` with **no** `HERMES_HOME` check now route through it, fixing Docker deployments and profile isolation (`hermes -p`) for the achievements plugin, profile-tui script, slack manifest fallback, and openclaw migration default.

## Changes

- `plugins/hermes-achievements/dashboard/plugin_api.py` — `state_path()`, `snapshot_path()`, `checkpoint_path()` now use `get_hermes_home()` (with ImportError shim)
- `scripts/profile-tui.py` — `DEFAULT_STATE_DB` and `DEFAULT_LOG` route through `get_hermes_home()` (with ImportError shim)
- `hermes_cli/slack_cli.py` — `except Exception` fallback uses `os.environ.get("HERMES_HOME") or ...`
- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` — `--target` argparse default checks env var
- `scripts/release.py` — add AUTHOR_MAP entry for @web-dev0521

## Validation

E2E test with `HERMES_HOME=/tmp/hermes_e2e_xxx`:
- `state_path()` → `/tmp/hermes_e2e_xxx/plugins/hermes-achievements/state.json` ✓
- `snapshot_path()` → `/tmp/hermes_e2e_xxx/plugins/hermes-achievements/scan_snapshot.json` ✓
- `checkpoint_path()` → `/tmp/hermes_e2e_xxx/plugins/hermes-achievements/scan_checkpoint.json` ✓
- `profile-tui DEFAULT_STATE_DB` → `/tmp/hermes_e2e_xxx/state.db` ✓
- `profile-tui DEFAULT_LOG` → `/tmp/hermes_e2e_xxx/perf.log` ✓

## Scope note

Salvaged from #18068 (thanks @web-dev0521, authorship preserved via rebase-merge). The original PR proposed changes to 15 files but most were already respecting `HERMES_HOME` — `os.environ.get("HERMES_HOME", default)` returns the default only when the var is **missing**, so Docker/profile deployments were already working through those sites. Narrowing to the 4 sites that had no env check at all.