### PR TITLE
fix(memory/hindsight): mirror llm_api_key into config.json + warn about macOS LaunchAgent ghosts

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -289,6 +289,27 @@ def _embedded_profile_name(config: dict[str, Any]) -> str:
     return str(profile or "hermes")
 
 
+def _detect_hindsight_launchagents() -> list:
+    """Return any installed io.hindsight.* LaunchAgent plists on macOS.
+
+    A stale LaunchAgent with ``KeepAlive: true`` silently revives the Hindsight
+    daemon with old config after the user kills it, producing port-conflict
+    dead loops with the Hermes-managed daemon. Only the Hermes wizard knows
+    to warn about this; detection is best-effort and never fatal.
+    """
+    import sys
+    from pathlib import Path
+    if sys.platform != "darwin":
+        return []
+    la_dir = Path.home() / "Library" / "LaunchAgents"
+    if not la_dir.is_dir():
+        return []
+    try:
+        return sorted(la_dir.glob("io.hindsight.*.plist"))
+    except OSError:
+        return []
+
+
 def _load_simple_env(path) -> dict[str, str]:
     """Parse a simple KEY=VALUE env file, ignoring comments and blank lines."""
     if not path.exists():
@@ -621,6 +642,22 @@ class HindsightMemoryProvider(MemoryProvider):
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
         else:  # local_embedded
