### PR TITLE
feat(matrix): add scoped native tools and reaction controls

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -771,7 +771,10 @@ PLATFORM_HINTS = {
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.jpg, .png, .webp) are sent as inline photos, "
         "audio (.ogg, .mp3) as voice/audio messages, video (.mp4) inline, "
-        "and other files as downloadable attachments."
+        "and other files as downloadable attachments. "
+        "When Matrix-specific tools are available, use them for Matrix-native "
+        "room actions such as reactions, redactions, invites, room creation, "
+        "history lookup, and presence updates."
     ),
     "feishu": (
         "You are in a Feishu (Lark) workspace communicating with your user. "

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -127,12 +127,13 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # "new"/"all" spam permanent lines in channels (hermes-agent#14663).
     "slack":           {**_TIER_MEDIUM, "tool_progress": "off"},
     "mattermost":      _TIER_MEDIUM,
-    # Matrix clients commonly treat edits/replacements as read-relevant events.
-    # Keep Matrix quiet by default; operators can opt back into live progress or
-    # streaming with display.platforms.matrix.* when their client behaves well.
+    # Matrix clients commonly treat edits/replacements as read-relevant events,
+    # so keep token/interim streaming off. Tool activity is still useful for
+    # agent workflows and is rendered as a single collapsible formatted message
+    # by the Matrix adapter when clients support <details>/<summary>.
     "matrix": {
         **_TIER_MEDIUM,
-        "tool_progress": "off",
+        "tool_progress": "new",
         "streaming": False,
         "tool_preview_length": 160,
     },

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -127,7 +127,15 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # "new"/"all" spam permanent lines in channels (hermes-agent#14663).
     "slack":           {**_TIER_MEDIUM, "tool_progress": "off"},
     "mattermost":      _TIER_MEDIUM,
-    "matrix":          _TIER_MEDIUM,
+    # Matrix clients commonly treat edits/replacements as read-relevant events.
+    # Keep Matrix quiet by default; operators can opt back into live progress or
+    # streaming with display.platforms.matrix.* when their client behaves well.
+    "matrix": {
+        **_TIER_MEDIUM,
+        "tool_progress": "off",
+        "streaming": False,
+        "tool_preview_length": 160,
+    },
     "feishu":          _TIER_MEDIUM,
 
     # Tier 3 — no edit support, progress messages are permanent

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -135,7 +135,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
         **_TIER_MEDIUM,
         "tool_progress": "new",
         "streaming": False,
-        "tool_preview_length": 320,
+        "tool_preview_length": 1000,
     },
     "feishu":          _TIER_MEDIUM,
 

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -135,7 +135,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
         **_TIER_MEDIUM,
         "tool_progress": "new",
         "streaming": False,
-        "tool_preview_length": 1000,
+        "tool_preview_length": 320,
     },
     "feishu":          _TIER_MEDIUM,
 

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -135,7 +135,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
         **_TIER_MEDIUM,
         "tool_progress": "new",
         "streaming": False,
-        "tool_preview_length": 160,
+        "tool_preview_length": 320,
     },
     "feishu":          _TIER_MEDIUM,
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16519,9 +16519,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _cleanup_progress = False
             _cleanup_adapter = None
         _cleanup_msg_ids: List[str] = []
-        _matrix_show_reasoning = bool(
-            resolve_display_setting(user_config, platform_key, "show_reasoning", False)
-        )
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17267,6 +17267,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                                     await _roll_progress_overflow_if_needed()
+                            elif (
+                                source.platform == Platform.MATRIX
+                                and isinstance(raw, tuple)
+                                and await _handle_matrix_progress_tuple(raw)
+                            ):
+                                continue
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh
@@ -17275,7 +17281,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if can_edit and progress_lines and progress_msg_id:
                                     _pending_text = _progress_text(progress_lines)
                                     try:
-                                        await _edit_progress_message(progress_msg_id, _pending_text)
+                                        if source.platform == Platform.MATRIX:
+                                            progress_msg_id = await _send_or_edit_progress(
+                                                progress_msg_id,
+                                                _pending_text,
+                                                matrix_tool_activity=True,
+                                            )
+                                        else:
+                                            await _edit_progress_message(progress_msg_id, _pending_text)
                                     except Exception:
                                         pass
                                 progress_msg_id = None
@@ -17293,7 +17306,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if can_edit and progress_lines and progress_msg_id:
                         full_text = _progress_text(progress_lines)
                         try:
-                            await _edit_progress_message(progress_msg_id, full_text)
+                            if source.platform == Platform.MATRIX:
+                                progress_msg_id = await _send_or_edit_progress(
+                                    progress_msg_id,
+                                    full_text,
+                                    matrix_tool_activity=True,
+                                )
+                            else:
+                                await _edit_progress_message(progress_msg_id, full_text)
                         except Exception:
                             pass
                     return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16522,6 +16522,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _matrix_show_reasoning = bool(
             resolve_display_setting(user_config, platform_key, "show_reasoning", False)
         )
+        _MATRIX_TOOL_ACTIVITY_PREVIEW_CAP = 1000
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
@@ -16718,7 +16719,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verb_drops_preview,
                 )
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
+                _cap = (
+                    _pl
+                    if _pl > 0
+                    else (
+                        _MATRIX_TOOL_ACTIVITY_PREVIEW_CAP
+                        if source.platform == Platform.MATRIX
+                        else 40
+                    )
+                )
                 if len(preview) > _cap:
                     preview = preview[:_cap - 3] + "..."
                 # Friendly labels: render a human-phrased line for built-in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2200,6 +2200,33 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _display_platform_setting_configured(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+) -> bool:
+    """Return True when display.platforms.<platform> explicitly sets a key."""
+    return _display_platform_setting_value(user_config, platform_key, setting) is not None
+
+
+def _display_platform_setting_value(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+) -> Any:
+    """Return display.platforms.<platform>.<setting>, or None when absent."""
+    display_cfg = user_config.get("display") if isinstance(user_config, dict) else None
+    if not isinstance(display_cfg, dict):
+        return None
+    platforms_cfg = display_cfg.get("platforms")
+    if not isinstance(platforms_cfg, dict):
+        return None
+    platform_cfg = platforms_cfg.get(platform_key)
+    if not isinstance(platform_cfg, dict) or setting not in platform_cfg:
+        return None
+    return platform_cfg.get(setting)
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -16014,11 +16041,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _plat_streaming = resolve_display_setting(
             user_config, platform_key, "streaming"
         )
-        _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
-        )
+        if (
+            source.platform == Platform.MATRIX
+            and not _display_platform_setting_configured(
+                user_config, platform_key, "streaming"
+            )
+        ):
+            _streaming_enabled = False
+        else:
+            _streaming_enabled = (
+                _scfg.enabled and _scfg.transport != "off"
+                if _plat_streaming is None
+                else bool(_plat_streaming)
+            )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
@@ -16360,21 +16395,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
+        _platform_tool_progress_configured = (
+            isinstance(_platform_cfg, dict)
+            and "tool_progress" in _platform_cfg
+        )
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
-            or (
-                isinstance(_platform_cfg, dict)
-                and "tool_progress" in _platform_cfg
-            )
+            or _platform_tool_progress_configured
             or (
                 isinstance(_legacy_tp_overrides, dict)
                 and platform_key in _legacy_tp_overrides
             )
         )
-        progress_mode = (
-            _env_tp
-            if _env_tp and not _tool_progress_configured
-            else (_resolved_tp or _env_tp or "all")
+        if (
+            source.platform == Platform.MATRIX
+            and not _platform_tool_progress_configured
+            and not _env_tp
+        ):
+            progress_mode = "off"
+        else:
+            progress_mode = (
+                _env_tp
+                if _env_tp and not _tool_progress_configured
+                else (_resolved_tp or _env_tp or "all")
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
@@ -17295,12 +17338,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _plat_streaming = resolve_display_setting(
                 user_config, platform_key, "streaming"
             )
-            # None = no per-platform override → follow global config
-            _streaming_enabled = (
-                _scfg.enabled and _scfg.transport != "off"
-                if _plat_streaming is None
-                else bool(_plat_streaming)
-            )
+            if (
+                source.platform == Platform.MATRIX
+                and not _display_platform_setting_configured(
+                    user_config, platform_key, "streaming"
+                )
+            ):
+                _streaming_enabled = False
+            else:
+                # None = no per-platform override → follow global config
+                _streaming_enabled = (
+                    _scfg.enabled and _scfg.transport != "off"
+                    if _plat_streaming is None
+                    else bool(_plat_streaming)
+                )
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16407,17 +16407,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and platform_key in _legacy_tp_overrides
             )
         )
