### PR TITLE
feat(webhook): per-subscription provider/model override

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -687,6 +687,18 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Per-event LLM provider/model override.
+    # When set, the gateway runner installs this as a session-scoped override
+    # in ``_session_model_overrides`` BEFORE the agent runs, so the dispatched
+    # task uses the requested provider regardless of the global default.
+    # Currently populated by the webhook adapter from per-subscription config
+    # (``hermes webhook subscribe --provider <p> --model <m>``); other adapters
+    # may opt in later.  Keys mirror the existing override schema:
+    #   {"model": str, "provider": str, "api_key": str?, "base_url": str?, "api_mode": str?}
+    # ``model``/``provider`` are required when set; the rest are optional and
+    # resolved from env / OAuth state when omitted (e.g. openai-codex).
+    provider_override: Optional[Dict[str, Any]] = None
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -445,21 +445,43 @@ class WebhookAdapter(BasePlatformAdapter):
             user_id=f"webhook:{route_name}",
             user_name=route_name,
         )
+        # Per-subscription provider/model override.  When set on the
+        # subscription, the gateway runner installs this as a session-scoped
+        # override before the agent runs, so this webhook's dispatch uses
+        # the requested provider regardless of the global default.  This is
+        # how PaperClip / external-orchestrator integrations route specific
+        # webhooks through the OAuth-backed openai-codex provider so Hermes'
+        # native MCP tools fire (rather than the bridge text-relay path).
+        provider_override: Optional[Dict[str, Any]] = None
+        sub_provider = (route_config.get("provider") or "").strip()
+        sub_model = (route_config.get("model") or "").strip()
+        if sub_provider or sub_model:
+            provider_override = {}
+            if sub_provider:
+                provider_override["provider"] = sub_provider
+            if sub_model:
+                provider_override["model"] = sub_model
+
         event = MessageEvent(
             text=prompt,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=payload,
             message_id=delivery_id,
+            provider_override=provider_override,
         )
 
         logger.info(
-            "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s",
+            "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s%s",
             request.method,
             event_type,
             route_name,
             len(prompt),
             delivery_id,
+            (
+                f" override=provider:{sub_provider or '-'},model:{sub_model or '-'}"
+                if provider_override else ""
+            ),
         )
 
         # Non-blocking — return 202 Accepted immediately

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2718,6 +2718,65 @@ class GatewayRunner:
         # forwarded it to the user; now the user's reply goes back via
         # .update_response so the update process can continue.
         _quick_key = self._session_key_for_source(source)
+
+        # Per-event provider/model override (currently populated by the
+        # webhook adapter from per-subscription config).  Resolve via the
+        # same ``switch_model`` pipeline the /model command uses, so OAuth
+        # providers (openai-codex) get correct base_url + api_mode rather
+        # than inheriting whatever the gateway default left in place.
+        # The override auto-clears when the session ends (existing pop
+        # calls in this file).
+        _ev_override = getattr(event, "provider_override", None)
+        if _ev_override and isinstance(_ev_override, dict):
+            try:
+                from hermes_cli.model_switch import switch_model as _ev_switch
+                _user_cfg = _load_gateway_config()
+                _cur_model = _resolve_gateway_model(_user_cfg)
+                _cur_provider = _user_cfg.get("provider", "") or ""
+                _ev_provider = (_ev_override.get("provider") or "").strip()
+                _ev_model = (_ev_override.get("model") or "").strip()
+                # Use the requested model if given, else the gateway default
+                # (switch_model will auto-detect on the target provider).
+                _raw_input = _ev_model or _cur_model
+                _result = _ev_switch(
+                    raw_input=_raw_input,
+                    current_provider=_cur_provider,
+                    current_model=_cur_model,
+                    current_base_url="",
+                    current_api_key="",
+                    is_global=False,
+                    explicit_provider=_ev_provider,
+                    user_providers=_user_cfg.get("providers", {}),
+                    custom_providers=_user_cfg.get("custom_providers"),
+                )
+                if getattr(_result, "success", False):
+                    self._session_model_overrides[_quick_key] = {
+                        "model": _result.new_model,
+                        "provider": _result.target_provider,
+                        "api_key": getattr(_result, "api_key", "") or "",
+                        "base_url": getattr(_result, "base_url", "") or "",
+                        "api_mode": getattr(_result, "api_mode", "") or "",
+                    }
+                    logger.info(
+                        "Per-event provider override applied: session=%s provider=%s model=%s base_url=%s",
+                        _quick_key[:30],
+                        _result.target_provider,
+                        _result.new_model,
+                        getattr(_result, "base_url", "") or "(default)",
+                    )
+                    if hasattr(self, "_evict_cached_agent"):
+                        try:
+                            self._evict_cached_agent(_quick_key)
+                        except Exception:
+                            pass
+                else:
+                    logger.warning(
+                        "Per-event provider override failed to resolve: provider=%s model=%s error=%s",
+                        _ev_provider, _ev_model,
+                        getattr(_result, "error_message", "(unknown)"),
+                    )
+            except Exception as _e:
+                logger.warning("Failed to apply event provider override: %s", _e, exc_info=True)
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5014,6 +5014,18 @@ For more help on a command:
     wh_sub.add_argument("--deliver", default="log", help="Delivery target: log, telegram, discord, slack, etc.")
     wh_sub.add_argument("--deliver-chat-id", default="", help="Target chat ID for cross-platform delivery")
     wh_sub.add_argument("--secret", default="", help="HMAC secret (auto-generated if omitted)")
