### PR TITLE
fix(anthropic): add anthropic_model_family override for opaque endpoint ids

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -240,6 +240,15 @@ def _resolve_anthropic_messages_max_tokens(
     )
 
 
+def _effective_model_id(model: str, family_hint: Optional[str]) -> str:
+    """Return the model identifier used for local capability checks."""
+    if isinstance(family_hint, str):
+        family = family_hint.strip()
+        if family:
+            return family
+    return model
+
+
 def _supports_adaptive_thinking(model: str) -> bool:
     """Return True for Claude models that use adaptive thinking (4.6+).
 
@@ -2466,6 +2475,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    anthropic_model_family: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -2511,12 +2521,13 @@ def build_anthropic_kwargs(
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
     model = normalize_model_name(model, preserve_dots=preserve_dots)
+    model_for_checks = _effective_model_id(model, anthropic_model_family)
     # effective_max_tokens = output cap for this call (≠ total context window)
     # Use the resolver helper so non-positive values (negative ints,
     # fractional floats, NaN, non-numeric) fail locally with a clear error
     # rather than 400-ing at the Anthropic API. See openclaw/openclaw#66664.
     effective_max_tokens = _resolve_anthropic_messages_max_tokens(
-        max_tokens, model, context_length=context_length
+        max_tokens, model_for_checks, context_length=context_length
     )
 
     # Clamp output cap to fit inside the total context window.
@@ -2640,10 +2651,13 @@ def build_anthropic_kwargs(
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
     _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
-        if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
+        if (
+            reasoning_config.get("enabled") is not False
+            and "haiku" not in model_for_checks.lower()
+        ):
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
-            if _supports_adaptive_thinking(model):
+            if _supports_adaptive_thinking(model_for_checks):
                 kwargs["thinking"] = {
                     "type": "adaptive",
                     "display": "summarized",
@@ -2651,7 +2665,9 @@ def build_anthropic_kwargs(
                 adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "medium")
                 # Downgrade xhigh→max on models that don't list xhigh as a
                 # supported level (Opus/Sonnet 4.6). Opus 4.7+ keeps xhigh.
-                if adaptive_effort == "xhigh" and not _supports_xhigh_effort(model):
+                if adaptive_effort == "xhigh" and not _supports_xhigh_effort(
+                    model_for_checks
+                ):
                     adaptive_effort = "max"
                 kwargs["output_config"] = {
                     "effort": adaptive_effort,
@@ -2667,7 +2683,7 @@ def build_anthropic_kwargs(
     # Callers (auxiliary_client, etc.) may set these for older models;
     # drop them here as a safety net so upstream 4.6 → 4.7 migrations
     # don't require coordinated edits everywhere.
-    if _forbids_sampling_params(model):
+    if _forbids_sampling_params(model_for_checks):
         for _sampling_key in ("temperature", "top_p", "top_k"):
             kwargs.pop(_sampling_key, None)
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1862,6 +1862,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     reasoning_config=agent.reasoning_config,
                     is_oauth=agent._is_anthropic_oauth,
                     preserve_dots=agent._anthropic_preserve_dots(),
+                    context_length=getattr(
+                        getattr(agent, "context_compressor", None),
+                        "context_length",
+                        None,
+                    ),
+                    base_url=getattr(agent, "_anthropic_base_url", None),
                     anthropic_model_family=_resolve_anthropic_model_family(agent),
                 )
                 summary_response = agent._anthropic_messages_create(_ant_kw)
@@ -1898,6 +1904,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     max_tokens=agent.max_tokens,
                     reasoning_config=agent.reasoning_config,
                     preserve_dots=agent._anthropic_preserve_dots(),
+                    context_length=getattr(
+                        getattr(agent, "context_compressor", None),
+                        "context_length",
+                        None,
+                    ),
+                    base_url=getattr(agent, "_anthropic_base_url", None),
                     anthropic_model_family=_resolve_anthropic_model_family(agent),
                 )
                 retry_response = agent._anthropic_messages_create(_ant_kw2)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -772,6 +772,18 @@ def interruptible_api_call(agent, api_kwargs: dict):
         _reset_stale_streak(agent)
     return result["response"]
 
+def _resolve_anthropic_model_family(agent) -> Optional[str]:
+    custom_providers = getattr(agent, "_custom_providers", None)
+    if not isinstance(custom_providers, list):
+        return None
+
+    from hermes_cli.config import get_custom_provider_anthropic_model_family
+
+    return get_custom_provider_anthropic_model_family(
+        model=agent.model,
+        base_url=agent.base_url,
+        custom_providers=custom_providers,
+    )
 
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
@@ -798,6 +810,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            anthropic_model_family=_resolve_anthropic_model_family(agent),
         )
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
@@ -1841,10 +1854,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
             if agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
-                _ant_kw = _tsum.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                               max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
-                               is_oauth=agent._is_anthropic_oauth,
-                               preserve_dots=agent._anthropic_preserve_dots())
+                _ant_kw = _tsum.build_kwargs(
+                    model=agent.model,
+                    messages=api_messages,
+                    tools=None,
+                    max_tokens=agent.max_tokens,
+                    reasoning_config=agent.reasoning_config,
+                    is_oauth=agent._is_anthropic_oauth,
+                    preserve_dots=agent._anthropic_preserve_dots(),
+                    anthropic_model_family=_resolve_anthropic_model_family(agent),
+                )
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
@@ -1871,10 +1890,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_cnr_retry.content or "").strip()
             elif agent.api_mode == "anthropic_messages":
                 _tretry = agent._get_transport()
-                _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                                is_oauth=agent._is_anthropic_oauth,
-                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
-                                preserve_dots=agent._anthropic_preserve_dots())
+                _ant_kw2 = _tretry.build_kwargs(
+                    model=agent.model,
+                    messages=api_messages,
+                    tools=None,
+                    is_oauth=agent._is_anthropic_oauth,
+                    max_tokens=agent.max_tokens,
+                    reasoning_config=agent.reasoning_config,
+                    preserve_dots=agent._anthropic_preserve_dots(),
+                    anthropic_model_family=_resolve_anthropic_model_family(agent),
+                )
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_retry_result.content or "").strip()

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -59,6 +59,7 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            anthropic_model_family: str | None
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
@@ -75,6 +76,7 @@ class AnthropicTransport(ProviderTransport):
             base_url=params.get("base_url"),
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
+            anthropic_model_family=params.get("anthropic_model_family"),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5178,6 +5178,51 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_anthropic_model_family(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Return the canonical Claude family for an opaque custom-provider model."""
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = base_url.rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = str(entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_config = models.get(model)
+        if not isinstance(model_config, dict):
+            continue
+        family = model_config.get("anthropic_model_family")
+        if not isinstance(family, str):
+            continue
+        family = family.strip()
+        if family:
+            return family
+    return None
+
+
 def _coerce_config_version(value: Any) -> int:
     """Return a safe integer config version, treating invalid values as legacy."""
     if isinstance(value, bool):

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1352,6 +1352,129 @@ class TestBuildAnthropicKwargs:
         )
         assert kwargs["model"] == "claude-sonnet-4-20250514"
 
