### PR TITLE
Add Cursor Harness provider route

### DIFF
--- a/agent/cursor_harness_adapter.py
+++ b/agent/cursor_harness_adapter.py
@@ -1,0 +1,226 @@
+"""Hermes provider adapter for the external Hermes Cursor Harness plugin.
+
+The harness remains an independently installable plugin/package.  This module
+is the thin Hermes-core route that lets normal provider selection delegate a
+turn to Cursor while Hermes keeps session ownership, callbacks, and transcript
+persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+CURSOR_HARNESS_PROVIDER = "cursor-harness"
+CURSOR_HARNESS_API_MODE = "cursor_harness"
+CURSOR_MODEL_PREFIX = "cursor/"
+
+
+class CursorHarnessUnavailable(RuntimeError):
+    """Raised when the provider route is selected but the harness is missing."""
+
+
+def is_cursor_harness_route(
+    *,
+    provider: str | None = None,
+    api_mode: str | None = None,
+    model: str | None = None,
+) -> bool:
+    provider_norm = (provider or "").strip().lower()
+    mode_norm = (api_mode or "").strip().lower()
+    model_norm = (model or "").strip().lower()
+    return (
+        provider_norm in {CURSOR_HARNESS_PROVIDER, "cursor"}
+        or mode_norm == CURSOR_HARNESS_API_MODE
+        or model_norm.startswith(CURSOR_MODEL_PREFIX)
+    )
+
+
+def cursor_model_from_hermes(model: str | None) -> str | None:
+    """Map Hermes model ids such as ``cursor/composer-2`` to Cursor ids."""
+
+    raw = (model or "").strip()
+    if not raw:
+        return None
+    if raw.lower().startswith(CURSOR_MODEL_PREFIX):
+        raw = raw.split("/", 1)[1].strip()
+    if raw.lower() in {"", "default"}:
+        return None
+    return raw
+
+
+def render_cursor_prompt(
+    *,
+    messages: list[dict[str, Any]],
+    system_prompt: str | None = None,
+    current_turn_user_idx: int | None = None,
+    user_injections: Iterable[str] = (),
+    hermes_session_id: str | None = None,
+    model: str | None = None,
+    platform: str | None = None,
+) -> str:
+    """Render Hermes chat state into a single Cursor-agent prompt."""
+
+    sections: list[str] = []
+    header: dict[str, str] = {}
+    if hermes_session_id:
+        header["hermes_session_id"] = hermes_session_id
+    if model:
+        header["hermes_model"] = model
+    if platform:
+        header["hermes_platform"] = platform
+    if header:
+        sections.append("<hermes_turn_metadata>\n" + json.dumps(header, indent=2, sort_keys=True) + "\n</hermes_turn_metadata>")
+
+    if system_prompt and str(system_prompt).strip():
+        sections.append("<hermes_system_context>\n" + str(system_prompt).strip() + "\n</hermes_system_context>")
+
+    rendered_messages: list[str] = []
+    injection_text = "\n\n".join(str(item).strip() for item in user_injections if str(item).strip())
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "unknown").strip() or "unknown"
+        content = _message_text(msg)
+        if idx == current_turn_user_idx and role == "user" and injection_text:
+            content = (content + "\n\n" + injection_text).strip()
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            content = (content + "\n\nTool calls:\n" + _stable_json(tool_calls)).strip()
+        if content:
+            rendered_messages.append(f"{role}:\n{content}")
+
+    if rendered_messages:
+        sections.append("<hermes_conversation>\n" + "\n\n---\n\n".join(rendered_messages) + "\n</hermes_conversation>")
+
+    sections.append(
+        "You are Cursor Agent running inside a Hermes-owned session. "
+        "Use the repository as the source of truth, follow the current user request, "
+        "and return the final answer for Hermes to deliver."
+    )
+    return "\n\n".join(sections).strip()
+
+
+def run_cursor_harness_provider_turn(
+    *,
+    prompt: str,
+    hermes_session_id: str,
+    model: str | None = None,
+    project: str | None = None,
+    mode: str | None = None,
+    transport: str | None = None,
+    timeout_sec: float | None = None,
+    event_callback: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Run one provider-routed Cursor turn through the installed harness."""
+
+    _ensure_harness_importable()
+    from hermes_cursor_harness.config import load_config
+    from hermes_cursor_harness.harness import run_turn
+    from hermes_cursor_harness.store import HarnessStore
+
+    cfg = load_config()
+    store = HarnessStore(cfg.state_dir)
+    return run_turn(
+        cfg=cfg,
+        store=store,
+        project=project or _default_project(),
+        prompt=prompt,
+        mode=mode or _env("HERMES_CURSOR_HARNESS_MODE"),
+        model=cursor_model_from_hermes(model),
+        hermes_session_id=hermes_session_id,
+        new_session=False,
+        transport=transport or _env("HERMES_CURSOR_HARNESS_TRANSPORT"),
+        timeout_sec=timeout_sec,
+        event_callback=event_callback,
+    )
+
+
+def _message_text(msg: dict[str, Any]) -> str:
+    content = msg.get("content", "")
+    text = _content_text(content).strip()
+    if msg.get("tool_name"):
+        text = f"{msg.get('tool_name')}: {text}".strip()
+    return text
+
+
+def _content_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            text = _content_text(item)
+            if text:
+                parts.append(text)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        for key in ("text", "content", "result"):
+            value = content.get(key)
+            if isinstance(value, str):
+                return value
+        return _stable_json(content)
+    return str(content)
+
+
+def _stable_json(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _env(name: str) -> str | None:
+    value = os.getenv(name, "").strip()
+    return value or None
+
+
+def _default_project() -> str:
+    return _env("HERMES_CURSOR_PROJECT") or _env("HERMES_CURSOR_HARNESS_PROJECT") or os.getcwd()
+
+
+def _ensure_harness_importable() -> None:
+    try:
+        import hermes_cursor_harness  # noqa: F401
+        return
+    except Exception:
+        pass
+
+    for candidate in _candidate_harness_paths():
+        if candidate.exists():
+            sys.path.insert(0, str(candidate))
+            try:
+                import hermes_cursor_harness  # noqa: F401
+                return
+            except Exception:
+                try:
+                    sys.path.remove(str(candidate))
+                except ValueError:
+                    pass
+
+    raise CursorHarnessUnavailable(
+        "The cursor-harness provider requires the hermes-cursor-harness plugin. "
+        "Install it into ~/.hermes/plugins/hermes-cursor-harness or install the "
+        "package on PYTHONPATH."
+    )
+
+
+def _candidate_harness_paths() -> list[Path]:
+    paths: list[Path] = []
+    explicit = _env("HERMES_CURSOR_HARNESS_PYTHONPATH")
+    if explicit:
+        paths.append(Path(explicit).expanduser())
+    hermes_home = Path(os.getenv("HERMES_HOME", "~/.hermes")).expanduser()
+    paths.append(hermes_home / "plugins" / "hermes-cursor-harness")
+
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        paths.append(parent / "hermes-cursor-harness")
+        paths.append(parent.parent / "hermes-cursor-harness")
+    return paths

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -174,6 +174,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor-harness": ProviderConfig(
+        id="cursor-harness",
+        name="Cursor Harness",
+        auth_type="external_process",
+        inference_base_url="cursor://harness",
+        base_url_env_var="HERMES_CURSOR_HARNESS_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -1127,6 +1134,8 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "cursor": "cursor-harness", "cursor-agent": "cursor-harness",
+        "cursor-harness": "cursor-harness",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
@@ -3416,6 +3425,26 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def get_cursor_harness_status() -> Dict[str, Any]:
+    """Status snapshot for the Cursor Harness provider route."""
+    command = (
+        os.getenv("HERMES_CURSOR_HARNESS_STREAM_COMMAND", "").strip().split(" ", 1)[0]
+        or shutil.which("agent")
+        or shutil.which("cursor-agent")
+        or shutil.which("cursor")
+        or ""
+    )
+    plugin_dir = Path(os.getenv("HERMES_HOME", "~/.hermes")).expanduser() / "plugins" / "hermes-cursor-harness"
+    return {
+        "configured": bool(command and (plugin_dir.exists() or os.getenv("HERMES_CURSOR_HARNESS_PYTHONPATH"))),
+        "provider": "cursor-harness",
+        "name": "Cursor Harness",
+        "command": command,
+        "plugin_dir": str(plugin_dir),
+        "logged_in": bool(command),
+    }
+
+
 def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Generic auth status dispatcher."""
     target = provider_id or get_active_provider()
@@ -3431,6 +3460,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "copilot-acp":
         return get_external_process_provider_status(target)
+    if target == "cursor-harness":
+        return get_cursor_harness_status()
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -154,6 +154,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor-harness": [
+        "cursor/default",
+        "cursor/auto",
+        "cursor/composer-2-fast",
+        "cursor/composer-2",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -721,6 +727,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+    ProviderEntry("cursor-harness", "Cursor Harness",           "Cursor Harness (delegates Hermes turns to Cursor Agent)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
@@ -758,6 +765,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor": "cursor-harness",
+    "cursor-agent": "cursor-harness",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -1802,6 +1811,20 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "cursor-harness":
+        try:
+            from agent.cursor_harness_adapter import _ensure_harness_importable
+
+            _ensure_harness_importable()
+            from hermes_cursor_harness.config import load_config
+            from hermes_cursor_harness.models import list_cursor_models
+
+            result = list_cursor_models(load_config(), timeout_sec=10)
+            live = [f"cursor/{item['id']}" for item in result.get("models", []) if item.get("id")]
+            if live:
+                return live
+        except Exception:
+            pass
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -77,6 +77,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor-harness": HermesOverlay(
+        transport="cursor_harness",
+        auth_type="external_process",
+        base_url_override="cursor://harness",
+        base_url_env_var="HERMES_CURSOR_HARNESS_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -242,6 +248,8 @@ ALIASES: Dict[str, str] = {
     "copilot": "github-copilot",
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
+    "cursor": "cursor-harness",
+    "cursor-agent": "cursor-harness",
 
     # vercel (models.dev ID for AI Gateway)
     "ai-gateway": "vercel",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -164,7 +164,7 @@ def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
         return "chat_completions"
 
 
-_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}
+_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "cursor_harness"}
 
 
 def _parse_api_mode(raw: Any) -> Optional[str]:
@@ -832,6 +832,18 @@ def resolve_runtime_provider(
     behavior (api_mode derived from config).
     """
     requested_provider = resolve_requested_provider(requested)
+    model_cfg = _get_model_config()
+    model_hint = str(target_model or model_cfg.get("default") or "").strip().lower()
+
+    if requested_provider in {"cursor", "cursor-harness"} or model_hint.startswith("cursor/"):
+        return {
+            "provider": "cursor-harness",
+            "api_mode": "cursor_harness",
+            "base_url": os.getenv("HERMES_CURSOR_HARNESS_BASE_URL", "cursor://harness").rstrip("/"),
+            "api_key": "cursor-harness",
+            "source": "cursor-agent",
+            "requested_provider": requested_provider,
+        }
 
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
@@ -881,7 +893,6 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
-    model_cfg = _get_model_config()
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,
         requested_provider=requested_provider,

--- a/run_agent.py
+++ b/run_agent.py
@@ -900,7 +900,8 @@ class AIAgent:
             base_url (str): Base URL for the model API (optional)
             api_key (str): API key for authentication (optional, uses env var if not provided)
             provider (str): Provider identifier (optional; used for telemetry/routing hints)
-            api_mode (str): API mode override: "chat_completions" or "codex_responses"
+            api_mode (str): API mode override: "chat_completions", "codex_responses",
+                "anthropic_messages", "bedrock_converse", or "cursor_harness"
             model (str): Model name to use (default: "anthropic/claude-opus-4.6")
             max_iterations (int): Maximum number of tool calling iterations (default: 90)
             tool_delay (float): Delay between tool calls in seconds (default: 1.0)
@@ -972,8 +973,11 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "cursor_harness"}:
             self.api_mode = api_mode
