### PR TITLE
fix(tests): unblock CI on eight unrelated test failures

### DIFF
--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -200,6 +200,8 @@ class TestSessionOps:
             "context",
             "reset",
             "compact",
+            "steer",
+            "queue",
             "version",
         ]
         model_cmd = next(

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -942,8 +942,14 @@ class TestAgentCacheSpilloverLive:
         monkeypatch.setattr(gw_run, "_AGENT_CACHE_MAX_SIZE", CAP)
         runner = self._runner()
 
+        # 8 threads × 10 inserts = 80 real-AIAgent constructions targeted at a
+        # 16-slot cache — still ~5× over cap so concurrent eviction is
+        # exercised, but small enough to finish well under the join timeout
+        # on slow shared CI runners (AIAgent init does plugin scanning, MCP
+        # tool refresh, and config validation, all of which contend for the
+        # GIL when 8 workers race).
         N_THREADS = 8
-        PER_THREAD = 20  # 8 * 20 = 160 inserts into a 16-slot cache
+        PER_THREAD = 10
 
         def worker(tid: int):
             for j in range(PER_THREAD):
@@ -960,7 +966,7 @@ class TestAgentCacheSpilloverLive:
         for t in threads:
             t.start()
         for t in threads:
-            t.join(timeout=30)
+            t.join(timeout=60)
             assert not t.is_alive(), "Worker thread hung — possible deadlock?"
 
         # Let daemon cleanup threads settle.

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -38,6 +38,9 @@ def _ensure_teams_mock():
     microsoft_teams_cards = types.ModuleType("microsoft_teams.cards")
     microsoft_teams_apps_http = types.ModuleType("microsoft_teams.apps.http")
     microsoft_teams_apps_http_adapter = types.ModuleType("microsoft_teams.apps.http.adapter")
+    microsoft_teams_common = types.ModuleType("microsoft_teams.common")
+    microsoft_teams_common_http = types.ModuleType("microsoft_teams.common.http")
+    microsoft_teams_common_http_client = types.ModuleType("microsoft_teams.common.http.client")
 
     # App class mock
     class MockApp:
@@ -134,6 +137,14 @@ def _ensure_teams_mock():
     microsoft_teams_apps_http_adapter.HttpMethod = HttpMethod
     microsoft_teams_apps_http_adapter.HttpRouteHandler = HttpRouteHandler
 
+    # ClientOptions mock — microsoft-teams-apps 2.0.0 introduced this for
+    # custom HTTP client headers (User-Agent etc.).
+    class MockClientOptions:
+        def __init__(self, headers=None, **kwargs):
+            self.headers = headers or {}
+
+    microsoft_teams_common_http_client.ClientOptions = MockClientOptions
+
     # Wire the hierarchy
     for name, mod in {
         "microsoft_teams": microsoft_teams,
@@ -149,6 +160,9 @@ def _ensure_teams_mock():
         "microsoft_teams.cards": microsoft_teams_cards,
         "microsoft_teams.apps.http": microsoft_teams_apps_http,
         "microsoft_teams.apps.http.adapter": microsoft_teams_apps_http_adapter,
+        "microsoft_teams.common": microsoft_teams_common,
+        "microsoft_teams.common.http": microsoft_teams_common_http,
+        "microsoft_teams.common.http.client": microsoft_teams_common_http_client,
     }.items():
         sys.modules.setdefault(name, mod)
 

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -8,11 +8,49 @@ Covers:
      input() call) and the stash is applied automatically
 """
 
+import importlib
 import subprocess
+import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from hermes_cli.main import cmd_update
+import pytest
+
+
+# Other tests in the suite (notably ``test_env_loader.py`` and
+# ``test_skills_subparser.py``) evict ``hermes_cli.main`` from
+# ``sys.modules`` mid-run.  When that happens on the same xdist worker
+# before we run, a module-top ``from hermes_cli.main import cmd_update``
+# binds against the *old* module object — and ``cmd_update.__globals__``
+# stays pointed at the old ``hermes_cli.main.__dict__``.
+# ``@patch("hermes_cli.main.X")`` then patches the *new* module's
+# attribute, but ``cmd_update`` still resolves every internal call
+# (``_install_hangup_protection``, ``_cmd_update_impl``,
+# ``_stash_local_changes_if_needed``, ``_restore_stashed_changes``, ``sys``,
+# …) via the stale ``__globals__``, so every patch is a no-op and the
+# real production code runs through.  This is the same xdist pollution
+# that ``test_update_stale_dashboard.py`` works around — see the
+# autouse fixture there for the original write-up.
+#
+# Get ``cmd_update`` from the *live* module inside each test instead.
+def _live_cmd_update():
+    live = sys.modules.get("hermes_cli.main")
+    if live is None:
+        live = importlib.import_module("hermes_cli.main")
+    return live.cmd_update
+
+
+@pytest.fixture(autouse=True)
+def _ensure_hermes_cli_main_loaded():
+    """Make sure ``hermes_cli.main`` is loaded before tests in this file run.
+
+    If a prior test on the worker evicted it, re-import here so
+    ``@patch("hermes_cli.main.X")`` targets the same module that
+    ``_live_cmd_update()`` will resolve against.
+    """
+    if "hermes_cli.main" not in sys.modules:
+        importlib.import_module("hermes_cli.main")
+    yield
 
 
 # `cmd_update` wraps `_cmd_update_impl` in `_install_hangup_protection`, which
@@ -22,9 +60,8 @@ from hermes_cli.main import cmd_update
 # wrapper stores the original (still-mocked) stream as ``_original`` but
 # replaces ``sys.stdout`` with itself, so subsequent ``sys.stdout.isatty()``
 # calls go through the wrapper's ``isatty()``, whose return value depends on
-# whether earlier writes flagged ``_original_broken`` — flaky under xdist.
-# Bypass the wrapping with a no-op state so isatty() answers the mock
-# directly.
+# whether earlier writes flagged ``_original_broken``.  Bypass the wrapping
+# with a no-op state so isatty() answers the mock directly.
 _HANGUP_PROTECTION_NOOP_STATE = {
     "prev_stdout": None,
     "prev_stderr": None,
@@ -99,7 +136,7 @@ class TestUpdateYesConfigMigration:
         args = SimpleNamespace(yes=True)
 
         with patch("builtins.input") as mock_input:
-            cmd_update(args)
+            _live_cmd_update()(args)
             # Never prompted the user.
             mock_input.assert_not_called()
 
@@ -150,7 +187,7 @@ class TestUpdateYesConfigMigration:
         ) as mock_sys:
             mock_sys.stdin.isatty.return_value = True
             mock_sys.stdout.isatty.return_value = True
-            cmd_update(args)
+            _live_cmd_update()(args)
             # The user was actually prompted.
             assert mock_input.called
             prompts = [c.args[0] if c.args else "" for c in mock_input.call_args_list]
@@ -195,7 +232,7 @@ class TestUpdateYesStashRestore:
 
         args = SimpleNamespace(yes=True)
 
-        cmd_update(args)
+        _live_cmd_update()(args)
 
         # _restore_stashed_changes was called, and called with prompt_user=False
         # every time (so the user never sees "Restore local changes now?").

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -15,6 +15,24 @@ from unittest.mock import patch
 from hermes_cli.main import cmd_update
 
 
+# `cmd_update` wraps `_cmd_update_impl` in `_install_hangup_protection`, which
+# replaces ``sys.stdout`` / ``sys.stderr`` with ``_UpdateOutputStream`` mirrors
+# during the update.  In tests that patch ``hermes_cli.main.sys`` to make
+# isatty() return True, that wrapping subverts the patch on stdout: the
+# wrapper stores the original (still-mocked) stream as ``_original`` but
+# replaces ``sys.stdout`` with itself, so subsequent ``sys.stdout.isatty()``
+# calls go through the wrapper's ``isatty()``, whose return value depends on
+# whether earlier writes flagged ``_original_broken`` — flaky under xdist.
+# Bypass the wrapping with a no-op state so isatty() answers the mock
+# directly.
+_HANGUP_PROTECTION_NOOP_STATE = {
+    "prev_stdout": None,
+    "prev_stderr": None,
+    "log_file": None,
+    "installed": False,
+}
+
+
 def _make_run_side_effect(
     branch="main", verify_ok=True, commit_count="1", dirty=False
 ):
@@ -50,6 +68,11 @@ def _make_run_side_effect(
 class TestUpdateYesConfigMigration:
     """--yes auto-answers the config-migration prompt and skips API-key prompts."""
 
+    @patch("hermes_cli.main._finalize_update_output")
+    @patch(
+        "hermes_cli.main._install_hangup_protection",
+        return_value=dict(_HANGUP_PROTECTION_NOOP_STATE),
+    )
     @patch("hermes_cli.config.migrate_config")
     @patch("hermes_cli.config.check_config_version", return_value=(1, 2))
     @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
@@ -64,6 +87,8 @@ class TestUpdateYesConfigMigration:
         _mock_missing_cfg,
         _mock_version,
         mock_migrate,
+        _mock_install_hangup,
+        _mock_finalize,
         capsys,
     ):
         mock_run.side_effect = _make_run_side_effect(
@@ -89,6 +114,11 @@ class TestUpdateYesConfigMigration:
         # The "Would you like to configure them now?" prompt text never appears.
         assert "Would you like to configure them now?" not in out
 
+    @patch("hermes_cli.main._finalize_update_output")
+    @patch(
+        "hermes_cli.main._install_hangup_protection",
+        return_value=dict(_HANGUP_PROTECTION_NOOP_STATE),
+    )
     @patch("hermes_cli.config.migrate_config")
     @patch("hermes_cli.config.check_config_version", return_value=(1, 2))
     @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
@@ -103,6 +133,8 @@ class TestUpdateYesConfigMigration:
         _mock_missing_cfg,
         _mock_version,
         mock_migrate,
+        _mock_install_hangup,
+        _mock_finalize,
         capsys,
     ):
         """Regression guard: without --yes, the TTY prompt path still fires."""
@@ -128,6 +160,11 @@ class TestUpdateYesConfigMigration:
 class TestUpdateYesStashRestore:
     """--yes auto-restores the pre-update autostash without prompting."""
 
+    @patch("hermes_cli.main._finalize_update_output")
+    @patch(
+        "hermes_cli.main._install_hangup_protection",
+        return_value=dict(_HANGUP_PROTECTION_NOOP_STATE),
+    )
     @patch("hermes_cli.main._restore_stashed_changes")
     @patch(
         "hermes_cli.main._stash_local_changes_if_needed",
@@ -147,6 +184,8 @@ class TestUpdateYesStashRestore:
         _mock_version,
         _mock_stash,
         mock_restore,
+        _mock_install_hangup,
+        _mock_finalize,
         capsys,
     ):
         # Not on main → cmd_update switches to main → autostash fires.

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -478,9 +478,17 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     kb.init_db()
 
     # Stub web_server so _check_ws_token has a token to compare against.
+    # Both ``sys.modules["hermes_cli.web_server"]`` and the ``web_server``
+    # attribute on the ``hermes_cli`` package must be replaced — when an
+    # earlier test on the same xdist worker imported the real module,
+    # ``from hermes_cli import web_server`` resolves via the package
+    # attribute (set during the original import) and silently bypasses any
+    # ``sys.modules`` override.
     import types
+    import hermes_cli as _hermes_cli_pkg
     stub = types.SimpleNamespace(_SESSION_TOKEN="secret-xyz")
     monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(_hermes_cli_pkg, "web_server", stub, raising=False)
 
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -3,9 +3,20 @@
 import concurrent.futures
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _permissive_decision(*_args, **_kwargs):
+    """Build a `ToolGuardrailDecision`-shaped object that allows execution."""
+    return SimpleNamespace(
+        action="allow",
+        allows_execution=True,
+        should_halt=False,
+        message=None,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +43,13 @@ def _make_agent(monkeypatch):
         verbose_logging = False
         log_prefix_chars = 200
         _checkpoint_mgr = MagicMock(enabled=False)
+        # Permissive guardrail stub — every before_call/after_call returns a
+        # decision that allows execution and never halts.  These tests
+        # exercise interrupt fanout, not guardrail behaviour.
+        _tool_guardrails = MagicMock(
+            before_call=MagicMock(side_effect=_permissive_decision),
+            after_call=MagicMock(side_effect=_permissive_decision),
+        )
         _subdirectory_hints = MagicMock()
         tool_progress_callback = None
         tool_start_callback = None
@@ -77,6 +95,12 @@ def _make_agent(monkeypatch):
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
     stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
     stub.clear_interrupt = _ra.AIAgent.clear_interrupt.__get__(stub)
+    # Concurrent execution wraps tool results in a guardrail observation
+    # before appending to messages.  Bind the production helper so the stub
+    # exercises the same code path; our `_tool_guardrails` MagicMock returns
+    # permissive `SimpleNamespace` decisions, so this is a no-op.
+    stub._append_guardrail_observation = _ra.AIAgent._append_guardrail_observation.__get__(stub)
+    stub._set_tool_guardrail_halt = MagicMock()
     # /steer injection (added in PR #12116) fires after every concurrent
     # tool batch. Stub it as a no-op — this test exercises interrupt
     # fanout, not steer injection.
@@ -107,7 +131,7 @@ def test_concurrent_interrupt_cancels_pending(monkeypatch):
 
     original_invoke = agent._invoke_tool
 
-    def slow_tool(name, args, task_id, call_id=None):
+    def slow_tool(name, args, task_id, call_id=None, **kwargs):
         if name == "slow_one":
             # Block until the test sets the interrupt
             barrier.wait(timeout=10)
@@ -184,7 +208,7 @@ def test_running_concurrent_worker_sees_is_interrupted(monkeypatch):
     observed = {"saw_true": False, "poll_count": 0, "worker_tid": None}
     worker_started = threading.Event()
 
-    def polling_tool(name, args, task_id, call_id=None, messages=None):
+    def polling_tool(name, args, task_id, call_id=None, messages=None, **kwargs):
         observed["worker_tid"] = threading.current_thread().ident
         worker_started.set()
         deadline = time.monotonic() + 5.0

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -107,7 +107,14 @@ def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
 
 def test_dockerfile_installs_tui_dependencies(dockerfile_text):
     assert "ui-tui/package.json" in dockerfile_text
-    assert "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
+    # The bundled @hermes/ink workspace lives under ui-tui/packages/hermes-ink
+    # and is referenced as a `file:` dep from ui-tui/package.json.  The
+    # Dockerfile must copy that subtree into the build context (either as the
+    # whole directory or as the manifest pair) so npm can resolve it.
+    assert (
+        "ui-tui/packages/hermes-ink/" in dockerfile_text
+        or "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
+    )
     assert any(
         "ui-tui" in step and "npm" in step and (" install" in step or " ci" in step)
         for step in _run_steps(dockerfile_text)
@@ -122,7 +129,16 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
 
 
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
-    assert any(
+    # The bundled @hermes/ink workspace must reach node_modules/@hermes/ink at
+    # runtime.  Two approaches are accepted: an explicit cp/install materialize
+    # block, or `npm_config_install_links=false` which makes npm resolve
+    # `file:` deps as symlinks even on older npm versions.
+    instructions = _dockerfile_instructions(dockerfile_text)
+    install_links_off = any(
+        "npm_config_install_links=false" in instruction
+        for instruction in instructions
+    )
+    explicit_materialize = any(
         "ui-tui" in step
         and "node_modules/@hermes/ink" in step
         and "packages/hermes-ink" in step
@@ -132,6 +148,12 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "rm -rf node_modules/@hermes/ink/node_modules/react" in step
         and "await import('@hermes/ink')" in step
         for step in _run_steps(dockerfile_text)
+    )
+    assert install_links_off or explicit_materialize, (
+        "Dockerfile must materialize the bundled @hermes/ink package — either "
+        "via an explicit cp/install RUN step, or by setting "
+        "npm_config_install_links=false so npm resolves the `file:` dep as a "
+        "symlink into ui-tui/packages/hermes-ink/."
     )
 
 


### PR DESCRIPTION
## Summary

Eight independent test-only fixes to unblock the `Tests` workflow on `main`. None are functionality changes — each fix targets a test that has been failing on `main @ 75e1339d` independently of any open PR. The two run-to-run variants (`update_yes_flag` and the kanban WS test, alternating between back-to-back failing runs) share root causes with the others — recent production changes drifted from frozen test contracts, or test mocks no longer cover the full surface they patch.

Reference run: https://github.com/NousResearch/hermes-agent/actions/runs/25210234363

## Failures addressed

| Test | Root cause | Fix |
|---|---|---|
| `tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update` | `_ADVERTISED_COMMANDS` grew to add `steer` and `queue`; the test still asserted the 7-command list. | Update the expected list to match `_ADVERTISED_COMMANDS`. |
| `tests/gateway/test_teams.py::TestTeamsSend::test_send_typing` | Teams adapter started importing `microsoft_teams.common.http.client.ClientOptions` (microsoft-teams-apps 2.0.0); the test's fake SDK didn't register that submodule, so the whole `try` import block fell to `except ImportError` and `TypingActivityInput` became `None`. `send_typing` then raised inside its bare `except`, swallowing the call. | Register `microsoft_teams.common.http.client.ClientOptions` in the test mock so the import block stays on the success path. |
| `tests/gateway/test_agent_cache.py::TestAgentCacheSpilloverLive::test_concurrent_inserts_settle_at_cap` | 8 threads × 20 real-`AIAgent` constructions (160 inits) exceeded the 30 s thread-join after recent guardrail/MCP work made `AIAgent.__init__` measurably heavier. | Halve to 80 inits (still ~5× over the 16-slot cap, so eviction races are still exercised) and bump the join timeout to 60 s. |
| `tests/hermes_cli/test_update_yes_flag.py::TestUpdateYesConfigMigration::test_no_yes_flag_still_prompts_in_tty` <br> `tests/hermes_cli/test_update_yes_flag.py::TestUpdateYesStashRestore::test_yes_restores_stash_without_prompting` | `cmd_update` wraps `_cmd_update_impl` in `_install_hangup_protection`, which replaces `sys.stdout` / `sys.stderr` with `_UpdateOutputStream` mirrors. Under xdist the wrapper's own `isatty()` answer became race-dependent on prior writes flagging `_original_broken`, subverting the test's `patch("hermes_cli.main.sys")`. | Patch `_install_hangup_protection` to a no-op state and stub `_finalize_update_output` so `isatty()` answers the test mock directly. |
| `tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required` | `_check_ws_token` resolves `hermes_cli.web_server` via `from hermes_cli import web_server as _ws`. When an earlier test on the same xdist worker imported the real module, `web_server` was cached as an attribute on the `hermes_cli` package; subsequent `from hermes_cli import web_server` resolved via that attribute and silently bypassed the test's `sys.modules` stub, comparing the test token against the real module's per-process random `_SESSION_TOKEN`. | Patch the `web_server` attribute on the package in addition to the `sys.modules` entry so both import shapes return the stub. |
| `tests/run_agent/test_concurrent_interrupt.py::test_concurrent_interrupt_cancels_pending` <br> `tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted` | Concurrent-tool path now consults `self._tool_guardrails.before_call(...)` and calls `self._append_guardrail_observation(...)` after each result; the hand-rolled `_Stub` had neither, raising `AttributeError` before exercising interrupt fan-out. | Add a permissive `_tool_guardrails` MagicMock that returns always-allow `SimpleNamespace` decisions, bind the real `_append_guardrail_observation` (no-op under the permissive mock), stub `_set_tool_guardrail_halt`, and accept `**kwargs` in the fake tool callables so the new `pre_tool_block_checked=` argument doesn't trip them. |
| `tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_installs_tui_dependencies` <br> `tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_materializes_local_tui_ink_package` | PR a49f4c617 ("fix: prevent tui rebuilding assets") intentionally replaced the explicit cp-then-install materialize block with the simpler `COPY ui-tui/packages/hermes-ink/` + `npm_config_install_links=false` approach (npm 10+ default symlink behaviour), but the contract tests still asserted the old command sequence verbatim. | Update both tests to accept either materialization shape — the behavioural contract (`@hermes/ink` reachable at `node_modules/@hermes/ink` at runtime) is preserved by both paths. |

## Verification

Targeted run, twice (no flakes):

```
python -m pytest -q -o addopts="-m 'not integration'" \
  tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update \
  tests/gateway/test_teams.py::TestTeamsSend::test_send_typing \
  tests/gateway/test_agent_cache.py::TestAgentCacheSpilloverLive::test_concurrent_inserts_settle_at_cap \
  tests/hermes_cli/test_update_yes_flag.py \
  tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required \
  tests/run_agent/test_concurrent_interrupt.py \
  tests/tools/test_dockerfile_pid1_reaping.py
# 17 passed (run 1)
# 17 passed (run 2)
```

Broader regression — all touched test files:

```
python -m pytest -q tests/acp/ tests/gateway/test_teams.py \
  tests/gateway/test_agent_cache.py tests/hermes_cli/test_update_yes_flag.py \
  tests/plugins/test_kanban_dashboard_plugin.py \
  tests/run_agent/test_concurrent_interrupt.py \
  tests/tools/test_dockerfile_pid1_reaping.py
# 321 passed
```

No production code is touched; the diff is test-files-only.