### PR TITLE
fix: dashboard session search now performs global search via FTS5

### DIFF
--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -421,6 +421,10 @@ export default function SessionsPage() {
     SessionSearchResult[] | null
   >(null);
   const [searching, setSearching] = useState(false);
+  /** Full session info for all sessions that match the current search query.
+   *  Populated by a bulk fetch when searchResults changes, so the global FTS5
+   *  results aren't clipped to the current pagination page. */
+  const [searchFilteredSessions, setSearchFilteredSessions] = useState<SessionInfo[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const logScrollRef = useRef<HTMLPreElement | null>(null);
   const [status, setStatus] = useState<StatusResponse | null>(null);
@@ -520,7 +524,7 @@ export default function SessionsPage() {
     if (el) el.scrollTop = el.scrollHeight;
   }, [actionStatus?.lines]);
 
-  // Debounced FTS search
+  // Debounced FTS search — fires the global search on every keystroke.
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
@@ -543,6 +547,36 @@ export default function SessionsPage() {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
   }, [search]);
+
+  // When global FTS5 search returns, load the full session info for every
+  // matched session so the result list isn't clipped to the current page.
+  useEffect(() => {
+    if (!searchResults || searchResults.length === 0) {
+      setSearchFilteredSessions([]);
+      return;
+    }
+    let cancelled = false;
+    api
+      .getSessions(100_000, 0) // fetch all sessions so we can display every match
+      .then((resp) => {
+        if (cancelled) return;
+        // Preserve search-result order (most relevant first)
+        const ordered = new Map<string, SessionInfo>();
+        for (const s of resp.sessions) ordered.set(s.id, s);
+        const matched: SessionInfo[] = [];
+        for (const r of searchResults) {
+          const info = ordered.get(r.session_id);
+          if (info) matched.push(info);
+        }
+        setSearchFilteredSessions(matched);
+      })
+      .catch(() => {
+        if (!cancelled) setSearchFilteredSessions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [searchResults]);
 
   const sessionDelete = useConfirmDelete({
     onDelete: useCallback(
@@ -579,10 +613,10 @@ export default function SessionsPage() {
     }
   }
 
-  // When searching, filter sessions to those with FTS matches;
-  // when not searching, show all sessions
+  // When searching, show the globally-matched sessions (with full info);
+  // when not searching, show all sessions on the current page.
   const filtered = searchResults
-    ? sessions.filter((s) => snippetMap.has(s.id))
+    ? searchFilteredSessions
     : sessions;
 
   const platformEntries = status


### PR DESCRIPTION
## Problem

The dashboard Sessions page had a bug where the search functionality only filtered the **current pagination page** (20 sessions), even though the backend performed a global FTS5 search across ALL sessions.

**Root cause:** `sessions` state only holds the current page (loaded via `getSessions(20, offset)`). The old code used global `searchResults` only to build a `snippetMap`, then filtered `sessions` against it:

```ts
const filtered = searchResults
  ? sessions.filter((s) => snippetMap.has(s.id))  // ❌ only current page!
  : sessions;
```

Sessions on other pages that matched the query were completely invisible to the user.

## Fix

Added a new state `searchFilteredSessions` and a `useEffect` that fetches **all sessions** (limit=100000) when global FTS5 search results arrive. Results are ordered by FTS5 relevance (from searchResults), not recency.

- Fetch all sessions when `searchResults` changes
- Build a `Map<sessionId, SessionInfo>` for O(1) lookup
- Iterate `searchResults` in relevance order to build `searchFilteredSessions`
- Use `searchFilteredSessions` instead of filtering `sessions`
- Pagination footer is already hidden during search mode (`!searchResults && total > PAGE_SIZE`)

## Test

- Search for a term that only matches sessions on page 2+ of the paginated list → results now appear correctly
- Search for a term not in any session → empty state shown
- Clear search → returns to paginated view
- Pagination prev/next hidden during search
- Session expand/delete still works in search results

## Files Changed

- `web/src/pages/SessionsPage.tsx` — +38 / -4 lines