### PR TITLE
fix(transports): dedupe OpenAI tool schemas before strict providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -526,6 +526,9 @@ class _CodexCompletionsAdapter:
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")
         if tools:
+            from agent.transports.base import dedupe_openai_tool_definitions_for_api
+
+            tools = dedupe_openai_tool_definitions_for_api(tools)
             converted = []
             for t in tools:
                 fn = t.get("function", {}) if isinstance(t, dict) else {}
@@ -3237,7 +3240,9 @@ def _build_call_kwargs(
             kwargs["max_tokens"] = max_tokens
 
     if tools:
-        kwargs["tools"] = tools
+        from agent.transports.base import dedupe_openai_tool_definitions_for_api
+
+        kwargs["tools"] = dedupe_openai_tool_definitions_for_api(tools)
 
     # Provider-specific extra_body
     merged_extra = dict(extra_body or {})

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -6,7 +6,7 @@ This transport owns format conversion and normalization — NOT client lifecycle
 
 from typing import Any, Dict, List, Optional
 
-from agent.transports.base import ProviderTransport
+from agent.transports.base import ProviderTransport, dedupe_openai_tool_definitions_for_api
 from agent.transports.types import NormalizedResponse
 
 
@@ -62,6 +62,7 @@ class AnthropicTransport(ProviderTransport):
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
+        tools = dedupe_openai_tool_definitions_for_api(tools)
         return build_anthropic_kwargs(
             model=model,
             messages=messages,

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -7,10 +7,56 @@ It does NOT own: client construction, streaming, credential refresh,
 prompt caching, interrupt handling, or retry logic.  Those stay on AIAgent.
 """
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from agent.transports.types import NormalizedResponse
+
+_LOG = logging.getLogger(__name__)
+
+
+def dedupe_openai_tool_definitions_for_api(
+    tools: Optional[List[Dict[str, Any]]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Keep the first OpenAI-format tool for each ``function.name``.
+
+    Several providers (Anthropic, Vertex, Bedrock, Azure, strict OpenAI-compat
+    routes) reject duplicate tool names with HTTP 400.
+    """
+    if not tools:
+        return tools
+
+    seen: set[str] = set()
+    out: List[Dict[str, Any]] = []
+    dupes = 0
+    for item in tools:
+        if not isinstance(item, dict):
+            out.append(item)
+            continue
+        fn = item.get("function")
+        name = ""
+        if isinstance(fn, dict):
+            raw = fn.get("name")
+            if isinstance(raw, str):
+                name = raw
+        key = name if name else f"__noname_{id(item)}__"
+        if key.startswith("__noname_"):
+            out.append(item)
+            continue
+        if name in seen:
+            dupes += 1
+            continue
+        seen.add(name)
+        out.append(item)
+
+    if dupes:
+        _LOG.debug(
+            "Removed %d duplicate tool definition(s) before API request "
+            "(strict providers require unique function names)",
+            dupes,
+        )
+    return tools if len(out) == len(tools) else out
 
 
 class ProviderTransport(ABC):

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -8,7 +8,7 @@ boto3 calls stay on AIAgent.
 
 from typing import Any, Dict, List, Optional
 
-from agent.transports.base import ProviderTransport
+from agent.transports.base import ProviderTransport, dedupe_openai_tool_definitions_for_api
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
@@ -51,6 +51,7 @@ class BedrockTransport(ProviderTransport):
         region = params.get("region", "us-east-1")
         guardrail = params.get("guardrail_config")
 
+        tools = dedupe_openai_tool_definitions_for_api(tools)
         kwargs = build_converse_kwargs(
             model=model,
             messages=messages,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
-from agent.transports.base import ProviderTransport
+from agent.transports.base import ProviderTransport, dedupe_openai_tool_definitions_for_api
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
@@ -257,6 +257,7 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Tools
         if tools:
+            tools = dedupe_openai_tool_definitions_for_api(tools)
             # Moonshot/Kimi uses a stricter flavored JSON Schema.  Rewriting
             # tool parameters here keeps aggregator routes (Nous, OpenRouter,
             # etc.) compatible, in addition to direct moonshot.ai endpoints.

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -60,6 +60,7 @@ class ResponsesApiTransport(ProviderTransport):
             _chat_messages_to_responses_input,
             _responses_tools,
         )
+        from agent.transports.base import dedupe_openai_tool_definitions_for_api
 
         from run_agent import DEFAULT_AGENT_IDENTITY
 
@@ -93,7 +94,7 @@ class ResponsesApiTransport(ProviderTransport):
             "model": model,
             "instructions": instructions,
             "input": _chat_messages_to_responses_input(payload_messages),
-            "tools": _responses_tools(tools),
+            "tools": _responses_tools(dedupe_openai_tool_definitions_for_api(tools)),
             "tool_choice": "auto",
             "parallel_tool_calls": True,
             "store": False,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1116,6 +1116,26 @@ class TestKimiTemperatureOmitted:
         assert "temperature" not in kwargs
 
 
+class TestAuxiliaryChatCompletionsToolDedup:
+    """Duplicate tool names must not reach strict OpenAI-compatible APIs (#18478)."""
+
+    def test_build_call_kwargs_dedupes_tool_names(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        tools = [
+            {"type": "function", "function": {"name": "x", "description": "a", "parameters": {}}},
+            {"type": "function", "function": {"name": "x", "description": "b", "parameters": {}}},
+        ]
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+        )
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["tools"][0]["function"]["description"] == "a"
+
+
 # ---------------------------------------------------------------------------
 # async_call_llm payment / connection fallback (#7512 bug 2)
 # ---------------------------------------------------------------------------

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -72,6 +72,24 @@ class TestChatCompletionsBuildKwargs:
         kw = transport.build_kwargs(model="gpt-4o", messages=msgs, tools=tools)
         assert kw["tools"] == tools
 
+    def test_tools_duplicate_names_keep_first(self, transport):
+        """Strict chat-completions providers reject duplicate function names (see #18478)."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        first = {
+            "type": "function",
+            "function": {"name": "dup", "description": "first", "parameters": {}},
+        }
+        second = {
+            "type": "function",
+            "function": {"name": "dup", "description": "second", "parameters": {}},
+        }
+        other = {"type": "function", "function": {"name": "ok", "parameters": {}}}
+        tools = [first, second, other]
+        kw = transport.build_kwargs(model="gpt-4o", messages=msgs, tools=tools)
+        assert len(kw["tools"]) == 2
+        assert kw["tools"][0]["function"]["description"] == "first"
+        assert kw["tools"][1]["function"]["name"] == "ok"
+
     def test_openrouter_provider_prefs(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary

Several providers (Anthropic direct, Vertex AI, Azure OpenAI, Bedrock Converse, and other strict OpenAI-compatible routes) reject requests when the `tools` array contains duplicate `function.name` entries, typically with HTTP 400 and messages like `Tool names must be unique`. This change adds a shared guard that keeps the **first** schema for each name and drops later duplicates **at the transport / auxiliary boundary**, so bad lists cannot reach the wire.

## What changed

- New helper `dedupe_openai_tool_definitions_for_api` in `agent/transports/base.py`.
- Applied before outbound tool payloads from:
  - `ChatCompletionsTransport.build_kwargs`
  - `AnthropicTransport` / `BedrockTransport` / `CodexTransport` `build_kwargs`
  - `agent/auxiliary_client` (chat completions `_build_call_kwargs`, plus Codex auxiliary tool conversion path)
- Duplicate removals are logged at **debug** level with a count.

This complements existing **agent-side** dedup (e.g. context-engine schema injection) by hardening the last mile for any caller that still assembled a duplicate list.

## Testing

```bash
pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_tools_included \
       tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_tools_duplicate_names_keep_first \
       tests/agent/test_auxiliary_client.py::TestAuxiliaryChatCompletionsToolDedup -q -o addopts=