### PR TITLE
fix: make /busy command available on gateway platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9216,13 +9216,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # /fast and /reasoning are config-only and take effect next
             # message, so they fall through to the catch-all busy response
             # below — users should wait and set them between turns.
-            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose"}:
+            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose", "busy"}:
                 if _cmd_def_inner.name == "yolo":
                     return await self._handle_yolo_command(event)
                 if _cmd_def_inner.name == "verbose":
                     return await self._handle_verbose_command(event)
                 if _cmd_def_inner.name == "footer":
                     return await self._handle_footer_command(event)
+                if _cmd_def_inner.name == "busy":
+                    return await self._handle_busy_command(event)
 
             # Gateway-handled info/control commands with dedicated
             # running-agent handlers.
@@ -9561,6 +9563,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "yolo":
             return await self._handle_yolo_command(event)
+
+        if canonical == "busy":
+            return await self._handle_busy_command(event)
 
         if canonical == "model":
             return await self._handle_model_command(event)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17208,6 +17208,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "yolo": self._handle_yolo_command,
                 "verbose": self._handle_verbose_command,
                 "footer": self._handle_footer_command,
+                "busy": self._handle_busy_command,
                 "help": self._handle_help_command,
                 "commands": self._handle_commands_command,
                 "profile": self._handle_profile_command,
@@ -18454,6 +18455,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "yolo":
             return await self._handle_yolo_command(event)
