### PR TITLE
fix(mattermost): harden threaded root session isolation

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -870,8 +870,9 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
-        # Thread support: if the post is in a thread, use root_id. In
-        # thread mode, top-level channel posts are valid roots for progress.
+        # Thread support: replies carry root_id. In thread mode, a top-level
+        # channel post is its own root. Flat mode and DMs retain their existing
+        # channel-scoped session behavior.
         thread_id = post.get("root_id") or None
         if (
             not thread_id
@@ -881,8 +882,18 @@ class MattermostAdapter(BasePlatformAdapter):
         ):
             thread_id = post_id
 
-        # Determine message type.
+        # Ignore textless posts with no files. After mention stripping, a bare
+        # mention or empty wake-up would otherwise become a blank user turn and
+        # can replay the previous interrupted tool intent.
         file_ids = post.get("file_ids") or []
+        if not str(message_text or "").strip() and not file_ids:
+            logger.debug(
+                "Mattermost: ignoring empty post with no attachments (channel=%s, post=%s)",
+                channel_id,
+                post_id,
+            )
+            return
+
         msg_type = MessageType.TEXT
         if message_text[:1].isspace() and message_text.lstrip().startswith("/"):
             message_text = message_text.lstrip()

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -11,6 +11,7 @@ from gateway.run import (
     _resolve_gateway_display_bool,
     _resolve_progress_thread_id,
 )
+from gateway.session import build_session_key
 
 
 class TestMattermostProgressThreadRouting:
@@ -194,7 +195,8 @@ def _make_adapter():
     config = PlatformConfig(
         enabled=True,
         token="test-token",
-        extra={"url": "https://mm.example.com"},
+        # Keep the host process' real Mattermost allowlist out of adapter tests.
+        extra={"url": "https://mm.example.com", "allowed_channels": ""},
     )
     adapter = MattermostAdapter(config)
     return adapter
@@ -661,6 +663,96 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.thread_id == "root_post_123"
+
+    @pytest.mark.parametrize(
+        ("post_id", "channel_type", "reply_mode", "expected_thread_id"),
+        [
+            ("root_post_456", "O", "thread", "root_post_456"),
+            ("flat_post_456", "O", "off", None),
+            ("dm_post_456", "D", "thread", None),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_top_level_thread_session_scope(
+        self, post_id, channel_type, reply_mode, expected_thread_id
+    ):
+        """Only threaded channel roots seed threads; flat mode and DMs do not."""
+        self.adapter._reply_mode = reply_mode
+        post_data = {
+            "id": post_id,
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id New root thread",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": channel_type,
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        handler = self.adapter.handle_message
+        assert getattr(handler, "called")
+        msg_event = getattr(handler, "call_args")[0][0]
+        assert msg_event.source.thread_id == expected_thread_id
+
+    @pytest.mark.asyncio
+    async def test_threaded_top_level_posts_build_distinct_session_keys(self):
+        """Independent Mattermost roots must not share an active-session key."""
+        self.adapter._reply_mode = "thread"
+        keys = []
+        for post_id in ("root_post_a", "root_post_b"):
+            post_data = {
+                "id": post_id,
+                "user_id": "user_123",
+                "channel_id": "chan_456",
+                "message": "@bot_user_id New root thread",
+            }
+            event = {
+                "event": "posted",
+                "data": {
+                    "post": json.dumps(post_data),
+                    "channel_type": "O",
+                    "sender_name": "@alice",
+                },
+            }
+            await self.adapter._handle_ws_event(event)
+            handler = self.adapter.handle_message
+            msg_event = getattr(handler, "call_args")[0][0]
+            keys.append(build_session_key(msg_event.source))
+            getattr(handler, "reset_mock")()
+
+        assert keys[0] != keys[1]
+        assert keys[0].endswith(":chan_456:root_post_a")
+        assert keys[1].endswith(":chan_456:root_post_b")
+
+    @pytest.mark.parametrize(
+        ("message", "channel_type"),
+        [("@bot_user_id   ", "O"), ("   ", "D")],
+    )
+    @pytest.mark.asyncio
+    async def test_blank_posts_without_files_are_ignored(self, message, channel_type):
+        """Blank posts must not create turns that replay interrupted tools."""
+        post_data = {
+            "id": "post_blank",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": message,
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": channel_type,
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert not getattr(self.adapter.handle_message, "called")
 
     @pytest.mark.asyncio
     async def test_invalid_post_json_ignored(self):


### PR DESCRIPTION
## Summary

Harden Mattermost root-thread session isolation and cover the real session-key path.

Current upstream already seeds top-level channel posts as thread roots when `reply_mode="thread"`. This revision incorporates the maintainer review instead of broadening that behavior:

- retain the `reply_mode="thread"` boundary
- retain flat-mode and DM session behavior
- prove two top-level Mattermost roots build distinct `build_session_key()` values
- prove flat mode does not silently become per-post sessions
- ignore textless posts with no files after mention stripping, preventing a bare mention / blank wake-up from creating an empty agent turn

## Why this remains useful

The original root-thread bug is now implemented upstream, but the previous tests stopped at the adapter's `source.thread_id`. The added regression exercises the downstream session-key contract that caused the real production symptom: unrelated Mattermost root posts sharing one active-session guard.

The blank-post guard is the remaining behavior fix. It prevents an empty wake-up from becoming a blank user turn after the bot mention is stripped.

## Scope

Two files, one commit:

- `plugins/platforms/mattermost/adapter.py`
- `tests/gateway/test_mattermost.py`

No flat-mode or DM compatibility change.

## Current rebase

```text
base: 94c944363 feat(tui): show the plan catalog in /subscription on Free (#68357)
head: 6ecac2612 fix(mattermost): isolate root threads as sessions
```

## Tests

```text
venv/bin/python -m pytest tests/gateway/test_mattermost.py tests/gateway/test_send_multiple_images.py -q
87 passed, 2 warnings in 9.59s
```

The adapter/session regression confirms:

- threaded root A and root B build distinct Mattermost session keys
- replies retain their existing root
- flat mode remains channel/user scoped
- DMs remain channel scoped
- blank posts without attachments are ignored