+        elif self.provider == "cursor-harness" or (self.model or "").strip().lower().startswith("cursor/"):
+            self.api_mode = "cursor_harness"
+            self.provider = "cursor-harness"
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
         elif self.provider == "xai":
@@ -1038,7 +1042,7 @@ class AIAgent:
         if (
             api_mode is None
             and self.api_mode == "chat_completions"
-            and self.provider != "copilot-acp"
+            and self.provider not in {"copilot-acp", "cursor-harness"}
             and not str(self.base_url or "").lower().startswith("acp://copilot")
             and not str(self.base_url or "").lower().startswith("acp+tcp://")
             and not self._is_azure_openai_url()
@@ -1313,6 +1317,14 @@ class AIAgent:
             if not self.quiet_mode:
                 _gr_label = " + Guardrails" if self._bedrock_guardrail_config else ""
                 print(f"🤖 AI Agent initialized with model: {self.model} (AWS Bedrock, {self._bedrock_region}{_gr_label})")
+        elif self.api_mode == "cursor_harness":
+            self.provider = "cursor-harness"
+            self.api_key = api_key or "cursor-harness"
+            self.base_url = base_url or "cursor://harness"
+            self.client = None
+            self._client_kwargs = {}
+            if not self.quiet_mode:
+                print(f"🤖 AI Agent initialized with model: {self.model or 'cursor/default'} (Cursor Harness)")
         else:
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
@@ -9200,6 +9212,218 @@ class AIAgent:
 
         return final_response
 
+    def _cursor_harness_overrides(self) -> Dict[str, Any]:
+        overrides = getattr(self, "request_overrides", None)
+        return overrides if isinstance(overrides, dict) else {}
+
+    def _cursor_harness_option(self, *keys: str) -> Any:
+        overrides = self._cursor_harness_overrides()
+        for key in keys:
+            if key in overrides and overrides[key] not in (None, ""):
+                return overrides[key]
+        return None
+
+    def _cursor_harness_event_callback(self, stream_callback: Optional[callable] = None) -> callable:
+        def _on_event(item: dict[str, Any]) -> None:
+            if not isinstance(item, dict):
+                return
+            etype = item.get("type")
+            if etype == "message_delta" and item.get("role") == "assistant":
+                text = str(item.get("text") or "")
+                if not text:
+                    return
+                self._response_was_previewed = True
+                callbacks = []
+                seen_callbacks = set()
+                for callback in (self.stream_delta_callback, self._stream_callback, stream_callback):
+                    if callback is None:
+                        continue
+                    ident = id(callback)
+                    if ident in seen_callbacks:
+                        continue
+                    seen_callbacks.add(ident)
+                    callbacks.append(callback)
+                for callback in callbacks:
+                    try:
+                        callback(text)
+                    except Exception:
+                        logger.debug("Cursor harness stream callback failed", exc_info=True)
+                return
+            if etype == "tool_call":
+                tool_name = str(item.get("tool_name") or "cursor_tool")
+                if self.tool_progress_callback:
+                    try:
+                        self.tool_progress_callback(tool_name, item.get("payload"))
+                    except Exception:
+                        logger.debug("Cursor harness tool callback failed", exc_info=True)
+                else:
+                    self._emit_status(f"Cursor tool: {tool_name}")
+                return
+            if etype in {"session_started", "mode_changed"}:
+                detail = item.get("mode") or item.get("cursor_session_id") or "started"
+                self._emit_status(f"Cursor harness {etype.replace('_', ' ')}: {detail}")
+
+        return _on_event
+
+    def _run_cursor_harness_conversation(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        active_system_prompt: str,
+        current_turn_user_idx: int,
+        original_user_message: Any,
+        plugin_user_context: str,
+        external_prefetch_context: str,
+        effective_task_id: str,
+        conversation_history: Optional[List[Dict[str, Any]]],
+        stream_callback: Optional[callable],
+    ) -> Dict[str, Any]:
+        from agent.cursor_harness_adapter import (
+            render_cursor_prompt,
+            run_cursor_harness_provider_turn,
+        )
+
+        injections: list[str] = []
+        if external_prefetch_context:
+            fenced = build_memory_context_block(external_prefetch_context)
+            if fenced:
+                injections.append(fenced)
+        if plugin_user_context:
+            injections.append(plugin_user_context)
+
+        prompt = render_cursor_prompt(
+            messages=messages,
+            system_prompt=active_system_prompt,
+            current_turn_user_idx=current_turn_user_idx,
+            user_injections=injections,
+            hermes_session_id=self.session_id,
+            model=self.model,
+            platform=getattr(self, "platform", None) or "",
+        )
+
+        timeout_raw = self._cursor_harness_option("cursor_timeout_sec", "cursor_harness_timeout_sec")
+        timeout_sec = float(timeout_raw) if timeout_raw not in (None, "") else None
+        self._touch_activity("running Cursor harness turn")
+        self._emit_status("Delegating this turn to Cursor Harness")
+
+        try:
+            cursor_result = run_cursor_harness_provider_turn(
+                prompt=prompt,
+                hermes_session_id=self.session_id,
+                model=self.model,
+                project=self._cursor_harness_option("cursor_project", "cursor_harness_project", "project"),
+                mode=self._cursor_harness_option("cursor_mode", "cursor_harness_mode", "mode"),
+                transport=self._cursor_harness_option("cursor_transport", "cursor_harness_transport"),
+                timeout_sec=timeout_sec,
+                event_callback=self._cursor_harness_event_callback(stream_callback),
+            )
+        except Exception as exc:
+            logger.warning("Cursor harness provider turn failed: %s", exc, exc_info=True)
+            self._emit_warning(f"Cursor Harness failed: {exc}")
+            cursor_result = {
+                "success": False,
+                "transport": "cursor_harness",
+                "text": "",
+                "error": str(exc),
+                "events": [],
+            }
+
+        final_response = str(cursor_result.get("text") or "").strip()
+        if not final_response:
+            error = cursor_result.get("error") or cursor_result.get("fallback_reason")
+            final_response = f"Cursor harness did not return a final response. {error}".strip() if error else "(empty)"
+
+        assistant_msg = {
+            "role": "assistant",
+            "content": final_response,
+            "finish_reason": cursor_result.get("stop_reason") or "stop",
+            "cursor_harness": {
+                "harness_session_id": cursor_result.get("harness_session_id"),
+                "cursor_session_id": cursor_result.get("cursor_session_id"),
+                "transport": cursor_result.get("transport"),
+                "modified_files": cursor_result.get("modified_files") or [],
+            },
+        }
+        messages.append(assistant_msg)
+
+        completed = bool(cursor_result.get("success", True))
+        self._save_trajectory(messages, _summarize_user_message_for_log(original_user_message), completed)
+        self._cleanup_task_resources(effective_task_id)
+        self._persist_session(messages, conversation_history)
+
+        logger.info(
+            "Turn ended: reason=cursor_harness(%s) model=%s provider=%s response_len=%d session=%s",
+            cursor_result.get("transport") or "unknown",
+            self.model,
+            self.provider or "cursor-harness",
+            len(final_response),
+            self.session_id or "none",
+        )
+
+        if final_response:
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "post_llm_call",
+                    session_id=self.session_id,
+                    user_message=original_user_message,
+                    assistant_response=final_response,
+                    conversation_history=list(messages),
+                    model=self.model,
+                    platform=getattr(self, "platform", None) or "",
+                )
+            except Exception as exc:
+                logger.warning("post_llm_call hook failed: %s", exc)
+
+        result = {
+            "final_response": final_response,
+            "last_reasoning": None,
+            "messages": messages,
+            "api_calls": 1,
+            "completed": completed,
+            "partial": False,
+            "interrupted": False,
+            "response_previewed": getattr(self, "_response_was_previewed", False),
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "input_tokens": self.session_input_tokens,
+            "output_tokens": self.session_output_tokens,
+            "cache_read_tokens": self.session_cache_read_tokens,
+            "cache_write_tokens": self.session_cache_write_tokens,
+            "reasoning_tokens": self.session_reasoning_tokens,
+            "prompt_tokens": self.session_prompt_tokens,
+            "completion_tokens": self.session_completion_tokens,
+            "total_tokens": self.session_total_tokens,
+            "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
+            "estimated_cost_usd": self.session_estimated_cost_usd,
+            "cost_status": self.session_cost_status,
+            "cost_source": self.session_cost_source,
+            "cursor_harness": cursor_result,
+        }
+        self._response_was_previewed = False
+        self._sync_external_memory_for_turn(
+            original_user_message=original_user_message,
+            final_response=final_response,
+            interrupted=False,
+        )
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_end",
+                session_id=self.session_id,
+                completed=completed,
+                interrupted=False,
+                model=self.model,
+                platform=getattr(self, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_end hook failed: %s", exc)
+
+        self.clear_interrupt()
+        self._stream_callback = None
+        return result
+
     def run_conversation(
         self,
         user_message: str,
@@ -9568,6 +9792,19 @@ class AIAgent:
                 _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
+
+        if self.api_mode == "cursor_harness" or self.provider == "cursor-harness":
+            return self._run_cursor_harness_conversation(
+                messages=messages,
+                active_system_prompt=active_system_prompt,
+                current_turn_user_idx=current_turn_user_idx,
+                original_user_message=original_user_message,
+                plugin_user_context=_plugin_user_context,
+                external_prefetch_context=_ext_prefetch_cache,
+                effective_task_id=effective_task_id,
+                conversation_history=conversation_history,
+                stream_callback=stream_callback,
+            )
 
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot

--- a/tests/test_cursor_harness_provider.py
+++ b/tests/test_cursor_harness_provider.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+def test_cursor_model_prefix_resolves_cursor_runtime(monkeypatch):
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "resolve_requested_provider", lambda requested=None: "auto")
+    monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {"default": "cursor/default"})
+
+    runtime = runtime_provider.resolve_runtime_provider()
+
+    assert runtime["provider"] == "cursor-harness"
+    assert runtime["api_mode"] == "cursor_harness"
+    assert runtime["base_url"] == "cursor://harness"
+
+
+def test_cursor_provider_request_resolves_cursor_runtime(monkeypatch):
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "resolve_requested_provider", lambda requested=None: "cursor-harness")
+    monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {"default": "cursor/composer-2"})
+
+    runtime = runtime_provider.resolve_runtime_provider()
+
+    assert runtime["provider"] == "cursor-harness"
+    assert runtime["api_mode"] == "cursor_harness"
+    assert runtime["requested_provider"] == "cursor-harness"
+
+
+def test_cursor_model_mapping_and_prompt_rendering():
+    from agent.cursor_harness_adapter import cursor_model_from_hermes, render_cursor_prompt
+
+    assert cursor_model_from_hermes("cursor/default") is None
+    assert cursor_model_from_hermes("cursor/composer-2") == "composer-2"
+
+    prompt = render_cursor_prompt(
+        messages=[{"role": "user", "content": "Fix the test"}],
+        system_prompt="Hermes system context",
+        current_turn_user_idx=0,
+        user_injections=["Memory context"],
+        hermes_session_id="hermes-1",
+        model="cursor/default",
+        platform="cli",
+    )
+
+    assert "<hermes_system_context>" in prompt
+    assert "Fix the test" in prompt
+    assert "Memory context" in prompt
+    assert "hermes-1" in prompt


