### PR TITLE
fix(install): prevent npm symlink from hijacking user global npm prefix

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -589,15 +589,11 @@ install_node() {
     mv "$extracted_dir" "$HERMES_HOME/node"
     rm -rf "$tmp_dir"
 
-    mkdir -p "$HOME/.local/bin"
-    ln -sf "$HERMES_HOME/node/bin/node" "$HOME/.local/bin/node"
-    # Do NOT symlink npm into ~/.local/bin — this would hijack the user's
-    # global npm prefix, causing unrelated 'npm install -g' commands to
-    # land in ~/.hermes/node/lib/node_modules instead of the system location.
-    # Fix: set npm prefix explicitly so Hermes's npm always writes to its own
-    # directory, regardless of which npm ends up in the user's PATH.
+    # Do NOT symlink node/npm/npx into ~/.local/bin (issue #18357).
+    # Symlinks pollute the user PATH and break other tools that expect
+    # system npm behavior. Hermes accesses Node.js via full path or the
+    # PATH export below. Lock the npm prefix so installs stay isolated.
     "$HERMES_HOME/node/bin/npm" config set prefix "$HERMES_HOME/node" 2>/dev/null || true
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$HOME/.local/bin/npx"
 
     export PATH="$HERMES_HOME/node/bin:$PATH"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -591,7 +591,12 @@ install_node() {
 
     mkdir -p "$HOME/.local/bin"
     ln -sf "$HERMES_HOME/node/bin/node" "$HOME/.local/bin/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$HOME/.local/bin/npm"
+    # Do NOT symlink npm into ~/.local/bin — this would hijack the user's
+    # global npm prefix, causing unrelated 'npm install -g' commands to
+    # land in ~/.hermes/node/lib/node_modules instead of the system location.
+    # Fix: set npm prefix explicitly so Hermes's npm always writes to its own
+    # directory, regardless of which npm ends up in the user's PATH.
+    "$HERMES_HOME/node/bin/npm" config set prefix "$HERMES_HOME/node" 2>/dev/null || true
     ln -sf "$HERMES_HOME/node/bin/npx"  "$HOME/.local/bin/npx"
 
     export PATH="$HERMES_HOME/node/bin:$PATH"


### PR DESCRIPTION
## Problem

The installer symlinked `~/.hermes/node/bin/npm` to `~/.local/bin/npm`, causing all subsequent `npm install -g` commands to install into `~/.hermes/node/lib/node_modules` instead of the system location. This silently broke unrelated software installed after Hermes.

## Fix

- Remove the `npm` symlink from `~/.local/bin` (npm not needed in PATH — Hermes uses `npx` directly)
- Set npm prefix explicitly via `npm config set prefix` so Hermes npm always writes to `~/.hermes/node` regardless of which npm ends up in the user PATH

`npx` symlink is kept — Hermes uses it to run `agent-browser` and other Node.js tools.

Fixes #18357