### PR TITLE
feat(skills): add bundled Web3 read-only EVM JSON-RPC skill

### DIFF
--- a/optional-skills/blockchain/evm/SKILL.md
+++ b/optional-skills/blockchain/evm/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: evm
 description: "Read-only EVM client: wallets, tokens, gas across 8 chains."
-version: 1.0.0
-author: Mibayy (@Mibayy), youssefea (@youssefea), ethernet8023 (@ethernet8023), Hermes Agent
+version: 1.1.0
+author: Mibayy (@Mibayy), youssefea (@youssefea), ethernet8023 (@ethernet8023), xyiy001 (@xyiy001), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -16,9 +16,10 @@ metadata:
 # EVM Blockchain Skill
 
 Query EVM-compatible blockchain data across 8 chains with USD pricing.
-14 commands: wallet portfolio, token info, transactions, activity, gas tracker,
+15 commands: wallet portfolio, token info, transactions, activity, gas tracker,
 network stats, price lookup, multi-chain scan, whale detection, ENS resolution,
-allowance checker, contract inspector, and transaction decoder.
+allowance checker, contract inspector, transaction decoder, and whitelist-gated
+raw `rpc` (read-only JSON-RPC).
 
 Supports 8 chains: Ethereum, BNB Chain (BSC), Base, Arbitrum One, Polygon,
 Optimism, Avalanche (C-Chain), zkSync Era.
@@ -45,6 +46,7 @@ No API key needed. Zero external dependencies — Python standard library only
 - User wants to check if a contract has dangerous token approvals
 - User wants to inspect a smart contract (proxy? ERC-20? ERC-721? bytecode size?)
 - User wants to compare gas costs across chains before a transaction
+- User needs a **whitelist-gated raw JSON-RPC** probe (`eth_chainId`, `eth_call`, …) without `web3.py`
 
 ---
 
@@ -100,6 +102,10 @@ python3 $SCRIPT ens 0xd8dA...96045               # Address -> ENS name
 # Whale detection
 python3 $SCRIPT whale                            # Large transfers (last 20 blocks, >$10k)
 python3 $SCRIPT whale --blocks 50 --min-usd 100000 --chain arbitrum
