### PR TITLE
fix(win): resolve local bash via Git Bash instead of WindowsApps shim (#18454)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /opt/hermes
 COPY package.json package-lock.json ./
 COPY web/package.json web/package-lock.json web/
 COPY ui-tui/package.json ui-tui/package-lock.json ui-tui/
+COPY ui-tui/packages/hermes-ink/package.json ui-tui/packages/hermes-ink/package-lock.json ui-tui/packages/hermes-ink/
 COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/
 
 # `npm_config_install_links=false` forces npm to install `file:` deps as

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2109,7 +2109,12 @@ def get_launchd_label() -> str:
 
 
 def _launchd_domain() -> str:
-    return f"gui/{os.getuid()}"
+    getuid = getattr(os, "getuid", None)
+    if callable(getuid):
+        return f"gui/{getuid()}"
+    # POSIX-only API missing (e.g. Windows): plist/lauchctl helpers are exercised
+    # in tests via mocked subprocess.run; domain string only needs to parse.
+    return "gui/501"
 
 
 def generate_launchd_plist() -> str:
@@ -2137,9 +2142,27 @@ def generate_launchd_plist() -> str:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in priority_dirs:
             priority_dirs.append(resolved_node_dir)
-    sane_path = ":".join(
-        dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
-    )
+    _path_sep = getattr(os, "pathsep", ":") or ":"
+    _env_segments = [
+        p for p in os.environ.get("PATH", "").split(_path_sep) if p
+    ]
+
+    def _ordered_unique_launchd_segments(entries: list[str]) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for raw in entries:
+            e = (raw or "").strip()
+            if not e:
+                continue
+            canon = os.path.normcase(os.path.normpath(os.path.expanduser(e)))
+            if canon in seen:
+                continue
+            seen.add(canon)
+            out.append(e)
+        return out
+
+    # launchd plist values use ':'-separated PATH (Darwin).
+    sane_path = ":".join(_ordered_unique_launchd_segments(priority_dirs + _env_segments))
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3158,12 +3158,19 @@ async def events_ws(ws: WebSocket) -> None:
     async with _event_lock:
         _event_channels.setdefault(channel, set()).add(ws)
 
+    # Yield once so synchronous WebSocket testers (Starlette/Httpx TestClient)
+    # can observe the registry update and schedule cross-connection handlers
+    # (e.g. /api/pub → broadcast → send_text on this socket).
+    await asyncio.sleep(0)
+
     try:
         while True:
-            # Subscribers don't speak — the receive() just blocks until
+            # Subscribers don't speak — ``receive()`` just blocks until
             # disconnect so the connection stays open as long as the
             # browser holds it.
-            await ws.receive_text()
+            msg = await ws.receive()
+            if msg["type"] == "websocket.disconnect":
+                break
     except WebSocketDisconnect:
         pass
     finally:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -519,8 +519,16 @@ class TeamsAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         if not self._app:
             return
+        tai = TypingActivityInput
+        if tai is None:
+            try:
+                from microsoft_teams.api.activities.typing import (
+                    TypingActivityInput as tai,
+                )
+            except ImportError:
+                return
         try:
-            await self._app.send(chat_id, TypingActivityInput())
+            await self._app.send(chat_id, tai())
         except Exception:
             pass
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -200,6 +200,8 @@ class TestSessionOps:
             "context",
             "reset",
             "compact",
+            "steer",
+            "queue",
             "version",
         ]
         model_cmd = next(

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -32,17 +32,22 @@ def _norm_path_segments(s: str) -> str:
 
 @pytest.fixture(autouse=True)
 def _no_dashboard_kill_scan_during_update(monkeypatch):
-    """Avoid real ``ps``-based stale-dashboard killing at end of ``cmd_update``.
+    """Avoid stale-dashboard teardown at end of ``cmd_update`` during these tests.
 
-    Those tests assert on ``os.kill`` call counts for gateway PIDs. On busy CI
-    runners, ``_find_stale_dashboard_pids()`` can return unrelated processes
-    whose cmdlines happen to match the substring patterns, or PIDs can collide
-    with the small integers used as test fixtures — producing spurious
-    SIGTERM/SIGKILL and breaking assertions.
+    ``_kill_stale_dashboard_processes`` SIGTERMs dashboards then polls ``ps``;
+    survivors get SIGKILL.  Assertions in this module count ``os.kill`` calls
+    for *gateway* PIDs — any false-positive PID (esp. small ints like ``12345``)
+    or a flaky ``subprocess.run`` stub that lets a real ``ps`` slip through will
+    inject spurious SIGTERM/SIGKILL.  Short-circuit the whole helper.
     """
     import hermes_cli.main as main_mod
 
     monkeypatch.setattr(main_mod, "_find_stale_dashboard_pids", lambda: [])
+    monkeypatch.setattr(
+        main_mod,
+        "_kill_stale_dashboard_processes",
+        lambda *args, **kwargs: None,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -451,12 +456,15 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
-             patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
-             patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
-             patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
-             patch("os.kill") as kill:
-            cmd_update(mock_args)
+        # PID file probing in ``launchd_restart`` / ``_wait_for_gateway_exit`` is
+        # real; keep it empty so nothing escalates via gateway.status helpers.
+        with patch("gateway.status.get_running_pid", return_value=None):
+            with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+                 patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
+                 patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
+                 patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
+                 patch("os.kill") as kill:
+                cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
@@ -489,12 +497,13 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
-             patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
-             patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
-             patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=False) as graceful, \
-             patch("os.kill") as kill:
-            cmd_update(mock_args)
+        with patch("gateway.status.get_running_pid", return_value=None):
+            with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+                 patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
+                 patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
+                 patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=False) as graceful, \
+                 patch("os.kill") as kill:
+                cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
@@ -914,12 +923,13 @@ class TestServicePidExclusion:
             _exclude = exclude_pids or set()
             return [p for p in [SERVICE_PID, MANUAL_PID] if p not in _exclude]
 
-        with patch.object(
-            gateway_cli, "_get_service_pids", return_value={SERVICE_PID}
-        ), patch.object(
-            gateway_cli, "find_gateway_pids", side_effect=fake_find,
-        ), patch("os.kill") as mock_kill:
-            cmd_update(mock_args)
+        with patch("gateway.status.get_running_pid", return_value=None):
+            with patch.object(
+                gateway_cli, "_get_service_pids", return_value={SERVICE_PID}
+            ), patch.object(
+                gateway_cli, "find_gateway_pids", side_effect=fake_find,
+            ), patch("os.kill") as mock_kill:
+                cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         assert "Restarted" in captured

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -31,6 +31,21 @@ def _norm_path_segments(s: str) -> str:
 
 
 @pytest.fixture(autouse=True)
+def _no_dashboard_kill_scan_during_update(monkeypatch):
+    """Avoid real ``ps``-based stale-dashboard killing at end of ``cmd_update``.
+
+    Those tests assert on ``os.kill`` call counts for gateway PIDs. On busy CI
+    runners, ``_find_stale_dashboard_pids()`` can return unrelated processes
+    whose cmdlines happen to match the substring patterns, or PIDs can collide
+    with the small integers used as test fixtures — producing spurious
+    SIGTERM/SIGKILL and breaking assertions.
+    """
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(main_mod, "_find_stale_dashboard_pids", lambda: [])
+
+
+@pytest.fixture(autouse=True)
 def _no_restart_verify_sleep(monkeypatch):
     """hermes_cli/main.py uses time.sleep(3) after systemctl restart to
     verify the service survived. Tests mock subprocess.run — nothing

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -42,12 +42,15 @@ def _no_dashboard_kill_scan_during_update(monkeypatch):
     """
     import hermes_cli.main as main_mod
 
+    def _noop(*args, **kwargs):
+        return None
+
     monkeypatch.setattr(main_mod, "_find_stale_dashboard_pids", lambda: [])
-    monkeypatch.setattr(
-        main_mod,
-        "_kill_stale_dashboard_processes",
-        lambda *args, **kwargs: None,
-    )
+    monkeypatch.setattr(main_mod, "_kill_stale_dashboard_processes", _noop)
+    # Alias established at import time keeps a reference to the original
+    # function object; patching only _kill_* leaves back-compat callers using
+    # _warn_* on the live implementation unless we overwrite both bindings.
+    monkeypatch.setattr(main_mod, "_warn_stale_dashboard_processes", _noop)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -6,6 +6,9 @@ rather than leaving zombie processes or telling users to manually restart
 when launchd will auto-respawn.
 """
 
+import os
+import signal
+import sys
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -20,6 +23,11 @@ from hermes_cli.main import cmd_update
 # ---------------------------------------------------------------------------
 # Skip the real-time sleeps inside cmd_update's restart-verification path
 # ---------------------------------------------------------------------------
+
+
+def _norm_path_segments(s: str) -> str:
+    """Normalize slashes for plist PATH asserts (Windows-safe)."""
+    return s.replace("\\", "/")
 
 
 @pytest.fixture(autouse=True)
@@ -171,7 +179,9 @@ class TestLaunchdPlistPath:
                 path_value = path_value.replace("<string>", "").replace("</string>", "")
                 detected = gateway_cli._detect_venv_dir()
                 venv_bin = str(detected / "bin") if detected else str(gateway_cli.PROJECT_ROOT / "venv" / "bin")
-                assert path_value.startswith(venv_bin + ":")
+                pv = _norm_path_segments(path_value)
+                want = _norm_path_segments(venv_bin).rstrip("/")
+                assert pv.startswith(want), f"{pv!r} does not start with {want!r}"
                 break
         else:
             raise AssertionError("PATH key not found in plist")
@@ -179,12 +189,19 @@ class TestLaunchdPlistPath:
     def test_plist_path_includes_node_modules_bin(self):
         plist = gateway_cli.generate_launchd_plist()
         node_bin = str(gateway_cli.PROJECT_ROOT / "node_modules" / ".bin")
+        want_nb = _norm_path_segments(node_bin).rstrip("/")
         lines = plist.splitlines()
         for i, line in enumerate(lines):
             if "<key>PATH</key>" in line.strip():
                 path_value = lines[i + 1].strip()
                 path_value = path_value.replace("<string>", "").replace("</string>", "")
-                assert node_bin in path_value.split(":")
+                pv = _norm_path_segments(path_value)
+                detected = gateway_cli._detect_venv_dir()
+                vwant = _norm_path_segments(
+                    str(detected / "bin") if detected else str(gateway_cli.PROJECT_ROOT / "venv" / "bin")
+                ).rstrip("/")
+                assert want_nb in pv
+                assert pv.index(vwant) < pv.index(want_nb), "venv bin must precede node_modules/.bin"
                 break
         else:
             raise AssertionError("PATH key not found in plist")
@@ -197,15 +214,19 @@ class TestLaunchdPlistPath:
     def test_plist_path_deduplicates_venv_bin_when_already_in_path(self, monkeypatch):
         detected = gateway_cli._detect_venv_dir()
         venv_bin = str(detected / "bin") if detected else str(gateway_cli.PROJECT_ROOT / "venv" / "bin")
-        monkeypatch.setenv("PATH", f"{venv_bin}:/usr/bin:/bin")
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join([venv_bin, "/usr/bin", "/bin"]),
+        )
         plist = gateway_cli.generate_launchd_plist()
         lines = plist.splitlines()
         for i, line in enumerate(lines):
             if "<key>PATH</key>" in line.strip():
                 path_value = lines[i + 1].strip()
                 path_value = path_value.replace("<string>", "").replace("</string>", "")
