### PR TITLE
fix(docker): expand ~ in user-configured volume mounts

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -114,6 +114,32 @@ def test_ensure_docker_available_uses_resolved_executable(monkeypatch):
     ]
 
 
+def test_user_volumes_with_tilde_are_expanded(monkeypatch, tmp_path):
+    # podman/docker don't expand ~ in -v args; hermes must do it before
+    # handing the spec off, otherwise the runtime tries to mount a literal
+    # "~" directory and fails with exit 125.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        volumes=[
+            "~/Documents/projects:/workspace/projects",
+            "~/.hermes:/.hermes:ro",
+            "/already/absolute:/abs",
+        ],
+    )
+
+    run_cmd = next(cmd for cmd, _ in calls if isinstance(cmd, list) and "run" in cmd)
+    expected_home = str(home)
+    assert f"{expected_home}/Documents/projects:/workspace/projects" in run_cmd
+    assert f"{expected_home}/.hermes:/.hermes:ro" in run_cmd
+    assert "/already/absolute:/abs" in run_cmd
+    # nothing literal-tilde should reach the runtime
+    assert not any(arg.startswith("~/") for arg in run_cmd)
+
+
 def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     """Opt-in docker cwd mounting should bind the host cwd to /workspace."""
     project_dir = tmp_path / "my-project"

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -351,6 +351,13 @@ class DockerEnvironment(BaseEnvironment):
             if not vol:
                 continue
             if ":" in vol:
+                # Docker/Podman don't expand ~ in -v arguments; they'd try to
+                # mount a literal "~" directory. Expand the host side of
+                # host:container[:opts] before handing it off.
+                host_part, sep, rest = vol.partition(":")
+                if host_part.startswith("~"):
+                    host_part = os.path.expanduser(host_part)
+                vol = f"{host_part}{sep}{rest}"
                 volume_args.extend(["-v", vol])
                 if ":/workspace" in vol:
                     workspace_explicitly_mounted = True


### PR DESCRIPTION
## Summary

`docker_volumes` entries from `config.yaml` were forwarded straight to docker/podman as `-v` arguments, but neither runtime expands `~` itself. A spec like:

```yaml
terminal:
  docker_volumes:
    - ~/Documents/projects:/workspace/projects
    - ~/.hermes:/.hermes:ro
```

caused podman to try to mount a literal `~` directory and fail with exit 125 / `no such file or directory`, breaking `terminal_tool` for any user with home-relative volume mounts.

## Fix

Expand the host side of `host:container[:opts]` before forwarding. Mirrors the existing `os.path.expanduser(host_cwd)` handling at `tools/environments/docker.py:360`.

```python
host_part, sep, rest = vol.partition(":")
if host_part.startswith("~"):
    host_part = os.path.expanduser(host_part)
vol = f"{host_part}{sep}{rest}"
```

Only applies to entries that start with `~` — absolute paths and any other input pass through untouched.

## Test plan

- [x] New unit test in `tests/tools/test_docker_environment.py` verifying mixed `~` and absolute entries both reach the runtime correctly and no literal `~/` slips through
- [x] Existing 23 docker-environment tests still pass
- [x] Reproduced the bug locally with podman + the example config above, confirmed fix resolves it

## Repro

```yaml
terminal:
  docker_volumes:
    - ~/Documents/projects:/workspace/projects
```

Before: `subprocess.CalledProcessError: ... returned non-zero exit status 125` from podman with `'-v', '~/Documents/projects:/workspace/projects'` in the command.
After: container starts cleanly with the expanded path.