### PR TITLE
fix(transport): apply default temperature and parallel_tool_calls for custom OpenAI-compat endpoints (#18470)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -193,6 +193,8 @@ class ChatCompletionsTransport(ProviderTransport):
             # Temperature
             fixed_temperature: Any — from _fixed_temperature_for_model()
             omit_temperature: bool
+            # Custom OpenAI-compatible servers (llama.cpp, vLLM, …)
+            custom_openai_request_options: dict | None
             # Reasoning
             supports_reasoning: bool
             github_reasoning_extra: dict | None
@@ -249,6 +251,15 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.pop("temperature", None)
         elif fixed_temp is not None:
             api_kwargs["temperature"] = fixed_temp
+        elif params.get("is_custom_provider"):
+            compat = params.get("custom_openai_request_options") or {}
+            if compat.get("omit_temperature"):
+                pass
+            elif isinstance(compat.get("temperature"), (int, float)):
+                api_kwargs["temperature"] = float(compat["temperature"])
+            else:
+                # Local stacks often default to temperature=1.0 when omitted (#18470).
+                api_kwargs["temperature"] = 0.2
 
         # Qwen metadata (caller precomputes {sessionId, promptId})
         qwen_meta = params.get("qwen_session_metadata")
@@ -263,6 +274,14 @@ class ChatCompletionsTransport(ProviderTransport):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
+            # Many OpenAI-compat locals require explicit parallel_tool_calls to batch
+            # tool rounds; OpenRouter-style hosts keep their own defaults (#18470).
+            if params.get("is_custom_provider"):
+                compat_pt = params.get("custom_openai_request_options") or {}
+                if isinstance(compat_pt.get("parallel_tool_calls"), bool):
+                    api_kwargs["parallel_tool_calls"] = compat_pt["parallel_tool_calls"]
+                else:
+                    api_kwargs["parallel_tool_calls"] = True
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/cli.py
+++ b/cli.py
@@ -3397,6 +3397,12 @@ class HermesCLI:
         self.api_key = api_key
         self.base_url = base_url
 
+        _compat_opts = runtime.get("custom_openai_request_options")
+        _compat_flat = dict(_compat_opts) if isinstance(_compat_opts, dict) else {}
+        compat_changed = _compat_flat != getattr(self, "_resolved_custom_compat_opts", {})
+
+        setattr(self, "_resolved_custom_compat_opts", _compat_flat)
+
         # When a custom_provider entry carries an explicit `model` field,
         # use it as the effective model name.  Without this, running
         # `hermes chat --model <provider-name>` sends the provider name
@@ -3435,7 +3441,7 @@ class HermesCLI:
 
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
         # routing, or the effective model changed.
-        if (credentials_changed or routing_changed or model_changed) and self.agent is not None:
+        if (credentials_changed or routing_changed or model_changed or compat_changed) and self.agent is not None:
             self.agent = None
             self._active_agent_route_signature = None
 
@@ -3451,6 +3457,7 @@ class HermesCLI:
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
+        _compat_pick = getattr(self, "_resolved_custom_compat_opts", {}) or {}
         runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,
@@ -3459,6 +3466,7 @@ class HermesCLI:
             "command": self.acp_command,
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
+            "custom_openai_request_options": dict(_compat_pick),
         }
         route = {
             "model": self.model,
@@ -3470,6 +3478,7 @@ class HermesCLI:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                tuple(sorted(_compat_pick.items())),
             ),
         }
 
@@ -3571,8 +3580,12 @@ class HermesCLI:
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
                 "credential_pool": getattr(self, "_credential_pool", None),
+                "custom_openai_request_options": dict(
+                    getattr(self, "_resolved_custom_compat_opts", {}) or {},
+                ),
             }
             effective_model = model_override or self.model
+            _co_pick = runtime.get("custom_openai_request_options") or {}
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -3582,6 +3595,7 @@ class HermesCLI:
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
+                custom_openai_request_options=_co_pick if isinstance(_co_pick, dict) else None,
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 disabled_toolsets=self.disabled_toolsets,
@@ -3630,6 +3644,7 @@ class HermesCLI:
                 runtime.get("api_mode"),
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
+                tuple(sorted((_co_pick or {}).items())),
             )
 
             # Force-create DB row on /title intent, then apply title.
@@ -6734,6 +6749,9 @@ class HermesCLI:
                     reasoning_config=self.reasoning_config,
                     service_tier=self.service_tier,
                     request_overrides=turn_route.get("request_overrides"),
