### PR TITLE
fix: end TUI sessions in state.db to prevent ghost rows in /resume

### DIFF
--- a/tests/tui_gateway/test_ghost_sessions.py
+++ b/tests/tui_gateway/test_ghost_sessions.py
@@ -1,0 +1,83 @@
+"""Tests for TUI ghost session fix (#18269).
+
+Verify that ``_finalize_session`` calls ``db.end_session`` so that
+sessions created eagerly by the TUI are properly closed in state.db
+when the user quits without sending a message.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_session(key: str = "ses_abc123", *, with_agent: bool = False) -> dict:
+    session: dict = {
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": key,
+    }
+    if with_agent:
+        agent = MagicMock()
+        agent.session_id = key
+        session["agent"] = agent
+    return session
+
+
+class TestFinalizeSessionEndsDB:
+    """_finalize_session must call db.end_session to avoid ghost rows."""
+
+    def test_end_session_called_on_finalize(self):
+        from tui_gateway.server import _finalize_session
+
+        mock_db = MagicMock()
+        session = _make_session("ses_test1")
+
+        with patch("tui_gateway.server._get_db", return_value=mock_db):
+            _finalize_session(session)
+
+        mock_db.end_session.assert_called_once_with("ses_test1", "tui_close")
+
+    def test_end_session_custom_reason(self):
+        from tui_gateway.server import _finalize_session
+
+        mock_db = MagicMock()
+        session = _make_session("ses_test2")
+
+        with patch("tui_gateway.server._get_db", return_value=mock_db):
+            _finalize_session(session, end_reason="tui_shutdown")
+
+        mock_db.end_session.assert_called_once_with("ses_test2", "tui_shutdown")
+
+    def test_no_double_finalize(self):
+        from tui_gateway.server import _finalize_session
+
+        mock_db = MagicMock()
+        session = _make_session("ses_test3")
+
+        with patch("tui_gateway.server._get_db", return_value=mock_db):
+            _finalize_session(session)
+            _finalize_session(session)  # second call should be no-op
+
+        mock_db.end_session.assert_called_once()
+
+    def test_no_crash_when_db_unavailable(self):
+        from tui_gateway.server import _finalize_session
+
+        session = _make_session("ses_test4")
+
+        with patch("tui_gateway.server._get_db", return_value=None):
+            _finalize_session(session)  # should not raise
+
+    def test_no_crash_when_end_session_raises(self):
+        from tui_gateway.server import _finalize_session
+
+        mock_db = MagicMock()
+        mock_db.end_session.side_effect = Exception("db locked")
+        session = _make_session("ses_test5")
+
+        with patch("tui_gateway.server._get_db", return_value=mock_db):
+            _finalize_session(session)  # should not raise

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -280,8 +280,12 @@ def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
         pass
 
 
-def _finalize_session(session: dict | None) -> None:
-    """Best-effort finalize hook + memory commit for a session."""
+def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> None:
+    """Best-effort finalize hook + memory commit for a session.
+
+    Also marks the session as ended in state.db so that empty/abandoned
+    sessions don't linger as ghost rows in ``/resume``.
+    """
     if not session or session.get("_finalized"):
         return
     session["_finalized"] = True
@@ -299,13 +303,25 @@ def _finalize_session(session: dict | None) -> None:
         except Exception:
             pass
 
-    session_id = getattr(agent, "session_id", None) or session.get("session_key")
+    session_key = session.get("session_key")
+    session_id = getattr(agent, "session_id", None) or session_key
     _notify_session_boundary("on_session_finalize", session_id)
+
+    # Mark the session as ended in the DB so it doesn't appear as a ghost
+    # row in /resume.  CLI already does this (cli.py end_session calls);
+    # TUI was missing the equivalent.  See #18269.
+    if session_key:
+        try:
+            db = _get_db()
+            if db is not None:
+                db.end_session(session_key, end_reason)
+        except Exception:
+            pass
 
 
 def _shutdown_sessions() -> None:
     for session in list(_sessions.values()):
-        _finalize_session(session)
+        _finalize_session(session, end_reason="tui_shutdown")
         try:
             worker = session.get("slash_worker")
             if worker:
@@ -2512,6 +2528,11 @@ def _(rid, params: dict) -> dict:
         )
     except Exception as e:
         return _err(rid, 5000, f"agent init failed on branch: {e}")
+    # End the old session in DB — mirrors CLI behavior (cli.py "branched").
+    try:
+        db.end_session(old_key, "branched")
+    except Exception:
+        pass
     return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
 
 


### PR DESCRIPTION
## Summary

Fixes #18269 — TUI sessions created eagerly in `state.db` were never marked as ended, leaving ghost rows (with `ended_at=NULL`, `message_count=0`) cluttering `/resume`.

## Problem

`_finalize_session()` committed memory and fired hooks but never called `db.end_session()`. By contrast, CLI properly calls `end_session()` on quit, `/new`, `/branch`, and `/resume`. Every TUI session — even ones closed immediately without sending a message — persisted as an open row in the sessions table.

## Changes

**`tui_gateway/server.py`**
- `_finalize_session()` now accepts an `end_reason` parameter (default `"tui_close"`) and calls `db.end_session(session_key, end_reason)` after the existing memory-commit and hook logic. Wrapped in `try/except` to avoid disrupting finalization if DB is unavailable.
- `_shutdown_sessions()` passes `end_reason="tui_shutdown"` to distinguish atexit cleanup.
- `session.branch` handler now calls `db.end_session(old_key, "branched")` on the parent session, mirroring CLI behavior.

**`tests/tui_gateway/test_ghost_sessions.py`** (new)
- 5 tests verifying: `end_session` is called with correct reason, no double-finalize, graceful handling when DB is `None` or raises.

## Testing

```
pytest tests/tui_gateway/ -v  # 70 passed (including 5 new)
```

No changes to `hermes_state.py` or CLI — the `SessionDB.end_session()` API already exists and is battle-tested.