### PR TITLE
feat(file-safety): add `hermes file-safety check` diagnostic command

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -72,22 +72,37 @@ def get_safe_write_root() -> Optional[str]:
         return None
 
 
-def is_write_denied(path: str) -> bool:
-    """Return True if path is blocked by the write denylist or safe root."""
+def explain_write_denial(path: str) -> Optional[str]:
+    """Return a short reason string when *path* is write-blocked, else ``None``.
+
+    The reason is one of:
+      * ``"denylist:<resolved-path>"`` — exact match against the sensitive-file list
+      * ``"prefix:<resolved-prefix>"`` — under a sensitive-directory prefix
+      * ``"outside-safe-root:<safe-root>"`` — outside ``HERMES_WRITE_SAFE_ROOT``
+
+    Powers ``hermes file-safety check`` so users can see *which* rule
+    matched instead of just "denied".
+    """
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
     if resolved in build_write_denied_paths(home):
-        return True
+        return f"denylist:{resolved}"
+
     for prefix in build_write_denied_prefixes(home):
         if resolved.startswith(prefix):
-            return True
+            return f"prefix:{prefix.rstrip(os.sep)}"
 
     safe_root = get_safe_write_root()
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
-        return True
+        return f"outside-safe-root:{safe_root}"
 
-    return False
+    return None
+
+
+def is_write_denied(path: str) -> bool:
+    """Return True if path is blocked by the write denylist or safe root."""
+    return explain_write_denial(path) is not None
 
 
 def get_read_block_error(path: str) -> Optional[str]:

