### PR TITLE
fix: preserve goals across compression session splits

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -204,6 +204,76 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
+def _goal_visible(state: Optional[GoalState]) -> bool:
+    return state is not None and state.status != "cleared"
+
+
+def resolve_goal_owner_session_id(session_id: str) -> Optional[str]:
+    """Find the session row that owns the active goal for this conversation.
+
+    Goals are stored in ``state_meta`` under ``goal:<session_id>``. Compression,
+    however, forks the logical conversation into a child session linked via
+    ``parent_session_id``. When a child has no direct goal row, walk backward
+    through compression ancestors and return the nearest ancestor that does.
+
+    We only follow true compression chains: each ancestor we adopt from must
+    itself have ended with ``end_reason='compression'``. This avoids borrowing
+    a goal from unrelated branch/new-session lineages that merely happen to use
+    ``parent_session_id``.
+    """
+    if not session_id:
+        return None
+
+    direct = load_goal(session_id)
+    if _goal_visible(direct):
+        return session_id
+
+    db = _get_session_db()
+    if db is None:
+        return None
+
+    current = session_id
+    seen = {current}
+    for _ in range(32):
+        try:
+            row = db.get_session(current)
+        except Exception as exc:
+            logger.debug("GoalManager: get_session(%s) failed: %s", current, exc)
+            return None
+        if not row:
+            return None
+        parent_id = row.get("parent_session_id") if isinstance(row, dict) else None
+        if not parent_id or parent_id in seen:
+            return None
+        try:
+            parent_row = db.get_session(parent_id)
+        except Exception as exc:
+            logger.debug("GoalManager: get_session(%s) failed: %s", parent_id, exc)
+            return None
+        if not parent_row or parent_row.get("end_reason") != "compression":
+            return None
+        parent_state = load_goal(parent_id)
+        if _goal_visible(parent_state):
+            return parent_id
+        seen.add(parent_id)
+        current = parent_id
+    return None
+
+
+def load_goal_for_session(session_id: str) -> Tuple[Optional[str], Optional[GoalState]]:
+    """Load the goal visible from ``session_id``.
+
+    Returns ``(owner_session_id, state)``. When the current session has no goal
+    row of its own, this may resolve to a compression ancestor.
+    """
+    if not session_id:
+        return None, None
+    owner_session_id = resolve_goal_owner_session_id(session_id)
+    if not owner_session_id:
+        return session_id, None
+    return owner_session_id, load_goal(owner_session_id)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Judge
 # ──────────────────────────────────────────────────────────────────────
@@ -356,8 +426,11 @@ class GoalManager:
 
     def __init__(self, session_id: str, *, default_max_turns: int = DEFAULT_MAX_TURNS):
         self.session_id = session_id
+        self.requested_session_id = session_id
         self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS)
-        self._state: Optional[GoalState] = load_goal(session_id)
+        owner_session_id, state = load_goal_for_session(session_id)
+        self.owner_session_id = owner_session_id or session_id
+        self._state: Optional[GoalState] = state
 
     # --- introspection ------------------------------------------------
 
@@ -391,6 +464,8 @@ class GoalManager:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
+        if self.owner_session_id and self.owner_session_id != self.session_id and self._state is not None:
+            clear_goal(self.owner_session_id)
         state = GoalState(
             goal=goal,
             status="active",
@@ -399,8 +474,9 @@ class GoalManager:
             created_at=time.time(),
             last_turn_at=0.0,
         )
+        self.owner_session_id = self.session_id
         self._state = state
-        save_goal(self.session_id, state)
+        save_goal(self.owner_session_id, state)
         return state
 
     def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
@@ -408,7 +484,7 @@ class GoalManager:
             return None
         self._state.status = "paused"
         self._state.paused_reason = reason
-        save_goal(self.session_id, self._state)
+        save_goal(self.owner_session_id, self._state)
         return self._state
 
     def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
@@ -418,14 +494,14 @@ class GoalManager:
         self._state.paused_reason = None
         if reset_budget:
             self._state.turns_used = 0
-        save_goal(self.session_id, self._state)
+        save_goal(self.owner_session_id, self._state)
         return self._state
 
     def clear(self) -> None:
         if self._state is None:
             return
         self._state.status = "cleared"
-        save_goal(self.session_id, self._state)
+        save_goal(self.owner_session_id, self._state)
         self._state = None
 
     def mark_done(self, reason: str) -> None:
@@ -434,7 +510,7 @@ class GoalManager:
         self._state.status = "done"
         self._state.last_verdict = "done"
         self._state.last_reason = reason
-        save_goal(self.session_id, self._state)
+        save_goal(self.owner_session_id, self._state)
 
     # --- the main entry point called after every turn -----------------
 
