### PR TITLE
fix(error_classifier): compress context on 500 when session is large

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -504,7 +504,20 @@ def _classify_by_status(
         )
 
     if status_code in (500, 502):
-        return result_fn(FailoverReason.server_error, retryable=True)
+        # Some providers (e.g. Alibaba/DashScope) return 500 when the context
+        # is too large for their backend, instead of a standard context overflow
+        # error.  Detect this by checking if the session is already large —
+        # compression is worth trying when a 500 co-occurs with a big context.
+        _compress_on_500 = (
+            approx_tokens > context_length * 0.3
+            or approx_tokens > 30000
+            or num_messages > 40
+        )
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            should_compress=_compress_on_500,
+        )
 
     if status_code in (503, 529):
         return result_fn(FailoverReason.overloaded, retryable=True)


### PR DESCRIPTION
## Summary

Some providers (e.g. Alibaba/DashScope/百炼) return HTTP 500 when the context is too large for their backend, instead of the standard `context_overflow` error. This causes the retry loop to blindly retry 3 times with the same oversized payload, wasting time and quota.

## Change

Add a heuristic in the 500/502 handler in `error_classifier.py`: when the session is already large (>30% of context_length, >30K tokens, or >40 messages), set `should_compress=True` so the retry loop attempts compression before exhausting retries.

The existing generic `should_compress` handler in `run_agent.py` (around line ~9972) already knows how to act on this flag for non-`context_overflow` errors — this change just makes the classifier set it appropriately.

## Conditions for compression on 500

```python
_compress_on_500 = (
    approx_tokens > context_length * 0.3
    or approx_tokens > 30000
    or num_messages > 40
)
```

If none of these conditions are met, the behavior is unchanged (simple retry with `retryable=True`, `should_compress=False`).
