### PR TITLE
fix(gateway): respect explicit Telegram disabled when TELEGRAM_BOT_TOKEN is set

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -779,7 +779,10 @@ def load_gateway_config() -> GatewayConfig:
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
-                    if plat_name == Platform.SLACK.value and "enabled" in plat_block:
+                    if plat_name in (
+                        Platform.SLACK.value,
+                        Platform.TELEGRAM.value,
+                    ) and "enabled" in plat_block:
                         merged_extra["_enabled_explicit"] = True
                     merged = {**existing, **plat_block}
                     if merged_extra:
@@ -876,7 +879,7 @@ def load_gateway_config() -> GatewayConfig:
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
-                if plat == Platform.SLACK and enabled_was_explicit:
+                if plat in (Platform.SLACK, Platform.TELEGRAM) and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
@@ -1209,22 +1212,33 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
-    
+
     # Telegram
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:
         if Platform.TELEGRAM not in config.platforms:
+            # No yaml config for Telegram — env-only setup, enable it
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
-        config.platforms[Platform.TELEGRAM].enabled = True
+            config.platforms[Platform.TELEGRAM].enabled = True
+        else:
+            telegram_config = config.platforms[Platform.TELEGRAM]
+            enabled_was_explicit = bool(telegram_config.extra.pop("_enabled_explicit", False))
+            if not telegram_config.enabled and not enabled_was_explicit:
+                # Top-level Telegram settings such as channel prompts should not
+                # turn an env-token setup into a disabled platform. Only an
+                # explicit telegram.enabled/platforms.telegram.enabled false should.
+                telegram_config.enabled = True
+        # Respect explicit enabled: false. Token is still stored for tools that
+        # send Telegram messages without activating the gateway adapter.
         config.platforms[Platform.TELEGRAM].token = telegram_token
-    
+
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = os.getenv("TELEGRAM_REPLY_TO_MODE", "").lower()
     if telegram_reply_mode in {"off", "first", "all"}:
         if Platform.TELEGRAM not in config.platforms:
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
         config.platforms[Platform.TELEGRAM].reply_to_mode = telegram_reply_mode
-    
+
     telegram_fallback_ips = os.getenv("TELEGRAM_FALLBACK_IPS", "")
     if telegram_fallback_ips:
         if Platform.TELEGRAM not in config.platforms:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -623,6 +623,79 @@ class TestLoadGatewayConfig:
         import os
         assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
 
+    def test_top_level_telegram_settings_do_not_disable_env_token_setup(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  reactions: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:abc")
+        monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+
+        config = load_gateway_config()
+
+        telegram_config = config.platforms[Platform.TELEGRAM]
+        assert telegram_config.enabled is True
+        assert telegram_config.token == "123:abc"
+        assert "_enabled_explicit" not in telegram_config.extra
+
+    def test_explicit_top_level_telegram_enabled_false_wins_over_env_token(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  enabled: false\n"
+            "  reactions: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:abc")
+        monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+
+        config = load_gateway_config()
+
+        telegram_config = config.platforms[Platform.TELEGRAM]
+        assert telegram_config.enabled is False
+        assert telegram_config.token == "123:abc"
+        assert "_enabled_explicit" not in telegram_config.extra
+
+    def test_explicit_platforms_telegram_enabled_false_wins_over_env_token(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: false\n"
+            "    extra:\n"
+            "      disable_link_previews: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:abc")
+
+        config = load_gateway_config()
+
+        telegram_config = config.platforms[Platform.TELEGRAM]
+        assert telegram_config.enabled is False
+        assert telegram_config.token == "123:abc"
+        assert telegram_config.extra.get("disable_link_previews") is True
+        assert "_enabled_explicit" not in telegram_config.extra
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already


### PR DESCRIPTION
## What does this PR do?

Telegram matched Slack's bug: `TELEGRAM_BOT_TOKEN` always forced `enabled: true`, so `telegram.enabled: false` / `platforms.telegram.enabled: false` was ignored. This mirrors the existing Slack `_enabled_explicit` pattern so users can keep the token for tools/cron while leaving the gateway adapter off.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py` — tag `platforms.telegram` / top-level `telegram.enabled` as explicit like Slack; only auto-enable from env token when disable was not explicit
- `tests/gateway/test_config.py` — regression tests for explicit Telegram disable with token present

## How to Test

1. `uv run pytest -o addopts= tests/gateway/test_config.py -k telegram -q`
2. Set `TELEGRAM_BOT_TOKEN` and `platforms.telegram.enabled: false` in config — confirm the Telegram gateway adapter does not start
3. Omit explicit disable — confirm token still auto-enables Telegram as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — delete this section otherwise.

## Screenshots / Logs

N/A
