### PR TITLE
fix(chat_completions): propagate temperature and parallel_tool_calls for custom providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -245,10 +245,15 @@ class ChatCompletionsTransport(ProviderTransport):
         # Temperature
         fixed_temp = params.get("fixed_temperature")
         omit_temp = params.get("omit_temperature", False)
+        is_custom = params.get("is_custom_provider", False)
         if omit_temp:
             api_kwargs.pop("temperature", None)
         elif fixed_temp is not None:
             api_kwargs["temperature"] = fixed_temp
+        elif is_custom:
+            # Custom OpenAI-compatible providers: set sensible default temperature
+            # (llama.cpp defaults to 1.0 which causes factual drift)
+            api_kwargs["temperature"] = params.get("temperature", 0.2)
 
         # Qwen metadata (caller precomputes {sessionId, promptId})
         qwen_meta = params.get("qwen_session_metadata")
@@ -263,6 +268,10 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            # Custom OpenAI-compatible providers: enable parallel_tool_calls by default
+            # (many local backends like llama.cpp require it explicitly)
+            if params.get("is_custom_provider", False):
+                api_kwargs.setdefault("parallel_tool_calls", True)
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -782,6 +782,13 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            # Profiles whose backends only batch tool rounds when the field is
+            # sent explicitly (local OpenAI-compat servers) declare a default
+            # here; request_overrides are merged later and still win.
+            if profile.parallel_tool_calls_default is not None:
+                api_kwargs.setdefault(
+                    "parallel_tool_calls", profile.parallel_tool_calls_default
+                )
 
         # max_tokens resolution — priority: ephemeral > user > profile default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -139,6 +139,13 @@ custom = CustomProfile(
     ),
     env_vars=(),  # No fixed key — custom endpoint
     base_url="",  # User-configured
+    # llama.cpp & friends default to temperature=1.0 when the field is omitted,
+    # which causes factual drift on local models (#18470); pin a sensible
+    # default instead. request_overrides are merged later and still win.
+    fixed_temperature=0.2,
+    # Same backends only batch multiple tool calls in one round when the flag
+    # is sent explicitly (#18470).
+    parallel_tool_calls_default=True,
     # Without this, no max_tokens is sent and Ollama falls back to its internal
     # num_predict=128, truncating responses after a few tokens (#39281). This is
     # only a floor used when the user hasn't set model.max_tokens — they can

--- a/providers/base.py
+++ b/providers/base.py
@@ -93,6 +93,10 @@ class ProviderProfile:
     # ── Request-level quirks ─────────────────────────────────
     # Temperature: None = use caller's default, OMIT_TEMPERATURE = don't send
     fixed_temperature: Any = None
+    # parallel_tool_calls: None = omit the field, True/False = send as the
+    # default (request_overrides still win). Local OpenAI-compat backends
+    # (llama.cpp et al.) batch tool rounds only when it is sent explicitly.
+    parallel_tool_calls_default: bool | None = None
     default_max_tokens: int | None = None
     default_aux_model: str = (
         ""  # cheap model for auxiliary tasks (compression, vision, etc.)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -148,6 +148,54 @@ class TestChatCompletionsBuildKwargs:
             "thinkingLevel": "high",
         }
 
