### PR TITLE
fix(docker): bootstrap HERMES_HOME as root before gosu drop

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,6 +22,11 @@ if [ "$(id -u)" = "0" ]; then
         groupmod -o -g "$HERMES_GID" hermes 2>/dev/null || true
     fi
 
+    # Create custom HERMES_HOME paths before permission checks so `stat`/chown helpers
+    # see real metadata. Hermes drops to a non-root user before bootstrapping; without
+    # this, anchors like `/home/hermes/` cannot be mkdir'd with root-only parents (#18482).
+    mkdir -p "$HERMES_HOME"
+
     # Fix ownership of the data volume. When HERMES_UID remaps the hermes user,
     # files created by previous runs (under the old UID) become inaccessible.
     # Always chown -R when UID was remapped; otherwise only if top-level is wrong.


### PR DESCRIPTION
## Summary

Hermes Docker/Podman entrypoint runs privileged setup as root and then switches to the `hermes` user via `gosu`. If `HERMES_HOME` points at a custom path whose parent directories only root can create (e.g. `HERMES_HOME=/home/hermes/.hermes` in Compose), the post-drop `mkdir -p "$HERMES_HOME"/...` fails with `Permission denied`.

Create `HERMES_HOME` with `mkdir -p` while still root **before** the existing ownership normalization and privilege drop so `stat`/chown logic sees a real directory and the runtime user only creates children under it.

## Related

Fixes https://github.com/NousResearch/hermes-agent/issues/18482

## Verification

- `bash -n docker/entrypoint.sh` (syntax check)