### PR TITLE
feat(config): support model.max_tokens override in config.yaml

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2748,10 +2748,95 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_max_tokens_from_config(
+    model: str,
+    base_url: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Resolve a ``max_tokens`` override from ``config.yaml``.
+
+    Custom OpenAI-compatible providers (vLLM, llama.cpp, ollama, ...) that
+    do not advertise a max_tokens default via /models cause responses to
+    truncate with ``finish_reason='length'`` because the agent never sends
+    a max_tokens hint.  This helper resolves an override the user can set
+    in config.yaml, mirroring the existing ``context_length`` lookup.
+
+    Lookup order (first valid positive int wins):
+      1. Top-level ``model.max_tokens`` (applies to whichever model is active)
+      2. ``custom_providers.<>.models.<model>.max_tokens`` (per-model, scoped
+         to the entry whose ``base_url`` matches ``base_url``)
+
+    Returns ``None`` when neither location holds a valid value.  Trailing
+    slashes on URLs are normalised before comparison.
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return None
+    if not isinstance(config, dict):
+        return None
+
+    # 1. Top-level model.max_tokens
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        raw = model_cfg.get("max_tokens")
+        if raw is not None:
+            try:
+                v = int(raw)
+                if v > 0:
+                    return v
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid model.max_tokens in config.yaml: %r — "
+                    "must be a positive integer (e.g. 32768, not '32K'). "
+                    "Falling back to per-model / provider defaults.",
+                    raw,
+                )
+
+    # 2. custom_providers.<>.models.<model>.max_tokens
+    if not model or not base_url:
+        return None
+    try:
+        custom_providers = get_compatible_custom_providers(config)
+    except Exception:
+        raw_cps = config.get("custom_providers")
+        custom_providers = raw_cps if isinstance(raw_cps, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_mt = model_cfg.get("max_tokens")
+        if raw_mt is None:
+            continue
+        try:
+            v = int(raw_mt)
+        except (TypeError, ValueError):
+            continue
+        if v > 0:
+            return v
+    return None
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.
-    
+
     Returns (current_version, latest_version).
     """
     config = load_config()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1916,7 +1916,20 @@ class AIAgent:
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
 
-
+        # Read max_tokens override from config (mirrors context_length above).
+        # Custom providers without a server-side max_tokens default truncate
+        # long responses with finish_reason='length'; this lets the user pin
+        # an explicit cap via model.max_tokens (top-level) or
+        # custom_providers.<>.models.<>.max_tokens (per-model).
+        # Applied only when the constructor did not pass an explicit value.
+        try:
+            from hermes_cli.config import get_max_tokens_from_config as _gmtfc
+            _config_max_tokens = _gmtfc(self.model, self.base_url, _agent_cfg)
+        except Exception:
+            _config_max_tokens = None
+        self._config_max_tokens = _config_max_tokens
+        if _config_max_tokens is not None and self.max_tokens is None:
+            self.max_tokens = _config_max_tokens
 
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting

--- a/tests/hermes_cli/test_max_tokens_config.py
+++ b/tests/hermes_cli/test_max_tokens_config.py
@@ -1,0 +1,180 @@
+"""Tests for ``get_max_tokens_from_config`` — model.max_tokens override.
+
+Custom OpenAI-compatible providers that do not advertise a ``max_tokens``
+default cause responses to truncate with ``finish_reason='length'``.  The
+helper resolves an override from config.yaml, mirroring the existing
+``get_custom_provider_context_length`` lookup pattern.
+"""
+from __future__ import annotations
+
+from hermes_cli.config import get_max_tokens_from_config
+
+
+class TestTopLevelModelMaxTokens:
+    """Top-level ``model.max_tokens`` is the preferred location."""
+
+    def test_returns_value_when_present(self) -> None:
+        cfg = {"model": {"max_tokens": 32768}}
+        assert (
+            get_max_tokens_from_config(
+                "qwen3.6-27b-fp8", "http://vllm.invalid/v1", cfg
+            )
+            == 32768
+        )
+
+    def test_returns_value_when_no_model_or_base_url(self) -> None:
+        # Top-level lookup does NOT depend on model/base_url.
+        cfg = {"model": {"max_tokens": 16000}}
+        assert get_max_tokens_from_config("", "", cfg) == 16000
+
+    def test_string_int_is_coerced(self) -> None:
+        cfg = {"model": {"max_tokens": "8192"}}
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            == 8192
+        )
+
+    def test_invalid_value_falls_through(self) -> None:
+        # Bad value at top level must not raise; lookup continues to
+        # custom_providers and finds the per-model override.
+        cfg = {
+            "model": {"max_tokens": "32K"},
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"m": {"max_tokens": 4096}},
+                }
+            ],
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) == 4096
+        )
+
+    def test_zero_or_negative_top_level_ignored(self) -> None:
+        cfg = {"model": {"max_tokens": 0}}
+        assert get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) is None
+        cfg = {"model": {"max_tokens": -1}}
+        assert get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) is None
+
+
+class TestPerModelCustomProviderMaxTokens:
+    """``custom_providers.<>.models.<>.max_tokens`` is the per-model fallback."""
+
+    def test_returns_per_model_when_no_top_level(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"qwen": {"max_tokens": 16384}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("qwen", "http://h.invalid/v1", cfg)
+            == 16384
+        )
+
+    def test_top_level_wins_over_per_model(self) -> None:
+        cfg = {
+            "model": {"max_tokens": 99999},
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"qwen": {"max_tokens": 16384}},
+                }
+            ],
+        }
+        assert (
+            get_max_tokens_from_config("qwen", "http://h.invalid/v1", cfg)
+            == 99999
+        )
+
+    def test_trailing_slash_insensitive(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1/",
+                    "models": {"m": {"max_tokens": 4096}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) == 4096
+        )
+
+    def test_url_mismatch_returns_none(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://other.invalid/v1",
+                    "models": {"m": {"max_tokens": 4096}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            is None
+        )
+
+    def test_model_mismatch_returns_none(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"other-model": {"max_tokens": 4096}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            is None
+        )
+
+
+class TestProvidersDictForm:
+    """The newer keyed ``providers:`` schema (v12+) is also covered via
+    ``get_compatible_custom_providers`` normalization."""
+
+    def test_providers_dict_with_models_subdict(self) -> None:
+        cfg = {
+            "providers": {
+                "vllm": {
+                    "name": "vllm",
+                    "api": "http://h.invalid/v1",
+                    "models": {"qwen": {"max_tokens": 8192}},
+                }
+            }
+        }
+        assert (
+            get_max_tokens_from_config("qwen", "http://h.invalid/v1", cfg)
+            == 8192
+        )
+
+
+class TestEdgeCases:
+    def test_empty_config_returns_none(self) -> None:
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", {}) is None
+        )
+
+    def test_none_config_arg_does_not_crash(self) -> None:
+        # Passing ``config=None`` triggers a load_config(); the call should
+        # not raise even when no override is configured.
+        result = get_max_tokens_from_config("nonexistent", "http://nowhere.invalid/v1")
+        assert result is None or isinstance(result, int)
+
+    def test_non_dict_config_returns_none(self) -> None:
+        assert get_max_tokens_from_config("m", "http://h.invalid/v1", "garbage") is None  # type: ignore[arg-type]
+
+    def test_no_model_section(self) -> None:
+        cfg = {"other": {}}
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            is None
+        )


### PR DESCRIPTION
## What does this PR do?

Adds a config-driven `max_tokens` override for OpenAI-compatible custom providers, mirroring the existing `model.context_length` lookup.

Custom providers (vLLM, llama.cpp, ollama, ...) that do not advertise a `max_tokens` default via `/models` cause responses to truncate with `finish_reason='length'` because the agent never sends a `max_tokens` hint. The `chat_completions` transport leaves `max_tokens` unset, the server uses its own (often conservative) default, and long answers get cut mid-sentence.

This PR introduces:

1. A new `get_max_tokens_from_config(model, base_url, config)` helper in `hermes_cli/config.py` — alongside the existing `get_custom_provider_context_length`.
2. A wire-up in `AIAgent.__init__` that calls the helper after the existing `context_length` resolution and applies its value to `self.max_tokens` only when the constructor didn't pass an explicit value.

**Lookup order** (first valid positive int wins):
- `model.max_tokens` (top-level — applies to whichever model is active)
- `custom_providers.<>.models.<model>.max_tokens` (per-model, scoped to the entry whose `base_url` matches)

No behaviour change for built-in providers (Anthropic / OpenAI / OpenRouter / Bedrock / Gemini) — they still resolve `max_tokens` through their own adapter logic.

Aligns with the schema proposed in issue #15037.

## Related Issue

Fixes the user-side workaround needed for #15037.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — add `get_max_tokens_from_config(model, base_url, config=None) -> Optional[int]`:
  - Reads top-level `model.max_tokens` first; logs a warning and falls through if non-int / non-positive.
  - Falls back to `custom_providers.<>.models.<>.max_tokens` (URL match is trailing-slash insensitive, value must be a positive int).
  - Returns `None` when neither location holds a valid value.
- `run_agent.py` — `AIAgent.__init__`: after the existing `context_length` resolution, call the helper and apply the value to `self.max_tokens` if the constructor didn't pass one.
- `tests/hermes_cli/test_max_tokens_config.py` — 15 unit tests covering top-level / per-model / precedence / edge cases / providers-dict (v12+) form.

## How to Test

1. Configure a custom provider in `~/.hermes/config.yaml`:
   ```yaml
   model:
     default: qwen3.6-27b-fp8
     provider: custom
     base_url: http://192.168.x.x:8080/v1
     max_tokens: 32768
   ```
2. Send a prompt likely to produce a long response (e.g. "summarise this 50K-word document").
3. **Before this fix:** the response gets cut off at the server's default cap (often 2K–4K) with `finish_reason='length'`.
4. **After this fix:** the agent sends `max_tokens=32768`, and the response runs to a natural stop.

Or run the unit tests:
```bash
pytest tests/hermes_cli/test_max_tokens_config.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(config): ...`)
- [x] I searched for existing PRs — #15037 proposes this schema but no implementation has landed
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and the changes don't introduce new failures (vs. main baseline)
- [x] I've added tests for the change (15 cases)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Qwen 3.6 27B FP8 served via vLLM

### Documentation & Housekeeping

- [x] No breaking change to the schema — `model.max_tokens` is opt-in
- [x] Existing `context_length` semantics unchanged
