### PR TITLE
fix(feishu): keep topic replies in active threads

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -713,6 +713,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "thread_follow_enabled" in platform_cfg:
+                    bridged["thread_follow_enabled"] = platform_cfg["thread_follow_enabled"]
+                if "thread_follow_ttl_seconds" in platform_cfg:
+                    bridged["thread_follow_ttl_seconds"] = platform_cfg["thread_follow_ttl_seconds"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -390,6 +390,8 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    thread_follow_enabled: bool = False
+    thread_follow_ttl_seconds: int = 1800
 
 
 @dataclass
@@ -536,6 +538,23 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Coerce bool-ish config/env values."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "y"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "n"}:
+            return False
+    return default
 
 
 # ---------------------------------------------------------------------------
@@ -1388,6 +1407,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
+        self._active_thread_follows: Dict[tuple[str, str], float] = {}
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
         self._app_lock_identity: Optional[str] = None
@@ -1504,6 +1524,15 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            thread_follow_enabled=_coerce_bool(
+                extra.get("thread_follow_enabled", os.getenv("HERMES_FEISHU_THREAD_FOLLOW_ENABLED")),
+                default=False,
+            ),
+            thread_follow_ttl_seconds=_coerce_required_int(
+                extra.get("thread_follow_ttl_seconds", os.getenv("HERMES_FEISHU_THREAD_FOLLOW_TTL_SECONDS")),
+                default=1800,
+                min_value=1,
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1536,6 +1565,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._thread_follow_enabled = settings.thread_follow_enabled
+        self._thread_follow_ttl_seconds = settings.thread_follow_ttl_seconds
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -3719,6 +3750,13 @@ class FeishuAdapter(BasePlatformAdapter):
         is_group = getattr(message, "chat_type", "p2p") != "p2p"
         chat_id = getattr(message, "chat_id", "") or ""
         require_mention = is_group and self._require_mention_for(chat_id)
+        mentions_self_value: Optional[bool] = None
+
+        def mentions_self() -> bool:
+            nonlocal mentions_self_value
+            if mentions_self_value is None:
+                mentions_self_value = self._mentions_self(message)
+            return mentions_self_value
 
         # Defensive only — Feishu doesn't echo our outbound back as inbound,
         # and open_id is always populated on both sides.
@@ -3734,7 +3772,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return "self_ids_unknown"
             # Step 4 covers mention enforcement for groups when require_mention
             # is on; check here only on paths step 4 won't reach.
-            if mode == "mentions" and not require_mention and not self._mentions_self(message):
+            if mode == "mentions" and not require_mention and not mentions_self():
                 return "bot_not_mentioned"
 
         if not is_group:
@@ -3744,7 +3782,13 @@ class FeishuAdapter(BasePlatformAdapter):
             getattr(sender, "sender_id", None), chat_id, is_bot=is_bot,
         ):
             return "group_policy_rejected"
-        if require_mention and not self._mentions_self(message):
+        if require_mention:
+            if mentions_self():
+                self._activate_thread_follow(message)
+                return None
+            if self._is_thread_follow_active(message):
+                self._activate_thread_follow(message)
+                return None
             return "group_policy_rejected"
         return None
 
@@ -3753,6 +3797,36 @@ class FeishuAdapter(BasePlatformAdapter):
         if rule and rule.require_mention is not None:
             return rule.require_mention
         return self._require_mention
+
+    def _thread_follow_key(self, message: Any) -> Optional[tuple[str, str]]:
+        chat_id = str(getattr(message, "chat_id", "") or "").strip()
+        thread_id = str(getattr(message, "thread_id", "") or "").strip()
+        if not chat_id or not thread_id:
+            return None
+        return (chat_id, thread_id)
+
+    def _activate_thread_follow(self, message: Any) -> None:
+        if not self._thread_follow_enabled:
+            return
+        key = self._thread_follow_key(message)
+        if key is None:
+            return
+        ttl = max(1, int(getattr(self, "_thread_follow_ttl_seconds", 1800) or 1800))
+        self._active_thread_follows[key] = time.time() + ttl
+
+    def _is_thread_follow_active(self, message: Any) -> bool:
+        if not self._thread_follow_enabled:
+            return False
+        key = self._thread_follow_key(message)
+        if key is None:
+            return False
+        expire_at = self._active_thread_follows.get(key)
+        if expire_at is None:
+            return False
+        if expire_at <= time.time():
+            self._active_thread_follows.pop(key, None)
+            return False
+        return True
 
     # --- Group policy ---------------------------------------------------------
 
@@ -4207,7 +4281,9 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         last_error: Optional[Exception] = None
-        active_reply_to = reply_to
+        active_reply_to = reply_to or (
+            (metadata or {}).get("reply_to_message_id") if metadata else None
+        )
         for attempt in range(_FEISHU_SEND_ATTEMPTS):
             try:
                 response = await self._send_raw_message(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3787,7 +3787,6 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._activate_thread_follow(message)
                 return None
             if self._is_thread_follow_active(message):
-                self._activate_thread_follow(message)
                 return None
             return "group_policy_rejected"
         return None
@@ -3808,11 +3807,12 @@ class FeishuAdapter(BasePlatformAdapter):
     def _activate_thread_follow(self, message: Any) -> None:
         if not self._thread_follow_enabled:
             return
+        self._prune_thread_follows()
         key = self._thread_follow_key(message)
         if key is None:
             return
         ttl = max(1, int(getattr(self, "_thread_follow_ttl_seconds", 1800) or 1800))
-        self._active_thread_follows[key] = time.time() + ttl
+        self._active_thread_follows[key] = time.monotonic() + ttl
 
     def _is_thread_follow_active(self, message: Any) -> bool:
         if not self._thread_follow_enabled:
@@ -3823,10 +3823,19 @@ class FeishuAdapter(BasePlatformAdapter):
         expire_at = self._active_thread_follows.get(key)
         if expire_at is None:
             return False
-        if expire_at <= time.time():
+        if expire_at <= time.monotonic():
             self._active_thread_follows.pop(key, None)
             return False
         return True
+
+    def _prune_thread_follows(self) -> None:
+        now = time.monotonic()
+        expired = [
+            key for key, expire_at in self._active_thread_follows.items()
+            if expire_at <= now
+        ]
+        for key in expired:
+            self._active_thread_follows.pop(key, None)
 
     # --- Group policy ---------------------------------------------------------
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3787,6 +3787,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._activate_thread_follow(message)
                 return None
             if self._is_thread_follow_active(message):
+                if not is_bot:
+                    self._activate_thread_follow(message)
                 return None
             return "group_policy_rejected"
         return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8091,7 +8091,10 @@ class GatewayRunner:
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
 
-            _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _thread_meta = self._thread_metadata_for_source(
+                event.source,
+                reply_to_message_id=event.message_id,
+            )
 
             from gateway.platforms.base import should_send_media_as_audio
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5212,7 +5212,10 @@ class GatewayRunner:
                 )
                 if any(marker in message_text for marker in _stt_fail_markers):
                     _stt_adapter = self.adapters.get(source.platform)
-                    _stt_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    _stt_meta = self._thread_metadata_for_source(
+                        source,
+                        reply_to_message_id=event.message_id,
+                    )
                     if _stt_adapter:
                         try:
                             _stt_msg = (
@@ -5666,7 +5669,10 @@ class GatewayRunner:
                         f"{_compress_token_threshold:,}",
                     )
 
-                    _hyg_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    _hyg_meta = self._thread_metadata_for_source(
+                        source,
+                        reply_to_message_id=event.message_id,
+                    )
 
                     try:
                         from run_agent import AIAgent
@@ -7194,7 +7200,10 @@ class GatewayRunner:
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
                         return "\n".join(lines)
 
-                    metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                    metadata = self._thread_metadata_for_source(
+                        source,
+                        reply_to_message_id=event.message_id,
+                    )
                     result = await adapter.send_model_picker(
                         chat_id=source.chat_id,
                         providers=providers,
@@ -8262,7 +8271,7 @@ class GatewayRunner:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
 
-        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        _thread_metadata = self._thread_metadata_for_source(source)
 
         try:
             user_config = _load_gateway_config()
@@ -9554,7 +9563,10 @@ class GatewayRunner:
         _slash_confirm_mod.register(session_key, confirm_id, command, handler)
 
         adapter = self.adapters.get(source.platform)
-        metadata = self._thread_metadata_for_source(source)
+        metadata = self._thread_metadata_for_source(
+            source,
+            reply_to_message_id=event.message_id,
+        )
 
         used_buttons = False
         if adapter is not None:
@@ -9594,12 +9606,28 @@ class GatewayRunner:
         except Exception:
             return {}
 
-    def _thread_metadata_for_source(self, source) -> Optional[Dict[str, Any]]:
-        """Build the metadata dict platforms need for thread-aware replies."""
-        thread_id = getattr(source, "thread_id", None)
-        if thread_id is None:
+    def _thread_metadata_for_source(
+        self,
+        source,
+        *,
+        thread_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build the metadata dict platforms need for thread-aware replies.
+
+        Feishu topic replies need both the topic id (``thread_id``) and the
+        originating message id.  The Feishu adapter uses the message id to call
+        the reply endpoint and ``thread_id`` to set ``reply_in_thread=True``;
+        sending a plain chat message with only ``thread_id`` creates a normal
+        group message outside the topic.
+        """
+        resolved_thread_id = thread_id if thread_id is not None else getattr(source, "thread_id", None)
+        if resolved_thread_id is None:
             return None
-        return {"thread_id": thread_id}
+        metadata: Dict[str, Any] = {"thread_id": resolved_thread_id}
+        if getattr(source, "platform", None) == Platform.FEISHU and reply_to_message_id:
+            metadata["reply_to_message_id"] = reply_to_message_id
+        return metadata
 
 
     # ------------------------------------------------------------------
@@ -11246,10 +11274,10 @@ class GatewayRunner:
             else bool(_plat_streaming)
         )
 
-        if source.thread_id:
-            _thread_metadata: Optional[Dict[str, Any]] = {"thread_id": source.thread_id}
-        else:
-            _thread_metadata = None
+        _thread_metadata = self._thread_metadata_for_source(
+            source,
+            reply_to_message_id=event_message_id,
+        )
 
         if _streaming_enabled:
             try:
@@ -11668,7 +11696,11 @@ class GatewayRunner:
             _progress_thread_id = source.thread_id or event_message_id
         else:
             _progress_thread_id = source.thread_id
-        _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _progress_metadata = self._thread_metadata_for_source(
+            source,
+            thread_id=_progress_thread_id,
+            reply_to_message_id=event_message_id,
+        )
 
         async def send_progress_messages():
             if not progress_queue:
@@ -11890,7 +11922,11 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_thread_metadata = self._thread_metadata_for_source(
+            source,
+            thread_id=_progress_thread_id,
+            reply_to_message_id=event_message_id,
+        )
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -12034,7 +12070,7 @@ class GatewayRunner:
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            metadata=_status_thread_metadata,
                             on_new_message=(
                                 (lambda: progress_queue.put(("__reset__",)))
                                 if progress_queue is not None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5343,6 +5343,17 @@ class GatewayRunner:
             source.chat_id or "unknown", _msg_preview,
         )
 
+        # Preserve the triggering platform message id on the current source so
+        # async side channels (background-process/watch notifications) can use
+        # Feishu/Lark's reply API later.  A topic id (omt_...) alone is not
+        # enough to reply inside a Feishu topic; the outbound path also needs a
+        # real message id (om_...) as reply_to_message_id.
+        if getattr(event, "message_id", None):
+            try:
+                source.message_id = event.message_id
+            except Exception:
+                pass
+
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
@@ -10271,6 +10282,7 @@ class GatewayRunner:
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            message_id=str(context.source.message_id) if getattr(context.source, "message_id", None) else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
@@ -10471,9 +10483,12 @@ class GatewayRunner:
         Falling back to the currently active foreground event is what causes
         cross-topic bleed, so don't do that.
         """
+        from dataclasses import replace
+
         from gateway.session import SessionSource
 
         session_key = str(evt.get("session_key") or "").strip()
+        message_id = str(evt.get("message_id") or evt.get("reply_to_message_id") or "").strip()
         derived_platform = ""
         derived_chat_type = ""
         derived_chat_id = ""
@@ -10483,6 +10498,8 @@ class GatewayRunner:
                 self.session_store._ensure_loaded()
                 entry = self.session_store._entries.get(session_key)
                 if entry and getattr(entry, "origin", None):
+                    if message_id:
+                        return replace(entry.origin, message_id=message_id)
                     return entry.origin
             except Exception as exc:
                 logger.debug(
@@ -10529,6 +10546,7 @@ class GatewayRunner:
             thread_id=str(evt.get("thread_id") or "").strip() or None,
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
+            message_id=message_id or None,
         )
 
     async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
@@ -10557,6 +10575,7 @@ class GatewayRunner:
                 text=synth_text,
                 message_type=MessageType.TEXT,
                 source=source,
+                message_id=getattr(source, "message_id", None),
                 internal=True,
             )
             logger.info(
@@ -10590,6 +10609,7 @@ class GatewayRunner:
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
         thread_id = watcher.get("thread_id", "")
+        message_id = watcher.get("message_id", "") or watcher.get("reply_to_message_id", "")
         user_id = watcher.get("user_id", "")
         user_name = watcher.get("user_name", "")
         agent_notify = watcher.get("notify_on_complete", False)
@@ -10640,6 +10660,7 @@ class GatewayRunner:
                         "platform": platform_name,
                         "chat_id": chat_id,
                         "thread_id": thread_id,
+                        "message_id": message_id,
                         "user_id": user_id,
                         "user_name": user_name,
                     })
@@ -10661,6 +10682,7 @@ class GatewayRunner:
                                 text=synth_text,
                                 message_type=MessageType.TEXT,
                                 source=source,
+                                message_id=getattr(source, "message_id", None),
                                 internal=True,
                             )
                             logger.info(
@@ -10695,6 +10717,9 @@ class GatewayRunner:
                     if adapter and chat_id:
                         try:
                             send_meta = {"thread_id": thread_id} if thread_id else None
+                            if platform_name == Platform.FEISHU.value and message_id:
+                                send_meta = send_meta or {}
+                                send_meta["reply_to_message_id"] = message_id
                             await adapter.send(chat_id, message_text, metadata=send_meta)
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)
@@ -10716,6 +10741,9 @@ class GatewayRunner:
                 if adapter and chat_id:
                     try:
                         send_meta = {"thread_id": thread_id} if thread_id else None
