### PR TITLE
fix(gateway): require explicit resume marker for auto-continue

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -422,18 +422,13 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
     return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
 
 
-# Only auto-continue interrupted gateway turns while the interruption is fresh.
-# Stale tool-tail/resume markers can otherwise revive an unrelated old task
-# after a gateway restart when the user's next message starts new work.
-#
-# The freshness signal is the timestamp of the last transcript row, which
-# ``hermes_state.get_messages`` carries on every persisted message.  This
-# handles the two auto-continue cases uniformly:
-#   * resume_pending (gateway restart/shutdown watchdog marked the session)
-#   * tool-tail     (last persisted message is a tool result the agent
-#                    never got to reply to)
-# In both cases "when did we last do anything on this transcript" is the
-# correct freshness question, so one signal replaces two divergent ones.
+# Only auto-continue gateway work that was explicitly marked as interrupted.
+# The trusted recovery signal is SessionEntry.last_resume_marked_at, written
+# by SessionStore.mark_resume_pending() for sessions still present in
+# GatewayRunner._running_agents after the restart/shutdown drain timeout.
+# Transcript shape (especially a trailing tool result) is intentionally NOT a
+# recovery signal: long-lived sessions can retain old unfinished history that
+# must not be revived by a later gateway restart.
 #
 # Default window: 1 hour.  This comfortably covers ``agent.gateway_timeout``
 # (30 min default) plus runtime slack — a legitimate long-running turn that
@@ -446,8 +441,9 @@ _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
     """Best-effort conversion of stored gateway timestamps to epoch seconds.
 
-    Missing/unparseable timestamps return None so legacy transcripts keep the
-    historical auto-continue behaviour instead of being silently dropped.
+    Missing/unparseable timestamps return None.  Callers that gate automatic
+    resume must treat None as stale/fail-closed unless they have an explicit
+    compatibility reason not to.
     Accepts: datetime, epoch seconds (int/float), epoch milliseconds (when
     the magnitude exceeds year-2286), ISO-8601 strings (with or without a
     trailing ``Z``), and numeric strings.
@@ -483,9 +479,8 @@ def _auto_continue_freshness_window() -> float:
     Reads ``HERMES_AUTO_CONTINUE_FRESHNESS`` (bridged from
     ``config.yaml`` ``agent.gateway_auto_continue_freshness`` at gateway
     startup, same pattern as ``HERMES_AGENT_TIMEOUT``).  Falls back to the
-    module default when unset or malformed.  Non-positive values disable
-    the freshness gate (restores the pre-fix "always fresh" behaviour for
-    users who want to opt out).
+    module default when unset or malformed.  Non-positive values disable only
+    the marker age gate; a session still needs an explicit resume marker.
     """
     raw = os.environ.get("HERMES_AUTO_CONTINUE_FRESHNESS")
     if raw is None or raw == "":
@@ -519,22 +514,22 @@ def _is_fresh_gateway_interruption(
 ) -> bool:
     """Return True when an interruption marker is fresh enough to auto-continue.
 
-    Unknown timestamps are treated as fresh for backward compatibility with
-    legacy transcripts (pre-dating timestamp persistence) and with in-memory
-    test scaffolding that constructs history entries without timestamps.
+    Unknown timestamps are treated as stale.  This is deliberate fail-closed
+    behaviour: if the gateway cannot prove when it explicitly marked a
+    running session as interrupted, it must not auto-continue old work.
 
-    A non-positive ``window_secs`` disables the gate (always fresh), which
-    restores the pre-fix behaviour for users who opt out via config.
+    A non-positive ``window_secs`` disables the age gate, but not the explicit
+    marker requirement; malformed/missing marker timestamps still fail closed.
     """
+    timestamp = _coerce_gateway_timestamp(value)
+    if timestamp is None:
+        return False
     window = (
         float(window_secs)
         if window_secs is not None
         else float(_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT)
     )
     if window <= 0:
-        return True
-    timestamp = _coerce_gateway_timestamp(value)
-    if timestamp is None:
         return True
     current = time.time() if now is None else now
     return current - timestamp <= window
@@ -731,9 +726,9 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
     Skips metadata-only rows (``session_meta``, system injections) that are
