### PR TITLE
Add plugin-driven per-turn model overrides in gateway dispatch

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -909,6 +909,13 @@ class MessageEvent:
     # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
+
+    # Optional per-turn model routing hints set by pre-dispatch plugins.
+    # These apply only to the current MessageEvent and do not mutate the
+    # session's /model override or profile default.
+    model_override: Optional[str] = None
+    provider_override: Optional[str] = None
+    model_tier_hint: Optional[str] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4217,6 +4217,10 @@ class GatewayRunner:
             for _result in _hook_results:
                 if not isinstance(_result, dict):
                     continue
+                for _field in ("model_override", "provider_override", "model_tier_hint"):
+                    _value = _result.get(_field)
+                    if isinstance(_value, str) and _value.strip():
+                        setattr(event, _field, _value.strip())
                 _action = _result.get("action")
                 if _action == "skip":
                     logger.info(
@@ -5895,6 +5899,9 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                model_override=event.model_override,
+                provider_override=event.provider_override,
+                model_tier_hint=event.model_tier_hint,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -10798,6 +10805,65 @@ class GatewayRunner:
                 runtime_kwargs[key] = val
         return model, runtime_kwargs
 
+    def _apply_turn_model_override(
+        self,
+        model: str,
+        runtime_kwargs: dict,
+        *,
+        model_override: Optional[str] = None,
+        provider_override: Optional[str] = None,
+        model_tier_hint: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> tuple[str, dict]:
+        """Apply a pre-dispatch plugin's per-turn model override.
+
+        This is intentionally ephemeral. It affects only the current
+        MessageEvent and does not persist as the chat's /model state.
+        """
+        target_model = str(model_override or "").strip()
+        target_provider = str(provider_override or "").strip()
+        if not target_model and not target_provider:
+            return model, runtime_kwargs
+
+        next_runtime = dict(runtime_kwargs)
+
+        if target_provider and target_provider != (runtime_kwargs.get("provider") or ""):
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                resolved = resolve_runtime_provider(requested=target_provider)
+                next_runtime.update({
+                    "api_key": resolved.get("api_key"),
+                    "base_url": resolved.get("base_url"),
+                    "provider": resolved.get("provider"),
+                    "api_mode": resolved.get("api_mode"),
+                    "command": resolved.get("command"),
+                    "args": list(resolved.get("args") or []),
+                    "credential_pool": resolved.get("credential_pool"),
+                })
+            except Exception as exc:
+                logger.warning(
+                    "Per-turn model override failed to resolve provider=%s tier=%s session=%s: %s; using %s",
+                    target_provider,
+                    model_tier_hint or "",
+                    session_key or "",
+                    exc,
+                    model,
+                )
+                return model, runtime_kwargs
+        elif target_provider:
+            next_runtime["provider"] = target_provider
+
+        next_model = target_model or model
+        logger.info(
+            "Per-turn model override: session=%s tier=%s model=%s provider=%s",
+            session_key or "",
+            model_tier_hint or "",
+            next_model,
+            next_runtime.get("provider") or "",
+        )
+        return next_model, next_runtime
+
     def _is_intentional_model_switch(self, session_key: str, agent_model: str) -> bool:
         """Return True if *agent_model* matches an active /model session override."""
         override = self._session_model_overrides.get(session_key)
@@ -11439,6 +11505,9 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        model_override: Optional[str] = None,
+        provider_override: Optional[str] = None,
+        model_tier_hint: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -11950,6 +12019,14 @@ class GatewayRunner:
                     source=source,
                     session_key=session_key,
                     user_config=user_config,
+                )
+                model, runtime_kwargs = self._apply_turn_model_override(
+                    model,
+                    runtime_kwargs,
+                    model_override=model_override,
+                    provider_override=provider_override,
+                    model_tier_hint=model_tier_hint,
+                    session_key=session_key,
                 )
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",
@@ -13125,6 +13202,9 @@ class GatewayRunner:
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_model_override = None
+                next_provider_override = None
+                next_model_tier_hint = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     next_message = await self._prepare_inbound_message_text(
@@ -13136,6 +13216,9 @@ class GatewayRunner:
                         return result
                     next_message_id = getattr(pending_event, "message_id", None)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_model_override = getattr(pending_event, "model_override", None)
+                    next_provider_override = getattr(pending_event, "provider_override", None)
+                    next_model_tier_hint = getattr(pending_event, "model_tier_hint", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -13161,6 +13244,9 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    model_override=next_model_override,
+                    provider_override=next_provider_override,
+                    model_tier_hint=next_model_tier_hint,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/tests/gateway/test_pre_gateway_dispatch_model_override.py
+++ b/tests/gateway/test_pre_gateway_dispatch_model_override.py
@@ -1,0 +1,230 @@
+"""Tests for plugin-driven per-turn model/provider overrides.
+
+These complement test_pre_gateway_dispatch.py. They cover the override
+mechanism added in this change:
+
+- pre_gateway_dispatch plugins can set MessageEvent.model_override,
+  MessageEvent.provider_override, and MessageEvent.model_tier_hint via
+  the hook result dict.
+- The dispatcher reads those fields and applies them per-turn via
+  GatewayRunner._apply_turn_model_override.
+- Overrides apply to the current dispatch only; they do not persist
+  to the next turn (the next MessageEvent starts with all overrides
+  None).
+- Override coexists with rewrite/skip actions on the same hook call.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _clear_auth_env(monkeypatch) -> None:
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "WHATSAPP_ALLOWED_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "WHATSAPP_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_event(text: str = "hello", platform: Platform = Platform.WHATSAPP) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_id="m1",
+        source=SessionSource(
+            platform=platform,
+            user_id="15551234567@s.whatsapp.net",
+            chat_id="15551234567@s.whatsapp.net",
+            user_name="tester",
+            chat_type="dm",
+        ),
+    )
+
+
+def _make_runner(platform: Platform = Platform.WHATSAPP):
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True)},
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {platform: adapter}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_store._is_rate_limited.return_value = False
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._update_prompt_pending = {}
+    return runner, adapter
+
+
+def test_no_override_preserves_existing_model_and_provider():
+    """When no plugin sets override fields, _apply_turn_model_override
+    must return the original model/runtime_kwargs unchanged."""
+    runner, _ = _make_runner()
+
+    base_model = "gpt-4o-mini"
+    base_runtime = {"provider": "openai", "api_key": "sk-test", "base_url": "https://api.openai.com/v1"}
+
+    out_model, out_runtime = runner._apply_turn_model_override(
+        base_model,
+        base_runtime,
+        model_override=None,
+        provider_override=None,
+        model_tier_hint=None,
+        session_key="test-session",
+    )
+
+    assert out_model == base_model
+    assert out_runtime is base_runtime  # exact same object, not a copy
+    assert out_runtime == {"provider": "openai", "api_key": "sk-test", "base_url": "https://api.openai.com/v1"}
+
+
+def test_override_swaps_model_and_provider_for_one_turn(monkeypatch):
+    """A plugin-set model_override + provider_override must swap both
+    via resolve_runtime_provider for the current turn."""
+    runner, _ = _make_runner()
+
+    fake_resolved = {
+        "provider": "anthropic",
+        "api_key": "sk-ant-test",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "messages",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    def _fake_resolve(requested=None):
+        assert requested == "anthropic"
+        return fake_resolved
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _fake_resolve)
+
+    base_model = "gpt-4o-mini"
+    base_runtime = {"provider": "openai", "api_key": "sk-test", "base_url": "https://api.openai.com/v1"}
+
+    out_model, out_runtime = runner._apply_turn_model_override(
+        base_model,
+        base_runtime,
+        model_override="claude-sonnet-4-6",
+        provider_override="anthropic",
+        model_tier_hint="frontier",
+        session_key="test-session",
+    )
+
+    assert out_model == "claude-sonnet-4-6"
+    assert out_runtime is not base_runtime  # must be a copy, not in-place mutation
+    assert out_runtime["provider"] == "anthropic"
+    assert out_runtime["api_key"] == "sk-ant-test"
+    assert out_runtime["base_url"] == "https://api.anthropic.com"
+    # Original runtime is untouched.
+    assert base_runtime["provider"] == "openai"
+    assert base_runtime["api_key"] == "sk-test"
+
+
+def test_override_does_not_persist_to_next_turn(monkeypatch):
+    """Override applies only to the turn whose MessageEvent set it.
+    A second call with no override must return the original model/runtime."""
+    runner, _ = _make_runner()
+
+    def _fake_resolve(requested=None):
+        return {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "messages",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _fake_resolve)
+
+    base_model = "gpt-4o-mini"
+    base_runtime = {"provider": "openai", "api_key": "sk-test", "base_url": "https://api.openai.com/v1"}
+
+    # Turn 1: override sets a different model+provider.
+    turn1_model, turn1_runtime = runner._apply_turn_model_override(
+        base_model,
+        base_runtime,
+        model_override="claude-sonnet-4-6",
+        provider_override="anthropic",
+        session_key="persist-test-session",
+    )
+    assert turn1_model == "claude-sonnet-4-6"
+    assert turn1_runtime["provider"] == "anthropic"
+
+    # Turn 2: no override (typical: a normal user turn after the
+    # overridden one). Must return the *base* model/runtime, NOT what
+    # turn 1 produced. The override is per-MessageEvent; nothing
+    # should leak to subsequent calls.
+    turn2_model, turn2_runtime = runner._apply_turn_model_override(
+        base_model,
+        base_runtime,
+        model_override=None,
+        provider_override=None,
+        session_key="persist-test-session",
+    )
+    assert turn2_model == base_model
+    assert turn2_runtime is base_runtime
+    assert turn2_runtime["provider"] == "openai"
+
+    # Also confirm: a fresh MessageEvent starts with all overrides None.
+    fresh = _make_event("turn 2 message")
+    assert fresh.model_override is None
+    assert fresh.provider_override is None
+    assert fresh.model_tier_hint is None
+
+
+@pytest.mark.asyncio
+async def test_hook_can_set_override_alongside_rewrite(monkeypatch):
+    """A plugin may return {'action': 'rewrite', 'text': ..., 'model_override': ...}.
+    Both effects must apply: text is rewritten AND override fields land on the event."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    captured = {}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{
+                "action": "rewrite",
+                "text": "REWRITTEN",
+                "model_override": "claude-sonnet-4-6",
+                "provider_override": "anthropic",
+                "model_tier_hint": "frontier",
+            }]
+        return []
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        captured["text"] = event.text
+        captured["model_override"] = event.model_override
+        captured["provider_override"] = event.provider_override
+        captured["model_tier_hint"] = event.model_tier_hint
+        return "ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = _capture  # noqa: SLF001
+
+    await runner._handle_message(_make_event("original"))
+
+    # Rewrite took effect.
+    assert captured["text"] == "REWRITTEN"
+    # Override fields landed on the event for the dispatcher to read.
+    assert captured["model_override"] == "claude-sonnet-4-6"
+    assert captured["provider_override"] == "anthropic"
+    assert captured["model_tier_hint"] == "frontier"


### PR DESCRIPTION
## Summary

This adds a generic way for gateway plugins to set a model/provider override for a single incoming turn.

`pre_gateway_dispatch` plugins can annotate the `MessageEvent` with:

- `model_override`
- `provider_override`
- `model_tier_hint`

The gateway then applies those values after normal session/runtime resolution and before constructing or updating the turn agent. This lets plugins route individual turns to cheaper, mid-tier, or frontier models without changing the session default model.

## Why

Gateway plugins already have a pre-dispatch interception point for rewrite/skip/allow. Some routing plugins need a third behavior: allow normal dispatch, but select a different model/provider for this turn only.

Examples:

- cheap model for capture/ack turns,
- mid-tier model for ordinary conversation,
- frontier model for deep synthesis,
- provider fallback based on local policy.

This avoids forcing model selection into user prompts or persistent session-level `/model` state.

## Behavior

- Overrides are optional.
- If no plugin sets them, behavior is unchanged.
- Session-level model configuration remains the default.
- Turn-level override applies only to the current dispatch.
- Plugin-set values are copied explicitly rather than relying on plugin-specific globals.
- Override propagates through the interrupt-resume path.

## Prior Art

The gateway already supports `pre_gateway_dispatch` for plugin-controlled skip/rewrite/allow behavior. This extends that same lifecycle point to support turn-scoped runtime selection.

The gateway also already has session model override machinery for `/model`; this change is the turn-scoped counterpart.

## Testing

`tests/gateway/test_pre_gateway_dispatch_model_override.py` — 4 tests, all passing:

- `test_no_override_preserves_existing_model_and_provider` — when no plugin sets overrides, `_apply_turn_model_override` returns the original model and runtime unchanged (same object identity, no copy).
- `test_override_swaps_model_and_provider_for_one_turn` — when overrides are set, the model is swapped and `resolve_runtime_provider` is called with the requested provider name; original `runtime_kwargs` dict is not mutated in place.
- `test_override_does_not_persist_to_next_turn` — calling the dispatcher twice (once with override, once without) returns the override on call 1 and the base model on call 2; a fresh `MessageEvent` starts with all overrides `None`.
- `test_hook_can_set_override_alongside_rewrite` — a plugin returning `{"action": "rewrite", "text": "...", "model_override": "...", "provider_override": "...", "model_tier_hint": "..."}` causes both effects to apply on the same hook call.

Local validation:

- `python3 -m py_compile gateway/run.py gateway/platforms/base.py hermes_cli/plugins.py` — clean.
- `pytest tests/gateway -q -k "plugin or model or dispatch"` — 121 passed, 8 skipped.
- `pytest tests/hermes_cli -q -k "plugin or goal or model"` — 860 passed.

## Notes

- Cherry-picked from a downstream Stan integration where the override path is already in production use to route capture-tier turns to gpt-4o-mini and mid/frontier turns to claude-sonnet-4-6 via a `pre_gateway_dispatch` plugin.
- Scope of this PR is the override mechanism only. The downstream branch also includes a `post_gateway_dispatch` hook (for capturing assistant turns); that's a separate lifecycle feature and will be a follow-up PR with its own contract and tests.