@@ -479,7 +555,7 @@ class GoalManager:
 
         if verdict == "done":
             state.status = "done"
-            save_goal(self.session_id, state)
+            save_goal(self.owner_session_id, state)
             return {
                 "status": "done",
                 "should_continue": False,
@@ -492,7 +568,7 @@ class GoalManager:
         if state.turns_used >= state.max_turns:
             state.status = "paused"
             state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
-            save_goal(self.session_id, state)
+            save_goal(self.owner_session_id, state)
             return {
                 "status": "paused",
                 "should_continue": False,
@@ -505,7 +581,7 @@ class GoalManager:
                 ),
             }
 
-        save_goal(self.session_id, state)
+        save_goal(self.owner_session_id, state)
         return {
             "status": "active",
             "should_continue": True,

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -8,6 +8,16 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 
+def _make_compression_child(parent_sid: str, child_sid: str):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    db.create_session(parent_sid, source="cli")
+    db.end_session(parent_sid, "compression")
+    db.create_session(child_sid, source="cli", parent_session_id=parent_sid)
+    return db
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Fixtures
 # ──────────────────────────────────────────────────────────────────────
@@ -333,7 +343,60 @@ class TestGoalManager:
         prompt = mgr.next_continuation_prompt()
         assert prompt is not None
         assert "port goal command to hermes" in prompt
-        assert prompt.strip()  # non-empty
+        assert prompt.strip()
+
+    def test_goal_follows_compression_child_session(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        _make_compression_child("parent-sid", "child-sid")
+        parent_mgr = GoalManager(session_id="parent-sid", default_max_turns=5)
+        parent_mgr.set("finish the migration")
+
+        child_mgr = GoalManager(session_id="child-sid", default_max_turns=5)
+
+        assert child_mgr.state is not None
+        assert child_mgr.state.goal == "finish the migration"
+        assert child_mgr.is_active()
+        assert child_mgr.status_line().startswith("⊙ Goal")
+
+    def test_evaluate_after_turn_uses_resolved_goal_owner_across_compression(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager, load_goal
+
+        _make_compression_child("parent-sid-2", "child-sid-2")
+        parent_mgr = GoalManager(session_id="parent-sid-2", default_max_turns=5)
+        parent_mgr.set("ship the fix")
+
+        child_mgr = GoalManager(session_id="child-sid-2", default_max_turns=5)
+        with patch.object(goals, "judge_goal", return_value=("continue", "keep going")):
+            decision = child_mgr.evaluate_after_turn("made progress")
+
+        assert decision["should_continue"] is True
+        assert child_mgr.state is not None
+        assert child_mgr.state.turns_used == 1
+        assert load_goal("parent-sid-2") is not None
+        assert load_goal("parent-sid-2").turns_used == 1
+        assert load_goal("parent-sid-2").goal == "ship the fix"
+
+    def test_goal_resolves_across_multiple_compression_hops(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        db.create_session("root-sid", source="cli")
+        db.end_session("root-sid", "compression")
+        db.create_session("mid-sid", source="cli", parent_session_id="root-sid")
+        db.end_session("mid-sid", "compression")
+        db.create_session("tip-sid", source="cli", parent_session_id="mid-sid")
+
+        root_mgr = GoalManager(session_id="root-sid", default_max_turns=5)
+        root_mgr.set("finish the long job")
+
+        tip_mgr = GoalManager(session_id="tip-sid", default_max_turns=5)
+
+        assert tip_mgr.state is not None
+        assert tip_mgr.state.goal == "finish the long job"
+        assert tip_mgr.is_active()
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make `/goal` resolve goal state through compression-linked session lineage
- keep writes attached to the resolved goal owner instead of blindly using the current physical session id
- add regression tests for child sessions, post-turn evaluation, and multi-hop compression chains

## Problem
PR #18262 stores standing goals under `goal:<session_id>`. That works while a conversation stays on one physical session row, but Hermes can split a session during context compression and continue work on a child session.

After that split, the logical conversation continues, but `/goal` looked only at the child session id. If the goal lived on the compression parent, `GoalManager` saw no active goal and continuation silently stopped.

## Root cause
`GoalManager` assumed a stable single `session_id`, while Hermes session state already supports compression lineage via `parent_session_id` and resume resolution.

## Fix
This change teaches goal loading to walk backward through a true compression chain and adopt the nearest visible ancestor goal for the active conversation. It does **not** borrow goals from arbitrary parent-linked sessions; adoption only happens when the ancestor session ended with `end_reason='compression'`.

## Test plan
- [x] `pytest tests/hermes_cli/test_goals.py -q`
- [x] regression: goal visible from compression child session
- [x] regression: `evaluate_after_turn()` updates the resolved goal owner across a compression split
- [x] regression: goal resolves across multiple compression hops
