### PR TITLE
fix(usage): read reasoning_tokens from completion_tokens_details (chat completions)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -526,6 +526,11 @@ def normalize_usage(
     - Codex Responses: input_tokens includes cache tokens; input_tokens_details.cached_tokens separates them
     - OpenAI Chat Completions: prompt_tokens includes cache tokens; prompt_tokens_details.cached_tokens separates them
 
+    Reasoning token accounting: prefer ``output_tokens_details.reasoning_tokens`` (Codex /
+    Responses-style); when zero or absent, fall back to
+    ``completion_tokens_details.reasoning_tokens`` as returned by Chat Completions for
+    reasoning-capable models.
+
     In both Codex and OpenAI modes, input_tokens is derived by subtracting cache
     tokens from the total — the API contract is that input/prompt totals include
     cached tokens and the details object breaks them out.
@@ -576,6 +581,10 @@ def normalize_usage(
     output_details = getattr(response_usage, "output_tokens_details", None)
     if output_details:
         reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+    if not reasoning_tokens:
+        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        if completion_details:
+            reasoning_tokens = _to_int(getattr(completion_details, "reasoning_tokens", 0))
 
     return CanonicalUsage(
         input_tokens=input_tokens,

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -39,6 +39,27 @@ def test_normalize_usage_openai_subtracts_cached_prompt_tokens():
     assert normalized.output_tokens == 700
 
 
+def test_normalize_usage_openai_reads_reasoning_from_completion_tokens_details():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=200,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=150),
+    )
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+    assert normalized.reasoning_tokens == 150
+
+
+def test_normalize_usage_prefers_output_tokens_details_for_reasoning():
+    usage = SimpleNamespace(
+        prompt_tokens=10,
+        completion_tokens=20,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=7),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=999),
+    )
+    normalized = normalize_usage(usage, provider="custom", api_mode="chat_completions")
+    assert normalized.reasoning_tokens == 7
+
+
 def test_normalize_usage_openai_reads_top_level_anthropic_cache_fields():
     """Some OpenAI-compatible proxies (OpenRouter, Vercel AI Gateway, Cline) expose
     Anthropic-style cache token counts at the top level of the usage object when


### PR DESCRIPTION
## Summary

`normalize_usage()` only read `output_tokens_details.reasoning_tokens`. For **Chat Completions** responses, some providers expose reasoning breakdown on `completion_tokens_details.reasoning_tokens`, so `session_reasoning_tokens` and related accounting stayed at **0** even when the API reported reasoning usage.

## Changes

- After reading `output_tokens_details.reasoning_tokens`, if still zero, fall back to `completion_tokens_details.reasoning_tokens`.
- Document the precedence in the `normalize_usage` docstring.

## Tests

- `test_normalize_usage_openai_reads_reasoning_from_completion_tokens_details`
- `test_normalize_usage_prefers_output_tokens_details_for_reasoning`

Run: `pytest tests/agent/test_usage_pricing.py -q`

## Related

Fixes #18466