### PR TITLE
[codex] Add Paperlight dashboard theme

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3238,6 +3238,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "paperlight", "label": "Paperlight",     "description": "Light paper workspace with high-contrast text"},
 ]
 
 

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -4,16 +4,15 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Typography } from "@/components/NouiTypography";
 import { BUILTIN_THEMES, useTheme } from "@/themes";
-import type { DashboardTheme } from "@/themes/types";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
 
 /**
  * Compact theme picker mounted next to the language switcher in the header.
- * Built-in themes render a compact chromatic icon derived from their palette
- * so users can preview the color direction before committing. User-defined
+ * Each dropdown row shows a 3-stop swatch (background / midground / warm
+ * glow) so users can preview the palette before committing. User-defined
  * themes from `~/.hermes/dashboard-themes/*.yaml` that aren't in
- * `BUILTIN_THEMES` render with a neutral placeholder.
+ * `BUILTIN_THEMES` render without swatches and apply the default palette.
  *
  * When placed at the bottom of a container (e.g. the sidebar rail), pass
  * `dropUp` so the menu opens above the trigger instead of clipping below
@@ -49,7 +48,6 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
   }, [open, close]);
 
   const current = availableThemes.find((th) => th.name === themeName);
-  const currentPreset = BUILTIN_THEMES[themeName];
   const label = current?.label ?? themeName;
 
   return (
@@ -64,11 +62,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
         aria-haspopup="listbox"
       >
         <span className="inline-flex items-center gap-1.5">
-          {currentPreset ? (
-            <ThemeToneIcon theme={currentPreset} className="h-4 w-4" />
-          ) : (
-            <Palette className="h-3.5 w-3.5" />
-          )}
+          <Palette className="h-3.5 w-3.5" />
 
           <Typography
             mondwest
@@ -116,9 +110,9 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
                 className="gap-3"
               >
                 {preset ? (
-                  <ThemeToneIcon theme={preset} />
+                  <ThemeSwatch theme={preset.name} />
                 ) : (
-                  <PlaceholderThemeIcon />
+                  <PlaceholderSwatch />
                 )}
 
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -150,36 +144,27 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
   );
 }
 
-function ThemeToneIcon({
-  className,
-  theme,
-}: {
-  className?: string;
-  theme: DashboardTheme;
-}) {
-  const { background, midground, warmGlow } = theme.palette;
-  const accent = theme.colorOverrides?.accent ?? warmGlow;
-  const primary = theme.colorOverrides?.primary ?? midground.hex;
-  const toneWheel = `conic-gradient(from 210deg, ${background.hex} 0 28%, ${accent} 28% 50%, ${midground.hex} 50% 73%, ${primary} 73% 88%, ${warmGlow} 88% 100%)`;
-
+function ThemeSwatch({ theme }: { theme: string }) {
+  const preset = BUILTIN_THEMES[theme];
+  if (!preset) return <PlaceholderSwatch />;
+  const { background, midground, warmGlow } = preset.palette;
   return (
-    <span
+    <div
       aria-hidden
-      className={cn(
-        "relative h-5 w-5 shrink-0 overflow-hidden rounded-full border border-current/25",
-        "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.25)]",
-        className,
-      )}
-      style={{ background: toneWheel }}
-    />
+      className="flex h-4 w-9 shrink-0 overflow-hidden border border-current/20"
+    >
+      <span className="flex-1" style={{ background: background.hex }} />
+      <span className="flex-1" style={{ background: midground.hex }} />
+      <span className="flex-1" style={{ background: warmGlow }} />
+    </div>
   );
 }
 
-function PlaceholderThemeIcon() {
+function PlaceholderSwatch() {
   return (
-    <span
+    <div
       aria-hidden
-      className="h-5 w-5 shrink-0 rounded-full border border-dashed border-current/25"
+      className="h-4 w-9 shrink-0 border border-dashed border-current/20"
     />
   );
 }

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -4,15 +4,16 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Typography } from "@/components/NouiTypography";
 import { BUILTIN_THEMES, useTheme } from "@/themes";
+import type { DashboardTheme } from "@/themes/types";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
 
 /**
  * Compact theme picker mounted next to the language switcher in the header.
- * Each dropdown row shows a 3-stop swatch (background / midground / warm
- * glow) so users can preview the palette before committing. User-defined
+ * Built-in themes render a compact chromatic icon derived from their palette
+ * so users can preview the color direction before committing. User-defined
  * themes from `~/.hermes/dashboard-themes/*.yaml` that aren't in
- * `BUILTIN_THEMES` render without swatches and apply the default palette.
+ * `BUILTIN_THEMES` render with a neutral placeholder.
  *
  * When placed at the bottom of a container (e.g. the sidebar rail), pass
  * `dropUp` so the menu opens above the trigger instead of clipping below
@@ -48,6 +49,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
   }, [open, close]);
 
   const current = availableThemes.find((th) => th.name === themeName);
+  const currentPreset = BUILTIN_THEMES[themeName];
   const label = current?.label ?? themeName;
 
   return (
@@ -62,7 +64,11 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
         aria-haspopup="listbox"
       >
         <span className="inline-flex items-center gap-1.5">
-          <Palette className="h-3.5 w-3.5" />
+          {currentPreset ? (
+            <ThemeToneIcon theme={currentPreset} className="h-4 w-4" />
+          ) : (
+            <Palette className="h-3.5 w-3.5" />
+          )}
 
           <Typography
             mondwest
@@ -110,9 +116,9 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
                 className="gap-3"
               >
                 {preset ? (
-                  <ThemeSwatch theme={preset.name} />
+                  <ThemeToneIcon theme={preset} />
                 ) : (
-                  <PlaceholderSwatch />
+                  <PlaceholderThemeIcon />
                 )}
 
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -144,27 +150,36 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
   );
 }
 
-function ThemeSwatch({ theme }: { theme: string }) {
-  const preset = BUILTIN_THEMES[theme];
-  if (!preset) return <PlaceholderSwatch />;
-  const { background, midground, warmGlow } = preset.palette;
+function ThemeToneIcon({
+  className,
+  theme,
+}: {
+  className?: string;
+  theme: DashboardTheme;
+}) {
+  const { background, midground, warmGlow } = theme.palette;
+  const accent = theme.colorOverrides?.accent ?? warmGlow;
+  const primary = theme.colorOverrides?.primary ?? midground.hex;
+  const toneWheel = `conic-gradient(from 210deg, ${background.hex} 0 28%, ${accent} 28% 50%, ${midground.hex} 50% 73%, ${primary} 73% 88%, ${warmGlow} 88% 100%)`;
+
   return (
-    <div
+    <span
       aria-hidden
-      className="flex h-4 w-9 shrink-0 overflow-hidden border border-current/20"
-    >
-      <span className="flex-1" style={{ background: background.hex }} />
-      <span className="flex-1" style={{ background: midground.hex }} />
-      <span className="flex-1" style={{ background: warmGlow }} />
-    </div>
+      className={cn(
+        "relative h-5 w-5 shrink-0 overflow-hidden rounded-full border border-current/25",
+        "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.25)]",
+        className,
+      )}
+      style={{ background: toneWheel }}
+    />
   );
 }
 
-function PlaceholderSwatch() {
+function PlaceholderThemeIcon() {
   return (
-    <div
+    <span
       aria-hidden
-      className="h-4 w-9 shrink-0 border border-dashed border-current/20"
+      className="h-5 w-5 shrink-0 rounded-full border border-dashed border-current/25"
     />
   );
 }

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -183,6 +183,127 @@ export const roseTheme: DashboardTheme = {
   },
 };
 
+export const paperlightTheme: DashboardTheme = {
+  name: "paperlight",
+  label: "Paperlight",
+  description: "Light paper workspace with high-contrast text",
+  palette: {
+    background: { hex: "#f7f1e5", alpha: 1 },
+    midground: { hex: "#0b1220", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0.28 },
+    warmGlow: "rgba(245, 174, 84, 0.18)",
+    noiseOpacity: 0.16,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Source Sans 3", "Avenir Next", "Segoe UI", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontDisplay: `"Source Serif 4", Georgia, serif`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&family=Source+Serif+4:wght@600;700&family=JetBrains+Mono:wght@400;500;600&display=swap",
+    lineHeight: "1.58",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.85rem",
+  },
+  assets: {
+    bg: "radial-gradient(circle at 12% 8%, rgba(255, 208, 128, 0.26), transparent 32%), radial-gradient(circle at 90% 4%, rgba(111, 143, 205, 0.18), transparent 30%), linear-gradient(135deg, #fbf7ef 0%, #f2eadb 48%, #e9dfcd 100%)",
+  },
+  componentStyles: {
+    page: {
+      background:
+        "linear-gradient(180deg, rgba(255, 252, 245, 0.96), rgba(244, 236, 222, 0.92))",
+    },
+    card: {
+      background:
+        "linear-gradient(180deg, rgba(255, 253, 248, 0.94), rgba(249, 244, 235, 0.90))",
+      boxShadow:
+        "0 18px 48px -34px rgba(29, 42, 62, 0.42), inset 0 0 0 1px rgba(96, 77, 46, 0.11)",
+    },
+    header: {
+      background:
+        "linear-gradient(180deg, rgba(255, 253, 248, 0.96), rgba(246, 239, 226, 0.92))",
+    },
+    sidebar: {
+      background:
+        "linear-gradient(180deg, rgba(255, 253, 248, 0.94), rgba(241, 232, 216, 0.92))",
+    },
+    tab: {
+      background: "rgba(255, 255, 255, 0.58)",
+    },
+    badge: {
+      background: "rgba(42, 83, 130, 0.10)",
+    },
+    backdrop: {
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+      fillerOpacity: "0.72",
+      fillerBlendMode: "normal",
+    },
+  },
+  colorOverrides: {
+    card: "#fffaf1",
+    cardForeground: "#0b1220",
+    popover: "#fffdf8",
+    popoverForeground: "#0b1220",
+    primary: "#245a92",
+    primaryForeground: "#ffffff",
+    secondary: "#eadcc5",
+    secondaryForeground: "#111827",
+    muted: "#eee3d1",
+    mutedForeground: "#303846",
+    accent: "#d88325",
+    accentForeground: "#20140a",
+    destructive: "#b42318",
+    destructiveForeground: "#ffffff",
+    success: "#20744f",
+    warning: "#c57a14",
+    border: "#d6c7af",
+    input: "#d1c1a8",
+    ring: "#245a92",
+  },
+  customCSS: `
+    :root body {
+      color-scheme: light;
+      color: #0b1220;
+    }
+
+    :root body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 0;
+      opacity: 0.22;
+      background-image:
+        linear-gradient(rgba(80, 65, 42, 0.055) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(80, 65, 42, 0.04) 1px, transparent 1px);
+      background-size: 32px 32px, 32px 32px;
+    }
+
+    :root .text-muted-foreground {
+      color: #303846;
+    }
+
+    :root .border-border {
+      border-color: rgba(114, 94, 62, 0.22);
+    }
+
+    :root input,
+    :root textarea,
+    :root select {
+      background-color: rgba(255, 253, 248, 0.9);
+    }
+
+    :root code,
+    :root pre {
+      background-color: rgba(36, 90, 146, 0.08);
+      color: #07111f;
+    }
+  `,
+};
+
 export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   midnight: midnightTheme,
@@ -190,4 +311,5 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
+  paperlight: paperlightTheme,
 };


### PR DESCRIPTION
## Summary

Adds Paperlight as a built-in dashboard theme for users who prefer a high-contrast light UI.

The theme uses a warm paper background, darker text colors, and light-friendly component overrides while reusing the existing theme swatch behavior in the picker.

## Validation

- `npm run build` in `web`
- `venv/bin/python -m py_compile hermes_cli/web_server.py`
