### PR TITLE
fix(config): prefer Z.AI /api/anthropic endpoint over /api/paas/v4

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -209,7 +209,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="zai",
         name="Z.AI / GLM",
         auth_type="api_key",
-        inference_base_url="https://api.z.ai/api/paas/v4",
+        inference_base_url="https://api.z.ai/api/anthropic",
         api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         base_url_env_var="GLM_BASE_URL",
     ),
@@ -554,10 +554,14 @@ def _resolve_api_key_provider_secret(
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
-    ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
-    ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
+    # Try /api/anthropic endpoints first (Anthropic protocol, more lenient limits)
+    ("global-anthropic",  "https://api.z.ai/api/anthropic",        ["glm-5"],   "Global (Anthropic)"),
+    ("cn-anthropic",      "https://open.bigmodel.cn/api/anthropic", ["glm-5"],   "China (Anthropic)"),
     ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
     ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    # Fallback to /api/paas/v4 endpoints (OpenAI-compatible, independent quota limits)
+    ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global (OpenAI-compat)"),
+    ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China (OpenAI-compat)"),
 ]
 
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -120,7 +120,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
-        assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
+        assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/anthropic"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["stepfun"].inference_base_url == STEPFUN_STEP_PLAN_INTL_BASE_URL
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
@@ -129,6 +129,35 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.gmi-serving.com/v1"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
+
+    def test_zai_anthropic_endpoint_preferred(self):
+        """Verify Z.AI defaults to /api/anthropic endpoint (issue #18302).
+        
+        The /api/anthropic endpoint has more lenient quota limits compared to
+        /api/paas/v4. By trying /api/anthropic first, we avoid
+        misleading 429 "insufficient balance" errors.
+        """
+        from hermes_cli.auth import ZAI_ENDPOINTS
+        
+        # Verify /api/anthropic endpoints come before /api/paas/v4
+        anthropic_indices = [
+            i for i, (_, base_url, _, _) in enumerate(ZAI_ENDPOINTS)
+            if "/api/anthropic" in base_url
+        ]
+        paas_indices = [
+            i for i, (_, base_url, _, _) in enumerate(ZAI_ENDPOINTS)
+            if "/api/paas/v4" in base_url
+        ]
+        
+        assert len(anthropic_indices) == 2, "Should have 2 /api/anthropic endpoints"
+        assert len(paas_indices) == 2, "Should have 2 /api/paas/v4 endpoints"
+        
+        # All anthropic indices should be less than all paas indices
+        assert all(a < min(paas_indices) for a in anthropic_indices), \
+            "/api/anthropic endpoints should be probed before /api/paas/v4"
+        
+        # Verify the default inference_base_url uses /api/anthropic
+        assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/anthropic"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""
@@ -410,7 +439,7 @@ class TestResolveApiKeyProviderCredentials:
         creds = resolve_api_key_provider_credentials("zai")
         assert creds["provider"] == "zai"
         assert creds["api_key"] == "glm-secret-key"
-        assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+        assert creds["base_url"] == "https://api.z.ai/api/anthropic"
         assert creds["source"] == "GLM_API_KEY"
 
     def test_resolve_copilot_with_github_token(self, monkeypatch):
@@ -602,7 +631,7 @@ class TestRuntimeProviderResolution:
         from hermes_cli.runtime_provider import resolve_runtime_provider
         result = resolve_runtime_provider(requested="zai")
         assert result["provider"] == "zai"
-        assert result["api_mode"] == "chat_completions"
+        assert result["api_mode"] == "anthropic_messages"
         assert result["api_key"] == "glm-key"
         assert "z.ai" in result["base_url"] or "api.z.ai" in result["base_url"]
 
@@ -976,7 +1005,7 @@ class TestKimiCodeCredentialAutoDetect:
         monkeypatch.setenv("GLM_API_KEY", "sk-kim...isnt")
         monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)
         creds = resolve_api_key_provider_credentials("zai")
-        assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+        assert creds["base_url"] == "https://api.z.ai/api/anthropic"
 
 
 class TestZaiEndpointAutoDetect:
@@ -1000,7 +1029,7 @@ class TestZaiEndpointAutoDetect:
         monkeypatch.setenv("GLM_API_KEY", "glm-key")
         monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)
         creds = resolve_api_key_provider_credentials("zai")
-        assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+        assert creds["base_url"] == "https://api.z.ai/api/anthropic"
 
     def test_env_override_skips_probe(self, monkeypatch):
         """GLM_BASE_URL should always win without probing."""


### PR DESCRIPTION
## What does this PR do?

Prefer Z.AI `/api/anthropic` endpoint over `/api/paas/v4` to avoid misleading 429 errors for Zhipu GLM API users.


### Root Cause

The Zhipu GLM API provides two endpoint protocols:
1. `/api/paas/v4` - OpenAI-compatible endpoint with independent quota limits
2. `/api/anthropic` - Anthropic native protocol endpoint with more lenient limits

Hermes was defaulting to `/api/paas/v4`, which returns HTTP 429 with error code 1113 ("insufficient balance") for certain accounts. The error message is misleading - it's actually an endpoint quota limit, not an account balance issue. The same API key works fine when using the `/api/anthropic` endpoint.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A