### PR TITLE
feat(agent): allow user-supplied default_headers per provider in config.yaml

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -94,6 +94,30 @@ model:
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
+#
+# default_headers (optional, dict of HTTP header name → value):
+# Merged into the OpenAI client's default headers for every request to that
+# provider.  User-supplied entries override Hermes' built-in host defaults on
+# conflicts (e.g. you can replace the User-Agent that Hermes sets for a known
+# host, or inject one for an unknown relay).
+#
+# Common use case: some third-party OpenAI-compatible relays run a WAF that
+# rejects the OpenAI Python SDK's default ``User-Agent: OpenAI/Python ...``.
+# Override it here so the request looks like a different client.
+#
+# Top-level ``model.default_headers`` applies to whichever provider is active.
+# A per-provider entry under ``providers:`` takes precedence on conflicts.
+#
+# model:
+#   default_headers:
+#     User-Agent: "claude-code/0.1.0"   # bypass relay WAFs that block OpenAI/Python
+#
+# providers:
+#   my-relay:
+#     base_url: https://relay.example.com/v1
+#     default_headers:
+#       User-Agent: "claude-code/0.1.0"
+#       X-Custom-Tag: "hermes-agent"
 
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2526,6 +2526,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
+        "default_headers",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -2616,7 +2617,53 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    default_headers = entry.get("default_headers")
+    sanitized_headers = _sanitize_default_headers(
+        default_headers, source=f"providers.{provider_key or name}"
+    )
+    if sanitized_headers:
+        normalized["default_headers"] = sanitized_headers
+
     return normalized