+    def test_opaque_opus_46_uses_adaptive_thinking_and_keeps_wire_model(self):
+        kwargs = build_anthropic_kwargs(
+            model="ep-opus-46",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            anthropic_model_family="claude-opus-4-6",
+        )
+        assert kwargs["model"] == "ep-opus-46"
+        assert kwargs["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+        }
+        assert kwargs["output_config"] == {"effort": "max"}
+        assert "budget_tokens" not in kwargs["thinking"]
+        assert "temperature" not in kwargs
+
+    def test_opaque_opus_48_preserves_xhigh_and_modern_payload(self):
+        kwargs = build_anthropic_kwargs(
+            model="ep-opus-48",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            anthropic_model_family="claude-opus-4-8",
+        )
+        assert kwargs["model"] == "ep-opus-48"
+        assert kwargs["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+        }
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+        assert "temperature" not in kwargs
+
+    def test_opaque_fable_uses_modern_claude_capabilities(self):
+        kwargs = build_anthropic_kwargs(
+            model="ep-fable",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            anthropic_model_family="claude-fable-5",
+        )
+        assert kwargs["model"] == "ep-fable"
+        assert kwargs["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+        }
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+        assert "temperature" not in kwargs
+
+    def test_fable_without_reasoning_config_omits_manual_thinking(self):
+        kwargs = build_anthropic_kwargs(
+            model="ep-fable",
+            messages=[{"role": "user", "content": "answer"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            anthropic_model_family="claude-fable-5",
+        )
+        assert kwargs["model"] == "ep-fable"
+        assert "thinking" not in kwargs
+        assert "temperature" not in kwargs
+
+    def test_family_hint_drives_output_limit(self):
+        kwargs = build_anthropic_kwargs(
+            model="ep-sonnet",
+            messages=[{"role": "user", "content": "answer"}],
+            tools=None,
+            max_tokens=None,
+            reasoning_config=None,
+            anthropic_model_family="claude-sonnet-4-6",
+        )
+        assert kwargs["model"] == "ep-sonnet"
+        assert kwargs["max_tokens"] == 64_000
+
+    def test_family_hint_drives_haiku_thinking_exclusion(self):
+        kwargs = build_anthropic_kwargs(
+            model="ep-haiku",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+            anthropic_model_family="claude-haiku-4-5",
+        )
+        assert kwargs["model"] == "ep-haiku"
+        assert "thinking" not in kwargs
+        assert "output_config" not in kwargs
+
+    @pytest.mark.parametrize("family", [None, "", "   ", 7])
+    def test_missing_or_invalid_family_preserves_opaque_legacy_behavior(self, family):
+        kwargs = build_anthropic_kwargs(
+            model="ep-legacy",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+            anthropic_model_family=family,
+        )
+        assert kwargs["model"] == "ep-legacy"
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["temperature"] == 1
+
+    def test_anthropic_transport_forwards_model_family(self):
+        transport = get_transport("anthropic_messages")
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_kwargs",
+            return_value={"sent": True},
+        ) as builder:
+            result = transport.build_kwargs(
+                model="ep-opus",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=4096,
+                reasoning_config=None,
+                anthropic_model_family="claude-opus-4-8",
+            )
+        assert result == {"sent": True}
+        assert builder.call_args.kwargs["anthropic_model_family"] == (
+            "claude-opus-4-8"
+        )
+
     def test_fast_mode_oauth_default_omits_context_1m_beta(self):
         """Default OAuth fast-mode avoids context-1m for subscriptions without it."""
         kwargs = build_anthropic_kwargs(

--- a/tests/agent/test_anthropic_model_family_wiring.py
+++ b/tests/agent/test_anthropic_model_family_wiring.py
@@ -1,0 +1,96 @@
+"""Live primary-request wiring for Anthropic opaque model family hints."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import build_api_kwargs
+
+
+def _provider(base_url, model, family):
+    return {
+        "base_url": base_url,
+        "models": {
+            model: {"anthropic_model_family": family},
+        },
+    }
+
+
+def _agent(custom_providers):
+    transport = MagicMock()
+    transport.build_kwargs.side_effect = lambda **kwargs: kwargs
+    agent = SimpleNamespace(
+        api_mode="anthropic_messages",
+        tools=[],
+        model="ep-primary",
+        base_url="https://primary.example/anthropic",
+        _custom_providers=custom_providers,
+        max_tokens=4096,
+        reasoning_config={"enabled": True, "effort": "high"},
+        _is_anthropic_oauth=False,
+        _oauth_1m_beta_disabled=False,
+        request_overrides={},
+        context_compressor=None,
+        _get_transport=lambda: transport,
+        _prepare_anthropic_messages_for_api=lambda messages: messages,
+        _anthropic_preserve_dots=lambda: False,
+    )
+    return agent, transport
+
+
+def test_primary_request_forwards_current_family():
+    providers = [
+        _provider(
+            "https://primary.example/anthropic",
+            "ep-primary",
+            "claude-opus-4-6",
+        )
+    ]
+    agent, transport = _agent(providers)
+
+    result = build_api_kwargs(
+        agent,
+        [{"role": "user", "content": "hi"}],
+    )
+
+    assert result["anthropic_model_family"] == "claude-opus-4-6"
+    assert transport.build_kwargs.call_count == 1
+
+
+def test_primary_request_re_resolves_after_runtime_route_change():
+    providers = [
+        _provider(
+            "https://primary.example/anthropic",
+            "ep-primary",
+            "claude-opus-4-6",
+        ),
+        _provider(
+            "https://switched.example/anthropic",
+            "ep-switched",
+            "claude-fable-5",
+        ),
+    ]
+    agent, transport = _agent(providers)
+
+    build_api_kwargs(agent, [{"role": "user", "content": "first"}])
+    agent.model = "ep-switched"
+    agent.base_url = "https://switched.example/anthropic"
+    build_api_kwargs(agent, [{"role": "user", "content": "second"}])
+
+    families = [
+        call.kwargs["anthropic_model_family"]
+        for call in transport.build_kwargs.call_args_list
+    ]
+    assert families == ["claude-opus-4-6", "claude-fable-5"]
+
+
+def test_missing_cached_provider_list_does_not_read_config_on_request():
+    agent, transport = _agent([])
+    del agent._custom_providers
+
+    with patch("hermes_cli.config.get_compatible_custom_providers") as loader:
+        build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    loader.assert_not_called()
+    assert transport.build_kwargs.call_args.kwargs[
+        "anthropic_model_family"
+    ] is None

--- a/tests/hermes_cli/test_custom_provider_anthropic_model_family.py
+++ b/tests/hermes_cli/test_custom_provider_anthropic_model_family.py
@@ -1,0 +1,111 @@
+"""Tests for per-model Anthropic family hints on custom providers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import get_custom_provider_anthropic_model_family
+
+
+def _providers():
+    return [
+        {
+            "name": "opaque-anthropic",
+            "base_url": "https://router.example/anthropic/",
+            "models": {
+                "ep-opus": {
+                    "anthropic_model_family": "  claude-opus-4-8  ",
+                },
+                "ep-fable": {
+                    "anthropic_model_family": "claude-fable-5",
+                },
+            },
+        }
+    ]
+
+
+def test_returns_stripped_family_for_exact_url_and_model():
+    assert get_custom_provider_anthropic_model_family(
+        "ep-opus",
+        "https://router.example/anthropic",
+        _providers(),
+    ) == "claude-opus-4-8"
+
+
+def test_trailing_slash_is_ignored_and_models_resolve_independently():
+    providers = _providers()
+    assert get_custom_provider_anthropic_model_family(
+        "ep-opus",
+        "https://router.example/anthropic/",
+        providers,
+    ) == "claude-opus-4-8"
+    assert get_custom_provider_anthropic_model_family(
+        "ep-fable",
+        "https://router.example/anthropic",
+        providers,
+    ) == "claude-fable-5"
+
+
+@pytest.mark.parametrize(
+    ("model", "base_url"),
+    [
+        ("missing", "https://router.example/anthropic"),
+        ("ep-opus", "https://other.example/anthropic"),
+        ("", "https://router.example/anthropic"),
+        ("ep-opus", ""),
+    ],
+)
+def test_missing_or_mismatched_route_returns_none(model, base_url):
+    assert get_custom_provider_anthropic_model_family(
+        model,
+        base_url,
+        _providers(),
+    ) is None
+
+
+@pytest.mark.parametrize("invalid", [None, "", "   ", 7, [], {}])
+def test_invalid_family_values_return_none(invalid):
+    providers = [
+        {
+            "base_url": "https://router.example/anthropic",
+            "models": {"ep": {"anthropic_model_family": invalid}},
+        }
+    ]
+    assert get_custom_provider_anthropic_model_family(
+        "ep",
+        "https://router.example/anthropic",
+        providers,
+    ) is None
+
+
+def test_malformed_entries_are_skipped_without_hiding_a_later_match():
+    providers = [
+        "not-a-dict",
+        None,
+        {"base_url": "https://router.example/anthropic", "models": []},
+        {
+            "base_url": "https://router.example/anthropic",
+            "models": {"ep": "not-a-dict"},
+        },
+        {
+            "base_url": "https://router.example/anthropic",
+            "models": {
+                "ep": {"anthropic_model_family": "claude-opus-4-6"},
+            },
+        },
+    ]
+    assert get_custom_provider_anthropic_model_family(
+        "ep",
+        "https://router.example/anthropic",
+        providers,
+    ) == "claude-opus-4-6"
+
+
+def test_explicit_provider_list_does_not_reload_configuration():
+    with patch("hermes_cli.config.get_compatible_custom_providers") as loader:
+        assert get_custom_provider_anthropic_model_family(
+            "ep-fable",
+            "https://router.example/anthropic",
+            _providers(),
+        ) == "claude-fable-5"
+    loader.assert_not_called()

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -211,6 +211,58 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
 
+    def test_anthropic_fallback_request_uses_fallback_opaque_family(self):
+        base_url = "https://fallback.example/anthropic"
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "ep-fable",
+                "base_url": base_url,
+            }
+        )
+        agent._custom_providers = [
+            {
+                "base_url": base_url,
+                "models": {
+                    "ep-fable": {
+                        "anthropic_model_family": "claude-fable-5",
+                    },
+                },
+            }
+        ]
+        agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        agent.max_tokens = 4096
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url=base_url, api_key="fallback-key"),
+                    "ep-fable",
+                ),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        kwargs = agent._build_api_kwargs(
+            [{"role": "user", "content": "hi"}],
+        )
+        assert agent.api_mode == "anthropic_messages"
+        assert kwargs["model"] == "ep-fable"
+        assert kwargs["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+        }
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3645,6 +3645,65 @@ class TestMcpParallelToolBatch:
 
 
 class TestHandleMaxIterations:
+    @staticmethod
+    def _configure_anthropic_summary_agent(agent):
+        base_url = "https://summary.example/anthropic"
+        agent.api_mode = "anthropic_messages"
+        agent.model = "ep-summary"
+        agent.base_url = base_url
+        agent.max_tokens = 4096
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent._cached_system_prompt = "You are helpful."
+        agent._custom_providers = [
+            {
+                "base_url": base_url,
+                "models": {
+                    "ep-summary": {
+                        "anthropic_model_family": "claude-opus-4-8",
+                    },
+                },
+            }
+        ]
+        transport = MagicMock()
+        transport.build_kwargs.return_value = {"model": "ep-summary"}
+        agent._get_transport = MagicMock(return_value=transport)
+        agent._anthropic_messages_create = MagicMock(return_value=MagicMock())
+        return transport
+
+    def test_anthropic_summary_forwards_current_family(self, agent):
+        transport = self._configure_anthropic_summary_agent(agent)
+        transport.normalize_response.return_value = SimpleNamespace(
+            content="Summary",
+        )
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        assert transport.build_kwargs.call_args.kwargs[
+            "anthropic_model_family"
+        ] == "claude-opus-4-8"
+
+    def test_anthropic_summary_retry_forwards_current_family(self, agent):
+        transport = self._configure_anthropic_summary_agent(agent)
+        transport.normalize_response.side_effect = [
+            SimpleNamespace(content=""),
+            SimpleNamespace(content="Retry summary"),
+        ]
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Retry summary"
+        assert [
+            call.kwargs["anthropic_model_family"]
+            for call in transport.build_kwargs.call_args_list
+        ] == ["claude-opus-4-8", "claude-opus-4-8"]
+
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")
         agent.client.chat.completions.create.return_value = resp

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3704,6 +3704,55 @@ class TestHandleMaxIterations:
             for call in transport.build_kwargs.call_args_list
         ] == ["claude-opus-4-8", "claude-opus-4-8"]
 
+    def test_anthropic_summary_retry_preserves_route_context(self, agent):
+        from agent.transports import get_transport
+
+        base_url = "https://api.kimi.com/coding"
+        agent.api_mode = "anthropic_messages"
+        agent.model = "ep-summary"
+        agent.base_url = base_url
+        agent._anthropic_base_url = base_url
+        agent.max_tokens = None
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent._cached_system_prompt = "You are helpful."
+        agent.context_compressor.context_length = 8192
+        agent._custom_providers = [
+            {
+                "base_url": base_url,
+                "models": {
+                    "ep-summary": {
+                        "anthropic_model_family": "claude-sonnet-4-6",
+                    },
+                },
+            }
+        ]
+        agent._get_transport = MagicMock(
+            return_value=get_transport("anthropic_messages")
+        )
+        agent._anthropic_messages_create = MagicMock(
+            side_effect=[
+                SimpleNamespace(content=[], stop_reason="end_turn"),
+                SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="Retry summary")],
+                    stop_reason="end_turn",
+                ),
+            ]
+        )
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Retry summary"
+        request_kwargs = [
+            call.args[0]
+            for call in agent._anthropic_messages_create.call_args_list
+        ]
+        assert len(request_kwargs) == 2
+        assert [kwargs["max_tokens"] for kwargs in request_kwargs] == [8191, 8191]
+        assert all("thinking" not in kwargs for kwargs in request_kwargs)
+
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")
         agent.client.chat.completions.create.return_value = resp

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -73,3 +73,54 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_request_uses_new_opaque_family():
+    agent = _make_agent_with_compressor(config_context_length=None)
+    base_url = "https://switch.example/anthropic"
+    providers = [
+        {
+            "base_url": base_url,
+            "models": {
+                "ep-opus-48": {
+                    "anthropic_model_family": "claude-opus-4-8",
+                },
+            },
+        }
+    ]
+    agent._custom_providers = providers
+    agent.tools = []
+    agent.max_tokens = 4096
+    agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+    agent.request_overrides = {}
+    agent._oauth_1m_beta_disabled = False
+
+    with (
+        patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ),
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=1_000_000,
+        ),
+    ):
+        agent.switch_model(
+            "ep-opus-48",
+            "custom",
+            api_key="switch-key",
+            base_url=base_url,
+            api_mode="anthropic_messages",
+        )
+
+    kwargs = agent._build_api_kwargs(
+        [{"role": "user", "content": "hi"}],
+    )
+    assert kwargs["model"] == "ep-opus-48"
+    assert kwargs["thinking"] == {
+        "type": "adaptive",
+        "display": "summarized",
+    }
+    assert kwargs["output_config"] == {"effort": "xhigh"}


