### PR TITLE
fix(toolsets): merge plugin-registered tools into built-in toolset definitions

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -231,3 +231,41 @@ class TestPluginToolsets:
         all_toolsets = get_all_toolsets()
         assert "plugin_bundle" in all_toolsets
         assert all_toolsets["plugin_bundle"]["tools"] == ["plugin_tool"]
+
+    def test_plugin_tool_merged_into_builtin_toolset(self, monkeypatch):
+        """Plugin-added tools targeting a built-in toolset must appear in
+        get_toolset() and resolve_toolset() results.  Regression test for #18314."""
+        # Pick a real built-in toolset and note its static tools
+        builtin_name = "image_gen"
+        static_tools = list(TOOLSETS[builtin_name]["tools"])
+        assert static_tools, "Need at least one static tool for the test"
+
+        reg = ToolRegistry()
+        # Register the existing static tools so the registry knows them
+        for t in static_tools:
+            reg.register(
+                name=t,
+                toolset=builtin_name,
+                schema=_make_schema(t, t),
+                handler=_dummy_handler,
+            )
+        # Register a *new* plugin tool into the same built-in toolset
+        reg.register(
+            name="image_generate_advanced",
+            toolset=builtin_name,
+            schema=_make_schema("image_generate_advanced", "Plugin image tool"),
+            handler=_dummy_handler,
+        )
+
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        ts = get_toolset(builtin_name)
+        assert ts is not None
+        assert "image_generate_advanced" in ts["tools"], (
+            "Plugin tool missing from get_toolset() for built-in toolset"
+        )
+
+        resolved = resolve_toolset(builtin_name)
+        assert "image_generate_advanced" in resolved, (
+            "Plugin tool missing from resolve_toolset() for built-in toolset"
+        )

--- a/toolsets.py
+++ b/toolsets.py
@@ -522,6 +522,21 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
     """
     toolset = TOOLSETS.get(name)
     if toolset:
+        # Merge any plugin-registered tools targeting this built-in toolset
+        # so that plugins adding tools to existing toolsets are not silently
+        # dropped during resolution.
+        try:
+            from tools.registry import registry
+            registry_tools = set(registry.get_tool_names_for_toolset(name))
+        except Exception:
+            registry_tools = set()
+        static_tools = set(toolset.get("tools", []))
+        if registry_tools - static_tools:
+            # Return a merged copy to avoid mutating the static definition
+            return {
+                **toolset,
+                "tools": sorted(static_tools | registry_tools),
+            }
         return toolset
 
     try:


### PR DESCRIPTION
## Summary
Fixes #18314.

When a plugin registers a tool into an existing built-in toolset (e.g. `image_gen`), `get_toolset()` returned only the static `TOOLSETS` definition, silently dropping the plugin-added tool. This caused `resolve_toolset()` and `get_tool_definitions()` to omit the plugin tool from sessions.

## Changes
- **`toolsets.py`**: In `get_toolset()`, when a built-in toolset is matched, query the live tool registry for additional tools registered under the same toolset name and merge them into the returned definition. Returns a copy to avoid mutating the static `TOOLSETS` dict. No-op when no extra tools exist.
- **`tests/test_toolsets.py`**: Added regression test `test_plugin_tool_merged_into_builtin_toolset` that registers a plugin tool into a built-in toolset and verifies it appears in both `get_toolset()` and `resolve_toolset()` results.

## Testing
- `pytest tests/test_toolsets.py` — 25/25 passed
- The fix is scoped to a single early-return path in `get_toolset()`; no other code paths are affected.