-        if (
-            source.platform == Platform.MATRIX
-            and not _platform_tool_progress_configured
-            and not _env_tp
-        ):
-            progress_mode = "off"
-        else:
-            progress_mode = (
-                _env_tp
-                if _env_tp and not _tool_progress_configured
-                else (_resolved_tp or _env_tp or "all")
+        progress_mode = (
+            _env_tp
+            if _env_tp and not _tool_progress_configured
+            else (_resolved_tp or _env_tp or "all")
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
@@ -16526,6 +16519,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _cleanup_progress = False
             _cleanup_adapter = None
         _cleanup_msg_ids: List[str] = []
+        _matrix_show_reasoning = bool(
+            resolve_display_setting(user_config, platform_key, "show_reasoning", False)
+        )
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
@@ -16573,6 +16569,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
                 except Exception as _hint_err:
                     logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
+
+            if (
+                tool_progress_enabled
+                and event_type == "tool.completed"
+                and source.platform == Platform.MATRIX
+            ):
+                progress_queue.put((
+                    "__matrix_tool_completed__",
+                    tool_name,
+                    float(kwargs.get("duration") or 0.0),
+                    bool(kwargs.get("is_error")),
+                ))
                 return
 
             # "_thinking" is assistant scratch text between tool calls.  It
@@ -16846,6 +16854,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
+            thinking_msg_id = None   # Matrix-only reasoning/thinking pane
+            thinking_text = ""       # Latest accumulated Matrix thinking text
             can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
@@ -16867,22 +16877,58 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
             # Detect whether the adapter's edit_message accepts metadata so
-            # overflow edits preserve Telegram topic/thread routing (#27487).
+            # overflow edits preserve platform-specific routing/formatting
+            # metadata, including Telegram topics and Matrix formatted bodies.
             _edit_accepts_metadata = False
-            if _progress_metadata:
-                try:
-                    _edit_params = inspect.signature(adapter.edit_message).parameters
-                    _edit_accepts_metadata = (
-                        "metadata" in _edit_params
-                        or any(
-                            param.kind is inspect.Parameter.VAR_KEYWORD
-                            for param in _edit_params.values()
-                        )
+            try:
+                _edit_params = inspect.signature(adapter.edit_message).parameters
+                _edit_accepts_metadata = (
+                    "metadata" in _edit_params
+                    or any(
+                        param.kind is inspect.Parameter.VAR_KEYWORD
+                        for param in _edit_params.values()
                     )
-                except (TypeError, ValueError):
-                    _edit_accepts_metadata = False
+                )
+            except (TypeError, ValueError):
+                _edit_accepts_metadata = False
 
-            async def _edit_progress_message(message_id: str, content: str):
+            def _matrix_tool_activity_metadata(content: str) -> tuple[str, Dict[str, Any]]:
+                """Return Matrix plain text plus collapsible formatted-body metadata."""
+                import html as _html
+
+                lines = [line for line in str(content or "").splitlines() if line.strip()]
+                count = len(lines)
+                summary = f"🛠 Tool activity ({count} update{'s' if count != 1 else ''})"
+                plain = summary if not lines else f"{summary}\n" + "\n".join(lines)
+                escaped_summary = _html.escape(summary)
+                escaped_body = _html.escape("\n".join(lines))
+                if escaped_body:
+                    formatted = (
+                        f"<details><summary>{escaped_summary}</summary>"
+                        f"<pre><code>{escaped_body}</code></pre></details>"
+                    )
+                else:
+                    formatted = f"<details><summary>{escaped_summary}</summary></details>"
+                metadata = dict(_progress_metadata or {})
+                metadata["matrix_body"] = plain
+                metadata["matrix_formatted_body"] = formatted
+                return plain, metadata
+
+            def _prepare_progress_payload(
+                content: str,
+                *,
+                matrix_tool_activity: bool = False,
+            ) -> tuple[str, Optional[Dict[str, Any]]]:
+                if source.platform == Platform.MATRIX and matrix_tool_activity:
+                    return _matrix_tool_activity_metadata(content)
+                return content, _progress_metadata
+
+            async def _edit_progress_message(
+                message_id: str,
+                content: str,
+                metadata: Optional[Dict[str, Any]] = None,
+            ):
+                effective_metadata = _progress_metadata if metadata is None else metadata
                 kwargs = {
                     "chat_id": source.chat_id,
                     "message_id": message_id,
@@ -16890,8 +16936,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
                     kwargs["finalize"] = True
-                if _edit_accepts_metadata:
-                    kwargs["metadata"] = _progress_metadata
+                if _edit_accepts_metadata and effective_metadata is not None:
+                    kwargs["metadata"] = effective_metadata
                 return await adapter.edit_message(**kwargs)
 
             def _progress_text(lines: list) -> str:
@@ -16920,12 +16966,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ):
                     _cleanup_msg_ids.append(str(result.message_id))
 
-            async def _send_progress_text(text: str):
+            async def _send_progress_text(
+                text: str,
+                metadata: Optional[Dict[str, Any]] = None,
+            ):
+                effective_metadata = _progress_metadata if metadata is None else metadata
                 result = await adapter.send(
                     chat_id=source.chat_id,
                     content=text,
                     reply_to=_progress_reply_to,
-                    metadata=_progress_metadata,
+                    metadata=effective_metadata,
                 )
                 _track_progress_result(result)
                 return result
@@ -16943,20 +16993,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if len(groups) <= 1:
                     return False
 
-                first_text = _progress_text(groups[0])
+                first_text, first_metadata = _prepare_progress_payload(
+                    _progress_text(groups[0]),
+                    matrix_tool_activity=source.platform == Platform.MATRIX,
+                )
                 if progress_msg_id is not None:
-                    result = await _edit_progress_message(progress_msg_id, first_text)
+                    result = await _edit_progress_message(
+                        progress_msg_id,
+                        first_text,
+                        first_metadata,
+                    )
                     if not result.success:
                         can_edit = False
                         # Fall back to the existing non-edit behavior below.
                         return False
                 else:
-                    result = await _send_progress_text(first_text)
+                    result = await _send_progress_text(first_text, first_metadata)
                     if result.success and result.message_id:
                         progress_msg_id = result.message_id
 
                 for group in groups[1:]:
-                    result = await _send_progress_text(_progress_text(group))
+                    group_text, group_metadata = _prepare_progress_payload(
+                        _progress_text(group),
+                        matrix_tool_activity=source.platform == Platform.MATRIX,
+                    )
+                    result = await _send_progress_text(group_text, group_metadata)
                     if result.success and result.message_id:
                         progress_msg_id = result.message_id
 
@@ -16965,6 +17026,74 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # replaying the full historical transcript into new messages.
                 progress_lines = groups[-1]
                 return True
+
+            async def _send_or_edit_progress(
+                message_id: Optional[str],
+                content: str,
+                *,
+                matrix_tool_activity: bool = False,
+            ) -> Optional[str]:
+                if not content:
+                    return message_id
+                content, send_metadata = _prepare_progress_payload(
+                    content,
+                    matrix_tool_activity=matrix_tool_activity,
+                )
+                if can_edit and message_id is not None:
+                    result = await _edit_progress_message(message_id, content, send_metadata)
+                    if result.success:
+                        return message_id
+                    message_id = None
+                result = await _send_progress_text(content, send_metadata)
+                if result.success and result.message_id:
+                    return result.message_id
+                return message_id
+
+            async def _handle_matrix_progress_tuple(raw: tuple) -> bool:
+                """Handle Matrix-specific pane updates. Returns True if consumed."""
+                nonlocal progress_msg_id, progress_lines, thinking_msg_id, thinking_text
+                tag = raw[0] if raw else ""
+                if tag == "__matrix_thinking__":
+                    addition = str(raw[1] if len(raw) > 1 else "").strip()
+                    if not addition:
+                        return True
+                    if thinking_text:
+                        thinking_text = f"{thinking_text}\n\n{addition}"
+                    else:
+                        thinking_text = addition
+                    if len(thinking_text) > 3500:
+                        thinking_text = "...\n" + thinking_text[-3496:]
+                    thinking_msg_id = await _send_or_edit_progress(
+                        thinking_msg_id,
+                        f"💭 Thinking\n\n{thinking_text}",
+                    )
+                    return True
+                if tag == "__matrix_tool_completed__":
+                    tool = str(raw[1] if len(raw) > 1 else "tool")
+                    duration = float(raw[2] if len(raw) > 2 else 0.0)
+                    is_error = bool(raw[3] if len(raw) > 3 else False)
+                    marker = "❌" if is_error else "✅"
+                    state = "failed" if is_error else "completed"
+                    progress_lines.append(f"{marker} {tool} {state} ({duration:.1f}s)")
+                    progress_msg_id = await _send_or_edit_progress(
+                        progress_msg_id,
+                        "\n".join(progress_lines),
+                        matrix_tool_activity=True,
+                    )
+                    return True
+                if tag == "__matrix_finalize__":
+                    outcome = str(raw[1] if len(raw) > 1 else "")
+                    if outcome in ("failed", "aborted") and progress_lines:
+                        marker = "❌" if outcome == "failed" else "⚠️"
+                        label = "Tool activity failed" if outcome == "failed" else "Tool activity aborted"
+                        progress_lines.append(f"{marker} {label}")
+                        progress_msg_id = await _send_or_edit_progress(
+                            progress_msg_id,
+                            "\n".join(progress_lines),
+                            matrix_tool_activity=True,
+                        )
+                    return True
+                return False
 
             while True:
                 try:
@@ -17000,6 +17129,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif (
+                        source.platform == Platform.MATRIX
+                        and isinstance(raw, tuple)
+                        and await _handle_matrix_progress_tuple(raw)
+                    ):
+                        _last_edit_ts = time.monotonic()
+                        continue
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                         # Content bubble just landed on the platform — close off
                         # the current tool-progress bubble so the next tool
@@ -17040,6 +17176,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     if not _run_still_current():
                         return
+
+                    if source.platform == Platform.MATRIX:
+                        progress_msg_id = await _send_or_edit_progress(
+                            progress_msg_id,
+                            "\n".join(progress_lines),
+                            matrix_tool_activity=True,
+                        )
+                        _last_edit_ts = time.monotonic()
+                        await asyncio.sleep(0.3)
+                        if _run_still_current():
+                            await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
+                        continue
 
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
@@ -19230,6 +19378,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
+            if progress_queue is not None and source.platform == Platform.MATRIX:
+                try:
+                    _response_for_progress = locals().get("response")
+                    if isinstance(_response_for_progress, dict) and _response_for_progress.get("failed"):
+                        progress_queue.put(("__matrix_finalize__", "failed"))
+                    elif _interrupt_detected.is_set():
+                        progress_queue.put(("__matrix_finalize__", "aborted"))
+                except Exception:
+                    pass
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
                 progress_task.cancel()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16522,7 +16522,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _matrix_show_reasoning = bool(
             resolve_display_setting(user_config, platform_key, "show_reasoning", False)
         )
-        _MATRIX_TOOL_ACTIVITY_PREVIEW_CAP = 1000
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
@@ -16719,15 +16718,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verb_drops_preview,
                 )
                 _pl = get_tool_preview_max_len()
-                _cap = (
-                    _pl
-                    if _pl > 0
-                    else (
-                        _MATRIX_TOOL_ACTIVITY_PREVIEW_CAP
-                        if source.platform == Platform.MATRIX
-                        else 40
-                    )
-                )
+                _cap = _pl if _pl > 0 else 40
                 if len(preview) > _cap:
                     preview = preview[:_cap - 3] + "..."
                 # Friendly labels: render a human-phrased line for built-in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16862,8 +16862,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
-            thinking_msg_id = None   # Matrix-only reasoning/thinking pane
-            thinking_text = ""       # Latest accumulated Matrix thinking text
             can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
@@ -17059,23 +17057,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             async def _handle_matrix_progress_tuple(raw: tuple) -> bool:
                 """Handle Matrix-specific pane updates. Returns True if consumed."""
-                nonlocal progress_msg_id, progress_lines, thinking_msg_id, thinking_text
+                nonlocal progress_msg_id, progress_lines
                 tag = raw[0] if raw else ""
-                if tag == "__matrix_thinking__":
-                    addition = str(raw[1] if len(raw) > 1 else "").strip()
-                    if not addition:
-                        return True
-                    if thinking_text:
-                        thinking_text = f"{thinking_text}\n\n{addition}"
-                    else:
-                        thinking_text = addition
-                    if len(thinking_text) > 3500:
-                        thinking_text = "...\n" + thinking_text[-3496:]
-                    thinking_msg_id = await _send_or_edit_progress(
-                        thinking_msg_id,
-                        f"💭 Thinking\n\n{thinking_text}",
-                    )
-                    return True
                 if tag == "__matrix_tool_completed__":
                     tool = str(raw[1] if len(raw) > 1 else "tool")
                     duration = float(raw[2] if len(raw) > 2 else 0.0)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16448,6 +16448,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             platform=source.platform,
             require_platform_override_for={Platform.MATTERMOST},
         )
+        # Matrix edits/reactions are room timeline events, so high-frequency
+        # thinking deltas can flood rooms and homeservers. Keep this disabled
+        # until Matrix has a bounded, rate-limited rendering design.
+        if source.platform == Platform.MATRIX and _thinking_enabled:
+            if not getattr(self, "_matrix_thinking_progress_disabled_warned", False):
+                logger.warning(
+                    "Matrix: display.platforms.matrix.thinking_progress is disabled "
+                    "because live thinking progress can flood Matrix rooms"
+                )
+                self._matrix_thinking_progress_disabled_warned = True
+            _thinking_enabled = False
         needs_progress_queue = tool_progress_enabled or _thinking_enabled
 
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -398,7 +398,7 @@ _MATRIX_CAPABILITIES: Dict[str, str] = {
     "reactions": "yes",
     "approvals": "yes",
     "model picker": "yes",
-    "thinking panes": "yes",
+    "live thinking progress": "no",
     "images": "yes",
     "multiple images": "yes",
     "files": "yes",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2028,9 +2028,10 @@ class MatrixAdapter(BasePlatformAdapter):
             f"Reason: {description}\n\n"
             "Reply `!approve` to execute, `!approve session` to approve this pattern for the session, "
             "`!approve always` to approve permanently, or `!deny` to cancel.\n\n"
-            "You can also click the reaction to approve:\n"
-            "✅ = approve\n"
-            "❎ = deny"
+            "You can also react to this prompt:\n"
+            "✅ = approve once\n"
+            "♾️ = approve always\n"
+            "❌ = deny"
         )
 
         result = await self.send(chat_id, text, metadata=metadata)
@@ -2056,8 +2057,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 # Save the bot's reaction event_id for later cleanup
                 if reaction_result:
                     prompt.bot_reaction_events[emoji] = str(reaction_result)
+                else:
+                    logger.warning(
+                        "Matrix: failed to add approval reaction %s to %s",
+                        emoji,
+                        result.message_id,
+                    )
             except Exception as exc:
-                logger.debug("Matrix: failed to add approval reaction %s: %s", emoji, exc)
+                logger.warning("Matrix: failed to add approval reaction %s: %s", emoji, exc)
 
         return result
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -208,9 +208,10 @@ class _MatrixHtmlSanitizer(HTMLParser):
     """Allowlist sanitizer for Matrix-compatible formatted HTML."""
 
     _ALLOWED_TAGS = {
-        "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
-        "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
+        "a", "b", "blockquote", "br", "code", "del", "details", "em", "h1",
+        "h2", "h3", "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre",
+        "s", "strike", "strong", "summary", "table", "tbody", "td", "th",
+        "thead", "tr", "ul",
     }
     _VOID_TAGS = {"br", "hr"}
 
@@ -243,6 +244,11 @@ class _MatrixHtmlSanitizer(HTMLParser):
                 if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", raw_value):
                     safe.append(f' class="{_html_escape(raw_value, quote=True)}"')
         return "".join(safe)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in self._VOID_TAGS and not self._skip_depth:
+            self._parts.append(f"<{tag}>")
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
@@ -1593,6 +1599,8 @@ class MatrixAdapter(BasePlatformAdapter):
         last_event_id = None
         for i, chunk in enumerate(chunks):
             msg_content = self._build_text_message_content(chunk)
+            if i == 0:
+                self._apply_formatted_body_metadata(msg_content, metadata)
 
             self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
 
@@ -1716,15 +1724,22 @@ class MatrixAdapter(BasePlatformAdapter):
 
 
     async def edit_message(
-        self, chat_id: str, message_id: str, content: str, *, finalize: bool = False
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
 
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
+        self._apply_formatted_body_metadata(new_content, metadata)
         msg_content: Dict[str, Any] = {
             "msgtype": "m.text",
-            "body": f"* {formatted}",
+            "body": f"* {new_content.get('body', formatted)}",
             "m.new_content": new_content,
         }
         if "m.mentions" in new_content:
@@ -3995,6 +4010,23 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["formatted_body"] = html
 
         return msg_content
+
+    def _apply_formatted_body_metadata(
+        self,
+        msg_content: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        """Apply Matrix-specific formatted-body override metadata."""
+        if not isinstance(metadata, dict):
+            return
+        formatted_body = metadata.get("matrix_formatted_body")
+        if not formatted_body:
+            return
+        body = metadata.get("matrix_body")
+        if body:
+            msg_content["body"] = str(body)
+        msg_content["format"] = "org.matrix.custom.html"
+        msg_content["formatted_body"] = _sanitize_matrix_html(str(formatted_body))
 
     def _apply_relation_metadata(
         self,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1114,6 +1114,7 @@ class TestPromptBuilderConstants:
         assert "Matrix" in hint
         assert "MEDIA:" in hint
         assert "Markdown" in hint
+        assert "Matrix-specific tools" in hint
 
     def test_platform_hints_feishu(self):
         hint = PLATFORM_HINTS["feishu"]

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -205,7 +205,7 @@ class TestPlatformDefaults:
         """Matrix opt-in progress uses longer previews when enabled."""
         from gateway.display_config import resolve_display_setting
 
-        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 1000
+        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 320
 
     def test_slack_defaults_tool_progress_off(self):
         """Slack defaults to quiet tool progress (permanent chat noise otherwise)."""

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -205,7 +205,7 @@ class TestPlatformDefaults:
         """Matrix opt-in progress uses longer previews when enabled."""
         from gateway.display_config import resolve_display_setting
 
-        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 320
+        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 1000
 
     def test_slack_defaults_tool_progress_off(self):
         """Slack defaults to quiet tool progress (permanent chat noise otherwise)."""

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -194,11 +194,11 @@ class TestPlatformDefaults:
         for plat in ("mattermost", "feishu", "whatsapp"):
             assert resolve_display_setting({}, plat, "tool_progress") == "new", plat
 
-    def test_matrix_defaults_to_quiet_progress_and_streaming(self):
-        """Matrix defaults to final-answer-only to avoid edit/read-marker churn."""
+    def test_matrix_defaults_to_tool_progress_without_streaming(self):
+        """Matrix defaults to tool activity, but not response/thinking streaming."""
         from gateway.display_config import resolve_display_setting
 
-        assert resolve_display_setting({}, "matrix", "tool_progress") == "off"
+        assert resolve_display_setting({}, "matrix", "tool_progress") == "new"
         assert resolve_display_setting({}, "matrix", "streaming") is False
 
     def test_matrix_default_tool_preview_length_is_room_friendly(self):

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -188,11 +188,24 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "discord", "tool_progress") == "all"
 
     def test_medium_tier_platforms(self):
-        """Mattermost, Matrix, Feishu, WhatsApp default to 'new' tool progress."""
+        """Mattermost, Feishu, WhatsApp default to 'new' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("mattermost", "matrix", "feishu", "whatsapp"):
+        for plat in ("mattermost", "feishu", "whatsapp"):
             assert resolve_display_setting({}, plat, "tool_progress") == "new", plat
+
+    def test_matrix_defaults_to_quiet_progress_and_streaming(self):
+        """Matrix defaults to final-answer-only to avoid edit/read-marker churn."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "matrix", "tool_progress") == "off"
+        assert resolve_display_setting({}, "matrix", "streaming") is False
+
+    def test_matrix_default_tool_preview_length_is_room_friendly(self):
+        """Matrix opt-in progress uses longer previews when enabled."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 160
 
     def test_slack_defaults_tool_progress_off(self):
         """Slack defaults to quiet tool progress (permanent chat noise otherwise)."""

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -205,7 +205,7 @@ class TestPlatformDefaults:
         """Matrix opt-in progress uses longer previews when enabled."""
         from gateway.display_config import resolve_display_setting
 
-        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 160
+        assert resolve_display_setting({}, "matrix", "tool_preview_length") == 320
 
     def test_slack_defaults_tool_progress_off(self):
         """Slack defaults to quiet tool progress (permanent chat noise otherwise)."""

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2580,7 +2580,7 @@ class TestMatrixDiagnostics:
             "reactions": "yes",
             "approvals": "yes",
             "model picker": "yes",
-            "thinking panes": "yes",
+            "live thinking progress": "no",
             "images": "yes",
             "multiple images": "yes",
             "files": "yes",
@@ -2600,7 +2600,6 @@ class TestMatrixDiagnostics:
             "reactions": "_send_reaction",
             "approvals": "send_exec_approval",
             "model picker": "send_model_picker",
-            "thinking panes": "edit_message",
             "images": "send_image",
             "multiple images": "send_multiple_images",
             "files": "send_document",
@@ -2612,6 +2611,7 @@ class TestMatrixDiagnostics:
         for capability, method in required_methods.items():
             assert capabilities[capability] == "yes"
             assert hasattr(MatrixAdapter, method), f"{capability} needs {method}"
+        assert capabilities["live thinking progress"] == "no"
         assert capabilities["E2EE"] == "off / optional / required"
 
     def test_matrix_docs_capability_table_matches_declaration(self):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1140,7 +1140,7 @@ class TestMatrixMarkdownToHtml:
         assert "<td>Apples</td>" in result
 
     def test_matrix_markdown_preserves_details_summary(self):
-        from gateway.platforms.matrix import _sanitize_matrix_html
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
 
         result = _sanitize_matrix_html(
             "<details><summary>Tool activity</summary><pre><code>terminal</code></pre></details>"

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1139,6 +1139,17 @@ class TestMatrixMarkdownToHtml:
         assert "<th>Item</th>" in result
         assert "<td>Apples</td>" in result
 
+    def test_matrix_markdown_preserves_details_summary(self):
+        from gateway.platforms.matrix import _sanitize_matrix_html
+
+        result = _sanitize_matrix_html(
+            "<details><summary>Tool activity</summary><pre><code>terminal</code></pre></details>"
+        )
+        assert "<details>" in result
+        assert "<summary>" in result
+        assert "Tool activity" in result
+        assert "terminal" in result
+
 
 # ---------------------------------------------------------------------------
 # Helper: display name extraction

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -165,7 +165,8 @@ class TestMatrixExecApprovalReactions:
         assert "sess-1" not in adapter._approval_prompt_by_session
 
     @pytest.mark.asyncio
-    async def test_model_picker_reaction_selects_model(self):
+    async def test_model_picker_reaction_selects_model(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org")
         from gateway.platforms.matrix import MatrixAdapter
 
         adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -35,7 +35,7 @@ class TestMatrixExecApprovalReactions:
 
     @pytest.mark.asyncio
     async def test_send_exec_approval_stores_requester_user(self, monkeypatch):
-        from gateway.platforms.matrix import MatrixAdapter
+        from plugins.platforms.matrix.adapter import MatrixAdapter
 
         adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
         adapter._client = types.SimpleNamespace()
@@ -82,7 +82,7 @@ class TestMatrixExecApprovalReactions:
     @pytest.mark.asyncio
     async def test_infinity_reaction_resolves_approval_always(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
-        from gateway.platforms.matrix import MatrixAdapter, _MatrixApprovalPrompt
+        from plugins.platforms.matrix.adapter import MatrixAdapter, _MatrixApprovalPrompt
 
         adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
         adapter._user_id = "@bot:example.org"
@@ -107,7 +107,7 @@ class TestMatrixExecApprovalReactions:
     @pytest.mark.asyncio
     async def test_reaction_from_non_requester_gets_feedback(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org,@bob:example.org")
-        from gateway.platforms.matrix import MatrixAdapter, _MatrixApprovalPrompt
+        from plugins.platforms.matrix.adapter import MatrixAdapter, _MatrixApprovalPrompt
 
         adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
         adapter._user_id = "@bot:example.org"
@@ -136,7 +136,7 @@ class TestMatrixExecApprovalReactions:
     @pytest.mark.asyncio
     async def test_expired_approval_reaction_does_not_resolve(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org")
-        from gateway.platforms.matrix import MatrixAdapter, _MatrixApprovalPrompt
+        from plugins.platforms.matrix.adapter import MatrixAdapter, _MatrixApprovalPrompt
 
         adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
         adapter._user_id = "@bot:example.org"
@@ -167,7 +167,7 @@ class TestMatrixExecApprovalReactions:
     @pytest.mark.asyncio
     async def test_model_picker_reaction_selects_model(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org")
-        from gateway.platforms.matrix import MatrixAdapter
+        from plugins.platforms.matrix.adapter import MatrixAdapter
 
         adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
         adapter._client = types.SimpleNamespace()

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -32,6 +32,28 @@ class TestMatrixExecApprovalReactions:
         assert adapter._send_reaction.await_count == 3
         emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
         assert emojis == ["✅", "♾️", "❌"]
+        prompt_text = adapter.send.await_args.args[1]
+        assert "✅ = approve once" in prompt_text
+        assert "♾️ = approve always" in prompt_text
+        assert "❌ = deny" in prompt_text
+        assert "❎ = deny" not in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_warns_when_seed_reaction_fails(self, caplog):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._client = types.SimpleNamespace()
+        adapter.send = AsyncMock(return_value=types.SimpleNamespace(success=True, message_id="$evt1"))
+        adapter._send_reaction = AsyncMock(return_value=None)
+
+        await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="rm -rf /tmp/test",
+            session_key="sess-1",
+        )
+
+        assert "failed to add approval reaction" in caplog.text
 
     @pytest.mark.asyncio
     async def test_send_exec_approval_stores_requester_user(self, monkeypatch):

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -1,3 +1,4 @@
+import time
 import types
 
 import pytest
@@ -27,9 +28,28 @@ class TestMatrixExecApprovalReactions:
         assert result.success is True
         assert adapter._approval_prompt_by_session["sess-1"] == "$evt1"
         assert adapter._approval_prompts_by_event["$evt1"].session_key == "sess-1"
+        assert adapter._approval_prompts_by_event["$evt1"].requester_user_id is None
         assert adapter._send_reaction.await_count == 3
         emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
         assert emojis == ["✅", "♾️", "❌"]
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_stores_requester_user(self, monkeypatch):
+        from gateway.platforms.matrix import MatrixAdapter
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._client = types.SimpleNamespace()
+        adapter.send = AsyncMock(return_value=types.SimpleNamespace(success=True, message_id="$evt1"))
+        adapter._send_reaction = AsyncMock(return_value="$r")
+
+        await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="rm -rf /tmp/test",
+            session_key="sess-1",
+            metadata={"requester_user_id": "@alice:example.org"},
+        )
+
+        assert adapter._approval_prompts_by_event["$evt1"].requester_user_id == "@alice:example.org"
 
     @pytest.mark.asyncio
     async def test_reaction_resolves_pending_approval(self, monkeypatch):
@@ -58,3 +78,133 @@ class TestMatrixExecApprovalReactions:
         mock_resolve.assert_called_once_with("sess-1", "once")
         assert "$target" not in adapter._approval_prompts_by_event
         assert "sess-1" not in adapter._approval_prompt_by_session
+
+    @pytest.mark.asyncio
+    async def test_infinity_reaction_resolves_approval_always(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+        from gateway.platforms.matrix import MatrixAdapter, _MatrixApprovalPrompt
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._user_id = "@bot:example.org"
+        adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
+            session_key="sess-1", chat_id="!room:example.org", message_id="$target"
+        )
+        adapter._approval_prompt_by_session["sess-1"] = "$target"
+        adapter._redact_bot_approval_reactions = AsyncMock()
+
+        event = types.SimpleNamespace(
+            sender="@liizfq:liizfq.top",
+            event_id="$react1",
+            room_id="!room:example.org",
+            content={"m.relates_to": {"event_id": "$target", "key": "♾️"}},
+        )
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_called_once_with("sess-1", "always")
+
+    @pytest.mark.asyncio
+    async def test_reaction_from_non_requester_gets_feedback(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org,@bob:example.org")
+        from gateway.platforms.matrix import MatrixAdapter, _MatrixApprovalPrompt
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._user_id = "@bot:example.org"
+        adapter.send = AsyncMock(return_value=types.SimpleNamespace(success=True, message_id="$feedback"))
+        adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
+            session_key="sess-1",
+            chat_id="!room:example.org",
+            message_id="$target",
+            requester_user_id="@alice:example.org",
+        )
+
+        event = types.SimpleNamespace(
+            sender="@bob:example.org",
+            event_id="$react1",
+            room_id="!room:example.org",
+            content={"m.relates_to": {"event_id": "$target", "key": "✅"}},
+        )
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_not_called()
+        adapter.send.assert_awaited_once()
+        assert "Only the user" in adapter.send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_expired_approval_reaction_does_not_resolve(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org")
+        from gateway.platforms.matrix import MatrixAdapter, _MatrixApprovalPrompt
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._user_id = "@bot:example.org"
+        adapter.send = AsyncMock(return_value=types.SimpleNamespace(success=True, message_id="$feedback"))
+        adapter._redact_bot_approval_reactions = AsyncMock()
+        adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
+            session_key="sess-1",
+            chat_id="!room:example.org",
+            message_id="$target",
+            expires_at=time.monotonic() - 1,
+        )
+        adapter._approval_prompt_by_session["sess-1"] = "$target"
+
+        event = types.SimpleNamespace(
+            sender="@alice:example.org",
+            event_id="$react1",
+            room_id="!room:example.org",
+            content={"m.relates_to": {"event_id": "$target", "key": "✅"}},
+        )
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_not_called()
+        assert "$target" not in adapter._approval_prompts_by_event
+        assert "sess-1" not in adapter._approval_prompt_by_session
+
+    @pytest.mark.asyncio
+    async def test_model_picker_reaction_selects_model(self):
+        from gateway.platforms.matrix import MatrixAdapter
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._client = types.SimpleNamespace()
+        adapter._user_id = "@bot:example.org"
+        adapter.send = AsyncMock(return_value=types.SimpleNamespace(success=True, message_id="$picker"))
+        adapter._send_reaction = AsyncMock(side_effect=["$r1", "$r2"])
+
+        selected = {}
+
+        async def on_selected(room_id, model_id, provider_slug):
+            selected.update(room_id=room_id, model_id=model_id, provider_slug=provider_slug)
+            return "switched"
+
+        await adapter.send_model_picker(
+            chat_id="!room:example.org",
+            providers=[{"slug": "openai", "name": "OpenAI", "models": ["gpt-5.4", "gpt-5.3"]}],
+            current_model="gpt-5.3",
+            current_provider="openai",
+            session_key="sess-1",
+            on_model_selected=on_selected,
+            metadata={"requester_user_id": "@alice:example.org"},
+        )
+        adapter._redact_bot_model_picker_reactions = AsyncMock()
+        adapter.send = AsyncMock(return_value=types.SimpleNamespace(success=True, message_id="$confirm"))
+
+        event = types.SimpleNamespace(
+            sender="@alice:example.org",
+            event_id="$react1",
+            room_id="!room:example.org",
+            content={"m.relates_to": {"event_id": "$picker", "key": "1️⃣"}},
+        )
+
+        await adapter._on_reaction(event)
+
+        assert selected == {
+            "room_id": "!room:example.org",
+            "model_id": "gpt-5.4",
+            "provider_slug": "openai",
+        }
+        assert "$picker" not in adapter._model_picker_prompts_by_event
+        adapter.send.assert_awaited_once_with("!room:example.org", "switched", reply_to="$picker")

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -258,6 +258,33 @@ class TestOutboundMentions:
         assert content["msgtype"] == "m.notice"
         assert content["m.mentions"] == {"user_ids": ["@alice:example.org"]}
 
+    @pytest.mark.asyncio
+    async def test_room_wide_mention_is_gated_by_default(self):
+        result = await self.adapter.send(
+            "!room1:example.org",
+            "Heads up @room",
+        )
+
+        assert result.success is True
+        content = self._sent_content(self.mock_client)
+        assert "m.mentions" not in content
+
+    @pytest.mark.asyncio
+    async def test_room_wide_mention_can_be_enabled(self):
+        self.adapter._allow_room_mentions = True
+
+        result = await self.adapter.send(
+            "!room1:example.org",
+            "Heads up @room and @alice:example.org",
+        )
+
+        assert result.success is True
+        content = self._sent_content(self.mock_client)
+        assert content["m.mentions"] == {
+            "room": True,
+            "user_ids": ["@alice:example.org"],
+        }
+
 
 # ---------------------------------------------------------------------------
 # Require-mention gating in _on_room_message

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -271,6 +271,24 @@ async def test_matrix_inbound_handler_keeps_project_a_and_b_distinct():
     assert build_session_key(captured[0].source) != build_session_key(captured[1].source)
 
 
+def test_matrix_project_b_tool_call_cannot_target_project_a_by_default():
+    from gateway.session_context import set_session_vars
+    from tools.matrix_tools import matrix_fetch_history
+
+    adapter = SimpleNamespace(fetch_history=AsyncMock(return_value=[]))
+    runner = SimpleNamespace(adapters={Platform.MATRIX: adapter})
+    tokens = set_session_vars(platform="matrix", chat_id=PROJECT_B_ROOM_ID)
+    try:
+        with patch("gateway.run._gateway_runner_ref", return_value=runner):
+            result = matrix_fetch_history({"room_id": PROJECT_A_ROOM_ID})
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+
+    assert "current room" in result
+    adapter.fetch_history.assert_not_called()
+
+
 def test_matrix_room_scope_group_sessions_per_user_true_separates_users():
     alice = _make_matrix_source(PROJECT_B_ROOM_ID, PROJECT_B_NAME, PROJECT_B_TOPIC)
     bob = _make_matrix_source(PROJECT_B_ROOM_ID, PROJECT_B_NAME, PROJECT_B_TOPIC)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1113,41 +1113,6 @@ async def test_run_agent_matrix_defaults_to_tool_activity_without_response_strea
 
 
 @pytest.mark.asyncio
-async def test_run_agent_matrix_tool_activity_uses_wide_default_preview(monkeypatch, tmp_path):
-    adapter, result = await _run_with_agent(
-        monkeypatch,
-        tmp_path,
-        LongPreviewAgent,
-        session_id="sess-matrix-wide-tool-preview",
-        config_data={
-            "display": {
-                "tool_preview_length": 0,
-                "platforms": {"matrix": {"tool_progress": "all"}},
-            },
-        },
-        platform=Platform.MATRIX,
-        chat_id="!room:matrix.example.org",
-        chat_type="group",
-        thread_id="$thread",
-    )
-
-    assert result["final_response"] == "done"
-    all_contents = [call["content"] for call in adapter.sent + adapter.edits]
-    assert any(LongPreviewAgent.LONG_CMD in text for text in all_contents)
-    assert all("..." not in text for text in all_contents if "terminal" in text)
-    matrix_metadata = [
-        call.get("metadata") or {}
-        for call in adapter.sent + adapter.edits
-        if call.get("metadata")
-    ]
-    assert any(
-        "python -m pytest tests/gateway/test_run_progress_topics.py" in
-        meta.get("matrix_formatted_body", "")
-        for meta in matrix_metadata
-    )
-
-
-@pytest.mark.asyncio
 async def test_run_agent_matrix_suppresses_thinking_by_default(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1103,8 +1103,8 @@ async def test_run_agent_matrix_defaults_to_tool_activity_without_response_strea
     assert adapter.sent
     assert adapter.edits
     all_contents = [call["content"] for call in adapter.sent + adapter.edits]
-    assert any("terminal" in text for text in all_contents)
-    assert any("browser_navigate" in text for text in all_contents)
+    assert any("Running pwd" in text for text in all_contents)
+    assert any("Browsing https://example.com" in text for text in all_contents)
     assert all("done" not in text for text in all_contents)
     matrix_metadata = [
         call.get("metadata") or {}
@@ -1114,6 +1114,10 @@ async def test_run_agent_matrix_defaults_to_tool_activity_without_response_strea
     assert matrix_metadata
     assert any("<details>" in meta.get("matrix_formatted_body", "") for meta in matrix_metadata)
     assert any("<summary>" in meta.get("matrix_formatted_body", "") for meta in matrix_metadata)
+    assert any(
+        "Browsing https://example.com" in meta.get("matrix_formatted_body", "")
+        for meta in matrix_metadata
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1113,6 +1113,41 @@ async def test_run_agent_matrix_defaults_to_tool_activity_without_response_strea
 
 
 @pytest.mark.asyncio
+async def test_run_agent_matrix_tool_activity_uses_wide_default_preview(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        LongPreviewAgent,
+        session_id="sess-matrix-wide-tool-preview",
+        config_data={
+            "display": {
+                "tool_preview_length": 0,
+                "platforms": {"matrix": {"tool_progress": "all"}},
+            },
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+    assert result["final_response"] == "done"
+    all_contents = [call["content"] for call in adapter.sent + adapter.edits]
+    assert any(LongPreviewAgent.LONG_CMD in text for text in all_contents)
+    assert all("..." not in text for text in all_contents if "terminal" in text)
+    matrix_metadata = [
+        call.get("metadata") or {}
+        for call in adapter.sent + adapter.edits
+        if call.get("metadata")
+    ]
+    assert any(
+        "python -m pytest tests/gateway/test_run_progress_topics.py" in
+        meta.get("matrix_formatted_body", "")
+        for meta in matrix_metadata
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_agent_matrix_suppresses_thinking_by_default(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -39,12 +39,13 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         )
         return SendResult(success=True, message_id="progress-1")
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content, **kwargs) -> SendResult:
         self.edits.append(
             {
                 "chat_id": chat_id,
                 "message_id": message_id,
                 "content": content,
+                "metadata": kwargs.get("metadata"),
             }
         )
         return SendResult(success=True, message_id=message_id)
@@ -118,7 +119,7 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
     SUPPORTS_MESSAGE_EDITING = False
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content, **kwargs) -> SendResult:
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
@@ -1077,7 +1078,7 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
 
 
 @pytest.mark.asyncio
-async def test_run_agent_matrix_defaults_to_final_answer_only(monkeypatch, tmp_path):
+async def test_run_agent_matrix_defaults_to_tool_activity_without_response_streaming(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,
@@ -1095,8 +1096,40 @@ async def test_run_agent_matrix_defaults_to_final_answer_only(monkeypatch, tmp_p
 
     assert result["final_response"] == "done"
     assert not result.get("already_sent")
-    assert adapter.sent == []
-    assert adapter.edits == []
+    assert adapter.sent
+    assert adapter.edits
+    all_contents = [call["content"] for call in adapter.sent + adapter.edits]
+    assert any("terminal" in text for text in all_contents)
+    assert any("browser_navigate" in text for text in all_contents)
+    assert all("done" not in text for text in all_contents)
+    matrix_metadata = [
+        call.get("metadata") or {}
+        for call in adapter.sent + adapter.edits
+        if call.get("metadata")
+    ]
+    assert matrix_metadata
+    assert any("<details>" in meta.get("matrix_formatted_body", "") for meta in matrix_metadata)
+    assert any("<summary>" in meta.get("matrix_formatted_body", "") for meta in matrix_metadata)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_matrix_suppresses_thinking_by_default(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThinkingAgent,
+        session_id="sess-matrix-no-thinking",
+        config_data={"display": {"platforms": {"matrix": {"tool_progress": "all"}}}},
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+    assert result["final_response"] == "done"
+    all_contents = [call["content"] for call in adapter.sent + adapter.edits]
+    assert not any("Thinking" in text for text in all_contents)
+    assert not any("Need view minimax ref" in text for text in all_contents)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1000,7 +1000,11 @@ async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
         StreamingRefineAgent,
         session_id="sess-matrix-streaming",
         config_data={
-            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "display": {
+                "tool_progress": "off",
+                "interim_assistant_messages": False,
+                "platforms": {"matrix": {"streaming": True}},
+            },
             "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
         },
         platform=Platform.MATRIX,
@@ -1070,6 +1074,29 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert any("[plugin appended this]" in text for text in edited_texts), (
         f"expected transformed text in adapter.edits, got: {edited_texts!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_matrix_defaults_to_final_answer_only(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FakeAgent,
+        session_id="sess-matrix-final-only",
+        config_data={
+            "display": {"tool_progress": "all", "interim_assistant_messages": True},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+    assert result["final_response"] == "done"
+    assert not result.get("already_sent")
+    assert adapter.sent == []
+    assert adapter.edits == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1141,6 +1141,37 @@ async def test_run_agent_matrix_suppresses_thinking_by_default(monkeypatch, tmp_
 
 
 @pytest.mark.asyncio
+async def test_run_agent_matrix_ignores_thinking_progress_opt_in(
+    monkeypatch, tmp_path, caplog
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThinkingAgent,
+        session_id="sess-matrix-thinking-disabled-even-if-enabled",
+        config_data={
+            "display": {
+                "platforms": {
+                    "matrix": {
+                        "tool_progress": "off",
+                        "thinking_progress": True,
+                    }
+                }
+            }
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+    assert result["final_response"] == "done"
+    all_contents = [call["content"] for call in adapter.sent + adapter.edits]
+    assert not any("weighing the options here" in text for text in all_contents)
+    assert "thinking_progress is disabled" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monkeypatch, tmp_path):
     QueuedCommentaryAgent.calls = 0
     adapter, result = await _run_with_agent(

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1057,7 +1057,11 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
         TransformedStreamAgent,
         session_id="sess-transformed-stream",
         config_data={
-            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "display": {
+                "tool_progress": "off",
+                "interim_assistant_messages": False,
+                "platforms": {"matrix": {"streaming": True}},
+            },
             "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
         },
         platform=Platform.MATRIX,

--- a/tests/tools/test_matrix_tools.py
+++ b/tests/tools/test_matrix_tools.py
@@ -1,0 +1,291 @@
+import json
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session_context import set_session_vars
+
+
+@pytest.fixture
+def matrix_tool_context(monkeypatch):
+    for name in (
+        "MATRIX_TOOLS_ALLOW_REDACTION",
+        "MATRIX_TOOLS_ALLOW_INVITES",
+        "MATRIX_TOOLS_ALLOW_ROOM_CREATE",
+        "MATRIX_TOOLS_ALLOW_CROSS_ROOM",
+        "MATRIX_TOOLS_ALLOW_CROSS_ROOM_DESTRUCTIVE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    tokens = set_session_vars(platform="matrix", chat_id="!room:example.org", user_id="@alice:example.org")
+    adapter = types.SimpleNamespace(
+        _send_reaction=AsyncMock(return_value="$reaction"),
+        redact_message=AsyncMock(return_value=True),
+        create_room=AsyncMock(return_value="!new:example.org"),
+        invite_user=AsyncMock(return_value=True),
+        fetch_history=AsyncMock(return_value=[{"event_id": "$evt", "body": "hello"}]),
+        set_presence=AsyncMock(return_value=True),
+    )
+    runner = types.SimpleNamespace(adapters={Platform.MATRIX: adapter})
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+    try:
+        yield adapter
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+
+
+def _loads(result):
+    return json.loads(result)
+
+
+def test_matrix_tools_are_context_gated():
+    from gateway.session_context import set_session_vars
+    from tools.matrix_tools import matrix_set_presence
+
+    tokens = set_session_vars(platform="discord", chat_id="123")
+    try:
+        result = _loads(matrix_set_presence({"state": "online"}))
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+
+    assert "error" in result
+    assert "only available" in result["error"]
+
+
+def test_matrix_send_reaction_defaults_to_current_room(matrix_tool_context):
+    from tools.matrix_tools import matrix_send_reaction
+
+    result = _loads(matrix_send_reaction({"event_id": "$evt", "emoji": "👍"}))
+
+    assert result == {"success": True, "event_id": "$reaction"}
+    matrix_tool_context._send_reaction.assert_awaited_once_with(
+        "!room:example.org", "$evt", "👍"
+    )
+
+
+def test_matrix_redact_message(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_redact_message
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_REDACTION", "true")
+    result = _loads(matrix_redact_message({"event_id": "$evt", "reason": "cleanup"}))
+
+
+    assert result == {"success": True}
+    matrix_tool_context.redact_message.assert_awaited_once_with(
+        "!room:example.org", "$evt", "cleanup"
+    )
+
+
+def test_matrix_redact_message_blocked_by_default(matrix_tool_context):
+    from tools.matrix_tools import matrix_redact_message
+
+    result = _loads(matrix_redact_message({"event_id": "$evt", "reason": "cleanup"}))
+
+    assert "error" in result
+    assert "MATRIX_TOOLS_ALLOW_REDACTION" in result["error"]
+    matrix_tool_context.redact_message.assert_not_called()
+
+
+def test_matrix_create_room_blocks_public_by_default(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_create_room
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", "true")
+    result = _loads(matrix_create_room({"name": "Public", "preset": "public_chat"}))
+
+    assert "error" in result
+    assert "MATRIX_ALLOW_PUBLIC_ROOMS" in result["error"]
+    matrix_tool_context.create_room.assert_not_called()
+
+
+def test_matrix_create_room_private(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_create_room
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_ROOM_CREATE", "true")
+    result = _loads(matrix_create_room({"name": "Project", "invite": ["@bob:example.org"]}))
+
+    assert result == {"success": True, "room_id": "!new:example.org"}
+    matrix_tool_context.create_room.assert_awaited_once_with(
+        name="Project",
+        topic="",
+        invite=["@bob:example.org"],
+        is_direct=False,
+        preset="private_chat",
+    )
+
+
+def test_matrix_create_room_blocked_by_default(matrix_tool_context):
+    from tools.matrix_tools import matrix_create_room
+
+    result = _loads(matrix_create_room({"name": "Project"}))
+
+    assert "error" in result
+    assert "MATRIX_TOOLS_ALLOW_ROOM_CREATE" in result["error"]
+    matrix_tool_context.create_room.assert_not_called()
+
+
+def test_matrix_invite_user(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_invite_user
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_INVITES", "true")
+    result = _loads(matrix_invite_user({"user_id": "@bob:example.org"}))
+
+    assert result == {"success": True}
+    matrix_tool_context.invite_user.assert_awaited_once_with(
+        "!room:example.org", "@bob:example.org"
+    )
+
+
+def test_matrix_invite_user_blocked_by_default(matrix_tool_context):
+    from tools.matrix_tools import matrix_invite_user
+
+    result = _loads(matrix_invite_user({"user_id": "@bob:example.org"}))
+
+    assert "error" in result
+    assert "MATRIX_TOOLS_ALLOW_INVITES" in result["error"]
+    matrix_tool_context.invite_user.assert_not_called()
+
+
+def test_matrix_fetch_history(matrix_tool_context):
+    from tools.matrix_tools import matrix_fetch_history
+
+    result = _loads(matrix_fetch_history({"limit": 5}))
+
+    assert result == {"success": True, "events": [{"event_id": "$evt", "body": "hello"}]}
+    matrix_tool_context.fetch_history.assert_awaited_once_with("!room:example.org", 5, "")
+
+
+def test_matrix_tool_blocks_cross_room_reaction_by_default(matrix_tool_context):
+    from tools.matrix_tools import matrix_send_reaction
+
+    result = _loads(
+        matrix_send_reaction(
+            {"room_id": "!other:example.org", "event_id": "$evt", "emoji": "👍"}
+        )
+    )
+
+    assert "error" in result
+    assert "current room" in result["error"]
+    matrix_tool_context._send_reaction.assert_not_called()
+
+
+def test_matrix_tool_blocks_cross_room_history_by_default(matrix_tool_context):
+    from tools.matrix_tools import matrix_fetch_history
+
+    result = _loads(matrix_fetch_history({"room_id": "!other:example.org"}))
+
+    assert "error" in result
+    assert "current room" in result["error"]
+    matrix_tool_context.fetch_history.assert_not_called()
+
+
+def test_matrix_tool_blocks_cross_room_redaction_by_default(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_redact_message
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_REDACTION", "true")
+    result = _loads(
+        matrix_redact_message({"room_id": "!other:example.org", "event_id": "$evt"})
+    )
+
+    assert "error" in result
+    assert "current room" in result["error"]
+    matrix_tool_context.redact_message.assert_not_called()
+
+
+def test_matrix_tool_allows_cross_room_when_explicitly_enabled(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_send_reaction
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_CROSS_ROOM", "true")
+
+    result = _loads(
+        matrix_send_reaction(
+            {"room_id": "!other:example.org", "event_id": "$evt", "emoji": "👍"}
+        )
+    )
+
+    assert result == {"success": True, "event_id": "$reaction"}
+    matrix_tool_context._send_reaction.assert_awaited_once_with(
+        "!other:example.org", "$evt", "👍"
+    )
+
+
+def test_matrix_tool_cross_room_respects_allowed_rooms(matrix_tool_context, monkeypatch):
+    from tools.matrix_tools import matrix_fetch_history
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_CROSS_ROOM", "true")
+    monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!room:example.org")
+
+    result = _loads(matrix_fetch_history({"room_id": "!other:example.org"}))
+
+    assert "error" in result
+    assert "MATRIX_ALLOWED_ROOMS" in result["error"]
+    matrix_tool_context.fetch_history.assert_not_called()
+
+
+def test_matrix_tool_cross_room_redaction_requires_destructive_opt_in(
+    matrix_tool_context,
+    monkeypatch,
+):
+    from tools.matrix_tools import matrix_redact_message
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_CROSS_ROOM", "true")
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_REDACTION", "true")
+
+    result = _loads(
+        matrix_redact_message({"room_id": "!other:example.org", "event_id": "$evt"})
+    )
+
+    assert "error" in result
+    assert "DESTRUCTIVE" in result["error"]
+    matrix_tool_context.redact_message.assert_not_called()
+
+
+def test_matrix_tool_cross_room_redaction_allows_destructive_opt_in(
+    matrix_tool_context,
+    monkeypatch,
+):
+    from tools.matrix_tools import matrix_redact_message
+
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_CROSS_ROOM", "true")
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_CROSS_ROOM_DESTRUCTIVE", "true")
+    monkeypatch.setenv("MATRIX_TOOLS_ALLOW_REDACTION", "true")
+
+    result = _loads(
+        matrix_redact_message({"room_id": "!other:example.org", "event_id": "$evt"})
+    )
+
+    assert result == {"success": True}
+    matrix_tool_context.redact_message.assert_awaited_once_with(
+        "!other:example.org", "$evt", ""
+    )
+
+
+def test_matrix_fetch_history_clamps_limit(matrix_tool_context):
+    from tools.matrix_tools import matrix_fetch_history
+
+    low = _loads(matrix_fetch_history({"limit": -5}))
+    high = _loads(matrix_fetch_history({"limit": 1000}))
+
+    assert low["success"] is True
+    assert high["success"] is True
+    assert matrix_tool_context.fetch_history.await_args_list[0].args == (
+        "!room:example.org",
+        1,
+        "",
+    )
+    assert matrix_tool_context.fetch_history.await_args_list[1].args == (
+        "!room:example.org",
+        100,
+        "",
+    )
+
+
+def test_matrix_set_presence(matrix_tool_context):
+    from tools.matrix_tools import matrix_set_presence
+
+    result = _loads(matrix_set_presence({"state": "unavailable", "status_msg": "busy"}))
+
+    assert result == {"success": True}
+    matrix_tool_context.set_presence.assert_awaited_once_with("unavailable", "busy")

--- a/tools/matrix_tools.py
+++ b/tools/matrix_tools.py
@@ -1,0 +1,333 @@
+"""Matrix-native gateway tools.
+
+These tools are intentionally context-gated at call time. They are included
+only in the Matrix platform toolset, but the runtime guard keeps them safe if a
+cached schema is reused outside a Matrix session.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from gateway.session_context import get_session_env
+from tools.registry import registry, tool_error, tool_result
+
+
+def _matrix_adapter():
+    if get_session_env("HERMES_SESSION_PLATFORM", "").lower() != "matrix":
+        return None, "Matrix tools are only available while handling a Matrix conversation."
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        if not runner:
+            return None, "Matrix gateway is not running."
+        adapter = runner.adapters.get(Platform.MATRIX)
+        if not adapter:
+            return None, "Matrix adapter is not connected."
+        return adapter, ""
+    except Exception as exc:
+        return None, f"Failed to resolve Matrix adapter: {exc}"
+
+
+def _current_room_id(room_id: str = "") -> str:
+    return str(room_id or get_session_env("HERMES_SESSION_CHAT_ID", "") or "")
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name, "true" if default else "false")
+    return raw.lower() in ("true", "1", "yes", "on")
+
+
+def _allowed_rooms() -> set[str]:
+    raw = os.getenv("MATRIX_ALLOWED_ROOMS", "")
+    return {room.strip() for room in raw.split(",") if room.strip()}
+
+
+def _admin_gate_enabled(name: str) -> bool:
+    return _env_enabled(name, default=False)
+
+
+def _require_admin_gate(name: str, action: str) -> str:
+    if _admin_gate_enabled(name):
+        return ""
+    return f"{action} requires {name}=true."
+
+
+def _authorize_room_id(
+    requested_room_id: str = "",
+    *,
+    destructive: bool = False,
+) -> tuple[str, str]:
+    """Authorize a Matrix tool room target against the current session room.
+
+    Matrix tools are room-local by default. Cross-room operation requires an
+    explicit operator opt-in, and destructive/member-changing operations have a
+    separate opt-in so read/reaction access cannot silently become redaction or
+    invite access.
+    """
+    current_room_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    room_id = _current_room_id(requested_room_id)
+    if not room_id:
+        return "", "room_id is required."
+
+    allowed = _allowed_rooms()
+    if allowed and room_id not in allowed:
+        return "", "Matrix tool target room is not listed in MATRIX_ALLOWED_ROOMS."
+
+    if current_room_id and room_id != current_room_id:
+        if not _env_enabled("MATRIX_TOOLS_ALLOW_CROSS_ROOM", default=False):
+            return "", (
+                "Matrix tools are limited to the current room by default. "
+                "Set MATRIX_TOOLS_ALLOW_CROSS_ROOM=true to allow explicit cross-room targets."
+            )
+        if destructive and not _env_enabled(
+            "MATRIX_TOOLS_ALLOW_CROSS_ROOM_DESTRUCTIVE",
+            default=False,
+        ):
+            return "", (
+                "Cross-room Matrix redaction/invite actions require "
+                "MATRIX_TOOLS_ALLOW_CROSS_ROOM_DESTRUCTIVE=true."
+            )
+    return room_id, ""
+
+
+def _run(coro):
+    from model_tools import _run_async
+
+    return _run_async(coro)
+
+
+def _ok(success: bool, **extra: Any) -> str:
+    return tool_result(success=bool(success), **extra)
+
+
+def matrix_send_reaction(args, **kw) -> str:
+    room_id, auth_error = _authorize_room_id(args.get("room_id", ""))
+    if auth_error:
+        return tool_error(auth_error)
+    event_id = str(args.get("event_id", "") or "")
+    emoji = str(args.get("emoji", "") or "")
+    if not room_id or not event_id or not emoji:
+        return tool_error("room_id, event_id, and emoji are required.")
+    adapter, err = _matrix_adapter()
+    if err:
+        return tool_error(err)
+    event = _run(adapter._send_reaction(room_id, event_id, emoji))
+    return _ok(bool(event), event_id=str(event) if event else "")
+
+
+def matrix_redact_message(args, **kw) -> str:
+    gate_error = _require_admin_gate("MATRIX_TOOLS_ALLOW_REDACTION", "Matrix redaction")
+    if gate_error:
+        return tool_error(gate_error)
+    room_id, auth_error = _authorize_room_id(
+        args.get("room_id", ""),
+        destructive=True,
+    )
+    if auth_error:
+        return tool_error(auth_error)
+    event_id = str(args.get("event_id", "") or "")
+    reason = str(args.get("reason", "") or "")
+    if not room_id or not event_id:
+        return tool_error("room_id and event_id are required.")
+    adapter, err = _matrix_adapter()
+    if err:
+        return tool_error(err)
+    return _ok(_run(adapter.redact_message(room_id, event_id, reason)))
+
+
+def matrix_create_room(args, **kw) -> str:
+    gate_error = _require_admin_gate("MATRIX_TOOLS_ALLOW_ROOM_CREATE", "Matrix room creation")
+    if gate_error:
+        return tool_error(gate_error)
+    preset = str(args.get("preset", "private_chat") or "private_chat")
+    if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in (
+        "true",
+        "1",
+        "yes",
+    ):
+        return tool_error("Public Matrix room creation requires MATRIX_ALLOW_PUBLIC_ROOMS=true.")
+    invite = args.get("invite") or []
+    if isinstance(invite, str):
+        invite = [u.strip() for u in invite.split(",") if u.strip()]
+    adapter, err = _matrix_adapter()
+    if err:
+        return tool_error(err)
+    room_id = _run(
+        adapter.create_room(
+            name=str(args.get("name", "") or ""),
+            topic=str(args.get("topic", "") or ""),
+            invite=list(invite),
+            is_direct=bool(args.get("is_direct", False)),
+            preset=preset,
+        )
+    )
+    if not room_id:
+        return tool_error("Matrix room creation failed.")
+    return tool_result(success=True, room_id=str(room_id))
+
+
+def matrix_invite_user(args, **kw) -> str:
+    gate_error = _require_admin_gate("MATRIX_TOOLS_ALLOW_INVITES", "Matrix invites")
+    if gate_error:
+        return tool_error(gate_error)
+    room_id, auth_error = _authorize_room_id(
+        args.get("room_id", ""),
+        destructive=True,
+    )
+    if auth_error:
+        return tool_error(auth_error)
+    user_id = str(args.get("user_id", "") or "")
+    if not room_id or not user_id:
+        return tool_error("room_id and user_id are required.")
+    adapter, err = _matrix_adapter()
+    if err:
+        return tool_error(err)
+    return _ok(_run(adapter.invite_user(room_id, user_id)))
+
+
+def matrix_fetch_history(args, **kw) -> str:
+    room_id, auth_error = _authorize_room_id(args.get("room_id", ""))
+    if auth_error:
+        return tool_error(auth_error)
+    try:
+        limit = int(args.get("limit", 20) or 20)
+    except (TypeError, ValueError):
+        return tool_error("limit must be an integer.")
+    limit = max(1, min(100, limit))
+    adapter, err = _matrix_adapter()
+    if err:
+        return tool_error(err)
+    events = _run(adapter.fetch_history(room_id, limit, str(args.get("from_token", "") or "")))
+    return tool_result(success=True, events=events)
+
+
+def matrix_set_presence(args, **kw) -> str:
+    state = str(args.get("state", "online") or "online")
+    status_msg = str(args.get("status_msg", "") or "")
+    adapter, err = _matrix_adapter()
+    if err:
+        return tool_error(err)
+    return _ok(_run(adapter.set_presence(state, status_msg)))
+
+
+registry.register(
+    name="matrix_send_reaction",
+    toolset="matrix",
+    schema={
+        "name": "matrix_send_reaction",
+        "description": "Add a Matrix reaction to a message in the current room or a specified room.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string", "description": "Matrix room ID. Defaults to the current Matrix room."},
+                "event_id": {"type": "string", "description": "Target Matrix event ID."},
+                "emoji": {"type": "string", "description": "Reaction emoji to add."},
+            },
+            "required": ["event_id", "emoji"],
+        },
+    },
+    handler=matrix_send_reaction,
+)
+
+registry.register(
+    name="matrix_redact_message",
+    toolset="matrix",
+    schema={
+        "name": "matrix_redact_message",
+        "description": "Redact a Matrix message or event when MATRIX_TOOLS_ALLOW_REDACTION=true and the bot has permission.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string", "description": "Matrix room ID. Defaults to the current Matrix room."},
+                "event_id": {"type": "string", "description": "Matrix event ID to redact."},
+                "reason": {"type": "string", "description": "Optional redaction reason."},
+            },
+            "required": ["event_id"],
+        },
+    },
+    handler=matrix_redact_message,
+)
+
+registry.register(
+    name="matrix_create_room",
+    toolset="matrix",
+    schema={
+        "name": "matrix_create_room",
+        "description": "Create a private Matrix room when MATRIX_TOOLS_ALLOW_ROOM_CREATE=true and optionally invite users. Public rooms require MATRIX_ALLOW_PUBLIC_ROOMS=true.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Room name."},
+                "topic": {"type": "string", "description": "Room topic."},
+                "invite": {"type": "array", "items": {"type": "string"}, "description": "Matrix user IDs to invite."},
+                "is_direct": {"type": "boolean", "description": "Whether to mark the room as a direct chat."},
+                "preset": {
+                    "type": "string",
+                    "enum": ["private_chat", "trusted_private_chat", "public_chat"],
+                    "description": "Matrix create-room preset. Defaults to private_chat.",
+                },
+            },
+            "required": [],
+        },
+    },
+    handler=matrix_create_room,
+)
+
+registry.register(
+    name="matrix_invite_user",
+    toolset="matrix",
+    schema={
+        "name": "matrix_invite_user",
+        "description": "Invite a Matrix user when MATRIX_TOOLS_ALLOW_INVITES=true to the current room or a specified room.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string", "description": "Matrix room ID. Defaults to the current Matrix room."},
+                "user_id": {"type": "string", "description": "Matrix user ID to invite."},
+            },
+            "required": ["user_id"],
+        },
+    },
+    handler=matrix_invite_user,
+)
+
+registry.register(
+    name="matrix_fetch_history",
+    toolset="matrix",
+    schema={
+        "name": "matrix_fetch_history",
+        "description": "Fetch recent Matrix room history from the current room or a specified room.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string", "description": "Matrix room ID. Defaults to the current Matrix room."},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "description": "Maximum events to fetch."},
+                "from_token": {"type": "string", "description": "Optional pagination token."},
+            },
+            "required": [],
+        },
+    },
+    handler=matrix_fetch_history,
+)
+
+registry.register(
+    name="matrix_set_presence",
+    toolset="matrix",
+    schema={
+        "name": "matrix_set_presence",
+        "description": "Set the Matrix bot presence state.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "state": {"type": "string", "enum": ["online", "offline", "unavailable"]},
+                "status_msg": {"type": "string", "description": "Optional presence status message."},
+            },
+            "required": [],
+        },
+    },
+    handler=matrix_set_presence,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -276,6 +276,19 @@ TOOLSETS = {
         "includes": [],
     },
 
