### PR TITLE
fix(voice): distinguish PortAudio runtime errors from missing Python packages

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1,6 +1,7 @@
 """Tests for tools.voice_mode -- all mocked, no real microphone or API calls."""
 
 import os
+import sys
 import struct
 import time
 import wave
@@ -269,7 +270,7 @@ class TestCheckVoiceRequirements:
         assert result["missing_packages"] == []
 
     def test_missing_audio_packages(self, monkeypatch):
-        monkeypatch.setattr("tools.voice_mode._audio_available", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._voice_audio_import_status", lambda: (False, "import"))
         monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
                             lambda: {"available": False, "warnings": ["Audio libraries not installed"]})
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test-key")
@@ -281,6 +282,27 @@ class TestCheckVoiceRequirements:
         assert result["audio_available"] is False
         assert "sounddevice" in result["missing_packages"]
         assert "numpy" in result["missing_packages"]
+
+    def test_missing_portaudio_oserror_lists_system_dependency(self, monkeypatch):
+        """Missing PortAudio (OSError) must not pretend Python wheels are missing."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test-key")
+        monkeypatch.setattr(
+            "tools.voice_mode._import_audio",
+            lambda: (_ for _ in ()).throw(OSError("PortAudio library not found")),
+        )
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: None)
+
+        from tools.voice_mode import check_voice_requirements
+
+        result = check_voice_requirements()
+        assert result["available"] is False
+        assert result["audio_available"] is False
+        assert "sounddevice" not in result["missing_packages"]
+        assert any("portaudio" in p for p in result["missing_packages"])
+        assert any("PortAudio" in line for line in result["details"].splitlines())
 
     def test_missing_stt_provider(self, monkeypatch):
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
@@ -388,6 +410,21 @@ class TestAudioRecorder:
         recorder = AudioRecorder()
         with pytest.raises(RuntimeError, match="sounddevice and numpy"):
             recorder.start()
+
+    def test_start_raises_portaudio_oserror_not_pip_wheels(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.voice_mode._voice_audio_import_status",
+            lambda: (False, "oserror"),
+        )
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        with pytest.raises(RuntimeError) as ei:
+            recorder.start()
+        lowered = str(ei.value).lower()
+        assert "portaudio" in lowered
+        assert "pip install sounddevice" not in lowered
 
     def test_start_creates_and_starts_stream(self, mock_sd):
         mock_stream = MagicMock()
@@ -1146,6 +1183,7 @@ class TestConfigurableSilenceParams:
 class TestSubprocessTimeoutKill:
     """Bug: proc.wait(timeout) raised TimeoutExpired but process was not killed."""
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix sleep binary not available on Windows PATH")
     def test_timeout_kills_process(self):
         import subprocess, os
         proc = subprocess.Popen(["sleep", "600"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -40,13 +40,21 @@ def _import_audio():
     return sd, np
 
 
-def _audio_available() -> bool:
-    """Return True if audio libraries can be imported."""
+def _voice_audio_import_status() -> tuple[bool, Optional[str]]:
+    """Return (ok, failure_kind) — failure_kind is ``import`` or ``oserror`` when not ok."""
     try:
         _import_audio()
-        return True
-    except (ImportError, OSError):
-        return False
+        return True, None
+    except ImportError:
+        return False, "import"
+    except OSError:
+        return False, "oserror"
+
+
+def _audio_available() -> bool:
+    """Return True if audio libraries can be imported."""
+    ok, _ = _voice_audio_import_status()
+    return ok
 
 
 from hermes_constants import is_termux as _is_termux_environment
@@ -56,6 +64,29 @@ def _voice_capture_install_hint() -> str:
     if _is_termux_environment():
         return "pkg install python-numpy portaudio && python -m pip install sounddevice"
     return "pip install sounddevice numpy"
+
+
+def _portaudio_system_install_hint() -> str:
+    """User-facing hints when PortAudio native libs are missing (not Python wheels)."""
+    if _is_termux_environment():
+        return (
+            "PortAudio system library not found -- install it first:\n"
+            "  Termux: pkg install portaudio\n"
+            "Then retry /voice on."
+        )
+    tail = "Then retry /voice on."
+    if platform.system().lower() == "windows":
+        return (
+            "PortAudio runtime not available for this Python build -- install matching native libs "
+            "or run under WSL2 with PulseAudio for capture.\n"
+            + tail
+        )
+    return (
+        "PortAudio system library not found -- install it first:\n"
+        "  Linux:  sudo apt-get install libportaudio2\n"
+        "  macOS:  brew install portaudio\n"
+        + tail
+    )
 
 
 def _termux_microphone_command() -> Optional[str]:
@@ -159,19 +190,8 @@ def detect_audio_environment() -> dict:
             warnings.append(
                 "Termux:API Android app is not installed. Install/update the Termux:API app to use termux-microphone-record."
             )
-        elif _is_termux_environment():
-            warnings.append(
-                "PortAudio system library not found -- install it first:\n"
-                "  Termux: pkg install portaudio\n"
-                "Then retry /voice on."
-            )
         else:
-            warnings.append(
-                "PortAudio system library not found -- install it first:\n"
-                "  Linux:  sudo apt-get install libportaudio2\n"
-                "  macOS:  brew install portaudio\n"
-                "Then retry /voice on."
-            )
+            warnings.append(_portaudio_system_install_hint())
 
     return {
         "available": not warnings,
@@ -578,13 +598,18 @@ class AudioRecorder:
         Raises ``RuntimeError`` if sounddevice/numpy are not installed
         or if a recording is already in progress.
         """
