### PR TITLE
feat(moa): config-driven multi-provider routing for references and aggregator

### DIFF
--- a/tests/tools/test_mixture_of_agents_tool.py
+++ b/tests/tools/test_mixture_of_agents_tool.py
@@ -8,6 +8,25 @@ import pytest
 moa = importlib.import_module("tools.mixture_of_agents_tool")
 
 
+@pytest.fixture(autouse=True)
+def _clear_route_cache():
+    moa._reset_route_cache()
+    yield
+    moa._reset_route_cache()
+
+
+def _fake_completion(text: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text, reasoning=None))]
+    )
+
+
+def _fake_client(create_mock):
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+
 def test_moa_defaults_are_well_formed():
     # Invariants, not a catalog snapshot: the exact model list churns with
     # OpenRouter availability (see PR #6636 where gemini-3-pro-preview was
@@ -21,27 +40,124 @@ def test_moa_defaults_are_well_formed():
     assert "/" in moa.AGGREGATOR_MODEL
 
 
+def test_normalize_route_accepts_string():
+    route = moa._normalize_route("anthropic/claude-opus-4.6")
+    assert route["provider"] == "openrouter"
+    assert route["model"] == "anthropic/claude-opus-4.6"
+    assert route["label"] == "anthropic/claude-opus-4.6"
+
+
+def test_normalize_route_accepts_dict():
+    route = moa._normalize_route(
+        {
+            "provider": "ollama-cloud",
+            "model": "kimi-k2.5",
+            "temperature": 0.3,
+            "max_tokens": 8192,
+            "extra_body": {"custom": "value"},
+        }
+    )
+    assert route["provider"] == "ollama-cloud"
+    assert route["model"] == "kimi-k2.5"
+    assert route["label"] == "ollama-cloud:kimi-k2.5"
+    assert route["temperature"] == 0.3
+    assert route["max_tokens"] == 8192
+    assert route["extra_body"] == {"custom": "value"}
+
+
+@pytest.mark.parametrize(
+    "spec,expected_msg",
+    [
+        ({"model": "kimi-k2.5"}, "missing required 'provider'"),
+        ({"provider": "ollama-cloud"}, "missing required 'model'"),
+        ("", "must not be empty"),
+        (123, "must be a string or mapping"),
+        ({"provider": "x", "model": "y", "extra_body": "not a dict"}, "must be a mapping"),
+    ],
+)
+def test_normalize_route_validation_errors(spec, expected_msg):
+    with pytest.raises(ValueError, match=expected_msg):
+        moa._normalize_route(spec)
+
+
+def test_extra_body_defaults_per_provider():
+    or_route = moa._normalize_route("anthropic/claude-opus-4.6")
+    assert moa._resolve_extra_body(or_route) == {
+        "reasoning": {"enabled": True, "effort": "xhigh"}
+    }
+    ollama_route = moa._normalize_route(
+        {"provider": "ollama-cloud", "model": "kimi-k2.5"}
+    )
+    assert moa._resolve_extra_body(ollama_route) is None
+    explicit = moa._normalize_route(
+        {"provider": "ollama-cloud", "model": "kimi-k2.5", "extra_body": {"x": 1}}
+    )
+    assert moa._resolve_extra_body(explicit) == {"x": 1}
+
+
+def test_should_send_temperature_default_and_explicit_omit():
+    # legacy "gpt-*" carve-out only fires for bare slugs (no vendor prefix);
+    # OpenRouter vendor-prefixed slugs and other providers send temperature.
+    bare_gpt_route = moa._normalize_route("gpt-4o-mini")
+    assert moa._should_send_temperature(bare_gpt_route) is False
+    claude_route = moa._normalize_route("anthropic/claude-opus-4.6")
+    assert moa._should_send_temperature(claude_route) is True
+    explicit_omit = moa._normalize_route(
+        {"provider": "ollama-cloud", "model": "kimi-k2.5", "omit_temperature": True}
+    )
+    assert moa._should_send_temperature(explicit_omit) is False
+    # ollama-cloud sends temperature by default
+    ollama_route = moa._normalize_route(
+        {"provider": "ollama-cloud", "model": "kimi-k2.5"}
+    )
+    assert moa._should_send_temperature(ollama_route) is True
+
+
+def test_resolve_client_for_route_caches(monkeypatch):
+    sentinel_client = SimpleNamespace(name="sentinel")
+    resolve_calls = []
+
+    def fake_resolve(provider, model=None, async_mode=False, **kw):
+        resolve_calls.append((provider, model))
+        return sentinel_client, model
+
+    monkeypatch.setattr(moa, "resolve_provider_client", fake_resolve)
+    route = moa._normalize_route({"provider": "ollama-cloud", "model": "kimi-k2.5"})
+    c1, m1 = moa._resolve_client_for_route(route)
+    c2, m2 = moa._resolve_client_for_route(route)
+    assert c1 is c2 is sentinel_client
+    assert m1 == m2 == "kimi-k2.5"
+    assert len(resolve_calls) == 1
+
+
+def test_resolve_client_for_route_raises_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(
+        moa, "resolve_provider_client", lambda *a, **kw: (None, None)
+    )
+    route = moa._normalize_route({"provider": "requesty", "model": "qwen-3"})
+    with pytest.raises(RuntimeError, match="provider 'requesty' is not configured"):
+        moa._resolve_client_for_route(route)
+
+
 @pytest.mark.asyncio
 async def test_reference_model_retry_warnings_avoid_exc_info_until_terminal_failure(monkeypatch):
