### PR TITLE
fix(kanban): improve drawer metadata readability

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -9,6 +9,18 @@
   width: 100%;
 }
 
+.hermes-kanban ::selection {
+  background: rgba(127, 127, 127, 0.35);
+  background: color-mix(in srgb, var(--color-ring) 35%, transparent);
+  color: var(--color-foreground);
+}
+
+.hermes-kanban ::-moz-selection {
+  background: rgba(127, 127, 127, 0.35);
+  background: color-mix(in srgb, var(--color-ring) 35%, transparent);
+  color: var(--color-foreground);
+}
+
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {
@@ -411,11 +423,15 @@
   min-width: 6rem;
 }
 .hermes-kanban-event-payload {
-  color: var(--color-muted-foreground);
+  color: var(--color-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 280px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: var(--radius-sm, 0.25rem);
+  background: color-mix(in srgb, var(--color-card) 92%, var(--color-foreground) 8%);
+  padding: 0.05rem 0.25rem;
 }
 
 .hermes-kanban-drawer-comment-row {
@@ -752,8 +768,12 @@
 .hermes-kanban-run-meta {
   display: block;
   font-size: 0.65rem;
-  padding: 0.15rem 0 0;
-  color: var(--color-muted-foreground);
+  margin-top: 0.2rem;
+  padding: 0.2rem 0.3rem;
+  color: var(--color-foreground);
+  background: color-mix(in srgb, var(--color-card) 92%, var(--color-foreground) 8%);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: var(--radius-sm, 0.25rem);
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, ui-monospace, monospace);

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -422,15 +422,22 @@
   color: var(--color-foreground);
   min-width: 6rem;
 }
-.hermes-kanban-event-payload {
+/* Shared chip styling for code/JSON snippets in the drawer (event
+   payloads, run metadata). Layout-specific props (padding, max-width,
+   white-space, …) stay on each individual class. */
+.hermes-kanban-event-payload,
+.hermes-kanban-run-meta {
   color: var(--color-foreground);
+  background: color-mix(in srgb, var(--color-card) 92%, var(--color-foreground) 8%);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: var(--radius-sm, 0.25rem);
+}
+
+.hermes-kanban-event-payload {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 280px;
-  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
-  border-radius: var(--radius-sm, 0.25rem);
-  background: color-mix(in srgb, var(--color-card) 92%, var(--color-foreground) 8%);
   padding: 0.05rem 0.25rem;
 }
 
@@ -770,10 +777,6 @@
   font-size: 0.65rem;
   margin-top: 0.2rem;
   padding: 0.2rem 0.3rem;
-  color: var(--color-foreground);
-  background: color-mix(in srgb, var(--color-card) 92%, var(--color-foreground) 8%);
-  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
-  border-radius: var(--radius-sm, 0.25rem);
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, ui-monospace, monospace);


### PR DESCRIPTION
## Summary
- Scope Kanban dashboard text-selection styling so browser selection highlights do not obscure JSON/log metadata
- Increase contrast for task event payloads and run metadata chips across dashboard themes
- Keep styling theme-driven via existing CSS variables

## Why
In the Kanban task drawer, selecting or dragging across run-history/event JSON can use the browser/OS default selection color. On some systems this appears as a high-opacity peach/orange overlay that makes the payload text unreadable across every dashboard theme.

## Test Plan
- `git diff --check -- plugins/kanban/dashboard/dist/style.css`
- CSS sanity check: balanced braces and expected selectors present
- Static scan of added lines for secret/shell/eval/deserialization/SQL patterns
- Independent reviewer pass

## Notes
- This is a CSS-only change in the Kanban dashboard plugin.
- The selection override is scoped to `.hermes-kanban` and includes a plain `rgba()` fallback before the theme-driven `color-mix()` value.