### PR DESCRIPTION
## Summary

Adds an opt-in `anthropic_model_family` hint for opaque model IDs used with Anthropic-compatible endpoints. The hint lets Hermes apply the correct Claude capability policy while keeping the real opaque model ID unchanged on the wire.

The family is resolved from the current `base_url` + `model` for every request, so runtime model switching and fallback activation cannot leave a stale cached family behind.

## Motivation

Hermes chooses adaptive versus legacy thinking, output limits, xhigh support, sampling behavior, and Haiku exclusions from the model ID. Opaque routing IDs such as Bedrock inference profiles or custom endpoint IDs do not contain a recognizable Claude family, so capability detection can choose the wrong payload shape.

For example, an opaque endpoint routing to Claude Opus 4.6 may receive legacy thinking:

```text
thinking={"type":"enabled","budget_tokens":...}
```

when the routed model requires adaptive thinking plus `output_config.effort`.

## Configuration

```yaml
custom_providers:
  - name: my-provider
    base_url: https://example.invalid/anthropic
    api_mode: anthropic_messages
    models:
      ep-XXXX:
        context_length: 1000000
        anthropic_model_family: claude-opus-4-6
```

`anthropic_model_family` affects local capability checks only. `ep-XXXX` remains the model sent to the provider.

## Implementation

