### PR TITLE
fix: remove invalid exclude-newer = "7 days" from [tool.uv]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,3 @@ not-iterable = "ignore"
 
 [tool.ruff]
 exclude = ["*"]
-
-[tool.uv]
-exclude-newer = "7 days"


### PR DESCRIPTION
The relative duration string is not valid uv syntax — uv requires an absolute ISO 8601 datetime. The TOML parse error blocks fresh installs via 'uv pip install -e ".[all]"'.

A rolling relative constraint cannot be expressed in static TOML config without a pre-commit hook or release script.

Closes NousResearch#17908

---

PR #15705 proposed replacing with a hardcoded ISO date; this approach removes the line entirely (matching the fix in #17925) since neither a rolling constraint nor a static date is ideal.