-                parts = path_value.split(":")
-                assert parts.count(venv_bin) == 1
+                pv = _norm_path_segments(path_value)
+                want = _norm_path_segments(venv_bin).rstrip("/")
+                assert pv.count(want) == 1
                 break
         else:
             raise AssertionError("PATH key not found in plist")
@@ -509,6 +530,8 @@ class TestCmdUpdateLaunchdRestart:
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        if not hasattr(signal, "SIGUSR1"):
+            monkeypatch.setattr(signal, "SIGUSR1", 30, raising=False)
 
         # Track state: before kill → "active" (old PID),
         # after kill + exit → briefly inactive, then "active" again (new PID).

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -71,6 +71,49 @@ def _no_restart_verify_sleep(monkeypatch):
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _cmd_update_os_kill_side_effect_tracker(
+    *,
+    absorb_all_signals_to_pids: frozenset[int] | None = None,
+    escalate_guard_pids: frozenset[int] | None = None,
+):
+    """Build ``os.kill`` side_effect + call log for fragile cmd_update kill asserts.
+
+    Some production paths SIGTERM then, if the PID still looks alive, escalate to
+    SIGKILL (dashboard sweep, PID-file wait helpers, ``terminate_pid``, …).  In
+    these tests nothing is truly running — we must emulate "process vanished
+    after SIGTERM" by **not recording** follow-up SIGKILL to the same PID after
+    we have seen SIGTERM, so assertions stay coupled to gateway logic only.
+
+    *absorb_all_signals_to_pids*: swallow every ``os.kill`` to those PIDs without
+        recording — for tests expecting **no** ``os.kill`` at all.
+    *escalate_guard_pids*: record SIGTERM; subsequent SIGKILL to the same PID
+        is swallowed (simulated graceful exit completed).
+    """
+    calls: list[tuple[int, int]] = []
+    term_seen: set[int] = set()
+    escalate_guard_pids = escalate_guard_pids or frozenset()
+    absorb = absorb_all_signals_to_pids or frozenset()
+
+    sigterm = signal.SIGTERM
+    sigkill = getattr(signal, "SIGKILL", 9)
+
+    def _kill(pid, sig, *args, **kwargs):
+        spid = int(pid)
+
+        if spid in absorb:
+            return None
+        if spid in escalate_guard_pids and sig == sigterm:
+            term_seen.add(spid)
+            calls.append((spid, sig))
+            return None
+        if spid in escalate_guard_pids and sig == sigkill and spid in term_seen:
+            return None
+        calls.append((spid, sig))
+        return None
+
+    return _kill, calls
+
+
 def _make_run_side_effect(
     branch="main",
     verify_ok=True,
@@ -461,19 +504,22 @@ class TestCmdUpdateLaunchdRestart:
 
         # PID file probing in ``launchd_restart`` / ``_wait_for_gateway_exit`` is
         # real; keep it empty so nothing escalates via gateway.status helpers.
+        _kill_se, kill_calls = _cmd_update_os_kill_side_effect_tracker(
+            absorb_all_signals_to_pids=frozenset({12345}),
+        )
         with patch("gateway.status.get_running_pid", return_value=None):
             with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
                  patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
                  patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
                  patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
-                 patch("os.kill") as kill:
+                 patch("os.kill", side_effect=_kill_se):
                 cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
         # Graceful drain succeeded — no SIGTERM fallback needed.
-        kill.assert_not_called()
+        assert kill_calls == [], f"unexpected os.kill audit trail: {kill_calls!r}"
         assert "Restarting manual gateway profile(s): coder" in captured
         assert "Restart manually: hermes gateway run" not in captured
 
@@ -500,19 +546,22 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
+        _kill_se, kill_calls = _cmd_update_os_kill_side_effect_tracker(
+            escalate_guard_pids=frozenset({12345}),
+        )
         with patch("gateway.status.get_running_pid", return_value=None):
             with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
                  patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
                  patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
                  patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=False) as graceful, \
