### PR TITLE
fix(cli): honor LITELLM_KEY for OpenAI-compatible /models metadata probes

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -592,12 +592,16 @@ def fetch_endpoint_model_metadata(
     if alternate and alternate not in candidates:
         candidates.append(alternate)
 
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    effective_key = (api_key or "").strip()
+    if not effective_key:
+        effective_key = os.getenv("LITELLM_KEY", "").strip()
+
+    headers = {"Authorization": f"Bearer {effective_key}"} if effective_key else {}
     last_error: Optional[Exception] = None
 
     if is_local_endpoint(normalized):
         try:
-            if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
+            if detect_local_server_type(normalized, api_key=effective_key) == "lm-studio":
                 server_url = normalized[:-3].rstrip("/") if normalized.endswith("/v1") else normalized
                 response = requests.get(
                     server_url.rstrip("/") + "/api/v1/models",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1317,6 +1317,16 @@ def _resolve_openrouter_api_key() -> str:
     return os.getenv("OPENROUTER_API_KEY", "").strip()
 
 
+def _litellm_proxy_metadata_api_key() -> str:
+    """LiteLLM proxy master key for authenticated OpenAI-compat ``/models`` probes.
+
+    Users often run a LiteLLm proxy with ``LITELLM_KEY`` while Hermes resolves an
+    empty per-endpoint API key (custom base URL only).  Re-use the same env var
+    for metadata fetches only — never override an explicit API key.
+    """
+    return os.getenv("LITELLM_KEY", "").strip()
+
+
 def _resolve_nous_pricing_credentials() -> tuple[str, str]:
     """Return ``(api_key, base_url)`` for Nous Portal pricing, or empty strings."""
     try:
@@ -2809,11 +2819,15 @@ def probe_api_models(
 
     tried: list[str] = []
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
-    if api_key and api_mode == "anthropic_messages":
-        headers["x-api-key"] = api_key
-        headers["anthropic-version"] = "2023-06-01"
-    elif api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+    if api_mode == "anthropic_messages":
+        resolved = (api_key or "").strip()
+        if resolved:
+            headers["x-api-key"] = resolved
+            headers["anthropic-version"] = "2023-06-01"
+    else:
+        bearer = (api_key or "").strip() or _litellm_proxy_metadata_api_key()
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -30,6 +30,7 @@ from agent.model_metadata import (
     get_cached_context_length,
     parse_context_limit_from_error,
     save_context_length,
+    fetch_endpoint_model_metadata,
     fetch_model_metadata,
     _MODEL_CACHE_TTL,
 )
@@ -843,6 +844,52 @@ class TestFetchModelMetadata:
 
         result = fetch_model_metadata(force_refresh=True)
         assert result == {}
+
+
+class TestFetchEndpointModelMetadataLitellm:
+    """LITELLM_KEY fallback for OpenAI-compat endpoint metadata."""
+
+    def _reset_endpoint_cache(self):
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    @patch("agent.model_metadata.requests.get")
+    def test_uses_litellm_key_when_api_key_empty(self, mock_get, monkeypatch):
+        monkeypatch.setenv("LITELLM_KEY", "lm-master")
+        self._reset_endpoint_cache()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"id": "m1", "context_length": 8192}]}
+        mock_response.raise_for_status = MagicMock()
+        mock_response.ok = True
+        mock_get.return_value = mock_response
+
+        result = fetch_endpoint_model_metadata(
+            "http://127.0.0.1:4000/v1",
+            api_key="",
+            force_refresh=True,
+        )
+        assert "m1" in result
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer lm-master"
+
+    @patch("agent.model_metadata.requests.get")
+    def test_explicit_api_key_wins_over_litellm_env(self, mock_get, monkeypatch):
+        monkeypatch.setenv("LITELLM_KEY", "lm-master")
+        self._reset_endpoint_cache()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"id": "m1", "context_length": 4096}]}
+        mock_response.raise_for_status = MagicMock()
+        mock_response.ok = True
+        mock_get.return_value = mock_response
+
+        fetch_endpoint_model_metadata(
+            "http://127.0.0.1:4001/v1",
+            api_key="custom-user-key",
+            force_refresh=True,
+        )
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer custom-user-key"
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -304,6 +304,57 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
         assert probe["used_fallback"] is False
 
+    def test_probe_api_models_falls_back_to_litellm_key(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_KEY", "lit-only")
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "proxy-model"}]}'
+
+        captured: list[dict[str, str]] = []
+
+        def _fake_urlopen(req, timeout=5.0):
+            captured.append({k.lower(): v for k, v in req.header_items()})
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+            probe = probe_api_models("", "http://127.0.0.1:4000/v1")
+
+        assert probe["models"] == ["proxy-model"]
+        assert captured
+        assert captured[0].get("authorization") == "Bearer lit-only"
+
+    def test_probe_api_models_anthropic_mode_does_not_emit_litellm_bearer(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_KEY", "lit-only")
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": []}'
+
+        captured: list[dict[str, str]] = []
+
+        def _fake_urlopen(req, timeout=5.0):
+            captured.append({k.lower(): v for k, v in req.header_items()})
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+            probe_api_models("", "https://api.anthropic.com", api_mode="anthropic_messages")
+
+        for hdrs in captured:
+            assert "Bearer lit-only" not in hdrs.get("authorization", "")
+
     def test_fetch_github_model_catalog_filters_non_chat_models(self):
         class _Resp:
             def __enter__(self):


### PR DESCRIPTION
## Summary

When users run an OpenAI-compatible gateway (including LiteLLM) with **`LITELLM_KEY`** but Hermes resolves an empty per-endpoint API key, `/models` discovery and cached endpoint metadata previously sent **no** `Authorization` header. That breaks model listing / context probing for keyed proxies.

This PR:

- **`probe_api_models`**: uses `Bearer` **`LITELLM_KEY`** when the primary API key is empty, **except** for `api_mode == "anthropic_messages"` (where `Bearer` LiteLLM would be incorrect).
- **`fetch_endpoint_model_metadata`**: derives an `effective_key` with the same fallback and uses it consistently for LM Studio detection + HTTP metadata fetches.

`fetch_models_with_pricing` is **unchanged**: we avoid sending `LITELLM_KEY` to OpenRouter’s pricing fetch when `OPENROUTER_API_KEY` is unset.

Related: #4914, #4975  

## Test plan

- `pytest tests/hermes_cli/test_model_validation.py::TestFetchApiModels::test_probe_api_models_falls_back_to_litellm_key tests/hermes_cli/test_model_validation.py::TestFetchApiModels::test_probe_api_models_anthropic_mode_does_not_emit_litellm_bearer tests/agent/test_model_metadata.py::TestFetchEndpointModelMetadataLitellm -q -o addopts=`