+                        if platform_name == Platform.FEISHU.value and message_id:
+                            send_meta = send_meta or {}
+                            send_meta["reply_to_message_id"] = message_id
                         await adapter.send(chat_id, message_text, metadata=send_meta)
                     except Exception as e:
                         logger.error("Watcher delivery error: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8252,7 +8252,12 @@ class GatewayRunner:
 
         # Fire-and-forget the background task
         _task = asyncio.create_task(
-            self._run_background_task(prompt, source, task_id)
+            self._run_background_task(
+                prompt,
+                source,
+                task_id,
+                reply_to_message_id=event.message_id,
+            )
         )
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
@@ -8261,7 +8266,12 @@ class GatewayRunner:
         return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'
 
     async def _run_background_task(
-        self, prompt: str, source: "SessionSource", task_id: str
+        self,
+        prompt: str,
+        source: "SessionSource",
+        task_id: str,
+        *,
+        reply_to_message_id: Optional[str] = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
@@ -8271,7 +8281,10 @@ class GatewayRunner:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
 
-        _thread_metadata = self._thread_metadata_for_source(source)
+        _thread_metadata = self._thread_metadata_for_source(
+            source,
+            reply_to_message_id=reply_to_message_id,
+        )
 
         try:
             user_config = _load_gateway_config()
@@ -9622,7 +9635,7 @@ class GatewayRunner:
         group message outside the topic.
         """
         resolved_thread_id = thread_id if thread_id is not None else getattr(source, "thread_id", None)
-        if resolved_thread_id is None:
+        if not resolved_thread_id:
             return None
         metadata: Dict[str, Any] = {"thread_id": resolved_thread_id}
         if getattr(source, "platform", None) == Platform.FEISHU and reply_to_message_id:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -52,6 +52,7 @@ _SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_U
 _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
+_SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
@@ -67,6 +68,7 @@ _VAR_MAP = {
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+    "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
@@ -81,6 +83,7 @@ def set_session_vars(
     chat_id: str = "",
     chat_name: str = "",
     thread_id: str = "",
+    message_id: str = "",
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
@@ -98,6 +101,7 @@ def set_session_vars(
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
+        _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
@@ -121,6 +125,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
+        _SESSION_MESSAGE_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -16,13 +16,15 @@ def make_sender(sender_type: str = "user", open_id: str = "ou_human",
 
 
 def make_message(message_id: str = "om_xxx", chat_type: str = "p2p",
-                 chat_id: str = "oc_1", mentions: Optional[list] = None) -> Any:
+                 chat_id: str = "oc_1", mentions: Optional[list] = None,
+                 thread_id: Optional[str] = None, content: str = "") -> Any:
     return SimpleNamespace(
         message_id=message_id,
         chat_type=chat_type,
         chat_id=chat_id,
+        thread_id=thread_id,
         mentions=mentions,
-        content="",
+        content=content,
         message_type="text",
     )
 
@@ -34,6 +36,8 @@ def make_adapter_skeleton(
     allow_bots: str = "none",
     require_mention: bool = True,
     group_policy: str = "allowlist",
+    thread_follow_enabled: bool = False,
+    thread_follow_ttl_seconds: int = 1800,
 ) -> Any:
     from gateway.platforms.feishu import FeishuAdapter
 
@@ -49,6 +53,9 @@ def make_adapter_skeleton(
     adapter._allowed_group_users = frozenset()
     adapter._allow_bots = allow_bots
     adapter._require_mention = require_mention
+    adapter._thread_follow_enabled = thread_follow_enabled
+    adapter._thread_follow_ttl_seconds = thread_follow_ttl_seconds
+    adapter._active_thread_follows = {}
     return adapter
 
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -50,15 +50,17 @@ def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     return runner
 
 
-def _watcher_dict(session_id="proc_test", thread_id=""):
+def _watcher_dict(session_id="proc_test", thread_id="", message_id="", platform="telegram"):
     d = {
         "session_id": session_id,
         "check_interval": 0,
-        "platform": "telegram",
+        "platform": platform,
         "chat_id": "123",
     }
     if thread_id:
         d["thread_id"] = thread_id
+    if message_id:
+        d["message_id"] = message_id
     return d
 
 
@@ -224,6 +226,34 @@ async def test_thread_id_passed_to_send(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_feishu_thread_notification_passes_reply_message_id(monkeypatch, tmp_path):
+    """Feishu topic sends need both thread_id and an om_ reply target."""
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.FEISHU] = adapter
+
+    await runner._run_process_watcher(
+        _watcher_dict(platform="feishu", thread_id="omt_thread", message_id="om_origin")
+    )
+
+    assert adapter.send.await_count == 1
+    _, kwargs = adapter.send.call_args
+    assert kwargs["metadata"] == {
+        "thread_id": "omt_thread",
+        "reply_to_message_id": "om_origin",
+    }
+
+
+@pytest.mark.asyncio
 async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     """When thread_id is empty, metadata should be None (general topic)."""
     import tools.process_registry as pr_module
@@ -257,6 +287,7 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
             chat_id="-100",
             chat_type="group",
             thread_id="42",
+            message_id="om_origin",
             user_id="123",
             user_name="Emiliyan",
         )
@@ -276,6 +307,7 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     assert synth_event.source.chat_id == "-100"
     assert synth_event.source.chat_type == "group"
     assert synth_event.source.thread_id == "42"
+    assert synth_event.message_id == "om_origin"
     assert synth_event.source.user_id == "123"
     assert synth_event.source.user_name == "Emiliyan"
 
@@ -319,6 +351,7 @@ async def test_inject_watch_notification_ignores_foreground_event_source(monkeyp
             chat_id="-100",
             chat_type="group",
             thread_id="42",
+            message_id="om_origin",
             user_id="proc_owner",
             user_name="alice",
         )
@@ -336,6 +369,7 @@ async def test_inject_watch_notification_ignores_foreground_event_source(monkeyp
     synth_event = adapter.handle_message.await_args.args[0]
     # Must route to thread 42 (process origin), NOT some other thread
     assert synth_event.source.thread_id == "42"
+    assert synth_event.message_id == "om_origin"
     assert synth_event.source.user_id == "proc_owner"
 
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1900,6 +1900,47 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_metadata_reply_to_message_id_for_thread_reply(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _ReplyAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_ReplyAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    metadata={"thread_id": "omt-thread", "reply_to_message_id": "om_parent"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_reply")
+        self.assertEqual(captured["request"].message_id, "om_parent")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -130,6 +130,32 @@ def test_feishu_load_settings_parses_per_group_require_mention(monkeypatch):
     assert settings.group_rules["oc_inherit"].require_mention is None
 
 
+@pytest.mark.parametrize(
+    "env_enabled, extra, expected_enabled, expected_ttl",
+    [
+        (None, {}, False, 1800),
+        ("true", {}, True, 1800),
+        ("false", {"thread_follow_enabled": True, "thread_follow_ttl_seconds": 60}, True, 60),
+        ("yes", {"thread_follow_ttl_seconds": "5"}, True, 5),
+    ],
+)
+def test_feishu_load_settings_thread_follow(monkeypatch, env_enabled, extra, expected_enabled, expected_ttl):
+    from gateway.platforms.feishu import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    if env_enabled is None:
+        monkeypatch.delenv("HERMES_FEISHU_THREAD_FOLLOW_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_FEISHU_THREAD_FOLLOW_ENABLED", env_enabled)
+    monkeypatch.delenv("HERMES_FEISHU_THREAD_FOLLOW_TTL_SECONDS", raising=False)
+
+    settings = FeishuAdapter._load_settings(extra=extra)
+
+    assert settings.thread_follow_enabled is expected_enabled
+    assert settings.thread_follow_ttl_seconds == expected_ttl
+
+
 # --- Module-level helpers --------------------------------------------------
 
 
@@ -425,6 +451,65 @@ def test_admit_group_mention_checked_once_per_call():
     sender = make_sender(sender_type="bot", open_id="ou_peer")
     assert adapter._admit(sender, make_message(chat_type="group")) is None
     assert calls == 1
+
+
+# --- Thread follow ----------------------------------------------------------
+
+
+def test_admit_mentioned_topic_activates_thread_follow_for_later_unmentioned_messages():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=60,
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+
+    stub_mention(adapter, True)
+    assert adapter._admit(sender, make_message(chat_type="group", chat_id="oc_1", thread_id="omt_1")) is None
+
+    stub_mention(adapter, False)
+    assert adapter._admit(sender, make_message(chat_type="group", chat_id="oc_1", thread_id="omt_1")) is None
+    assert (
+        adapter._admit(sender, make_message(chat_type="group", chat_id="oc_1", thread_id="omt_other"))
+        == "group_policy_rejected"
+    )
+
+
+def test_admit_thread_follow_does_not_bypass_group_policy():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="allowlist",
+        thread_follow_enabled=True,
+    )
+    adapter._active_thread_follows[("oc_1", "omt_1")] = 9999999999.0
+    sender = make_sender(sender_type="user", open_id="ou_blocked")
+    stub_mention(adapter, False)
+
+    assert (
+        adapter._admit(sender, make_message(chat_type="group", chat_id="oc_1", thread_id="omt_1"))
+        == "group_policy_rejected"
+    )
+
+
+def test_admit_thread_follow_rejects_expired_topic():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+    )
+    adapter._active_thread_follows[("oc_1", "omt_1")] = 0.0
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    stub_mention(adapter, False)
+
+    assert (
+        adapter._admit(sender, make_message(chat_type="group", chat_id="oc_1", thread_id="omt_1"))
+        == "group_policy_rejected"
+    )
+    assert ("oc_1", "omt_1") not in adapter._active_thread_follows
 
 
 # --- Per-group require_mention override ------------------------------------

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -477,6 +477,61 @@ def test_admit_mentioned_topic_activates_thread_follow_for_later_unmentioned_mes
     )
 
 
+def test_admit_thread_follow_ttl_does_not_refresh_without_mention(monkeypatch):
+    from gateway.platforms import feishu
+
+    now = [100.0]
+    monkeypatch.setattr(feishu.time, "monotonic", lambda: now[0])
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=60,
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = make_message(chat_type="group", chat_id="oc_1", thread_id="omt_1")
+
+    stub_mention(adapter, True)
+    assert adapter._admit(sender, message) is None
+    assert adapter._active_thread_follows[("oc_1", "omt_1")] == 160.0
+
+    now[0] = 150.0
+    stub_mention(adapter, False)
+    assert adapter._admit(sender, message) is None
+    assert adapter._active_thread_follows[("oc_1", "omt_1")] == 160.0
+
+    now[0] = 161.0
+    assert adapter._admit(sender, message) == "group_policy_rejected"
+
+
+def test_activate_thread_follow_prunes_expired_topics(monkeypatch):
+    from gateway.platforms import feishu
+
+    monkeypatch.setattr(feishu.time, "monotonic", lambda: 100.0)
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=60,
+    )
+    adapter._active_thread_follows.update(
+        {
+            ("oc_1", "omt_expired_1"): 10.0,
+            ("oc_1", "omt_active"): 120.0,
+            ("oc_2", "omt_expired_2"): 99.0,
+        }
+    )
+
+    adapter._activate_thread_follow(make_message(chat_type="group", chat_id="oc_new", thread_id="omt_new"))
+
+    assert adapter._active_thread_follows == {
+        ("oc_1", "omt_active"): 120.0,
+        ("oc_new", "omt_new"): 160.0,
+    }
+
+
 def test_admit_thread_follow_does_not_bypass_group_policy():
     adapter = make_adapter_skeleton(
         bot_open_id="ou_self",

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -477,7 +477,7 @@ def test_admit_mentioned_topic_activates_thread_follow_for_later_unmentioned_mes
     )
 
 
-def test_admit_thread_follow_ttl_does_not_refresh_without_mention(monkeypatch):
+def test_admit_thread_follow_ttl_refreshes_on_unmentioned_human_message(monkeypatch):
     from gateway.platforms import feishu
 
     now = [100.0]
@@ -499,9 +499,13 @@ def test_admit_thread_follow_ttl_does_not_refresh_without_mention(monkeypatch):
     now[0] = 150.0
     stub_mention(adapter, False)
     assert adapter._admit(sender, message) is None
-    assert adapter._active_thread_follows[("oc_1", "omt_1")] == 160.0
+    assert adapter._active_thread_follows[("oc_1", "omt_1")] == 210.0
 
-    now[0] = 161.0
+    now[0] = 170.0
+    assert adapter._admit(sender, message) is None
+    assert adapter._active_thread_follows[("oc_1", "omt_1")] == 230.0
+
+    now[0] = 231.0
     assert adapter._admit(sender, message) == "group_policy_rejected"
 
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -212,6 +212,56 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_run_agent_progress_includes_reply_message_for_feishu_topic(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-thread",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu",
+        session_key="agent:main:feishu:group:oc_chat:omt-thread",
+        event_message_id="om_origin",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "omt-thread",
+        "reply_to_message_id": "om_origin",
+    }
+    assert all(
+        call["metadata"] == {
+            "thread_id": "omt-thread",
+            "reply_to_message_id": "om_origin",
+        }
+        for call in adapter.typing
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(monkeypatch, tmp_path):
     """Telegram DM progress must not reuse event message id as thread metadata."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -65,6 +65,29 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class MediaCaptureAdapter(ProgressCaptureAdapter):
+    async def send_multiple_images(self, chat_id, images, metadata=None, human_delay=0.0):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": images,
+                "reply_to": None,
+                "metadata": metadata,
+            }
+        )
+
+    async def send_document(self, chat_id, file_path, caption=None, file_name=None, reply_to=None, metadata=None, **kwargs):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": file_path,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="doc-1")
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -301,6 +324,40 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
     assert adapter.sent
     assert adapter.sent[0]["metadata"] is None
     assert all(call["metadata"] is None for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_post_stream_media_includes_reply_message_for_feishu_topic(tmp_path):
+    adapter = MediaCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    image_path = tmp_path / "poster.png"
+    image_path.write_bytes(b"fake image bytes")
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-thread",
+    )
+    event = MessageEvent(
+        message_id="om_origin",
+        source=source,
+        text=f"MEDIA:{image_path}",
+        message_type=MessageType.TEXT,
+    )
+
+    await runner._deliver_media_from_response(f"done\nMEDIA:{image_path}", event, adapter)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "oc_chat",
+            "content": [(f"file://{image_path}", "")],
+            "reply_to": None,
+            "metadata": {
+                "thread_id": "omt-thread",
+                "reply_to_message_id": "om_origin",
+            },
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -304,6 +304,70 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
 
 
 @pytest.mark.asyncio