+
+
+def _sanitize_default_headers(
+    raw: Any, *, source: str
+) -> Optional[Dict[str, str]]:
+    """Validate a ``default_headers`` mapping; return a clean ``str -> str`` dict.
+
+    Accepts any mapping whose keys and values coerce cleanly to non-empty
+    strings.  Logs a warning and returns ``None`` for malformed entries so
+    callers can fall through to host defaults.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        logger.warning(
+            "%s.default_headers must be a mapping of header name to value "
+            "(got %s) — ignored",
+            source, type(raw).__name__,
+        )
+        return None
+
+    cleaned: Dict[str, str] = {}
+    for k, v in raw.items():
+        if not isinstance(k, str) or not k.strip():
+            logger.warning(
+                "%s.default_headers: ignoring entry with non-string key %r",
+                source, k,
+            )
+            continue
+        if v is None:
+            continue
+        if not isinstance(v, (str, int, float, bool)):
+            logger.warning(
+                "%s.default_headers[%r]: value must be a scalar (got %s) — ignored",
+                source, k, type(v).__name__,
+            )
+            continue
+        cleaned[k.strip()] = str(v)
+    return cleaned or None
 
 
 def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
@@ -2780,6 +2827,10 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
+    # default_headers — user-supplied HTTP headers merged into the OpenAI
+    # client's request headers (overrides built-in host defaults on conflicts).
+    # See run_agent.py:_resolve_user_default_headers.
+    "default_headers",
 }
 
 # Fields that look like they should be inside custom_providers, not at root

--- a/run_agent.py
+++ b/run_agent.py
@@ -1505,6 +1505,14 @@ class AIAgent:
                         headers["x-anthropic-beta"] = _FINE_GRAINED
                     client_kwargs["default_headers"] = headers
 
+            # User-supplied HTTP headers from config.yaml — merged on top of
+            # built-in host defaults so the user can override e.g. User-Agent
+            # for relays whose WAF blocks the OpenAI Python SDK's default UA.
+            _user_default_headers = self._resolve_user_default_headers()
+            if _user_default_headers:
+                _existing = client_kwargs.get("default_headers") or {}
+                client_kwargs["default_headers"] = {**_existing, **_user_default_headers}
+
             self.api_key = client_kwargs.get("api_key", "")
             self.base_url = client_kwargs.get("base_url", self.base_url)
             try:
@@ -6129,26 +6137,90 @@ class AIAgent:
         from agent.auxiliary_client import _AI_GATEWAY_HEADERS, _OR_HEADERS
 
         if base_url_host_matches(base_url, "openrouter.ai"):
-            self._client_kwargs["default_headers"] = dict(_OR_HEADERS)
+            host_headers: Dict[str, str] = dict(_OR_HEADERS)
         elif base_url_host_matches(base_url, "ai-gateway.vercel.sh"):
-            self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
+            host_headers = dict(_AI_GATEWAY_HEADERS)
         elif base_url_host_matches(base_url, "api.routermint.com"):
-            self._client_kwargs["default_headers"] = _routermint_headers()
+            host_headers = _routermint_headers()
         elif base_url_host_matches(base_url, "api.githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
-            self._client_kwargs["default_headers"] = copilot_default_headers()
+            host_headers = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
-            self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            host_headers = {"User-Agent": "claude-code/0.1.0"}
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
-            self._client_kwargs["default_headers"] = _qwen_portal_headers()
+            host_headers = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):
             from agent.auxiliary_client import _codex_cloudflare_headers
-            self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
+            host_headers = _codex_cloudflare_headers(
                 self._client_kwargs.get("api_key", "")
             )
         else:
+            host_headers = {}
+
+        # User-supplied headers from config.yaml take precedence on conflicts.
+        merged: Dict[str, str] = {**host_headers, **self._resolve_user_default_headers()}
+        if merged:
+            self._client_kwargs["default_headers"] = merged
+        else:
             self._client_kwargs.pop("default_headers", None)
+
+    def _resolve_user_default_headers(self) -> Dict[str, str]:
+        """Return user-supplied default HTTP headers from config.yaml.
+
+        Reads, in order of increasing precedence:
+          1. ``model.default_headers`` (top-level — applies to whichever
+             provider/base_url is currently active).
+          2. ``providers.<provider_name>.default_headers`` (per-provider).
+
+        Per-provider entries override top-level on conflicts.  Malformed
+        entries are skipped with a warning by the sanitizer.
+        """
+        try:
+            from hermes_cli.config import (
+                _sanitize_default_headers,
+                load_config,
+            )
+        except Exception:
+            return {}
+
+        try:
+            config = load_config()
+        except Exception:
+            return {}
+        if not isinstance(config, dict):
+            return {}
+
+        merged: Dict[str, str] = {}
+
+        model_block = config.get("model")
+        if isinstance(model_block, dict):
+            cleaned = _sanitize_default_headers(
+                model_block.get("default_headers"), source="model"
+            )
+            if cleaned:
+                merged.update(cleaned)
+
+        provider_name = (getattr(self, "provider", "") or "").strip().lower()
+        if provider_name:
+            providers_block = config.get("providers")
+            if isinstance(providers_block, dict):
+                for key, entry in providers_block.items():
+                    if not isinstance(key, str):
+                        continue
+                    if key.strip().lower() != provider_name:
+                        continue
+                    if not isinstance(entry, dict):
+                        continue
+                    cleaned = _sanitize_default_headers(
+                        entry.get("default_headers"),
+                        source=f"providers.{key}",
+                    )
+                    if cleaned:
+                        merged.update(cleaned)
+                    break
+
+        return merged
 
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")

--- a/tests/hermes_cli/test_default_headers.py
+++ b/tests/hermes_cli/test_default_headers.py
@@ -1,0 +1,240 @@
+"""Tests for user-configurable provider HTTP ``default_headers``.
+
+Covers:
+
+* :func:`hermes_cli.config._sanitize_default_headers` — input validation.
+* :func:`hermes_cli.config._normalize_custom_provider_entry` — schema flow-through.
+* :func:`run_agent.AIAgent._resolve_user_default_headers` — config lookup with
+  per-provider overrides taking precedence over top-level ``model.default_headers``.
+
+The relevant feature is documented in ``cli-config.yaml.example`` next to the
+``providers:`` section.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import (
+    _normalize_custom_provider_entry,
+    _sanitize_default_headers,
+)
+
+
+class TestSanitizeDefaultHeaders:
+    def test_returns_none_for_none(self):
+        assert _sanitize_default_headers(None, source="model") is None
+
+    def test_returns_none_for_non_mapping(self):
+        assert _sanitize_default_headers("oops", source="model") is None
+        assert _sanitize_default_headers(["a", "b"], source="model") is None
+        assert _sanitize_default_headers(42, source="model") is None
+
+    def test_returns_none_for_empty_dict(self):
+        assert _sanitize_default_headers({}, source="model") is None
+
+    def test_passes_through_clean_string_values(self):
+        out = _sanitize_default_headers(
+            {"User-Agent": "claude-code/0.1.0"}, source="model"
+        )
+        assert out == {"User-Agent": "claude-code/0.1.0"}
+
+    def test_coerces_scalar_values_to_string(self):
+        out = _sanitize_default_headers(
+            {"X-Retry": 3, "X-Cache": True, "X-Ratio": 0.5}, source="model"
+        )
+        assert out == {"X-Retry": "3", "X-Cache": "True", "X-Ratio": "0.5"}
+
+    def test_strips_whitespace_from_keys(self):
+        out = _sanitize_default_headers(
+            {"  User-Agent  ": "ua"}, source="model"
+        )
+        assert out == {"User-Agent": "ua"}
+
+    def test_skips_non_string_keys(self):
+        out = _sanitize_default_headers(
+            {1: "v", "X-Real": "ok"}, source="model"
+        )
+        assert out == {"X-Real": "ok"}
+
+    def test_skips_blank_keys(self):
+        out = _sanitize_default_headers(
+            {"   ": "ignored", "X-Real": "ok"}, source="model"
+        )
+        assert out == {"X-Real": "ok"}
+
+    def test_skips_non_scalar_values(self):
+        out = _sanitize_default_headers(
+            {"X-List": [1, 2], "X-Dict": {"a": 1}, "X-Real": "ok"},
+            source="model",
+        )
+        assert out == {"X-Real": "ok"}
+
+    def test_skips_none_values(self):
+        # Explicit ``None`` is silently dropped — config readers commonly
+        # produce ``None`` for missing YAML scalars; surfacing a warning would
+        # be noisy without adding any safety value.
+        out = _sanitize_default_headers(
+            {"X-None": None, "X-Real": "ok"}, source="model"
+        )
+        assert out == {"X-Real": "ok"}
+
+
+class TestNormalizeCustomProviderEntryHeaders:
+    def test_default_headers_flow_through(self):
+        entry = {
+            "name": "openclaudecode",
+            "base_url": "https://www.openclaudecode.cn/v1",
+            "default_headers": {"User-Agent": "claude-code/0.1.0"},
+        }
+        normalized = _normalize_custom_provider_entry(
+            entry, provider_key="openclaudecode"
+        )
+        assert normalized is not None
+        assert normalized["default_headers"] == {
+            "User-Agent": "claude-code/0.1.0"
+        }
+
+    def test_missing_default_headers_omits_field(self):
+        entry = {
+            "name": "openclaudecode",
+            "base_url": "https://www.openclaudecode.cn/v1",
+        }
+        normalized = _normalize_custom_provider_entry(
+            entry, provider_key="openclaudecode"
+        )
+        assert normalized is not None
+        assert "default_headers" not in normalized
+
+    def test_invalid_default_headers_dropped(self):
+        entry = {
+            "name": "openclaudecode",
+            "base_url": "https://www.openclaudecode.cn/v1",
+            "default_headers": "not-a-dict",
+        }
+        normalized = _normalize_custom_provider_entry(
+            entry, provider_key="openclaudecode"
+        )
+        assert normalized is not None
+        # Malformed value drops silently; sanitizer logs the warning.
+        assert "default_headers" not in normalized
+
+
+class _FakeAgent:
+    """Minimal stub binding ``_resolve_user_default_headers`` for direct calls.
+
+    The helper only reads ``self.provider``; constructing the real ``AIAgent``
+    requires network/auth setup that's irrelevant to header resolution.
+    """
+
+    def __init__(self, provider: str = ""):
+        self.provider = provider
+
+    @staticmethod
+    def _resolve(provider: str) -> Dict[str, str]:
+        from run_agent import AIAgent
+
+        agent = _FakeAgent(provider)
+        return AIAgent._resolve_user_default_headers(agent)
+
+
+class TestResolveUserDefaultHeaders:
+    def _patch_config(self, cfg: Dict[str, Any]):
+        return patch("hermes_cli.config.load_config", return_value=cfg)
+
+    def test_returns_empty_when_no_config(self):
+        with self._patch_config({}):
+            assert _FakeAgent._resolve("custom") == {}
+
+    def test_reads_top_level_model_block(self):
+        cfg = {
+            "model": {
+                "default_headers": {"User-Agent": "claude-code/0.1.0"},
+            }
+        }
+        with self._patch_config(cfg):
+            assert _FakeAgent._resolve("custom") == {
+                "User-Agent": "claude-code/0.1.0"
+            }
+
+    def test_reads_per_provider_block_when_provider_matches(self):
+        cfg = {
+            "providers": {
+                "openclaudecode": {
+                    "base_url": "https://www.openclaudecode.cn/v1",
+                    "default_headers": {"User-Agent": "claude-code/0.1.0"},
+                }
+            }
+        }
+        with self._patch_config(cfg):
+            assert _FakeAgent._resolve("openclaudecode") == {
+                "User-Agent": "claude-code/0.1.0"
+            }
+
+    def test_per_provider_match_is_case_insensitive(self):
+        cfg = {
+            "providers": {
+                "OpenClaudeCode": {
+                    "base_url": "https://www.openclaudecode.cn/v1",
+                    "default_headers": {"User-Agent": "ua"},
+                }
+            }
+        }
+        with self._patch_config(cfg):
+            assert _FakeAgent._resolve("openclaudecode") == {"User-Agent": "ua"}
+
+    def test_per_provider_overrides_top_level_on_conflict(self):
+        cfg = {
+            "model": {
+                "default_headers": {
+                    "User-Agent": "fallback-ua",
+                    "X-Common": "from-model",
+                },
+            },
+            "providers": {
+                "custom": {
+                    "base_url": "https://example.invalid/v1",
+                    "default_headers": {"User-Agent": "winner-ua"},
+                },
+            },
+        }
+        with self._patch_config(cfg):
+            out = _FakeAgent._resolve("custom")
+        assert out == {
+            "User-Agent": "winner-ua",  # per-provider wins
+            "X-Common": "from-model",   # non-conflicting top-level survives
+        }
+
+    def test_provider_block_ignored_when_provider_unset(self):
+        cfg = {
+            "providers": {
+                "custom": {
+                    "base_url": "https://example.invalid/v1",
+                    "default_headers": {"User-Agent": "should-not-appear"},
+                }
+            }
+        }
+        with self._patch_config(cfg):
+            assert _FakeAgent._resolve("") == {}
+
+    def test_malformed_provider_block_does_not_crash(self):
+        cfg = {
+            "model": {
+                "default_headers": {"User-Agent": "fallback"},
+            },
+            "providers": "not-a-dict",
+        }
+        with self._patch_config(cfg):
+            assert _FakeAgent._resolve("custom") == {"User-Agent": "fallback"}
+
+    def test_load_config_failure_is_swallowed(self):
+        with patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("disk on fire")
+        ):
+            assert _FakeAgent._resolve("custom") == {}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What does this PR do?