-    dropped before being handed to the agent.  Returns ``None`` when no
-    usable row carries a timestamp — callers should treat that as "fresh"
-    for backward compatibility.
+    dropped before being handed to the agent.  This helper is intentionally
+    not used as an automatic-resume signal; transcript recency is not proof
+    that a gateway restart interrupted the current turn.
     """
     if not history:
         return None
@@ -4740,8 +4735,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         now = datetime.now()
         scheduled = 0
         for entry in candidates:
-            marker = entry.last_resume_marked_at or entry.updated_at
-            if marker is not None and (now - marker).total_seconds() > window:
+            if not _is_fresh_gateway_interruption(
+                entry.last_resume_marked_at,
+                now=now.timestamp(),
+                window_secs=window,
+            ):
                 continue
 
             # Already being resumed (e.g. scheduled at startup and still
@@ -14683,50 +14681,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _msn:
                 message = _msn + "\n\n" + message
 
-            # Auto-continue: if the loaded history ends with a tool result,
-            # the previous agent turn was interrupted mid-work (gateway
-            # restart, crash, SIGTERM).  Prepend a system note so the model
-            # finishes processing the pending tool results before addressing
-            # the user's new message.  (#4493)
+            # Auto-continue: only a session explicitly marked resume_pending
+            # by gateway restart/shutdown drain handling can prepend a system
+            # note that asks the model to finish interrupted work before
+            # addressing the user's new message.
             #
-            # Session-level resume_pending (set on drain-timeout shutdown)
-            # escalates the wording — the transcript's last role may be
-            # anything (tool, assistant with unfinished work, etc.), so we
-            # give a stronger, reason-aware instruction that subsumes the
-            # tool-tail case.
+            # Only a session-level resume_pending marker set by the gateway
+            # restart/shutdown watchdog is allowed to auto-continue, and even
+            # that marker must be fresh.  A bare tool tail remains in history
+            # for context, but no longer overrides the user's new message.
             #
-            # Freshness gate (#16802): both branches are gated on the age
-            # of the last persisted transcript row.  That is the correct
-            # "when did we last do anything here" signal for both the
-            # resume_pending path (restart watchdog) and the tool-tail
-            # path (in-flight tool loop killed).  We read ``history[-1]``
-            # here because ``agent_history`` has already stripped the
-            # ``timestamp`` field off tool/tool_call rows for API purity
-            # (see the `k != "timestamp"` filter above).  Rows without a
-            # timestamp (legacy transcripts) are treated as fresh so the
-            # historical auto-continue behaviour is preserved.
+            # Freshness reads the explicit marker timestamp written by
+            # SessionStore.mark_resume_pending().  Do not use transcript
+            # timestamps here: a long-lived chat can contain old tool-tail or
+            # abandoned work that should not become the restart recovery target.
             _freshness_window = _auto_continue_freshness_window()
-            _interruption_is_fresh = _is_fresh_gateway_interruption(
-                _last_transcript_timestamp(history),
-                window_secs=_freshness_window,
-            )
-
             _resume_entry = None
             if session_key:
                 try:
                     _resume_entry = self.session_store._entries.get(session_key)
                 except Exception:
                     _resume_entry = None
-            _is_resume_pending = bool(
+            _has_resume_pending = bool(
                 _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
-                and _interruption_is_fresh
             )
-            _has_fresh_tool_tail = bool(
-                agent_history
-                and agent_history[-1].get("role") == "tool"
-                and _interruption_is_fresh
+            _resume_marker_is_fresh = (
+                _is_fresh_gateway_interruption(
+                    getattr(_resume_entry, "last_resume_marked_at", None),
+                    window_secs=_freshness_window,
+                )
+                if _has_resume_pending
+                else False
             )
+            if _has_resume_pending and not _resume_marker_is_fresh and session_key:
+                try:
+                    self.session_store.clear_resume_pending(session_key)
+                except Exception as _e:
+                    logger.debug(
+                        "clear stale resume_pending failed for %s: %s",
+                        session_key[:20], _e,
+                    )
+            _is_resume_pending = _has_resume_pending and _resume_marker_is_fresh
 
             if _is_resume_pending:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
@@ -14747,16 +14743,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"user is asking now.]\n\n"
                     + message
                 )
-            elif _has_fresh_tool_tail:
-                _persist_user_message_override = message
-                message = (
-                    "[System note: A new message has arrived. The conversation "
-                    "history contains pending tool outputs from an interrupted turn. "
-                    "IGNORE those pending results. Address the user's NEW message "
-                    "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-                    + message
-                )
-
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same
             # queue pattern as CLI: prepend to the NEXT user message, then

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -902,18 +902,19 @@ DEFAULT_CONFIG = {
         # bot is dead and /restart.
         "gateway_notify_interval": 180,
         # Freshness window for the gateway auto-continue note (seconds).
-        # After a gateway crash/restart/SIGTERM mid-run, the next user
-        # message gets a "[System note: your previous turn was
+        # After a gateway restart/SIGTERM mid-run, sessions explicitly
+        # marked resume_pending get a "[System note: your previous turn was
         # interrupted — process the unfinished tool result(s) first]"
         # prepended so the model picks up where it left off.  That's the
-        # right behaviour while the interruption is fresh, but stale
-        # markers (transcript last touched hours or days ago) can revive
-        # an unrelated old task when the user's next message starts new
-        # work.  This window is the max age of the last persisted
-        # transcript row for which we still inject the continue note.
-        # Default 3600s comfortably covers a long turn (gateway_timeout
-        # default is 1800s) plus runtime slack.  Set to 0 to disable the
-        # gate and restore pre-fix behaviour (always inject).
+        # right behaviour while the marker is fresh, but stale markers can
+        # revive an unrelated old task when the user's next message starts
+        # new work.  This window is the max age of the explicit
+        # last_resume_marked_at marker for which we still inject the
+        # continue note.  A bare trailing tool result is not a resume
+        # marker.  Default 3600s comfortably covers a long turn
+        # (gateway_timeout default is 1800s) plus runtime slack.  Set to 0
+        # to disable only the marker age gate; an explicit marker is still
+        # required.
         "gateway_auto_continue_freshness": 3600,
         # How user-attached images are presented to the main model on each turn.
         #   "auto"   — attach natively when the active model reports

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -1,98 +1,95 @@
-"""Tests for the auto-continue feature (#4493 / #45232).
+"""Tests for strict gateway auto-continue resume-marker behavior.
 
-When the gateway restarts mid-agent-work, the session transcript can end on a
-tool result that the agent never processed.  The auto-continue logic detects
-this and prepends an API-only system note to the next user message so the model
-does not re-execute stale interrupted tool calls before addressing new input.
+A trailing tool result alone is not sufficient to auto-continue gateway work.
+Only sessions explicitly marked ``resume_pending`` by gateway restart/shutdown
+recovery should receive the restart-resume system note.
 """
 
+from datetime import datetime
+
+from gateway.run import _is_fresh_gateway_interruption
+from gateway.session import SessionEntry
 
 
-def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
-    """Reproduce the auto-continue injection logic from _run_agent().
-
-    This mirrors the exact code in gateway/run.py so we can test the
-    detection and message transformation without spinning up a full
-    gateway runner.
-    """
-    message = user_message
-    if agent_history and agent_history[-1].get("role") == "tool":
-        message = (
-            "[System note: A new message has arrived. The conversation "
-            "history contains pending tool outputs from an interrupted turn. "
-            "IGNORE those pending results. Address the user's NEW message "
-            "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
-            + message
+def _simulate_strict_auto_continue(
+    *,
+    resume_entry: SessionEntry | None,
+    user_message: str,
+    window_secs: float = 3600,
+) -> str:
+    """Reproduce the strict resume-marker predicate from gateway/run.py."""
+    has_resume_pending = bool(
+        resume_entry is not None
+        and getattr(resume_entry, "resume_pending", False)
+    )
+    marker_is_fresh = (
+        _is_fresh_gateway_interruption(
+            getattr(resume_entry, "last_resume_marked_at", None),
+            window_secs=window_secs,
         )
-    return message
+        if has_resume_pending
+        else False
+    )
+    if has_resume_pending and marker_is_fresh:
+        return (
+            "[System note: A new message has arrived. The previous turn "
+            "was interrupted by a gateway restart. "
+            "Address the user's NEW message below FIRST. "
+            "Do NOT re-execute old tool calls — skip any unfinished "
+            "work from the conversation history and focus on what the "
+            "user is asking now.]\n\n"
+            + user_message
+        )
+    return user_message
 
 
-class TestAutoDetection:
-    """Test that trailing tool results are correctly detected."""
+def _pending_entry(*, marked_at=None) -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key="agent:main:telegram:dm:1",
+        session_id="sid",
+        created_at=now,
+        updated_at=now,
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=marked_at if marked_at is not None else now,
+    )
 
-    def test_trailing_tool_result_triggers_note(self):
-        history = [
-            {"role": "user", "content": "deploy the app"},
-            {"role": "assistant", "content": None, "tool_calls": [
-                {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}
-            ]},
-            {"role": "tool", "tool_call_id": "call_1", "content": "deployed successfully"},
-        ]
-        result = _simulate_auto_continue(history, "what happened?")
+
+class TestStrictResumeMarker:
+    def test_trailing_tool_result_without_marker_does_not_trigger_note(self):
+        result = _simulate_strict_auto_continue(
+            resume_entry=None,
+            user_message="what happened?",
+        )
+        assert result == "what happened?"
+
+    def test_explicit_resume_marker_triggers_note(self):
+        result = _simulate_strict_auto_continue(
+            resume_entry=_pending_entry(),
+            user_message="what happened?",
+        )
         assert "[System note:" in result
-        assert "interrupted" in result
+        assert "gateway restart" in result
         assert "NEW message" in result
         assert "Do NOT re-execute" in result
-        assert "what happened?" in result
+        assert result.endswith("what happened?")
 
-    def test_trailing_assistant_message_no_note(self):
-        history = [
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "Hi there!"},
-        ]
-        result = _simulate_auto_continue(history, "how are you?")
-        assert "[System note:" not in result
-        assert result == "how are you?"
+    def test_pending_entry_without_marker_timestamp_fails_closed(self):
+        entry = _pending_entry()
+        entry.last_resume_marked_at = None
+        result = _simulate_strict_auto_continue(
+            resume_entry=entry,
+            user_message="start new work",
+        )
+        assert result == "start new work"
 
