### PR TITLE
fix(agent): handle context_length_exceeded short form parser

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -815,6 +815,7 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     error_lower = error_msg.lower()
     # Pattern: look for numbers near context-related keywords
     patterns = [
+        r'context_length_exceeded:\s*(\d{4,})',  # Short form "context_length_exceeded: 131072"
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -904,6 +904,11 @@ class TestParseContextLimitFromError:
         msg = "context_length_exceeded: maximum context length is 131072"
         assert parse_context_limit_from_error(msg) == 131072
 
+    def test_context_length_exceeded_short_form(self):
+        """Test the documented short form 'context_length_exceeded: 131072'."""
+        msg = "context_length_exceeded: 131072"
+        assert parse_context_limit_from_error(msg) == 131072
+
     def test_context_size_exceeded(self):
         msg = "Maximum context size 65536 exceeded"
         assert parse_context_limit_from_error(msg) == 65536


### PR DESCRIPTION
## Summary

Fix `parse_context_limit_from_error()` to handle the documented short form error message `"context_length_exceeded: 131072"`.

## Root Cause

The function's docstring lists this format as supported:
```python
"context_length_exceeded: 131072"
```

However, the regex patterns expected `context ` (with space) followed by keywords like `length|size|window`. The short form uses `context_length_exceeded` (underscore) directly, so the pattern never matched.

## Fix

Add a new pattern at the top of the patterns list to match `context_length_exceeded: <number>`:
```python
r'context_length_exceeded:\s*(\d{4,})',
```

This pattern is checked first before the more generic patterns, ensuring the short form is handled correctly.

## Regression Coverage

Added `test_context_length_exceeded_short_form()` to `TestParseContextLimitFromError` class. This test:
- Uses the exact short form from the issue report
- Confirms the fix returns the correct limit (131072)
- Runs as RED → GREEN in TDD flow

All existing 13 tests in `TestParseContextLimitFromError` continue to pass.

## Testing

```bash
# Targeted test
pytest tests/agent/test_model_metadata.py::TestParseContextLimitFromError::test_context_length_exceeded_short_form

# Full test class
pytest tests/agent/test_model_metadata.py::TestParseContextLimitFromError -v

# Full file
bash scripts/run_tests.sh tests/agent/test_model_metadata.py -v
```

All 93 tests in `test_model_metadata.py` pass.

## Files Changed

- `agent/model_metadata.py`: Added 1 regex pattern (1 line)
- `tests/agent/test_model_metadata.py`: Added 1 test (5 lines)

Total: 2 files, 6 insertions

Closes #17983