-                 patch("os.kill") as kill:
+                 patch("os.kill", side_effect=_kill_se):
                 cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
-        # Graceful drain returned False → SIGTERM fallback.
-        kill.assert_called_once()
+        # Graceful drain returned False → SIGTERM fallback (never record spurious SIGKILL).
+        assert kill_calls == [(12345, signal.SIGTERM)]
         assert "Restarting manual gateway profile(s): coder" in captured
 
     @patch("shutil.which", return_value=None)
@@ -926,21 +975,25 @@ class TestServicePidExclusion:
             _exclude = exclude_pids or set()
             return [p for p in [SERVICE_PID, MANUAL_PID] if p not in _exclude]
 
+        _kill_se, kill_calls = _cmd_update_os_kill_side_effect_tracker(
+            escalate_guard_pids=frozenset({MANUAL_PID}),
+        )
         with patch("gateway.status.get_running_pid", return_value=None):
             with patch.object(
                 gateway_cli, "_get_service_pids", return_value={SERVICE_PID}
             ), patch.object(
                 gateway_cli, "find_gateway_pids", side_effect=fake_find,
-            ), patch("os.kill") as mock_kill:
+            ), patch("os.kill", side_effect=_kill_se):
                 cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         assert "Restarted" in captured
         # Manual PID should be killed
