### PR TITLE
fix(cli): wrap long approval commands in prompt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8841,7 +8841,10 @@ class HermesCLI:
         # Pre-wrap the mandatory content — command + choices must always render.
         cmd_wrapped = _wrap_panel_text(cmd_display, inner_text_width)
         if not show_full and "view" in choices and len(cmd_wrapped) > 4:
-            cmd_wrapped = cmd_wrapped[:3] + ["… (choose Show full command)"]
+            cmd_wrapped = cmd_wrapped[:3] + _wrap_panel_text(
+                "… (choose Show full command)",
+                inner_text_width,
+            )
 
         # (choice_index, wrapped_line) so we can re-apply selected styling below
         choice_wrapped: list[tuple[int, str]] = []
@@ -8891,7 +8894,10 @@ class HermesCLI:
         max_cmd_rows = max(1, available - chrome_rows - len(choice_wrapped))
         if len(cmd_wrapped) > max_cmd_rows:
             keep = max(1, max_cmd_rows - 1) if max_cmd_rows > 1 else 1
-            cmd_wrapped = cmd_wrapped[:keep] + ["… (command truncated — use /logs or /debug for full text)"]
+            cmd_wrapped = cmd_wrapped[:keep] + _wrap_panel_text(
+                "… (command truncated — use /logs or /debug for full text)",
+                inner_text_width,
+            )
 
         # Allocate any remaining rows to description. The extra -1 in full mode
         # accounts for the blank separator between choices and description.

--- a/cli.py
+++ b/cli.py
@@ -8816,7 +8816,7 @@ class HermesCLI:
         show_full = state.get("show_full", False)
 
         title = "⚠️  Dangerous Command"
-        cmd_display = command if show_full or len(command) <= 70 else command[:70] + '...'
+        cmd_display = command
         choice_labels = {
             "once": "Allow once",
             "session": "Allow for this session",
@@ -8840,6 +8840,8 @@ class HermesCLI:
 
         # Pre-wrap the mandatory content — command + choices must always render.
         cmd_wrapped = _wrap_panel_text(cmd_display, inner_text_width)
+        if not show_full and "view" in choices and len(cmd_wrapped) > 4:
+            cmd_wrapped = cmd_wrapped[:3] + ["… (choose Show full command)"]
 
         # (choice_index, wrapped_line) so we can re-apply selected styling below
         choice_wrapped: list[tuple[int, str]] = []

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -157,6 +157,30 @@ class TestCliApprovalUi:
         assert "keyring.gpg" in rendered
         assert "status=progress" in rendered
 
+    def test_approval_display_wraps_preview_hint_on_narrow_terminal(self):
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "sudo " + ("very-long-command-segment-" * 8),
+            "description": "shell command via -c/-lc flag",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((30, 24))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+        lines = rendered.splitlines()
+        border_width = len(lines[0])
+
+        assert "Show full" in rendered
+        assert "command)" in rendered
+        assert all(len(line) == border_width for line in lines)
+
     def test_approval_display_shows_full_command_after_view(self):
         cli = _make_cli_stub()
         full_command = "sudo dd if=/tmp/in of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress"

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -153,7 +153,9 @@ class TestCliApprovalUi:
         assert "Dangerous Command" not in lines[0]
         assert any("Dangerous Command" in line for line in lines[1:3])
         assert "Show full command" in rendered
-        assert "githubcli-archive-keyring.gpg" not in rendered
+        assert "githubcli-archive-" in rendered
+        assert "keyring.gpg" in rendered
+        assert "status=progress" in rendered
 
     def test_approval_display_shows_full_command_after_view(self):
         cli = _make_cli_stub()


### PR DESCRIPTION
## What does this PR do?

Fixes #18376.

The CLI dangerous-command approval prompt already wraps panel text, but the command preview was shortened to 70 characters before wrapping. That meant a long command could still hide the important tail unless the user selected the extra "Show full command" action.

This PR lets the prompt wrap the command preview across panel lines first. For very long commands, the preview is still capped so the approve/deny choices stay visible, and the existing "Show full command" action remains available.

## Related Issue

Fixes #18376

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: stop hard-cutting approval commands at 70 characters before wrapping.
- `cli.py`: cap only multi-line previews when needed, so choices remain visible.
- `tests/cli/test_cli_approval_ui.py`: assert that a long command tail is visible in the default approval panel.

## How to Test

1. `source /Users/blackishgreen03/workspace/hermes-agent/venv/bin/activate`
2. `python -m pytest tests/cli/test_cli_approval_ui.py -q`
3. I also tried `python -m pytest tests/ -q` in the same local venv while validating the related branch. It is not green in this environment: it fails in unrelated suites, including missing optional dependencies (`acp`, `fastapi`, `numpy`) and many existing failures outside this diff.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test result:

```text
11 passed in 3.46s
```