-    def test_empty_history_no_note(self):
-        result = _simulate_auto_continue([], "hello")
+    def test_empty_history_no_note_without_marker(self):
+        result = _simulate_strict_auto_continue(
+            resume_entry=None,
+            user_message="hello",
+        )
         assert result == "hello"
-
-    def test_trailing_user_message_no_note(self):
-        """Shouldn't happen in practice, but ensure no false positive."""
-        history = [
-            {"role": "user", "content": "hello"},
-        ]
-        result = _simulate_auto_continue(history, "hello again")
-        assert result == "hello again"
-
-    def test_multiple_tool_results_still_triggers(self):
-        """Multiple tool calls in a row — last one is still role=tool."""
-        history = [
-            {"role": "user", "content": "search and read"},
-            {"role": "assistant", "content": None, "tool_calls": [
-                {"id": "call_1", "function": {"name": "search", "arguments": "{}"}},
-                {"id": "call_2", "function": {"name": "read", "arguments": "{}"}},
-            ]},
-            {"role": "tool", "tool_call_id": "call_1", "content": "found it"},
-            {"role": "tool", "tool_call_id": "call_2", "content": "file content here"},
-        ]
-        result = _simulate_auto_continue(history, "continue")
-        assert "[System note:" in result
-
-    def test_original_message_preserved_after_note(self):
-        """The user's actual message must appear after the system note."""
-        history = [
-            {"role": "assistant", "content": None, "tool_calls": [
-                {"id": "c1", "function": {"name": "t", "arguments": "{}"}}
-            ]},
-            {"role": "tool", "tool_call_id": "c1", "content": "done"},
-        ]
-        result = _simulate_auto_continue(history, "now do X")
-        # System note comes first, then user's message
-        note_end = result.index("]\n\n")
-        user_msg_start = result.index("now do X")
-        assert user_msg_start > note_end
 
 
 class TestInterruptedReplayFiltering:

