### PR TITLE
fix(transports): set temperature and parallel_tool_calls for custom chat_completions

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -193,6 +193,7 @@ class ChatCompletionsTransport(ProviderTransport):
             # Temperature
             fixed_temperature: Any — from _fixed_temperature_for_model()
             omit_temperature: bool
+            temperature: float | None — optional sampling override for is_custom_provider
             # Reasoning
             supports_reasoning: bool
             github_reasoning_extra: dict | None
@@ -249,6 +250,13 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.pop("temperature", None)
         elif fixed_temp is not None:
             api_kwargs["temperature"] = fixed_temp
+        elif params.get("is_custom_provider", False):
+            # Local OpenAI-compatible stacks (llama.cpp, vLLM, ...) often assume
+            # temperature=1.0 when we omit the field altogether (#18470).
+            _user_temp = params.get("temperature")
+            api_kwargs["temperature"] = (
+                float(_user_temp) if _user_temp is not None else 0.2
+            )
 
         # Qwen metadata (caller precomputes {sessionId, promptId})
         qwen_meta = params.get("qwen_session_metadata")
@@ -263,6 +271,8 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            if params.get("is_custom_provider", False):
+                api_kwargs.setdefault("parallel_tool_calls", True)
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -354,6 +354,74 @@ class TestChatCompletionsBuildKwargs:
         assert "temperature" not in kw
 
 
+class TestChatCompletionsCustomProvider:
+    """OpenAI-compat custom endpoints (llama.cpp/vLLM): issue #18470."""
+
+    _tool = {
+        "type": "function",
+        "function": {"name": "read", "parameters": {"type": "object", "properties": {}}},
+    }
+
+    def test_default_temperature_when_fixed_not_set(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="local-model",
+            messages=msgs,
+            is_custom_provider=True,
+        )
+        assert kw["temperature"] == 0.2
+
+    def test_explicit_temperature_override(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="local-model",
+            messages=msgs,
+            is_custom_provider=True,
+            temperature=0.35,
+        )
+        assert kw["temperature"] == pytest.approx(0.35)
+
+    def test_omit_temperature_skips_default(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="local-model",
+            messages=msgs,
+            is_custom_provider=True,
+            omit_temperature=True,
+        )
+        assert "temperature" not in kw
+
+    def test_fixed_temperature_beats_custom_default(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            is_custom_provider=True,
+            fixed_temperature=0.55,
+        )
+        assert kw["temperature"] == pytest.approx(0.55)
+
+    def test_parallel_tool_calls_when_tools_present(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="local-model",
+            messages=msgs,
+            tools=[self._tool],
+            is_custom_provider=True,
+        )
+        assert kw["parallel_tool_calls"] is True
+
+    def test_parallel_tool_calls_not_injected_for_standard_route(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            tools=[self._tool],
+            is_custom_provider=False,
+        )
+        assert "parallel_tool_calls" not in kw
+
+
 class TestChatCompletionsKimi:
     """Regression tests for the Kimi/Moonshot quirks migrated into the transport."""
 


### PR DESCRIPTION
## Summary

Hermes forwards `provider == "custom"` through the Chat Completions transport. Those stacks often default omitted `temperature` to `1.0` and omit `parallel_tool_calls`, which forces sequential tool rounds even when the server supports parallel tool calls.

Fill in a conservative sampling default when Hermes supplies neither `omit_temperature` nor `fixed_temperature`, and mirror the Codex transport default by allowing parallel tool batches when tools are present.

## Changes

- `agent/transports/chat_completions.py`: custom-provider temperature default + parallel tool calls when tools exist.
- `tests/agent/transports/test_chat_completions.py`: regression coverage.

## Verification

```bash
pytest tests/agent/transports/test_chat_completions.py -q -o addopts=