+
+        if canonical == "busy":
+            return await self._handle_busy_command(event)
 
         if canonical == "approvals":
             return await self._handle_approvals_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2978,9 +2978,8 @@ class GatewaySlashCommandsMixin:
             /busy steer         Inject messages mid-run without interrupting
             /busy interrupt     Interrupt the current run (default)
         """
-        text = (event.text or "").strip()
-        parts = text.split(maxsplit=1)
-        if len(parts) < 2 or parts[1].strip().lower() == "status":
+        arg = event.get_command_args().strip().lower()
+        if not arg or arg == "status":
             mode = self._busy_input_mode
             if mode == "queue":
                 behavior = "queues for next turn"
@@ -2989,18 +2988,17 @@ class GatewaySlashCommandsMixin:
             else:
                 behavior = "interrupts current run"
             return EphemeralReply(
-                f"**Busy input mode: `{mode}`**\n"
-                f"Messages while busy: _{behavior}_\n"
+                f"**Busy input mode: `{mode}`" + "\n"
+                f"Messages while busy: _{behavior}_" + "\n"
                 f"Change with `/busy queue`, `/busy steer`, or `/busy interrupt`."
             )
 
-        arg = parts[1].strip().lower()
         if arg not in {"queue", "interrupt", "steer"}:
             return EphemeralReply(
                 f"Unknown mode `{arg}`. Use `/busy queue`, `/busy steer`, or `/busy interrupt`."
             )
 
-        # Persist before mutate — prevents divergent state when save fails
+        # Persist before mutate
         try:
             from cli import save_config_value
             if save_config_value("display.busy_input_mode", arg):
@@ -3012,7 +3010,7 @@ class GatewaySlashCommandsMixin:
                 else:
                     behavior = "Messages will interrupt the current run while Hermes is busy."
                 return EphemeralReply(
-                    f"Busy input mode set to **`{arg}`** (saved).\n"
+                    f"Busy input mode set to **`{arg}`** (saved)." + "\n"
                     f"_{behavior}_"
                 )
             else:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2968,6 +2968,63 @@ class GatewaySlashCommandsMixin:
             logger.warning("Failed to save tool_progress mode: %s", e)
             return f"{descriptions[new_mode]}\n" + t("gateway.verbose.save_failed", error=e)
 
+    async def _handle_busy_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Handle /busy — control what happens when messaging while Hermes is working.
+
+        Usage:
+            /busy               Show current busy input mode
+            /busy status        Show current busy input mode
+            /busy queue         Queue messages for the next turn
+            /busy steer         Inject messages mid-run without interrupting
+            /busy interrupt     Interrupt the current run (default)
+        """
+        text = (event.text or "").strip()
+        parts = text.split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            mode = self._busy_input_mode
+            if mode == "queue":
+                behavior = "queues for next turn"
+            elif mode == "steer":
+                behavior = "steers into current run (after next tool call)"
+            else:
+                behavior = "interrupts current run"
+            return EphemeralReply(
+                f"**Busy input mode: `{mode}`**\n"
+                f"Messages while busy: _{behavior}_\n"
+                f"Change with `/busy queue`, `/busy steer`, or `/busy interrupt`."
+            )
+
+        arg = parts[1].strip().lower()
+        if arg not in {"queue", "interrupt", "steer"}:
+            return EphemeralReply(
+                f"Unknown mode `{arg}`. Use `/busy queue`, `/busy steer`, or `/busy interrupt`."
+            )
+
+        # Persist before mutate — prevents divergent state when save fails
+        try:
+            from cli import save_config_value
+            if save_config_value("display.busy_input_mode", arg):
+                self._busy_input_mode = arg
+                if arg == "queue":
+                    behavior = "Messages will be queued for the next turn while Hermes is busy."
+                elif arg == "steer":
+                    behavior = "Messages will be steered into the current run (after the next tool call)."
+                else:
+                    behavior = "Messages will interrupt the current run while Hermes is busy."
+                return EphemeralReply(
+                    f"Busy input mode set to **`{arg}`** (saved).\n"
+                    f"_{behavior}_"
+                )
+            else:
+                return EphemeralReply(
+                    f"Busy input mode could not be saved to config. Mode unchanged."
+                )
+        except Exception as e:
+            logger.warning("Failed to save busy_input_mode: %s", e)
+            return EphemeralReply(
+                f"Could not save busy input mode: {e}. Mode unchanged."
+            )
+
     async def _handle_footer_command(self, event: MessageEvent) -> str:
         """Handle /footer command — toggle the runtime-metadata footer.
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4169,6 +4169,63 @@ class GatewaySlashCommandsMixin:
             logger.warning("Failed to save tool_progress mode: %s", e)
             return f"{descriptions[new_mode]}\n" + t("gateway.verbose.save_failed", error=e)
 
+    async def _handle_busy_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Handle /busy — control what happens when messaging while Hermes is working.
+
+        Usage:
+            /busy               Show current busy input mode
+            /busy status        Show current busy input mode
+            /busy queue         Queue messages for the next turn
+            /busy steer         Inject messages mid-run without interrupting
+            /busy interrupt     Interrupt the current run (default)
+        """
+        text = (event.text or "").strip()
+        parts = text.split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            mode = self._busy_input_mode
+            if mode == "queue":
+                behavior = "queues for next turn"
+            elif mode == "steer":
+                behavior = "steers into current run (after next tool call)"
+            else:
+                behavior = "interrupts current run"
+            return EphemeralReply(
+                f"**Busy input mode: `{mode}`**\n"
+                f"Messages while busy: _{behavior}_\n"
+                f"Change with `/busy queue`, `/busy steer`, or `/busy interrupt`."
+            )
+
+        arg = parts[1].strip().lower()
+        if arg not in {"queue", "interrupt", "steer"}:
+            return EphemeralReply(
+                f"Unknown mode `{arg}`. Use `/busy queue`, `/busy steer`, or `/busy interrupt`."
+            )
+
+        # Persist before mutate — prevents divergent state when save fails
+        try:
+            from cli import save_config_value
+            if save_config_value("display.busy_input_mode", arg):
+                self._busy_input_mode = arg
+                if arg == "queue":
+                    behavior = "Messages will be queued for the next turn while Hermes is busy."
+                elif arg == "steer":
+                    behavior = "Messages will be steered into the current run (after the next tool call)."
+                else:
+                    behavior = "Messages will interrupt the current run while Hermes is busy."
+                return EphemeralReply(
+                    f"Busy input mode set to **`{arg}`** (saved).\n"
+                    f"_{behavior}_"
+                )
+            else:
+                return EphemeralReply(
+                    f"Busy input mode could not be saved to config. Mode unchanged."
+                )
+        except Exception as e:
+            logger.warning("Failed to save busy_input_mode: %s", e)
+            return EphemeralReply(
+                f"Could not save busy input mode: {e}. Mode unchanged."
+            )
+
     async def _handle_footer_command(self, event: MessageEvent) -> str:
         """Handle /footer command — toggle the runtime-metadata footer.
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4181,7 +4181,10 @@ class GatewaySlashCommandsMixin:
         """
         arg = event.get_command_args().strip().lower()
         if not arg or arg == "status":
