### PR TITLE
fix: harden Hermes observability instrumentation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,9 +21,11 @@ import re
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
+from agent.redact import redact_sensitive_text
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
@@ -33,7 +35,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -94,10 +96,36 @@ CREATE TABLE IF NOT EXISTS state_meta (
     value TEXT
 );
 
+CREATE TABLE IF NOT EXISTS observability_runs (
+    id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    session_id TEXT,
+    source TEXT,
+    provider TEXT,
+    model TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    duration_ms INTEGER,
+    status TEXT NOT NULL DEFAULT 'running',
+    error_type TEXT,
+    error_message TEXT,
+    api_call_count INTEGER DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    estimated_cost_usd REAL,
+    metadata TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_observability_runs_session ON observability_runs(session_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_observability_runs_started ON observability_runs(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_observability_runs_status ON observability_runs(status);
 """
 
 FTS_SQL = """
@@ -703,6 +731,135 @@ class SessionDB:
             )
             row = cursor.fetchone()
         return dict(row) if row else None
+
+    # ── Native observability run ledger ─────────────────────────────────
+
+    @staticmethod
+    def _redact_observability_text(value: Optional[str]) -> Optional[str]:
+        """Redact free-form observability text before it reaches the ledger."""
+        if not value:
+            return None
+        redacted = redact_sensitive_text(value, force=True)
+        redacted = re.sub(
+            r"(?i)\b(api[_-]?key|token|password|secret|authorization)\s*=\s*([^\s,;]+)",
+            lambda match: f"{match.group(1)}=***",
+            redacted,
+        )
+        return redacted
+
+    @classmethod
+    def _safe_metadata_json(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Serialize metadata after forced secret redaction."""
+        if not metadata:
+            return None
+        try:
+            redacted = json.loads(redact_sensitive_text(json.dumps(metadata, default=str), force=True))
+            return json.dumps(redacted, sort_keys=True, default=str)
+        except Exception:
+            return json.dumps({"serialization_error": True})
+
+    def record_run_start(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        source: Optional[str] = None,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Record the beginning of a Hermes agent run.
+
+        This is the local system-of-record ledger for run-level observability.
+        It stores metadata only; prompts, tool arguments, and raw outputs do not
+        belong here.
+        """
+        run_id = str(uuid.uuid4())
+        trace_id = str(uuid.uuid4())
+        started_at = time.time()
+        metadata_json = self._safe_metadata_json(metadata)
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO observability_runs
+                   (id, trace_id, session_id, source, provider, model, started_at, status, metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?)""",
+                (run_id, trace_id, session_id, source, provider, model, started_at, metadata_json),
+            )
+        self._execute_write(_do)
+        return run_id
+
+    def record_run_finish(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        error_type: Optional[str] = None,
+        error_message: Optional[str] = None,
+        api_call_count: int = 0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        estimated_cost_usd: Optional[float] = None,
+    ) -> None:
+        """Mark a run complete. Unknown run IDs are a no-op."""
+        ended_at = time.time()
+        safe_error = self._redact_observability_text(error_message)
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT started_at FROM observability_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+            if not row:
+                return
+            started_at = row["started_at"] if isinstance(row, sqlite3.Row) else row[0]
+            duration_ms = max(0, int((ended_at - float(started_at)) * 1000))
+            conn.execute(
+                """UPDATE observability_runs SET
+                   ended_at = ?, duration_ms = ?, status = ?, error_type = ?, error_message = ?,
+                   api_call_count = ?, input_tokens = ?, output_tokens = ?,
+                   cache_read_tokens = ?, cache_write_tokens = ?, reasoning_tokens = ?,
+                   estimated_cost_usd = ?
+                   WHERE id = ?""",
+                (
+                    ended_at,
+                    duration_ms,
+                    status,
+                    error_type,
+                    safe_error,
+                    api_call_count,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    reasoning_tokens,
+                    estimated_cost_usd,
+                    run_id,
+                ),
+            )
+        self._execute_write(_do)
+
+    def get_observability_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a run-ledger row by ID."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM observability_runs WHERE id = ?",
+                (run_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        result = dict(row)
+        if result.get("metadata"):
+            try:
+                result["metadata"] = json.loads(result["metadata"])
+            except (json.JSONDecodeError, TypeError):
+                result["metadata"] = {}
+        else:
+            result["metadata"] = {}
+        return result
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.

--- a/run_agent.py
+++ b/run_agent.py
@@ -24,6 +24,7 @@ import asyncio
 import base64
 import concurrent.futures
 import copy
+import functools
 import hashlib
 import json
 import logging
@@ -39,7 +40,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Callable
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -104,6 +105,222 @@ if _loaded_env_paths:
         logger.info("Loaded environment variables from %s", _env_path)
 else:
     logger.info("No .env file found. Using system environment variables.")
+
+
+_AGENTOPS_CLIENT_READY = False
+_AGENTOPS_INIT_LOCK = threading.Lock()
+_AGENTOPS_UNAVAILABLE_LOGGED = False
+
+
+def _agentops_disabled() -> bool:
+    value = (os.environ.get("HERMES_AGENTOPS_ENABLED") or "").strip().lower()
+    return value in {"0", "false", "no", "off"}
+
+
+def _ensure_agentops_initialized():
+    """Initialize AgentOps once when AGENTOPS_API_KEY is configured.
+
+    AgentOps is optional observability. It must never break Hermes if the SDK,
+    credentials, or upstream service are unavailable.
+    """
+    global _AGENTOPS_CLIENT_READY, _AGENTOPS_UNAVAILABLE_LOGGED
+
+    if _agentops_disabled() or not (os.environ.get("AGENTOPS_API_KEY") or "").strip():
+        return None
+
+    with _AGENTOPS_INIT_LOCK:
+        try:
+            import agentops  # type: ignore
+        except Exception as exc:
+            if not _AGENTOPS_UNAVAILABLE_LOGGED:
+                logger.warning("AgentOps requested but unavailable: %s", exc)
+                _AGENTOPS_UNAVAILABLE_LOGGED = True
+            return None
+
+        if not _AGENTOPS_CLIENT_READY:
+            try:
+                agentops.init(
+                    auto_start_session=False,
+                    default_tags=["hermes-agent"],
+                    env_data_opt_out=True,
+                    fail_safe=True,
+                    instrument_llm_calls=False,
+                    log_session_replay_url=False,
+                    skip_auto_end_session=True,
+                    trace_name="hermes",
+                )
+                _AGENTOPS_CLIENT_READY = True
+                logger.info("AgentOps observability initialized")
+            except Exception as exc:
+                if not _AGENTOPS_UNAVAILABLE_LOGGED:
+                    logger.warning("AgentOps initialization failed: %s", exc)
+                    _AGENTOPS_UNAVAILABLE_LOGGED = True
+                return None
+
+        return agentops
+
+
+def _agentops_safe_tags(attributes: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return redacted/allowlisted tags safe for external observability sinks."""
+    if not attributes:
+        return {}
+    allowed = {
+        "api_mode",
+        "model",
+        "operation",
+        "provider",
+        "streaming",
+    }
+    tags: Dict[str, Any] = {}
+    for key in allowed:
+        value = attributes.get(key)
+        if value is None:
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            tags[key] = value
+        else:
+            tags[key] = str(type(value).__name__)
+    return tags
+
+
+def _agentops_run_operation(
+    name: str,
+    attributes: Optional[Dict[str, Any]],
+    operation: Callable[[], Any],
+) -> Any:
+    """Run an operation under AgentOps when available, always fail-open."""
+    try:
+        if not _ensure_agentops_initialized():
+            return operation()
+        import agentops
+
+        decorator = getattr(agentops, "operation", None)
+        if not callable(decorator):
+            return operation()
+
+        call_state = {"called": False, "result": None, "exception": None}
+
+        def _tracked_operation():
+            call_state["called"] = True
+            try:
+                call_state["result"] = operation()
+                return call_state["result"]
+            except BaseException as exc:
+                call_state["exception"] = exc
+                raise
+
+        wrapped = decorator(
+            name=name,
+            tags=_agentops_safe_tags(attributes),
+            capture_request=False,
+            capture_response=False,
+        )(_tracked_operation)
+    except Exception:
+        logger.debug("AgentOps operation setup failed open", exc_info=True)
+        return operation()
+
+    try:
+        return wrapped()
+    except Exception:
+        if call_state["exception"] is not None:
+            raise call_state["exception"]
+        if call_state["called"]:
+            logger.debug("AgentOps operation instrumentation failed after operation", exc_info=True)
+            return call_state["result"]
+        logger.debug("AgentOps operation instrumentation failed before operation", exc_info=True)
+        return operation()
+
+
+def _agentops_observe_run_conversation(func):
+    """Trace every AIAgent.run_conversation call when observability is configured."""
+
+    def _start_native_run(self) -> Optional[str]:
+        session_db = getattr(self, "_session_db", None)
+        if not session_db or not hasattr(session_db, "record_run_start"):
+            return None
+        try:
+            return session_db.record_run_start(
+                session_id=getattr(self, "session_id", None),
+                source=getattr(self, "platform", None) or getattr(self, "source", None) or "unknown",
+                provider=getattr(self, "provider", None),
+                model=getattr(self, "model", None),
+                metadata={
+                    "span_name": "hermes.run_conversation",
+                    "schema": "hermes.observability.run.v1",
+                    "exporters": ["local_ledger", "agentops" if os.environ.get("AGENTOPS_API_KEY") else "none"],
+                },
+            )
+        except Exception as exc:
+            logger.debug("Native observability run start failed: %s", exc)
+            return None
+
+    def _finish_native_run(self, run_id: Optional[str], status: str, exc: Optional[BaseException] = None) -> None:
+        if not run_id:
+            return
+        session_db = getattr(self, "_session_db", None)
+        if not session_db or not hasattr(session_db, "record_run_finish"):
+            return
+        try:
+            session_db.record_run_finish(
+                run_id,
+                status=status,
+                error_type=type(exc).__name__ if exc else None,
+                error_message=str(exc) if exc else None,
+                api_call_count=getattr(self, "session_api_calls", 0) or 0,
+                input_tokens=getattr(self, "session_input_tokens", 0) or 0,
+                output_tokens=getattr(self, "session_output_tokens", 0) or 0,
+                cache_read_tokens=getattr(self, "session_cache_read_tokens", 0) or 0,
+                cache_write_tokens=getattr(self, "session_cache_write_tokens", 0) or 0,
+                reasoning_tokens=getattr(self, "session_reasoning_tokens", 0) or 0,
+                estimated_cost_usd=getattr(self, "session_estimated_cost_usd", None),
+            )
+        except Exception as finish_exc:
+            logger.debug("Native observability run finish failed: %s", finish_exc)
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        native_run_id = _start_native_run(self)
+        agentops = _ensure_agentops_initialized()
+        trace_context = None
+        if agentops is not None:
+            try:
+                trace_context = agentops.start_trace(
+                    trace_name="hermes.run_conversation",
+                    tags={
+                        "platform": getattr(self, "platform", None) or "unknown",
+                        "provider": getattr(self, "provider", None) or "unknown",
+                        "model": getattr(self, "model", None) or "unknown",
+                        "session_id": getattr(self, "session_id", None) or "unknown",
+                    },
+                )
+            except Exception as exc:
+                logger.debug("AgentOps start_trace failed: %s", exc)
+                trace_context = None
+
+        try:
+            result = func(self, *args, **kwargs)
+        except BaseException as exc:
+            _finish_native_run(self, native_run_id, "error", exc)
+            if agentops is not None and trace_context is not None:
+                try:
+                    agentops.end_trace(trace_context, end_state="Error")
+                except Exception as end_exc:
+                    logger.debug("AgentOps end_trace(Error) failed: %s", end_exc)
+            raise
+
+        completed = bool(result.get("completed")) if isinstance(result, dict) else True
+        interrupted = bool(result.get("interrupted")) if isinstance(result, dict) else False
+        native_status = "success" if completed and not interrupted else "partial"
+        _finish_native_run(self, native_run_id, native_status)
+
+        if agentops is not None and trace_context is not None:
+            try:
+                agentops.end_trace(trace_context, end_state="Success")
+            except Exception as exc:
+                logger.debug("AgentOps end_trace(Success) failed: %s", exc)
+        return result
+
+    return wrapper
 
 
 # Import our tool system
@@ -10148,6 +10365,7 @@ class AIAgent:
 
         return final_response
 
+    @_agentops_observe_run_conversation
     def run_conversation(
         self,
         user_message: str,
@@ -10953,12 +11171,23 @@ class AIAgent:
                         if isinstance(getattr(self, "client", None), Mock):
                             _use_streaming = False
 
-                    if _use_streaming:
-                        response = self._interruptible_streaming_api_call(
-                            api_kwargs, on_first_delta=_stop_spinner
-                        )
-                    else:
-                        response = self._interruptible_api_call(api_kwargs)
+                    def _perform_llm_call():
+                        if _use_streaming:
+                            return self._interruptible_streaming_api_call(
+                                api_kwargs, on_first_delta=_stop_spinner
+                            )
+                        return self._interruptible_api_call(api_kwargs)
+
+                    response = _agentops_run_operation(
+                        "hermes.llm",
+                        {
+                            "api_mode": self.api_mode,
+                            "model": self.model,
+                            "provider": self.provider,
+                            "streaming": _use_streaming,
+                        },
+                        _perform_llm_call,
+                    )
                     
                     api_duration = time.time() - api_start_time
                     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_REDACT_SECRETS",
     "HERMES_BACKGROUND_NOTIFICATIONS",
     "HERMES_EXEC_ASK",
+    "HERMES_CRON_SESSION",
     "HERMES_HOME_MODE",
     "TERMINAL_CWD",
     "TERMINAL_ENV",
@@ -234,6 +235,14 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "SLACK_REACTIONS",
     "DISCORD_REQUIRE_MENTION",
     "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_ALLOWED_CHANNELS",
+    "DISCORD_IGNORED_CHANNELS",
+    "DISCORD_NO_THREAD_CHANNELS",
+    "DISCORD_AUTO_THREAD",
+    "DISCORD_ALLOWED_ROLES",
+    "DISCORD_ALLOW_BOTS",
+    "DISCORD_COMMAND_SYNC_POLICY",
+    "DISCORD_REACTIONS",
     "TELEGRAM_REQUIRE_MENTION",
     "WHATSAPP_REQUIRE_MENTION",
     "DINGTALK_REQUIRE_MENTION",
@@ -242,7 +251,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
 
 
 @pytest.fixture(autouse=True)
-def _hermetic_environment(tmp_path, monkeypatch):
+def _hermetic_environment(tmp_path, monkeypatch, request):
     """Blank out all credential/behavioral env vars so local and CI match.
 
     Also redirects HOME and HERMES_HOME to per-test tempdirs so code that
@@ -292,6 +301,21 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.setenv("AWS_METADATA_SERVICE_TIMEOUT", "1")
     monkeypatch.setenv("AWS_METADATA_SERVICE_NUM_ATTEMPTS", "1")
 
+    # 4c. Keep local macOS Keychain credentials out of ordinary tests. The
+    #     dedicated keychain tests opt in by mocking the security command
+    #     themselves; everything else should behave like CI and use only the
+    #     temp files/env vars set inside the test.
+    if request.node.path.name != "test_anthropic_keychain.py":
+        try:
+            import agent.anthropic_adapter as _anthropic_adapter
+            monkeypatch.setattr(
+                _anthropic_adapter,
+                "_read_claude_code_credentials_from_keychain",
+                lambda: None,
+            )
+        except Exception:
+            pass
+
     # 5. Reset plugin singleton so tests don't leak plugins from
     #    ~/.hermes/plugins/ (which, per step 3, is now empty — but the
     #    singleton might still be cached from a previous test).
@@ -331,7 +355,7 @@ def _isolate_hermes_home(_hermetic_environment):
 # from one test's session into another's.
 
 @pytest.fixture(autouse=True)
-def _reset_module_state():
+def _reset_module_state(_hermetic_environment):
     """Clear module-level mutable state and ContextVars between tests.
 
     Keeps state from leaking across tests on the same xdist worker. Modules
@@ -359,6 +383,19 @@ def _reset_module_state():
         # falls through to the env var / default path, matching a fresh
         # process.
         _approval_mod._approval_session_key.set("")
+    except Exception:
+        pass
+
+    # --- cron.scheduler — module constants are computed at import time from
+    #     HERMES_HOME. If cron.scheduler was imported by an earlier test, keep
+    #     its lock path aligned with this test's isolated HERMES_HOME instead
+    #     of reusing a stale tempdir or the developer's real cron lock.
+    try:
+        from cron import scheduler as _cron_sched
+        from hermes_paths import get_hermes_home as _get_hermes_home
+        _cron_sched._hermes_home = _get_hermes_home()
+        _cron_sched._LOCK_DIR = _cron_sched._hermes_home / "cron"
+        _cron_sched._LOCK_FILE = _cron_sched._LOCK_DIR / ".tick.lock"
     except Exception:
         pass
 

--- a/tests/test_agentops_observability_wrapper.py
+++ b/tests/test_agentops_observability_wrapper.py
@@ -1,0 +1,179 @@
+"""Regression tests for AgentOps/native observability wrapper."""
+
+import sys
+from types import SimpleNamespace
+
+from run_agent import _agentops_observe_run_conversation, _agentops_run_operation
+
+
+class _FakeSessionDB:
+    def __init__(self):
+        self.started = []
+        self.finished = []
+
+    def record_run_start(self, **kwargs):
+        self.started.append(kwargs)
+        return "run-1"
+
+    def record_run_finish(self, run_id, **kwargs):
+        self.finished.append((run_id, kwargs))
+
+
+class _FakeAgent:
+    platform = "discord"
+    provider = "openai-codex"
+    model = "gpt-5.5"
+    session_id = "session-1"
+    session_api_calls = 2
+    session_input_tokens = 100
+    session_output_tokens = 25
+    session_cache_read_tokens = 3
+    session_cache_write_tokens = 4
+    session_reasoning_tokens = 5
+    session_estimated_cost_usd = 0.01
+
+    def __init__(self):
+        self._session_db = _FakeSessionDB()
+
+
+def test_observability_wrapper_finishes_success_without_signature_error(monkeypatch):
+    monkeypatch.setenv("HERMES_AGENTOPS_ENABLED", "0")
+
+    @_agentops_observe_run_conversation
+    def run_conversation(self):
+        return {"completed": True, "interrupted": False}
+
+    agent = _FakeAgent()
+    assert run_conversation(agent) == {"completed": True, "interrupted": False}
+
+    assert len(agent._session_db.finished) == 1
+    run_id, finish_kwargs = agent._session_db.finished[0]
+    assert run_id == "run-1"
+    assert finish_kwargs["status"] == "success"
+    assert finish_kwargs["api_call_count"] == 2
+    assert finish_kwargs["input_tokens"] == 100
+    assert finish_kwargs["output_tokens"] == 25
+
+
+def test_observability_wrapper_finishes_error_then_reraises(monkeypatch):
+    monkeypatch.setenv("HERMES_AGENTOPS_ENABLED", "0")
+
+    @_agentops_observe_run_conversation
+    def run_conversation(self):
+        raise RuntimeError("boom")
+
+    agent = _FakeAgent()
+    try:
+        run_conversation(agent)
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    assert len(agent._session_db.finished) == 1
+    run_id, finish_kwargs = agent._session_db.finished[0]
+    assert run_id == "run-1"
+    assert finish_kwargs["status"] == "error"
+    assert finish_kwargs["error_type"] == "RuntimeError"
+    assert finish_kwargs["error_message"] == "boom"
+
+
+class _FakeAgentOps:
+    def __init__(self, fail=False, fail_after_call=False):
+        self.fail = fail
+        self.fail_after_call = fail_after_call
+        self.operations = []
+
+    def operation(self, **kwargs):
+        self.operations.append(kwargs)
+        if self.fail:
+            raise RuntimeError("agentops broken")
+
+        def decorator(func):
+            def wrapped(*args, **inner_kwargs):
+                result = func(*args, **inner_kwargs)
+                if self.fail_after_call:
+                    raise RuntimeError("agentops broke after operation")
+                return result
+            return wrapped
+        return decorator
+
+
+def test_agentops_operation_helper_uses_manual_operation_without_capture(monkeypatch):
+    fake_agentops = _FakeAgentOps()
+    monkeypatch.setitem(sys.modules, "agentops", fake_agentops)
+    monkeypatch.setenv("AGENTOPS_API_KEY", "test-key")
+    monkeypatch.setenv("HERMES_AGENTOPS_ENABLED", "1")
+    monkeypatch.setattr("run_agent._AGENTOPS_CLIENT_READY", True)
+
+    result = _agentops_run_operation(
+        "hermes.llm",
+        {"provider": "openai-codex", "model": "gpt-5.5", "prompt": "secret"},
+        lambda: "ok",
+    )
+
+    assert result == "ok"
+    assert fake_agentops.operations == [
+        {
+            "name": "hermes.llm",
+            "tags": {"provider": "openai-codex", "model": "gpt-5.5"},
+            "capture_request": False,
+            "capture_response": False,
+        }
+    ]
+
+
+def test_agentops_operation_helper_fails_open(monkeypatch):
+    fake_agentops = _FakeAgentOps(fail=True)
+    monkeypatch.setitem(sys.modules, "agentops", fake_agentops)
+    monkeypatch.setenv("AGENTOPS_API_KEY", "test-key")
+    monkeypatch.setenv("HERMES_AGENTOPS_ENABLED", "1")
+    monkeypatch.setattr("run_agent._AGENTOPS_CLIENT_READY", True)
+
+    result = _agentops_run_operation(
+        "hermes.llm",
+        {"provider": "openai-codex", "messages": [{"role": "user", "content": "secret"}]},
+        lambda: "ok",
+    )
+
+    assert result == "ok"
+
+
+def test_agentops_operation_helper_does_not_repeat_completed_operation(monkeypatch):
+    fake_agentops = _FakeAgentOps(fail_after_call=True)
+    monkeypatch.setitem(sys.modules, "agentops", fake_agentops)
+    monkeypatch.setenv("AGENTOPS_API_KEY", "test-key")
+    monkeypatch.setenv("HERMES_AGENTOPS_ENABLED", "1")
+    monkeypatch.setattr("run_agent._AGENTOPS_CLIENT_READY", True)
+    calls = []
+
+    result = _agentops_run_operation(
+        "hermes.llm",
+        {"provider": "openai-codex", "model": "gpt-5.5"},
+        lambda: calls.append("called") or "ok",
+    )
+
+    assert result == "ok"
+    assert calls == ["called"]
+
+
+def test_agentops_operation_helper_preserves_operation_errors(monkeypatch):
+    fake_agentops = _FakeAgentOps()
+    monkeypatch.setitem(sys.modules, "agentops", fake_agentops)
+    monkeypatch.setenv("AGENTOPS_API_KEY", "test-key")
+    monkeypatch.setenv("HERMES_AGENTOPS_ENABLED", "1")
+    monkeypatch.setattr("run_agent._AGENTOPS_CLIENT_READY", True)
+    calls = []
+
+    def failing_operation():
+        calls.append("called")
+        raise RuntimeError("provider failed")
+
+    try:
+        _agentops_run_operation("hermes.llm", {"provider": "openai-codex"}, failing_operation)
+    except RuntimeError as exc:
+        assert str(exc) == "provider failed"
+    else:
+        raise AssertionError("expected provider failure")
+
+    assert calls == ["called"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import json
 import time
 import pytest
 from pathlib import Path
@@ -134,6 +135,59 @@ class TestSessionLifecycle:
 
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
+
+
+# =========================================================================
+# Native observability run ledger
+# =========================================================================
+
+class TestObservabilityRunLedger:
+    def test_record_run_start_and_finish(self, db):
+        run_id = db.record_run_start(
+            session_id="s1",
+            source="discord",
+            provider="openai-codex",
+            model="gpt-5.5",
+            metadata={"trace_source": "native", "api_key": "test-secret-value"},
+        )
+
+        assert run_id
+        run = db.get_observability_run(run_id)
+        assert run["session_id"] == "s1"
+        assert run["source"] == "discord"
+        assert run["status"] == "running"
+        assert run["provider"] == "openai-codex"
+        assert run["model"] == "gpt-5.5"
+        assert run["metadata"]["trace_source"] == "native"
+        assert run["metadata"]["api_key"] == "***"
+        assert "test-secret-value" not in json.dumps(run["metadata"])
+        assert run["started_at"] is not None
+        assert run["ended_at"] is None
+
+        db.record_run_finish(
+            run_id,
+            status="success",
+            api_call_count=2,
+            input_tokens=123,
+            output_tokens=45,
+            estimated_cost_usd=0.0123,
+            error_message="api_key=test-secret-value",
+        )
+
+        finished = db.get_observability_run(run_id)
+        assert finished["status"] == "success"
+        assert finished["ended_at"] >= finished["started_at"]
+        assert finished["duration_ms"] >= 0
+        assert finished["api_call_count"] == 2
+        assert finished["input_tokens"] == 123
+        assert finished["output_tokens"] == 45
+        assert finished["estimated_cost_usd"] == 0.0123
+        assert finished["error_message"] == "api_key=***"
+        assert "test-secret-value" not in finished["error_message"]
+
+    def test_record_run_finish_unknown_id_is_noop(self, db):
+        db.record_run_finish("missing", status="error", error_type="RuntimeError")
+        assert db.get_observability_run("missing") is None
 
 
 # =========================================================================
@@ -1316,7 +1370,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 12
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1372,12 +1426,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 12
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2481,7 +2535,7 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 12
         finally:
             session_db.close()
 


### PR DESCRIPTION
## Summary
- disables fragile AgentOps OpenAI auto-instrumentation while keeping AgentOps as an optional sink
- adds a Hermes-owned fail-open `hermes.llm` AgentOps operation wrapper with allowlisted/redacted tags only
- preserves provider/runtime errors and prevents AgentOps post-call failures from re-running completed provider calls
- adds test-harness isolation for ambient Hermes/Discord/keychain/cron scheduler state that was causing local broad-suite failures

## Safety / Privacy
- no raw prompts, outputs, tool args, headers, env vars, file contents, or secrets are sent to AgentOps
- AgentOps request/response capture remains disabled
- local native Hermes SQLite observability ledger remains source of truth
- exporter/AgentOps failures are non-critical-path and fail open

## Test Plan
- `python -m py_compile run_agent.py hermes_state.py`
- `python -m pytest tests/test_agentops_observability_wrapper.py -q -o 'addopts='` → 6 passed
- `python -m pytest tests/test_hermes_state.py -q -o 'addopts='` → 200 passed
- targeted test-harness regression subset → 18 passed
- broad non-service suite with raised FD limit still exposes pre-existing/order-dependent API server SSE keepalive flake: isolated test passes repeatedly, broad order fails at `tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_stream_sends_keepalive_during_quiet_tool_gap`

## Operational Note
No gateway restart, reload, token refresh, live smoke, or service-affecting action was performed.