+    wh_sub.add_argument(
+        "--provider",
+        default="",
+        help="Override LLM provider for this webhook (e.g. openai-codex, anthropic). "
+             "Defaults to the gateway's auto-selected provider.",
+    )
+    wh_sub.add_argument(
+        "--model",
+        default="",
+        help="Override model for this webhook (e.g. gpt-5.4, claude-sonnet-4-6). "
+             "Used together with --provider; defaults to the provider's default model.",
+    )
 
     webhook_subparsers.add_parser("list", aliases=["ls"], help="List all dynamic subscriptions")
 

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -158,6 +158,18 @@ def _cmd_subscribe(args):
     if args.deliver_chat_id:
         route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
 
+    # Optional per-subscription provider/model override.  Persisted in the
+    # subscription JSON; the webhook adapter forwards them on every dispatch
+    # so the agent runs through the requested provider regardless of the
+    # gateway's default (e.g. routing PaperClip-triggered webhooks through
+    # ``openai-codex`` so Hermes' native MCP tools fire over OAuth).
+    sub_provider = (getattr(args, "provider", "") or "").strip()
+    sub_model = (getattr(args, "model", "") or "").strip()
+    if sub_provider:
+        route["provider"] = sub_provider
+    if sub_model:
+        route["model"] = sub_model
+
     subs[name] = route
     _save_subscriptions(subs)
 
@@ -172,6 +184,8 @@ def _cmd_subscribe(args):
     else:
         print("  Events: (all)")
     print(f"  Deliver: {route['deliver']}")
+    if sub_provider or sub_model:
+        print(f"  Provider override: provider={sub_provider or '(default)'} model={sub_model or '(default)'}")
     if route.get("prompt"):
         prompt_preview = route["prompt"][:80] + ("..." if len(route["prompt"]) > 80 else "")
         print(f"  Prompt: {prompt_preview}")
@@ -199,6 +213,11 @@ def _cmd_list(args):
         print(f"    URL:     {base_url}/webhooks/{name}")
         print(f"    Events:  {events}")
         print(f"    Deliver: {deliver}")
+        if route.get("provider") or route.get("model"):
+            print(
+                f"    Override: provider={route.get('provider') or '(default)'} "
+                f"model={route.get('model') or '(default)'}"
+            )
         print()
 
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -434,6 +434,145 @@ class TestIdempotency:
 
 
 # ===================================================================