| Area | Change |
|---|---|
| `hermes_cli/config.py` | Adds strict `base_url` + model lookup for a non-empty family hint, with trailing-slash normalization and malformed-value fallback. |
| `agent/anthropic_adapter.py` | Uses the effective family for output ceilings, Haiku thinking exclusion, adaptive/manual thinking, xhigh support, and sampling restrictions. The real model still controls wire identity, endpoint policy, Kimi behavior, and Fast Mode. |
| `agent/transports/anthropic.py` | Forwards the optional hint to the adapter. |
| `agent/chat_completion_helpers.py` | Resolves the family at request time and forwards it through primary, iteration-limit summary, and retry paths. Summary/retry also preserve the active Anthropic `base_url` and compressor `context_length`. |
| Tests | Cover config lookup, adapter payloads, real transport forwarding, primary/summary/retry calls, dynamic switch/fallback routes, opaque wire IDs, Opus 4.6/4.8, and Fable 5 family hints. |

## Review feedback addressed

- Moved live request plumbing to `agent/chat_completion_helpers.py`; current `run_agent.py` remains untouched.
- Removed ineffective auxiliary-client plumbing; `agent/auxiliary_client.py` remains untouched.
- Resolves the hint from the current route on every request instead of caching it once.
- Added switch and fallback regression coverage.
- Added a real-transport summary/retry regression proving that Kimi endpoint policy and an 8K context clamp are preserved on both calls.

## Verification

- Focused config, adapter, transport, primary, summary/retry, switch, and fallback suite: **663 passed, 0 failed** after excluding three known macOS OAuth/Keychain mock baseline failures.
- Summary/retry route-context regression: failed before the fix with `max_tokens=64000`; passes with `max_tokens=8191` on both calls and no Kimi-incompatible `thinking` field.
- `ruff check .`: passed.
- Windows footgun scan: **760 files passed**.
- `git diff --check`: passed.
- Two independent read-only final reviews reported no Critical, Important, or Minor findings.

## Current CI note

The PR is mergeable and all review threads are resolved. The required-check aggregate currently fails only because two Gemini model-validation tests fail in the Python slice. The same two tests fail on current `main@226e8de`, and this PR does not modify `hermes_cli/models.py` or `tests/hermes_cli/test_model_validation.py`:

- [PR failing job](https://github.com/NousResearch/hermes-agent/actions/runs/29309160217/job/87009262887)
- [Current main failing run](https://github.com/NousResearch/hermes-agent/actions/runs/29308540479)

## Scope

10 files changed, 654 insertions, 13 deletions. No changes to `run_agent.py`, `agent/agent_init.py`, `agent/auxiliary_client.py`, or `scripts/release.py`.
