### PR TITLE
fix(pricing): resolve provider/model aliases in usage cost estimation

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -535,6 +535,10 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name in {"gemini", "google", "google-gemini", "google-ai-studio"}:
+        return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "deepseek" or base_url_host_matches(base_url or "", "api.deepseek.com"):
+        return BillingRoute(provider="deepseek", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
@@ -560,18 +564,24 @@ def _normalize_anthropic_model_name(model: str) -> str:
 
 
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
-    model = route.model.lower()
+    model_lower = route.model.lower()
     # Direct lookup first
-    entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model))
-    if entry:
+    entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model_lower))
+    if entry is not None:
         return entry
     # Try normalized name for Anthropic (handles dot-notation like opus-4.7)
     if route.provider == "anthropic":
-        normalized = _normalize_anthropic_model_name(model)
-        if normalized != model:
+        normalized = _normalize_anthropic_model_name(model_lower)
+        if normalized != model_lower:
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
-            if entry:
+            if entry is not None:
                 return entry
+    # Fallback: match unversioned model aliases (e.g. "claude-sonnet-4"
+    # matches "claude-sonnet-4-20250514").  Only consider entries for the
+    # same provider whose canonical name starts with the requested model.
+    for (p, m), candidate in _OFFICIAL_DOCS_PRICING.items():
+        if p == route.provider and m.startswith(model_lower + "-"):
+            return candidate
     return None
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -928,6 +928,7 @@ AUTHOR_MAP = {
     "jhin.lee@unity3d.com": "leehack",  # PR #22053 salvage (telegram DM topic reply fallback)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
     "ayman.a.kamal@hotmail.com": "A-kamal",  # PR #18678 (xAI image resolution fix)
+    "kagura.agent.ai@gmail.com": "kagura-agent",
 }
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -190,3 +190,44 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
 
     assert float(entry.input_cost_per_million) == 0.5
     assert float(entry.output_cost_per_million) == 2.0
+
+
+def test_estimate_usage_cost_gemini_provider_alias():
+    """Provider name 'gemini' (Hermes internal name) should resolve to
+    'google' pricing entries."""
+    result = estimate_usage_cost(
+        "gemini-2.5-pro",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="gemini",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    assert float(result.amount_usd) > 0
+
+
+def test_estimate_usage_cost_anthropic_unversioned_model_alias():
+    """Short model names like 'claude-sonnet-4' should match versioned
+    entries like 'claude-sonnet-4-20250514'."""
+    result = estimate_usage_cost(
+        "claude-sonnet-4",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="anthropic",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    assert float(result.amount_usd) > 0
+
+
+def test_estimate_usage_cost_deepseek_provider_route():
+    """DeepSeek provider should resolve to official_docs_snapshot pricing."""
+    result = estimate_usage_cost(
+        "deepseek-chat",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    assert float(result.amount_usd) > 0


### PR DESCRIPTION
## Summary

Fixes #18304 — `estimated_cost_usd` and `actual_cost_usd` are always 0 in `state.db` even when tokens are recorded correctly.

## Root Cause

Two issues in `agent/usage_pricing.py`:

1. **Provider name mismatch for Google/Gemini:** Hermes internally uses `"gemini"` as the provider name (see `hermes_cli/models.py`), but `_OFFICIAL_DOCS_PRICING` uses `"google"` as the provider key. `resolve_billing_route()` had no mapping for `"gemini"` → `"google"`, so the pricing lookup always returned `None`.

2. **Model alias mismatch for Anthropic Claude 4:** Users configure models with short names like `claude-sonnet-4`, but the pricing dict only has versioned entries like `claude-sonnet-4-20250514`. The lookup did exact matching with no alias resolution.

In both cases, `get_pricing_entry()` returned `None`, causing `estimate_usage_cost()` to return `amount_usd=None`, which gets stored as `0` in the DB (`COALESCE(?, 0)`).

## Changes

- **`resolve_billing_route()`**: Added `gemini`/`google-gemini`/`google-ai-studio` as provider aliases that route to the `"google"` pricing entries. Also added explicit `deepseek` provider routing.
- **`_lookup_official_docs_pricing()`**: Added prefix-based fallback — when an exact lookup fails, matches unversioned model names (e.g. `claude-sonnet-4`) against versioned entries (`claude-sonnet-4-20250514`) for the same provider.

## Verification

Before fix:
```
claude-sonnet-4 (anthropic): status=unknown, amount=None
gemini-2.5-pro (gemini): status=unknown, amount=None
```

After fix:
```
claude-sonnet-4 (anthropic): status=estimated, amount=0.0105
gemini-2.5-pro (gemini): status=estimated, amount=0.00625
```

## Tests

Added 3 new tests covering:
- Gemini provider alias resolution
- Anthropic unversioned model alias resolution
- DeepSeek provider routing

All 12 pricing tests pass. Full suite: 18719 passed (95 pre-existing failures unrelated to this change).