### PR TITLE
fix(kanban): share board path with worker profiles

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1,8 +1,8 @@
 """SQLite-backed Kanban board for multi-profile collaboration.
 
-The board lives at ``$HERMES_HOME/kanban.db`` (profile-agnostic on purpose:
-multiple profiles on the same machine all see the same board, which IS the
-coordination primitive).
+The board lives at ``$HERMES_HOME/kanban.db`` by default. Dispatchers pass
+``HERMES_KANBAN_DB`` to worker profiles so multiple profiles on the same
+machine all see the same board, which IS the coordination primitive.
 
 Schema is intentionally small: tasks, task_links, task_comments,
 task_events.  The ``workspace_kind`` field decouples coordination from git
@@ -62,7 +62,15 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
+    """Return the path to the shared kanban database.
+
+    ``HERMES_KANBAN_DB`` lets a dispatcher launched from one profile pin the
+    board path before spawning worker profiles, so profile-local HERMES_HOME
+    values do not split the board.
+    """
+    override = os.environ.get("HERMES_KANBAN_DB")
+    if override:
+        return Path(override).expanduser().resolve()
     from hermes_constants import get_hermes_home
     return get_hermes_home() / "kanban.db"
 
@@ -2070,6 +2078,7 @@ def _default_spawn(task: Task, workspace: str) -> Optional[int]:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    env["HERMES_KANBAN_DB"] = str(kanban_db_path())
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -200,6 +200,8 @@ class TestSessionOps:
             "context",
             "reset",
             "compact",
+            "steer",
+            "queue",
             "version",
         ]
         model_cmd = next(

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -161,6 +161,11 @@ _teams_mod = load_plugin_adapter("teams")
 
 _teams_mod.TEAMS_SDK_AVAILABLE = True
 _teams_mod.AIOHTTP_AVAILABLE = True
+if _teams_mod.TypingActivityInput is None:
+    class _MockTypingActivityInput:
+        pass
+
+    _teams_mod.TypingActivityInput = _MockTypingActivityInput
 
 TeamsAdapter = _teams_mod.TeamsAdapter
 check_requirements = _teams_mod.check_requirements

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2215,6 +2215,7 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     env = captured["env"]
     assert env.get("HERMES_KANBAN_TASK") == tid
     assert env.get("HERMES_PROFILE") == "some-profile"
+    assert env.get("HERMES_KANBAN_DB") == str(kanban_home / "kanban.db")
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -38,6 +38,21 @@ def test_init_db_is_idempotent(kanban_home):
     assert tasks[0].title == "persisted"
 
 
+def test_kanban_db_path_honors_shared_override(tmp_path, monkeypatch):
+    shared_db = tmp_path / ".hermes" / "kanban.db"
+    profile_home = tmp_path / ".hermes" / "profiles" / "market-advisor"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(shared_db))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert kb.kanban_db_path() == shared_db.resolve()
+    kb.init_db()
+
+    assert shared_db.exists()
+    assert not (profile_home / "kanban.db").exists()
+
+
 def test_init_creates_expected_tables(kanban_home):
     with kb.connect() as conn:
         rows = conn.execute(

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -479,8 +479,10 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
 
     # Stub web_server so _check_ws_token has a token to compare against.
     import types
+    import hermes_cli
     stub = types.SimpleNamespace(_SESSION_TOKEN="secret-xyz")
     monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
 
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -20,6 +20,7 @@ def _make_agent(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "")
     # Avoid full AIAgent init — just import the class and build a stub
     import run_agent as _ra
+    from agent.tool_guardrails import ToolCallGuardrailController
 
     class _Stub:
         _interrupt_requested = False
@@ -53,6 +54,7 @@ def _make_agent(monkeypatch):
             self._tool_worker_threads: set = set()
             self._tool_worker_threads_lock = threading.Lock()
             self._active_children_lock = threading.Lock()
+            self._tool_guardrails = ToolCallGuardrailController()
 
         def _touch_activity(self, desc):
             self._last_activity = time.time()
@@ -77,6 +79,9 @@ def _make_agent(monkeypatch):
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
     stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
     stub.clear_interrupt = _ra.AIAgent.clear_interrupt.__get__(stub)
+    stub._append_guardrail_observation = (
+        _ra.AIAgent._append_guardrail_observation.__get__(stub)
+    )
     # /steer injection (added in PR #12116) fires after every concurrent
     # tool batch. Stub it as a no-op — this test exercises interrupt
     # fanout, not steer injection.
@@ -107,7 +112,7 @@ def test_concurrent_interrupt_cancels_pending(monkeypatch):
 
     original_invoke = agent._invoke_tool
 
-    def slow_tool(name, args, task_id, call_id=None):
+    def slow_tool(name, args, task_id, call_id=None, **kwargs):
         if name == "slow_one":
             # Block until the test sets the interrupt
             barrier.wait(timeout=10)
@@ -184,7 +189,7 @@ def test_running_concurrent_worker_sees_is_interrupted(monkeypatch):
     observed = {"saw_true": False, "poll_count": 0, "worker_tid": None}
     worker_started = threading.Event()
 
-    def polling_tool(name, args, task_id, call_id=None, messages=None):
+    def polling_tool(name, args, task_id, call_id=None, messages=None, **kwargs):
         observed["worker_tid"] = threading.current_thread().ident
         worker_started.set()
         deadline = time.monotonic() + 5.0
@@ -261,4 +266,3 @@ def test_clear_interrupt_clears_worker_tids(monkeypatch):
         "clear_interrupt() did not clear the interrupt bit for a tracked "
         "worker tid — stale interrupt can leak into the next turn"
     )
-

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -86,6 +86,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_LOCAL_STT_COMMAND` | Optional local speech-to-text command template. Supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders |
 | `HERMES_LOCAL_STT_LANGUAGE` | Default language passed to `HERMES_LOCAL_STT_COMMAND` or auto-detected local `whisper` CLI fallback (default: `en`) |
 | `HERMES_HOME` | Override Hermes config directory (default: `~/.hermes`). Also scopes the gateway PID file and systemd service name, so multiple installations can run concurrently |
+| `HERMES_KANBAN_DB` | Override the Kanban SQLite board path. The dispatcher sets this for spawned profile workers so all profiles read and write the same shared board. |
 
 ## Provider Auth (OAuth)
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -243,6 +243,7 @@ Visually the target is the familiar Linear / Fusion layout: dark theme, column h
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
+<!-- ascii-guard-ignore -->
 ```
 ┌────────────────────────┐      WebSocket (tails task_events)
 │   React SPA (plugin)   │ ◀──────────────────────────────────┐
@@ -262,6 +263,7 @@ The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer wi
 │  (WAL, shared)         │
 └────────────────────────┘
 ```
+<!-- ascii-guard-ignore-end -->
 
 ### REST surface
 


### PR DESCRIPTION
## What

Fix Hermes Kanban worker profile board resolution so dispatched profile workers use the same Kanban SQLite database as the originating dispatcher profile.

Changes:
- Add `HERMES_KANBAN_DB` support in `hermes_cli.kanban_db.kanban_db_path()`.
- Pass the currently resolved Kanban DB path into spawned worker processes from `_default_spawn()`.
- Add regression coverage for profile-local `HERMES_HOME` with a shared Kanban DB override.
- Document `HERMES_KANBAN_DB` in the environment variable reference.
- Keep the existing Kanban dashboard ASCII diagram accepted by docs lint after touching website docs.
- Align stale CI test expectations with current behavior for ACP command metadata, Teams typing mocks, concurrent interrupt test scaffolding, and Kanban dashboard websocket token stubbing.

## Why

Kanban is documented as a shared multi-profile board, but spawned workers run under `hermes -p <assignee>`, which changes `HERMES_HOME` to the assignee profile directory. Before this fix, Kanban tools inside the worker resolved `kanban.db` from the worker profile home, for example:

- default profile: `~/.hermes/kanban.db`
- worker profile: `~/.hermes/profiles/<profile>/kanban.db`

That split the board and made `kanban_show()` / `kanban_complete()` unable to see tasks assigned from the default profile.

## Developer Impact

The dispatcher now pins the board path at spawn time and workers inherit it through `HERMES_KANBAN_DB`. Direct Kanban usage without the override still falls back to the existing default path, `get_hermes_home() / "kanban.db"`, so existing single-profile behavior is preserved.

The follow-up test changes do not alter runtime behavior. They update stale test scaffolding that was already out of sync with current code paths and became visible in CI on this branch.

## How To Test

Ran the focused Kanban regression tests with the repo wrapper:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py::test_kanban_db_path_honors_shared_override tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_auto_loads_kanban_worker_skill
```

Result:

```text
2 passed
```

Ran the previously failing CI nodes plus Kanban regressions:

```bash
scripts/run_tests.sh tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update tests/gateway/test_teams.py::TestTeamsSend::test_send_typing tests/run_agent/test_concurrent_interrupt.py::test_concurrent_interrupt_cancels_pending tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required tests/plugins/test_kanban_dashboard_plugin.py::test_bulk_empty_ids_400 tests/hermes_cli/test_kanban_db.py::test_kanban_db_path_honors_shared_override tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_auto_loads_kanban_worker_skill
```

Result:

```text
8 passed
```

GitHub checks are passing on this PR:

- `test`
- `docs-site-checks`
- `e2e`
- `nix (macos-latest)`
- `nix (ubuntu-latest)`
- `check-attribution`
- supply-chain scan

## Platforms Tested

- macOS local checkout
- GitHub Actions PR checks

## Docs

Updated `website/docs/reference/environment-variables.md` to include `HERMES_KANBAN_DB`. Existing CLI docs already describe Kanban as a shared multi-profile board, so no CLI behavior doc change was needed.

Also marked the existing Kanban dashboard ASCII diagram as intentionally allowed for `ascii-guard`, because touching `website/**` runs docs lint in CI.