### PR TITLE
fix(discord): close stale client before reconnect to prevent zombie websocket (#18187)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -608,6 +608,20 @@ class DiscordAdapter(BasePlatformAdapter):
             if proxy_url:
                 logger.info("[%s] Using proxy for Discord: %s", self.name, proxy_url)
 
+            # Close any existing client before creating a new one.  On
+            # reconnect connect() is called again; without this guard the old
+            # websocket stays alive long enough for Discord to deliver each
+            # inbound event twice — once to the orphaned client and once to
+            # the new one — causing duplicate agent turns (#18187).
+            if self._client is not None and not self._client.is_closed():
+                logger.debug("[%s] Closing existing Discord client before reconnect", self.name)
+                try:
+                    await self._client.close()
+                except Exception:  # noqa: BLE001
+                    pass
+            self._client = None
+            self._ready_event.clear()
+
             # Create bot — proxy= for HTTP, connector= for SOCKS.
             # allowed_mentions is set with safe defaults (no @everyone/roles)
             # so LLM output or echoed user content can't ping the whole


### PR DESCRIPTION
## Problem

On gateway restart or adapter reconnect, `connect()` created a new `commands.Bot` instance without closing the previous one. Discord's gateway does not immediately terminate an orphaned websocket — both the old and new client remain live for a window of time. During that window, every inbound event is delivered to **both** connections independently.

`MessageDeduplicator` cannot prevent this because the two `on_message` coroutines may check `is_duplicate` before either has marked the ID as seen (race condition). The result: two separate agent turns are spawned per message, each producing a different response.

With `auto_thread: true` this is especially visible: one response lands in the thread (correct path) and a second response lands in the parent channel (incorrect path).

## Fix

Before instantiating a new `commands.Bot`, await the old client's `close()` if it is not already closed, then clear `_ready_event`:

```python
if self._client is not None and not self._client.is_closed():
    await self._client.close()
self._client = None
self._ready_event.clear()
```

This mirrors the guard already present in `disconnect()` (~line 779) and ensures only one Discord websocket is ever active for the adapter at any time.

## Testing

- Gateway restart no longer produces double responses in any channel configuration
- `auto_thread` mode: only one response appears in the thread, no response leaks to the parent channel
- Single `connect()` call on first start: no change in behavior (`self._client` is `None`, guard is a no-op)

Closes #18187