### PR TITLE
feat(anthropic): read HERMES_ANTHROPIC_EXTRA_HEADERS env var into default_headers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -592,6 +592,21 @@ def build_anthropic_client(
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
+    # Apply any extra headers from HERMES_ANTHROPIC_EXTRA_HEADERS env var.
+    # This allows custom providers (e.g. brconnector) to require specific
+    # User-Agent strings without modifying provider-specific code.
+    # Format: JSON object string, e.g. '{"User-Agent": "claude-code-cli/2.1.52"}'
+    _extra_headers_raw = os.environ.get("HERMES_ANTHROPIC_EXTRA_HEADERS", "").strip()
+    if _extra_headers_raw:
+        try:
+            import json as _json
+            _extra_headers = _json.loads(_extra_headers_raw)
+            if isinstance(_extra_headers, dict) and _extra_headers:
+                existing = kwargs.get("default_headers", {})
+                kwargs["default_headers"] = {**existing, **_extra_headers}
+        except Exception:
+            pass  # Silently ignore malformed JSON to avoid breaking the client
+
     return _anthropic_sdk.Anthropic(**kwargs)
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -139,6 +139,49 @@ class TestBuildAnthropicClient:
             }
 
 
+    def test_extra_headers_env_var_merges_into_default_headers(self, monkeypatch):
+        """HERMES_ANTHROPIC_EXTRA_HEADERS merges into default_headers for regular API keys."""
+        monkeypatch.setenv(
+            "HERMES_ANTHROPIC_EXTRA_HEADERS",
+            '{"User-Agent": "claude-code-cli/2.1.52"}',
+        )
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-some-regular-key")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["User-Agent"] == "claude-code-cli/2.1.52"
+            # Common betas must still be present alongside the extra header
+            assert "anthropic-beta" in kwargs["default_headers"]
+
+    def test_extra_headers_env_var_overrides_existing_header(self, monkeypatch):
+        """HERMES_ANTHROPIC_EXTRA_HEADERS can override an existing default_headers entry."""
+        monkeypatch.setenv(
+            "HERMES_ANTHROPIC_EXTRA_HEADERS",
+            '{"anthropic-beta": "my-custom-beta"}',
+        )
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-some-regular-key")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["anthropic-beta"] == "my-custom-beta"
+
+    def test_extra_headers_env_var_invalid_json_is_ignored(self, monkeypatch):
+        """Malformed HERMES_ANTHROPIC_EXTRA_HEADERS must not break client creation."""
+        monkeypatch.setenv("HERMES_ANTHROPIC_EXTRA_HEADERS", "not-valid-json")
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-some-regular-key")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            # Client is still created; default_headers contains betas as normal
+            assert "default_headers" in kwargs
+            assert "anthropic-beta" in kwargs["default_headers"]
+
+    def test_extra_headers_env_var_not_set(self, monkeypatch):
+        """When HERMES_ANTHROPIC_EXTRA_HEADERS is absent, behaviour is unchanged."""
+        monkeypatch.delenv("HERMES_ANTHROPIC_EXTRA_HEADERS", raising=False)
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-some-regular-key")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert "User-Agent" not in kwargs.get("default_headers", {})
+
+
 class TestReadClaudeCodeCredentials:
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"


### PR DESCRIPTION
## Summary

Allow users to inject arbitrary HTTP headers into every Anthropic client request via the `HERMES_ANTHROPIC_EXTRA_HEADERS` environment variable.

## Motivation

Custom reverse-proxy providers (e.g. brconnector) may require a specific `User-Agent` to route requests correctly. Previously there was no way to inject such headers without modifying provider-specific code.

## Implementation

After all auth-branch logic in `build_anthropic_client()`, read `HERMES_ANTHROPIC_EXTRA_HEADERS` from the environment:

- Parse it as a JSON object and merge into `default_headers`, so existing headers (`anthropic-beta`, `user-agent` for OAuth, etc.) are preserved and extra headers are layered on top.
- Malformed JSON is silently ignored to avoid breaking client creation.

## Usage

```bash
HERMES_ANTHROPIC_EXTRA_HEADERS='{"User-Agent": "claude-code-cli/2.1.52"}'
```

## Tests

4 new test cases in `tests/agent/test_anthropic_adapter.py`:

- `test_extra_headers_env_var_merges_into_default_headers`
- `test_extra_headers_env_var_overrides_existing_header`
- `test_extra_headers_env_var_invalid_json_is_ignored`
- `test_extra_headers_env_var_not_set`