### PR TITLE
fix: kanban button

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -231,7 +231,7 @@
               String(this.state.error && this.state.error.message || this.state.error)),
             h(Button, {
               onClick: () => this.setState({ error: null }),
-              className: "h-7 px-3 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+              size: "sm",
             }, "Reload view"),
           ),
         );
@@ -599,11 +599,11 @@
       h("div", { className: "flex-1" }),
       h(Button, {
         onClick: props.onNudgeDispatch,
-        className: "h-8 px-3 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+        size: "sm",
       }, "Nudge dispatcher"),
       h(Button, {
         onClick: props.onRefresh,
-        className: "h-8 px-3 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+        size: "sm",
       }, "Refresh"),
     );
   }
@@ -619,21 +619,21 @@
         `${props.count} selected`),
       h(Button, {
         onClick: function () { props.onApply({ status: "ready" }); },
-        className: "hermes-kanban-bulk-btn",
+        size: "sm",
       }, "→ ready"),
       h(Button, {
         onClick: function () {
           props.onApply({ status: "done" },
             `Mark ${props.count} task(s) as done?`);
         },
-        className: "hermes-kanban-bulk-btn",
+        size: "sm",
       }, "Complete"),
       h(Button, {
         onClick: function () {
           props.onApply({ archive: true },
             `Archive ${props.count} task(s)?`);
         },
-        className: "hermes-kanban-bulk-btn",
+        size: "sm",
       }, "Archive"),
       h("div", { className: "hermes-kanban-bulk-reassign" },
         h(Select, {
@@ -654,14 +654,13 @@
             setAssignee("");
           },
           disabled: !assignee,
-          className: cn("hermes-kanban-bulk-btn",
-            !assignee ? "opacity-40 cursor-not-allowed" : ""),
+          size: "sm",
         }, "Apply"),
       ),
       h("div", { className: "flex-1" }),
       h(Button, {
         onClick: props.onClear,
-        className: "hermes-kanban-bulk-btn",
+        size: "sm",
       }, "Clear"),
     );
   }
@@ -993,11 +992,11 @@
       h("div", { className: "flex gap-2" },
         h(Button, {
           onClick: submit,
-          className: "h-7 px-2 text-xs border border-border hover:bg-foreground/10 cursor-pointer flex-1",
+          size: "sm",
         }, "Create"),
         h(Button, {
           onClick: props.onCancel,
-          className: "h-7 px-2 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+          size: "sm",
         }, "Cancel"),
       ),
     );
@@ -1125,7 +1124,7 @@
           }),
           h(Button, {
             onClick: handleComment,
-            className: "h-8 px-3 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+            size: "sm",
           }, "Comment"),
         ) : null,
       ),
@@ -1355,10 +1354,10 @@
         className: "h-8 text-sm flex-1",
       }),
       h(Button, { onClick: save,
-        className: "h-7 px-2 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+        size: "sm",
       }, "Save"),
       h(Button, { onClick: props.onCancel,
-        className: "h-7 px-2 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+        size: "sm",
       }, "Cancel"),
     );
   }
@@ -1439,10 +1438,10 @@
         editing
           ? h("div", { className: "flex gap-1" },
               h(Button, { onClick: save,
-                className: "h-6 px-2 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+                size: "sm",
               }, "Save"),
               h(Button, { onClick: function () { setEditing(false); setV(props.task.body || ""); },
-                className: "h-6 px-2 text-xs border border-border hover:bg-foreground/10 cursor-pointer",
+                size: "sm",
               }, "Cancel"),
             )
           : h("button", {
@@ -1516,8 +1515,7 @@
             props.onAddParent(newParent).then(function () { setNewParent(""); });
           },
           disabled: !newParent,
-          className: cn("h-7 px-2 text-xs border border-border cursor-pointer",
-            !newParent ? "opacity-40 cursor-not-allowed" : "hover:bg-foreground/10"),
+          size: "sm",
         }, "+ parent"),
       ),
       h("div", { className: "hermes-kanban-deps-row" },
@@ -1556,8 +1554,7 @@
             props.onAddChild(newChild).then(function () { setNewChild(""); });
           },
           disabled: !newChild,
