### PR TITLE
chore: increase default child agent timeout to 1 hour

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -474,7 +474,7 @@ def _preserve_parent_mcp_toolsets(
 
 
 DEFAULT_MAX_ITERATIONS = 50
-DEFAULT_CHILD_TIMEOUT = 600  # seconds before a child agent is considered stuck
+DEFAULT_CHILD_TIMEOUT = 3600  # seconds before a child agent is considered stuck
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 # Stale-heartbeat thresholds. A child with no API-call progress is either:
 #   - idle between turns (no current_tool) — probably stuck on a slow API call


### PR DESCRIPTION
Bump DEFAULT_CHILD_TIMEOUT from 600 to 3600 seconds to better accommodate long-running delegated tasks.