### PR TITLE
fix: preserve feishu media attachments in send_message

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -547,6 +547,30 @@ class TestSendToPlatformChunking:
         helper.assert_not_awaited()
         lightweight.assert_awaited_once()
 
+    def test_feishu_media_uses_native_adapter_helper(self, tmp_path):
+        image_path = tmp_path / "screenshot.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        helper = AsyncMock(return_value={"success": True, "platform": "feishu", "chat_id": "oc_123", "message_id": "om_456"})
+        with patch("tools.send_message_tool._send_feishu", helper):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "oc_123",
+                    "桌面截图",
+                    media_files=[(str(image_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        helper.assert_awaited_once()
+        call = helper.await_args
+        assert call.args[1] == "oc_123"
+        assert call.args[2] == "桌面截图"
+        assert call.kwargs["media_files"] == [(str(image_path), False)]
+        assert "warnings" not in result
+
     def test_send_matrix_via_adapter_sends_document(self, tmp_path):
         file_path = tmp_path / "report.pdf"
         file_path.write_bytes(b"%PDF-1.4 test")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -557,6 +557,23 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu/Lark: preserve native media uploads via adapter helper ---
+    if platform == Platform.FEISHU:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Signal: native attachment support via JSON-RPC attachments param ---
     if platform == Platform.SIGNAL and media_files:
         last_result = None
@@ -592,7 +609,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, feishu, weixin, signal and yuanbao; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -600,7 +617,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, feishu, weixin, signal and yuanbao"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary
- route Feishu/Lark sends with media through the native adapter helper
- preserve image/file/video/audio attachments instead of dropping them in the generic fallback path
- add a regression test covering Feishu media delivery through `send_message`

## Testing
- python -m pytest tests/tools/test_send_message_tool.py -q

## Context
Previously `send_message` only preserved native media delivery for Telegram, Discord, Matrix, and Weixin. Feishu already had adapter-level media send support, but the top-level routing logic never used it, so attachments were omitted before reaching the adapter.