+
+# Whitelist raw JSON-RPC (read-only; endpoint URL redacted in output)
+python3 $SCRIPT rpc eth_chainId
+python3 $SCRIPT rpc eth_call --params '[{"to":"0x...","data":"0x..."},"latest"]'
 ```
 
 ---

--- a/optional-skills/blockchain/evm/scripts/evm_client.py
+++ b/optional-skills/blockchain/evm/scripts/evm_client.py
@@ -333,7 +333,7 @@ _ETH_CALL_DATA_MAX_HEX_CHARS = 20_480
 
 
 def redact_rpc_url(url: str) -> str:
-    """Strip credentials / query tokens from RPC URLs before printing."""
+    """Return scheme://[***@]host[:port] only — drop userinfo, path, query, fragment."""
     try:
         parts = urllib.parse.urlsplit(url)
     except Exception:
@@ -343,7 +343,8 @@ def redact_rpc_url(url: str) -> str:
         host = f"{host}:{parts.port}"
     if parts.username or parts.password:
         host = f"***@{host}"
-    return urllib.parse.urlunsplit((parts.scheme, host, parts.path, "", ""))
+    # Origin-only: never echo path (provider key routes), query, or fragment.
+    return urllib.parse.urlunsplit((parts.scheme, host, "", "", ""))
 
 
 # ---------------------------------------------------------------------------

--- a/optional-skills/blockchain/evm/scripts/evm_client.py
+++ b/optional-skills/blockchain/evm/scripts/evm_client.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -315,6 +316,35 @@ def _short_addr(addr: str) -> str:
 
 def print_json(data: Any) -> None:
     print(json.dumps(data, indent=2, default=str))
+
+
+# Read-only JSON-RPC methods exposed via the `rpc` subcommand. Everything else
+# (eth_send*, admin_*, personal_*, debug_*, miner_*, txpool_*) stays blocked.
+READONLY_RPC_METHODS: frozenset[str] = frozenset({
+    "eth_chainId",
+    "eth_blockNumber",
+    "eth_gasPrice",
+    "eth_getBalance",
+    "eth_getTransactionCount",
+    "eth_getCode",
+    "eth_call",
+})
+_ETH_CALL_DATA_MAX_HEX_CHARS = 20_480
+
+
+def redact_rpc_url(url: str) -> str:
+    """Strip credentials / query tokens from RPC URLs before printing."""
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except Exception:
+        return "<redacted>"
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    if parts.username or parts.password:
+        host = f"***@{host}"
+    return urllib.parse.urlunsplit((parts.scheme, host, parts.path, "", ""))
+
 
 # ---------------------------------------------------------------------------
 # HTTP / JSON-RPC layer
@@ -1376,6 +1406,65 @@ def cmd_contract(args: argparse.Namespace) -> None:
 # Argument parsing & dispatch
 # ---------------------------------------------------------------------------
 
+def cmd_rpc(args: argparse.Namespace) -> None:
+    """Whitelist-gated raw JSON-RPC for chain inspection / eth_call only."""
+    method = str(args.method or "").strip()
+    endpoint = redact_rpc_url(get_rpc_url(args.chain))
+    if method not in READONLY_RPC_METHODS:
+        print_json({
+            "ok": False,
+            "error": f"disallowed method {method!r}",
+            "allowed": sorted(READONLY_RPC_METHODS),
+            "endpoint": endpoint,
+        })
+        sys.exit(2)
+
+    params: List[Any]
+    if args.params:
+        try:
+            params = json.loads(args.params)
+        except json.JSONDecodeError as exc:
+            print_json({"ok": False, "error": f"invalid --params JSON: {exc}", "endpoint": endpoint})
+            sys.exit(2)
+        if not isinstance(params, list):
+            print_json({"ok": False, "error": "--params must be a JSON array", "endpoint": endpoint})
+            sys.exit(2)
+    else:
+        params = []
+
+    if method == "eth_call":
+        if not params or not isinstance(params[0], dict):
+            print_json({
+                "ok": False,
+                "error": "eth_call requires params [call_object, block_tag]",
+                "endpoint": endpoint,
+            })
+            sys.exit(2)
+        data = params[0].get("data") or ""
+        if isinstance(data, str) and data.startswith("0x"):
+            if len(data) - 2 > _ETH_CALL_DATA_MAX_HEX_CHARS:
+                print_json({
+                    "ok": False,
+                    "error": "eth_call data exceeds maximum hex length",
+                    "endpoint": endpoint,
+                })
+                sys.exit(2)
+
+    try:
+        result = rpc_call(args.chain, method, params)
+    except Exception as exc:
+        print_json({"ok": False, "error": str(exc), "method": method, "endpoint": endpoint})
+        sys.exit(1)
+
+    print_json({
+        "ok": True,
+        "method": method,
+        "result": result,
+        "endpoint": endpoint,
+        "chain": args.chain,
+    })
+
+
 def build_parser() -> argparse.ArgumentParser:
     chain_choices = list(CHAINS.keys())
 
@@ -1459,6 +1548,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_contract.add_argument("address", help="Contract address (0x...)")
     p_contract.add_argument("--chain", default=DEFAULT_CHAIN, choices=chain_choices)
 
+    # -- rpc (whitelist raw JSON-RPC) --
+    p_rpc = sub.add_parser(
+        "rpc",
+        help="Raw read-only JSON-RPC (whitelist: chainId/block/gas/balance/code/call)",
+    )
+    p_rpc.add_argument("method", help="JSON-RPC method name (whitelist only)")
+    p_rpc.add_argument(
+        "--params",
+        default="[]",
+        help='JSON array of params (default: [])',
+    )
+    p_rpc.add_argument("--chain", default=DEFAULT_CHAIN, choices=chain_choices)
+
     return parser
 
 
@@ -1477,6 +1579,7 @@ DISPATCH = {
     "decode":     cmd_decode,
     "ens":        cmd_ens,
     "contract":   cmd_contract,
+    "rpc":        cmd_rpc,
 }
 
 

--- a/tests/skills/test_evm_skill.py
+++ b/tests/skills/test_evm_skill.py
@@ -1,0 +1,80 @@
+"""Tests for optional-skills/blockchain/evm (whitelist raw RPC extension)."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "blockchain"
+    / "evm"
+    / "scripts"
+    / "evm_client.py"
+)
+
+
+@pytest.fixture(scope="module")
+def evm():
+    spec = importlib.util.spec_from_file_location("evm_client_under_test", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_redact_rpc_url_strips_query_and_userinfo(evm):
+    redacted = evm.redact_rpc_url(
+        "https://user:secret@rpc.example.com/v1?apikey=abc123"
+    )
+    assert "secret" not in redacted
+    assert "abc123" not in redacted
+    assert "rpc.example.com" in redacted
+
+
+def test_rpc_rejects_disallowed_method(evm, capsys):
+    args = argparse.Namespace(method="eth_sendRawTransaction", params="[]", chain="ethereum")
+    with mock.patch.object(evm, "get_rpc_url", return_value="https://key@rpc.example/v1"):
+        with pytest.raises(SystemExit) as exited:
+            evm.cmd_rpc(args)
+    assert exited.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "disallowed" in payload["error"]
+    assert "key@" not in payload["endpoint"]
+
+
+def test_rpc_allows_chain_id(evm, capsys):
+    args = argparse.Namespace(method="eth_chainId", params="[]", chain="ethereum")
+    with mock.patch.object(evm, "get_rpc_url", return_value="https://rpc.example/v1?token=xyz"):
+        with mock.patch.object(evm, "rpc_call", return_value="0x1") as mocked:
+            evm.cmd_rpc(args)
+            mocked.assert_called_once_with("ethereum", "eth_chainId", [])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"] == "0x1"
+    assert "token=xyz" not in payload["endpoint"]
+
+
+def test_rpc_eth_call_rejects_oversize_data(evm, capsys):
+    huge = "0x" + ("ab" * (evm._ETH_CALL_DATA_MAX_HEX_CHARS + 1))
+    args = argparse.Namespace(
+        method="eth_call",
+        params=json.dumps([{"to": "0x" + "11" * 20, "data": huge}, "latest"]),
+        chain="ethereum",
+    )
+    with mock.patch.object(evm, "get_rpc_url", return_value="https://rpc.example/v1"):
+        with pytest.raises(SystemExit) as exited:
+            evm.cmd_rpc(args)
+    assert exited.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "maximum hex length" in payload["error"]

--- a/tests/skills/test_evm_skill.py
+++ b/tests/skills/test_evm_skill.py
@@ -31,13 +31,15 @@ def evm():
     return mod
 
 
-def test_redact_rpc_url_strips_query_and_userinfo(evm):
+def test_redact_rpc_url_strips_query_userinfo_and_path(evm):
     redacted = evm.redact_rpc_url(
-        "https://user:secret@rpc.example.com/v1?apikey=abc123"
+        "https://user:secret@rpc.example.com/v1/xyz?apikey=abc123#frag"
     )
+    assert redacted == "https://***@rpc.example.com"
     assert "secret" not in redacted
     assert "abc123" not in redacted
-    assert "rpc.example.com" in redacted
+    assert "/v1" not in redacted
+    assert "frag" not in redacted
 
 
 def test_rpc_rejects_disallowed_method(evm, capsys):


### PR DESCRIPTION
### Summary

Adds a new bundled playbook under `skills/web3/evm-readonly-jsonrpc/` plus a tiny stdlib+Pydantic helper for **HTTPS-only**, **whitelist-gated** Ethereum-compatible JSON-RPC (read/simulation only).

### What’s included

- **Skill content**: `SKILL.md`, `references/rpc-methods.md` (allowed methods, `eth_call` notes, safety boundaries).
- **CLI helper**: `scripts/evm_jsonrpc.py` + `scripts/_evm_transport.py`
  - Methods allowed: `eth_chainId`, `eth_blockNumber`, `eth_gasPrice`, `eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, `eth_call`.
  - **No** `eth_send*` / admin / miner / debug methods.
  - RPC URL discovery: `HERMES_SKILL_EVM_RPC_URL`, or comma-separated `HERMES_SKILL_EVM_RPC_URLS` (fallback order).
  - Configurable timeouts/retries via env (`HERMES_SKILL_EVM_RPC_TIMEOUT_SEC`, `HERMES_SKILL_EVM_RPC_RETRY_PER_URL`).
  - **`eth_call` guard**: rejects oversize hex `data` to reduce abuse risk on shared RPC tiers.
- **Docs**: catalog row (`website/docs/reference/skills-catalog.md`) + bundled doc page mirror.
- **Tests**: `tests/skills/test_web3_evm_readonly_jsonrpc.py` (mocked `urllib`, no live chain).

### Non-goals / scope boundaries

Intentionally does **not** modify MCP plumbing, wallets, governance layers, sandbox providers, memory providers, or core agent loops — this complements heavier optional MCP Web3 setups with a lightweight, audited read path.

### How to verify

Run:

`python -m pytest tests/skills/test_web3_evm_readonly_jsonrpc.py -q -o addopts=`

(Optionally CI parity via `scripts/run_tests.sh`.)