### PR TITLE
fix(teams): import prompt/print helpers from cli_output, not config

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -592,6 +592,8 @@ def interactive_setup() -> None:
     from hermes_cli.config import (
         get_env_value,
         save_env_value,
+    )
+    from hermes_cli.cli_output import (
         prompt,
         prompt_yes_no,
         print_info,


### PR DESCRIPTION
## Problem

`hermes setup` crashes with `ImportError` as soon as the user picks Teams in the messaging-platforms wizard:

```
File ".../plugins/platforms/teams/adapter.py", line 592, in interactive_setup
    from hermes_cli.config import (
ImportError: cannot import name 'prompt' from 'hermes_cli.config'
```

## Cause

`plugins/platforms/teams/adapter.py::interactive_setup()` imports `prompt`, `prompt_yes_no`, `print_info`, `print_success`, and `print_warning` from `hermes_cli.config`, but those helpers live in `hermes_cli.cli_output`. Only `get_env_value` / `save_env_value` live in `hermes_cli.config`.

## Fix

Split the import: credential helpers from `hermes_cli.config`, UI helpers from `hermes_cli.cli_output`. No behavior change beyond making the wizard reachable.

## Verification

- `python3 -c "import ast; ast.parse(open('plugins/platforms/teams/adapter.py').read())"` → OK
- `hermes setup` → Teams branch now reaches the Client ID prompt instead of traceback.