### PR TITLE
fix: catch kqueue EINVAL selector error on uv-managed macOS Python

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11627,19 +11627,38 @@ class HermesCLI:
                 return  # silently suppress
             if isinstance(exc, KeyError) and "is not registered" in str(exc):
                 return  # suppress selector registration failures (#6393)
-            if isinstance(exc, OSError) and getattr(exc, "errno", None) == errno.EIO:
-                return  # suppress I/O errors from broken stdout on interrupt (#13710)
+            if isinstance(exc, OSError) and getattr(exc, "errno", None) in (errno.EIO, errno.EINVAL):
+                return  # suppress I/O errors from broken stdout on interrupt (#13710) and kqueue EINVAL (#6393)
             # Fall back to default handler for everything else
             loop.default_exception_handler(context)
 
         # Validate stdin before launching prompt_toolkit — on macOS with
         # uv-managed Python, fd 0 can be invalid or unregisterable with the
-        # asyncio selector, causing "KeyError: '0 is not registered'" (#6393).
+        # asyncio selector, causing "KeyError: '0 is not registered'" (#6393)
+        # or "OSError: [Errno 22] Invalid argument" from kqueue.
         try:
             os.fstat(0)
         except OSError:
             print(
                 "Error: stdin (fd 0) is not available.\n"
+                "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
+                "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
+            )
+            _run_cleanup()
+            self._print_exit_summary()
+            return
+
+        # Probe the selector backend — fstat(0) can succeed even when kqueue
+        # refuses to register fd 0 (uv-managed cPython on macOS).
+        try:
+            import selectors as _sel
+            _s = _sel.DefaultSelector()
+            _s.register(0, _sel.EVENT_READ)
+            _s.unregister(0)
+            _s.close()
+        except (KeyError, OSError) as _probe_err:
+            print(
+                f"Error: stdin (fd 0) is not usable by the asyncio selector ({_probe_err}).\n"
                 "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
                 "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
             )
@@ -11663,9 +11682,9 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393)
             # and I/O errors from broken stdout during interrupt (#13710).
-            if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:
-                pass  # suppress broken-stdout I/O errors on interrupt (#13710)
-            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) in (errno.EIO, errno.EINVAL):
+                pass  # suppress broken-stdout I/O errors and kqueue EINVAL on macOS (#6393)
+            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err) or "Invalid argument" in str(_stdin_err):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"


### PR DESCRIPTION
## Summary

- On macOS with uv-managed cPython, the kqueue selector fails to register stdin (fd 0) with `OSError: [Errno 22] Invalid argument`. The existing error handlers only caught `errno.EIO` and string-matched `"is not registered"` / `"Bad file descriptor"`, causing an unhandled crash.

## Changes

1. **Selector probe** — Before launching prompt_toolkit, actively tries to register fd 0 with `selectors.DefaultSelector()`. Catches the failure early with a user-friendly message instead of a traceback.
2. **Async exception handler** — Added `errno.EINVAL` alongside `errno.EIO` so kqueue EINVAL errors are suppressed in the event loop handler.
3. **`app.run()` exception handler** — Added `errno.EINVAL` to the errno check and `"Invalid argument"` to the string match.

## Test plan

- Reproduced the crash on macOS with uv-managed cPython 3.11 (`/Users/henrytran/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none/`)
- Verified the fix shows a clean error message instead of a traceback
- Existing tests for stdin/stdout error handling remain unaffected