### PR TITLE
feat: add parallel Hermes mission runner

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -734,189 +734,57 @@ _active_worktree: Optional[Dict[str, str]] = None
 
 def _git_repo_root() -> Optional[str]:
     """Return the git repo root for CWD, or None if not in a repo."""
-    import subprocess
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip()
-    except Exception:
-        pass
-    return None
+    from hermes_cli.worktree import git_repo_root
+
+    return git_repo_root()
 
 
 def _path_is_within_root(path: Path, root: Path) -> bool:
     """Return True when a resolved path stays within the expected root."""
-    try:
-        path.relative_to(root)
-        return True
-    except ValueError:
-        return False
+    from hermes_cli.worktree import path_is_within_root
+
+    return path_is_within_root(path, root)
 
 
 def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
-    """Create an isolated git worktree for this CLI session.
+    """Create an isolated git worktree for this CLI session."""
+    from hermes_cli.worktree import setup_worktree
 
-    Returns a dict with worktree metadata on success, None on failure.
-    The dict contains: path, branch, repo_root.
-    """
-    import subprocess
-
-    repo_root = repo_root or _git_repo_root()
-    if not repo_root:
+    info = setup_worktree(repo_root)
+    if not info:
         print("\033[31m✗ --worktree requires being inside a git repository.\033[0m")
         print("  cd into your project repo first, then run hermes -w")
         return None
 
-    short_id = uuid.uuid4().hex[:8]
-    wt_name = f"hermes-{short_id}"
-    branch_name = f"hermes/{wt_name}"
-
-    worktrees_dir = Path(repo_root) / ".worktrees"
-    worktrees_dir.mkdir(parents=True, exist_ok=True)
-
-    wt_path = worktrees_dir / wt_name
-
-    # Ensure .worktrees/ is in .gitignore
-    gitignore = Path(repo_root) / ".gitignore"
-    _ignore_entry = ".worktrees/"
-    try:
-        existing = gitignore.read_text() if gitignore.exists() else ""
-        if _ignore_entry not in existing.splitlines():
-            with open(gitignore, "a") as f:
-                if existing and not existing.endswith("\n"):
-                    f.write("\n")
-                f.write(f"{_ignore_entry}\n")
-    except Exception as e:
-        logger.debug("Could not update .gitignore: %s", e)
-
-    # Create the worktree
-    try:
-        result = subprocess.run(
-            ["git", "worktree", "add", str(wt_path), "-b", branch_name, "HEAD"],
-            capture_output=True, text=True, timeout=30, cwd=repo_root,
-        )
-        if result.returncode != 0:
-            print(f"\033[31m✗ Failed to create worktree: {result.stderr.strip()}\033[0m")
-            return None
-    except Exception as e:
-        print(f"\033[31m✗ Failed to create worktree: {e}\033[0m")
-        return None
-
-    # Copy files listed in .worktreeinclude (gitignored files the agent needs)
-    include_file = Path(repo_root) / ".worktreeinclude"
-    if include_file.exists():
-        try:
-            repo_root_resolved = Path(repo_root).resolve()
-            wt_path_resolved = wt_path.resolve()
-            for line in include_file.read_text().splitlines():
-                entry = line.strip()
-                if not entry or entry.startswith("#"):
-                    continue
-                src = Path(repo_root) / entry
-                dst = wt_path / entry
-                # Prevent path traversal and symlink escapes: both the resolved
-                # source and the resolved destination must stay inside their
-                # expected roots before any file or symlink operation happens.
-                try:
-                    src_resolved = src.resolve(strict=False)
-                    dst_resolved = dst.resolve(strict=False)
-                except (OSError, ValueError):
-                    logger.debug("Skipping invalid .worktreeinclude entry: %s", entry)
-                    continue
-                if not _path_is_within_root(src_resolved, repo_root_resolved):
-                    logger.warning("Skipping .worktreeinclude entry outside repo root: %s", entry)
-                    continue
-                if not _path_is_within_root(dst_resolved, wt_path_resolved):
-                    logger.warning("Skipping .worktreeinclude entry that escapes worktree: %s", entry)
-                    continue
-                if src.is_file():
-                    dst.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(str(src), str(dst))
-                elif src.is_dir():
-                    # Symlink directories (faster, saves disk)
-                    if not dst.exists():
-                        dst.parent.mkdir(parents=True, exist_ok=True)
-                        os.symlink(str(src_resolved), str(dst))
-        except Exception as e:
-            logger.debug("Error copying .worktreeinclude entries: %s", e)
-
-    info = {
-        "path": str(wt_path),
-        "branch": branch_name,
-        "repo_root": repo_root,
-    }
-
-    print(f"\033[32m✓ Worktree created:\033[0m {wt_path}")
-    print(f"  Branch: {branch_name}")
-
-    return info
+    print(f"\033[32m✓ Worktree created:\033[0m {info.path}")
+    print(f"  Branch: {info.branch}")
+    return info.to_dict()
 
 
 def _cleanup_worktree(info: Dict[str, str] = None) -> None:
-    """Remove a worktree and its branch on exit.
-
-    Preserves the worktree only if it has unpushed commits (real work
-    that hasn't been pushed to any remote).  Uncommitted changes alone
-    (untracked files, test artifacts) are not enough to keep it — agent
-    work lives in commits/PRs, not the working tree.
-    """
+    """Remove a worktree and its branch on exit."""
     global _active_worktree
-    info = info or _active_worktree
+    if not info:
+        info = _active_worktree
     if not info:
         return
 
-    import subprocess
+    from hermes_cli.worktree import WorktreeInfo, cleanup_worktree
 