-        try:
-            _import_audio()
-        except (ImportError, OSError) as e:
+        ok, kind = _voice_audio_import_status()
+        if not ok:
+            if kind == "import":
+                raise RuntimeError(
+                    "Voice mode requires sounddevice and numpy.\n"
+                    f"Install with: {sys.executable} -m pip install sounddevice numpy\n"
+                    "Or: pip install hermes-agent[voice]"
+                )
             raise RuntimeError(
-                "Voice mode requires sounddevice and numpy.\n"
-                f"Install with: {sys.executable} -m pip install sounddevice numpy"
-            ) from e
+                "sounddevice imported but audio capture failed (typically missing PortAudio).\n"
+                + _portaudio_system_install_hint()
+            )
 
         with self._lock:
             if self._recording:
@@ -937,10 +962,14 @@ def check_voice_requirements() -> Dict[str, Any]:
 
     missing: List[str] = []
     termux_capture = _termux_voice_capture_available()
-    has_audio = _audio_available() or termux_capture
+    audio_ok, audio_kind = _voice_audio_import_status()
+    has_audio = audio_ok or termux_capture
 
-    if not has_audio:
-        missing.extend(["sounddevice", "numpy"])
+    if not has_audio and not termux_capture:
+        if audio_kind == "import":
+            missing.extend(["sounddevice", "numpy"])
+        elif audio_kind == "oserror":
+            missing.append("portaudio (system)")
 
     # Environment detection
     env_check = detect_audio_environment()
@@ -953,7 +982,12 @@ def check_voice_requirements() -> Dict[str, Any]:
     elif has_audio:
         details_parts.append("Audio capture: OK")
     else:
-        details_parts.append(f"Audio capture: MISSING ({_voice_capture_install_hint()})")
+        if audio_kind == "oserror":
+            details_parts.append(
+                "Audio capture: MISSING - PortAudio/native runtime (see Environment section below)."
+            )
+        else:
+            details_parts.append(f"Audio capture: MISSING ({_voice_capture_install_hint()})")
 
     if not stt_enabled:
         details_parts.append("STT provider: DISABLED in config (stt.enabled: false)")


### PR DESCRIPTION
## Summary
- Classify `sounddevice`/`numpy` load failures: `ImportError` (missing wheels) vs `OSError` (typically missing or broken PortAudio native runtime).
- `AudioRecorder.start` now surfaces PortAudio-oriented install hints for `OSError` instead of only suggesting `pip install`.
- `check_voice_requirements` reports `portaudio (system)` in `missing_packages` when import fails with `OSError`, and clarifies the details line so users are not told to reinstall wheels unnecessarily.
- Centralize PortAudio user hints in `_portaudio_system_install_hint()` (reused by `detect_audio_environment` and the recorder path).
- Tests: regression coverage for the new behavior; skip the subprocess timeout test on Windows where `sleep` is not available on PATH.

## Related
Closes #18432

## How to verify
1. Environment without PortAudio (or broken PortAudio) but with `sounddevice`/`numpy` installed: trigger voice capture or `check_voice_requirements` — message should point at system PortAudio / platform hints, not only pip.
2. Environment without `sounddevice`/`numpy`: message should still recommend installing wheels (via `python -m pip ...`).

## Tests
`pytest tests/tools/test_voice_mode.py -q`