+async def test_background_task_includes_reply_message_for_feishu_topic(monkeypatch, tmp_path):
+    class BackgroundFakeAgent:
+        def __init__(self, **kwargs):
+            self.tools = []
+
+        def run_conversation(self, **kwargs):
+            return {
+                "final_response": "done",
+                "messages": [],
+                "api_calls": 1,
+            }
+
+    async def run_inline(fn):
+        return fn()
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = BackgroundFakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **kwargs: ("fake", {"api_key": "fake"}),
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda *args, **kwargs: {"model": "fake", "runtime": {"api_key": "fake"}},
+    )
+    monkeypatch.setattr(runner, "_resolve_session_reasoning_config", lambda **kwargs: None)
+    monkeypatch.setattr(runner, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(runner, "_run_in_executor_with_context", run_inline)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id="omt-thread",
+    )
+
+    await runner._run_background_task(
+        "summarize this",
+        source,
+        "bg_test",
+        reply_to_message_id="om_origin",
+    )
+
+    assert adapter.sent
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "omt-thread",
+        "reply_to_message_id": "om_origin",
+    }
+
+
+@pytest.mark.asyncio
 async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch, tmp_path):
     """Slack DM progress should keep event ts fallback threading."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -109,6 +109,7 @@ class ProcessSession:
     watcher_user_id: str = ""
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
+    watcher_message_id: str = ""
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
     # Watch patterns — trigger agent notification when output matches any pattern
@@ -278,6 +279,7 @@ class ProcessRegistry:
                     "user_id": session.watcher_user_id,
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
+                    "message_id": session.watcher_message_id,
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -310,6 +312,7 @@ class ProcessRegistry:
             "user_id": session.watcher_user_id,
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
+            "message_id": session.watcher_message_id,
         })
 
     def _global_watch_admit(self, now: float) -> bool:
@@ -783,9 +786,16 @@ class ProcessRegistry:
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
+                "session_key": session.session_key,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "output": output_tail,
+                "platform": session.watcher_platform,
+                "chat_id": session.watcher_chat_id,
+                "user_id": session.watcher_user_id,
+                "user_name": session.watcher_user_name,
+                "thread_id": session.watcher_thread_id,
+                "message_id": session.watcher_message_id,
             })
 
     # ----- Query Methods -----
@@ -1251,6 +1261,7 @@ class ProcessRegistry:
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
+                            "watcher_message_id": s.watcher_message_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
@@ -1314,6 +1325,7 @@ class ProcessRegistry:
                     watcher_user_id=entry.get("watcher_user_id", ""),
                     watcher_user_name=entry.get("watcher_user_name", ""),
                     watcher_thread_id=entry.get("watcher_thread_id", ""),
+                    watcher_message_id=entry.get("watcher_message_id", ""),
                     watcher_interval=entry.get("watcher_interval", 0),
                     notify_on_complete=entry.get("notify_on_complete", False),
                     watch_patterns=entry.get("watch_patterns", []),
@@ -1334,6 +1346,7 @@ class ProcessRegistry:
                         "user_id": session.watcher_user_id,
                         "user_name": session.watcher_user_name,
                         "thread_id": session.watcher_thread_id,
+                        "message_id": session.watcher_message_id,
                         "notify_on_complete": session.notify_on_complete,
                     })
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1935,6 +1935,7 @@ def terminal_tool(
                     if _gw_platform:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
                         _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
+                        _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
                         _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
                         _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
                         proc_session.watcher_platform = _gw_platform
@@ -1942,6 +1943,7 @@ def terminal_tool(
                         proc_session.watcher_user_id = _gw_user_id
                         proc_session.watcher_user_name = _gw_user_name
                         proc_session.watcher_thread_id = _gw_thread_id
+                        proc_session.watcher_message_id = _gw_message_id
 
                 # Mutual exclusion: if both notify_on_complete and watch_patterns
                 # are set, drop watch_patterns. The combination produces duplicate
@@ -1978,6 +1980,7 @@ def terminal_tool(
                             "user_id": proc_session.watcher_user_id,
                             "user_name": proc_session.watcher_user_name,
                             "thread_id": proc_session.watcher_thread_id,
+                            "message_id": proc_session.watcher_message_id,
                             "notify_on_complete": True,
                         })
 


### PR DESCRIPTION
## Summary
- keep Feishu/Lark topic replies in the active topic by carrying the inbound `om_...` message id as `reply_to_message_id`
- use Feishu reply API metadata fallback so progress/status/final sends can reply with `reply_in_thread=True` instead of only carrying `omt_...` topic id
- add opt-in Feishu topic follow mode (`feishu.thread_follow_enabled`, `feishu.thread_follow_ttl_seconds`) so a mentioned topic can continue without repeated @mentions until TTL expiry
- refresh active topic follow windows on accepted unmentioned human messages, making the TTL an inactivity timeout instead of a fixed window from the initial @mention
- route post-stream `MEDIA:<path>` image/file delivery through the same Feishu topic metadata helper so native attachments also reply inside the originating topic

## Test Plan
- `python -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu_bot_admission.py`
- `./venv/bin/python -m py_compile gateway/run.py gateway/platforms/feishu.py gateway/config.py tests/gateway/test_feishu_bot_admission.py`
- `./venv/bin/python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_run_progress_topics.py -q`
- `/root/.hermes/scripts/hermes-feishu-topic-patch-verify.sh`

Result: 292 passed, 8 dependency deprecation warnings.