--- a/hermes_cli/file_safety_cmd.py
+++ b/hermes_cli/file_safety_cmd.py
@@ -1,0 +1,76 @@
+"""``hermes file-safety`` subcommand — diagnose why a path is read/write blocked.
+
+Wraps :func:`agent.file_safety.explain_write_denial` and
+:func:`agent.file_safety.get_read_block_error` so the user can see exactly
+which rule matched (denylist exact path / sensitive prefix / safe-root
+violation / internal skill cache read-block) instead of just a generic
+"denied" from the file tools.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from agent.file_safety import explain_write_denial, get_read_block_error
+
+
+def _build_report(raw_path: str) -> Dict[str, Any]:
+    resolved = os.path.realpath(os.path.expanduser(raw_path))
+    write_reason = explain_write_denial(raw_path)
+    read_reason = get_read_block_error(raw_path)
+    return {
+        "input_path": raw_path,
+        "resolved_path": resolved,
+        "exists": Path(resolved).exists(),
+        "write": {
+            "allowed": write_reason is None,
+            "reason": write_reason,
+        },
+        "read": {
+            "allowed": read_reason is None,
+            "reason": read_reason,
+        },
+    }
+
+
+def _print_human(report: Dict[str, Any]) -> None:
+    print(f"path:     {report['input_path']}")
+    print(f"resolved: {report['resolved_path']}")
+    print(f"exists:   {report['exists']}")
+    print()
+
+    write = report["write"]
+    if write["allowed"]:
+        print("write:    OK (allowed)")
+    else:
+        print(f"write:    BLOCKED  {write['reason']}")
+
+    read = report["read"]
+    if read["allowed"]:
+        print("read:     OK (allowed)")
+    else:
+        print(f"read:     BLOCKED  {read['reason']}")
+
+
+def file_safety_command(args) -> None:
+    """Entry point for ``hermes file-safety check <path>``.
+
+    Exits 0 when both read and write are allowed, 1 when either is blocked.
+    """
+    raw_path = getattr(args, "path", None)
+    if not raw_path:
+        print("Path is required. Usage: hermes file-safety check <path>", file=sys.stderr)
+        raise SystemExit(2)
+
+    report = _build_report(raw_path)
+    if getattr(args, "json", False):
+        print(_json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+
+    blocked = (not report["write"]["allowed"]) or (not report["read"]["allowed"])
+    raise SystemExit(1 if blocked else 0)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4989,6 +4989,21 @@ def cmd_auth(args):
     auth_command(args)
 
 
+def cmd_file_safety(args):
+    """Diagnose why a path is read/write blocked by Hermes file-safety rules."""
+    action = getattr(args, "file_safety_action", None)
+    if action == "check":
+        from hermes_cli.file_safety_cmd import file_safety_command
+
+        file_safety_command(args)
+        return
+    print(
+        "Usage: hermes file-safety check <path> [--json]",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
 def cmd_status(args):
     """Show status of all components."""
     from hermes_cli.status import show_status
@@ -8495,6 +8510,26 @@ def main():
     auth_spotify.add_argument("--no-browser", action="store_true", help="Do not attempt to open the browser automatically")
     auth_spotify.add_argument("--timeout", type=float, help="Callback/token exchange timeout in seconds")
     auth_parser.set_defaults(func=cmd_auth)
+
+    # =========================================================================
+    # file-safety command — diagnose write/read denial rules
+    # =========================================================================
+    file_safety_parser = subparsers.add_parser(
+        "file-safety",
+        help="Diagnose Hermes file-safety read/write rules for a given path",
+    )
+    file_safety_subparsers = file_safety_parser.add_subparsers(
+        dest="file_safety_action"
+    )
+    file_safety_check = file_safety_subparsers.add_parser(
+        "check",
+        help="Check whether a path is read/write blocked, and which rule matched",
+    )
+    file_safety_check.add_argument("path", help="Filesystem path to check")
+    file_safety_check.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON"
+    )
+    file_safety_parser.set_defaults(func=cmd_file_safety)
 
     # =========================================================================
     # status command

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -661,6 +661,7 @@ AUTHOR_MAP = {
     "web3blind@gmail.com": "web3blind",
     "ztzheng@163.com": "chengoak",  # PR #17467
     "24110240104@m.fudan.edu.cn": "YuShu",  # co-author only
+    "googs1025@gmail.com": "googs1025",
 }
 
 

--- a/tests/agent/test_file_safety_explain.py
+++ b/tests/agent/test_file_safety_explain.py
@@ -1,0 +1,111 @@
+"""Tests for ``explain_write_denial`` — the diagnostic counterpart to
+``is_write_denied``.
+
+``explain_write_denial`` returns a short string identifying which rule
+blocked a write (or ``None`` when the path is allowed). It powers the
+``hermes file-safety check`` CLI so users can see exactly which rule
+matched instead of just "denied".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent import file_safety
+
+
+class TestExplainWriteDenialAllowed:
+    def test_returns_none_for_normal_path(self, tmp_path: Path):
+        assert file_safety.explain_write_denial(str(tmp_path / "ok.txt")) is None
+
+    def test_returns_none_for_path_under_cwd(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert file_safety.explain_write_denial("file.txt") is None
+
+
+class TestExplainWriteDenialDenylistExact:
+    def test_etc_shadow_matched_by_denylist(self):
+        reason = file_safety.explain_write_denial("/etc/shadow")
+        assert reason is not None
+        assert reason.startswith("denylist:")
+        assert "shadow" in reason
+
+    def test_etc_passwd_matched_by_denylist(self):
+        reason = file_safety.explain_write_denial("/etc/passwd")
+        assert reason is not None
+        assert reason.startswith("denylist:")
+
+    def test_ssh_id_rsa_matched_by_denylist(self):
+        path = str(Path.home() / ".ssh" / "id_rsa")
+        reason = file_safety.explain_write_denial(path)
+        assert reason is not None
+        assert reason.startswith("denylist:")
+        assert "id_rsa" in reason
+
+
+class TestExplainWriteDenialPrefix:
+    def test_aws_credentials_dir_matched_by_prefix(self):
+        path = str(Path.home() / ".aws" / "credentials")
+        reason = file_safety.explain_write_denial(path)
+        assert reason is not None
+        assert reason.startswith("prefix:")
+        assert ".aws" in reason
+
+    def test_etc_sudoers_d_subpath_matched_by_prefix(self):
+        reason = file_safety.explain_write_denial("/etc/sudoers.d/myrule")
+        assert reason is not None
+        assert reason.startswith("prefix:")
+        assert "sudoers.d" in reason
+
+
+class TestExplainWriteDenialSafeRoot:
+    def test_outside_safe_root_blocked(self, tmp_path: Path, monkeypatch):
+        safe_root = tmp_path / "allowed"
+        safe_root.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        outside = tmp_path / "elsewhere" / "x.txt"
+        reason = file_safety.explain_write_denial(str(outside))
+        assert reason is not None
+        assert reason.startswith("outside-safe-root:")
+
+    def test_inside_safe_root_allowed(self, tmp_path: Path, monkeypatch):
+        safe_root = tmp_path / "allowed"
+        safe_root.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        inside = safe_root / "x.txt"
+        assert file_safety.explain_write_denial(str(inside)) is None
+
+    def test_safe_root_itself_allowed(self, tmp_path: Path, monkeypatch):
+        safe_root = tmp_path / "allowed"
+        safe_root.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        assert file_safety.explain_write_denial(str(safe_root)) is None
+
+
+class TestIsWriteDeniedDelegatesToExplain:
+    """is_write_denied must keep its bool contract — it now wraps
+    explain_write_denial. Verifies they agree on every case above."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/etc/shadow",
+            "/etc/passwd",
+            "/etc/sudoers.d/myrule",
+            str(Path.home() / ".ssh" / "id_rsa"),
+            str(Path.home() / ".aws" / "credentials"),
+        ],
+    )
+    def test_denied_paths_agree(self, path: str):
+        assert file_safety.is_write_denied(path) is True
+        assert file_safety.explain_write_denial(path) is not None
+
+    def test_allowed_path_agrees(self, tmp_path: Path):
+        path = str(tmp_path / "ok.txt")
+        assert file_safety.is_write_denied(path) is False
+        assert file_safety.explain_write_denial(path) is None

--- a/tests/hermes_cli/test_file_safety_cmd.py
+++ b/tests/hermes_cli/test_file_safety_cmd.py
@@ -1,0 +1,88 @@
+"""Tests for ``hermes file-safety check`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.file_safety_cmd import file_safety_command
+
+
+def _args(path: str, *, json_out: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(path=path, json=json_out)
+
+
+class TestFileSafetyCheckHuman:
+    def test_allowed_path_exits_zero(self, tmp_path: Path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args(str(tmp_path / "x.txt")))
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "OK" in out or "allowed" in out.lower()
+
+    def test_denylist_path_exits_one(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args("/etc/shadow"))
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "denylist" in out
+        assert "shadow" in out
+
+    def test_prefix_path_exits_one(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args(str(Path.home() / ".aws" / "credentials")))
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "prefix" in out
+        assert ".aws" in out
+
+    def test_safe_root_violation_exits_one(self, tmp_path: Path, monkeypatch, capsys):
+        safe_root = tmp_path / "allowed"
+        safe_root.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args(str(tmp_path / "elsewhere.txt")))
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "outside-safe-root" in out
+
+
+class TestFileSafetyCheckJSON:
+    def test_allowed_emits_json_with_allowed_true(self, tmp_path: Path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args(str(tmp_path / "ok.txt"), json_out=True))
+        assert exc.value.code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["write"]["allowed"] is True
+        assert payload["write"]["reason"] is None
+        assert payload["read"]["allowed"] is True
+        assert "resolved_path" in payload
+
+    def test_denied_emits_json_with_reason(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args("/etc/passwd", json_out=True))
+        assert exc.value.code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["write"]["allowed"] is False
+        assert payload["write"]["reason"].startswith("denylist:")
+
+
+class TestFileSafetyCheckReadBlock:
+    """Read-block errors come from get_read_block_error (skill cache files)."""
+
+    def test_internal_skill_cache_read_blocked(self, tmp_path: Path, monkeypatch, capsys):
+        # Point HERMES_HOME at tmp_path; the cache dir is then
+        # tmp_path/skills/.hub/index-cache
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cache_path = tmp_path / "skills" / ".hub" / "index-cache" / "x.json"
+
+        with pytest.raises(SystemExit) as exc:
+            file_safety_command(_args(str(cache_path), json_out=True))
+        assert exc.value.code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["read"]["allowed"] is False
+        assert payload["read"]["reason"]


### PR DESCRIPTION
When a write tool is rejected, there's no way to tell which rule fired (denylist / sensitive prefix / safe-root / internal cache). This adds a diagnostic so the matched rule is visible.

* explain_write_denial(path) -> Optional[str] in agent/file_safety.py
* `hermes file-safety check <path> [--json]` subcommand
* Exits 1 when read or write is blocked

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