-    wt_path = info["path"]
-    branch = info["branch"]
-    repo_root = info["repo_root"]
-
-    if not Path(wt_path).exists():
-        return
-
-    # Check for unpushed commits — commits reachable from HEAD but not
-    # from any remote branch.  These represent real work the agent did
-    # but didn't push.
-    has_unpushed = False
-    try:
-        result = subprocess.run(
-            ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-            capture_output=True, text=True, timeout=10, cwd=wt_path,
-        )
-        has_unpushed = bool(result.stdout.strip())
-    except Exception:
-        has_unpushed = True  # Assume unpushed on error — don't delete
-
-    if has_unpushed:
-        print(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {wt_path}\033[0m")
-        print(f"  To clean up manually: git worktree remove --force {wt_path}")
+    worktree_info = WorktreeInfo(
+        path=info["path"], branch=info["branch"], repo_root=info["repo_root"]
+    )
+    existed = Path(worktree_info.path).exists()
+    removed = cleanup_worktree(worktree_info)
+    if removed:
         _active_worktree = None
+        if existed:
+            print(f"\033[32m✓ Worktree cleaned up: {worktree_info.path}\033[0m")
         return
 
-    # Remove worktree (even if working tree is dirty — uncommitted
-    # changes without unpushed commits are just artifacts)
-    try:
-        subprocess.run(
-            ["git", "worktree", "remove", wt_path, "--force"],
-            capture_output=True, text=True, timeout=15, cwd=repo_root,
-        )
-    except Exception as e:
-        logger.debug("Failed to remove worktree: %s", e)
-
-    # Delete the branch
-    try:
-        subprocess.run(
-            ["git", "branch", "-D", branch],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-    except Exception as e:
-        logger.debug("Failed to delete branch %s: %s", branch, e)
-
+    print(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {worktree_info.path}\033[0m")
+    print(f"  To clean up manually: git worktree remove --force {worktree_info.path}")
     _active_worktree = None
-    print(f"\033[32m✓ Worktree cleaned up: {wt_path}\033[0m")
 
 
 def _run_state_db_auto_maintenance(session_db) -> None:
@@ -985,145 +853,17 @@ def _run_checkpoint_auto_maintenance() -> None:
 
 
 def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
-    """Remove stale worktrees and orphaned branches on startup.
+    """Remove stale worktrees and orphaned branches on startup."""
+    from hermes_cli.worktree import prune_stale_worktrees
 
-    Age-based tiers:
-    - Under max_age_hours (24h): skip — session may still be active.
-    - 24h–72h: remove if no unpushed commits.
-    - Over 72h: force remove regardless (nothing should sit this long).
-
-    Also prunes orphaned ``hermes/*`` and ``pr-*`` local branches that
-    have no corresponding worktree.
-    """
-    import subprocess
-    import time
-
-    worktrees_dir = Path(repo_root) / ".worktrees"
-    if not worktrees_dir.exists():
-        _prune_orphaned_branches(repo_root)
-        return
-
-    now = time.time()
-    soft_cutoff = now - (max_age_hours * 3600)       # 24h default
-    hard_cutoff = now - (max_age_hours * 3 * 3600)   # 72h default
-
-    for entry in worktrees_dir.iterdir():
-        if not entry.is_dir() or not entry.name.startswith("hermes-"):
-            continue
-
-        # Check age
-        try:
-            mtime = entry.stat().st_mtime
-            if mtime > soft_cutoff:
-                continue  # Too recent — skip
-        except Exception:
-            continue
-
-        force = mtime <= hard_cutoff  # Over 72h — force remove
-
-        if not force:
-            # 24h–72h tier: only remove if no unpushed commits
-            try:
-                result = subprocess.run(
-                    ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-                    capture_output=True, text=True, timeout=5, cwd=str(entry),
-                )
-                if result.stdout.strip():
-                    continue  # Has unpushed commits — skip
-            except Exception:
-                continue  # Can't check — skip
-
-        # Safe to remove
-        try:
-            branch_result = subprocess.run(
-                ["git", "branch", "--show-current"],
-                capture_output=True, text=True, timeout=5, cwd=str(entry),
-            )
-            branch = branch_result.stdout.strip()
-
-            subprocess.run(
-                ["git", "worktree", "remove", str(entry), "--force"],
-                capture_output=True, text=True, timeout=15, cwd=repo_root,
-            )
-            if branch:
-                subprocess.run(
-                    ["git", "branch", "-D", branch],
-                    capture_output=True, text=True, timeout=10, cwd=repo_root,
-                )
-            logger.debug("Pruned stale worktree: %s (force=%s)", entry.name, force)
-        except Exception as e:
-            logger.debug("Failed to prune worktree %s: %s", entry.name, e)
-
-    _prune_orphaned_branches(repo_root)
+    prune_stale_worktrees(repo_root, max_age_hours=max_age_hours)
 
 
 def _prune_orphaned_branches(repo_root: str) -> None:
-    """Delete local ``hermes/hermes-*`` and ``pr-*`` branches with no worktree.
+    """Delete local auto-generated branches with no active worktree."""
+    from hermes_cli.worktree import prune_orphaned_branches
 
-    These are auto-generated by ``hermes -w`` sessions and PR review
-    workflows respectively.  Once their worktree is gone they serve no
-    purpose and just accumulate.
-    """
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["git", "branch", "--format=%(refname:short)"],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-        if result.returncode != 0:
-            return
-        all_branches = [b.strip() for b in result.stdout.strip().split("\n") if b.strip()]
-    except Exception:
-        return
-
-    # Collect branches that are actively checked out in a worktree
-    active_branches: set = set()
-    try:
-        wt_result = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-        for line in wt_result.stdout.split("\n"):
-            if line.startswith("branch refs/heads/"):
-                active_branches.add(line.split("branch refs/heads/", 1)[-1].strip())
-    except Exception:
-        return  # Can't determine active branches — bail
-
-    # Also protect the currently checked-out branch and main
-    try:
-        head_result = subprocess.run(
-            ["git", "branch", "--show-current"],
-            capture_output=True, text=True, timeout=5, cwd=repo_root,
-        )
-        current = head_result.stdout.strip()
-        if current:
-            active_branches.add(current)
-    except Exception:
-        pass
-    active_branches.add("main")
-
-    orphaned = [
-        b for b in all_branches
-        if b not in active_branches
-        and (b.startswith("hermes/hermes-") or b.startswith("pr-"))
-    ]
-
-    if not orphaned:
-        return
-
-    # Delete in batches
-    for i in range(0, len(orphaned), 50):
-        batch = orphaned[i:i + 50]
-        try:
-            subprocess.run(
-                ["git", "branch", "-D"] + batch,
-                capture_output=True, text=True, timeout=30, cwd=repo_root,
-            )
-        except Exception as e:
-            logger.debug("Failed to prune orphaned branches: %s", e)
-
-    logger.debug("Pruned %d orphaned branches", len(orphaned))
+    prune_orphaned_branches(repo_root)
 
 # ============================================================================
 # ASCII Art & Branding

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8137,6 +8137,56 @@ def main():
     chat_parser.set_defaults(func=cmd_chat)
 
     # =========================================================================
+    # parallel command
+    # =========================================================================
+    parallel_parser = subparsers.add_parser(
+        "parallel",
+        help="Run multiple Hermes agent sessions with shared mission coordination",
+        description="Coordinate two or more Hermes child sessions in isolated git worktrees",
+    )
+    parallel_subparsers = parallel_parser.add_subparsers(dest="parallel_action")
+
+    parallel_run = parallel_subparsers.add_parser(
+        "run",
+        help="Launch a coordinated parallel mission",
+    )
+    parallel_run.add_argument("--name", default="parallel-mission", help="Mission name")
+    parallel_run.add_argument("--goal", default=None, help="Shared goal injected into every child prompt")
+    parallel_run.add_argument(
+        "--agent",
+        action="append",
+        required=True,
+        help="Agent role and task as role::task. Repeat at least twice.",
+    )
+    parallel_run.add_argument("--verify", default=None, help="Final verification shell command")
+    parallel_run.add_argument("--repo", default=None, help="Repo root or subdirectory. Defaults to cwd.")
+    parallel_run.add_argument("--no-worktrees", action="store_true", help="Run without creating isolated git worktrees")
+    parallel_run.add_argument("--model", default=None, help="Model for child Hermes sessions")
+    parallel_run.add_argument("--provider", default=None, help="Provider for child Hermes sessions")
+    parallel_run.add_argument("--toolsets", default=None, help="Comma-separated toolsets for child sessions")
+    parallel_run.add_argument(
+        "--skills",
+        action="append",
+        default=[],
+        help="Skill to preload in child sessions. Repeat or comma-separate.",
+    )
+
+    parallel_status = parallel_subparsers.add_parser(
+        "status",
+        help="Show a saved parallel mission manifest and summary",
+    )
+    parallel_status.add_argument("mission_id", help="Mission id from parallel run")
+
+    def cmd_parallel(args):
+        from hermes_cli.parallel import parallel_command
+
+        code = parallel_command(args)
+        if code is not None:
+            sys.exit(code)
+
+    parallel_parser.set_defaults(func=cmd_parallel)
+
+    # =========================================================================
     # model command
     # =========================================================================
     model_parser = subparsers.add_parser(
@@ -10337,6 +10387,7 @@ Examples:
         "cron":    ("cron_command",    {"run", "tick"}),
         "gateway": ("gateway_command", {"run"}),
         "mcp":     ("mcp_action",      {"serve"}),
+        "parallel": ("parallel_action", {"run"}),
     }
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
     if (

--- a/hermes_cli/parallel.py
+++ b/hermes_cli/parallel.py
@@ -1,0 +1,416 @@
+"""Coordinate multiple Hermes child sessions for parallel missions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Sequence
+
+from hermes_cli.config import get_hermes_home
+from hermes_cli.worktree import (
+    WorktreeInfo,
+    changed_files_between_ref,
+    cleanup_worktree,
+    git_repo_root,
+    setup_worktree,
+)
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    role: str
+    task: str
+
+
+@dataclass(frozen=True)
+class AgentRun:
+    spec: AgentSpec
+    worktree: WorktreeInfo | None
+    command: list[str]
+    log_path: Path
+    cwd: Path
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip().lower()).strip("-")
+    return slug[:64] or "parallel-mission"
+
+
+def parse_agent_spec(raw: str, index: int = 1) -> AgentSpec:
+    if "::" in raw:
+        role, task = raw.split("::", 1)
+        role_slug = slugify(role)
+        task_text = task.strip()
+    else:
+        role_slug = f"agent-{index}"
+        task_text = raw.strip()
+    if not task_text:
+        raise ValueError("Agent task cannot be empty")
+    return AgentSpec(role=role_slug, task=task_text)
+
+
+def build_agent_prompt(
+    *,
+    mission_name: str,
+    shared_goal: str,
+    spec: AgentSpec,
+    verification_command: str | None,
+    worktree_path: str,
+    repo_root: str,
+) -> str:
+    verify_line = verification_command or "Run the smallest relevant verification command for your task and report it."
+    return f"""You are one Hermes worker in a coordinated parallel mission.
+
+Mission: {mission_name}
+Shared goal: {shared_goal}
+Role: {spec.role}
+Your task: {spec.task}
+
+Workspace:
+- Original repo: {repo_root}
+- Your isolated worktree: {worktree_path}
+
+Coordination rules:
+- Work only inside your isolated worktree.
+- Do not edit files outside your assigned scope unless your task explicitly requires it.
+- If your task needs a file owned by another role, stop and report the conflict instead of silently editing it.
+- Prefer small focused commits if you change code.
+- Never hardcode secrets.
+- Use TDD for code changes: write or update a failing test first, implement, then verify.
+
+Verification:
+- Required verification command: {verify_line}
+- If this command is not applicable to your role, explain why and run the nearest targeted check.
+
+Final response contract:
+Return exactly these sections:
+1. Summary
+2. Files changed
+3. Verification run
+4. Blockers or conflicts
+5. Next handoff
+""".strip()
+
+
+def mission_id_for(name: str, now: str | None = None) -> str:
+    stamp = now or time.strftime("%Y%m%d-%H%M%S")
+    return f"{stamp}-{slugify(name)}"
+
+
+def mission_dir_for(mission_id: str) -> Path:
+    return get_hermes_home() / "parallel" / mission_id
+
+
+def build_child_command(
+    *,
+    prompt: str,
+    model: str | None,
+    provider: str | None,
+    toolsets: str | None,
+    skills: Sequence[str] | None,
+    pass_session_id: bool,
+) -> list[str]:
+    hermes_bin = os.getenv("HERMES_PARALLEL_CHILD_BIN", "hermes")
+    command = [hermes_bin, "chat", "-q", prompt, "--source", "parallel", "-Q"]
+    if model:
+        command.extend(["--model", model])
+    if provider:
+        command.extend(["--provider", provider])
+    if toolsets:
+        command.extend(["--toolsets", toolsets])
+    for skill in skills or []:
+        command.extend(["--skills", skill])
+    if pass_session_id:
+        command.append("--pass-session-id")
+    return command
+
+
+def write_manifest(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def detect_changed_file_overlaps(changes_by_role: dict[str, list[str]]) -> dict[str, list[str]]:
+    owners: dict[str, list[str]] = {}
+    for role, files in changes_by_role.items():
+        for file_path in files:
+            owners.setdefault(file_path, []).append(role)
+    return {file_path: roles for file_path, roles in sorted(owners.items()) if len(roles) > 1}
+
+
+def build_changed_file_summary(runs: Sequence[AgentRun]) -> dict[str, object]:
+    changes_by_role: dict[str, list[str]] = {}
+    for run in runs:
+        if run.worktree:
+            ref = run.worktree.base_commit or "HEAD"
+            changes_by_role[run.spec.role] = changed_files_between_ref(run.worktree.path, ref=ref)
+        else:
+            changes_by_role[run.spec.role] = []
+    return {
+        "by_role": changes_by_role,
+        "overlaps": detect_changed_file_overlaps(changes_by_role),
+    }
+
+
+def print_changed_file_summary(summary: dict[str, object]) -> None:
+    print("Changed files:")
+    by_role = summary.get("by_role", {})
+    if isinstance(by_role, dict):
+        for role, files in by_role.items():
+            if isinstance(files, list) and files:
+                print(f"  {role}: {', '.join(str(file_path) for file_path in files)}")
+            else:
+                print(f"  {role}: no changes detected")
+    overlaps = summary.get("overlaps", {})
+    if isinstance(overlaps, dict) and overlaps:
+        print("Potential conflicts:")
+        for file_path, roles in overlaps.items():
+            if isinstance(roles, list):
+                print(f"  {file_path}: {', '.join(str(role) for role in roles)}")
+    else:
+        print("Potential conflicts: none")
+
+
+def run_verification(command: str, *, cwd: str | Path, mission_dir: Path) -> int:
+    log_path = mission_dir / "verify.log"
+    print(f"Running verification: {command}")
+    shell_command = ["cmd", "/c", command] if os.name == "nt" else ["/bin/sh", "-lc", command]
+    with log_path.open("w", encoding="utf-8") as log_file:
+        proc = subprocess.run(
+            shell_command,
+            cwd=str(cwd),
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    print(f"Verification exit={proc.returncode} log={log_path}")
+    return int(proc.returncode)
+
+
+def _mission_agent_payload(run: AgentRun) -> dict[str, object]:
+    return {
+        "role": run.spec.role,
+        "task": run.spec.task,
+        "worktree": run.worktree.to_dict() if run.worktree else None,
+        "log_path": str(run.log_path),
+        "cwd": str(run.cwd),
+        "command": run.command,
+    }
+
+
+def _spawn_child_process(run: AgentRun, *, env: dict[str, str], log_file: object) -> object:
+    return subprocess.Popen(
+        run.command,
+        cwd=str(run.cwd),
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _terminate_started_processes(processes: Sequence[tuple[AgentRun, object, object]]) -> None:
+    for _run, proc, log_file in processes:
+        try:
+            terminate = getattr(proc, "terminate", None)
+            if callable(terminate):
+                terminate()
+            wait = getattr(proc, "wait", None)
+            if callable(wait):
+                wait()
+        except Exception:
+            pass
+        finally:
+            try:
+                log_file.close()
+            except Exception:
+                pass
+
+
+def cleanup_parallel_worktrees(
+    runs: Sequence[AgentRun],
+    summary: dict[str, object],
+    *,
+    print_status: bool = True,
+) -> dict[str, str]:
+    """Clean up per-agent worktrees that have no changed files.
+
+    Worktrees with tracked, untracked, or committed changes are intentionally
+    preserved so agents never lose handoff artifacts.
+    """
+    by_role = summary.get("by_role", {})
+    changes_by_role = by_role if isinstance(by_role, dict) else {}
+    cleanup_status: dict[str, str] = {}
+    for run in runs:
+        if not run.worktree:
+            cleanup_status[run.spec.role] = "skipped"
+            continue
+        role_changes = changes_by_role.get(run.spec.role, [])
+        if isinstance(role_changes, list) and role_changes:
+            cleanup_status[run.spec.role] = "preserved-changes"
+            if print_status:
+                print(f"Preserved {run.spec.role} worktree with changes: {run.worktree.path}")
+            continue
+        removed = cleanup_worktree(run.worktree)
+        cleanup_status[run.spec.role] = "removed" if removed else "preserved"
+        if print_status:
+            verb = "Removed" if removed else "Preserved"
+            print(f"{verb} {run.spec.role} worktree: {run.worktree.path}")
+    return cleanup_status
+
+
+def _cleanup_runs_after_failure(runs: Sequence[AgentRun]) -> None:
+    summary = {"by_role": {run.spec.role: [] for run in runs}}
+    cleanup_parallel_worktrees(runs, summary)
+
+
+def run_parallel_mission(args: object) -> int:
+    raw_agents = getattr(args, "agent", None) or []
+    try:
+        specs = [parse_agent_spec(raw, index=index + 1) for index, raw in enumerate(raw_agents)]
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if len(specs) < 2:
+        print("Error: hermes parallel run requires at least two --agent entries", file=sys.stderr)
+        return 2
+
+    requested_repo = getattr(args, "repo", None)
+    repo_root = git_repo_root(requested_repo or Path.cwd())
+    no_worktrees = bool(getattr(args, "no_worktrees", False))
+    if not repo_root and not no_worktrees:
+        print("Error: hermes parallel run requires a git repo unless --no-worktrees is set", file=sys.stderr)
+        return 2
+    execution_root = Path(repo_root or requested_repo or Path.cwd()).resolve()
+    repo_label = str(Path(repo_root).resolve()) if repo_root else str(execution_root)
+
+    mission_name = getattr(args, "name", None) or "parallel-mission"
+    mission_id = mission_id_for(mission_name)
+    mission_dir = mission_dir_for(mission_id)
+    mission_dir.mkdir(parents=True, exist_ok=True)
+
+    runs: list[AgentRun] = []
+    for spec in specs:
+        worktree = None
+        worktree_path = str(execution_root)
+        run_cwd = execution_root
+        if not no_worktrees:
+            worktree = setup_worktree(
+                repo_root,
+                prefix=f"hermes-parallel-{slugify(mission_name)}-{spec.role}",
+                branch_prefix=f"hermes/parallel/{slugify(mission_name)}",
+            )
+            if not worktree:
+                print(f"Error: failed to create worktree for {spec.role}", file=sys.stderr)
+                _cleanup_runs_after_failure(runs)
+                return 1
+            worktree_path = worktree.path
+            run_cwd = Path(worktree.path)
+
+        prompt = build_agent_prompt(
+            mission_name=mission_name,
+            shared_goal=getattr(args, "goal", None) or mission_name,
+            spec=spec,
+            verification_command=getattr(args, "verify", None),
+            worktree_path=worktree_path,
+            repo_root=repo_label,
+        )
+        log_path = mission_dir / f"{spec.role}.log"
+        command = build_child_command(
+            prompt=prompt,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None) or [],
+            pass_session_id=True,
+        )
+        runs.append(AgentRun(spec=spec, worktree=worktree, command=command, log_path=log_path, cwd=run_cwd))
+
+    manifest = {
+        "mission_id": mission_id,
+        "name": mission_name,
+        "goal": getattr(args, "goal", None) or mission_name,
+        "repo_root": repo_label,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "agents": [_mission_agent_payload(run) for run in runs],
+    }
+    write_manifest(mission_dir / "manifest.json", manifest)
+
+    print(f"Mission: {mission_id}")
+    print(f"Mission dir: {mission_dir}")
+
+    processes: list[tuple[AgentRun, object, object]] = []
+    for run in runs:
+        env = os.environ.copy()
+        env["HERMES_PARALLEL_MISSION_ID"] = mission_id
+        env["HERMES_PARALLEL_AGENT_ROLE"] = run.spec.role
+        if run.worktree:
+            env["TERMINAL_CWD"] = run.worktree.path
+        log_file = run.log_path.open("w", encoding="utf-8")
+        try:
+            proc = _spawn_child_process(run, env=env, log_file=log_file)
+        except OSError as exc:
+            log_file.close()
+            print(f"Error: failed to start {run.spec.role}: {exc}", file=sys.stderr)
+            _terminate_started_processes(processes)
+            _cleanup_runs_after_failure(runs)
+            return 1
+        processes.append((run, proc, log_file))
+        print(f"Started {run.spec.role}: pid={proc.pid} log={run.log_path}")
+
+    exit_codes: dict[str, int] = {}
+    for run, proc, log_file in processes:
+        code = proc.wait()
+        log_file.close()
+        exit_codes[run.spec.role] = int(code)
+        print(f"Finished {run.spec.role}: exit={code}")
+
+    summary = build_changed_file_summary(runs)
+    cleanup_status = cleanup_parallel_worktrees(runs, summary)
+    write_manifest(
+        mission_dir / "summary.json",
+        {"exit_codes": exit_codes, "changes": summary, "cleanup": cleanup_status},
+    )
+    print_changed_file_summary(summary)
+
+    verify_command = getattr(args, "verify", None)
+    verify_code = run_verification(verify_command, cwd=execution_root, mission_dir=mission_dir) if verify_command else 0
+    return 0 if all(code == 0 for code in exit_codes.values()) and verify_code == 0 else 1
+
+
+def _split_skills(raw_skills: Sequence[str] | None) -> list[str]:
+    result: list[str] = []
+    for value in raw_skills or []:
+        result.extend(part.strip() for part in value.split(",") if part.strip())
+    return result
+
+
+def show_status(mission_id: str) -> int:
+    mission_dir = mission_dir_for(mission_id)
+    manifest_path = mission_dir / "manifest.json"
+    summary_path = mission_dir / "summary.json"
+    if not manifest_path.exists():
+        print(f"Mission not found: {mission_id}", file=sys.stderr)
+        return 1
+    print(manifest_path.read_text(encoding="utf-8"))
+    if summary_path.exists():
+        print(summary_path.read_text(encoding="utf-8"))
+    return 0
+
+
+def parallel_command(args: object) -> int:
+    action = getattr(args, "parallel_action", None)
+    if action == "run":
+        setattr(args, "skills", _split_skills(getattr(args, "skills", [])))
+        return run_parallel_mission(args)
+    if action == "status":
+        return show_status(getattr(args, "mission_id"))
+    print("Usage: hermes parallel run --agent role::task --agent role::task", file=sys.stderr)
+    return 2

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -65,6 +65,7 @@ TIPS = [
     # --- CLI Flags ---
     "hermes -c resumes your most recent CLI session. hermes -c \"project name\" resumes by title.",
     "hermes -w creates an isolated git worktree — perfect for parallel agent workflows.",
+    "hermes parallel run --agent impl::\"Fix bug\" --agent review::\"Review and test\" launches coordinated isolated agent worktrees.",
     "hermes -w -q \"Fix issue #42\" combines worktree isolation with a one-shot query.",
     "hermes chat -t web,terminal enables only specific toolsets for a focused session.",
     "hermes chat -s github-pr-workflow preloads a skill at launch.",

--- a/hermes_cli/worktree.py
+++ b/hermes_cli/worktree.py
@@ -1,0 +1,424 @@
+"""Reusable git worktree helpers for Hermes CLI workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import time
+import uuid
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    """Metadata for an isolated git worktree."""
+
+    path: str
+    branch: str
+    repo_root: str
+    base_commit: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        payload = {"path": self.path, "branch": self.branch, "repo_root": self.repo_root}
+        if self.base_commit:
+            payload["base_commit"] = self.base_commit
+        return payload
+
+
+def git_repo_root(cwd: str | Path | None = None) -> str | None:
+    """Return the git repo root for ``cwd``, or None if not in a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(cwd) if cwd else None,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        logger.debug("Could not resolve git repo root", exc_info=True)
+    return None
+
+
+def path_is_within_root(path: Path, root: Path) -> bool:
+    """Return True when a resolved path stays within the expected root."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_slug(value: str, fallback: str) -> str:
+    slug = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in value).strip("-")
+    return slug or fallback
+
+
+def _safe_branch_prefix(value: str, fallback: str) -> str:
+    parts = [_safe_slug(part, "") for part in value.strip("/").split("/")]
+    cleaned = [part for part in parts if part]
+    return "/".join(cleaned) or fallback
+
+
+def _ensure_worktrees_gitignore(repo_root: Path) -> None:
+    gitignore = repo_root / ".gitignore"
+    ignore_entry = ".worktrees/"
+    try:
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+        if ignore_entry not in existing.splitlines():
+            with gitignore.open("a", encoding="utf-8") as handle:
+                if existing and not existing.endswith("\n"):
+                    handle.write("\n")
+                handle.write(f"{ignore_entry}\n")
+    except Exception as exc:
+        logger.debug("Could not update .gitignore: %s", exc)
+
+
+def _copy_worktreeinclude_entries(repo_root: Path, wt_path: Path) -> None:
+    include_file = repo_root / ".worktreeinclude"
+    if not include_file.exists():
+        return
+
+    try:
+        repo_root_resolved = repo_root.resolve()
+        wt_path_resolved = wt_path.resolve()
+        for line in include_file.read_text(encoding="utf-8").splitlines():
+            entry = line.strip()
+            if not entry or entry.startswith("#"):
+                continue
+
+            src = repo_root / entry
+            dst = wt_path / entry
+            try:
+                src_resolved = src.resolve(strict=False)
+                dst_resolved = dst.resolve(strict=False)
+            except (OSError, ValueError):
+                logger.debug("Skipping invalid .worktreeinclude entry: %s", entry)
+                continue
+
+            if not path_is_within_root(src_resolved, repo_root_resolved):
+                logger.warning("Skipping .worktreeinclude entry outside repo root: %s", entry)
+                continue
+            if not path_is_within_root(dst_resolved, wt_path_resolved):
+                logger.warning("Skipping .worktreeinclude entry that escapes worktree: %s", entry)
+                continue
+
+            if src.is_file():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(str(src), str(dst))
+            elif src.is_dir() and not dst.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(str(src_resolved), str(dst))
+    except Exception as exc:
+        logger.debug("Error copying .worktreeinclude entries: %s", exc)
+
+
+def setup_worktree(
+    repo_root: str | Path | None = None,
+    *,
+    prefix: str = "hermes",
+    branch_prefix: str = "hermes",
+) -> WorktreeInfo | None:
+    """Create an isolated git worktree and return its metadata."""
+    root = str(Path(repo_root).resolve()) if repo_root else git_repo_root()
+    if not root:
+        return None
+
+    safe_prefix = _safe_slug(prefix, "hermes")
+    safe_branch_prefix = _safe_branch_prefix(branch_prefix, "hermes")
+    short_id = uuid.uuid4().hex[:8]
+    wt_name = f"{safe_prefix}-{short_id}"
+    branch_name = f"{safe_branch_prefix}/{wt_name}"
+
+    try:
+        base_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=root,
+        )
+        base_commit = base_result.stdout.strip() if base_result.returncode == 0 else None
+    except Exception:
+        base_commit = None
+
+    worktrees_dir = Path(root) / ".worktrees"
+    worktrees_dir.mkdir(parents=True, exist_ok=True)
+    wt_path = worktrees_dir / wt_name
+
+    _ensure_worktrees_gitignore(Path(root))
+
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "add", str(wt_path), "-b", branch_name, "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=root,
+        )
+    except Exception:
+        logger.debug("Failed to create worktree", exc_info=True)
+        return None
+
+    if result.returncode != 0:
+        logger.error("Failed to create worktree: %s", result.stderr.strip())
+        return None
+
+    _copy_worktreeinclude_entries(Path(root), wt_path)
+    return WorktreeInfo(path=str(wt_path), branch=branch_name, repo_root=root, base_commit=base_commit)
+
+
+def cleanup_worktree(info: WorktreeInfo) -> bool:
+    """Remove a worktree and branch unless it has unpushed commits.
+
+    Returns True when the worktree is absent after cleanup and False when it is
+    intentionally preserved.
+    """
+    wt_path = info.path
+    branch = info.branch
+    repo_root = info.repo_root
+
+    if not Path(wt_path).exists():
+        return True
+
+    has_unpushed = False
+    try:
+        if info.base_commit:
+            result = subprocess.run(
+                ["git", "rev-list", "--count", f"{info.base_commit}..HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=wt_path,
+            )
+            has_unpushed = result.returncode != 0 or int((result.stdout or "0").strip() or "0") > 0
+        else:
+            result = subprocess.run(
+                ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=wt_path,
+            )
+            has_unpushed = bool(result.stdout.strip())
+    except Exception:
+        has_unpushed = True
+
+    if has_unpushed:
+        return False
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "remove", wt_path, "--force"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=repo_root,
+        )
+    except Exception as exc:
+        logger.debug("Failed to remove worktree: %s", exc)
+
+    try:
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=repo_root,
+        )
+    except Exception as exc:
+        logger.debug("Failed to delete branch %s: %s", branch, exc)
+
+    return not Path(wt_path).exists()
+
+
+def changed_files(path: str | Path) -> list[str]:
+    """Return changed tracked and untracked files for a worktree."""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(path),
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+
+    files: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        file_part = line[3:].strip()
+        if " -> " in file_part:
+            file_part = file_part.split(" -> ", 1)[1].strip()
+        files.append(file_part)
+    return sorted(set(files))
+
+
+def changed_files_between_ref(path: str | Path, ref: str = "HEAD") -> list[str]:
+    """Return files changed against ``ref``, including untracked files."""
+    files = set(changed_files(path))
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", ref],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(path),
+        )
+    except Exception:
+        return sorted(files)
+    if result.returncode == 0:
+        files.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+    return sorted(files)
+
+
+def prune_stale_worktrees(repo_root: str | Path, max_age_hours: int = 24) -> None:
+    """Remove stale Hermes worktrees and orphaned local branches."""
+    root = str(repo_root)
+    worktrees_dir = Path(root) / ".worktrees"
+    if not worktrees_dir.exists():
+        prune_orphaned_branches(root)
+        return
+
+    now = time.time()
+    soft_cutoff = now - (max_age_hours * 3600)
+    hard_cutoff = now - (max_age_hours * 3 * 3600)
+
+    for entry in worktrees_dir.iterdir():
+        if not entry.is_dir() or not entry.name.startswith("hermes-"):
+            continue
+
+        try:
+            mtime = entry.stat().st_mtime
+            if mtime > soft_cutoff:
+                continue
+        except Exception:
+            continue
+
+        force = mtime <= hard_cutoff
+        if not force:
+            try:
+                result = subprocess.run(
+                    ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=str(entry),
+                )
+                if result.stdout.strip():
+                    continue
+            except Exception:
+                continue
+
+        try:
+            branch_result = subprocess.run(
+                ["git", "branch", "--show-current"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                cwd=str(entry),
+            )
+            branch = branch_result.stdout.strip()
+            subprocess.run(
+                ["git", "worktree", "remove", str(entry), "--force"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                cwd=root,
+            )
+            if branch:
+                subprocess.run(
+                    ["git", "branch", "-D", branch],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    cwd=root,
+                )
+            logger.debug("Pruned stale worktree: %s (force=%s)", entry.name, force)
+        except Exception as exc:
+            logger.debug("Failed to prune worktree %s: %s", entry.name, exc)
+
+    prune_orphaned_branches(root)
+
+
+def prune_orphaned_branches(repo_root: str | Path) -> None:
+    """Delete auto-generated local branches with no active worktree."""
+    root = str(repo_root)
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--format=%(refname:short)"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=root,
+        )
+        if result.returncode != 0:
+            return
+        all_branches = [branch.strip() for branch in result.stdout.splitlines() if branch.strip()]
+    except Exception:
+        return
+
+    active_branches: set[str] = set()
+    try:
+        wt_result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=root,
+        )
+        for line in wt_result.stdout.splitlines():
+            if line.startswith("branch refs/heads/"):
+                active_branches.add(line.split("branch refs/heads/", 1)[-1].strip())
+    except Exception:
+        return
+
+    try:
+        head_result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=root,
+        )
+        current = head_result.stdout.strip()
+        if current:
+            active_branches.add(current)
+    except Exception:
+        pass
+    active_branches.add("main")
+
+    orphaned = [
+        branch
+        for branch in all_branches
+        if branch not in active_branches
+        and (branch.startswith("hermes/hermes-") or branch.startswith("pr-"))
+    ]
+    if not orphaned:
+        return
+
+    for index in range(0, len(orphaned), 50):
+        batch = orphaned[index : index + 50]
+        try:
+            subprocess.run(
+                ["git", "branch", "-D", *batch],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=root,
+            )
+        except Exception as exc:
+            logger.debug("Failed to prune orphaned branches: %s", exc)
+
+    logger.debug("Pruned %d orphaned branches", len(orphaned))

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -125,6 +125,24 @@ def _cleanup_worktree(info):
 # Tests
 # ---------------------------------------------------------------------------
 