+    "matrix": {
+        "description": "Matrix-native room controls for the current Matrix gateway context",
+        "tools": [
+            "matrix_send_reaction",
+            "matrix_redact_message",
+            "matrix_create_room",
+            "matrix_invite_user",
+            "matrix_fetch_history",
+            "matrix_set_presence",
+        ],
+        "includes": [],
+    },
+
     "discord": {
         "description": "Discord read and participate tools (fetch messages, search members, create threads)",
         "tools": ["discord"],
@@ -503,7 +516,14 @@ TOOLSETS = {
 
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": _HERMES_CORE_TOOLS + [
+            "matrix_send_reaction",
+            "matrix_redact_message",
+            "matrix_create_room",
+            "matrix_invite_user",
+            "matrix_fetch_history",
+            "matrix_set_presence",
+        ],
         "includes": []
     },
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -101,7 +101,7 @@ Platform toolsets define the complete tool configuration for a deployment target
 | `hermes-slack` | Same as `hermes-cli`. |
 | `hermes-whatsapp` | Same as `hermes-cli`. |
 | `hermes-signal` | Same as `hermes-cli`. |
-| `hermes-matrix` | Same as `hermes-cli`. |
+| `hermes-matrix` | Adds Matrix-native tools (`matrix_send_reaction`, `matrix_redact_message`, `matrix_create_room`, `matrix_invite_user`, `matrix_fetch_history`, `matrix_set_presence`) on top of `hermes-cli`. |
 | `hermes-mattermost` | Same as `hermes-cli`. |
 | `hermes-email` | Same as `hermes-cli`. |
 | `hermes-sms` | Same as `hermes-cli`. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1517,9 +1517,11 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
 Matrix defaults to live tool activity, rendered as a single formatted
