### PR TITLE
fix(prompt_builder): include skills manifest digest in cache key

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -5,6 +5,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
 import json
+import hashlib
 import logging
 import os
 import re
@@ -588,6 +589,22 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
+def _skills_manifest_digest(skills_dir: Path) -> str:
+    """Return a stable digest of one skills directory's manifest."""
+    manifest = _build_skills_manifest(skills_dir)
+    payload = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _skills_cache_state(skills_dir: Path, external_dirs: list[Path]) -> tuple[tuple[str, str], ...]:
+    """Return cache state tokens for local + external skill directories."""
+    dirs = [skills_dir, *external_dirs]
+    return tuple(
+        (str(directory.resolve()), _skills_manifest_digest(directory))
+        for directory in dirs
+    )
+
+
 def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
@@ -745,7 +762,7 @@ def build_skills_system_prompt(
     disabled = get_disabled_skill_names()
     cache_key = (
         str(skills_dir.resolve()),
-        tuple(str(d) for d in external_dirs),
+        _skills_cache_state(skills_dir, external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -372,6 +372,28 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_rebuilds_prompt_when_skill_files_change(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        first_skill = tmp_path / "skills" / "tools" / "first-skill"
+        first_skill.mkdir(parents=True)
+        (first_skill / "SKILL.md").write_text(
+            "---\nname: first-skill\ndescription: First skill\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "first-skill" in first
+        assert "second-skill" not in first
+
+        second_skill = tmp_path / "skills" / "tools" / "second-skill"
+        second_skill.mkdir(parents=True)
+        (second_skill / "SKILL.md").write_text(
+            "---\nname: second-skill\ndescription: Second skill\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "first-skill" in second
+        assert "second-skill" in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)
@@ -1086,6 +1108,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a stale-cache bug in `build_skills_system_prompt`'s in-process LRU.

The cache key was based only on directory paths (`skills_dir.resolve()` + a tuple of external dir paths). Edits to skill files within those directories — add, edit, remove, rename — did not invalidate the cache, so a long-running agent kept serving a stale system prompt until the process restarted.

The disk snapshot (Layer 2) already validates against a manifest of `mtime`/`size` pairs; this PR folds the same manifest digest into the in-process cache key (Layer 1) so both layers share invalidation semantics. Two new helpers — `_skills_manifest_digest()` and `_skills_cache_state()` — compute a per-directory SHA-1 over a sorted manifest and feed the result into the existing cache key tuple.

## Related Issue

No existing issue. Discovered while iterating on a skill — agent kept serving the old prompt until I restarted the gateway.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`
  - Add `_skills_manifest_digest(skills_dir)` — SHA-1 over a sorted JSON dump of `_build_skills_manifest()`'s output.
  - Add `_skills_cache_state(skills_dir, external_dirs)` — tuple of `(resolved_path, digest)` pairs across local + external dirs.
  - Replace `tuple(str(d) for d in external_dirs)` in the cache key with `_skills_cache_state(...)`.
- `tests/agent/test_prompt_builder.py` — extend with cases that mutate skill files and assert the cache key changes.

## How to Test

1. Start a session with skills loaded: `hermes chat -q "list skills"`.
2. Edit any `SKILL.md` content in `~/.hermes/skills/<some-skill>/` (without restarting hermes).
3. Trigger another prompt-build (e.g., new chat session in the same process).
4. **Before this fix:** the in-process cache returns the old skills prompt — agent doesn't see the edit.
5. **After this fix:** the manifest digest differs, cache misses, and the new content is loaded.

Or run the unit tests directly:
```bash
pytest tests/agent/test_prompt_builder.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(prompt_builder): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and the changes don't introduce new failures (vs. main baseline)
- [x] I've added tests for the change
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] No public API surface changed
- [x] No config schema changed
