### PR TITLE
fix(tui): end_session on finalize to prevent ghost sessions in /resume (#18269)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -280,7 +280,7 @@ def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
         pass
 
 
-def _finalize_session(session: dict | None) -> None:
+def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> None:
     """Best-effort finalize hook + memory commit for a session."""
     if not session or session.get("_finalized"):
         return
@@ -301,6 +301,18 @@ def _finalize_session(session: dict | None) -> None:
 
     session_id = getattr(agent, "session_id", None) or session.get("session_key")
     _notify_session_boundary("on_session_finalize", session_id)
+
+    # Mark the session as ended in the DB so it does not appear as an orphaned
+    # open entry in /resume.  CLI already does this in end_session() calls;
+    # TUI was missing equivalent end_session() coverage (#18269).
+    key = session.get("session_key")
+    if key:
+        try:
+            db = _get_db()
+            if db is not None:
+                db.end_session(key, end_reason)
+        except Exception:
+            pass
 
 
 def _shutdown_sessions() -> None:


### PR DESCRIPTION
## Problem

TUI sessions were eagerly persisted to `state.db` via `db.create_session()` inside `_start_agent_build()/_build()`, but `db.end_session()` was **never** called when a TUI session closed. All three close paths converge on `_finalize_session()`:

| Path | Code |
|------|------|
| Normal quit / `/quit` | `session.close` RPC → `_finalize_session(session)` |
| Ctrl+C | `atexit` → `_shutdown_sessions()` → `_finalize_session(session)` |
| `/new` (new session within TUI) | Eventually also goes through finalize |

`_finalize_session()` committed memory and fired hooks but never called `db.end_session()`. Every session row therefore accumulated with `ended_at = NULL` and appeared as a resumable entry in `/resume`.

On one user's install: **24 out of 52 TUI sessions (46%) were ghost rows** with `message_count = 0`.

## Fix

Add `db.end_session(key, end_reason)` at the end of `_finalize_session()`:

```python
key = session.get("session_key")
if key:
    db = _get_db()
    if db is not None:
        db.end_session(key, end_reason)
```

This mirrors how the CLI handles session lifecycle — `cli.py` already calls `end_session()` on `/new` and quit. A default `end_reason="tui_close"` is added so the audit trail matches CLI conventions.

## No risk to existing sessions

`db.end_session()` is a no-op when `ended_at` is already set (see `hermes_state.py:547`):

```sql
UPDATE sessions SET ended_at = ?, end_reason = ?
WHERE id = ? AND ended_at IS NULL   -- ← no-op for already-ended sessions
```

So sessions that are ended through other paths (e.g. compression, `/branch`) won't be double-ended.

## Verification



Closes #18269