### PR TITLE
fix(tui): preserve reasoning content in resumed session transcript

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -254,6 +254,52 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
     ]
 
 
+def test_history_to_messages_preserves_reasoning_for_resume_display():
+    """_history_to_messages must include 'thinking' from reasoning fields.
+
+    When resuming a session, assistant messages should retain their
+    reasoning/thinking content.  See issue #18414.
+    """
+    history = [
+        {"role": "user", "content": "explain quantum computing"},
+        {
+            "role": "assistant",
+            "content": "Quantum computing uses qubits.",
+            "reasoning": "The user wants a clear explanation. Let me cover basics.",
+        },
+        {"role": "user", "content": "go deeper"},
+        {
+            "role": "assistant",
+            "content": "Qubits can exist in superposition.",
+            "reasoning_content": "Expanding on superposition and entanglement.",
+        },
+    ]
+
+    result = server._history_to_messages(history)
+    assert len(result) == 4
+    # First assistant message should have thinking from 'reasoning'
+    assert result[1]["role"] == "assistant"
+    assert result[1]["text"] == "Quantum computing uses qubits."
+    assert result[1]["thinking"] == "The user wants a clear explanation. Let me cover basics."
+    # Second assistant message should have thinking from 'reasoning_content'
+    assert result[3]["role"] == "assistant"
+    assert result[3]["text"] == "Qubits can exist in superposition."
+    assert result[3]["thinking"] == "Expanding on superposition and entanglement."
+
+
+def test_history_to_messages_no_reasoning_field_when_absent():
+    """When no reasoning content exists, 'thinking' should not appear."""
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+
+    result = server._history_to_messages(history)
+    assert len(result) == 2
+    assert result[1]["role"] == "assistant"
+    assert "thinking" not in result[1]
+
+
 def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1942,7 +1942,13 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             continue
         if not (m.get("content") or "").strip():
             continue
-        messages.append({"role": role, "text": m.get("content") or ""})
+        entry: dict = {"role": role, "text": m.get("content") or ""}
+        # Preserve reasoning/thinking content for resumed sessions.
+        # Different providers store reasoning in different fields.
+        reasoning = m.get("reasoning") or m.get("reasoning_content")
+        if reasoning:
+            entry["thinking"] = reasoning
+        messages.append(entry)
 
     return messages
 

--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -19,6 +19,27 @@ describe('toTranscriptMessages', () => {
     ])
     expect(toTranscriptMessages(rows)[1]?.tools?.[0]).toContain('Search Files')
   })
+
+  it('passes through thinking from assistant rows for resume', () => {
+    const rows = [
+      { role: 'user', text: 'question' },
+      { role: 'assistant', text: 'answer', thinking: 'my reasoning' },
+    ]
+
+    const result = toTranscriptMessages(rows)
+    expect(result).toHaveLength(2)
+    expect(result[1]?.thinking).toBe('my reasoning')
+  })
+
+  it('does not include thinking when absent', () => {
+    const rows = [
+      { role: 'assistant', text: 'answer' },
+    ]
+
+    const result = toTranscriptMessages(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.thinking).toBeUndefined()
+  })
 })
 
 describe('upsert', () => {

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -44,7 +44,7 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
       continue
     }
 
-    const { context, name, role, text } = row as TranscriptRow
+    const { context, name, role, text, thinking } = row as TranscriptRow
 
     if (role === 'tool') {
       pending.push(buildToolTrailLine(name ?? 'tool', context ?? ''))
@@ -57,7 +57,7 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
     }
 
     if (role === 'assistant') {
-      out.push({ role, text, ...(pending.length && { tools: pending }) })
+      out.push({ role, text, ...(thinking && { thinking }), ...(pending.length && { tools: pending }) })
       pending = []
     } else if (role === 'user' || role === 'system') {
       out.push({ role, text })
@@ -88,4 +88,5 @@ interface TranscriptRow {
   name?: string
   role?: string
   text?: string
+  thinking?: string
 }


### PR DESCRIPTION
## What does this PR do?

Preserve reasoning/thinking content when resuming a TUI session via `/resume`. Currently, resumed assistant messages show only the text — all thinking blocks are silently dropped.


### Root Cause

`_history_to_messages()` in `tui_gateway/server.py` converts DB message rows to TUI display format for the `session.resume` response. It only emitted `{role, text}` — completely ignoring the `reasoning` and `reasoning_content` fields that are correctly persisted in the SQLite `messages` table.

On the frontend side, `toTranscriptMessages()` in `ui-tui/src/domain/messages.ts` did not destructure or pass through a `thinking` field, even though the `Msg` interface already supports `thinking?: string`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A