### PR TITLE
fix(auxiliary): ignore null task config values

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3051,13 +3051,28 @@ def _resolve_task_provider_model(
     cfg_api_key = None
     cfg_api_mode = None
 
+    def _clean_optional_str(value: Any) -> Optional[str]:
+        """Normalize optional config strings.
+
+        YAML null values load as None; converting them with str(None) creates
+        the literal "None", which previously made auxiliary.base_url settings
+        resolve to a bogus custom endpoint named "None". Treat null-ish strings
+        as absent so provider/model fallback behaves correctly.
+        """
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        if not cleaned or cleaned.lower() in {"none", "null"}:
+            return None
+        return cleaned
+
     if task:
         task_config = _get_auxiliary_task_config(task)
-        cfg_provider = str(task_config.get("provider", "")).strip() or None
-        cfg_model = str(task_config.get("model", "")).strip() or None
-        cfg_base_url = str(task_config.get("base_url", "")).strip() or None
-        cfg_api_key = str(task_config.get("api_key", "")).strip() or None
-        cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
+        cfg_provider = _clean_optional_str(task_config.get("provider"))
+        cfg_model = _clean_optional_str(task_config.get("model"))
+        cfg_base_url = _clean_optional_str(task_config.get("base_url"))
+        cfg_api_key = _clean_optional_str(task_config.get("api_key"))
+        cfg_api_mode = _clean_optional_str(task_config.get("api_mode"))
 
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,7 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
+    _resolve_task_provider_model,
 )
 
 
@@ -53,6 +54,36 @@ def codex_auth_dir(tmp_path, monkeypatch):
         lambda: "codex-test-token-abc123",
     )
     return codex_dir
+
+
+class TestResolveTaskProviderModel:
+    def test_null_auxiliary_base_url_does_not_force_custom_endpoint(self):
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={
+            "provider": "deepseek",
+            "model": "deepseek-v4-flash",
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("compression")
+
+        assert provider == "deepseek"
+        assert model == "deepseek-v4-flash"
+        assert base_url is None
+        assert api_key is None
+        assert api_mode is None
+
+    def test_nullish_auxiliary_base_url_string_does_not_force_custom_endpoint(self):
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={
+            "provider": "deepseek",
+            "model": "deepseek-v4-flash",
+            "base_url": "None",
+        }):
+            provider, model, base_url, _, _ = _resolve_task_provider_model("compression")
+
+        assert provider == "deepseek"
+        assert model == "deepseek-v4-flash"
+        assert base_url is None
 
 
 class TestNormalizeAuxProvider:


### PR DESCRIPTION
## Summary
- Normalize optional auxiliary task config values so YAML null / null-ish strings are treated as unset
- Prevent `auxiliary.<task>.base_url: null` from forcing a bogus custom endpoint like `None/`
- Add regression coverage for null and "None" auxiliary base_url values

## Test plan
- `python -m pytest tests/agent/test_auxiliary_client.py::TestResolveTaskProviderModel -q`
- `python -m py_compile agent/auxiliary_client.py`

## Context
A gateway session can fail context compression when `auxiliary.compression.base_url` is YAML null: `str(None)` becomes the literal `"None"`, so compression resolves to a custom endpoint at `None/` instead of the configured provider.