+
+def test_real_worktree_module_creates_info_dataclass(git_repo):
+    from hermes_cli.worktree import (
+        WorktreeInfo,
+        cleanup_worktree,
+        setup_worktree,
+    )
+
+    info = setup_worktree(git_repo, prefix="hermes-test", branch_prefix="hermes-test")
+
+    assert isinstance(info, WorktreeInfo)
+    assert Path(info.path).exists()
+    assert info.branch.startswith("hermes-test/hermes-test-")
+    assert Path(info.repo_root).resolve() == git_repo.resolve()
+
+    assert cleanup_worktree(info) is True
+
+
 class TestGitRepoDetection:
     """Test git repo root detection."""
 

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -20,6 +20,13 @@ def git_repo(tmp_path):
     return repo
 
 
+def _setup_worktree_for_test(git_repo: Path) -> dict | None:
+    from hermes_cli.worktree import setup_worktree
+
+    info = setup_worktree(str(git_repo))
+    return info.to_dict() if info else None
+
+
 def _force_remove_worktree(info: dict | None) -> None:
     if not info:
         return
@@ -39,15 +46,13 @@ def _force_remove_worktree(info: dict | None) -> None:
 
 class TestWorktreeIncludeSecurity:
     def test_rejects_parent_directory_file_traversal(self, git_repo):