-`<details>` / `<summary>` message where the Matrix client supports it. Reasoning
-text, interim assistant commentary, and token-level response streaming remain
-off unless `display.platforms.matrix.*` explicitly opts in. Global
+`<details>` / `<summary>` message where the Matrix client supports it. Live
+thinking progress is disabled for Matrix because high-frequency thinking deltas
+can flood rooms and homeservers. Interim assistant commentary and token-level
+response streaming remain off unless `display.platforms.matrix.*` explicitly
+opts in. Global
 `display.tool_progress`, `display.interim_assistant_messages`, and
 `streaming.enabled` do not enable those Matrix behaviors unless the platform
 override opts in — this avoids client read-marker jumps from edited events.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1516,11 +1516,13 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
-Matrix is intentionally stricter than the generic fallback: global
+Matrix defaults to live tool activity, rendered as a single formatted
+`<details>` / `<summary>` message where the Matrix client supports it. Reasoning
+text, interim assistant commentary, and token-level response streaming remain
+off unless `display.platforms.matrix.*` explicitly opts in. Global
 `display.tool_progress`, `display.interim_assistant_messages`, and
-`streaming.enabled` do not enable live Matrix progress or partial-response
-edits unless `display.platforms.matrix.*` explicitly opts in. This avoids
-client read-marker jumps from edited Matrix events.
+`streaming.enabled` do not enable those Matrix behaviors unless the platform
+override opts in — this avoids client read-marker jumps from edited events.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1516,6 +1516,12 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
+Matrix is intentionally stricter than the generic fallback: global
+`display.tool_progress`, `display.interim_assistant_messages`, and
+`streaming.enabled` do not enable live Matrix progress or partial-response
+edits unless `display.platforms.matrix.*` explicitly opts in. This avoids
+client read-marker jumps from edited Matrix events.
+
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
 ## Privacy
