### PR TITLE
docs: clarify profile clone behavior

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -11,7 +11,7 @@ zero migration needed.
 Usage::
 
     hermes profile create coder          # fresh profile + bundled skills
-    hermes profile create coder --clone  # also copy config, .env, SOUL.md
+    hermes profile create coder --clone  # also copy config, .env, SOUL.md, and built-in memory files
     hermes profile create coder --clone-all  # full copy of source profile
     coder chat                           # use via wrapper alias
     hermes -p coder chat                 # or via flag
@@ -388,7 +388,8 @@ def create_profile(
     clone_all:
         If True, do a full copytree of the source (all state).
     clone_config:
-        If True, copy only config files (config.yaml, .env, SOUL.md).
+        If True, copy config files plus built-in memory files
+        (config.yaml, .env, SOUL.md, memories/MEMORY.md, memories/USER.md).
     no_alias:
         If True, skip wrapper script creation.
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -872,7 +872,7 @@ Manage profiles — multiple isolated Hermes instances, each with its own config
 |------------|-------------|
 | `list` | List all profiles. |
 | `use <name>` | Set a sticky default profile. |
-| `create <name> [--clone] [--clone-all] [--clone-from <source>] [--no-alias]` | Create a new profile. `--clone` copies config, `.env`, and `SOUL.md` from the active profile. `--clone-all` copies all state. `--clone-from` specifies a source profile. |
+| `create <name> [--clone] [--clone-all] [--clone-from <source>] [--no-alias]` | Create a new profile. `--clone` copies config, `.env`, `SOUL.md`, and built-in memory files from the active profile, but it is not a full auth/session clone. `--clone-all` copies nearly all profile state, then strips transient runtime files. `--clone-from` specifies a source profile. |
 | `delete <name> [-y]` | Delete a profile. |
 | `show <name>` | Show profile details (home directory, config, etc.). |
 | `alias <name> [--remove] [--name NAME]` | Manage wrapper scripts for quick profile access. |

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -76,8 +76,8 @@ Creates a new profile.
 | Argument / Option | Description |
 |-------------------|-------------|
 | `<name>` | Name for the new profile. Must be a valid directory name (alphanumeric, hyphens, underscores). |
-| `--clone` | Copy `config.yaml`, `.env`, and `SOUL.md` from the current profile. |
-| `--clone-all` | Copy everything (config, memories, skills, sessions, state) from the current profile. |
+| `--clone` | Copy `config.yaml`, `.env`, `SOUL.md`, and built-in memory files (`memories/MEMORY.md` / `memories/USER.md`) from the current profile. Useful for multi-agent setups because it preserves core identity and `.env`-based keys, but it is not a full auth/session clone. |
+| `--clone-all` | Copy nearly all profile state (config, memories, skills, sessions, state, and provider auth), then strip transient runtime files like gateway PID/process artifacts. |
 | `--clone-from <profile>` | Clone from a specific profile instead of the current one. Used with `--clone` or `--clone-all`. |
 | `--no-alias` | Skip wrapper script creation. |
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -38,7 +38,7 @@ Creates a fresh profile with bundled skills seeded. Run `mybot setup` to configu
 hermes profile create work --clone
 ```
 
-Copies your current profile's `config.yaml`, `.env`, and `SOUL.md` into the new profile. Same API keys and model, but fresh sessions and memory. Edit `~/.hermes/profiles/work/.env` for different API keys, or `~/.hermes/profiles/work/SOUL.md` for a different personality.
+Copies your current profile's `config.yaml`, `.env`, `SOUL.md`, and built-in memory files (`memories/MEMORY.md` and `memories/USER.md`) into the new profile. `.env`-based API keys and baseline identity context come over, but this is not a full auth/session clone: providers backed by `auth.json` may still require re-authentication, and the new profile starts with fresh sessions/state. Edit `~/.hermes/profiles/work/.env` for different API keys, or `~/.hermes/profiles/work/SOUL.md` for a different personality.
 
 ### Clone everything (`--clone-all`)
 
@@ -46,7 +46,7 @@ Copies your current profile's `config.yaml`, `.env`, and `SOUL.md` into the new 
 hermes profile create backup --clone-all
 ```
 
-Copies **everything** — config, API keys, personality, all memories, full session history, skills, cron jobs, plugins. A complete snapshot. Useful for backups or forking an agent that already has context.
+Copies nearly all profile state — config, API keys, personality, memories, session history, skills, cron jobs, and plugins — then strips transient runtime files like `gateway.pid`, `gateway_state.json`, and `processes.json`. Useful for backups or forking an agent that already has context.
 
 ### Clone from a specific profile
 


### PR DESCRIPTION
## Summary
- clarify that `--clone` copies config, `.env`, `SOUL.md`, and built-in memory files
- explain that `--clone` is not a full auth/session clone
- refine `--clone-all` wording to match the implementation and stripped runtime files
- align the in-code usage comment and docstring in `hermes_cli/profiles.py`

## Testing
- not run (docs/comment-only changes)

## Notes
- validated against the actual `create_profile` implementation and reviewer pass