-          className: cn("h-7 px-2 text-xs border border-border cursor-pointer",
-            !newChild ? "opacity-40 cursor-not-allowed" : "hover:bg-foreground/10"),
+          size: "sm",
         }, "+ child"),
       ),
     );
@@ -1569,10 +1566,7 @@
       return h(Button, {
         onClick: function () { if (enabled !== false) props.onPatch(patch, { confirm: confirmMsg }); },
         disabled: enabled === false,
-        className: cn(
-          "h-7 px-2 text-xs border border-border cursor-pointer",
-          enabled === false ? "opacity-40 cursor-not-allowed" : "hover:bg-foreground/10",
-        ),
+        size: "sm",
       }, label);
     };
     return h("div", { className: "hermes-kanban-actions" },

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -251,6 +251,11 @@
   border-radius: var(--radius-sm, 0.25rem);
 }
 
+.hermes-kanban-inline-create > .flex.gap-2:last-child > button:first-of-type {
+  flex: 1;
+  min-width: 0;
+}
+
 /* ---- Drawer (task detail side panel) --------------------------------- */
 
 .hermes-kanban-drawer-shade {
@@ -460,14 +465,17 @@
   font-size: 0.75rem;
   padding-right: 0.25rem;
 }
-.hermes-kanban-bulk-btn {
+
+.hermes-kanban-bulk > button,
+.hermes-kanban-bulk-reassign > button {
   height: 1.7rem !important;
   padding: 0 0.5rem !important;
   font-size: 0.7rem !important;
   border: 1px solid var(--color-border);
   cursor: pointer;
 }
-.hermes-kanban-bulk-btn:hover {
+.hermes-kanban-bulk > button:hover:not(:disabled),
+.hermes-kanban-bulk-reassign > button:hover:not(:disabled) {
   background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
 }
 .hermes-kanban-bulk-reassign {


### PR DESCRIPTION
## What does this PR do?

Kanban dashboard plugin buttons stop using ad hoc Tailwind `className` overrides (fixed heights such as `h-8`, borders, hover utilities). Each design-system `Button` uses `size="sm"` only so label alignment matches `@nous-research/ui` and avoids the `leading-0` + grid `items-center` issue when an explicit height was applied.

Bulk actions used the `hermes-kanban-bulk-btn` class; that hook is removed from JSX. `plugins/kanban/dashboard/dist/style.css` instead targets `.hermes-kanban-bulk > button` and `.hermes-kanban-bulk-reassign > button` so compact height, padding, and hover stay the same. Inline **Create** still flexes via `.hermes-kanban-inline-create > .flex.gap-2:last-child > button:first-of-type { flex: 1 }`.

`disabled` is unchanged on **Apply**, dependency **+ parent** / **+ child**, and status actions; only extra `opacity-40` / `cursor-not-allowed` utility classes were removed in favor of the Button component’s built-in disabled styles.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/dist/index.js` — all `Button`s: `size: "sm"`, drop `className` / `cn(...)` (filters, bulk bar, inline create, drawer, meta editors, description editor, dependency editor, status actions, error boundary).
- `plugins/kanban/dashboard/dist/style.css` — replace `.hermes-kanban-bulk-btn` with `.hermes-kanban-bulk > button` and `.hermes-kanban-bulk-reassign > button`; add inline-create first-button `flex: 1` next to `.hermes-kanban-inline-create`.

## How to Test

1. Run the Hermes web dashboard and open the Kanban plugin tab.
2. Filter row: **Nudge dispatcher** and **Refresh** — labels centered, hover OK.
3. Select card(s): bulk **→ ready** / **Complete** / **Archive** / **Apply** / **Clear** — compact layout; **Apply** disabled until assignee (or path) allows action.
4. Task drawer: **Comment**, meta **Save** / **Cancel**, description **Save** / **Cancel**, **+ parent** / **+ child**, status buttons — correct enabled/disabled and layout.
5. Column inline create: **Create** still grows in the row; **Cancel** works.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Optional: before/after for filter row and bulk bar buttons.