@@ -1609,6 +1615,10 @@ streaming:
 ```
 
 When enabled, the bot sends a message on the first token, then progressively edits it as more tokens arrive. Platforms that don't support message editing (Signal, Email, Home Assistant) are auto-detected on the first attempt — streaming is gracefully disabled for that session with no flood of messages.
+
+Matrix also requires `display.platforms.matrix.streaming: true`; top-level
+`streaming.enabled: true` alone is not enough to enable Matrix partial-response
+edits.
 
 For separate natural mid-turn assistant updates without progressive token editing, set `display.interim_assistant_messages: true`.
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -474,7 +474,7 @@ display:
   platforms:
     matrix:
       tool_progress: new      # off | new | all | verbose
-      tool_preview_length: 1000
+      tool_preview_length: 320
       show_reasoning: false   # true only if you want raw thinking panes
       streaming: false        # true enables progressive response edits
       interim_assistant_messages: false

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -21,8 +21,8 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **Threads** | Hermes supports Matrix threads (MSC3440). If you reply in a thread, Hermes keeps the thread context isolated from the main room timeline. Threads where the bot has already participated do not require a mention. |
 | **Auto-threading** | By default, Hermes auto-creates a thread for each message it responds to in a room. This keeps conversations isolated. Set `MATRIX_AUTO_THREAD=false` to disable. Set `MATRIX_DM_AUTO_THREAD=true` (default false) to also auto-create threads for DM messages — this is distinct from `MATRIX_DM_MENTION_THREADS`, which only starts a thread when the bot is `@mentioned` in a DM. |
 | **Commands** | Hermes accepts normal `/commands` when your Matrix client sends them. If your client reserves `/` for local commands, use `!commands` instead; Hermes normalizes known `!command` aliases to `/command`. |
-| **Interactive controls** | Dangerous-command approval and `/model` selection can use Matrix reactions. Approval reactions can be limited to the user who requested the action. |
-| **Thinking and tool activity** | Matrix sends final answers only by default. Live thinking/tool panes are opt-in because Matrix clients often treat edits as read-marker-relevant events. |
+| **Interactive controls** | Dangerous-command approval and `/model` selection use Matrix reactions. Approval reactions can be limited to the user who requested the action. |
+| **Thinking and tool activity** | Matrix shows live tool activity by default in one edited message. Raw thinking text and response streaming are off by default because Matrix clients often treat edits as read-marker-relevant events. |
 | **Shared rooms with multiple users** | By default, Hermes isolates session history per user inside the room. Two people talking in the same room do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -440,14 +440,25 @@ Security-sensitive Matrix tool gates:
 If `MATRIX_ALLOWED_ROOMS` is set, Matrix tools may only target those rooms even
 when cross-room tool access is enabled.
 
-Reaction controls use:
+### Matrix Interactive Controls
+
+Matrix does not currently provide a portable native button surface equivalent to
+Slack Block Kit, Discord components, or Telegram inline keyboards. Hermes uses
+Matrix reactions for interactive controls because they work across standard
+Matrix homeservers and clients without custom client code:
 
 - ✅ approve once
 - ♾️ approve always
 - ❌ deny
 - number reactions for `/model` choices
 
-Set `MATRIX_APPROVAL_REQUIRE_SENDER=false` if you intentionally want any authorized Matrix user in the room to operate an approval/model picker prompt. The default is requester-bound when Hermes knows who requested the action.
+Set `MATRIX_APPROVAL_REQUIRE_SENDER=false` if you intentionally want any
+authorized Matrix user in the room to operate an approval/model picker prompt.
+The default is requester-bound when Hermes knows who requested the action.
+
+Optional homeserver/client extensions can render richer controls, but the
+upstream Matrix adapter keeps the core approval path reaction-based so standard
+Matrix deployments remain compatible.
 
 ### Matrix Progress and Streaming
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -463,7 +463,7 @@ display:
   platforms:
     matrix:
       tool_progress: new      # off | new | all | verbose
-      tool_preview_length: 160
+      tool_preview_length: 320
       show_reasoning: false   # true only if you want raw thinking panes
       streaming: false        # true enables progressive response edits
       interim_assistant_messages: false

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -42,7 +42,7 @@ are disabled, opportunistic, or required.
 | reactions | yes |
 | approvals | yes |
 | model picker | yes |
-| thinking panes | yes |
+| live thinking progress | no |
 | images | yes |
 | multiple images | yes |
 | files | yes |
@@ -50,12 +50,6 @@ are disabled, opportunistic, or required.
 | video | yes |
 | E2EE | off / optional / required |
 | diagnostics | yes |
-
-:::note
-Matrix thinking panes are available, but disabled by default with Matrix live
-progress/streaming. Enable them only if your Matrix client handles edited
-messages without jumping read position.
-:::
 
 ### Session Model in Matrix
 
@@ -465,7 +459,8 @@ Matrix deployments remain compatible.
 Matrix defaults to live tool activity without response/thinking streaming. Tool
 activity is sent as one Matrix formatted message using a `<details>` / `<summary>`
 block where the client supports it, with a plain-text fallback in the event body.
-Reasoning/thinking text is hidden by default.
+Live thinking progress is disabled for Matrix because high-frequency thinking
+deltas can flood Matrix rooms and homeservers.
 
 To tune Matrix progress:
 
@@ -475,15 +470,15 @@ display:
     matrix:
       tool_progress: new      # off | new | all | verbose
       tool_preview_length: 320
-      show_reasoning: false   # true only if you want raw thinking panes
+      show_reasoning: false   # true prepends final captured reasoning when available
       streaming: false        # true enables progressive response edits
       interim_assistant_messages: false
 ```
 
 Global `display.tool_progress` applies to Matrix unless overridden here.
 Global `display.interim_assistant_messages` and `streaming.enabled` do not make