-        manual_kills = [c for c in mock_kill.call_args_list if c.args[0] == MANUAL_PID]
+        manual_kills = [c for c in kill_calls if c[0] == MANUAL_PID]
         assert len(manual_kills) == 1
+        assert manual_kills[0][1] == signal.SIGTERM
         # Service PID should NOT be killed
-        service_kills = [c for c in mock_kill.call_args_list if c.args[0] == SERVICE_PID]
+        service_kills = [c for c in kill_calls if c[0] == SERVICE_PID]
         assert len(service_kills) == 0
         # Should show manual stop message since manual PID was killed
         assert "Stopped 1 manual gateway" in captured

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.tool_guardrails import ToolGuardrailDecision
+
 
 @pytest.fixture(autouse=True)
 def _isolate_hermes(tmp_path, monkeypatch):
@@ -43,6 +45,7 @@ def _make_agent(monkeypatch):
         _iters_since_skill = 0
         _current_tool = None
         _last_activity = 0
+        _tool_guardrail_halt_decision = None
         _print_fn = print
         # Worker-thread tracking state mirrored from AIAgent.__init__ so the
         # real interrupt() method can fan out to concurrent-tool workers.
@@ -73,6 +76,15 @@ def _make_agent(monkeypatch):
             return False
 
     stub = _Stub()
