### PR TITLE
fix(config): make ~/.hermes/.env authoritative over os.environ in get_env_value (#18254)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4355,14 +4355,27 @@ def reload_env() -> int:
 
 
 def get_env_value(key: str) -> Optional[str]:
-    """Get a value from ~/.hermes/.env or environment."""
-    # Check environment first
-    if key in os.environ:
-        return os.environ[key]
-    
-    # Then check .env file
+    """Get a value from ~/.hermes/.env or environment.
+
+    ``~/.hermes/.env`` is checked **first** so that changes made there after
+    the process has started (e.g. replacing a stale API key) are picked up on
+    the next load rather than being shadowed by a potentially stale value that
+    a parent shell process exported into ``os.environ`` at launch time.
+
+    ``os.environ`` is used as a fallback so that CI/CD pipelines and Docker
+    environments that inject keys purely via environment variables continue to
+    work unchanged.  The only scenario where the old behaviour differed is
+    when a key exists in **both** sources; ``~/.hermes/.env`` now wins in that
+    case, which matches the documented intent of the file being the
+    authoritative Hermes secrets store (#18254).
+    """
+    # ~/.hermes/.env is the authoritative source; check it first.
     env_vars = load_env()
-    return env_vars.get(key)
+    if key in env_vars:
+        return env_vars[key]
+
+    # Fall back to the process environment for CI/Docker/shell-injected keys.
+    return os.environ.get(key)
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

`get_env_value()` checked `os.environ` first, then fell back to `~/.hermes/.env`. If a parent process (Codex CLI, a test script, the user's shell) had exported a stale API key, that value shadowed the correct key in `.env`. The credential pool then cached the stale token in `auth.json` and never re-read `.env`, resulting in persistent 401 errors:

```
# Before: os.environ takes priority
if key in os.environ:
    return os.environ[key]   # stale value from shell wins
env_vars = load_env()
return env_vars.get(key)
```

This is counterintuitive — users expect that editing `~/.hermes/.env` and restarting the gateway will pick up the new key. It doesn't when the old key is still exported in the environment.

## Fix

Reverse the priority: check `~/.hermes/.env` first, fall back to `os.environ`:

```python
env_vars = load_env()
if key in env_vars:
    return env_vars[key]        # .env wins — authoritative secrets store
return os.environ.get(key)      # fallback for CI/Docker injection
```

## Compatibility

- **CI/CD and Docker** environments that inject keys **only** via `os.environ` (nothing in `.env`): **no change** — the fallback path is hit as before.
- **Local development** with a `.env` file and a stale shell export: `.env` now wins, which is the correct and expected behavior.
- **`reload_env()`**: existing reload logic is unaffected; it operates on `os.environ` directly and is orthogonal to this change.

Closes #18254