+# Per-subscription provider/model override
+# ===================================================================
+
+
+class TestProviderOverride:
+    """A subscription's ``provider``/``model`` config rides the dispatched
+    ``MessageEvent`` so the gateway runner can install a session-scoped
+    override before the agent runs.  The webhook adapter itself stays out
+    of provider resolution — it only forwards the hint."""
+
+    @pytest.mark.asyncio
+    async def test_override_attached_when_subscription_has_provider(self):
+        """When the subscription declares ``provider``, the dispatched
+        MessageEvent.provider_override carries the value."""
+        routes = {
+            "ovr": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "task",
+                "provider": "openai-codex",
+                "model": "gpt-5.4",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ovr", json={"x": 1})
+            assert resp.status == 202
+            # Let the dispatched task run.
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None, "handle_message was never invoked"
+        assert evt.provider_override == {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+        }
+
+    @pytest.mark.asyncio
+    async def test_override_partial_provider_only(self):
+        """Provider without model still carries through (gateway uses provider
+        default model when ``model`` is absent)."""
+        routes = {
+            "ovr-p": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "task",
+                "provider": "openai-codex",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ovr-p", json={})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None
+        assert evt.provider_override == {"provider": "openai-codex"}
+
+    @pytest.mark.asyncio
+    async def test_no_override_when_subscription_silent(self):
+        """A subscription without ``provider``/``model`` produces no override
+        (gateway uses its global default)."""
+        routes = {"plain": {"secret": _INSECURE_NO_AUTH, "prompt": "task"}}
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/plain", json={})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None
+        assert evt.provider_override is None
+
+    @pytest.mark.asyncio
+    async def test_override_empty_strings_treated_as_absent(self):
+        """Empty-string provider/model fields don't produce an override."""
+        routes = {
+            "ovr-empty": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "task",
+                "provider": "",
+                "model": "  ",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        captured = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        adapter.handle_message = _capture
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ovr-empty", json={})
+            assert resp.status == 202
+            for _ in range(20):
+                if captured.get("event") is not None:
+                    break
+                await asyncio.sleep(0.01)
+
+        evt = captured["event"]
+        assert evt is not None
+        assert evt.provider_override is None
+
+
+# ===================================================================
 # Rate limiting
 # ===================================================================
 


### PR DESCRIPTION
## Summary

- Adds `--provider` and `--model` flags to `hermes webhook subscribe` so each webhook route can target a specific LLM provider/model regardless of the gateway's auto-selected default.
- New `MessageEvent.provider_override` field (Optional[Dict[str, Any]]); the webhook adapter copies the route's `provider`/`model` config onto the dispatched event.
- `_handle_message` resolves the override via the existing `hermes_cli.model_switch.switch_model` pipeline — the same code path the `/model` slash command uses — and seeds `_session_model_overrides[session_key]` with the fully-resolved `{model, provider, api_key, base_url, api_mode}` BEFORE the agent runs. Crucially this resolves OAuth providers (`openai-codex`) to their real endpoint instead of inheriting the gateway-default `base_url`.

## Why

External orchestrators (e.g. PaperClip) integrate with Hermes most cleanly via webhooks — a plain HTTP POST triggers an agent run with a prompt template. But without per-subscription provider control, every webhook hits the gateway's default provider, which on multi-provider setups is often a text-only relay (e.g. claude-bridge) where MCP tool execution is dropped. With this patch a single subscription can route through e.g. `openai-codex` (OAuth) so the agent's MCP tools fire natively over the canonical OAuth endpoint.

## Implementation

| File | Change |
|---|---|
| `gateway/platforms/base.py` | New `MessageEvent.provider_override` field (Optional[Dict[str, Any]]) |
| `gateway/platforms/webhook.py` | `_handle_webhook` reads `route.provider` / `route.model` and attaches to the event; logs `override=…` on accept |
| `gateway/run.py` | `_handle_message` calls `switch_model(...)` to resolve credentials, then sets `_session_model_overrides[session_key]` and evicts the cached agent so the next turn picks up the override |
| `hermes_cli/main.py` | New `--provider` and `--model` argparse flags on `webhook subscribe` |
| `hermes_cli/webhook.py` | Persist `provider`/`model` to `webhook_subscriptions.json`; show `Override: provider=… model=…` in `webhook list` |
| `tests/gateway/test_webhook_adapter.py` | New `TestProviderOverride` class — 4 tests covering full provider+model, provider-only, no-override, and empty-string handling |

## End-to-end smoke

```bash
hermes webhook subscribe r16-codex \
  --secret INSECURE_NO_AUTH \
  --provider openai-codex \
  --model gpt-5.4 \
  --deliver log \
  --prompt 'Call mcp_agent_os_toolkit_os_remember with key=r16_codex_webhook_proof
            and value=hermes_webhook_codex_e2e_works. Then reply DONE.'

curl -X POST -H 'Content-Type: application/json' -d '{}' \
  http://localhost:8644/webhooks/r16-codex
# → 202 Accepted, delivery_id=1777634622997
```

Logs:

```
[webhook] POST event=unknown route=r16-codex prompt_len=311 delivery=1777634622997
         override=provider:openai-codex,model:gpt-5.4
gateway.run: Per-event provider override applied: session=agent:main:webhook:webhook:web
             provider=openai-codex model=gpt-5.4
             base_url=https://chatgpt.com/backend-api/codex
…
gateway.run: response ready: platform=webhook chat=webhook:r16-codex:1777634622997
             time=11.6s api_calls=2 response='DONE'
```

The agent ran through ChatGPT-Codex OAuth (no bridge in path), invoked `mcp_agent_os_toolkit_os_remember` as instructed, and replied `DONE` in 11.6s. The MCP tool wrote the requested memory file with the operator-supplied value.

## Test plan

- [x] `pytest tests/gateway/test_webhook_adapter.py` — 40/40 pass (existing 36 + 4 new in `TestProviderOverride`)
- [x] CLI smoke: `hermes webhook subscribe <name> --provider openai-codex --model gpt-5.4 …` persists fields to `webhook_subscriptions.json`
- [x] `hermes webhook list` shows `Override: provider=… model=…` line
- [x] End-to-end POST through neocore: webhook → gateway → override resolution → Codex OAuth → MCP tool call → memory file written → `DONE` response
- [x] Subscriptions without `--provider` continue to use the gateway default (no behavior change for existing routes)

## Compatibility

No schema breakage. `provider`/`model` on a subscription are optional and backward-compatible with existing `webhook_subscriptions.json` files — missing fields fall through to the gateway default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
