### PR TITLE
fix(browser_tool): surface MEDIA: tag so browser_vision screenshots actually reach the user

### DIFF
--- a/tests/tools/test_browser_vision_delivery.py
+++ b/tests/tools/test_browser_vision_delivery.py
@@ -1,0 +1,71 @@
+"""Tests for browser_vision delivery hint to messaging gateways.
+
+When a user on Telegram (or any messaging platform) asks the agent for a
+screenshot, the gateway only forwards the file if the agent's reply
+contains a ``MEDIA:<path>`` tag (see ``gateway/platforms/base.py`` —
+``extract_local_files`` / ``extract_images``).
+
+Previously, ``browser_vision`` returned ``screenshot_path`` as a JSON field
+and relied on the tool description ("include MEDIA:<screenshot_path> in
+your response") to nudge the model. In practice models routinely
+paraphrased the analysis but dropped the path, leaving the user with no
+image while the agent believed the screenshot was sent.
+
+These tests verify that the tool result now includes a ready-to-paste
+``delivery_tag`` plus an explicit ``delivery_instruction``, and that
+suspiciously small (likely-blank) screenshots are flagged via
+``size_warning``.
+"""
+
+import os
+
+
+def _read_browser_tool_source() -> str:
+    base = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    with open(os.path.join(base, "tools", "browser_tool.py")) as f:
+        return f.read()
+
+
+class TestBrowserVisionDeliveryHint:
+    """tools/browser_tool.py — browser_vision() must surface MEDIA: tag."""
+
+    def test_response_includes_delivery_tag_field(self):
+        src = _read_browser_tool_source()
+        assert '"delivery_tag": media_tag' in src, (
+            "browser_vision response_data must include `delivery_tag` so "
+            "models can echo the MEDIA:<path> verbatim into their reply"
+        )
+
+    def test_media_tag_uses_correct_prefix(self):
+        src = _read_browser_tool_source()
+        assert 'media_tag = f"MEDIA:{screenshot_path}"' in src, (
+            "delivery_tag must use the MEDIA:<path> form recognised by "
+            "gateway/platforms/base.py extract_local_files"
+        )
+
+    def test_response_includes_delivery_instruction(self):
+        src = _read_browser_tool_source()
+        assert '"delivery_instruction"' in src, (
+            "browser_vision response_data must include a "
+            "`delivery_instruction` string telling the model the tag is "
+            "required for the user to actually receive the screenshot"
+        )
+
+
+class TestBrowserVisionBlankScreenshotWarning:
+    """tools/browser_tool.py — flag near-empty screenshots."""
+
+    def test_size_warning_threshold_present(self):
+        src = _read_browser_tool_source()
+        assert "if _shot_bytes < 5_000:" in src, (
+            "browser_vision must warn when the captured screenshot is "
+            "smaller than 5KB (typically a blank/unrendered page) so the "
+            "agent can re-take instead of delivering blank to the user"
+        )
+
+    def test_size_warning_field_emitted(self):
+        src = _read_browser_tool_source()
+        assert '"size_warning"' in src, (
+            "size_warning field must surface in response_data when the "
+            "screenshot is suspiciously small"
+        )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2502,11 +2502,45 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         # Redact secrets the vision LLM may have read from the screenshot.
         from agent.redact import redact_sensitive_text
         analysis = redact_sensitive_text(analysis)
+
+        # Delivery hint: messaging gateways (telegram/discord/etc) only forward
+        # screenshots to the user if the agent's reply contains MEDIA:<path>.
+        # We surface a ready-to-paste tag here AFTER redaction so the model can
+        # echo it verbatim. Without this, models routinely paraphrase the
+        # analysis but drop the path, leaving the user with no actual image.
+        media_tag = f"MEDIA:{screenshot_path}"
+
+        # Sanity-check the captured screenshot. A near-empty PNG (< 5 KB) is
+        # almost always a blank/unrendered page — surface a warning so the
+        # agent can re-take after waiting, instead of silently delivering blank.
+        size_warning = None
+        try:
+            _shot_bytes = screenshot_path.stat().st_size
+            if _shot_bytes < 5_000:
+                size_warning = (
+                    f"Screenshot is only {_shot_bytes} bytes — page likely "
+                    f"blank or not yet rendered. Consider waiting for content "
+                    f"(browser_wait_for_selector or a short delay) and re-taking."
+                )
+                logger.warning(
+                    "browser_vision: suspiciously small screenshot %s (%d bytes)",
+                    screenshot_path, _shot_bytes,
+                )
+        except OSError:
+            pass
+
         response_data = {
             "success": True,
             "analysis": analysis or "Vision analysis returned no content.",
             "screenshot_path": str(screenshot_path),
+            "delivery_tag": media_tag,
+            "delivery_instruction": (
+                f"To send this screenshot to the user, your reply MUST contain "
+                f"the line `{media_tag}` exactly as written."
+            ),
         }
