### PR TITLE
fix(bluebubbles): IPv4 webhook URL + drop duplicate updated-message subscription

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -219,10 +219,28 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     @property
     def _webhook_url(self) -> str:
-        """Compute the external webhook URL for BlueBubbles registration."""
+        """Compute the external webhook URL for BlueBubbles registration.
+
+        Use the IPv4 loopback literal (``127.0.0.1``) for any address that
+        means "the local host". On macOS (and modern Linux), ``localhost``
+        resolves to BOTH ``127.0.0.1`` AND ``::1`` via /etc/hosts; HTTP
+        clients (including BB's axios) often try IPv6 first. Since the
+        webhook listener below is started with ``aiohttp.web.TCPSite`` bound
+        to whatever was supplied (typically ``127.0.0.1`` — IPv4 only), BB
+        hits ECONNREFUSED on ``::1:<port>`` and never retries on IPv4.
+
+        Symptom in BB Server log:
+            [WebhookService] Failed to dispatch "new-message" event to webhook:
+            http://localhost:<port>/...
+              -> Error: connect ECONNREFUSED ::1:<port>
+
+        Fix: rewrite all loopback-equivalent forms to ``127.0.0.1`` so the
+        URL registered with BB is unambiguously IPv4 and matches the bind
+        address aiohttp uses.
+        """
         host = self.webhook_host
-        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
-            host = "localhost"
+        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::", "::1"):
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -289,9 +289,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
             return True
 
+        # Subscribe to ``new-message`` only. BB fires both ``new-message`` and
+        # ``updated-message`` for every iMessage (the latter for delivery
+        # confirmations + edits + read receipts), causing the agent to be
+        # invoked twice and reply twice per inbound message. Until edit
+        # handling is implemented separately, ``new-message`` alone is the
+        # right primary trigger.
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message"],
+            "events": ["new-message"],
         }
 
         try:


### PR DESCRIPTION
## Summary

Two related BlueBubbles webhook bugs that together cause silent inbound-message loss on macOS, AND duplicate agent replies when messages do come through. Bundled because they're encountered as a single end-user symptom (BB→hermes flow misbehaves) and reasoning about one informs the other.

## Bug 1 — IPv4 webhook URL (commit 1)

On dual-stack systems (macOS by default; modern Linux often), `localhost` resolves to **both** `127.0.0.1` AND `::1` via `/etc/hosts`. HTTP clients — including BB Server's axios — try IPv6 first.

`gateway/platforms/bluebubbles.py:_webhook_url` rewrites the operator-supplied `BLUEBUBBLES_WEBHOOK_HOST` (typically `127.0.0.1`) to `localhost` when constructing the URL it registers with BB. The webhook listener is started with `aiohttp.web.TCPSite(host=self.webhook_host, ...)` — bound to `127.0.0.1` only (IPv4). BB POSTs hit `ECONNREFUSED ::1:<port>` and **never retry on IPv4**.

**Result: silent inbound-message loss.** BB stores the iMessage and fires the webhook, but hermes never sees it.

BB Server log smoking gun:
```
[WebhookService] Dispatching event to webhook: http://localhost:8765/bluebubbles/webhook?password=...
[WebhookService] Failed to dispatch "new-message" event to webhook
  -> Error: connect ECONNREFUSED ::1:8765
```

**Fix**: rewrite all loopback-equivalent forms (added `::1`) to `127.0.0.1` instead of `localhost`. The URL registered with BB is then unambiguously IPv4 and matches the bind address aiohttp uses.

## Bug 2 — Duplicate webhook subscription causes 2× agent replies (commit 2)

BB fires **both** `new-message` AND `updated-message` events for every inbound iMessage; the latter covers delivery confirmations, read receipts, and message edits. For typical messages the two fire near-simultaneously.

Hermes' `_MESSAGE_EVENTS` (line 57) includes `"updated-message"`, so the handler treats both as agent-invocation triggers. **Result: agent invoked twice, replies twice** per actual inbound iMessage.

BB Server log evidence:
```
[WebhookService] Dispatching event ... 01:50:42.466
[WebhookService] Dispatching event ... 01:50:42.466    <-- same millisecond
[WebhookService] Dispatching event ... 01:50:45.647
[WebhookService] Dispatching event ... 01:50:45.647    <-- same millisecond
```

End-user sees the bot send the same reply twice in iMessage.

**Fix**: register webhook with `["new-message"]` only. Operators wanting edit-handling can register a second webhook manually via BB API (or this can be added later as a separate feature with proper dedup against the originating `new-message`).

## Reproducer (both bugs)

- macOS 26.4.1 (Tahoe) Apple Silicon
- BlueBubbles Server 1.9.9 with Private API + Helper enabled
- `BLUEBUBBLES_WEBHOOK_HOST=127.0.0.1` (default behavior)

Send any iMessage to the BB-bound Apple ID:
- **Before either fix**: BB log shows `ECONNREFUSED ::1:<port>`, hermes log shows nothing, no reply on phone
- **After Bug 1 only**: BB log shows successful `127.0.0.1` dispatches (in pairs), hermes processes both events, phone receives 2 identical replies
- **After both fixes**: BB log shows single dispatch, hermes log shows single inbound, phone receives single reply

## Test plan

- [x] Reproduced on real macOS + BB Server 1.9.9 — confirmed `ECONNREFUSED ::1:<port>` and paired event firing
- [x] Patched venv on test deployment — single dispatch + single reply per inbound iMessage
- [ ] Maintainer verification on a fresh BB+hermes setup

## Risk

Both changes are minimal and surgical:
- Commit 1 changes the rewrite destination; the trigger set is preserved + extended with `::1` for symmetry
- Commit 2 drops one event type from registration; the handler code in `_MESSAGE_EVENTS` is untouched (continues to accept `updated-message` if any operator subscribes manually)

Operators running BB on a different host than hermes need a routable IP/hostname for `BLUEBUBBLES_WEBHOOK_HOST`; neither this patch nor prior code handles that case (both rewrite local-bind values; non-local values pass through unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)