-        import cli as cli_mod
-
         outside_file = git_repo.parent / "sensitive.txt"
         outside_file.write_text("SENSITIVE DATA")
         (git_repo / ".worktreeinclude").write_text("../sensitive.txt\n")
 
         info = None
         try:
-            info = cli_mod._setup_worktree(str(git_repo))
+            info = _setup_worktree_for_test(git_repo)
             assert info is not None
 
             wt_path = Path(info["path"])
@@ -57,8 +62,6 @@ class TestWorktreeIncludeSecurity:
             _force_remove_worktree(info)
 
     def test_rejects_parent_directory_directory_traversal(self, git_repo):
-        import cli as cli_mod
-
         outside_dir = git_repo.parent / "outside-dir"
         outside_dir.mkdir()
         (outside_dir / "secret.txt").write_text("SENSITIVE DIR DATA")
@@ -66,7 +69,7 @@ class TestWorktreeIncludeSecurity:
 
         info = None
         try:
-            info = cli_mod._setup_worktree(str(git_repo))
+            info = _setup_worktree_for_test(git_repo)
             assert info is not None
 
             wt_path = Path(info["path"])
@@ -77,8 +80,6 @@ class TestWorktreeIncludeSecurity:
             _force_remove_worktree(info)
 
     def test_rejects_symlink_that_resolves_outside_repo(self, git_repo):