-Matrix emit thinking/interim text or partial responses unless the Matrix-specific
-override is set.
+Matrix emit interim text or partial responses unless the Matrix-specific
+override is set. `display.platforms.matrix.thinking_progress` is ignored.
 
 ### Media Limits
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -451,25 +451,28 @@ Set `MATRIX_APPROVAL_REQUIRE_SENDER=false` if you intentionally want any authori
 
 ### Matrix Progress and Streaming
 
-Matrix defaults to final-answer-only output even when global gateway progress or
-streaming is enabled. This avoids Matrix client read-marker jumps caused by
-edited `m.replace` progress messages and partially streamed replies.
+Matrix defaults to live tool activity without response/thinking streaming. Tool
+activity is sent as one Matrix formatted message using a `<details>` / `<summary>`
+block where the client supports it, with a plain-text fallback in the event body.
+Reasoning/thinking text is hidden by default.
 
-To opt into live Matrix progress for a client/room where edits behave well, set
-explicit Matrix platform overrides:
+To tune Matrix progress:
 
 ```yaml
 display:
   platforms:
     matrix:
       tool_progress: new      # off | new | all | verbose
-      streaming: true         # progressive response edits
-      interim_assistant_messages: true
+      tool_preview_length: 160
+      show_reasoning: false   # true only if you want raw thinking panes
+      streaming: false        # true enables progressive response edits
+      interim_assistant_messages: false
 ```
 
