### PR TITLE
feat: add supervised goal loop command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6472,6 +6472,7 @@ class HermesCLI:
     def _handle_goal_command(self, cmd: str):
         """Handle /goal <prompt> — run an autonomous supervised loop in the background."""
         from hermes_cli.goal_loop import (
+            expand_goal_skill_invocation,
             get_goal_max_loops,
             make_goal_supervisor_prompt,
             make_goal_worker_prompt,
@@ -6486,16 +6487,20 @@ class HermesCLI:
             return
 
         goal = parts[1].strip()
+        display_goal = goal
         self._background_task_counter += 1
         task_num = self._background_task_counter
         task_id = f"goal_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        goal, loaded_skill_name = expand_goal_skill_invocation(goal, task_id=task_id)
         max_loops = get_goal_max_loops()
 
         if not self._ensure_runtime_credentials():
             _cprint("  (>_<) Cannot start goal: no valid credentials.")
             return
 
-        _cprint(f"  🎯 Goal loop #{task_num} started: \"{goal[:60]}{'...' if len(goal) > 60 else ''}\"")
+        _cprint(f"  🎯 Goal loop #{task_num} started: \"{display_goal[:60]}{'...' if len(display_goal) > 60 else ''}\"")
+        if loaded_skill_name:
+            _cprint(f"  Loaded nested skill: {loaded_skill_name}")
         _cprint(f"  Task ID: {task_id}")
         _cprint(f"  Max supervisor loops: {max_loops}")
         _cprint("  You can continue chatting — the final goal report will appear when done.\n")
@@ -6579,7 +6584,7 @@ class HermesCLI:
                 ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
                 status = "complete" if completed else f"stopped after {max_loops} loop(s)"
                 _cprint(f"  🎯 Goal loop #{task_num} {status}")
-                _cprint(f"  Goal: \"{goal[:80]}{'...' if len(goal) > 80 else ''}\"")
+                _cprint(f"  Goal: \"{display_goal[:80]}{'...' if len(display_goal) > 80 else ''}\"")
                 if supervisor_feedback:
                     _cprint(f"  Supervisor: {supervisor_feedback[:240]}{'...' if len(supervisor_feedback) > 240 else ''}")
                 ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")

--- a/cli.py
+++ b/cli.py
@@ -6320,6 +6320,8 @@ class HermesCLI:
             self._handle_agents_command()
         elif canonical == "background":
             self._handle_background_command(cmd_original)
+        elif canonical == "goal":
+            self._handle_goal_command(cmd_original)
         elif canonical == "queue":
             # Extract prompt after "/queue " or "/q "
             parts = cmd_original.split(None, 1)
@@ -6467,6 +6469,156 @@ class HermesCLI:
         
         return True
     
+    def _handle_goal_command(self, cmd: str):
+        """Handle /goal <prompt> — run an autonomous supervised loop in the background."""
+        from hermes_cli.goal_loop import (
+            get_goal_max_loops,
+            make_goal_supervisor_prompt,
+            make_goal_worker_prompt,
+            parse_goal_supervisor_decision,
+        )
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /goal <prompt>")
+            _cprint("  Example: /goal finish the current feature, run tests, and summarize blockers")
+            _cprint("  Runs in a separate session; a supervisor model decides whether to continue.")
+            return
+
+        goal = parts[1].strip()
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"goal_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        max_loops = get_goal_max_loops()
+
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start goal: no valid credentials.")
+            return
+
+        _cprint(f"  🎯 Goal loop #{task_num} started: \"{goal[:60]}{'...' if len(goal) > 60 else ''}\"")
+        _cprint(f"  Task ID: {task_id}")
+        _cprint(f"  Max supervisor loops: {max_loops}")
+        _cprint("  You can continue chatting — the final goal report will appear when done.\n")
+
+        turn_route = self._resolve_turn_agent_config(goal)
+
+        def _new_agent(session_suffix: str, *, tools_enabled: bool):
+            agent = AIAgent(
+                model=turn_route["model"],
+                api_key=turn_route["runtime"].get("api_key"),
+                base_url=turn_route["runtime"].get("base_url"),
+                provider=turn_route["runtime"].get("provider"),
+                api_mode=turn_route["runtime"].get("api_mode"),
+                acp_command=turn_route["runtime"].get("command"),
+                acp_args=turn_route["runtime"].get("args"),
+                max_iterations=self.max_turns,
+                enabled_toolsets=self.enabled_toolsets if tools_enabled else [],
+                quiet_mode=True,
+                verbose_logging=False,
+                session_id=f"{task_id}_{session_suffix}",
+                platform="cli",
+                session_db=self._session_db,
+                reasoning_config=self.reasoning_config,
+                service_tier=self.service_tier,
+                request_overrides=turn_route.get("request_overrides"),
+                providers_allowed=self._providers_only,
+                providers_ignored=self._providers_ignore,
+                providers_order=self._providers_order,
+                provider_sort=self._provider_sort,
+                provider_require_parameters=self._provider_require_params,
+                provider_data_collection=self._provider_data_collection,
+                fallback_model=self._fallback_model,
+            )
+            agent._print_fn = lambda *_a, **_kw: None
+            return agent
+
+        def run_goal():
+            set_sudo_password_callback(self._sudo_password_callback)
+            set_approval_callback(self._approval_callback)
+            try:
+                set_secret_capture_callback(self._secret_capture_callback)
+            except Exception:
+                pass
+            final_response = ""
+            decision_text = ""
+            completed = False
+            try:
+                previous_response = ""
+                supervisor_feedback = ""
+                for iteration in range(1, max_loops + 1):
+                    if not self._agent_running:
+                        self._spinner_text = f"/goal loop {iteration}/{max_loops}"
+                        if self._app:
+                            self._app.invalidate()
+                    worker = _new_agent(f"worker_{iteration}", tools_enabled=True)
+                    worker_prompt = make_goal_worker_prompt(
+                        goal, iteration, previous_response=previous_response, supervisor_feedback=supervisor_feedback
+                    )
+                    result = worker.run_conversation(user_message=worker_prompt, task_id=f"{task_id}_worker_{iteration}")
+                    final_response = result.get("final_response", "") if result else ""
+                    if not final_response and result and result.get("error"):
+                        final_response = f"Error: {result['error']}"
+
+                    supervisor = _new_agent(f"supervisor_{iteration}", tools_enabled=False)
+                    sup_result = supervisor.run_conversation(
+                        user_message=make_goal_supervisor_prompt(goal, iteration, final_response),
+                        task_id=f"{task_id}_supervisor_{iteration}",
+                    )
+                    decision_text = sup_result.get("final_response", "") if sup_result else ""
+                    decision = parse_goal_supervisor_decision(decision_text)
+                    supervisor_feedback = decision.feedback
+                    if decision.complete:
+                        completed = True
+                        break
+                    previous_response = final_response
+
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                status = "complete" if completed else f"stopped after {max_loops} loop(s)"
+                _cprint(f"  🎯 Goal loop #{task_num} {status}")
+                _cprint(f"  Goal: \"{goal[:80]}{'...' if len(goal) > 80 else ''}\"")
+                if supervisor_feedback:
+                    _cprint(f"  Supervisor: {supervisor_feedback[:240]}{'...' if len(supervisor_feedback) > 240 else ''}")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                response = final_response or decision_text or "(No response generated)"
+                _chat_console = ChatConsole()
+                _chat_console.print(Panel(
+                    _render_final_assistant_content(response, mode=self.final_response_markdown),
+                    title=f"[{_accent_hex()} bold]⚕ Hermes (/goal #{task_num})[/]",
+                    title_align="left",
+                    border_style=_accent_hex(),
+                    box=rich_box.HORIZONTALS,
+                    padding=(1, 4),
+                ))
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                _cprint(f"  ❌ Goal loop #{task_num} failed: {e}")
+            finally:
+                try:
+                    set_sudo_password_callback(None)
+                    set_approval_callback(None)
+                    set_secret_capture_callback(None)
+                except Exception:
+                    pass
+                self._background_tasks.pop(task_id, None)
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_goal, daemon=True, name=f"goal-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
+
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7140,6 +7140,7 @@ class GatewayRunner:
         """Execute a /goal worker/supervisor loop and deliver the result to the chat."""
         from run_agent import AIAgent
         from hermes_cli.goal_loop import (
+            expand_goal_skill_invocation,
             get_goal_max_loops,
             make_goal_supervisor_prompt,
             make_goal_worker_prompt,
@@ -7154,6 +7155,7 @@ class GatewayRunner:
         _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
         max_loops = get_goal_max_loops()
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        worker_goal, loaded_skill_name = expand_goal_skill_invocation(prompt, task_id=task_id)
 
         try:
             user_config = _load_gateway_config()
@@ -7174,7 +7176,7 @@ class GatewayRunner:
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(worker_goal, model, runtime_kwargs)
 
             def run_sync():
                 previous_response = ""
@@ -7217,7 +7219,7 @@ class GatewayRunner:
                     try:
                         result = worker.run_conversation(
                             user_message=make_goal_worker_prompt(
-                                prompt,
+                                worker_goal,
                                 iteration,
                                 previous_response=previous_response,
                                 supervisor_feedback=supervisor_feedback,
@@ -7258,6 +7260,8 @@ class GatewayRunner:
             feedback = (result or {}).get("supervisor_feedback", "")
             status = "complete" if completed else f"stopped after {max_loops} loop(s)"
             header = f'🎯 Goal loop {status}\nGoal: "{preview}"\n'
+            if loaded_skill_name:
+                header += f"Loaded skill: {loaded_skill_name}\n"
             if feedback:
                 header += f"Supervisor: {feedback[:240]}{'...' if len(feedback) > 240 else ''}\n"
             header += "\n"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3944,12 +3944,14 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "agents":
                 return await self._handle_agents_command(event)
 
-            # /background must bypass the running-agent guard — it starts a
-            # parallel task and must never interrupt the active conversation.
+            # /background and /goal must bypass the running-agent guard — they start
+            # parallel tasks and must never interrupt the active conversation.
             # /btw is an alias of /background and resolves to the same canonical
             # name, so this branch handles both commands.
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
+            if _cmd_def_inner and _cmd_def_inner.name == "goal":
+                return await self._handle_goal_command(event)
 
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
@@ -4245,6 +4247,9 @@ class GatewayRunner:
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "goal":
+            return await self._handle_goal_command(event)
 
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
@@ -7103,6 +7108,186 @@ class GatewayRunner:
                 f"A pre-rollback snapshot was saved automatically."
             )
         return f"❌ {result['error']}"
+
+    async def _handle_goal_command(self, event: MessageEvent) -> str:
+        """Handle /goal <prompt> — run a supervised autonomous loop in the background."""
+        from hermes_cli.goal_loop import get_goal_max_loops
+
+        prompt = event.get_command_args().strip()
+        if not prompt:
+            return (
+                "Usage: /goal <prompt>\n"
+                "Example: /goal finish the current feature, run tests, and summarize blockers\n\n"
+                "Runs the prompt in a separate session. A supervisor model decides whether to continue."
+            )
+
+        source = event.source
+        task_id = f"goal_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        _task = asyncio.create_task(self._run_goal_task(prompt, source, task_id))
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        max_loops = get_goal_max_loops()
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        return (
+            f'🎯 Goal loop started: "{preview}"\n'
+            f"Task ID: {task_id}\n"
+            f"Max supervisor loops: {max_loops}\n"
+            "You can keep chatting — the final goal report will appear when done."
+        )
+
+    async def _run_goal_task(self, prompt: str, source: "SessionSource", task_id: str) -> None:
+        """Execute a /goal worker/supervisor loop and deliver the result to the chat."""
+        from run_agent import AIAgent
+        from hermes_cli.goal_loop import (
+            get_goal_max_loops,
+            make_goal_supervisor_prompt,
+            make_goal_worker_prompt,
+            parse_goal_supervisor_decision,
+        )
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in goal task %s", source.platform, task_id)
+            return
+
+        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        max_loops = get_goal_max_loops()
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+
+        try:
+            user_config = _load_gateway_config()
+            model, runtime_kwargs = self._resolve_session_agent_runtime(source=source, user_config=user_config)
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    f"❌ Goal task {task_id} failed: no provider credentials configured.",
+                    metadata=_thread_metadata,
+                )
+                return
+
+            platform_key = _platform_config_key(source.platform)
+            from hermes_cli.tools_config import _get_platform_tools
+            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            pr = self._provider_routing
+            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            reasoning_config = self._resolve_session_reasoning_config(source=source)
+            self._reasoning_config = reasoning_config
+            self._service_tier = self._load_service_tier()
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+
+            def run_sync():
+                previous_response = ""
+                supervisor_feedback = ""
+                final_response = ""
+                decision_text = ""
+                completed = False
+
+                def new_agent(session_suffix: str, *, tools_enabled: bool):
+                    return AIAgent(
+                        model=turn_route["model"],
+                        **turn_route["runtime"],
+                        max_iterations=max_iterations,
+                        quiet_mode=True,
+                        verbose_logging=False,
+                        enabled_toolsets=enabled_toolsets if tools_enabled else [],
+                        reasoning_config=reasoning_config,
+                        service_tier=self._service_tier,
+                        request_overrides=turn_route.get("request_overrides"),
+                        providers_allowed=pr.get("only"),
+                        providers_ignored=pr.get("ignore"),
+                        providers_order=pr.get("order"),
+                        provider_sort=pr.get("sort"),
+                        provider_require_parameters=pr.get("require_parameters", False),
+                        provider_data_collection=pr.get("data_collection"),
+                        session_id=f"{task_id}_{session_suffix}",
+                        platform=platform_key,
+                        user_id=source.user_id,
+                        user_name=source.user_name,
+                        chat_id=source.chat_id,
+                        chat_name=source.chat_name,
+                        chat_type=source.chat_type,
+                        thread_id=source.thread_id,
+                        session_db=self._session_db,
+                        fallback_model=self._fallback_model,
+                    )
+
+                for iteration in range(1, max_loops + 1):
+                    worker = new_agent(f"worker_{iteration}", tools_enabled=True)
+                    try:
+                        result = worker.run_conversation(
+                            user_message=make_goal_worker_prompt(
+                                prompt,
+                                iteration,
+                                previous_response=previous_response,
+                                supervisor_feedback=supervisor_feedback,
+                            ),
+                            task_id=f"{task_id}_worker_{iteration}",
+                        )
+                    finally:
+                        self._cleanup_agent_resources(worker)
+                    final_response = result.get("final_response", "") if result else ""
+                    if not final_response and result and result.get("error"):
+                        final_response = f"Error: {result['error']}"
+
+                    supervisor = new_agent(f"supervisor_{iteration}", tools_enabled=False)
+                    try:
+                        sup_result = supervisor.run_conversation(
+                            user_message=make_goal_supervisor_prompt(prompt, iteration, final_response),
+                            task_id=f"{task_id}_supervisor_{iteration}",
+                        )
+                    finally:
+                        self._cleanup_agent_resources(supervisor)
+                    decision_text = sup_result.get("final_response", "") if sup_result else ""
+                    decision = parse_goal_supervisor_decision(decision_text)
+                    supervisor_feedback = decision.feedback
+                    if decision.complete:
+                        completed = True
+                        break
+                    previous_response = final_response
+
+                return {
+                    "final_response": final_response or decision_text,
+                    "completed": completed,
+                    "supervisor_feedback": supervisor_feedback,
+                }
+
+            result = await self._run_in_executor_with_context(run_sync)
+            response = (result or {}).get("final_response", "") or "(No response generated)"
+            completed = bool((result or {}).get("completed"))
+            feedback = (result or {}).get("supervisor_feedback", "")
+            status = "complete" if completed else f"stopped after {max_loops} loop(s)"
+            header = f'🎯 Goal loop {status}\nGoal: "{preview}"\n'
+            if feedback:
+                header += f"Supervisor: {feedback[:240]}{'...' if len(feedback) > 240 else ''}\n"
+            header += "\n"
+
+            media_files, response = adapter.extract_media(response)
+            images, text_content = adapter.extract_images(response)
+            if text_content:
+                await adapter.send(source.chat_id, header + text_content, metadata=_thread_metadata)
+            elif not images and not media_files:
+                await adapter.send(source.chat_id, header + "(No response generated)", metadata=_thread_metadata)
+            for image_url, alt_text in (images or []):
+                try:
+                    await adapter.send_image(source.chat_id, image_url, caption=alt_text, metadata=_thread_metadata)
+                except Exception:
+                    pass
+            for media_path, _is_voice in (media_files or []):
+                try:
+                    await adapter.send_document(source.chat_id, file_path=media_path, metadata=_thread_metadata)
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.exception("Goal task %s failed", task_id)
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"❌ Goal task {task_id} failed: {e}",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
 
     async def _handle_background_command(self, event: MessageEvent) -> str:
         """Handle /background <prompt> — run a prompt in a separate background session.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -87,6 +87,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>"),
+    CommandDef("goal", "Run a prompt in an autonomous supervisor loop", "Session",
+               args_hint="<prompt>"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",

--- a/hermes_cli/goal_loop.py
+++ b/hermes_cli/goal_loop.py
@@ -1,0 +1,84 @@
+"""Utilities for the /goal autonomous supervisor loop."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GoalDecision:
+    """Supervisor decision for one goal-loop iteration."""
+
+    complete: bool
+    feedback: str
+
+
+def parse_goal_supervisor_decision(text: str | None) -> GoalDecision:
+    """Parse the supervisor's compact COMPLETE/CONTINUE decision.
+
+    The supervisor prompt asks for one of:
+      COMPLETE: <why>
+      CONTINUE: <specific next-step instruction>
+
+    Be permissive so providers that add light formatting still work.
+    """
+
+    raw = (text or "").strip()
+    normalized = raw.lstrip("`*# \n\t").strip()
+    upper = normalized.upper()
+    if upper.startswith("COMPLETE"):
+        feedback = normalized.split(":", 1)[1].strip() if ":" in normalized else normalized
+        return GoalDecision(True, feedback or "Supervisor marked the goal complete.")
+    if upper.startswith("CONTINUE"):
+        feedback = normalized.split(":", 1)[1].strip() if ":" in normalized else normalized
+        return GoalDecision(False, feedback or "Continue toward the goal and address any remaining gaps.")
+
+    # Conservative fallback: ambiguous supervisor output means continue once with
+    # the raw critique rather than silently declaring success.
+    return GoalDecision(False, raw or "Supervisor returned an empty decision; continue and verify completion explicitly.")
+
+
+def get_goal_max_loops(default: int = 6) -> int:
+    """Return HERMES_GOAL_MAX_LOOPS as a safe positive integer."""
+
+    try:
+        return max(1, int(os.getenv("HERMES_GOAL_MAX_LOOPS", str(default))))
+    except (TypeError, ValueError):
+        return max(1, default)
+
+
+def make_goal_worker_prompt(goal: str, iteration: int, previous_response: str = "", supervisor_feedback: str = "") -> str:
+    """Build the prompt sent to the worker agent for a goal iteration."""
+
+    if iteration <= 1:
+        return (
+            "You are running under /goal autonomous mode. Work directly toward this goal and keep going until the "
+            "task is actually complete, using available tools for implementation and verification. Do not stop at a "
+            "plan if you can act. When you believe the goal is complete, provide a concise final summary with evidence.\n\n"
+            f"GOAL:\n{goal}"
+        )
+
+    return (
+        "You are continuing a /goal autonomous loop. The supervisor judged the previous attempt incomplete. "
+        "Address the feedback directly, continue implementation/verification with tools, and finish with concise evidence.\n\n"
+        f"ORIGINAL GOAL:\n{goal}\n\n"
+        f"SUPERVISOR FEEDBACK / NEXT STEP:\n{supervisor_feedback}\n\n"
+        f"PREVIOUS WORKER RESPONSE:\n{previous_response[-6000:]}"
+    )
+
+
+def make_goal_supervisor_prompt(goal: str, iteration: int, worker_response: str) -> str:
+    """Build the no-tools supervisor prompt for judging a worker iteration."""
+
+    return (
+        "You are the supervisor for a Hermes /goal loop. Decide whether the worker's latest response proves the "
+        "goal is complete. Be strict: require concrete evidence such as tests, commit/push/CI status, generated files, "
+        "or a clear explanation of an unrecoverable blocker. If more tool work is likely useful, choose CONTINUE.\n\n"
+        "Reply in exactly one of these formats:\n"
+        "COMPLETE: one-sentence reason\n"
+        "CONTINUE: specific next instruction for the worker\n\n"
+        f"GOAL:\n{goal}\n\n"
+        f"ITERATION: {iteration}\n\n"
+        f"WORKER RESPONSE:\n{worker_response[-12000:]}"
+    )

--- a/hermes_cli/goal_loop.py
+++ b/hermes_cli/goal_loop.py
@@ -48,6 +48,50 @@ def get_goal_max_loops(default: int = 6) -> int:
         return max(1, default)
 
 
+def expand_goal_skill_invocation(goal: str, task_id: str | None = None) -> tuple[str, str | None]:
+    """Expand a nested skill slash command used as the /goal prompt.
+
+    Gateway/CLI command dispatch consumes the outer ``/goal`` command, so a
+    prompt like ``/goal /automatestig-disa-coverage-batch keep batching`` would
+    otherwise hand the literal inner slash command to the worker instead of
+    loading the skill.  If the goal starts with a registered skill slash command,
+    replace it with the same skill-invocation payload normal chat dispatch uses.
+    Plain goals are returned unchanged.
+    """
+
+    raw = (goal or "").strip()
+    if not raw.startswith("/"):
+        return goal, None
+
+    parts = raw[1:].split(maxsplit=1)
+    if not parts or not parts[0]:
+        return goal, None
+
+    command = parts[0]
+    user_instruction = parts[1].strip() if len(parts) > 1 else ""
+
+    try:
+        from agent.skill_commands import (
+            build_skill_invocation_message,
+            resolve_skill_command_key,
+        )
+
+        cmd_key = resolve_skill_command_key(command)
+        if not cmd_key:
+            return goal, None
+        expanded = build_skill_invocation_message(
+            cmd_key,
+            user_instruction,
+            task_id=task_id,
+            runtime_note="Loaded from a nested skill slash command inside /goal.",
+        )
+        if not expanded:
+            return goal, None
+        return expanded, cmd_key.lstrip("/")
+    except Exception:
+        return goal, None
+
+
 def make_goal_worker_prompt(goal: str, iteration: int, previous_response: str = "", supervisor_feedback: str = "") -> str:
     """Build the prompt sent to the worker agent for a goal iteration."""
 

--- a/tests/gateway/test_goal_command.py
+++ b/tests/gateway/test_goal_command.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -24,6 +24,19 @@ def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
     runner._background_tasks = set()
+    runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._cleanup_agent_resources = MagicMock()
+    runner._resolve_session_agent_runtime = MagicMock(return_value=("test-model", {"api_key": "test-key", "provider": "test"}))
+    runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+    runner._load_service_tier = MagicMock(return_value=None)
+    runner._resolve_turn_agent_config = MagicMock(return_value={"model": "test-model", "runtime": {"api_key": "test-key", "provider": "test"}})
+
+    async def run_immediately(func):
+        return func()
+
+    runner._run_in_executor_with_context = AsyncMock(side_effect=run_immediately)
     return runner
 
 
@@ -65,3 +78,54 @@ class TestHandleGoalCommand:
             result = await runner._handle_goal_command(_make_event(f"/goal {long_prompt}"))
         assert "..." in result
         assert long_prompt not in result
+
+    @pytest.mark.asyncio
+    async def test_goal_task_expands_nested_skill_command_before_worker_runs(self, monkeypatch):
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.extract_media = MagicMock(side_effect=lambda text: ([], text))
+        adapter.extract_images = MagicMock(side_effect=lambda text: ([], text))
+        runner.adapters[Platform.SLACK] = adapter
+        sent_worker_prompts = []
+
+        def fake_resolve(command):
+            assert command == "automatestig-disa-coverage-batch"
+            return "/automatestig-disa-coverage-batch"
+
+        def fake_build(cmd_key, user_instruction="", task_id=None, runtime_note=""):
+            assert cmd_key == "/automatestig-disa-coverage-batch"
+            assert user_instruction == "keep batching"
+            assert task_id == "goal_test"
+            assert "nested skill" in runtime_note
+            return "[IMPORTANT: AutomateSTIG skill loaded]\n" + user_instruction
+
+        monkeypatch.setattr("agent.skill_commands.resolve_skill_command_key", fake_resolve)
+        monkeypatch.setattr("agent.skill_commands.build_skill_invocation_message", fake_build)
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_args, **_kwargs: {"terminal", "file"})
+
+        class FakeAgent:
+            def __init__(self, *args, enabled_toolsets=None, **kwargs):
+                self.enabled_toolsets = enabled_toolsets
+
+            def run_conversation(self, user_message, task_id=None):
+                if self.enabled_toolsets:
+                    sent_worker_prompts.append(user_message)
+                    return {"final_response": "worker done"}
+                return {"final_response": "COMPLETE: worker proved the AutomateSTIG batch is done"}
+
+        with patch("run_agent.AIAgent", FakeAgent):
+            await runner._run_goal_task(
+                "/automatestig-disa-coverage-batch keep batching",
+                _make_event().source,
+                "goal_test",
+            )
+
+        assert sent_worker_prompts
+        assert "AutomateSTIG skill loaded" in sent_worker_prompts[0]
+        assert "keep batching" in sent_worker_prompts[0]
+        assert "/automatestig-disa-coverage-batch keep batching" not in sent_worker_prompts[0]
+        adapter.send.assert_awaited_once()
+        sent_text = adapter.send.await_args.args[1]
+        assert "Loaded skill: automatestig-disa-coverage-batch" in sent_text

--- a/tests/gateway/test_goal_command.py
+++ b/tests/gateway/test_goal_command.py
@@ -1,0 +1,67 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/goal", platform=Platform.SLACK, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._background_tasks = set()
+    return runner
+
+
+class TestHandleGoalCommand:
+    @pytest.mark.asyncio
+    async def test_no_prompt_shows_usage(self):
+        runner = _make_runner()
+        result = await runner._handle_goal_command(_make_event("/goal"))
+        assert "Usage:" in result
+        assert "/goal" in result
+
+    @pytest.mark.asyncio
+    async def test_valid_prompt_starts_goal_task(self, monkeypatch):
+        runner = _make_runner()
+        monkeypatch.setenv("HERMES_GOAL_MAX_LOOPS", "2")
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            result = await runner._handle_goal_command(_make_event("/goal finish AutomateSTIG batch"))
+
+        assert "🎯" in result
+        assert "Goal loop started" in result
+        assert "goal_" in result
+        assert "Max supervisor loops: 2" in result
+        assert "finish AutomateSTIG batch" in result
+        assert len(created_tasks) == 1
+
+    @pytest.mark.asyncio
+    async def test_long_prompt_is_truncated(self):
+        runner = _make_runner()
+        long_prompt = "A" * 100
+        with patch("gateway.run.asyncio.create_task", side_effect=lambda c, **kw: (c.close(), MagicMock())[1]):
+            result = await runner._handle_goal_command(_make_event(f"/goal {long_prompt}"))
+        assert "..." in result
+        assert long_prompt not in result

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -188,3 +188,18 @@ async def test_btw_dispatches_mid_run():
     runner._handle_background_command.assert_awaited_once()
     assert result is not None
     assert "can't run mid-turn" not in result
+
+
+@pytest.mark.asyncio
+async def test_goal_dispatches_mid_run():
+    """/goal mid-run must spawn a parallel supervised loop, not interrupt the active run."""
+    runner = _make_runner()
+    runner._handle_goal_command = AsyncMock(
+        return_value='🎯 Goal loop started: "finish the batch"'
+    )
+
+    result = await runner._handle_message(_make_event("/goal finish the batch"))
+
+    runner._handle_goal_command.assert_awaited_once()
+    assert result is not None
+    assert "can't run mid-turn" not in result

--- a/tests/hermes_cli/test_goal_loop.py
+++ b/tests/hermes_cli/test_goal_loop.py
@@ -1,4 +1,5 @@
 from hermes_cli.goal_loop import (
+    expand_goal_skill_invocation,
     get_goal_max_loops,
     make_goal_supervisor_prompt,
     make_goal_worker_prompt,
@@ -57,3 +58,46 @@ def test_supervisor_prompt_requires_compact_decision():
     assert "COMPLETE:" in prompt
     assert "CONTINUE:" in prompt
     assert "I ran tests" in prompt
+
+
+def test_expand_goal_skill_invocation_loads_nested_skill(monkeypatch):
+    calls = {}
+
+    def fake_resolve(command):
+        calls["resolved"] = command
+        return "/automatestig-disa-coverage-batch"
+
+    def fake_build(cmd_key, user_instruction="", task_id=None, runtime_note=""):
+        calls["built"] = (cmd_key, user_instruction, task_id, runtime_note)
+        return "[IMPORTANT: The user has invoked the AutomateSTIG skill]\n" + user_instruction
+
+    monkeypatch.setattr("agent.skill_commands.resolve_skill_command_key", fake_resolve)
+    monkeypatch.setattr("agent.skill_commands.build_skill_invocation_message", fake_build)
+
+    expanded, skill_name = expand_goal_skill_invocation(
+        "/automatestig-disa-coverage-batch keep batching",
+        task_id="goal_123",
+    )
+
+    assert calls["resolved"] == "automatestig-disa-coverage-batch"
+    assert calls["built"] == (
+        "/automatestig-disa-coverage-batch",
+        "keep batching",
+        "goal_123",
+        "Loaded from a nested skill slash command inside /goal.",
+    )
+    assert skill_name == "automatestig-disa-coverage-batch"
+    assert "AutomateSTIG skill" in expanded
+    assert "keep batching" in expanded
+
+
+def test_expand_goal_skill_invocation_leaves_plain_goal_unchanged(monkeypatch):
+    def fail_resolve(_command):
+        raise AssertionError("plain goals should not resolve skill commands")
+
+    monkeypatch.setattr("agent.skill_commands.resolve_skill_command_key", fail_resolve)
+
+    expanded, skill_name = expand_goal_skill_invocation("keep batching AutomateSTIG")
+
+    assert expanded == "keep batching AutomateSTIG"
+    assert skill_name is None

--- a/tests/hermes_cli/test_goal_loop.py
+++ b/tests/hermes_cli/test_goal_loop.py
@@ -1,0 +1,59 @@
+from hermes_cli.goal_loop import (
+    get_goal_max_loops,
+    make_goal_supervisor_prompt,
+    make_goal_worker_prompt,
+    parse_goal_supervisor_decision,
+)
+
+
+def test_parse_complete_decision():
+    decision = parse_goal_supervisor_decision("COMPLETE: tests passed and CI is green")
+    assert decision.complete is True
+    assert "tests passed" in decision.feedback
+
+
+def test_parse_continue_decision():
+    decision = parse_goal_supervisor_decision("CONTINUE: run the failing test and fix it")
+    assert decision.complete is False
+    assert "failing test" in decision.feedback
+
+
+def test_parse_ambiguous_decision_continues():
+    decision = parse_goal_supervisor_decision("Needs more evidence")
+    assert decision.complete is False
+    assert decision.feedback == "Needs more evidence"
+
+
+def test_goal_max_loops_env_is_safe(monkeypatch):
+    monkeypatch.setenv("HERMES_GOAL_MAX_LOOPS", "not-an-int")
+    assert get_goal_max_loops() == 6
+    monkeypatch.setenv("HERMES_GOAL_MAX_LOOPS", "0")
+    assert get_goal_max_loops() == 1
+    monkeypatch.setenv("HERMES_GOAL_MAX_LOOPS", "3")
+    assert get_goal_max_loops() == 3
+
+
+def test_worker_prompt_first_iteration_mentions_goal():
+    prompt = make_goal_worker_prompt("ship the feature", 1)
+    assert "GOAL" in prompt
+    assert "ship the feature" in prompt
+    assert "Do not stop at a plan" in prompt
+
+
+def test_worker_prompt_followup_includes_feedback_and_previous_response():
+    prompt = make_goal_worker_prompt(
+        "ship the feature",
+        2,
+        previous_response="old summary",
+        supervisor_feedback="missing verification",
+    )
+    assert "ORIGINAL GOAL" in prompt
+    assert "missing verification" in prompt
+    assert "old summary" in prompt
+
+
+def test_supervisor_prompt_requires_compact_decision():
+    prompt = make_goal_supervisor_prompt("ship", 1, "I ran tests")
+    assert "COMPLETE:" in prompt
+    assert "CONTINUE:" in prompt
+    assert "I ran tests" in prompt


### PR DESCRIPTION
## Summary
- Adds /goal <prompt> for a background worker/supervisor loop
- Runs normal tools in worker iterations and a no-tools supervisor to decide COMPLETE vs CONTINUE
- Supports CLI and gateway, including mid-run gateway bypass like /background
- Adds regression tests for parsing, gateway start behavior, and mid-run dispatch

## Test Plan
- python -m py_compile hermes_cli/goal_loop.py cli.py gateway/run.py hermes_cli/commands.py
- python -m pytest tests/hermes_cli/test_goal_loop.py tests/gateway/test_goal_command.py tests/gateway/test_running_agent_session_toggles.py tests/gateway/test_background_command.py -q -o 'addopts='