-            mode = self._busy_input_mode
+            # Report the mode actually in effect for this source: with
+            # multiplex profiles a routed profile's startup snapshot can
+            # override the global default.
+            mode = self._effective_busy_input_mode(event.source)
             if mode == "queue":
                 behavior = "queues for next turn"
             elif mode == "steer":

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4179,9 +4179,8 @@ class GatewaySlashCommandsMixin:
             /busy steer         Inject messages mid-run without interrupting
             /busy interrupt     Interrupt the current run (default)
         """
-        text = (event.text or "").strip()
-        parts = text.split(maxsplit=1)
-        if len(parts) < 2 or parts[1].strip().lower() == "status":
+        arg = event.get_command_args().strip().lower()
+        if not arg or arg == "status":
             mode = self._busy_input_mode
             if mode == "queue":
                 behavior = "queues for next turn"
@@ -4190,18 +4189,17 @@ class GatewaySlashCommandsMixin:
             else:
                 behavior = "interrupts current run"
             return EphemeralReply(
-                f"**Busy input mode: `{mode}`**\n"
-                f"Messages while busy: _{behavior}_\n"
+                f"**Busy input mode: `{mode}`" + "\n"
+                f"Messages while busy: _{behavior}_" + "\n"
                 f"Change with `/busy queue`, `/busy steer`, or `/busy interrupt`."
             )
 
-        arg = parts[1].strip().lower()
         if arg not in {"queue", "interrupt", "steer"}:
             return EphemeralReply(
                 f"Unknown mode `{arg}`. Use `/busy queue`, `/busy steer`, or `/busy interrupt`."
             )
 
-        # Persist before mutate — prevents divergent state when save fails
+        # Persist before mutate
         try:
             from cli import save_config_value
             if save_config_value("display.busy_input_mode", arg):
@@ -4213,7 +4211,7 @@ class GatewaySlashCommandsMixin:
                 else:
                     behavior = "Messages will interrupt the current run while Hermes is busy."
                 return EphemeralReply(
-                    f"Busy input mode set to **`{arg}`** (saved).\n"
+                    f"Busy input mode set to **`{arg}`** (saved)." + "\n"
                     f"_{behavior}_"
                 )
             else:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1163,7 +1163,8 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - version: low-frequency diagnostic; /hermes version on Slack saves a slot.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "version"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -166,7 +166,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
-               cli_only=True, args_hint="[queue|steer|interrupt|status]",
+               args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),
 
     # Tools & Skills

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -309,9 +309,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[on|off|status]",
                subcommands=("on", "off", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
-               cli_only=True, args_hint="[queue|steer|interrupt|status]",
+               args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status"),
-               desktop="terminal"),
+               busy_policy="dispatch", desktop="terminal"),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1411,7 +1411,12 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform"})
+#   - busy: set-once preference for what a message does mid-run; reached via
+#     /hermes busy on Slack. Demoted at the 50-cap when /busy became
+#     gateway-available — without this entry /busy claims a native slot and
+#     silently clamps /insights (a recurring inspection surface), breaking
+#     Telegram parity.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "busy"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/tests/gateway/test_busy_command.py
+++ b/tests/gateway/test_busy_command.py
@@ -64,3 +64,71 @@ class TestBusyCommand:
         reply_text = str(result)
         assert "queue" in reply_text.lower()
         assert "busy" in reply_text.lower()
+
+
+class TestBusyCommandPersistence:
+    """Test /busy persistence with mocked save_config_value."""
+
+    @pytest.mark.asyncio
+    async def test_set_queue_persists(self, monkeypatch):
+        """/busy queue saves config and updates mode."""
+        runner = _make_runner(busy_mode="interrupt")
+        monkeypatch.setattr(
+            "cli.save_config_value", lambda k, v: True
+        )
+        event = _make_event("/busy queue")
+        result = await runner._handle_busy_command(event)
+        assert "queue" in str(result).lower()
+        assert runner._busy_input_mode == "queue"
+
+    @pytest.mark.asyncio
+    async def test_set_steer_persists(self, monkeypatch):
+        """/busy steer saves config and updates mode."""
+        runner = _make_runner(busy_mode="queue")
+        monkeypatch.setattr(
+            "cli.save_config_value", lambda k, v: True
+        )
+        event = _make_event("/busy steer")
+        result = await runner._handle_busy_command(event)
+        assert "steer" in str(result).lower()
+        assert runner._busy_input_mode == "steer"
+
+    @pytest.mark.asyncio
+    async def test_set_interrupt_persists(self, monkeypatch):
+        """/busy interrupt saves config and updates mode."""
+        runner = _make_runner(busy_mode="queue")
+        monkeypatch.setattr(
+            "cli.save_config_value", lambda k, v: True
+        )
+        event = _make_event("/busy interrupt")
+        result = await runner._handle_busy_command(event)
+        assert "interrupt" in str(result).lower()
+        assert runner._busy_input_mode == "interrupt"
+
+    @pytest.mark.asyncio
+    async def test_save_failure_preserves_mode(self, monkeypatch):
+        """When save_config_value returns False, mode is unchanged."""
+        runner = _make_runner(busy_mode="steer")
+        monkeypatch.setattr(
+            "cli.save_config_value", lambda k, v: False
+        )
+        event = _make_event("/busy queue")
+        result = await runner._handle_busy_command(event)
+        assert "unchanged" in str(result).lower()
+        assert runner._busy_input_mode == "steer"
+
+    @pytest.mark.asyncio
+    async def test_save_exception_preserves_mode(self, monkeypatch):
+        """When save_config_value raises, mode is unchanged."""
+        runner = _make_runner(busy_mode="interrupt")
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(
+            "cli.save_config_value", _raise
+        )
+        event = _make_event("/busy steer")
+        result = await runner._handle_busy_command(event)
+        assert "Could not save" in str(result)
+        assert runner._busy_input_mode == "interrupt"

--- a/tests/gateway/test_busy_command.py
+++ b/tests/gateway/test_busy_command.py
@@ -1,0 +1,66 @@
+"""Smoke tests for gateway /busy command dispatch."""
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import EphemeralReply, MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_runner(busy_mode="interrupt"):
+    """Create a GatewayRunner with known busy mode."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.session_store = None
+    runner.config = None
+    runner._busy_input_mode = busy_mode
+    return runner
+
+
+def _make_event(text: str, chat_id: str = "chat-test") -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=f"user-{chat_id}",
+        chat_id=chat_id,
+        user_name="tester",
+        chat_type="dm",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+class TestBusyCommand:
+    """Test /busy command dispatch without config persistence."""
+
+    @pytest.mark.asyncio
+    async def test_status_returns_current_mode(self):
+        """/busy status shows the current busy mode."""
+        runner = _make_runner(busy_mode="queue")
+        event = _make_event("/busy status")
+        result = await runner._handle_busy_command(event)
+        assert "queue" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_bare_busy_shows_status(self):
+        """/busy without arguments shows status."""
+        runner = _make_runner(busy_mode="steer")
+        event = _make_event("/busy")
+        result = await runner._handle_busy_command(event)
+        assert "steer" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_busy_invalid_arg(self):
+        """/busy with invalid arg returns error."""
+        runner = _make_runner()
+        event = _make_event("/busy bananas")
+        result = await runner._handle_busy_command(event)
+        assert "unknown" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_busy_toggle_messages(self):
+        """Status response includes the mode and behavior."""
+        runner = _make_runner(busy_mode="queue")
+        event = _make_event("/busy status")
+        result = await runner._handle_busy_command(event)
+        reply_text = str(result)
+        assert "queue" in reply_text.lower()
+        assert "busy" in reply_text.lower()


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes the `/busy` command being unavailable on gateway platforms (Telegram, Discord, etc.) despite onboarding hints telling users they can use it.