+            # Warn about macOS LaunchAgent plists from prior hindsight-embed
+            # installs (or other programs using hindsight-embed). A plist with
+            # KeepAlive=true silently revives the daemon with stale config
+            # after Hermes kills it, producing [Errno 48] port-conflict loops.
+            stale_plists = _detect_hindsight_launchagents()
+            if stale_plists:
+                print("\n  ⚠ Detected existing Hindsight LaunchAgent(s):")
+                for plist in stale_plists:
+                    print(f"    {plist}")
+                print("  These can silently revive the daemon with stale config and")
+                print("  collide with Hermes on the daemon port. Remove with:")
+                for plist in stale_plists:
+                    print(f"    launchctl bootout gui/$(id -u) {plist}")
+                    print(f"    rm {plist}")
+                print()
+
             providers_list = list(_PROVIDER_DEFAULT_MODELS.keys())
             llm_items = [
                 (p, f"default model: {_PROVIDER_DEFAULT_MODELS[p]}")
@@ -655,6 +692,10 @@ class HindsightMemoryProvider(MemoryProvider):
             llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
             if llm_key:
                 env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
+                # Mirror into config.json so the daemon picks it up even when
+                # .env / profile.env go stale. _build_embedded_profile_env()
+                # falls back to config["llm_api_key"] in that case.
+                provider_config["llm_api_key"] = llm_key
             else:
                 env_path = Path(hermes_home) / ".env"
                 existing_llm_key = ""
@@ -664,6 +705,8 @@ class HindsightMemoryProvider(MemoryProvider):
                             existing_llm_key = line.split("=", 1)[1]
                             break
                 env_writes["HINDSIGHT_LLM_API_KEY"] = existing_llm_key
+                if existing_llm_key and not provider_config.get("llm_api_key"):
+                    provider_config["llm_api_key"] = existing_llm_key
 
         # Step 4: Save everything
         provider_config.setdefault("bank_id", "hermes")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -431,6 +431,128 @@ class TestPostSetup:
         assert saved["HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE"] == "1"
         assert saved["timeout"] == 120
 
+    def test_local_embedded_setup_writes_llm_api_key_to_config_json(self, tmp_path, monkeypatch):
+        """Fresh setup should persist llm_api_key in config.json so the daemon
+        can recover the key if .env / profile.env go stale (issue #17414)."""
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        selections = iter([1, 0])  # local_embedded, openai
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-fresh-key")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        saved = json.loads((hermes_home / "hindsight" / "config.json").read_text())
+        assert saved["llm_api_key"] == "sk-fresh-key", (
+            "llm_api_key must be mirrored into config.json so the daemon "
+            "falls back to it when .env / profile.env are stale"
+        )
+
+    def test_local_embedded_setup_mirrors_existing_env_key_into_config_json(self, tmp_path, monkeypatch):
+        """If the user leaves the API-key prompt blank and there's an
+        existing HINDSIGHT_LLM_API_KEY in .env, that key should also be
+        mirrored into config.json (unless already present there)."""
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        selections = iter([1, 0])  # local_embedded, openai
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        env_path = hermes_home / ".env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text("HINDSIGHT_LLM_API_KEY=env-fallback-key\n")
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        saved = json.loads((hermes_home / "hindsight" / "config.json").read_text())
+        assert saved["llm_api_key"] == "env-fallback-key"
+
+    def test_local_embedded_setup_warns_about_macos_launchagent(self, tmp_path, monkeypatch, capsys):
+        """On macOS, detect Hindsight LaunchAgent plists and warn the user —
+        these can revive the daemon with stale config and cause port-conflict
+        dead loops (issue #17414, gap 4)."""
+        import sys as _sys
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        la_dir = user_home / "Library" / "LaunchAgents"
+        la_dir.mkdir(parents=True)
+        stale_plist = la_dir / "io.hindsight.daemon.plist"
+        stale_plist.write_text(
+            "<?xml version='1.0'?><plist><dict>"
+            "<key>KeepAlive</key><true/></dict></plist>\n"
+        )
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(_sys, "platform", "darwin")
+
+        selections = iter([1, 0])
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-k")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        out = capsys.readouterr().out
+        assert "Detected existing Hindsight LaunchAgent" in out
+        assert "io.hindsight.daemon.plist" in out
+        assert "launchctl bootout" in out
+
+    def test_local_embedded_setup_does_not_warn_when_no_launchagent(self, tmp_path, monkeypatch, capsys):
+        """No LaunchAgent → no warning. Absence of the directory or absence
+        of matching plists must both be silent."""
+        import sys as _sys
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(_sys, "platform", "darwin")
+
+        selections = iter([1, 0])
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-k")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        out = capsys.readouterr().out
+        assert "Detected existing Hindsight LaunchAgent" not in out
+
+    def test_detect_hindsight_launchagents_non_darwin_returns_empty(self, tmp_path, monkeypatch):
+        """On non-macOS platforms the detector short-circuits to empty."""
+        import sys as _sys
+        from plugins.memory.hindsight import _detect_hindsight_launchagents
+        user_home = tmp_path / "user-home"
+        la_dir = user_home / "Library" / "LaunchAgents"
+        la_dir.mkdir(parents=True)
+        (la_dir / "io.hindsight.daemon.plist").write_text("<plist/>")
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(_sys, "platform", "linux")
+
+        assert _detect_hindsight_launchagents() == []
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #17414.

## Problem

Reporter hit a compound-root-cause failure setting up Hindsight `local_embedded` on macOS Apple Silicon — 180s daemon startup timeouts with `HTTP 401 Missing Authentication header` and `[Errno 48] address already in use` loops. The surface errors don't point at the actual causes; the debugging path they had to walk was long.

From the issue, four distinct gaps in `hermes memory setup`. This PR addresses the two that are unambiguous and don't require separate design work:

| Gap | Fix in this PR |
|---|---|
| 1. `llm_api_key` missing from config.json → daemon gets empty key → 401 | **Yes** |
| 2. `memory.provider` cleared after wizard | **No** — couldn't reproduce; both wizard completion paths explicitly set `provider=\"hindsight\"` |
| 3. No post-setup daemon health check | **No** — needs a 30s+ blocking probe; deserves its own design |
| 4. macOS LaunchAgent ghost revives daemon with stale config | **Yes** |

## Fix 1 — mirror `llm_api_key` into config.json

The wizard currently writes the LLM API key to:
- `\$HERMES_HOME/.env` → `HINDSIGHT_LLM_API_KEY` (Hermes process)
- `~/.hindsight/profiles/<profile>.env` → `HINDSIGHT_API_LLM_API_KEY` (daemon process)

…but **not** `config.json`. When either file goes stale (common after upgrades, profile switches, or another tool editing them), the daemon has no recovery path.

`_build_embedded_profile_env()` already falls back to `config[\"llm_api_key\"]` as a last resort:

\`\`\`python
current_key = (
    config.get(\"llmApiKey\")
    or config.get(\"llm_api_key\")          # ← fallback already wired
    or os.environ.get(\"HINDSIGHT_LLM_API_KEY\", \"\")
)
\`\`\`

The wizard just wasn't populating it. Now it does, both on fresh key entry and when leaving the prompt blank with an existing `.env` key (so repeat runs remain self-healing).

## Fix 2 — detect macOS LaunchAgent ghosts

Any prior install that uses `hindsight-embed` (another Hermes profile, a different agent, or a standalone hindsight install) may have written `~/Library/LaunchAgents/io.hindsight.*.plist` with `KeepAlive=true`. When Hermes kills the \"unhealthy\" daemon and launches a fresh one, launchd revives the old one on the same port — the `[Errno 48]` never clears, and the reporter observed the dead loop continue indefinitely.

New `_detect_hindsight_launchagents()` (macOS-only, short-circuits to empty elsewhere) surfaces any matching plists at the start of `local_embedded` setup with the exact remediation commands:

\`\`\`
⚠ Detected existing Hindsight LaunchAgent(s):
    ~/Library/LaunchAgents/io.hindsight.daemon.plist
  These can silently revive the daemon with stale config and
  collide with Hermes on the daemon port. Remove with:
    launchctl bootout gui/\$(id -u) ~/Library/LaunchAgents/io.hindsight.daemon.plist
    rm ~/Library/LaunchAgents/io.hindsight.daemon.plist
\`\`\`

Non-fatal, advisory-only — keeps wizard flow intact.

## Tests

5 new, 91 existing → **96/96 pass** (`pytest tests/plugins/memory/test_hindsight_provider.py`):

- `test_local_embedded_setup_writes_llm_api_key_to_config_json`
- `test_local_embedded_setup_mirrors_existing_env_key_into_config_json`
- `test_local_embedded_setup_warns_about_macos_launchagent`
- `test_local_embedded_setup_does_not_warn_when_no_launchagent`
- `test_detect_hindsight_launchagents_non_darwin_returns_empty`

## Not in scope (deliberate)

- **Post-setup daemon health check** (gap 3). Proper implementation needs a daemon spawn, a bounded retry loop on the daemon port, and classification of the actual failure mode (key vs. port vs. model). Happy to do this as a follow-up if the shape is desired.
- **Provider-clearing claim** (gap 2). Both wizard completion paths in `post_setup` and `cmd_setup` explicitly set `provider=\"hindsight\"`. If a reproducer surfaces, will fix separately.

## Files

- `plugins/memory/hindsight/__init__.py`: +43 (helper + two wizard hooks)
- `tests/plugins/memory/test_hindsight_provider.py`: +122