### PR TITLE
fix: wrap _run_async coroutines in tasks to avoid aiohttp timeout context errors

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -123,7 +123,8 @@ def _run_async(coro):
             loop_ready.set()
             try:
                 asyncio.set_event_loop(worker_loop)
-                return worker_loop.run_until_complete(coro)
+                task = worker_loop.create_task(coro)
+                return worker_loop.run_until_complete(task)
             finally:
                 try:
                     # Cancel anything still pending (e.g. task cancelled
@@ -167,10 +168,12 @@ def _run_async(coro):
     # lifetime — preventing "Event loop is closed" on GC cleanup.
     if threading.current_thread() is not threading.main_thread():
         worker_loop = _get_worker_loop()
-        return worker_loop.run_until_complete(coro)
+        task = worker_loop.create_task(coro)
+        return worker_loop.run_until_complete(task)
 
     tool_loop = _get_tool_loop()
-    return tool_loop.run_until_complete(coro)
+    task = tool_loop.create_task(coro)
+    return tool_loop.run_until_complete(task)
 
 
 # =============================================================================

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -47,6 +47,23 @@ async def _create_and_return_transport():
 class TestRunAsyncLoopLifecycle:
     """Verify _run_async() keeps the event loop alive after returning."""
 
+    def test_run_async_executes_coroutine_inside_task(self):
+        """Persistent-loop branches must wrap the coroutine in a real Task.
+
+        aiohttp timeout contexts call asyncio.current_task(); running the
+        coroutine bare via loop.run_until_complete(coro) leaves current_task()
+        as None and breaks outbound Weixin sends with:
+        "Timeout context manager should be used inside a task".
+        """
+        from model_tools import _run_async
+
+        async def _probe_current_task():
+            return asyncio.current_task()
+
+        current = _run_async(_probe_current_task())
+        assert current is not None
+        assert isinstance(current, asyncio.Task)
+
     def test_loop_not_closed_after_run_async(self):
         """The loop used by _run_async must still be open after the call."""
         from model_tools import _run_async
@@ -86,6 +103,23 @@ class TestRunAsyncLoopLifecycle:
 
 class TestRunAsyncWorkerThread:
     """Verify worker threads get persistent per-thread loops (delegate_task fix)."""
+
+    def test_worker_thread_executes_coroutine_inside_task(self):
+        """Worker-thread persistent loops must also create a Task wrapper."""
+        from concurrent.futures import ThreadPoolExecutor
+        from model_tools import _run_async
+
+        async def _probe_current_task():
+            return asyncio.current_task()
+
+        def _run_on_worker():
+            return _run_async(_probe_current_task())
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            current = pool.submit(_run_on_worker).result()
+
+        assert current is not None
+        assert isinstance(current, asyncio.Task)
 
     def test_worker_thread_loop_not_closed(self):
         """A worker thread's loop must stay open after _run_async returns,
@@ -255,8 +289,10 @@ class TestRunAsyncWithRunningLoop:
             FakeExecutor,
         )
 
+        coro = _never_finishes()
         with pytest.raises(concurrent.futures.TimeoutError):
-            _run_async(_never_finishes())
+            _run_async(coro)
+        coro.close()
 
         assert events["result_timeout"] == 300
         # The worker wrapper creates its own event loop so _run_async can


### PR DESCRIPTION
                                                                                                 
     This PR fixes a sync-to-async bridge bug that could break outbound Weixin sends, including         
     cron delivery, with the following runtime error:                                                   
                                                                                                        
     Timeout context manager should be used inside a task                                               
                                                                                                        
     Root cause                                                                                         
                                                                                                        
     model_tools._run_async() previously executed some coroutines via                                   
     loop.run_until_complete(coro). While that provides an event loop, it does not guarantee that       
     the coroutine is running inside a real asyncio.Task.                                               
                                                                                                        
     This matters because aiohttp timeout contexts rely on asyncio.current_task(). In the outbound      
     Weixin path, once the request reached session.post(..., timeout=...) without a real task           
     context, aiohttp could raise:                                                                      
                                                                                                        
     RuntimeError: Timeout context manager should be used inside a task                                 
                                                                                                        
     Why inbound chat could still work                                                                  
                                                                                                        
     Normal inbound / gateway async flows may already run inside framework-managed asyncio tasks.       
                                                                                                        
     By contrast, outbound send_message(..., target="weixin:...") and cron delivery can go through      
     the sync tool bridge in _run_async(), which is why this issue mainly showed up in active sends     
     rather than regular inbound chat.                                                                  
                                                                                                        
     Fix                                                                                                
                                                                                                        
     Update _run_async() to explicitly create tasks before driving them to completion.                  
                                                                                                        
     This change covers:                                                                                
     - the main-thread persistent loop branch                                                           
     - the worker-thread persistent loop branch                                                         
     - the running-loop fallback worker branch                                                          
                                                                                                        
     In practice, the bridge now does:                                                                  
                                                                                                        
     - task = loop.create_task(coro)                                                                    
     - loop.run_until_complete(task)                                                                    
                                                                                                        
     instead of running a bare coroutine directly.                                                      
                                                                                                        
     This keeps the existing persistent-loop design intact while ensuring async handlers run inside     
     a real task context.                                                                               
                                                                                                        
     Tests                                                                                              
                                                                                                        
     Updated regression coverage in tests/test_model_tools_async_bridge.py to verify:                   
     - _run_async() executes coroutines inside a real asyncio.Task                                      
     - the worker-thread branch also provides task context                                              
     - timeout-related lifecycle tests still pass                                                       
     - the timeout regression test no longer emits a coroutine warning                                  
                                                                                                        
     Validation                                                                                         
                                                                                                        
     Verified with:                                                                                     
                                                                                                        
     pytest tests/test_model_tools_async_bridge.py -q -n 4                                              
                                                                                                        
     Result:                                                                                            
     - 14 passed                                                                                        
     - no warnings                                                                                      
                                                                                                        
     Notes                                                                                              
                                                                                                        
     This PR fixes the local async execution bug in Hermes.                                             
                                                                                                        
     It does not claim to resolve upstream Weixin / iLink errors such as:                               
                                                                                                        
     iLink sendmessage error: ret=-2 errcode=None errmsg=unknown error