--- a/tests/gateway/test_reload_skills_command.py
+++ b/tests/gateway/test_reload_skills_command.py
@@ -7,8 +7,8 @@ Verifies:
     human-readable diff
   * when any skills changed, a one-shot note is queued on
     ``runner._pending_skills_reload_notes[session_key]`` (the agent loop
-    consumes and clears it on the next user turn — see ``gateway/run.py``
-    near the ``_has_fresh_tool_tail`` block)
+    consumes and clears it on the next user turn near the resume-pending
+    system-note injection block)
   * the handler does NOT append to the session transcript out-of-band —
     message alternation must not be broken by a phantom user turn
 """

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -14,11 +14,10 @@ PRs #9850, #9934, #7536):
 2. ``suspended=True`` (from ``/stop`` or stuck-loop escalation) still
    wins over ``resume_pending`` — the forced-wipe path is preserved.
 
-3. The restart-resume system note injected into the next user message is
-   a superset of the existing tool-tail auto-continue note (from
-   PR #9934), using session-entry metadata rather than just transcript
-   shape so it fires even when the interrupted transcript does NOT end
-   with a ``tool`` role.
+3. The restart-resume system note injected into the next user message uses
+   session-entry metadata rather than transcript shape, so it fires for
+   explicitly marked interrupted turns and does not treat a bare trailing
+   ``tool`` role as permission to auto-continue.
 
 4. The existing ``.restart_failure_counts`` stuck-loop counter from
    PR #7536 remains the single source of escalation — no parallel
@@ -114,10 +113,9 @@ def _simulate_note_injection(
 ) -> str:
     """Mirror the note-injection logic in gateway/run.py _run_agent().
 