-    fake_client = SimpleNamespace(
-        chat=SimpleNamespace(
-            completions=SimpleNamespace(
-                create=AsyncMock(side_effect=RuntimeError("rate limited"))
-            )
-        )
+    # legacy test, updated to use the new client-resolution surface
+    create_mock = AsyncMock(side_effect=RuntimeError("rate limited"))
+    fake_client = _fake_client(create_mock)
+
+    monkeypatch.setattr(
+        moa, "_resolve_client_for_route", lambda route: (fake_client, route["model"])
     )
     warn = MagicMock()
     err = MagicMock()
-
-    monkeypatch.setattr(moa, "_get_openrouter_client", lambda: fake_client)
     monkeypatch.setattr(moa.logger, "warning", warn)
     monkeypatch.setattr(moa.logger, "error", err)
 
-    model, message, success = await moa._run_reference_model_safe(
+    label, message, success = await moa._run_reference_model_safe(
         "openai/gpt-5.4-pro", "hello", max_retries=2
     )
 
-    assert model == "openai/gpt-5.4-pro"
+    assert label == "openai/gpt-5.4-pro"
     assert success is False
     assert "failed after 2 attempts" in message
     assert warn.call_count == 2
@@ -51,8 +167,73 @@ async def test_reference_model_retry_warnings_avoid_exc_info_until_terminal_fail
 
 
 @pytest.mark.asyncio
+async def test_reference_model_unconfigured_provider_fails_fast(monkeypatch):
+    monkeypatch.setattr(
+        moa, "resolve_provider_client", lambda *a, **kw: (None, None)
+    )
+    label, message, success = await moa._run_reference_model_safe(
+        {"provider": "requesty", "model": "qwen-3"}, "hello", max_retries=5
+    )
+    assert success is False
+    assert label == "requesty:qwen-3"
+    assert "requesty" in message and "not configured" in message
+
+
+@pytest.mark.asyncio
+async def test_run_reference_passes_extra_body_only_for_openrouter(monkeypatch):
+    captured = {}
+
+    async def capture(**kwargs):
+        captured.update(kwargs)
+        return _fake_completion("ok")
+
+    monkeypatch.setattr(
+        moa,
+        "_resolve_client_for_route",
+        lambda route: (_fake_client(AsyncMock(side_effect=capture)), route["model"]),
+    )
+    label, content, success = await moa._run_reference_model_safe(
+        {"provider": "ollama-cloud", "model": "kimi-k2.5"}, "hello", max_retries=1
+    )
+    assert success is True
+    assert content == "ok"
+    assert label == "ollama-cloud:kimi-k2.5"
+    assert "extra_body" not in captured
+    assert captured["temperature"] == moa.REFERENCE_TEMPERATURE
+    assert captured["model"] == "kimi-k2.5"
+
+
+@pytest.mark.asyncio
+async def test_run_reference_forwards_per_route_extra_body(monkeypatch):
+    captured = {}
+
+    async def capture(**kwargs):
+        captured.update(kwargs)
+        return _fake_completion("ok")
+
+    monkeypatch.setattr(
+        moa,
+        "_resolve_client_for_route",
+        lambda route: (_fake_client(AsyncMock(side_effect=capture)), route["model"]),
+    )
+    await moa._run_reference_model_safe(
+        {
+            "provider": "ollama-cloud",
+            "model": "kimi-k2.5",
+            "extra_body": {"reasoning": {"effort": "high"}},
+            "temperature": 0.2,
+        },
+        "hello",
+        max_retries=1,
+    )
+    assert captured["extra_body"] == {"reasoning": {"effort": "high"}}
+    assert captured["temperature"] == 0.2
+
+
+@pytest.mark.asyncio
 async def test_moa_top_level_error_logs_single_traceback_on_aggregator_failure(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(moa, "_load_moa_config", lambda: {})
     monkeypatch.setattr(
         moa,
         "_run_reference_model_safe",
@@ -83,3 +264,162 @@ async def test_moa_top_level_error_logs_single_traceback_on_aggregator_failure(m
     assert "Error in MoA processing" in result["error"]
     err.assert_called_once()
     assert err.call_args.kwargs.get("exc_info") is True
+
+
+@pytest.mark.asyncio
+async def test_moa_uses_config_routes_when_no_args(monkeypatch):
+    monkeypatch.setattr(
+        moa,
+        "_load_moa_config",
+        lambda: {
+            "references": [
+                {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+                {"provider": "openrouter", "model": "anthropic/claude-opus-4.6"},
+            ],
+            "aggregator": {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+        },
+    )
+    captured_routes = []
+
+    async def fake_ref(route, prompt, temperature=None):
+        captured_routes.append(route)
+        return route["label"], "draft", True
+
+    captured_agg_route = {}
+
+    async def fake_agg(system_prompt, user_prompt, temperature=None, route=None):
+        captured_agg_route["route"] = route
+        return "final"
+
+    monkeypatch.setattr(moa, "_run_reference_model_safe", fake_ref)
+    monkeypatch.setattr(moa, "_run_aggregator_model", fake_agg)
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result["success"] is True
+    assert result["response"] == "final"
+    assert result["models_used"]["aggregator_model"] == "ollama-cloud:kimi-k2.5"
+    assert result["models_used"]["reference_models"] == [
+        "ollama-cloud:kimi-k2.5",
+        "anthropic/claude-opus-4.6",
+    ]
+    assert {r["provider"] for r in captured_routes} == {"ollama-cloud", "openrouter"}
+    assert captured_agg_route["route"]["provider"] == "ollama-cloud"
+
+
+@pytest.mark.asyncio
+async def test_moa_partial_failure_still_succeeds(monkeypatch):
+    monkeypatch.setattr(
+        moa,
+        "_load_moa_config",
+        lambda: {
+            "references": [
+                {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+                {"provider": "requesty", "model": "qwen-3"},
+            ],
+            "aggregator": {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+            "min_successful_references": 1,
+        },
+    )
+
+    async def fake_ref(route, prompt, temperature=None):
+        if route["provider"] == "requesty":
+            return route["label"], "boom", False
+        return route["label"], "draft", True
+
+    async def fake_agg(*args, **kwargs):
+        return "final"
+
+    monkeypatch.setattr(moa, "_run_reference_model_safe", fake_ref)
+    monkeypatch.setattr(moa, "_run_aggregator_model", fake_agg)
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("hello"))
+    assert result["success"] is True
+    assert result["response"] == "final"
+
+
+@pytest.mark.asyncio
+async def test_moa_bad_config_surfaces_clear_error(monkeypatch):
+    monkeypatch.setattr(
+        moa,
+        "_load_moa_config",
+        lambda: {"references": [{"provider": "ollama-cloud"}]},  # missing model
+    )
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+    result = json.loads(await moa.mixture_of_agents_tool("hello"))
+    assert result["success"] is False
+    assert "MoA configuration error" in result["error"]
+    assert "missing required 'model'" in result["error"]
+
+
+def test_check_moa_requirements_legacy_path(monkeypatch):
+    monkeypatch.setattr(moa, "_load_moa_config", lambda: {})
+    monkeypatch.setattr(moa, "check_openrouter_api_key", lambda: True)
+    assert moa.check_moa_requirements() is True
+    monkeypatch.setattr(moa, "check_openrouter_api_key", lambda: False)
+    assert moa.check_moa_requirements() is False
+
+
+def test_check_moa_requirements_config_driven(monkeypatch):
+    monkeypatch.setattr(
+        moa,
+        "_load_moa_config",
+        lambda: {
+            "references": [{"provider": "ollama-cloud", "model": "kimi-k2.5"}],
+            "aggregator": {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+        },
+    )
+    monkeypatch.setattr(moa, "check_openrouter_api_key", lambda: False)
+    monkeypatch.setattr(
+        moa,
+        "resolve_provider_client",
+        lambda provider, **kw: (SimpleNamespace(), "kimi-k2.5"),
+    )
+    assert moa.check_moa_requirements() is True
+
+    monkeypatch.setattr(
+        moa, "resolve_provider_client", lambda *a, **kw: (None, None)
+    )
+    assert moa.check_moa_requirements() is False
+
+
+def test_get_moa_configuration_reflects_overrides(monkeypatch):
+    monkeypatch.setattr(
+        moa,
+        "_load_moa_config",
+        lambda: {
+            "references": [
+                {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+                {"provider": "openrouter", "model": "anthropic/claude-opus-4.6"},
+            ],
+            "aggregator": {"provider": "ollama-cloud", "model": "kimi-k2.5"},
+            "reference_temperature": 0.7,
+            "aggregator_temperature": 0.5,
+            "min_successful_references": 2,
+        },
+    )
+    cfg = moa.get_moa_configuration()
+    assert cfg["aggregator_model"] == "ollama-cloud:kimi-k2.5"
+    assert cfg["reference_models"] == [
+        "ollama-cloud:kimi-k2.5",
+        "anthropic/claude-opus-4.6",
+    ]
+    assert cfg["reference_temperature"] == 0.7
+    assert cfg["aggregator_temperature"] == 0.5
+    assert cfg["min_successful_references"] == 2
+    assert cfg["total_reference_models"] == 2
+    assert cfg["failure_tolerance"] == "0/2 models can fail"

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -50,9 +50,9 @@ import logging
 import os
 import asyncio
 import datetime
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, TypedDict
 from tools.openrouter_client import get_async_client as _get_openrouter_client, check_api_key as check_openrouter_api_key
-from agent.auxiliary_client import extract_content_or_reasoning
+from agent.auxiliary_client import extract_content_or_reasoning, resolve_provider_client
 from tools.debug_helpers import DebugSession
 
 logger = logging.getLogger(__name__)
@@ -86,6 +86,142 @@ Responses from models:"""
 _debug = DebugSession("moa_tools", env_var="MOA_TOOLS_DEBUG")
 
 
+class ModelRoute(TypedDict, total=False):
+    """A single MoA route — provider+model plus optional per-route knobs."""
+
+    provider: str
+    model: str
+    label: str
+    temperature: float
+    max_tokens: int
+    omit_temperature: bool
+    extra_body: Dict[str, Any]
+
+
+_OPENROUTER_DEFAULT_EXTRA_BODY: Dict[str, Any] = {
+    "reasoning": {"enabled": True, "effort": "xhigh"}
+}
+
+_route_client_cache: Dict[Tuple[str, str], Tuple[Any, str]] = {}
+
+
+def _default_route_label(provider: str, model: str) -> str:
+    if provider == "openrouter":
+        return model
+    return f"{provider}:{model}"
+
+
+def _normalize_route(spec: Any, *, default_provider: str = "openrouter") -> ModelRoute:
+    """Coerce a route spec into a validated ModelRoute.
+
+    Accepts either a bare string (legacy: assumed OpenRouter slug) or a mapping
+    with at least ``provider`` and ``model``.
+    """
+    if isinstance(spec, str):
+        if not spec.strip():
+            raise ValueError("MoA route string must not be empty")
+        return {
+            "provider": default_provider,
+            "model": spec,
+            "label": _default_route_label(default_provider, spec),
+        }
+    if not isinstance(spec, Mapping):
+        raise ValueError(
+            f"MoA route must be a string or mapping, got {type(spec).__name__}: {spec!r}"
+        )
+    provider = (spec.get("provider") or "").strip()
+    model = (spec.get("model") or "").strip()
+    if not provider:
+        raise ValueError(f"MoA route missing required 'provider': {dict(spec)!r}")
+    if not model:
+        raise ValueError(f"MoA route missing required 'model': {dict(spec)!r}")
+    route: ModelRoute = {"provider": provider, "model": model}
+    label = spec.get("label")
+    route["label"] = str(label) if label else _default_route_label(provider, model)
+    if "temperature" in spec:
+        route["temperature"] = float(spec["temperature"])
+    if "max_tokens" in spec:
+        route["max_tokens"] = int(spec["max_tokens"])
+    if "omit_temperature" in spec:
+        route["omit_temperature"] = bool(spec["omit_temperature"])
+    if "extra_body" in spec and spec["extra_body"] is not None:
+        if not isinstance(spec["extra_body"], Mapping):
+            raise ValueError(
+                f"MoA route 'extra_body' must be a mapping if set: {dict(spec)!r}"
+            )
+        route["extra_body"] = dict(spec["extra_body"])
+    return route
+
+
+def _resolve_extra_body(route: ModelRoute) -> Optional[Dict[str, Any]]:
+    if "extra_body" in route:
+        return dict(route["extra_body"]) if route["extra_body"] else None
+    if route["provider"] == "openrouter":
+        return dict(_OPENROUTER_DEFAULT_EXTRA_BODY)
+    return None
+
+
+def _should_send_temperature(route: ModelRoute) -> bool:
+    if route.get("omit_temperature"):
+        return False
+    # legacy carve-out: gpt-* models on OpenRouter reject custom temperatures.
+    # Other providers route through their own normalization.
+    if route["provider"] == "openrouter" and route["model"].lower().startswith("gpt-"):
+        return False
+    return True
+
+
+def _resolve_client_for_route(route: ModelRoute) -> Tuple[Any, str]:
+    """Resolve an async client for a route, caching one client per provider+model."""
+    key = (route["provider"], route["model"])
+    cached = _route_client_cache.get(key)
+    if cached is not None:
+        return cached
+    if route["provider"] == "openrouter":
+        client = _get_openrouter_client()
+        resolved_model = route["model"]
+    else:
+        client, resolved_model = resolve_provider_client(
+            route["provider"], model=route["model"], async_mode=True
+        )
+    if client is None:
+        raise RuntimeError(
+            f"MoA: provider {route['provider']!r} is not configured "
+            f"(model={route['model']!r}). Run `hermes auth login {route['provider']}` "
+            f"or set the appropriate API key."
+        )
+    pair = (client, resolved_model or route["model"])
+    _route_client_cache[key] = pair
+    return pair
+
+
+def _reset_route_cache() -> None:
+    """Drop cached clients. Called between processes / by tests."""
+    _route_client_cache.clear()
+
+
+def _load_moa_config() -> Dict[str, Any]:
+    """Load the optional ``moa:`` section from ``~/.hermes/config.yaml``.
+
+    Returns an empty dict on missing section or load failure — callers fall
+    back to module-level defaults.
+    """
+    try:
+        from hermes_cli.config import load_config
+    except ImportError:
+        return {}
+    try:
+        cfg = load_config()
+    except Exception:
+        logger.debug("MoA: failed to load hermes config", exc_info=True)
+        return {}
+    section = cfg.get("moa") or {}
+    if not isinstance(section, Mapping):
+        logger.warning("MoA: config 'moa' section must be a mapping, ignoring")
+        return {}
+    return dict(section)
+
+
 def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
     """
     Construct the final system prompt for the aggregator including all model responses.
@@ -102,130 +238,130 @@ def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> st
 
 
 async def _run_reference_model_safe(
-    model: str,
+    route_or_model: Any,
     user_prompt: str,
     temperature: float = REFERENCE_TEMPERATURE,
     max_tokens: int = 32000,
-    max_retries: int = 6
+    max_retries: int = 6,
 ) -> tuple[str, str, bool]:
-    """
-    Run a single reference model with retry logic and graceful failure handling.
-    
-    Args:
-        model (str): Model identifier to use
-        user_prompt (str): The user's query
-        temperature (float): Sampling temperature for response generation
-        max_tokens (int): Maximum tokens in response
-        max_retries (int): Maximum number of retry attempts
-        
+    """Run a single reference route with retry logic and graceful failure handling.
+
+    Accepts either a bare model slug (legacy OpenRouter behaviour) or a
+    full route dict (provider, model, optional per-route knobs).
+
     Returns:
-        tuple[str, str, bool]: (model_name, response_content_or_error, success_flag)
+        ``(label, response_content_or_error, success_flag)``
     """
+    try:
+        route = _normalize_route(route_or_model)
+    except ValueError as exc:
+        # malformed route — surface immediately, no retries
+        label = str(route_or_model)
+        logger.error("%s: %s", label, exc, exc_info=True)
+        return label, str(exc), False
+
+    label = route["label"]
+    eff_temperature = route.get("temperature", temperature)
+    eff_max_tokens = route.get("max_tokens", max_tokens)
+    extra_body = _resolve_extra_body(route)
+
     for attempt in range(max_retries):
         try:
-            logger.info("Querying %s (attempt %s/%s)", model, attempt + 1, max_retries)
-            
-            # Build parameters for the API call
-            api_params = {
-                "model": model,
+            logger.info("Querying %s (attempt %s/%s)", label, attempt + 1, max_retries)
+            try:
+                client, _ = _resolve_client_for_route(route)
+            except RuntimeError as exc:
+                # provider not configured — fail fast, retries won't help
+                logger.error("%s", exc, exc_info=True)
+                return label, str(exc), False
+
+            api_params: Dict[str, Any] = {
+                "model": route["model"],
                 "messages": [{"role": "user", "content": user_prompt}],
-                "max_tokens": max_tokens,
-                "extra_body": {
-                    "reasoning": {
-                        "enabled": True,
-                        "effort": "xhigh"
-                    }
-                }
+                "max_tokens": eff_max_tokens,
             }
-            
-            # GPT models (especially gpt-4o-mini) don't support custom temperature values
-            # Only include temperature for non-GPT models
-            if not model.lower().startswith('gpt-'):
-                api_params["temperature"] = temperature
-            
-            response = await _get_openrouter_client().chat.completions.create(**api_params)
-            
+            if _should_send_temperature(route):
+                api_params["temperature"] = eff_temperature
+            if extra_body:
+                api_params["extra_body"] = extra_body
+
+            response = await client.chat.completions.create(**api_params)
+
             content = extract_content_or_reasoning(response)
             if not content:
-                # Reasoning-only response — let the retry loop handle it
-                logger.warning("%s returned empty content (attempt %s/%s), retrying", model, attempt + 1, max_retries)
+                logger.warning(
+                    "%s returned empty content (attempt %s/%s), retrying",
+                    label, attempt + 1, max_retries,
+                )
                 if attempt < max_retries - 1:
                     await asyncio.sleep(min(2 ** (attempt + 1), 60))
                     continue
-            logger.info("%s responded (%s characters)", model, len(content))
-            return model, content, True
-            
+            logger.info("%s responded (%s characters)", label, len(content))
+            return label, content, True
+
         except Exception as e:
             error_str = str(e)
-            # Keep retry-path logging concise; full tracebacks are reserved for
-            # terminal failure paths so long-running MoA retries don't flood logs.
             if "invalid" in error_str.lower():
-                logger.warning("%s invalid request error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s invalid request error (attempt %s): %s", label, attempt + 1, error_str)
             elif "rate" in error_str.lower() or "limit" in error_str.lower():
-                logger.warning("%s rate limit error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s rate limit error (attempt %s): %s", label, attempt + 1, error_str)
             else:
-                logger.warning("%s unknown error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s unknown error (attempt %s): %s", label, attempt + 1, error_str)
 
             if attempt < max_retries - 1:
-                # Exponential backoff for rate limiting: 2s, 4s, 8s, 16s, 32s, 60s
                 sleep_time = min(2 ** (attempt + 1), 60)
                 logger.info("Retrying in %ss...", sleep_time)
                 await asyncio.sleep(sleep_time)
             else:
-                error_msg = f"{model} failed after {max_retries} attempts: {error_str}"
+                error_msg = f"{label} failed after {max_retries} attempts: {error_str}"
                 logger.error("%s", error_msg, exc_info=True)
-                return model, error_msg, False
+                return label, error_msg, False
 
 
 async def _run_aggregator_model(
     system_prompt: str,
     user_prompt: str,
     temperature: float = AGGREGATOR_TEMPERATURE,
-    max_tokens: int = None
+    max_tokens: Optional[int] = None,
+    route: Optional[ModelRoute] = None,
 ) -> str:
-    """
-    Run the aggregator model to synthesize the final response.
-    
-    Args:
-        system_prompt (str): System prompt with all reference responses
-        user_prompt (str): Original user query
-        temperature (float): Focused temperature for consistent aggregation
-        max_tokens (int): Maximum tokens in final response
-        
-    Returns:
-        str: Synthesized final response
-    """
-    logger.info("Running aggregator model: %s", AGGREGATOR_MODEL)
+    """Run the aggregator route to synthesize the final response.
 
-    # Build parameters for the API call
-    api_params = {
-        "model": AGGREGATOR_MODEL,
+    When ``route`` is None, falls back to the module-level ``AGGREGATOR_MODEL``
+    (legacy OpenRouter slug) for backward compatibility.
+    """
+    if route is None:
+        route = _normalize_route(AGGREGATOR_MODEL)
+
+    label = route["label"]
+    eff_temperature = route.get("temperature", temperature)
+    eff_max_tokens = route.get("max_tokens", max_tokens)
+    extra_body = _resolve_extra_body(route)
+
+    logger.info("Running aggregator model: %s", label)
+
+    client, _ = _resolve_client_for_route(route)
+
+    api_params: Dict[str, Any] = {
+        "model": route["model"],
         "messages": [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt}
+            {"role": "user", "content": user_prompt},
         ],
-        "max_tokens": max_tokens,
-        "extra_body": {
-            "reasoning": {
-                "enabled": True,
-                "effort": "xhigh"
-            }
-        }
+        "max_tokens": eff_max_tokens,
     }
+    if _should_send_temperature(route):
+        api_params["temperature"] = eff_temperature
+    if extra_body:
+        api_params["extra_body"] = extra_body
 
-    # GPT models (especially gpt-4o-mini) don't support custom temperature values
-    # Only include temperature for non-GPT models
-    if not AGGREGATOR_MODEL.lower().startswith('gpt-'):
-        api_params["temperature"] = temperature
-
-    response = await _get_openrouter_client().chat.completions.create(**api_params)
-
+    response = await client.chat.completions.create(**api_params)
     content = extract_content_or_reasoning(response)
 
-    # Retry once on empty content (reasoning-only response)
+    # one retry on empty content (reasoning-only response)
     if not content:
         logger.warning("Aggregator returned empty content, retrying once")
-        response = await _get_openrouter_client().chat.completions.create(**api_params)
+        response = await client.chat.completions.create(**api_params)
         content = extract_content_or_reasoning(response)
 
     logger.info("Aggregation complete (%s characters)", len(content))
@@ -274,15 +410,31 @@ async def mixture_of_agents_tool(
         Exception: If MoA processing fails or API key is not set
     """
     start_time = datetime.datetime.now()
-    
-    debug_call_data = {
+    moa_cfg = _load_moa_config()
+
+    raw_refs = (
+        list(reference_models)
+        if reference_models is not None
+        else moa_cfg.get("references")
+        or REFERENCE_MODELS
+    )
+    raw_agg = (
+        aggregator_model
+        if aggregator_model is not None
+        else moa_cfg.get("aggregator") or AGGREGATOR_MODEL
+    )
+    ref_temperature = float(moa_cfg.get("reference_temperature", REFERENCE_TEMPERATURE))
+    agg_temperature = float(moa_cfg.get("aggregator_temperature", AGGREGATOR_TEMPERATURE))
+    min_refs = int(moa_cfg.get("min_successful_references", MIN_SUCCESSFUL_REFERENCES))
+
+    debug_call_data: Dict[str, Any] = {
         "parameters": {
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
-            "reference_models": reference_models or REFERENCE_MODELS,
-            "aggregator_model": aggregator_model or AGGREGATOR_MODEL,
-            "reference_temperature": REFERENCE_TEMPERATURE,
-            "aggregator_temperature": AGGREGATOR_TEMPERATURE,
-            "min_successful_references": MIN_SUCCESSFUL_REFERENCES
+            "reference_models": raw_refs,
+            "aggregator_model": raw_agg,
+            "reference_temperature": ref_temperature,
+            "aggregator_temperature": agg_temperature,
+            "min_successful_references": min_refs,
         },
         "error": None,
         "success": False,
@@ -291,149 +443,193 @@ async def mixture_of_agents_tool(
         "failed_models": [],
         "final_response_length": 0,
         "processing_time_seconds": 0,
-        "models_used": {}
+        "models_used": {},
     }
-    
+
     try:
+        try:
+            ref_routes = [_normalize_route(spec) for spec in raw_refs]
+            agg_route = _normalize_route(raw_agg)
+        except ValueError as exc:
+            raise ValueError(f"MoA configuration error: {exc}") from exc
+
         logger.info("Starting Mixture-of-Agents processing...")
         logger.info("Query: %s", user_prompt[:100])
-        
-        # Validate API key availability
-        if not os.getenv("OPENROUTER_API_KEY"):
-            raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        
-        # Use provided models or defaults
-        ref_models = reference_models or REFERENCE_MODELS
-        agg_model = aggregator_model or AGGREGATOR_MODEL
-        
-        logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_models))
-        
-        # Layer 1: Generate diverse responses from reference models (with failure handling)
+
+        # Legacy gate: if every route uses OpenRouter we still require the env var,
+        # so existing setups behave exactly as before.
+        if all(r["provider"] == "openrouter" for r in [*ref_routes, agg_route]):
+            if not os.getenv("OPENROUTER_API_KEY"):
+                raise ValueError("OPENROUTER_API_KEY environment variable not set")
+
+        ref_labels = [r["label"] for r in ref_routes]
+        logger.info("Using %s reference routes in 2-layer MoA architecture", len(ref_routes))
+
         logger.info("Layer 1: Generating reference responses...")
         model_results = await asyncio.gather(*[
-            _run_reference_model_safe(model, user_prompt, REFERENCE_TEMPERATURE)
-            for model in ref_models
+            _run_reference_model_safe(route, user_prompt, ref_temperature)
+            for route in ref_routes
         ])
-        
-        # Separate successful and failed responses
-        successful_responses = []
-        failed_models = []
-        
-        for model_name, content, success in model_results:
+
+        successful_responses: List[str] = []
+        failed_models: List[str] = []
+        for label, content, success in model_results:
             if success:
                 successful_responses.append(content)
             else:
-                failed_models.append(model_name)
-        
+                failed_models.append(label)
+
         successful_count = len(successful_responses)
         failed_count = len(failed_models)
-        
+
         logger.info("Reference model results: %s successful, %s failed", successful_count, failed_count)
-        
         if failed_models:
-            logger.warning("Failed models: %s", ', '.join(failed_models))
-        
-        # Check if we have enough successful responses to proceed
-        if successful_count < MIN_SUCCESSFUL_REFERENCES:
-            raise ValueError(f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). Need at least {MIN_SUCCESSFUL_REFERENCES} successful responses.")
-        
+            logger.warning("Failed models: %s", ", ".join(failed_models))
+
+        if successful_count < min_refs:
+            raise ValueError(
+                f"Insufficient successful reference models ({successful_count}/{len(ref_routes)}). "
+                f"Need at least {min_refs} successful responses."
+            )
+
         debug_call_data["reference_responses_count"] = successful_count
         debug_call_data["failed_models_count"] = failed_count
         debug_call_data["failed_models"] = failed_models
-        
-        # Layer 2: Aggregate responses using the aggregator model
+
         logger.info("Layer 2: Synthesizing final response...")
         aggregator_system_prompt = _construct_aggregator_prompt(
-            AGGREGATOR_SYSTEM_PROMPT, 
-            successful_responses
+            AGGREGATOR_SYSTEM_PROMPT,
+            successful_responses,
         )
-        
+
         final_response = await _run_aggregator_model(
             aggregator_system_prompt,
             user_prompt,
-            AGGREGATOR_TEMPERATURE
+            agg_temperature,
+            route=agg_route,
         )
-        
-        # Calculate processing time
+
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
+
         logger.info("MoA processing completed in %.2f seconds", processing_time)
-        
-        # Prepare successful response (only final aggregated result, minimal fields)
+
         result = {
             "success": True,
             "response": final_response,
             "models_used": {
-                "reference_models": ref_models,
-                "aggregator_model": agg_model
-            }
+                "reference_models": ref_labels,
+                "aggregator_model": agg_route["label"],
+            },
         }
-        
+
         debug_call_data["success"] = True
         debug_call_data["final_response_length"] = len(final_response)
         debug_call_data["processing_time_seconds"] = processing_time
         debug_call_data["models_used"] = result["models_used"]
-        
-        # Log debug information
+
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
+
         return json.dumps(result, indent=2, ensure_ascii=False)
-        
+
     except Exception as e:
         error_msg = f"Error in MoA processing: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
-        
-        # Calculate processing time even for errors
+
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
-        # Prepare error response (minimal fields)
+
+        # Best-effort labels for the error path: try to normalize, fall back to raw input
+        try:
+            err_ref_labels = [_normalize_route(spec)["label"] for spec in raw_refs]
+        except Exception:
+            err_ref_labels = [str(spec) for spec in raw_refs]
+        try:
+            err_agg_label = _normalize_route(raw_agg)["label"]
+        except Exception:
+            err_agg_label = str(raw_agg)
+
         result = {
             "success": False,
             "response": "MoA processing failed. Please try again or use a single model for this query.",
             "models_used": {
-                "reference_models": reference_models or REFERENCE_MODELS,
-                "aggregator_model": aggregator_model or AGGREGATOR_MODEL
+                "reference_models": err_ref_labels,
+                "aggregator_model": err_agg_label,
             },
-            "error": error_msg
+            "error": error_msg,
         }
-        
+
         debug_call_data["error"] = error_msg
         debug_call_data["processing_time_seconds"] = processing_time
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
+
         return json.dumps(result, indent=2, ensure_ascii=False)
 
 
 def check_moa_requirements() -> bool:
-    """
-    Check if all requirements for MoA tools are met.
-    
-    Returns:
-        bool: True if requirements are met, False otherwise
-    """
-    return check_openrouter_api_key()
+    """Return True if MoA can run with the current configuration.
 
+    With no ``moa:`` section in config, requires ``OPENROUTER_API_KEY`` (legacy).
+    With a configured section, requires that at least one provider across the
+    references and aggregator is reachable via ``resolve_provider_client``.
+    """
+    moa_cfg = _load_moa_config()
+    raw_refs = moa_cfg.get("references")
+    raw_agg = moa_cfg.get("aggregator")
+    if not raw_refs and not raw_agg:
+        return check_openrouter_api_key()
+
+    try:
+        routes: List[ModelRoute] = []
+        if raw_refs:
+            routes.extend(_normalize_route(spec) for spec in raw_refs)
+        if raw_agg:
+            routes.append(_normalize_route(raw_agg))
+    except ValueError:
+        return False
+
+    seen_providers = {r["provider"] for r in routes}
+    for provider in seen_providers:
+        if provider == "openrouter":
+            if check_openrouter_api_key():
+                return True
+            continue
+        try:
+            client, _ = resolve_provider_client(provider, async_mode=False)
+        except Exception:
+            continue
+        if client is not None:
+            return True
+    return False
 
 
 def get_moa_configuration() -> Dict[str, Any]:
-    """
-    Get the current MoA configuration settings.
-    
-    Returns:
-        Dict[str, Any]: Dictionary containing all configuration parameters
-    """
+    """Return the effective MoA configuration (config-driven if present)."""
+    moa_cfg = _load_moa_config()
+    raw_refs = moa_cfg.get("references") or REFERENCE_MODELS
+    raw_agg = moa_cfg.get("aggregator") or AGGREGATOR_MODEL
+    try:
+        ref_routes = [_normalize_route(spec) for spec in raw_refs]
+        agg_route = _normalize_route(raw_agg)
+    except ValueError:
+        ref_routes = [_normalize_route(spec) for spec in REFERENCE_MODELS]
+        agg_route = _normalize_route(AGGREGATOR_MODEL)
+
+    ref_temp = float(moa_cfg.get("reference_temperature", REFERENCE_TEMPERATURE))
+    agg_temp = float(moa_cfg.get("aggregator_temperature", AGGREGATOR_TEMPERATURE))
+    min_refs = int(moa_cfg.get("min_successful_references", MIN_SUCCESSFUL_REFERENCES))
+    total = len(ref_routes)
+
     return {
-        "reference_models": REFERENCE_MODELS,
-        "aggregator_model": AGGREGATOR_MODEL,
-        "reference_temperature": REFERENCE_TEMPERATURE,
-        "aggregator_temperature": AGGREGATOR_TEMPERATURE,
-        "min_successful_references": MIN_SUCCESSFUL_REFERENCES,
-        "total_reference_models": len(REFERENCE_MODELS),
-        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} models can fail"
+        "reference_models": [r["label"] for r in ref_routes],
+        "aggregator_model": agg_route["label"],
+        "reference_temperature": ref_temp,
+        "aggregator_temperature": agg_temp,
+        "min_successful_references": min_refs,
+        "total_reference_models": total,
+        "failure_tolerance": f"{max(0, total - min_refs)}/{total} models can fail",
     }
 
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded OpenRouter-only path in `mixture_of_agents_tool` with provider-agnostic routing through `resolve_provider_client`. Each reference and the aggregator can now point at any registered provider (OpenRouter, ollama-cloud, named custom providers from config.yaml, etc.) with per-route knobs for `temperature`, `max_tokens`, `omit_temperature`, and `extra_body`.

Closes #5725 (ability to use Ollama as the provider for the mixture of agents config).

## Configuration

New optional `moa:` section in `~/.hermes/config.yaml`:

```yaml
moa:
  references:
    - { provider: ollama-cloud, model: kimi-k2.6 }
    - { provider: ollama-cloud, model: glm-5.1 }
    - { provider: ollama-cloud, model: qwen3.5:397b }
  aggregator:
    provider: ollama-cloud
    model: kimi-k2.6
  min_successful_references: 1
```

Each route accepts a string (legacy OpenRouter slug) or a mapping with `provider` + `model` and optional per-route overrides:

```yaml
references:
  - provider: openrouter
    model: anthropic/claude-opus-4.6
    extra_body: { reasoning: { enabled: true, effort: xhigh } }
  - provider: ollama-cloud
    model: kimi-k2.6
    temperature: 0.5
    max_tokens: 16000
```

## Backward compatibility

With no `moa:` section in config, behavior is identical to before:
- Defaults to the existing OpenRouter slug list (`anthropic/claude-opus-4.6`, `google/gemini-2.5-pro`, `openai/gpt-5.4-pro`, `deepseek/deepseek-v3.2`)
- Sends the legacy `extra_body.reasoning` payload (OpenRouter-specific)
- `check_moa_requirements()` still requires `OPENROUTER_API_KEY`

When `moa:` is configured, `check_moa_requirements()` returns True if at least one configured provider has reachable credentials. Per-provider `extra_body` defaults: OpenRouter routes get the legacy reasoning payload; other providers get nothing unless explicitly set on the route.

## Design notes

- `_normalize_route` accepts string or dict and validates required fields (`provider`, `model`)
- `_resolve_client_for_route` caches one async client per `(provider, model)` to avoid re-resolving on every call
- `_should_send_temperature` honors `omit_temperature: true` per route, plus the legacy `gpt-` prefix carve-out
- `_run_reference_model_safe` and `_run_aggregator_model` now take routes; the legacy string-only signature on `_run_reference_model_safe` is preserved for backward compat (auto-normalizes to OpenRouter)
- Failure handling unchanged: `min_successful_references` (default 1) gates whether MoA proceeds; per-reference retries with exponential backoff still apply

## Relation to #14043

Different design from @DomLynch's [#14043](https://github.com/NousResearch/hermes-agent/pull/14043), which bundles a multi-provider refactor with MiMo-flavored defaults, a self-draft architecture, Spar forensics, and an `XIAOMI_API_KEY`+`OPENROUTER_API_KEY` env gate. This PR is intentionally minimal:

- Pure provider-routing refactor; no new architecture (no self-draft, no extra layers)
- No default model changes (OpenRouter slugs stay)
- No env-var gate hardcoding
- 100% backward compatible for existing setups

## Test plan

- [x] 23 unit tests pass — route normalization (string + dict), validation errors, per-provider extra_body defaults, client caching, unconfigured-provider fast-fail, partial-failure tolerance, mixed-provider references, aggregator on different provider than refs, bad-config error surfacing, legacy + config-driven `check_moa_requirements`
- [x] End-to-end smoke test against ollama-cloud with three references (`kimi-k2.6` + `glm-5.1` + `qwen3.5:397b`) and `kimi-k2.6` aggregator: all three references responded, aggregator synthesized correctly
- [x] No-config legacy path: `check_moa_requirements` still requires `OPENROUTER_API_KEY`, defaults are unchanged

## Files

- `tools/mixture_of_agents_tool.py` — main refactor
- `tests/tools/test_mixture_of_agents_tool.py` — coverage (~250 new lines)