### PR TITLE
feat(gateway): add MemOS bridge daemon lifecycle and reverse proxy

### DIFF
--- a/gateway/memos_daemon.py
+++ b/gateway/memos_daemon.py
@@ -1,0 +1,96 @@
+"""Async MemOS bridge daemon manager for the Hermes gateway.
+
+Wraps ``GatewayMemosManager`` from the memos-plugin (if installed) with
+lifecycle hooks for ``GatewayRunner``.
+
+    manager = MemosDaemonManager()
+    manager.ensure_running()
+    await manager.start_heartbeat()
+    ...
+    await manager.stop_heartbeat()
+    manager.stop()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MemosDaemonManager:
+    """Async lifecycle manager for the MemOS bridge subprocess."""
+
+    def __init__(self) -> None:
+        self._heartbeat_task: asyncio.Task | None = None
+        self._heartbeat_interval: float = 30.0
+
+        # Try to import from memos-plugin; graceful degrade if not installed.
+        self._inner = None
+        try:
+            # memos-plugin lives alongside hermes-agent under HERMES_HOME.
+            import os as _os
+            _hermes_home = _os.environ.get("HERMES_HOME", _os.path.expanduser("~/.hermes"))
+            _memos_path = _os.path.join(_hermes_home, "memos-plugin")
+            if _memos_path not in __import__("sys").path:
+                __import__("sys").path.insert(0, _memos_path)
+
+            from adapters.hermes.memos_provider.gateway_manager import (
+                GatewayMemosManager,
+            )
+            self._inner = GatewayMemosManager()
+        except ImportError:
+            logger.info(
+                "MemOS: memos-plugin not found. "
+                "Install via the Hermes setup wizard for local memory support."
+            )
+
+    def ensure_running(self) -> bool:
+        """Start (or confirm) the bridge daemon is running. Safe to call repeatedly."""
+        if self._inner is not None:
+            return self._inner.ensure_running()
+        return False
+
+    async def start_heartbeat(self, interval: float | None = None) -> None:
+        """Start background heartbeat that keeps the bridge alive."""
+        if self._inner is None:
+            return
+        if self._heartbeat_task is not None:
+            return
+        if interval is not None:
+            self._heartbeat_interval = interval
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        logger.info(
+            "MemOS: heartbeat started (interval=%ss)",
+            self._heartbeat_interval,
+        )
+
+    async def stop_heartbeat(self) -> None:
+        """Cancel the heartbeat task."""
+        task, self._heartbeat_task = self._heartbeat_task, None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    def stop(self) -> None:
+        """Gracefully shut down the bridge subprocess."""
+        if self._inner is not None:
+            self._inner.shutdown()
+            logger.info("MemOS: bridge daemon shut down")
+
+    async def _heartbeat_loop(self) -> None:
+        """Periodic loop that keeps the bridge alive."""
+        try:
+            while True:
+                await asyncio.sleep(self._heartbeat_interval)
+                try:
+                    if self._inner is not None:
+                        self._inner.ensure_running()
+                except Exception:
+                    logger.exception("MemOS: heartbeat ensure_running failed")
+        except asyncio.CancelledError:
+            pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -37,11 +37,13 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 try:
-    from aiohttp import web
+    from aiohttp import web, ClientSession, ClientTimeout
     AIOHTTP_AVAILABLE = True
 except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
+    ClientSession = None  # type: ignore[assignment]
+    ClientTimeout = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -2764,6 +2766,60 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._run_statuses.pop(run_id, None)
 
     # ------------------------------------------------------------------
+    # Memos webUI reverse proxy
+    # ------------------------------------------------------------------
+
+    _memos_target = "http://127.0.0.1:18902"
+    _memos_fallback = "http://127.0.0.1:18901"
+
+    async def _handle_memos_proxy(self, request: "web.Request") -> "web.StreamResponse":
+        """Reverse proxy to MemOS local viewer (port 18902, fallback 18901)."""
+        timeout = ClientTimeout(total=30, connect=5)
+
+        # Strip the /memos route prefix so the backend receives clean paths.
+        path_and_query = request.path_qs
+        if path_and_query.startswith("/memos"):
+            path_and_query = path_and_query[len("/memos"):] or "/"
+
+        last_error = None
+        for target in (self._memos_target, self._memos_fallback):
+            target_url = f"{target}{path_and_query}"
+            try:
+                async with ClientSession(timeout=timeout) as session:
+                    headers = {k: v for k, v in request.headers.items()
+                               if k.lower() not in ("host", "content-length")}
+                    body = await request.read() if request.method in ("POST", "PUT", "PATCH") else None
+
+                    async with session.request(
+                        request.method, target_url,
+                        headers=headers, data=body,
+                        allow_redirects=True,
+                    ) as upstream:
+                        resp = web.StreamResponse(
+                            status=upstream.status,
+                            headers={
+                                k: v for k, v in upstream.headers.items()
+                                if k.lower() not in ("transfer-encoding", "content-encoding")
+                            },
+                        )
+                        resp.headers.setdefault("Access-Control-Allow-Origin", "*")
+                        await resp.prepare(request)
+                        async for chunk in upstream.content.iter_chunked(65536):
+                            await resp.write(chunk)
+                        await resp.write_eof()
+                        return resp
+            except Exception as e:
+                last_error = e
+                continue
+
+        logger.debug("Memos proxy failed: %s", last_error, exc_info=True)
+        return web.Response(
+            status=502,
+            text="Memos viewer is not running. The gateway heartbeat will restart it shortly.\n"
+                 "If this persists, check that ~/.hermes/memos-plugin is installed correctly.",
+        )
+
+    # ------------------------------------------------------------------
     # BasePlatformAdapter interface
     # ------------------------------------------------------------------
 
@@ -2800,6 +2856,9 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
+            # Memos webUI reverse proxy — proxies /memos/* to the local viewer
+            self._app.router.add_route("*", "/memos/{tail:.*}", self._handle_memos_proxy)
+            self._app.router.add_route("*", "/memos/api/{tail:.*}", self._handle_memos_proxy)
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -999,6 +999,10 @@ class GatewayRunner:
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
 
+        # MemOS bridge daemon (TCP mode — serves viewer + memory provider)
+        from gateway.memos_daemon import MemosDaemonManager
+        self._memos_daemon = MemosDaemonManager()
+
 
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
         """Warn when Docker-backed gateways lack an explicit export mount.