-    The freshness signal reads ``history[-1].timestamp`` (the raw transcript
-    row), NOT ``agent_history[-1].timestamp`` (which has been stripped).
-    Tests pass the raw ``history`` — ``agent_history`` is derived from it
-    via the real conversion if not supplied explicitly.
+    The freshness signal reads the explicit ``last_resume_marked_at`` marker
+    from the session entry.  Raw transcript timestamps and bare trailing tool
+    rows are not trusted recovery signals.
     """
     if agent_history is None:
         agent_history = _build_agent_history(history)
@@ -127,22 +125,20 @@ def _simulate_note_injection(
         if window_secs is not None
         else _auto_continue_freshness_window()
     )
-    interruption_is_fresh = _is_fresh_gateway_interruption(
-        _last_transcript_timestamp(history),
-        window_secs=window,
-    )
-
     message = user_message
-    is_resume_pending = bool(
+    has_resume_pending = bool(
         resume_entry is not None
         and getattr(resume_entry, "resume_pending", False)
-        and interruption_is_fresh
     )
-    has_fresh_tool_tail = bool(
-        agent_history
-        and agent_history[-1].get("role") == "tool"
-        and interruption_is_fresh
+    resume_marker_is_fresh = (
+        _is_fresh_gateway_interruption(
+            getattr(resume_entry, "last_resume_marked_at", None),
+            window_secs=window,
+        )
+        if has_resume_pending
+        else False
     )
+    is_resume_pending = has_resume_pending and resume_marker_is_fresh
 
     if is_resume_pending:
         reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
@@ -160,14 +156,6 @@ def _simulate_note_injection(
             f"Do NOT re-execute old tool calls — skip any unfinished "
             f"work from the conversation history and focus on what the "
             f"user is asking now.]\n\n"
-            + message
-        )
-    elif has_fresh_tool_tail:
-        message = (
-            "[System note: A new message has arrived. The conversation "
-            "history contains pending tool outputs from an interrupted turn. "
-            "IGNORE those pending results. Address the user's NEW message "
-            "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
             + message
         )
     return message
@@ -487,8 +475,8 @@ class TestResumePendingSystemNote:
         # Old tool-tail wording absent
         assert "haven't responded to yet" not in result
 
-    def test_no_resume_pending_preserves_tool_tail_note(self):
-        """Regression: the old PR #9934 tool-tail behaviour is unchanged."""
+    def test_no_resume_pending_suppresses_tool_tail_note(self):
+        """Bare tool-tail history is not enough to auto-continue."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -497,9 +485,7 @@ class TestResumePendingSystemNote:
              "timestamp": time.time()},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert result == "ping"
 
     def test_stale_resume_pending_does_not_inject_restart_note(self):
         """Old restart markers must not revive an unrelated stale task.
