### PR TITLE
fix(kanban): anchor shared kanban.db at default Hermes root

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -62,9 +62,15 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban.db"
+    """Return the canonical ``kanban.db`` path shared by all profiles.
+
+    Boards are anchored at :func:`hermes_constants.get_default_hermes_root` per
+    the Kanban spec (coordination primitive must not fracture under
+    ``HERMES_HOME=<root>/profiles/<name>``).
+    """
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root() / "kanban.db"
 
 
 def workspaces_root() -> Path:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -23,6 +23,18 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def test_kanban_db_path_uses_install_root_under_profile(monkeypatch, tmp_path):
+    """Board DB stays at the install root (~/.hermes) when a profile tweaks HERMES_HOME."""
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    profile_home = root / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    assert kb.kanban_db_path() == root / "kanban.db"
+    assert kb.kanban_db_path().resolve() != (profile_home / "kanban.db").resolve()
+
+
 # ---------------------------------------------------------------------------
 # Schema / init
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`kanban_db_path()` used `get_hermes_home() / "kanban.db"`, which under
`HERMES_HOME=~/.hermes/profiles/<name>` created a **per-profile** database and
broke the documented “single shared board” model (dispatchers vs workers no
longer saw the same tasks). See #18442.

Resolve the file against `hermes_constants.get_default_hermes_root()` so all
standard profile layouts share one SQLite file under the install root.

## Test plan

- `pytest tests/hermes_cli/test_kanban_db.py -q`

## Related

- #18442