### PR TITLE
fix(auxiliary): strip trailing /v1 for OpenCode Zen/Go Anthropic bases

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -44,6 +44,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -1561,22 +1562,29 @@ def _maybe_wrap_anthropic(
         )
         return client_obj
 
+    # OpenCode Zen/Go persist OpenAI-style bases ending in /v1; Anthropic SDK
+    # adds /v1/messages (matches hermes_cli.runtime_provider — avoids double /v1).
+    anthropic_base = (base_url or "").strip()
+    if anthropic_base and "opencode.ai/zen/" in anthropic_base.lower():
+        anthropic_base = re.sub(r"/v1/?$", "", anthropic_base)
+
     try:
-        real_client = build_anthropic_client(api_key, base_url)
+        real_client = build_anthropic_client(api_key, anthropic_base)
     except Exception as exc:
         logger.warning(
             "Failed to build Anthropic client for %s (%s) — falling back to "
-            "OpenAI-wire client.", base_url, exc,
+            "OpenAI-wire client.", anthropic_base or base_url, exc,
         )
         return client_obj
 
+    log_base = anthropic_base[:60] if anthropic_base else ""
     logger.debug(
         "Auxiliary transport: wrapping client in AnthropicAuxiliaryClient "
         "(model=%s, base_url=%s, api_mode=%s)",
-        model, base_url[:60] if base_url else "", api_mode or "auto-detected",
+        model, log_base, api_mode or "auto-detected",
     )
     return AnthropicAuxiliaryClient(
-        real_client, model, api_key, base_url, is_oauth=False,
+        real_client, model, api_key, anthropic_base, is_oauth=False,
     )
 
 

--- a/tests/agent/test_auxiliary_transport_autodetect.py
+++ b/tests/agent/test_auxiliary_transport_autodetect.py
@@ -144,6 +144,28 @@ def test_maybe_wrap_anthropic_honors_explicit_anthropic_messages():
     assert isinstance(result, AnthropicAuxiliaryClient)
 
 
+def test_maybe_wrap_anthropic_strips_opencode_go_trailing_v1():
+    """OpenCode Go stores /v1 OpenAI-style bases; Anthropic SDK adds /v1/messages (#double-v1 404)."""
+    from agent.auxiliary_client import _maybe_wrap_anthropic, AnthropicAuxiliaryClient
+
+    plain_client = MagicMock(name="plain_openai")
+    fake_anthropic = MagicMock(name="anthropic_sdk_client")
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=fake_anthropic,
+    ) as bc:
+        result = _maybe_wrap_anthropic(
+            plain_client,
+            "minimax-m2.7",
+            "sk-test",
+            "https://opencode.ai/zen/go/v1",
+            api_mode="anthropic_messages",
+        )
+    bc.assert_called_once_with("sk-test", "https://opencode.ai/zen/go")
+    assert isinstance(result, AnthropicAuxiliaryClient)
+
+
 def test_maybe_wrap_anthropic_double_wrap_safe():
     """Already-wrapped AnthropicAuxiliaryClient passes through unchanged."""
     from agent.auxiliary_client import _maybe_wrap_anthropic, AnthropicAuxiliaryClient


### PR DESCRIPTION
## What does this PR do?

When auxiliary models use OpenCode Zen/Go with `api_mode: anthropic_messages`, persisted configs often keep an OpenAI-style base URL ending in `/v1`. The Anthropic SDK then appends `/v1/messages`, producing a double `/v1` segment and a 404/HTML response. This mirrors the existing CLI/model-switch strip logic for `opencode.ai/zen/` hosts before calling `build_anthropic_client`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py` — strip trailing `/v1` for OpenCode Zen/Go Anthropic-compat bases
- `tests/agent/test_auxiliary_transport_autodetect.py` — regression test for the strip behavior

## How to Test

1. `uv run pytest -o addopts= tests/agent/test_auxiliary_transport_autodetect.py -q`
2. Configure an auxiliary model with base URL `https://opencode.ai/zen/v1` and `api_mode: anthropic_messages` — confirm requests succeed without double `/v1`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — delete this section otherwise.

## Screenshots / Logs

N/A
