### PR TITLE
fix(web): include ddgs backend in check_web_api_key() availability check

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -620,6 +620,45 @@ class TestCheckWebApiKey:
                     from tools.web_tools import check_web_api_key
                     assert check_web_api_key() is True
 
+    def test_ddgs_configured_backend_returns_true(self):
+        """When backend is explicitly set to ddgs, check passes without API keys."""
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "ddgs"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_ddgs_fallback_when_no_paid_keys(self):
+        """When no paid backend keys are set but ddgs is importable, check passes."""
+        with patch("tools.web_tools._load_web_config", return_value={}):
+            # ddgs is importable in this test environment
+            import importlib
+            ddgs_spec = importlib.util.find_spec("ddgs")
+            if ddgs_spec is None:
+                # Mock the import succeeding
+                import sys
+                from unittest.mock import MagicMock
+                sys.modules["ddgs"] = MagicMock()
+                try:
+                    from tools.web_tools import check_web_api_key
+                    assert check_web_api_key() is True
+                finally:
+                    del sys.modules["ddgs"]
+            else:
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
+
+    def test_no_keys_no_ddgs_returns_false(self):
+        """When no paid backend keys are set and ddgs is not importable, check fails."""
+        with patch("tools.web_tools._load_web_config", return_value={}):
+            import builtins
+            real_import = builtins.__import__
+            def mock_import(name, *args, **kwargs):
+                if name == "ddgs":
+                    raise ImportError("No module named 'ddgs'")
+                return real_import(name, *args, **kwargs)
+            with patch("builtins.__import__", side_effect=mock_import):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is False
+
 
 def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1969,7 +1969,17 @@ def check_web_api_key() -> bool:
     configured = _load_web_config().get("backend", "").lower().strip()
     if configured in ("exa", "parallel", "firecrawl", "tavily"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    if configured == "ddgs":
+        return True
+    # Check paid backends
+    if any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily")):
+        return True
+    # Fallback: ddgs is free and needs no API key
+    try:
+        from ddgs import DDGS  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
 
 def check_auxiliary_model() -> bool:


### PR DESCRIPTION
## Summary
`web_search` and `web_extract` tools are never registered when only the free DuckDuckGo (`ddgs`) backend is available, because `check_web_api_key()` only checks paid backends.

## Root cause
`_get_backend()` correctly detects `ddgs` as a zero-config fallback (line ~107):
```python
try:
    from ddgs import DDGS
    return "ddgs"
```

But `check_web_api_key()` (the `check_fn` gating tool registration) only checks exa/parallel/firecrawl/tavily — it never considers ddgs. So even though `ddgs` is installed and `_get_backend()` returns `"ddgs"`, the tools are filtered out during registration and never appear in the agent's tool list.

This forces the agent to fall back to `browser_navigate` (fails without Chrome) or `execute_code` + `curl` (unreliable HTML scraping).

## Fix
`check_web_api_key()` now returns `True` when:
1. `web.backend` is explicitly set to `"ddgs"` in config, or
2. No paid backend is available but the `ddgs` package is importable

## Validation
- Confirmed `web_search` tool now appears in agent tool list after fix
- Confirmed DuckDuckGo search returns results via `web_search_tool()`
- Added 3 unit tests covering: explicit ddgs config, ddgs fallback, and no-backend-available case

## Testing
- Tested on Linux (Docker container running hermes-agent)
- `python -c "from tools.web_tools import check_web_api_key; print(check_web_api_key())"\ → True (was False before fix)