@@ -523,7 +509,7 @@ class TestResumePendingSystemNote:
         )
         assert result == "start a new task"
 
-    def test_fresh_tool_tail_preserves_auto_continue_note(self):
+    def test_fresh_tool_tail_without_marker_does_not_auto_continue(self):
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -536,9 +522,7 @@ class TestResumePendingSystemNote:
             },
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert result == "ping"
 
     def test_stale_tool_tail_does_not_inject_auto_continue_note(self):
         """The core bug fix: stale tool-tail must not revive a dead task.
@@ -612,8 +596,8 @@ class TestResumePendingSystemNote:
         )
         assert result == "start a new task"
 
-    def test_freshness_gate_disabled_via_zero_window(self):
-        """window_secs=0 restores pre-fix behaviour (always inject)."""
+    def test_zero_window_does_not_disable_marker_requirement(self):
+        """window_secs=0 disables age checks, not the explicit marker requirement."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -628,13 +612,10 @@ class TestResumePendingSystemNote:
         result = _simulate_note_injection(
             history, "ping", resume_entry=None, window_secs=0,
         )
-        assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert result == "ping"
 
-    def test_legacy_history_without_timestamps_still_injects(self):
-        """Transcripts predating timestamp persistence must keep the old
-        behaviour — freshness unknown → treat as fresh."""
+    def test_legacy_history_without_timestamps_does_not_inject_without_marker(self):
+        """Legacy transcript shape alone is not a trusted resume marker."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -642,9 +623,7 @@ class TestResumePendingSystemNote:
             {"role": "tool", "tool_call_id": "c1", "content": "result"},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
-        assert "pending tool outputs" in result
-        assert "Do NOT re-execute" in result
+        assert result == "ping"
 
     def test_no_note_when_nothing_to_resume(self):
         history = [
@@ -694,10 +673,10 @@ class TestFreshnessHelpers:
         assert _coerce_gateway_timestamp(False) is None
         assert _coerce_gateway_timestamp([1, 2, 3]) is None
 
-    def test_is_fresh_unknown_is_fresh(self):
-        """Legacy-compat: unknown timestamp → fresh."""
-        assert _is_fresh_gateway_interruption(None) is True
-        assert _is_fresh_gateway_interruption("not-a-timestamp") is True
+    def test_is_fresh_unknown_is_stale(self):
+        """Fail closed: missing/malformed marker timestamps are not fresh."""
+        assert _is_fresh_gateway_interruption(None) is False
+        assert _is_fresh_gateway_interruption("not-a-timestamp") is False
 
     def test_is_fresh_window_bounds(self):
         now = 1_700_000_000.0
@@ -961,6 +940,32 @@ async def test_startup_auto_resume_skips_stale_entries():
         last_resume_marked_at=stale_marker,
     )
     runner.session_store._entries = {stale_entry.session_key: stale_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_requires_explicit_marker():
+    """A fresh updated_at alone must not synthesize an auto-resume turn."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="missing-marker")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:missing-marker",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=None,
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
     adapter.handle_message = AsyncMock()
 
     scheduled = runner._schedule_resume_pending_sessions()


### PR DESCRIPTION
## Summary
- Require an explicit fresh gateway resume marker before injecting the auto-continue system note after restart.
- Removes the unsafe fallback where a bare trailing tool result in the transcript could be treated as resume intent.
- Makes restart recovery fail closed: old/malformed/missing markers do not auto-continue.

## Implementation
- Auto-continue now requires both `resume_pending` and a fresh `last_resume_marked_at`.
- `gateway_auto_continue_freshness <= 0` disables marker age checks only; it does not bypass the explicit-marker requirement.
- Keeps this PR scoped to the explicit resume marker / fail-closed auto-continue behavior; no gateway prompt, cache, or personality changes are included.
- Updates gateway resume tests to cover marker freshness and the no-bare-tool-tail behavior.

## Refresh / testing
- Refreshed onto current `origin/main` in an isolated worktree and force-pushed with an exact `--force-with-lease`.
- `uv run --python 3.11 pytest -o addopts='' tests/gateway/test_auto_continue.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_reload_skills_command.py -q` — 86 passed
- Independent reviewer re-ran the focused gateway tests and found no P0/P1/P2 issues.
