### PR TITLE
feat(telegram): fall back to send_document on Photo_invalid_dimensions

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2193,7 +2193,12 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """Send a local image file natively as a Telegram photo."""
+        """Send a local image file natively as a Telegram photo.
+
+        If Telegram rejects the image as a photo (for example, invalid
+        dimensions on very tall screenshots), retry as a document so the
+        original file still reaches the user unchanged.
+        """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
@@ -2212,13 +2217,30 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.error(
-                "[%s] Failed to send Telegram local image, falling back to base adapter: %s",
+            logger.warning(
+                "[%s] Failed to send Telegram local image as photo, retrying as document: %s",
                 self.name,
                 e,
                 exc_info=True,
             )
-            return await super().send_image_file(chat_id, image_path, caption, reply_to)
+            try:
+                return await self.send_document(
+                    chat_id=chat_id,
+                    file_path=image_path,
+                    caption=caption,
+                    file_name=os.path.basename(image_path),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            except Exception:
+                logger.error(
+                    "[%s] Failed to send Telegram local image as both photo and document, falling back to base adapter",
+                    self.name,
+                    exc_info=True,
+                )
+                return await super().send_image_file(
+                    chat_id, image_path, caption, reply_to, metadata=metadata
+                )
 
     async def send_document(
         self,

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -167,6 +167,30 @@ class TestTelegramSendImageFile:
         call_kwargs = adapter._bot.send_photo.call_args.kwargs
         assert call_kwargs["message_thread_id"] == 789
 
+    def test_photo_failure_retries_as_document(self, adapter, tmp_path):
+        """When Telegram rejects photo dimensions, retry the original file as a document."""
+        img = tmp_path / "very-tall.jpg"
+        img.write_bytes(b"\xff\xd8\xff" + b"\x00" * 50)
+
+        adapter._bot.send_photo = AsyncMock(side_effect=Exception("Photo_invalid_dimensions"))
+        mock_msg = MagicMock()
+        mock_msg.message_id = 44
+        adapter._bot.send_document = AsyncMock(return_value=mock_msg)
+
+        result = _run(
+            adapter.send_image_file(chat_id="12345", image_path=str(img), caption="cap")
+        )
+
+        assert result.success
+        assert result.message_id == "44"
+        adapter._bot.send_photo.assert_awaited_once()
+        adapter._bot.send_document.assert_awaited_once()
+
+        call_kwargs = adapter._bot.send_document.call_args.kwargs
+        assert call_kwargs["chat_id"] == 12345
+        assert call_kwargs["filename"] == "very-tall.jpg"
+        assert call_kwargs["caption"] == "cap"
+
 
 # ---------------------------------------------------------------------------
 # Discord send_image_file tests


### PR DESCRIPTION
## What does this PR do?

Adds a `send_document` fallback to the Telegram adapter's `send_image_file` when Telegram rejects the photo.

Telegram rejects photos with extreme aspect ratios (most commonly very tall full-page screenshots) with `Photo_invalid_dimensions`. Previously the adapter logged the error and called `super().send_image_file(...)`, which on the Telegram path silently dropped the file — the user got nothing.

This PR retries the same bytes via `send_document` when `send_photo` raises, so the original image still reaches the user (just as a file rather than an inline preview). Only fall through to the base adapter if both attempts fail.

This complements #17833 (which added a similar `send_voice` → `send_document` fallback for unplayable audio formats), but for the image path.

## Related Issue

No existing issue — observed in the wild while sending agent-rendered web-page screenshots over Telegram.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/telegram.py` — `send_image_file()`:
  - On `send_photo` exception: log a `warning` (was `error`) noting we're retrying as a document.
  - Retry via `self.send_document(...)` with the same bytes / caption / metadata.
  - If `send_document` also raises, log a final `error` and fall through to the base adapter (existing behaviour).
- `tests/gateway/test_send_image_file.py` — add a case asserting the document fallback is invoked when `send_photo` raises `BadRequest`.

## How to Test

1. Generate an extremely tall PNG (e.g. a full-page web screenshot via the `browser` skill).
2. Tell the agent to send it via Telegram with a chat session that produces an image attachment.
3. **Before this fix:** Telegram fails with `Photo_invalid_dimensions`; nothing arrives in the chat.
4. **After this fix:** the image arrives as a Telegram document, with the same caption preserved.

Or run the unit tests:
```bash
pytest tests/gateway/test_send_image_file.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(telegram): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#17833 covers `send_voice`, not `send_image_file`)
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and the changes don't introduce new failures (vs. main baseline)
- [x] I've added tests for the change
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] No public API surface changed
- [x] No config schema changed