+    def test_custom_provider_sets_default_temperature(self, transport):
+        """Custom OpenAI-compatible providers should get a sensible temperature default."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
+        kw = transport.build_kwargs(
+            model="custom-model",
+            messages=msgs,
+            tools=tools,
+            is_custom_provider=True,
+        )
+        assert "temperature" in kw
+        assert kw["temperature"] == 0.2
+
+    def test_custom_provider_with_explicit_temperature_not_overridden(self, transport):
+        """Custom providers with explicit fixed_temperature should not be overridden."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="custom-model",
+            messages=msgs,
+            is_custom_provider=True,
+            fixed_temperature=0.7,
+        )
+        assert kw["temperature"] == 0.7
+
+    def test_custom_provider_sets_parallel_tool_calls_default(self, transport):
+        """Custom OpenAI-compatible providers should enable parallel_tool_calls by default."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
+        kw = transport.build_kwargs(
+            model="custom-model",
+            messages=msgs,
+            tools=tools,
+            is_custom_provider=True,
+        )
+        assert "parallel_tool_calls" in kw
+        assert kw["parallel_tool_calls"] is True
+
+    def test_non_custom_provider_no_temperature_default(self, transport):
+        """Non-custom providers without fixed_temperature should not add temperature."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            is_custom_provider=False,
+        )
+        # Only add temperature if fixed_temperature is set
+        assert "temperature" not in kw
+
     def test_gemini_openai_compat_flash_reasoning_maps_to_nested_google_thinking_config(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -180,3 +180,19 @@ class TestCustomReasoningWithNumCtx:
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
 
+
+class TestCustomRequestQuirks:
+    """Declarative request-level quirks for local OpenAI-compat backends (#18470).
+
+    llama.cpp defaults to temperature=1.0 when the field is omitted (factual
+    drift), and local backends only batch tool rounds when parallel_tool_calls
+    is sent explicitly. The transport consumes both declarations; end-to-end
+    wiring is pinned in tests/providers/test_e2e_wiring.py.
+    """
+
+    def test_fixed_temperature_default(self, custom_profile):
+        assert custom_profile.fixed_temperature == 0.2
+
+    def test_parallel_tool_calls_default(self, custom_profile):
+        assert custom_profile.parallel_tool_calls_default is True
+

--- a/tests/providers/test_e2e_wiring.py
+++ b/tests/providers/test_e2e_wiring.py
@@ -105,3 +105,79 @@ class TestDeepSeekProfileWiring:
         assert kwargs["model"] == "deepseek-chat"
         assert kwargs.get("max_tokens") is None or "max_tokens" not in kwargs
 
+
+class TestCustomProfileWiring:
+    """provider=custom: temperature + parallel_tool_calls reach the wire (#18470).
+
+    Local OpenAI-compat backends (llama.cpp, vLLM) default to temperature=1.0
+    and refuse to batch tool rounds when the fields are omitted, so the custom
+    profile must emit both; request_overrides are merged last and still win.
+    """
+
+    TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "run a command",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    def test_custom_sends_temperature_and_parallel_tool_calls(self, transport):
+        profile = get_provider_profile("custom")
+        kwargs = transport.build_kwargs(
+            model="llama3",
+            messages=_msgs(),
+            tools=self.TOOLS,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config=None,
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        assert kwargs["temperature"] == 0.2
+        assert kwargs["parallel_tool_calls"] is True
+
+    def test_custom_parallel_tool_calls_omitted_without_tools(self, transport):
+        profile = get_provider_profile("custom")
+        kwargs = transport.build_kwargs(
+            model="llama3",
+            messages=_msgs(),
+            tools=None,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config=None,
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        # temperature still pinned; parallel_tool_calls is meaningless without
+        # tools and must stay off the wire
+        assert kwargs["temperature"] == 0.2
+        assert "parallel_tool_calls" not in kwargs
+
+    def test_custom_request_overrides_win(self, transport):
+        profile = get_provider_profile("custom")
+        kwargs = transport.build_kwargs(
+            model="llama3",
+            messages=_msgs(),
+            tools=self.TOOLS,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config=None,
+            request_overrides={"temperature": 0.7, "parallel_tool_calls": False},
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["parallel_tool_calls"] is False
+


### PR DESCRIPTION
## What does this PR do?

- Add default temperature (0.2) for custom OpenAI-compatible providers to avoid llama.cpp's default of 1.0 which causes factual drift
- Enable `parallel_tool_calls` by default for custom providers to allow multi-tool queries in a single turn instead of serializing into N sequential turns


### Root Cause

Custom OpenAI-compatible providers (configured via `custom_providers`) use `chat_completions` transport. Two important request fields were not being propagated:

1. **temperature**: The transport only sets temperature when `fixed_temperature` is provided (from `_fixed_temperature_for_model()` for specific cloud models). For custom providers, `fixed_temperature` is `None`, so no temperature field is sent. Backends like llama.cpp fall back to their default (often 1.0), causing factual drift on grounded tasks.

2. **parallel_tool_calls**: The transport never sets this field for `chat_completions` mode (only `codex.py` hardcodes it). Many local backends (llama.cpp, vLLM) require this field explicitly to enable batching tool calls; without it, multi-tool queries serialize into separate turns, incurring ~4× latency.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A