-        import cli as cli_mod
-
         outside_file = git_repo.parent / "linked-secret.txt"
         outside_file.write_text("LINKED SECRET")
         (git_repo / "leak.txt").symlink_to(outside_file)
@@ -86,7 +87,7 @@ class TestWorktreeIncludeSecurity:
 
         info = None
         try:
-            info = cli_mod._setup_worktree(str(git_repo))
+            info = _setup_worktree_for_test(git_repo)
             assert info is not None
 
             assert not (Path(info["path"]) / "leak.txt").exists()
@@ -94,14 +95,12 @@ class TestWorktreeIncludeSecurity:
             _force_remove_worktree(info)
 
     def test_allows_valid_file_include(self, git_repo):
-        import cli as cli_mod
-
         (git_repo / ".env").write_text("SECRET=***\n")
         (git_repo / ".worktreeinclude").write_text(".env\n")
 
         info = None
         try:
-            info = cli_mod._setup_worktree(str(git_repo))
+            info = _setup_worktree_for_test(git_repo)
             assert info is not None
 
             copied = Path(info["path"]) / ".env"
@@ -111,8 +110,6 @@ class TestWorktreeIncludeSecurity:
             _force_remove_worktree(info)
 
     def test_allows_valid_directory_include(self, git_repo):
-        import cli as cli_mod
-
         assets_dir = git_repo / ".venv" / "lib"
         assets_dir.mkdir(parents=True)
         (assets_dir / "marker.txt").write_text("venv marker")
