### PR TITLE
fix(copilot): use live model catalog in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1141,9 +1141,18 @@ def list_authenticated_providers(
         # For preferred providers, merge models.dev entries into the curated
         # catalog so newly released models (e.g. mimo-v2.5-pro on opencode-go)
         # show up in the picker without requiring a Hermes release.
-        model_ids = curated.get(hermes_id, [])
-        if hermes_id in _MODELS_DEV_PREFERRED:
-            model_ids = _merge_with_models_dev(hermes_id, model_ids)
+        # For copilot, prefer the live catalog from api.githubcopilot.com
+        # so newly released models appear in /model without a Hermes release.
+        if hermes_id in {"copilot", "copilot-acp"}:
+            try:
+                live_ids = provider_model_ids(hermes_id)
+                model_ids = live_ids if live_ids else curated.get(hermes_id, [])
+            except Exception:
+                model_ids = curated.get(hermes_id, [])
+        else:
+            model_ids = curated.get(hermes_id, [])
+            if hermes_id in _MODELS_DEV_PREFERRED:
+                model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 


### PR DESCRIPTION
## Problem

Slash `/model` in the CLI shows a stale, hard-coded Copilot model list (17 entries) while `hermes model` shows the live catalog from `api.githubcopilot.com/models` (22+ entries). Both commands use the same Copilot OAuth token, so the divergence is purely a code-path bug.

User-visible symptoms:
- New Copilot models (`gpt-5.5`, `claude-opus-4.7-*`, `gemini-3.1-pro-preview`, …) never appear in `/model` even after `hermes update`.
- Switching via `/model <name>` rejects models that `hermes model` accepts.
- `hermes model` and `/model` showing different lists for the same provider feels like a memory/caching bug, but it's deterministic.

## Root cause

`list_authenticated_providers()` in `hermes_cli/model_switch.py` has two sections that emit provider rows:

| Section | Driven by | Copilot model source |
|---|---|---|
| 1 (line ~1101) | `PROVIDER_TO_MODELS_DEV` (`copilot` → `github-copilot`) | `curated.get(hermes_id, [])` → static `_PROVIDER_MODELS["copilot"]` |
| 2 (line ~1167) | `HERMES_OVERLAYS` | Special-cases copilot via `provider_model_ids()` (line 1249) which does live fetch + static fallback |

Section 1 runs first and adds `copilot` to `seen_slugs`. Section 2 then skips it (`if hermes_slug.lower() in seen_slugs: continue`), so the live-fetch branch is never reached. The hard-coded list wins every time.

`hermes model` (CLI subcommand) bypasses `list_authenticated_providers()` entirely and calls `provider_model_ids()` directly — that's why the two diverge.

## Fix

In Section 1, special-case `copilot` / `copilot-acp` to call `provider_model_ids()` (same function Section 2 uses), with graceful fallback to the curated static list on exception. Other providers are unchanged.

```python
if hermes_id in {"copilot", "copilot-acp"}:
    try:
        live_ids = provider_model_ids(hermes_id)
        model_ids = live_ids if live_ids else curated.get(hermes_id, [])
    except Exception:
        model_ids = curated.get(hermes_id, [])
else:
    model_ids = curated.get(hermes_id, [])
    if hermes_id in _MODELS_DEV_PREFERRED:
        model_ids = _merge_with_models_dev(hermes_id, model_ids)
```

`provider_model_ids("copilot")` already wraps `_fetch_github_models(_resolve_copilot_catalog_api_key())` and falls through to `_PROVIDER_MODELS["copilot"]` on failure, so behaviour when the user has no valid token is identical to before.

## Verification

Local repro on `main`:
```
slug=copilot total=17
['gpt-5.4', 'gpt-5.4-mini', 'gpt-5-mini', 'gpt-5.3-codex', 'gpt-5.2-codex',
 'gpt-4.1', 'gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4.6', 'claude-sonnet-4',
 'claude-sonnet-4.5', 'claude-haiku-4.5', 'gemini-3.1-pro-preview',
 'gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro',
 'grok-code-fast-1']
```

After patch:
```
slug=copilot total=22
['claude-opus-4.6', 'claude-opus-4.7-1m-internal', 'claude-opus-4.7-high',
 'claude-opus-4.7-xhigh', 'claude-opus-4.7', 'claude-sonnet-4.6',
 'gemini-3.1-pro-preview', 'gpt-5.2-codex', 'gpt-5.3-codex', 'gpt-5.4-mini',
 'gpt-5.4', 'gpt-5.5', 'gpt-5-mini', 'claude-sonnet-4', 'claude-sonnet-4.5',
 'claude-opus-4.5', 'claude-haiku-4.5', 'gemini-3-flash-preview',
 'gemini-2.5-pro', 'gpt-5.2', 'gpt-4.1', 'gpt-4o']
```

Existing test suite (`tests/hermes_cli/` filtered to `list_authenticated`, `model_switch`, `copilot`): **215 passed, 0 failed**.

## Notes

- No new env vars or config required — uses the same Copilot token resolution path as the rest of the codebase (`_resolve_copilot_catalog_api_key`).
- Offline / unauthenticated users see exactly the same fallback list as before.
- The `hermes-agent` skill's troubleshooting note about `/model` showing a stale list (currently attributing it to token resolution) becomes obsolete after this change — happy to update that doc separately if desired.