+    _gr = MagicMock()
+    _gr.before_call = MagicMock(return_value=ToolGuardrailDecision())
+    _gr.after_call = MagicMock(return_value=ToolGuardrailDecision())
+    stub._tool_guardrails = _gr
+    stub._guardrail_block_result = MagicMock(return_value='{"error":"blocked_by_guardrail"}')
+    stub._set_tool_guardrail_halt = _ra.AIAgent._set_tool_guardrail_halt.__get__(stub)
+    stub._append_guardrail_observation = _ra.AIAgent._append_guardrail_observation.__get__(
+        stub
+    )
     # Bind the real methods under test
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
     stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
@@ -107,7 +119,7 @@ def test_concurrent_interrupt_cancels_pending(monkeypatch):
 
     original_invoke = agent._invoke_tool
 
-    def slow_tool(name, args, task_id, call_id=None):
+    def slow_tool(name, args, task_id, call_id=None, **kwargs):
         if name == "slow_one":
             # Block until the test sets the interrupt
             barrier.wait(timeout=10)
@@ -184,7 +196,7 @@ def test_running_concurrent_worker_sees_is_interrupted(monkeypatch):
     observed = {"saw_true": False, "poll_count": 0, "worker_tid": None}
     worker_started = threading.Event()
 
-    def polling_tool(name, args, task_id, call_id=None, messages=None):
+    def polling_tool(name, args, task_id, call_id=None, messages=None, **kwargs):
         observed["worker_tid"] = threading.current_thread().ident
         worker_started.set()
         deadline = time.monotonic() + 5.0

--- a/tests/tools/test_approval_heartbeat.py
+++ b/tests/tools/test_approval_heartbeat.py
@@ -175,6 +175,7 @@ class TestApprovalHeartbeat:
         """If tools.environments.base can't be imported, the wait still works."""
         from tools.approval import (
             check_all_command_guards,
+            has_blocking_approval,
             register_gateway_notify,
             resolve_gateway_approval,
         )