+                    custom_openai_request_options=turn_route["runtime"].get(
+                        "custom_openai_request_options",
+                    ),
                     providers_allowed=self._providers_only,
                     providers_ignored=self._providers_ignore,
                     providers_order=self._providers_order,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -521,7 +521,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    return {
+    resolved = {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -530,6 +530,10 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+    compat = runtime.get("custom_openai_request_options")
+    if isinstance(compat, dict) and compat:
+        resolved["custom_openai_request_options"] = dict(compat)
+    return resolved
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -1352,6 +1356,8 @@ class GatewayRunner:
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
+        _compat_gw = runtime_kwargs.get("custom_openai_request_options")
+        _compat_flat = dict(_compat_gw) if isinstance(_compat_gw, dict) else {}
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
             "base_url": runtime_kwargs.get("base_url"),
@@ -1360,6 +1366,7 @@ class GatewayRunner:
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
+            "custom_openai_request_options": _compat_flat,
         }
         route = {
             "model": model,
@@ -1371,6 +1378,7 @@ class GatewayRunner:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                tuple(sorted(_compat_flat.items())),
             ),
         }
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2616,6 +2616,17 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    if entry.get("omit_temperature") is True:
+        normalized["omit_temperature"] = True
+
+    req_temp = entry.get("temperature")
+    if isinstance(req_temp, (int, float)):
+        normalized["temperature"] = float(req_temp)
+
+    ptc = entry.get("parallel_tool_calls")
+    if isinstance(ptc, bool):
+        normalized["parallel_tool_calls"] = ptc
+
     return normalized
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -36,6 +36,22 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _compat_options_from_custom_provider_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract chat_completions knobs for bare-metal OpenAI-compatible servers (#18470)."""
+    out: Dict[str, Any] = {}
+    if not isinstance(entry, dict):
+        return out
+    if entry.get("omit_temperature") is True:
+        out["omit_temperature"] = True
+    temp = entry.get("temperature")
+    if isinstance(temp, (int, float)):
+        out["temperature"] = float(temp)
+    ptc = entry.get("parallel_tool_calls")
+    if isinstance(ptc, bool):
+        out["parallel_tool_calls"] = ptc
+    return out
+
+
 def _loopback_hostname(host: str) -> bool:
     h = (host or "").lower().rstrip(".")
     return h in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
@@ -528,6 +544,9 @@ def _resolve_named_custom_runtime(
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        _compat = _compat_options_from_custom_provider_entry(custom_provider)
+        if _compat:
+            pool_result["custom_openai_request_options"] = _compat
         return pool_result
 
     api_key_candidates = [
@@ -552,6 +571,9 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    _compat_opts = _compat_options_from_custom_provider_entry(custom_provider)
+    if _compat_opts:
+        result["custom_openai_request_options"] = _compat_opts
     return result
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -936,6 +936,7 @@ class AIAgent:
         reasoning_config: Dict[str, Any] = None,
         service_tier: str = None,
         request_overrides: Dict[str, Any] = None,
+        custom_openai_request_options: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
         user_id: str = None,
@@ -1209,6 +1210,7 @@ class AIAgent:
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
         self.request_overrides = dict(request_overrides or {})
+        self._custom_openai_request_options = dict(custom_openai_request_options or {})
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         
@@ -8400,6 +8402,9 @@ class AIAgent:
             lmstudio_reasoning_options=self._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
             anthropic_max_output=_ant_max,
             provider_name=self.provider,
+            custom_openai_request_options=(
+                self._custom_openai_request_options or None
+            ),
         )
 
     def _supports_reasoning_extra_body(self) -> bool:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -122,6 +122,51 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["think"] is False
 
+    def test_custom_provider_sets_default_temperature(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(model="llama", messages=msgs, is_custom_provider=True)
+        assert kw["temperature"] == 0.2
+
+    def test_custom_provider_parallel_tools_default(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "read", "parameters": {}}}]
+        kw = transport.build_kwargs(
+            model="llama", messages=msgs, tools=tools, is_custom_provider=True,
+        )
+        assert kw["parallel_tool_calls"] is True
+
+    def test_custom_provider_compat_yaml_overrides(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "read", "parameters": {}}}]
+        compat = {"temperature": 0.05, "parallel_tool_calls": False}
+        kw = transport.build_kwargs(
+            model="llama",
+            messages=msgs,
+            tools=tools,
+            is_custom_provider=True,
+            custom_openai_request_options=compat,
+        )
+        assert kw["temperature"] == 0.05
+        assert kw["parallel_tool_calls"] is False
+
+    def test_custom_provider_omit_temperature(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="llama",
+            messages=msgs,
+            is_custom_provider=True,
+            custom_openai_request_options={"omit_temperature": True},
+        )
+        assert "temperature" not in kw
+
+    def test_openrouter_does_not_inject_parallel_tool_calls(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{"type": "function", "function": {"name": "read", "parameters": {}}}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, tools=tools, is_openrouter=True,
+        )
+        assert "parallel_tool_calls" not in kw
+
     def test_gemini_native_without_explicit_reasoning_config_keeps_existing_behavior(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1026,6 +1026,7 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
+    _parent_compat = getattr(parent_agent, "_custom_openai_request_options", None) or {}
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -1034,6 +1035,9 @@ def _build_child_agent(
         api_mode=effective_api_mode,
         acp_command=effective_acp_command,
         acp_args=effective_acp_args,
+        custom_openai_request_options=(
+            dict(_parent_compat) if effective_provider == "custom" else None
+        ),
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,


### PR DESCRIPTION
## Summary

Hermes routed `provider=custom` through `chat_completions` without sending `temperature` or `parallel_tool_calls`. Many local OpenAI-compatible stacks (e.g. llama.cpp / vLLM) then keep server defaults (often `temperature=1.0`) and only batch tool rounds when `parallel_tool_calls` is explicit.

Fixes #18470.

## Changes

- **`ChatCompletionsTransport.build_kwargs`**  
  When `is_custom_provider` is true:
  - If no fixed/overridden temperature applies, send **`temperature: 0.2`** unless the user opts out (`omit_temperature` in compat options).
  - When **`tools`** are present, send **`parallel_tool_calls: true`** by default unless overridden.

- **`custom_providers`** (normalized in `hermes_cli/config.py`, surfaced via `resolve_runtime_provider`):
  - Optional: `temperature` (number), `parallel_tool_calls` (bool), `omit_temperature: true`.
  - Passed through CLI, gateway runtime dict, and `AIAgent(custom_openai_request_options=...)`.

- **Delegate**: subagents inherit parent compat options when `effective_provider == "custom"`.

## Config example

```yaml
custom_providers:
  - name: Local
    base_url: http://127.0.0.1:8080/v1
    model: your-model-alias
    temperature: 0.25
    parallel_tool_calls: true
    # omit_temperature: true   # uncomment to omit `temperature` and use server defaults