### PR TITLE
fix(telegram): send seed message after creating DM topics

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -761,6 +761,20 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Persist thread_id to config so we don't recreate on next restart
                     self._persist_dm_topic_thread_id(int(chat_id), topic_name, thread_id)
 
+                    # Send a seed message so the topic is visible in Telegram's client.
+                    # Empty topics are hidden by the client UI until they contain a message.
+                    try:
+                        await self._bot.send_message(
+                            chat_id=int(chat_id),
+                            message_thread_id=thread_id,
+                            text=f"\U0001f4cc {topic_name}",
+                        )
+                    except Exception as seed_err:
+                        logger.debug(
+                            "[%s] Could not send seed message to topic '%s': %s",
+                            self.name, topic_name, seed_err,
+                        )
+
     async def connect(self) -> bool:
         """Connect to Telegram via polling or webhook.
 


### PR DESCRIPTION
Telegram's client does not display empty forum topics in the chat's topic list. After `createForumTopic` succeeds, send a short pin message (`📌 {name}`) into the new topic so it becomes immediately visible to the user.

Without this, bot-created DM topics exist at the API level but are invisible in all Telegram clients until someone posts a message in them — confusing for users who just configured topics and see nothing.

Only fires for newly created topics (no `thread_id` in config yet). Failure to send the seed is non-fatal (debug-logged, topic still functional).