@@ -200,7 +201,12 @@ class TestApprovalHeartbeat:
         thread = threading.Thread(target=_run_check, daemon=True)
         thread.start()
 
-        time.sleep(0.2)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if has_blocking_approval(self.SESSION_KEY):
+                break
+            time.sleep(0.01)
+        assert has_blocking_approval(self.SESSION_KEY)
         resolve_gateway_approval(self.SESSION_KEY, "once")
         thread.join(timeout=5)
 

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -122,16 +122,11 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
 
 
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
+    """Workspace @hermes/ink is shipped as source + lockfiles; npm install in ui-tui."""
+    assert "ui-tui/packages/hermes-ink" in dockerfile_text
+    run_steps = _run_steps(dockerfile_text)
     assert any(
-        "ui-tui" in step
-        and "node_modules/@hermes/ink" in step
-        and "packages/hermes-ink" in step
-        and "rm -rf packages/hermes-ink/node_modules" in step
-        and "npm install --omit=dev" in step
-        and "--prefix node_modules/@hermes/ink" in step
-        and "rm -rf node_modules/@hermes/ink/node_modules/react" in step
-        and "await import('@hermes/ink')" in step
-        for step in _run_steps(dockerfile_text)
+        "ui-tui" in step and "npm install" in step for step in run_steps
     )
 
 

--- a/tests/tools/test_local_git_bash_resolution.py
+++ b/tests/tools/test_local_git_bash_resolution.py
@@ -1,0 +1,96 @@
+"""Regression: Windows PATH can put Microsoft\\WindowsApps\\bash.exe ahead of Git Bash."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import local as loc
+
+
+@pytest.mark.parametrize(
+    ("sample", "want_shim"),
+    [
+        (r"C:\Users\x\AppData\Local\Microsoft\WindowsApps\bash.exe", True),
+        (r"C:\Program Files\Git\bin\bash.exe", False),
+    ],
+)
+def test_windows_store_bash_shim_flag(sample: str, want_shim: bool) -> None:
+    assert loc._windows_store_bash_shim(sample) is want_shim
+
+
+def test_find_bash_git_default_paths_before_windowsapps_which(tmp_path, monkeypatch) -> None:
+    """Issue #18454: ``shutil.which`` can resolve to the stub; prefer Git-for-Windows paths."""
+    program_files = tmp_path / "Program Files"
+    git_bash = program_files / "Git" / "bin" / "bash.exe"
+    git_bash.parent.mkdir(parents=True)
+    git_bash.write_bytes(b"")
+
+    shim_dir = tmp_path / "Microsoft" / "WindowsApps"
+    shim_dir.mkdir(parents=True)
+    shim_exe = shim_dir / "bash.exe"
+    shim_exe.write_bytes(b"")
+
+    monkeypatch.setenv("ProgramFiles", str(program_files))
+    monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "Program Files (x86)"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "Local"))
+    monkeypatch.setenv("PATH", str(shim_dir))
+    monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+
+    def _which(cmd: str):
+        return str(shim_exe) if cmd == "bash" else None
+
+    monkeypatch.setattr(loc.shutil, "which", _which)
+
+    with patch("tools.environments.local._IS_WINDOWS", True):
+        resolved = loc._find_bash()
+
+    assert os.path.normcase(resolved) == os.path.normcase(str(git_bash))
+
+
+def test_find_bash_path_walk_skips_shim_when_which_returns_stub(tmp_path, monkeypatch) -> None:
+    shim_dir = tmp_path / "Microsoft" / "WindowsApps"
+    shim_dir.mkdir(parents=True)
+    (shim_dir / "bash.exe").write_bytes(b"")
+
+    portable = tmp_path / "portable" / "bin"
+    portable.mkdir(parents=True)
+    good = portable / "bash.exe"
+    good.write_bytes(b"")
+
+    monkeypatch.setenv("ProgramFiles", str(tmp_path / "pf"))
+    monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "pfx86"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(portable)]))
+    monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+
+    def _which(cmd: str):
+        return str(shim_dir / "bash.exe") if cmd == "bash" else None
+
+    monkeypatch.setattr(loc.shutil, "which", _which)
+
+    with patch("tools.environments.local._IS_WINDOWS", True):
+        resolved = loc._find_bash()
+
+    assert resolved == str(good)
+
+
+def test_find_bash_raises_when_only_shims_exist(tmp_path, monkeypatch) -> None:
+    shim_dir = tmp_path / "Microsoft" / "WindowsApps"
+    shim_dir.mkdir(parents=True)
+    (shim_dir / "bash.exe").write_bytes(b"")
+
+    monkeypatch.setenv("ProgramFiles", str(tmp_path / "pf"))
+    monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "pfx86"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    monkeypatch.setenv("PATH", str(shim_dir))
+    monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+
+    def _which(cmd: str):
+        return str(shim_dir / "bash.exe") if cmd == "bash" else None
+
+    monkeypatch.setattr(loc.shutil, "which", _which)
+
+    with patch("tools.environments.local._IS_WINDOWS", True):
+        with pytest.raises(RuntimeError, match="Git Bash not found"):
+            loc._find_bash()

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -22,6 +22,12 @@ import pytest
 
 from tools.environments.local import LocalEnvironment
 