-Without these Matrix-specific overrides, global `display.tool_progress`,
-`display.interim_assistant_messages`, and `streaming.enabled` do not make Matrix
-emit live progress or partial responses.
+Global `display.tool_progress` applies to Matrix unless overridden here.
+Global `display.interim_assistant_messages` and `streaming.enabled` do not make
+Matrix emit thinking/interim text or partial responses unless the Matrix-specific
+override is set.
 
 ### Media Limits
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -22,7 +22,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **Auto-threading** | By default, Hermes auto-creates a thread for each message it responds to in a room. This keeps conversations isolated. Set `MATRIX_AUTO_THREAD=false` to disable. Set `MATRIX_DM_AUTO_THREAD=true` (default false) to also auto-create threads for DM messages — this is distinct from `MATRIX_DM_MENTION_THREADS`, which only starts a thread when the bot is `@mentioned` in a DM. |
 | **Commands** | Hermes accepts normal `/commands` when your Matrix client sends them. If your client reserves `/` for local commands, use `!commands` instead; Hermes normalizes known `!command` aliases to `/command`. |
 | **Interactive controls** | Dangerous-command approval and `/model` selection can use Matrix reactions. Approval reactions can be limited to the user who requested the action. |
-| **Thinking and tool activity** | Matrix uses threaded, editable thinking/tool-activity panes when gateway progress is enabled, so updates do not flood the main room timeline. |
+| **Thinking and tool activity** | Matrix sends final answers only by default. Live thinking/tool panes are opt-in because Matrix clients often treat edits as read-marker-relevant events. |
 | **Shared rooms with multiple users** | By default, Hermes isolates session history per user inside the room. Two people talking in the same room do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -50,6 +50,12 @@ are disabled, opportunistic, or required.
 | video | yes |
 | E2EE | off / optional / required |
 | diagnostics | yes |