@@ -120,7 +117,7 @@ class TestWorktreeIncludeSecurity:
 
         info = None
         try:
-            info = cli_mod._setup_worktree(str(git_repo))
+            info = _setup_worktree_for_test(git_repo)
             assert info is not None
 
             linked_dir = Path(info["path"]) / ".venv"

--- a/tests/hermes_cli/test_parallel.py
+++ b/tests/hermes_cli/test_parallel.py
@@ -1,0 +1,295 @@
+import json
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_cli.parallel import (
+    AgentSpec,
+    build_agent_prompt,
+    build_child_command,
+    detect_changed_file_overlaps,
+    mission_id_for,
+    parse_agent_spec,
+    run_parallel_mission,
+)
+from hermes_cli.worktree import WorktreeInfo
+
+
+def test_parse_agent_spec_with_role_prefix():
+    spec = parse_agent_spec("impl::Implement auth fix")
+    assert spec.role == "impl"
+    assert spec.task == "Implement auth fix"
+
+
+def test_parse_agent_spec_without_role_uses_agent_index():
+    spec = parse_agent_spec("Review the diff", index=2)
+    assert spec.role == "agent-2"
+    assert spec.task == "Review the diff"
+
+
+def test_agent_prompt_contains_shared_boundaries_and_output_contract():
+    spec = AgentSpec(role="impl", task="Implement fix")
+    prompt = build_agent_prompt(
+        mission_name="mission-control-fix",
+        shared_goal="Fix Mission Control polling",
+        spec=spec,
+        verification_command="python -m pytest tests/foo.py -q",
+        worktree_path="/tmp/repo/.worktrees/hermes-parallel-impl-abc123",
+        repo_root="/tmp/repo",
+    )
+
+    assert "mission-control-fix" in prompt
+    assert "Role: impl" in prompt
+    assert "Implement fix" in prompt
+    assert "python -m pytest tests/foo.py -q" in prompt
+    assert "/tmp/repo/.worktrees/hermes-parallel-impl-abc123" in prompt
+    assert "Do not edit files outside your assigned scope" in prompt
+    assert "Final response contract" in prompt
+
+
+def test_mission_id_for_is_stable_shape():
+    mission_id = mission_id_for("Mission Control Fix", now="20260502-012245")
+    assert mission_id == "20260502-012245-mission-control-fix"
+
+
+def test_build_child_command_uses_chat_query_source_and_quiet():
+    command = build_child_command(
+        prompt="Do work",
+        model="gpt-5.3-codex",
+        provider="openai-codex",
+        toolsets="terminal,file",
+        skills=["test-driven-development"],
+        pass_session_id=True,
+    )
+
+    assert command[:3] == ["hermes", "chat", "-q"]
+    assert "Do work" in command
+    assert "--source" in command
+    assert "parallel" in command
+    assert "-Q" in command
+    assert "--model" in command
+    assert "gpt-5.3-codex" in command
+    assert "--provider" in command
+    assert "openai-codex" in command
+    assert "--toolsets" in command
+    assert "terminal,file" in command
+    assert command.count("--skills") == 1
+    assert "test-driven-development" in command
+    assert "--pass-session-id" in command
+
+
+def test_detect_changed_file_overlaps_reports_shared_files():
+    changes = {
+        "impl": ["src/a.py", "src/shared.py"],
+        "review": ["tests/a_test.py", "src/shared.py"],
+        "docs": ["README.md"],
+    }
+
+    overlaps = detect_changed_file_overlaps(changes)
+
+    assert overlaps == {"src/shared.py": ["impl", "review"]}
+
+
+def test_parallel_command_help_available():
+    result = subprocess.run(
+        ["python", "-m", "hermes_cli.main", "parallel", "--help"],
+        cwd="/Users/liebe/.hermes/hermes-agent",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0
+    assert "parallel" in result.stdout.lower()
+    assert "run" in result.stdout.lower()
+
+
+class FakeProcess:
+    def __init__(self, code=0):
+        self.pid = 12345
+        self._code = code
+        self.terminated = False
+
+    def wait(self):
+        return self._code
+
+    def terminate(self):
+        self.terminated = True
+
+
+def test_run_parallel_mission_writes_manifest_without_real_children(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+    (repo / "README.md").write_text("# Repo\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True, capture_output=True)
+
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr("hermes_cli.parallel._spawn_child_process", lambda *args, **kwargs: FakeProcess(0))
+    monkeypatch.setattr("hermes_cli.parallel.run_verification", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("hermes_cli.parallel.mission_id_for", lambda name: "20260502-012245-test")
+
+    args = Namespace(
+        agent=["impl::Implement", "review::Review"],
+        name="Test",
+        goal="Shared goal",
+        verify="python -m pytest -q",
+        repo=str(repo),
+        no_worktrees=False,
+        model=None,
+        provider=None,
+        toolsets="terminal,file",
+        skills=[],
+    )
+
+    code = run_parallel_mission(args)
+
+    assert code == 0
+    manifest = hermes_home / "parallel" / "20260502-012245-test" / "manifest.json"
+    assert manifest.exists()
+    payload = json.loads(manifest.read_text())
+    assert [agent["role"] for agent in payload["agents"]] == ["impl", "review"]
+
+
+def _base_args(repo: Path, *, no_worktrees: bool = False) -> Namespace:
+    return Namespace(
+        agent=["impl::Implement", "review::Review"],
+        name="Test",
+        goal="Shared goal",
+        verify="python -m pytest -q",
+        repo=str(repo),
+        no_worktrees=no_worktrees,
+        model=None,
+        provider=None,
+        toolsets="terminal,file",
+        skills=[],
+    )
+
+
+def test_no_worktrees_uses_requested_repo_as_child_cwd(tmp_path, monkeypatch):
+    repo = tmp_path / "plain-repo"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr("hermes_cli.parallel._spawn_child_process", lambda run, **kwargs: FakeProcess(0))
+    monkeypatch.setattr("hermes_cli.parallel.run_verification", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("hermes_cli.parallel.mission_id_for", lambda name: "20260502-012245-test")
+
+    captured_cwds = []
+
+    def fake_spawn(run, **kwargs):
+        captured_cwds.append(run.cwd)
+        return FakeProcess(0)
+
+    monkeypatch.setattr("hermes_cli.parallel._spawn_child_process", fake_spawn)
+
+    code = run_parallel_mission(_base_args(repo, no_worktrees=True))
+
+    assert code == 0
+    assert captured_cwds == [repo.resolve(), repo.resolve()]
+
+
+def test_run_parallel_mission_cleans_clean_worktrees(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr("hermes_cli.parallel.git_repo_root", lambda cwd: str(repo))
+    monkeypatch.setattr("hermes_cli.parallel._spawn_child_process", lambda *args, **kwargs: FakeProcess(0))
+    monkeypatch.setattr("hermes_cli.parallel.run_verification", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("hermes_cli.parallel.mission_id_for", lambda name: "20260502-012245-test")
+
+    created = []
+
+    def fake_setup(repo_root, *, prefix, branch_prefix):
+        role = prefix.rsplit("-", 1)[-1]
+        info = WorktreeInfo(path=str(tmp_path / f"wt-{role}"), branch=f"{branch_prefix}/{role}", repo_root=str(repo))
+        created.append(info)
+        return info
+
+    cleaned = []
+    monkeypatch.setattr("hermes_cli.parallel.setup_worktree", fake_setup)
+    monkeypatch.setattr("hermes_cli.parallel.cleanup_worktree", lambda info: cleaned.append(info) or True)
+
+    code = run_parallel_mission(_base_args(repo))
+
+    assert code == 0
+    assert cleaned == created
+
+
+def test_setup_failure_rolls_back_created_worktrees(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr("hermes_cli.parallel.git_repo_root", lambda cwd: str(repo))
+    monkeypatch.setattr("hermes_cli.parallel.mission_id_for", lambda name: "20260502-012245-test")
+
+    first = WorktreeInfo(path=str(tmp_path / "wt-impl"), branch="hermes/impl", repo_root=str(repo))
+    calls = [first, None]
+    cleaned = []
+    monkeypatch.setattr("hermes_cli.parallel.setup_worktree", lambda *args, **kwargs: calls.pop(0))
+    monkeypatch.setattr("hermes_cli.parallel.cleanup_worktree", lambda info: cleaned.append(info) or True)
+
+    code = run_parallel_mission(_base_args(repo))
+
+    assert code == 1
+    assert cleaned == [first]
+
+
+def test_worktree_with_changes_is_preserved(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr("hermes_cli.parallel.git_repo_root", lambda cwd: str(repo))
+    monkeypatch.setattr("hermes_cli.parallel._spawn_child_process", lambda *args, **kwargs: FakeProcess(0))
+    monkeypatch.setattr("hermes_cli.parallel.run_verification", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("hermes_cli.parallel.mission_id_for", lambda name: "20260502-012245-test")
+
+    impl = WorktreeInfo(path=str(tmp_path / "wt-impl"), branch="hermes/impl", repo_root=str(repo))
+    review = WorktreeInfo(path=str(tmp_path / "wt-review"), branch="hermes/review", repo_root=str(repo))
+    calls = [impl, review]
+    cleaned = []
+    monkeypatch.setattr("hermes_cli.parallel.setup_worktree", lambda *args, **kwargs: calls.pop(0))
+    monkeypatch.setattr(
+        "hermes_cli.parallel.build_changed_file_summary",
+        lambda runs: {"by_role": {"impl": ["src/app.py"], "review": []}, "overlaps": {}},
+    )
+    monkeypatch.setattr("hermes_cli.parallel.cleanup_worktree", lambda info: cleaned.append(info) or True)
+
+    code = run_parallel_mission(_base_args(repo))
+
+    assert code == 0
+    assert cleaned == [review]
+
+
+def test_spawn_failure_cleans_worktrees_and_terminates_started_process(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr("hermes_cli.parallel.git_repo_root", lambda cwd: str(repo))
+    monkeypatch.setattr("hermes_cli.parallel.mission_id_for", lambda name: "20260502-012245-test")
+
+    impl = WorktreeInfo(path=str(tmp_path / "wt-impl"), branch="hermes/impl", repo_root=str(repo))
+    review = WorktreeInfo(path=str(tmp_path / "wt-review"), branch="hermes/review", repo_root=str(repo))
+    setup_calls = [impl, review]
+    first_process = FakeProcess(0)
+    spawn_count = {"value": 0}
+    cleaned = []
+
+    def fake_spawn(*args, **kwargs):
+        spawn_count["value"] += 1
+        if spawn_count["value"] == 2:
+            raise FileNotFoundError("missing hermes")
+        return first_process
+
+    monkeypatch.setattr("hermes_cli.parallel.setup_worktree", lambda *args, **kwargs: setup_calls.pop(0))
+    monkeypatch.setattr("hermes_cli.parallel._spawn_child_process", fake_spawn)
+    monkeypatch.setattr("hermes_cli.parallel.cleanup_worktree", lambda info: cleaned.append(info) or True)
+
+    code = run_parallel_mission(_base_args(repo))
+
+    assert code == 1
+    assert first_process.terminated is True
+    assert cleaned == [impl, review]

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -37,6 +37,7 @@ hermes [global-options] <command> [subcommand/options]
 | Command | Purpose |
 |---------|---------|
 | `hermes chat` | Interactive or one-shot chat with the agent. |
+| `hermes parallel` | Launch coordinated child Hermes sessions with shared mission context and isolated git worktrees. |
 | `hermes model` | Interactively choose the default provider and model. |
 | `hermes fallback` | Manage fallback providers tried when the primary model errors. |
 | `hermes gateway` | Run or manage the messaging gateway service. |
@@ -142,6 +143,39 @@ HERMES_INFERENCE_MODEL=anthropic/claude-sonnet-4.6 hermes -z "…"
 ```
 
 Same agent, same tools, same skills — just strips every interactive / cosmetic layer. If you need tool output in the transcript too, use `hermes chat -q` instead; `-z` is explicitly for "I only want the final answer".
+
+## `hermes parallel`
+
+Launch two or more Hermes child sessions with a shared mission brief and isolated git worktrees.
+Each child runs as `hermes chat -q --source parallel`, writes a per-role log under the active Hermes home, and the parent command records a mission manifest plus changed-file overlap summary.
+
+```bash
+hermes parallel run \
+  --name auth-fix \
+  --agent impl::"Implement the fix using TDD" \
+  --agent review::"Review the diff and run targeted tests" \
+  --verify "python -m pytest tests/auth -q"
+```
+
+Useful options:
+
+| Option | Description |
+|--------|-------------|
+| `--name <name>` | Human-readable mission name. |
+| `--goal <goal>` | Shared goal injected into every child prompt. |
+| `--agent role::task` | Role-scoped child task. Repeat at least twice. |
+| `--verify <command>` | Final shell verification command run by the parent after children exit. |
+| `--repo <path>` | Repo root or subdirectory. Defaults to the current directory. |
+| `--no-worktrees` | Run without creating isolated git worktrees. |
+| `--model`, `--provider`, `--toolsets`, `--skills` | Child-session routing and context overrides. |
+
+Inspect a saved mission:
+
+```bash
+hermes parallel status <mission_id>
+```
+
+Mission files are saved under `parallel/<mission_id>/` in the active Hermes home.
 
 ## `hermes model`
 


### PR DESCRIPTION
## Summary
- Add `hermes parallel run` for coordinated multi-agent missions with role-scoped prompts and isolated git worktrees.
- Add mission manifests, per-agent logs, changed-file overlap detection, verification command support, status output, cleanup, and rollback safeguards.
- Extract reusable worktree helpers into `hermes_cli/worktree.py` and document the new CLI flow.

## Verification
- `venv/bin/python -m pytest tests/hermes_cli/test_parallel.py tests/cli/test_worktree.py tests/cli/test_worktree_security.py -q` -> 56 passed
- `venv/bin/python -m ruff check hermes_cli/worktree.py hermes_cli/parallel.py tests/hermes_cli/test_parallel.py` -> passed
- `venv/bin/python -m py_compile hermes_cli/worktree.py hermes_cli/parallel.py cli.py hermes_cli/main.py hermes_cli/tips.py` -> passed
- Smoke-tested `hermes parallel run/status` with `HERMES_PARALLEL_CHILD_BIN=/bin/echo`; verification exited 0 and clean worktrees were removed.
- Independent post-fix code review passed with no blocking issues.

## Known unrelated local baseline
- Broad local suite `venv/bin/python -m pytest tests/hermes_cli tests/cli -q` has existing unrelated failures in gateway/systemd, OpenClaw cleanup, custom provider model switch mock expectation, WSL systemd support, and web schema category.