### PR TITLE
feat(codex): add gpt-5.3-codex-spark model

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1095,6 +1095,7 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
     "gpt-5.3-codex": 272_000,
+    "gpt-5.3-codex-spark": 272_000,
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
     "gpt-5.5": 272_000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1095,7 +1095,7 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
     "gpt-5.3-codex": 272_000,
-    "gpt-5.3-codex-spark": 272_000,
+    "gpt-5.3-codex-spark": 128_000,
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
     "gpt-5.5": 272_000,

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -16,6 +16,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
     "gpt-5.4-mini",
     "gpt-5.4",
     "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
     "gpt-5.2-codex",
     "gpt-5.1-codex-max",
     "gpt-5.1-codex-mini",
@@ -26,6 +27,7 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.3-codex", ("gpt-5.2-codex",)),
+    ("gpt-5.3-codex-spark", ("gpt-5.3-codex", "gpt-5.2-codex")),
 ]
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -244,8 +244,9 @@ class TestDefaultContextLengths:
 class TestCodexOAuthContextLength:
     """ChatGPT Codex OAuth imposes lower context limits than the direct
     OpenAI API for the same slugs. Verified Apr 2026 via live probe of
-    chatgpt.com/backend-api/codex/models: every model returns 272k, while
+    chatgpt.com/backend-api/codex/models: most models return 272k, while
     models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
+    (Known exception: gpt-5.3-codex-spark is 128k.)
     """
 
     def setup_method(self):
@@ -259,26 +260,28 @@ class TestCodexOAuthContextLength:
         """
         from agent.model_metadata import get_model_context_length
 
+        expected = {
+            "gpt-5.5": 272_000,
+            "gpt-5.4": 272_000,
+            "gpt-5.4-mini": 272_000,
+            "gpt-5.3-codex": 272_000,
+            "gpt-5.3-codex-spark": 128_000,
+            "gpt-5.2-codex": 272_000,
+            "gpt-5.1-codex-max": 272_000,
+            "gpt-5.1-codex-mini": 272_000,
+        }
+
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.save_context_length"):
-            for model in (
-                "gpt-5.5",
-                "gpt-5.4",
-                "gpt-5.4-mini",
-                "gpt-5.3-codex",
-                "gpt-5.3-codex-spark",
-                "gpt-5.2-codex",
-                "gpt-5.1-codex-max",
-                "gpt-5.1-codex-mini",
-            ):
+            for model, expected_ctx in expected.items():
                 ctx = get_model_context_length(
                     model=model,
                     base_url="https://chatgpt.com/backend-api/codex",
                     api_key="",
                     provider="openai-codex",
                 )
-                assert ctx == 272_000, (
-                    f"Codex {model}: expected 272000 fallback, got {ctx} "
+                assert ctx == expected_ctx, (
+                    f"Codex {model}: expected {expected_ctx} fallback, got {ctx} "
                     "(models.dev leakage?)"
                 )
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -266,6 +266,7 @@ class TestCodexOAuthContextLength:
                 "gpt-5.4",
                 "gpt-5.4-mini",
                 "gpt-5.3-codex",
+                "gpt-5.3-codex-spark",
                 "gpt-5.2-codex",
                 "gpt-5.1-codex-max",
                 "gpt-5.1-codex-mini",

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -54,7 +54,7 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
 
     assert models[: len(DEFAULT_CODEX_MODELS)] == DEFAULT_CODEX_MODELS
     assert "gpt-5.4" in models
-    assert "gpt-5.3-codex-spark" not in models
+    assert "gpt-5.3-codex-spark" in models
 
 
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
@@ -65,7 +65,13 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+    assert models == [
+        "gpt-5.2-codex",
+        "gpt-5.4-mini",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+    ]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds `gpt-5.3-codex-spark` to Hermes' OpenAI Codex model catalog.

This updates both:

- the curated fallback list used when live Codex model discovery is unavailable
- the forward-compat synthetic model list used to surface newer compatible Codex variants

`gpt-5.3-codex-spark` is useful for Hermes-style agent work because it is a fast Codex-line model intended for real-time coding workflows. OpenAI describes Codex-Spark as an ultra-fast model for real-time coding in Codex, optimized for low-latency code iteration while remaining capable on real coding tasks:

https://openai.com/index/introducing-gpt-5-3-codex-spark/

This matters for Hermes because the `openai-codex` provider is commonly used for repo inspection, terminal/tool workflows, debugging, and focused coding edits. In that slot, a fast Codex-line model is often a better practical fit than a general mini-class model such as `gpt-5.4-mini`.

Spark also matters operationally for subscription users. During the research preview, OpenAI notes that Codex-Spark has its own rate limits and does not count toward standard rate limits. OpenAI's Codex rate card also lists `GPT-5.3-Codex-Spark` as a Codex research-preview model:

https://help.openai.com/en/articles/20001106-codex-rate-card

Without this catalog entry, Hermes can fail to show Spark when live model discovery is unavailable or incomplete, even though the model is a valuable option for users who have access to it.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/codex_models.py`
  - Add `gpt-5.3-codex-spark` to `DEFAULT_CODEX_MODELS`
  - Add `gpt-5.3-codex-spark` to `_FORWARD_COMPAT_TEMPLATE_MODELS`

- `tests/hermes_cli/test_codex_models.py`
  - Update fallback/default model assertions so Spark is expected
  - Update forward-compat synthesis assertions so Spark is included when older compatible Codex templates are present

## How to Test

1. Run the focused Codex model catalog tests:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_codex_models.py -k get_codex_model_ids
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(codex): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_codex_models.py -k get_codex_model_ids` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A