+
+:::note
+Matrix thinking panes are available, but disabled by default with Matrix live
+progress/streaming. Enable them only if your Matrix client handles edited
+messages without jumping read position.
+:::
 
 ### Session Model in Matrix
 
@@ -416,12 +422,23 @@ In Matrix conversations, Hermes exposes Matrix-specific tools to the agent:
 - `matrix_fetch_history`
 - `matrix_set_presence`
 
-These tools are scoped to Matrix contexts and are not available in non-Matrix toolsets. Admin-style tools are disabled by default: redaction requires `MATRIX_TOOLS_ALLOW_REDACTION=true`, invites require `MATRIX_TOOLS_ALLOW_INVITES=true`, and room creation requires `MATRIX_TOOLS_ALLOW_ROOM_CREATE=true`. Public room creation also requires `MATRIX_ALLOW_PUBLIC_ROOMS=true`.
-Matrix tools are limited to the current Matrix room by default. Explicit
-cross-room targets require `MATRIX_TOOLS_ALLOW_CROSS_ROOM=true`; redaction and
-invite-like cross-room actions additionally require
-`MATRIX_TOOLS_ALLOW_CROSS_ROOM_DESTRUCTIVE=true`. If `MATRIX_ALLOWED_ROOMS` is
-set, Matrix tools may only target those rooms.
+These tools are scoped to Matrix contexts and are not available in non-Matrix toolsets.
+They are also room-scoped by default: if a tool call provides an explicit
+`room_id`, Hermes rejects it unless it matches the current Matrix room.
+
+Security-sensitive Matrix tool gates:
+
+| Capability | Default | Required opt-in |
+|------------|---------|-----------------|
+| Target a different room | Blocked | `MATRIX_TOOLS_ALLOW_CROSS_ROOM=true` |
+| Cross-room redaction or invite-like action | Blocked | `MATRIX_TOOLS_ALLOW_CROSS_ROOM_DESTRUCTIVE=true` |
+| Redact Matrix messages | Disabled | `MATRIX_TOOLS_ALLOW_REDACTION=true` |
+| Invite Matrix users | Disabled | `MATRIX_TOOLS_ALLOW_INVITES=true` |
+| Create Matrix rooms | Disabled | `MATRIX_TOOLS_ALLOW_ROOM_CREATE=true` |
+| Create public Matrix rooms | Disabled | `MATRIX_ALLOW_PUBLIC_ROOMS=true` |
+
+If `MATRIX_ALLOWED_ROOMS` is set, Matrix tools may only target those rooms even
+when cross-room tool access is enabled.
 
 Reaction controls use:
 
@@ -431,6 +448,28 @@ Reaction controls use:
 - number reactions for `/model` choices
 
 Set `MATRIX_APPROVAL_REQUIRE_SENDER=false` if you intentionally want any authorized Matrix user in the room to operate an approval/model picker prompt. The default is requester-bound when Hermes knows who requested the action.
+
+### Matrix Progress and Streaming
+
+Matrix defaults to final-answer-only output even when global gateway progress or
+streaming is enabled. This avoids Matrix client read-marker jumps caused by
+edited `m.replace` progress messages and partially streamed replies.
+
+To opt into live Matrix progress for a client/room where edits behave well, set
+explicit Matrix platform overrides:
+
+```yaml
+display:
+  platforms:
+    matrix:
+      tool_progress: new      # off | new | all | verbose
+      streaming: true         # progressive response edits
+      interim_assistant_messages: true
+```
+
+Without these Matrix-specific overrides, global `display.tool_progress`,
+`display.interim_assistant_messages`, and `streaming.enabled` do not make Matrix
+emit live progress or partial responses.
 
 ### Media Limits
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -474,7 +474,7 @@ display:
   platforms:
     matrix:
       tool_progress: new      # off | new | all | verbose
-      tool_preview_length: 320
+      tool_preview_length: 1000
       show_reasoning: false   # true only if you want raw thinking panes
       streaming: false        # true enables progressive response edits
       interim_assistant_messages: false


### PR DESCRIPTION
## Summary

Adds the Matrix tools/interactions layer now that the Matrix foundation work from #18505 has merged into `main`.

## Scope

- Matrix-native tools and Matrix toolset registration.
- Current-room authorization for Matrix tools.
- Explicit admin gates for redaction, invites, and room creation.
- Reaction-based dangerous-command approvals and `/model` selection.
- Collapsible Matrix tool-activity messages with raw thinking hidden by default.

## Review Notes

This PR is now the active Matrix review target. It was rebuilt on top of current `main` after #18505 merged, so the PR commit list contains only this tools/interactions layer.

Matrix does not provide a portable native button surface equivalent to Slack Block Kit, Discord components, or Telegram inline keyboards. This PR keeps the upstream-safe path reaction-based so it works on ordinary Matrix homeservers and clients.

## Validation

- Local Matrix/browser subset: `375 passed, 1 skipped`.
- GitHub CI is green.