Adds a `default_headers` config knob so users can override or augment the HTTP headers Hermes sends to OpenAI-compatible providers — without editing source.

Today `run_agent.py` (`AIAgent.__init__` and `_apply_client_headers_for_base_url`) hardcodes a host-specific if/elif chain that only sets `default_headers` for six known hosts (openrouter, routermint, copilot, kimi, qwen, codex). For any other `base_url` it falls through and the OpenAI Python SDK's default `User-Agent: OpenAI/Python <version>` leaks unchanged.

That User-Agent is on the WAF block list of several third-party OpenAI-compatible relays — typically Chinese "new-api" channels. Such relays return HTTP 403 `Your request was blocked.` for every Hermes call, even though direct `curl` with any other UA succeeds against the very same endpoint. There is currently no in-tree escape hatch — `_VALID_CUSTOM_PROVIDER_FIELDS` does not include any header field, no env var injects one, and there is no `--header` CLI flag.

This PR makes that escape hatch official.

## Related Issue

Fixes # <!-- no issue filed; happy to open one if maintainers prefer -->

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py`
  - Add `default_headers` to `_VALID_CUSTOM_PROVIDER_FIELDS` and to the `_KNOWN_KEYS` set inside `_normalize_custom_provider_entry`.
  - New shared validator `_sanitize_default_headers(raw, source)` — accepts a mapping of header name to scalar value, drops malformed entries with a `logger.warning`, returns `None` for empty/invalid input.
- `run_agent.py`
  - New `AIAgent._resolve_user_default_headers()` reads `model.default_headers` (applies to whichever provider is active) and `providers.<provider_name>.default_headers` (per-provider override). Per-provider entries override top-level on conflicts.
  - The result is merged into `client_kwargs["default_headers"]` at init time (after the existing host-specific chain and the OpenRouter Claude beta logic, so user keys win without erasing host-specific keys like `HTTP-Referer`).
  - `_apply_client_headers_for_base_url` is refactored to assemble `host_headers` first, merge user headers on top, and only `pop("default_headers")` when the merged result is empty. This keeps the headers intact across `/model` switches and credential refreshes.
- `cli-config.yaml.example`
  - Documents the new field under the existing `providers:` block, with the WAF-bypass motivation and a working example.
- `tests/hermes_cli/test_default_headers.py`
  - 21 new tests covering sanitizer edge cases (non-dict, non-string keys, non-scalar values, empty dict, scalar coercion), schema flow-through via `_normalize_custom_provider_entry`, and `_resolve_user_default_headers` precedence (top-level vs per-provider, case-insensitive provider matching, malformed config tolerance, `load_config` failure swallowing).

## How to Test

1. **New tests pass**

   ```bash
   pytest tests/hermes_cli/test_default_headers.py -v
   ```

   21 passed locally.

2. **Existing config / provider tests still pass** (sanity check that schema additions didn't regress validation)

   ```bash
   pytest tests/hermes_cli/test_config.py \
          tests/hermes_cli/test_config_validation.py \
          tests/hermes_cli/test_custom_provider_context_length.py \
          tests/hermes_cli/test_custom_provider_model_switch.py \
          tests/hermes_cli/test_user_providers_model_switch.py \
          tests/hermes_cli/test_model_switch_custom_providers.py
   ```

   188 passed locally.

3. **End-to-end against a real WAF-blocked relay**

   In `~/.hermes/config.yaml`:

   ```yaml
   model:
     default: gpt-5.5
     provider: custom
     base_url: https://<your-relay>/v1
     api_key: sk-...
     default_headers:
       User-Agent: claude-code/0.1.0
   ```

   Before the PR: `hermes chat -q "say pong"` → `HTTP 403: Your request was blocked.`
   After the PR: `hermes chat -q "say pong"` → `pong`. Verified locally on a "new-api" channel that blocks `OpenAI/Python` UAs.

## Tested on

macOS 15 (darwin 25.2), Python 3.14, against a third-party new-api relay.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant test selectors (see above) and they all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` with the new config key
- [x] N/A — README / `docs/` / `CONTRIBUTING.md` / `AGENTS.md` not affected
- [x] N/A — no cross-platform impact (pure Python, stdlib `dict` operations, no FS / process / terminal touch)
- [x] N/A — no tool descriptions changed

## Notes for reviewers

- **Backward compatibility**: configs without `default_headers` produce identical behavior to today (the new merge step is a no-op when `_resolve_user_default_headers()` returns `{}`). Existing tests confirm this.
- **Header precedence**: built-in host headers form the base, user keys are layered on top. This means a user can override e.g. OpenRouter's `User-Agent` if they really want to, but won't accidentally erase `HTTP-Referer` / `X-OpenRouter-Title` by setting a single key. Documented in `cli-config.yaml.example` and the docstring on `_resolve_user_default_headers`.
- **Per-provider wins on conflict** (between top-level `model.default_headers` and `providers.<name>.default_headers`) is the natural specificity rule; tested explicitly in `test_per_provider_overrides_top_level_on_conflict`.
- **Sanitizer is permissive**: malformed entries are dropped with a warning rather than raising, matching the rest of the `_normalize_custom_provider_entry` flow which also `.warning()`s on unknown keys instead of failing.
- **AWS Bedrock**: not affected — the Bedrock path uses `boto3` rather than the OpenAI SDK, mirroring the existing scope note next to `request_timeout_seconds` in `cli-config.yaml.example`.