### PR DESCRIPTION
## Summary
- Add a native `cursor-harness` provider route for Hermes.
- Route `cursor/*` models to an installed `hermes-cursor-harness` package while Hermes keeps session ownership, callbacks, transcript persistence, and provider resolution.
- Add live Cursor model discovery fallback and provider/auth status wiring.
- Add focused provider-route tests.

Standalone package: https://github.com/Cosmic-Construct/hermes-cursor-harness
Release: https://github.com/Cosmic-Construct/hermes-cursor-harness/releases/tag/v0.1.1

## Validation
- Hermes provider-route tests passed locally: `pytest tests/test_cursor_harness_provider.py -q`.
- Standalone package release gate passed locally: `PYTHON=.venv/bin/python scripts/release_check.sh --skip-build --disable-sdk-sandbox`.
- Standalone package public CI is passing on macOS and Ubuntu across Python 3.10, 3.12, and 3.13.
- Standalone package private Cursor compatibility lane passed with SDK auth/catalog and compatibility matrix coverage.
- Standalone package live full smoke passed locally against Cursor SDK/ACP/stream-json.

## Security Notes
- The standalone package now uses a scoped child-process environment for Cursor SDK, ACP, stream-json, diagnostics, probes, and approval bridge subprocesses.
- Cursor credentials are forwarded only to Cursor children that need them; approval bridge subprocesses do not receive Cursor/API credentials.
- Regression tests cover non-inheritance of provider, Gateway, and GitHub tokens.

## Notes
- This keeps the harness package independent so Cursor SDK/CLI compatibility can evolve outside Hermes core.
- Ready for maintainer review; naming, docs placement, and route-shape feedback are welcome.