The `/busy` command was registered in `COMMAND_REGISTRY` with `cli_only=True`, making it CLI-only. Meanwhile, `agent/onboarding.py` tells users they can run `/busy interrupt`, `/busy queue`, `/busy steer`, and `/busy status` -- creating a confusing UX where gateway users receive onboarding hints for non-functional commands.

This PR:
1. Removes `cli_only=True` from the `/busy` `CommandDef` so it registers on all platforms
2. Adds `_handle_busy_command` to `gateway/run.py` with full subcommand support (`status`, `queue`, `steer`, `interrupt`)
3. Persists mode changes to `config.yaml` using the same pattern as other gateway toggle commands
4. Returns `EphemeralReply` so responses are only visible to the user
5. Adds smoke tests in `tests/gateway/test_busy_command.py` covering all subcommands

The approach mirrors existing gateway toggle commands (`/yolo`, `/verbose`) -- minimal handler, config persistence, non-interrupting replies.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #18362

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/commands.py`: Removed `cli_only=True` from `/busy` `CommandDef`
- `gateway/run.py`: Added `_handle_busy_command` method (+60 lines) with subcommand dispatch, config persistence, and `EphemeralReply` responses
- `gateway/run.py`: Added dispatch entries in active-session and non-running command routing paths
- `tests/gateway/test_busy_command.py`: New smoke tests (7 tests) covering all subcommands and invalid args

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Start Hermes gateway (e.g., Telegram)
2. Send `/busy` or `/busy status` -- should show current mode
3. Send `/busy queue` -- should set mode to queue and persist
4. Send `/busy steer` -- should set mode to steer and persist
5. Send `/busy interrupt` -- should set mode to interrupt and persist
6. Run `pytest tests/gateway/test_busy_command.py -v` -- all 7 tests pass

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> Ubuntu 24.04 (VPS)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) -- or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys -- or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A -- not a skill PR

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A -- gateway command handler, no visual UI changes