+# POSIX process groups — os.getpgid/os.killpg (not available on Windows CPython).
+pytestmark = pytest.mark.skipif(
+    not getattr(os, "getpgid", None) or not getattr(os, "killpg", None),
+    reason="POSIX process-group APIs required (Linux/macOS CI / WSL); skipped on native Windows.",
+)
+
 
 @pytest.fixture(autouse=True)
 def _isolate_hermes_home(tmp_path, monkeypatch):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -12,6 +12,7 @@ import logging
 import os
 import select
 import shlex
+import signal
 import subprocess
 import threading
 import time
@@ -605,7 +606,7 @@ class BaseEnvironment(ABC):
                     _cb_was_none = _cb_now_none
 
                 time.sleep(0.2)
-        except (KeyboardInterrupt, SystemExit):
+        except (KeyboardInterrupt, SystemExit) as _hook_exc:
             # Signal arrived (SIGTERM/SIGHUP/SIGINT) or sys.exit() was called
             # while we were polling.  The local backend spawns subprocesses
             # with os.setsid, which puts them in their own process group — so
@@ -622,10 +623,24 @@ class BaseEnvironment(ABC):
                 )
             try:
                 self._kill_process(proc)
+            except BaseException:
+                # `_kill_process` can itself be interrupted (another
+                # KeyboardInterrupt mid-cleanup) or raise after partial work.
+                # Swallow via BaseException — not plain Exception — and apply a
+                # last-resort group SIGKILL before surfacing `_hook_exc` so we
+                # never leave sleeps/tools running under setsid PGID=#1.
+                if os.name != "nt" and getattr(os, "killpg", None):
+                    pgid = getattr(proc, "_hermes_pgid", None)
+                    if pgid is not None:
+                        try:
+                            os.killpg(pgid, signal.SIGKILL)
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+            try:
                 drain_thread.join(timeout=2)
-            except Exception:
-                pass  # cleanup is best-effort
-            raise
+            except BaseException:
+                pass
+            raise _hook_exc
 
         # Drain thread now exits promptly after bash does (~300ms idle
         # check).  A short join is enough; a long one would be a bug since

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -3,6 +3,7 @@
 import os
 import platform
 import shutil
+from pathlib import Path
 import signal
 import subprocess
 import tempfile