+        if size_warning:
+            response_data["size_warning"] = size_warning
         # Include annotation data if annotated screenshot was taken
         if annotate and result.get("data", {}).get("annotations"):
             response_data["annotations"] = result["data"]["annotations"]


### PR DESCRIPTION
## What does this PR do?

When a user on a messaging platform (Telegram/Discord/etc) asks the agent for a screenshot, `browser_vision` correctly captures the PNG and analyses it with the vision model — but the user never receives the actual image. The agent describes what it saw and stops there, while believing the screenshot was delivered.

Root cause: `gateway/platforms/base.py` only forwards files as native attachments when the agent's text reply contains `MEDIA:<path>` (`extract_local_files` / `extract_images`). `browser_vision` returned the path under `screenshot_path` and relied on the tool description (_"include MEDIA:<screenshot_path> in your response"_) to nudge the model. In practice models routinely paraphrase the analysis but drop the path.

This PR makes the tool result a direct, ready-to-paste hint instead of a prose suggestion, and additionally flags suspiciously small (likely-blank) captures.

## Related Issue

Fixes # _(no upstream issue — discovered while debugging a live Telegram session)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py` (`browser_vision`)
  - Build `media_tag = f"MEDIA:{screenshot_path}"` after the redaction step and expose it in the result as `delivery_tag`, plus a `delivery_instruction` string telling the model the tag is required for the user to actually receive the image. Models echo a ready-to-paste line far more reliably than they follow a tool-description rule.
  - Add `size_warning` for screenshots smaller than 5 KB — almost always a blank/unrendered page — so the agent can wait + re-take instead of silently delivering blank.
- `tests/tools/test_browser_vision_delivery.py` — new file. Source-level verification matching the existing `test_browser_content_none_guard.py` pattern.

The contract additions are pure-additive (`screenshot_path` is unchanged), so existing callers and prompts continue to work.

## How to Test

**Reproduction (before the fix):**
1. Connect a Telegram chat to a Hermes profile.
2. Have the agent navigate to any page, then ask: "can you screenshot the page for me?"
3. Observe gateway log shows `Sending response (NNN chars)` only — never `extract_local_files found 1 file(s)` or `send_photo`. The PNG exists at `~/.hermes/<profile>/cache/screenshots/browser_screenshot_*.png` but the user receives only text.

**After the fix:**
1. Same flow. The agent reply now contains `MEDIA:/.../browser_screenshot_*.png`.
2. Gateway log shows `extract_local_files found 1 file(s)` followed by a `send_photo` call.
3. Telegram receives the actual image.

Confirmed working end-to-end on macOS 15 / Telegram. The user who reported the original bug re-asked for a screenshot post-patch and received it.

**Unit tests:**
```
pytest tests/tools/test_browser_vision_delivery.py -q
# 5 passed
pytest tests/tools/test_browser_content_none_guard.py -q
# 7 passed (no regression)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(browser_tool):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the existing tool description already mentions `MEDIA:<screenshot_path>`; this PR makes the model actually emit it)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — change is pure Python string/dict construction with no platform-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — tool description already accurate; only the result payload gained additive fields

## Screenshots / Logs

**Before** (live `gateway.log`, names redacted):
```
19:18:18 inbound message: msg='can you take a screenshot for me?'
19:18:27 [browser_vision captures screenshot: 3742 bytes]
19:19:23 response ready: response=333 chars
19:19:23 [Telegram] Sending response (333 chars) to <chat>
        ↑ no extract_local_files, no send_photo — user gets only text
```

**After** patch + gateway restart, same flow now produces `extract_local_files found 1 file(s)` and a `send_photo` call.

The 3742-byte capture above also illustrates why `size_warning` is useful — it was a near-blank page that the agent would otherwise have happily "delivered" as a real screenshot.