### PR TITLE
fix(tui): copy selection on Ctrl+C in approval overlay instead of denying

### DIFF
--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  resolveOverlayCtrlC,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
@@ -56,6 +57,16 @@ describe('shouldAllowIdleHotkeyExit', () => {
 
   it('disables idle exit hotkeys in dashboard chat', () => {
     expect(shouldAllowIdleHotkeyExit(true)).toBe(false)
+  })
+})
+
+describe('resolveOverlayCtrlC — copy selection instead of denying the overlay (#18375)', () => {
+  it('copies when the user has a text selection', () => {
+    expect(resolveOverlayCtrlC(true)).toBe('copy')
+  })
+
+  it('denies (cancels the overlay) when nothing is selected', () => {
+    expect(resolveOverlayCtrlC(false)).toBe('deny')
   })
 })
 

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -6,6 +6,7 @@ import {
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
   resolveCtrlCComposerAction,
+  resolveOverlayCtrlC,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
@@ -79,6 +80,16 @@ describe('resolveCtrlCComposerAction — draft wins over interrupt', () => {
 
   it('does not interrupt a busy session that has no sid yet', () => {
     expect(resolveCtrlCComposerAction({ busy: true, hasDraft: false, hasSession: false })).toBe('exit')
+  })
+})
+
+describe('resolveOverlayCtrlC — copy selection instead of denying the overlay (#18375)', () => {
+  it('copies when the user has a text selection', () => {
+    expect(resolveOverlayCtrlC(true)).toBe('copy')
+  })
+
+  it('denies (cancels the overlay) when nothing is selected', () => {
+    expect(resolveOverlayCtrlC(false)).toBe('deny')
   })
 })
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -128,6 +128,15 @@ export function dismissSensitivePrompt(
   }
 }
 
+// Decide what Ctrl+C does while a prompt overlay (approval / billing /
+// clarify / confirm) is up: copy the selection when the user has text
+// selected, otherwise deny/cancel the overlay. Extracted as a pure helper so
+// the selected-vs-unselected branch has direct regression coverage without
+// mounting the input hook (#18375).
+export function resolveOverlayCtrlC(hasSelection: boolean): 'copy' | 'deny' {
+  return hasSelection ? 'copy' : 'deny'
+}
+
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
 
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
@@ -342,7 +351,13 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       if (promptOverlay && !fallThroughForScroll) {
         if (isCtrl(key, ch, 'c')) {
-          cancelOverlayFromCtrlC()
+          // Selection-aware: copy beats deny when the user has text selected,
+          // matching the unblocked-path precedent (isCopyShortcut + clearSelection).
+          if (resolveOverlayCtrlC(terminal.hasSelection) === 'copy') {
+            copySelection()
+          } else {
+            cancelOverlayFromCtrlC()
+          }
         }
 
         return

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -165,6 +165,15 @@ export function dismissSensitivePrompt(
   }
 }
 
+// Decide what Ctrl+C does while a prompt overlay (approval / billing /
+// clarify / confirm) is up: copy the selection when the user has text
+// selected, otherwise deny/cancel the overlay. Extracted as a pure helper so
+// the selected-vs-unselected branch has direct regression coverage without
+// mounting the input hook (#18375).
+export function resolveOverlayCtrlC(hasSelection: boolean): 'copy' | 'deny' {
+  return hasSelection ? 'copy' : 'deny'
+}
+
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
 
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
@@ -402,7 +411,13 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       if (promptOverlay && !fallThroughForScroll) {
         if (isCtrl(key, ch, 'c')) {
-          cancelOverlayFromCtrlC()
+          // Selection-aware: copy beats deny when the user has text selected,
+          // matching the unblocked-path precedent (isCopyShortcut + clearSelection).
+          if (resolveOverlayCtrlC(terminal.hasSelection) === 'copy') {
+            copySelection()
+          } else {
+            cancelOverlayFromCtrlC()
+          }
         }
 
         return


### PR DESCRIPTION
## What does this PR do?

In the TUI dangerous-command approval overlay (and the sibling clarify/confirm overlays that share the same blocked-input path), `Ctrl+C` was unconditionally treated as **deny** — so users couldn't select the displayed command and copy it for review before approving/denying. The first `Ctrl+C` rejected the request before the clipboard write ever ran.

This PR makes the keystroke selection-aware in the blocked-overlay branch of `useInputHandlers`:

- text selected → run the existing `copySelection()` (same path the unblocked branch uses via `isCopyShortcut`)
- nothing selected → existing `cancelOverlayFromCtrlC()` deny behaviour, unchanged

The pattern mirrors the precedent already in this file at line ~358 where `Esc` clears a selection before falling through to other overlay handling, and #16181's selection-vs-interrupt distinction.

## Related Issue

Fixes #18375

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/useInputHandlers.ts` — in the `isBlocked` branch for `overlay.approval || overlay.clarify || overlay.confirm`, when `Ctrl+C` is received, call `copySelection()` if `terminal.hasSelection`, otherwise the existing `cancelOverlayFromCtrlC()`.

## How to Test

1. `hermes --tui`
2. Trigger a dangerous-command security scan (any terminal command matching `DANGEROUS_PATTERNS` — e.g. ask the agent to `rm -rf` something).
3. When the approval overlay appears, select part of the displayed command with the mouse.
4. Press `Ctrl+C` — selection is copied to the clipboard, overlay stays open.
5. With **no** selection, press `Ctrl+C` — overlay dismisses with deny, same as before.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` — pre-existing failures only, all in `tests/tools/` (transcription, file_read_guards, terminal_tool_requirements) unrelated to this change. `ui-tui` vitest suite (548 tests) passes.
- [ ] I've added tests for my changes — the `useInput` callback in `useInputHandlers.ts` has no existing unit-test infra in this repo (sibling intercept paths are also untested at unit level); a hook-test scaffold would be a separate PR. Verified via `tsc --noEmit` and manual TUI repro.
- [x] I've tested on my platform: macOS 15 (Darwin 23.2.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal handler change, no user-facing docs reference this binding)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `terminal.hasSelection` is platform-agnostic; `copySelection()` already handles macOS/Linux/tmux/OSC 52
- [x] I've updated tool descriptions/schemas — N/A