### PR TITLE
fix: avoid reserved Slack status slash command

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2521,8 +2521,13 @@ class SlackAdapter(BasePlatformAdapter):
                 text = "/help"
         else:
             # Native slash — /<slash_name> [args].  Route directly through the
-            # gateway command dispatcher by prepending the slash.
-            text = f"/{slash_name} {text}".strip()
+            # gateway command dispatcher by prepending the slash. Some Slack-
+            # visible names are renamed away from reserved Slack command names;
+            # map those back to Hermes' internal command before dispatch.
+            from hermes_cli.commands import slack_native_command_map
+            command_map = slack_native_command_map()
+            route_command = command_map.get(slash_name, f"/{slash_name}")
+            text = f"{route_command} {text}".strip()
 
         source = self.build_source(
             chat_id=channel_id,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -838,6 +838,12 @@ def discord_skill_commands_by_category(
 _SLACK_MAX_SLASH_COMMANDS = 50
 _SLACK_NAME_LIMIT = 32
 _SLACK_INVALID_CHARS = re.compile(r"[^a-z0-9_\-]")
+_SLACK_RESERVED_COMMAND_RENAMES: dict[str, str] = {
+    # Slack rejects /status in some workspaces because it conflicts with
+    # Slack's reserved command namespace. Keep Hermes' internal command name
+    # as "status", but expose a Slack-safe native slash.
+    "status": "status1",
+}
 
 
 def _sanitize_slack_name(raw: str) -> str:
@@ -850,6 +856,54 @@ def _sanitize_slack_name(raw: str) -> str:
     name = _SLACK_INVALID_CHARS.sub("", name)
     name = name.strip("-_")
     return name[:_SLACK_NAME_LIMIT]
+
+
+def _slack_public_name(raw: str) -> str:
+    """Return the Slack-visible slash name for an internal command name."""
+    name = _sanitize_slack_name(raw)
+    return _SLACK_RESERVED_COMMAND_RENAMES.get(name, name)
+
+
+def _slack_native_entries() -> list[tuple[str, str, str, str]]:
+    """Return (slash_name, route_name, description, usage_hint) entries."""
+    overrides = _resolve_config_gates()
+    entries: list[tuple[str, str, str, str]] = []
+    seen: set[str] = set()
+
+    # Reserve /hermes as the catch-all top-level command.
+    entries.append(("hermes", "hermes", "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
+    seen.add("hermes")
+
+    def _add(name: str, route_name: str, desc: str, hint: str) -> None:
+        slack_name = _slack_public_name(name)
+        if not slack_name or slack_name in seen:
+            return
+        if len(entries) >= _SLACK_MAX_SLASH_COMMANDS:
+            return
+        # Slack description cap is 2000 chars; keep it short.
+        entries.append((slack_name, route_name, desc[:140], hint[:100]))
+        seen.add(slack_name)
+
+    # First pass: canonical names (so they win slots if we hit the cap).
+    for cmd in COMMAND_REGISTRY:
+        if not _is_gateway_available(cmd, overrides):
+            continue
+        _add(cmd.name, cmd.name, cmd.description, cmd.args_hint or "")
+
+    # Second pass: aliases.
+    for cmd in COMMAND_REGISTRY:
+        if not _is_gateway_available(cmd, overrides):
+            continue
+        for alias in cmd.aliases:
+            # Skip aliases that only differ from canonical by case/punctuation
+            # normalization (already covered by _add dedup).
+            _add(alias, alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
+
+    # Third pass: plugin commands.
+    for name, description, args_hint in _iter_plugin_command_entries():
+        _add(name, name, description, args_hint or "")
+
+    return entries
 
 
 def slack_native_slashes() -> list[tuple[str, str, str]]:
@@ -869,44 +923,18 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     legacy ``/hermes <subcommand>`` form keeps working for anything that
     gets dropped by the clamp or for free-form questions.
     """
-    overrides = _resolve_config_gates()
-    entries: list[tuple[str, str, str]] = []
-    seen: set[str] = set()
+    return [
+        (slash_name, desc, hint)
+        for slash_name, _route_name, desc, hint in _slack_native_entries()
+    ]
 
-    # Reserve /hermes as the catch-all top-level command.
-    entries.append(("hermes", "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
-    seen.add("hermes")
 
-    def _add(name: str, desc: str, hint: str) -> None:
-        slack_name = _sanitize_slack_name(name)
-        if not slack_name or slack_name in seen:
-            return
-        if len(entries) >= _SLACK_MAX_SLASH_COMMANDS:
-            return
-        # Slack description cap is 2000 chars; keep it short.
-        entries.append((slack_name, desc[:140], hint[:100]))
-        seen.add(slack_name)
-
-    # First pass: canonical names (so they win slots if we hit the cap).
-    for cmd in COMMAND_REGISTRY:
-        if not _is_gateway_available(cmd, overrides):
-            continue
-        _add(cmd.name, cmd.description, cmd.args_hint or "")
-
-    # Second pass: aliases.
-    for cmd in COMMAND_REGISTRY:
-        if not _is_gateway_available(cmd, overrides):
-            continue
-        for alias in cmd.aliases:
-            # Skip aliases that only differ from canonical by case/punctuation
-            # normalization (already covered by _add dedup).
-            _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
-
-    # Third pass: plugin commands.
-    for name, description, args_hint in _iter_plugin_command_entries():
-        _add(name, description, args_hint or "")
-
-    return entries
+def slack_native_command_map() -> dict[str, str]:
+    """Return Slack-visible slash name -> internal Hermes command mapping."""
+    return {
+        slash_name: f"/{route_name}"
+        for slash_name, route_name, _desc, _hint in _slack_native_entries()
+    }
 
 
 def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/commands") -> dict[str, Any]:
@@ -951,6 +979,9 @@ def slack_subcommand_map() -> dict[str, str]:
         if not _is_gateway_available(cmd, overrides):
             continue
         mapping[cmd.name] = f"/{cmd.name}"
+        slack_name = _slack_public_name(cmd.name)
+        if slack_name and slack_name != cmd.name:
+            mapping[slack_name] = f"/{cmd.name}"
         for alias in cmd.aliases:
             mapping[alias] = f"/{alias}"
     for name, _description, _args_hint in _iter_plugin_command_entries():

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -21,6 +21,7 @@ from hermes_cli.commands import (
     gateway_help_lines,
     resolve_command,
     slack_app_manifest,
+    slack_native_command_map,
     slack_native_slashes,
     slack_subcommand_map,
     telegram_bot_commands,
@@ -107,6 +108,9 @@ class TestResolveCommand:
         assert resolve_command("set-home").name == "sethome"
         assert resolve_command("reload_mcp").name == "reload-mcp"
         assert resolve_command("tasks").name == "agents"
+
+    def test_slack_safe_status_name_is_not_global_alias(self):
+        assert resolve_command("status1") is None
 
     def test_leading_slash_stripped(self):
         assert resolve_command("/help").name == "help"
@@ -251,6 +255,10 @@ class TestSlackSubcommandMap:
         assert "bg" in mapping
         assert "reset" in mapping
 
+    def test_includes_slack_safe_status_alias(self):
+        mapping = slack_subcommand_map()
+        assert mapping["status1"] == "/status"
+
     def test_excludes_cli_only_without_config_gate(self):
         mapping = slack_subcommand_map()
         for cmd in COMMAND_REGISTRY:
@@ -299,8 +307,14 @@ class TestSlackNativeSlashes:
     def test_includes_canonical_commands(self):
         names = {n for n, _d, _h in slack_native_slashes()}
         # Sample of gateway-available canonical commands
-        for expected in ("new", "stop", "background", "model", "help", "status"):
+        for expected in ("new", "stop", "background", "model", "help"):
             assert expected in names, f"missing canonical /{expected}"
+
+    def test_renames_reserved_status_command(self):
+        names = {n for n, _d, _h in slack_native_slashes()}
+        assert "status" not in names
+        assert "status1" in names
+        assert slack_native_command_map()["status1"] == "/status"
 
     def test_includes_aliases_as_first_class_slashes(self):
         """Aliases (/btw, /bg, /reset, /q) must be registered as standalone
@@ -320,14 +334,14 @@ class TestSlackNativeSlashes:
         test fails loudly so we can curate the list rather than silently
         dropping parity.
         """
-        slack_names = {n for n, _d, _h in slack_native_slashes()}
+        slack_routes = {route.lstrip("/") for route in slack_native_command_map().values()}
         tg_names = {n for n, _d in telegram_bot_commands()}
         # Some Telegram names have underscores where Slack uses hyphens
         # (e.g. set_home vs sethome). Normalize both sides for comparison.
         def _norm(s: str) -> str:
             return s.replace("-", "_").replace("__", "_").strip("_")
 
-        slack_norm = {_norm(n) for n in slack_names}
+        slack_norm = {_norm(n) for n in slack_routes}
         tg_norm = {_norm(n) for n in tg_names}
         missing = tg_norm - slack_norm
         assert not missing, (
@@ -360,6 +374,12 @@ class TestSlackAppManifest:
         m = slack_app_manifest()
         commands = [c["command"] for c in m["features"]["slash_commands"]]
         assert "/btw" in commands
+
+    def test_manifest_uses_slack_safe_status_name(self):
+        m = slack_app_manifest()
+        commands = [c["command"] for c in m["features"]["slash_commands"]]
+        assert "/status" not in commands
+        assert "/status1" in commands
 
     def test_custom_request_url(self):
         m = slack_app_manifest(request_url="https://example.com/slack")


### PR DESCRIPTION
## Summary
- rename Hermes' Slack-native `/status` slash command to `/status1` in generated manifests
- add a Slack-native command map so incoming `/status1` dispatches to Hermes' existing internal `/status` handler
- keep `/hermes status1` routing back to `/status` for users who type the Slack-safe name through the legacy catch-all command

## Why
Slack rejected the generated manifest in at least one workspace with `the slash command has an invalid name` for `/status`. Local setup confirmed `/status1` is accepted while `/help` and `/reload_mcp` were not the blocker.

Closes #17054

## Test plan
- `/home/omid/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_commands.py`
- `/home/omid/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/platforms/slack.py hermes_cli/commands.py`

Note: `ruff check tests/hermes_cli/test_commands.py` still reports pre-existing unrelated issues (`E741` and unused `MagicMock`), so this PR only linted the touched source modules and ran the focused test file.
