### PR TITLE
fix(dashboard): compute honest per-day session averages

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2741,6 +2741,15 @@ async def get_usage_analytics(days: int = 30):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
+
+        # Compute actual span of data for honest per-day averages
+        first_session = db._conn.execute(
+            "SELECT MIN(started_at) FROM sessions WHERE started_at > ?", (cutoff,)
+        ).fetchone()[0]
+        span_days = days
+        if first_session:
+            span_days = max(1, min(days, int((time.time() - first_session) / 86400) + 1))
+
         insights_report = InsightsEngine(db).generate(days=days)
         skills = insights_report.get("skills", {
             "summary": {
@@ -2757,6 +2766,7 @@ async def get_usage_analytics(days: int = 30):
             "by_model": by_model,
             "totals": totals,
             "period_days": days,
+            "span_days": span_days,
             "skills": skills,
         }
     finally:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -465,6 +465,8 @@ export interface AnalyticsResponse {
     total_sessions: number;
     total_api_calls: number;
   };
+  period_days: number;
+  span_days: number;
   skills: {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -498,7 +498,7 @@ export default function AnalyticsPage() {
                     },
                     {
                       label: t.analytics.totalSessions,
-                      value: `${data.totals.total_sessions} (~${(data.totals.total_sessions / days).toFixed(1)}${t.analytics.perDayAvg})`,
+                      value: `${data.totals.total_sessions} (~${(data.totals.total_sessions / (data.span_days ?? days)).toFixed(1)}${t.analytics.perDayAvg})`,
                     },
                     {
                       label: t.analytics.apiCalls,


### PR DESCRIPTION
## Problem

The analytics dashboard showed sessions-per-day by dividing `total_sessions` by the user-selected window (7, 30 or 90 days). When the user had fewer actual days of history than the selection, this silently understated the average.

For example, selecting **90D** with only **10 days** of session history produced `~1.1/day` instead of the correct `~9.8/day`.

## Fix

- **Backend** (`web_server.py`): query `MIN(started_at)` inside the selected window, compute `span_days = max(1, min(days, time_since_first_session + 1))`, and return it alongside `period_days`.
- **API types** (`api.ts`): add `period_days` and `span_days` to `AnalyticsResponse`.
- **Frontend** (`AnalyticsPage.tsx`): divide by `data.span_days ?? data.period_days` instead of the raw `days` constant.

## Files changed

| File | What changed |
|------|-------------|
| `hermes_cli/web_server.py` | Compute + return `span_days` |
| `web/src/lib/api.ts` | Add `period_days` / `span_days` to `AnalyticsResponse` |
| `web/src/pages/AnalyticsPage.tsx` | Use `span_days` for avg denominator |