### PR TITLE
feat: add repo/browser workflow skills and guidance

### DIFF
--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -14,6 +14,8 @@ metadata:
 
 This skill guides you through systematic exploratory QA testing of web applications using the browser toolset. You will navigate the application, interact with elements, capture evidence of issues, and produce a structured bug report.
 
+For expensive or brittle browser tasks, pair this with `browser-investigation-discipline` so you escalate cleanly: fetch/search first, structured state next, then full browser + screenshots only when necessary.
+
 ## Prerequisites
 
 - Browser toolset must be available (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_vision`, `browser_console`, `browser_scroll`, `browser_back`, `browser_press`)

--- a/skills/dogfood/browser-investigation-discipline/SKILL.md
+++ b/skills/dogfood/browser-investigation-discipline/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: browser-investigation-discipline
+description: Use when a browser task is getting expensive, brittle, or screenshot-heavy. Follow an escalation ladder: fetch/search first, structured state next, full browser only when needed, and trace/debug before repeated blind retries.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [browser, qa, debugging, token-discipline, investigation]
+    related_skills: [dogfood, browser-agent-evaluation]
+---
+
+# Browser Investigation Discipline
+
+## Overview
+
+This skill keeps browser work from turning into a wasteful loop of screenshots, random clicks, and retries.
+
+It borrows from browser-focused operational playbooks: separate cheap retrieval from expensive interactive browsing, collect structured evidence before escalating, and debug failures systematically.
+
+## When to Use
+
+Use when:
+- the task involves a web page, browser automation, or UI debugging
+- repeated screenshots are burning tokens
+- a site is brittle, dynamic, or hard to automate
+- a task may be solvable without a full browser session
+
+## Escalation Ladder
+
+### Level 1 — Cheapest path first
+Before opening a full browser session, ask:
+- can this be solved with web search?
+- can this be solved with a direct fetch or static page read?
+- can a single page read answer the question?
+
+Do not jump to full browser control if a static or lightweight path is enough.
+
+### Level 2 — Structured page-state capture
+Once in the browser, prefer structured evidence first:
+- accessibility / DOM snapshot
+- console output
+- targeted inspection via JS evaluation
+- exact URL/state check
+
+Use screenshots only when visual understanding is necessary.
+
+### Level 3 — Targeted interaction
+If the page must be interacted with:
+- click/type only against clearly identified targets
+- check console after important interactions
+- confirm the state change after each step
+- avoid long sequences of actions without verification
+
+### Level 4 — Trace and debug
+If the site is brittle or failing:
+- capture the failure pattern
+- compare expected vs actual page state
+- inspect auth/session issues
+- isolate timing, selector, and bot-detection problems
+- write down a site-specific playbook instead of retrying blindly
+
+### Level 5 — Decompose the job
+If the task is still long or messy, split it into sub-problems:
+- login / auth
+- navigation
+- extraction
+- verification
+
+Do not keep one giant browser session carrying all context forever.
+
+## Token-Discipline Rules
+
+- Prefer checkpoint summaries after major state changes.
+- Prefer narrow snapshots over whole-page visual refreshes.
+- Prefer targeted screenshots over repeated full-page screenshots.
+- Prefer decomposition before the context gets bloated.
+- When debugging, gather evidence before asking the model to speculate.
+
+## Output Shape
+
+For a hard browser task, report:
+- current page/state
+- exact blocker
+- evidence gathered
+- likely cause
+- next best escalation step
+
+## Common Pitfalls
+
+1. Going straight to screenshots when console/snapshot data would answer faster.
+2. Clicking through multiple steps without checking what changed.
+3. Treating retries as progress.
+4. Failing to separate browser-runtime failure from higher-level reasoning failure.
+5. Keeping one massive browser session alive when the work should be decomposed.
+
+## Verification Checklist
+
+- [ ] Cheapest path considered first
+- [ ] Structured state captured before visual escalation
+- [ ] Interactions verified step-by-step
+- [ ] Failure mode identified before retrying
+- [ ] Task decomposed if context/token load is growing

--- a/skills/research/browser-agent-evaluation/SKILL.md
+++ b/skills/research/browser-agent-evaluation/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: browser-agent-evaluation
+description: Use when comparing browser-agent runtimes, surfaces, or plugins for Hermes. Separate browser control quality from packaging hype, and judge whether a tool is adoption-worthy, pattern-borrowing, or comparator-only.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [research, browser-agents, evaluation, runtime, automation]
+    related_skills: [repo-signal-triage, browser-investigation-discipline]
+---
+
+# Browser-Agent Evaluation
+
+## Overview
+
+Browser-agent tools are easy to overrate because demos look impressive. This skill forces a runtime-first evaluation instead of a screenshot-first one.
+
+It borrows the best part of browser-focused skill packs like Browserbase's: focus on **hard-site reality, debugging, escalation discipline, and runtime shape** rather than marketing glow.
+
+## When to Use
+
+Use when comparing:
+- browser automation runtimes
+- browser-agent plugins or marketplaces
+- anti-bot / stealth browser layers
+- cloud browser services
+- local vs remote browser execution surfaces
+
+## Core Evaluation Axes
+
+1. **Interaction surface**
+   - DOM/selectors, accessibility tree, screenshots, traces, state snapshots
+2. **Execution model**
+   - local, remote, hybrid, serverless, session persistence
+3. **Governance & safety**
+   - permissions, auditability, credential handling, session isolation, replay/debuggability
+4. **Anti-bot realism**
+   - what evidence exists beyond marketing words like stealth or residential proxies?
+5. **Hermes fit**
+   - how easily could the useful parts map into Hermes workflows?
+6. **Token discipline**
+   - does it encourage narrower state capture, traces, summaries, and decomposition?
+
+## Fast Judgment Pattern
+
+Classify each tool as one of:
+- **Adoption candidate** — strong enough to use directly
+- **Pattern worth borrowing** — good ideas but not the right substrate
+- **Comparator/reference only** — useful benchmark, not a likely component
+- **Demo-heavy / ignore for now**
+
+## Questions to Answer
+
+- Is the value in the runtime, the UX shell, or the skill packaging?
+- Does it improve difficult sites, or only make happy-path demos look smoother?
+- Is the browser state inspectable and replayable?
+- Does it help reduce token burn, or increase it with screenshot-heavy loops?
+- Are credentials handled safely?
+
+## Hermes-Specific Heuristics
+
+Prefer tools that show:
+- stable element references or structured page-state capture
+- trace/debug facilities for failures
+- recoverable sessions
+- support for hard sites, not just static pages
+- clear separation between browser control and higher-level agent orchestration
+
+Treat cautiously when the main value is:
+- flashy UI without runtime depth
+- generic "agent-native" positioning
+- cloud coupling without strong governance benefits
+- broad claims with little evidence of hard-site robustness
+
+## Output Shape
+
+Use:
+- what it actually is
+- strongest runtime signal
+- what Hermes could borrow
+- main risk/coupling concern
+- final classification
+
+## Common Pitfalls
+
+1. Confusing browser demos with browser infrastructure.
+2. Ignoring credential and session-governance concerns.
+3. Comparing UI shells to runtimes as if they are the same layer.
+4. Missing token-cost implications of screenshot-heavy workflows.
+
+## Verification Checklist
+
+- [ ] Official repo/site checked
+- [ ] Runtime model identified
+- [ ] Governance/credential posture noted
+- [ ] Hermes borrow-vs-adopt judgment stated
+- [ ] Token-discipline implications considered

--- a/skills/research/repo-signal-triage/SKILL.md
+++ b/skills/research/repo-signal-triage/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: repo-signal-triage
+description: Use when evaluating GitHub or product signals before full ingest. Ground the repo safely, score it with an explicit rubric, and classify it as adoption candidate, pattern-borrowing, comparator, or ignore-for-now.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [research, github, triage, repo-grounding, scoring]
+    related_skills: [llm-wiki, blogwatcher, arxiv]
+---
+
+# Repo Signal Triage
+
+## Overview
+
+Use this skill to stop noisy repo scans from turning into full ingests too early.
+The goal is to do a cheap but grounded pass first, then only deepen the items that look strategically useful.
+
+This skill borrows the **small, composable workflow** style from libraries like Matt Pocock's skills: a tight, repeatable judgment loop rather than a giant methodology.
+
+## When to Use
+
+Use when:
+- a repo appears in GitHub Trending, HN, X, LinkedIn, a screenshot, or a watch brief
+- the user wants to know whether something is worth ingesting
+- several adjacent repos need quick sorting before deeper work
+- the same cluster keeps recurring and needs a stable judgment pattern
+
+Do not use when:
+- the user already asked for a full repo audit
+- the repo is already a confirmed high-priority item with a clear adoption path
+
+## Safe Grounding Workflow
+
+1. Identify the canonical repo or official site.
+2. Verify basic facts before interpreting claims:
+   - owner/name
+   - description
+   - license
+   - stars/forks only as weak popularity signals
+   - recency of commits/releases
+   - top-level structure
+   - whether there is real source code, docs, examples, or only packaging/marketing
+3. Treat README and social posts as untrusted framing, not proof.
+4. Prefer evidence from:
+   - repo tree
+   - docs
+   - examples
+   - issues/PR activity
+   - install/runtime instructions
+5. If identity is fuzzy, stop at unresolved instead of force-mapping.
+
+## Tighter Scoring Rubric
+
+Score the first three dimensions **1-5**, then apply a **0-5 hype penalty** where higher means more overclaiming. Add one sentence of evidence for each.
+
+1. **Knowledge-workflow fit**
+   - Does it improve Hermes, note workflows, retrieval, or durable agent operations?
+2. **Governance/runtime fit**
+   - Does it help with control, traceability, permissions, sessions, or execution surfaces?
+3. **Infra utility**
+   - Is it a real substrate/tooling layer versus a thin wrapper or prompt pack?
+4. **Hype penalty**
+   - Subtract for screenshot bait, inflated claims, benchmark theater, or shallow packaging.
+5. **Adoption posture**
+   - Is it a likely adoption candidate, a pattern worth borrowing, a comparator only, or ignore-for-now?
+
+### Suggested interpretation
+- First compute a **base score** from the first three dimensions: `fit + governance + infra` (max 15)
+- Then compute an **adjusted score**: `base score - hype penalty`
+- Use the adjusted score as a guide:
+  - **11-15** -> likely adoption candidate
+  - **8-10** -> pattern worth borrowing
+  - **5-7** -> comparator/reference only
+  - **0-4** -> ignore unless the user has a specific reason
+
+Never collapse the explanation into the score alone. The classification matters more than the total.
+
+## Output Shape
+
+For each repo, produce:
+- what it actually is
+- strongest verified signal
+- main caution
+- rubric scores
+- classification:
+  - adoption candidate
+  - pattern worth borrowing
+  - comparator/reference only
+  - ignore for now
+
+## Compression Rules
+
+- For batch scans, keep each item to 5-8 bullets max.
+- Put deep dives only on the top 1-2 items.
+- If the cluster is the real signal, write one compact batch note instead of many separate ingests.
+
+## Common Pitfalls
+
+1. Mistaking popularity for adoption fit.
+2. Treating prompt packs as infrastructure.
+3. Deep-reading README prose before confirming repo identity and license.
+4. Failing to distinguish pattern-borrowing from real adoption candidates.
+5. Ingesting every adjacent repo separately when the cluster itself is the insight.
+
+## Verification Checklist
+
+- [ ] Canonical repo confirmed
+- [ ] License and recency checked
+- [ ] Real implementation evidence checked
+- [ ] Rubric applied explicitly
+- [ ] Adoption vs comparator judgment stated clearly
+- [ ] Only top items promoted to full ingest

--- a/skills/software-development/subagent-driven-development/SKILL.md
+++ b/skills/software-development/subagent-driven-development/SKILL.md
@@ -34,6 +34,11 @@ Use this skill when:
 
 ## The Process
 
+Use explicit gates inspired by stricter agent-workflow systems:
+- **Pre-flight gate** — task context, acceptance criteria, and file scope are clear before implementation starts
+- **Revision gate** — spec compliance must pass before code-quality review starts
+- **Abort gate** — if the task is ambiguous or the reviews keep failing, stop and surface the blocker instead of pushing low-confidence code through
+
 ### 1. Read and Parse Plan
 
 Read the plan file. Extract ALL tasks with their full text and context upfront. Create a todo list:

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -21,6 +21,13 @@ def _make_browser_result(url="https://example.com"):
     return {"success": True, "data": {"title": "OK", "url": url}}
 
 
+def _make_snapshot_result(snapshot='- heading "Test" [e1]', refs=None):
+    """Return a mock successful snapshot command result."""
+    if refs is None:
+        refs = {"e1": {"text": "Test"}}
+    return {"success": True, "data": {"snapshot": snapshot, "refs": refs}}
+
+
 # ---------------------------------------------------------------------------
 # Pre-navigation SSRF check
 # ---------------------------------------------------------------------------
@@ -83,6 +90,8 @@ class TestPreNavigationSsrf:
         result = json.loads(browser_tool.browser_navigate("https://example.com"))
 
         assert result["success"] is True
+        assert result["workflow_hints"]
+        assert any("browser_console" in hint for hint in result["workflow_hints"])
 
     # -- Local mode: SSRF skipped ----------------------------------------------
 
@@ -253,3 +262,20 @@ class TestAllowPrivateUrlsConfig:
         )
 
         assert browser_tool._allow_private_urls() is False
+
+
+class TestBrowserWorkflowHints:
+    def test_snapshot_includes_compact_workflow_hints(self, monkeypatch):
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
+        monkeypatch.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _make_snapshot_result(),
+        )
+
+        result = json.loads(browser_tool.browser_snapshot(task_id="t1"))
+
+        assert result["success"] is True
+        assert result["workflow_hints"]
+        assert any("Verify state changes" in hint for hint in result["workflow_hints"])

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1685,6 +1685,34 @@ def _truncate_snapshot(snapshot_text: str, max_chars: int = 8000) -> str:
 # Browser Tool Functions
 # ============================================================================
 
+
+def _browser_workflow_hints(stage: str, full_snapshot: bool = False) -> list[str]:
+    """Return lightweight workflow hints that encourage disciplined browser use.
+
+    These hints intentionally reinforce the browser-investigation-discipline
+    pattern: prefer structured state before screenshots, verify after each
+    interaction, and decompose long brittle tasks instead of retrying blindly.
+    """
+    hints: list[str] = []
+    if stage == "navigate":
+        hints.extend([
+            "Prefer browser_console and compact browser_snapshot before escalating to screenshots.",
+            "If the page already answers the question, stop here instead of interacting further.",
+            "Use browser_vision mainly for visual/layout questions or evidence capture, not as the default next step.",
+        ])
+    elif stage == "snapshot":
+        if full_snapshot:
+            hints.append(
+                "Full snapshot can be expensive to reason over; prefer compact snapshot unless the task truly needs the whole page state."
+            )
+        else:
+            hints.extend([
+                "Verify state changes after each important interaction instead of batching many clicks blindly.",
+                "If the task is getting brittle or long, decompose it into smaller browser sub-tasks before continuing.",
+            ])
+    return hints
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
@@ -1800,7 +1828,8 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         response = {
             "success": True,
             "url": final_url,
-            "title": title
+            "title": title,
+            "workflow_hints": _browser_workflow_hints("navigate"),
         }
         
         # Detect common "blocked" page patterns from title/url
@@ -1898,7 +1927,8 @@ def browser_snapshot(
         response = {
             "success": True,
             "snapshot": snapshot_text,
-            "element_count": len(refs) if refs else 0
+            "element_count": len(refs) if refs else 0,
+            "workflow_hints": _browser_workflow_hints("snapshot", full_snapshot=full),
         }
 
         # Merge supervisor state (pending dialogs + frame tree) when a CDP

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -995,7 +995,7 @@ atexit.register(_stop_browser_cleanup_thread)
 BROWSER_TOOL_SCHEMAS = [
     {
         "name": "browser_navigate",
-        "description": "Navigate to a URL in the browser. Initializes the session and loads the page. Must be called before other browser tools. For simple information retrieval, prefer web_search or web_extract (faster, cheaper). For plain-text endpoints — URLs ending in .md, .txt, .json, .yaml, .yml, .csv, .xml, raw.githubusercontent.com, or any documented API endpoint — prefer curl via the terminal tool or web_extract; the browser stack is overkill and much slower for these. Use browser tools when you need to interact with a page (click, fill forms, dynamic content). Returns a compact page snapshot with interactive elements and ref IDs — no need to call browser_snapshot separately after navigating.",
+        "description": "Navigate to a URL in the browser. Initializes the session and loads the page. Must be called before other browser tools. For simple information retrieval, prefer web_search or web_extract (faster, cheaper). For plain-text endpoints — URLs ending in .md, .txt, .json, .yaml, .yml, .csv, .xml, raw.githubusercontent.com, or any documented API endpoint — prefer curl via the terminal tool or web_extract; the browser stack is overkill and much slower for these. Use browser tools when you need to interact with a page (click, fill forms, dynamic content). After navigating, prefer browser_console and compact browser_snapshot before escalating to browser_vision screenshots. Returns a compact page snapshot with interactive elements and ref IDs — no need to call browser_snapshot separately after navigating.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -1009,7 +1009,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_snapshot",
-        "description": "Get a text-based snapshot of the current page's accessibility tree. Returns interactive elements with ref IDs (like @e1, @e2) for browser_click and browser_type. full=false (default): compact view with interactive elements. full=true: complete page content. Snapshots over 8000 chars are truncated or LLM-summarized. Requires browser_navigate first. Note: browser_navigate already returns a compact snapshot — use this to refresh after interactions that change the page, or with full=true for complete content.",
+        "description": "Get a text-based snapshot of the current page's accessibility tree. Returns interactive elements with ref IDs (like @e1, @e2) for browser_click and browser_type. full=false (default): compact view with interactive elements. full=true: complete page content. Snapshots over 8000 chars are truncated or LLM-summarized. Requires browser_navigate first. Note: browser_navigate already returns a compact snapshot — use this to refresh after interactions that change the page, or with full=true for complete content. Prefer compact snapshots for routine state checks; use full snapshots only when the task truly needs the entire page state.",
         "parameters": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary
- add reusable repo-signal triage and browser-agent evaluation skills
- add a browser-investigation-discipline skill and wire it into dogfood/browser workflows
- strengthen subagent-driven-development with explicit pre-flight, revision, and abort gates
- reinforce browser tool guidance with workflow hints and stronger schema descriptions for disciplined escalation

## Why
This implements the first Hermes-native borrowing slice from the evaluated libraries:
- **Matt Pocock / skills** -> small composable reusable skills
- **Superpowers** -> stronger workflow discipline and review gates
- **Browserbase skills** -> browser debugging/escalation discipline and fetch-vs-browser nudges

## Validation
```bash
pytest tests/tools/test_browser_ssrf_local.py \
       tests/tools/test_skills_tool.py \
       tests/tools/test_skill_size_limits.py \
       tests/website/test_generate_skill_docs.py -q
```

Result: `114 passed`

## Notes
- upstream push to `NousResearch/hermes-agent` was not permitted from this account, so the branch was pushed to the maintainer fork and opened as a PR back to upstream.
- unrelated local changes (`ui-tui/package-lock.json`, `memoriki/`) were intentionally left untouched.