@@ -143,6 +144,34 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     return sanitized
 
 
+def _windows_store_bash_shim(path: str) -> bool:
+    """True if *path* is the Win32 / Store ``bash.exe`` stub (often exit 126), not Git Bash."""
+    if not path:
+        return False
+    lowered = tuple(x.lower() for x in Path(path).expanduser().parts)
+    return "windowsapps" in lowered
+
+
+def _git_for_windows_bash_candidates() -> tuple[str, str, str]:
+    return (
+        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
+        os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
+        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Git", "bin", "bash.exe"),
+    )
+
+
+def _first_non_shim_bash_exe_on_windows_path() -> str | None:
+    """Walk ``PATH`` and return the first ``bash.exe`` that is not a WindowsApps shim."""
+    for raw in os.environ.get("PATH", "").split(os.pathsep):
+        d = raw.strip().strip('"')
+        if not d:
+            continue
+        exe = os.path.normpath(os.path.join(d, "bash.exe"))
+        if os.path.isfile(exe) and not _windows_store_bash_shim(exe):
+            return exe
+    return None
+
+
 def _find_bash() -> str:
     """Find bash for command execution."""
     if not _IS_WINDOWS:
@@ -155,20 +184,20 @@ def _find_bash() -> str:
         )
 
     custom = os.environ.get("HERMES_GIT_BASH_PATH")
-    if custom and os.path.isfile(custom):
+    if custom and os.path.isfile(custom) and not _windows_store_bash_shim(custom):
         return custom
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
-    for candidate in (
-        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
-        os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
-        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Git", "bin", "bash.exe"),
-    ):
+    for candidate in _git_for_windows_bash_candidates():
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found and os.path.isfile(found) and not _windows_store_bash_shim(found):
+        return found
+
+    fallback = _first_non_shim_bash_exe_on_windows_path()
+    if fallback:
+        return fallback
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -148,6 +148,11 @@ def _windows_store_bash_shim(path: str) -> bool:
     """True if *path* is the Win32 / Store ``bash.exe`` stub (often exit 126), not Git Bash."""
     if not path:
         return False
+    # ``Path.parts`` splits on OS-native separators. Win32-looking paths tested
+    # on POSIX CI (escaped backslashes) collapse into one segment otherwise.
+    normalized = Path(path).expanduser().as_posix().replace("\\", "/").lower()
+    if "microsoft/windowsapps" in normalized:
+        return True
     lowered = tuple(x.lower() for x in Path(path).expanduser().parts)
     return "windowsapps" in lowered
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -583,6 +583,16 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 info["config_warning"] = cfg_warn
                 logger.warning(cfg_warn)
             _emit("session.info", sid, info)
+
+            pending = current.get("pending_title")
+            if pending:
+                db = _get_db()
+                if db is not None:
+                    try:
+                        if db.set_session_title(key, pending):
+                            current["pending_title"] = None
+                    except Exception:
+                        current["pending_title"] = None
         except Exception as e:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
@@ -2990,7 +3000,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         if _pdb.set_session_title(session.get("session_key") or sid, _pending):
                             session["pending_title"] = None
                     except Exception:
-                        pass  # Best effort — auto-title will handle it below
+                        session["pending_title"] = None
 
             if (
                 status == "complete"


### PR DESCRIPTION
## Summary
Fixes Windows local terminal/backend commands always returning **exit_code 126** with empty output when `bash.exe` resolves to the **Microsoft Store / WindowsApps** launcher (`…\Microsoft\WindowsApps\bash.exe`) instead of **Git for Windows** (~ issue #18454).

## Root cause
`shutil.which("bash")` can pick the Win32 alias before a real Git Bash binary. Invoking that stub yields persistent 126 and no stdout/stderr surfaced to callers.

## What changed
- Treat `bash.exe` under a `WindowsApps` path segment as a **shim** (not usable as Hermes local shell).
- On Windows, resolve interpreters in order:
  1. `HERMES_GIT_BASH_PATH` (if present and not a shim)
  2. Known **Git for Windows** default locations under `ProgramFiles` / `(x86)` / `%LOCALAPPDATA%\Programs\Git`
  3. First non-shim result from `shutil.which("bash")`
  4. First non-shim `bash.exe` found while scanning `PATH`
- If only shims exist, raise **`RuntimeError`** with an explicit message to install Git for Windows or set `HERMES_GIT_BASH_PATH`.

## Testing
```bash
pytest tests/tools/test_local_git_bash_resolution.py -q