@@ -2766,6 +2770,11 @@ class GatewayRunner:
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
+        # Start MemOS daemon and heartbeat (ensures viewer is available)
+        if hasattr(self, "_memos_daemon"):
+            self._memos_daemon.ensure_running()
+            await self._memos_daemon.start_heartbeat()
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -3615,6 +3624,12 @@ class GatewayRunner:
                     continue
                 _task.cancel()
             self._background_tasks.clear()
+
+            # Stop MemOS daemon heartbeat and gracefully shut down the daemon
+            _memos = getattr(self, "_memos_daemon", None)
+            if _memos is not None:
+                await _memos.stop_heartbeat()
+                _memos.stop()
 
             self.adapters.clear()
             self._running_agents.clear()


### PR DESCRIPTION
## Summary

Adds optional MemOS/Memos local memory plugin lifecycle management to the
Hermes Gateway:

- **gateway/memos_daemon.py**: Async daemon manager with heartbeat loop,
  wraps memos-plugin's GatewayMemosManager when the plugin is installed
- **api_server.py**: Reverse proxy for MemOS webUI at
  `/memos/*` and `/memos/api/*` routes (18902 -> 18901 port fallback)
- **run.py**: GatewayRunner lifecycle hooks (init -> start -> stop)

## Design decisions

- **Graceful degrade**: When memos-plugin is not installed, all operations
  are no-ops with a single INFO log line. No crashes, no tracebacks.
- **Power-safe**: Uses `getattr` guard in run.py stop() so older checkouts
  without the `_memos_daemon` attribute don't break.
- **Async-friendly**: Heartbeat is a pure `asyncio.sleep` loop — no
  blocking calls. Underlying subprocess management is delegated to
  memos-plugin's `daemon_manager.py`.
- **Precise routing**: Only `/memos/*` and `/memos/api/*` are proxied.
  No broad `/api/*` wildcard that could shadow future routes.

## Testing

- Verified graceful degrade: import succeeds and returns False when
  memos-plugin is absent
- Syntax checked all three modified files
- 3 files changed, 164 insertions(+), 1 deletion(-)

## Related

Depends on memos-plugin PR (MemTensor/MemOS) adding `GatewayMemosManager`
to `adapters/hermes/memos_provider/gateway_manager.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)