### PR TITLE
fix: preserve unsigned thinking blocks for DeepSeek Anthropic endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1422,17 +1422,14 @@ def convert_messages_to_anthropic(
             continue
 
         if role == "assistant":
-            # For DeepSeek /anthropic and Kimi /coding endpoints, skip
-            # extracting signed thinking blocks from reasoning_details.
-            # Those blocks carry Anthropic-proprietary signatures that
-            # these endpoints cannot validate — they get stripped later
-            # in the thinking-block management pass, leaving no thinking
-            # block at all.  Instead, let the reasoning_content path
-            # (below) create unsigned blocks that these endpoints accept.
-            _skip_signed_thinking = (
-                _is_deepseek_anthropic_endpoint(base_url)
-                or _is_kimi_family_endpoint(base_url, model)
-            )
+            # For DeepSeek /anthropic endpoints, skip extracting signed
+            # thinking blocks from reasoning_details.  Those blocks carry
+            # Anthropic-proprietary signatures that DeepSeek cannot validate
+            # — they get stripped later in the thinking-block management pass,
+            # leaving no thinking block at all.  Instead, let the
+            # reasoning_content path (below) create unsigned blocks that
+            # DeepSeek accepts.
+            _skip_signed_thinking = _is_deepseek_anthropic_endpoint(base_url)
             blocks = [] if _skip_signed_thinking else _extract_preserved_thinking_blocks(m)
             if content:
                 if isinstance(content, list):

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1422,7 +1422,18 @@ def convert_messages_to_anthropic(
             continue
 
         if role == "assistant":
-            blocks = _extract_preserved_thinking_blocks(m)
+            # For DeepSeek /anthropic and Kimi /coding endpoints, skip
+            # extracting signed thinking blocks from reasoning_details.
+            # Those blocks carry Anthropic-proprietary signatures that
+            # these endpoints cannot validate — they get stripped later
+            # in the thinking-block management pass, leaving no thinking
+            # block at all.  Instead, let the reasoning_content path
+            # (below) create unsigned blocks that these endpoints accept.
+            _skip_signed_thinking = (
+                _is_deepseek_anthropic_endpoint(base_url)
+                or _is_kimi_family_endpoint(base_url, model)
+            )
+            blocks = [] if _skip_signed_thinking else _extract_preserved_thinking_blocks(m)
             if content:
                 if isinstance(content, list):
                     converted_content = _convert_content_to_anthropic(content)

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -130,10 +130,12 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
 })
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-chat",       # V3 on DeepSeek direct and most aggregators
-    "deepseek-reasoner",   # R1-family reasoning model
-    "deepseek-v4-pro",     # V4 Pro — first-class model ID
-    "deepseek-v4-flash",   # V4 Flash — first-class model ID
+    "deepseek-chat",             # V3 on DeepSeek direct and most aggregators
+    "deepseek-reasoner",         # R1-family reasoning model
+    "deepseek-v4-pro",           # V4 Pro — first-class model ID
+    "deepseek-v4-pro[1m]",       # V4 Pro — 1M context window variant
+    "deepseek-v4-flash",         # V4 Flash — first-class model ID
+    "deepseek-v4-flash[1m]",     # V4 Flash — 1M context window variant
 })
 
 # First-class V-series IDs (``deepseek-v4-pro``, ``deepseek-v4-flash``,

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -142,7 +142,7 @@ _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
 # ``provider: DeepSeek`` / ``model: deepseek-v4-flash-20260423`` when called
 # with ``model=deepseek/deepseek-v4-flash``, so these names are not aliases
 # of ``deepseek-chat`` and must not be folded into it.
-_DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
+_DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+.*$")
 
 
 def _normalize_for_deepseek(model_name: str) -> str:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -311,7 +311,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "deepseek": [
         "deepseek-v4-pro",
+        "deepseek-v4-pro[1m]",
         "deepseek-v4-flash",
+        "deepseek-v4-flash[1m]",
         "deepseek-chat",
         "deepseek-reasoner",
     ],


### PR DESCRIPTION
## Summary

- Fix HTTP 400 errors when using DeepSeek `/anthropic` endpoint with thinking mode enabled
- Widen DeepSeek V-series model regex to accept bracket suffixes like `[1m]` (e.g. `deepseek-v4-flash[1m]` for 1M context)

## Problem

When replaying multi-turn conversations through DeepSeek's `/anthropic` endpoint, the API returns:

```
HTTP 400: The `content[].thinking` in the thinking mode must be passed back to the API.
```

**Root cause:** `_extract_preserved_thinking_blocks()` extracts signed thinking blocks from `reasoning_details` first, setting `_already_has_thinking=True`. This prevents the `reasoning_content` path from creating unsigned blocks. The signed blocks are then stripped by the thinking-block management pass (since DeepSeek cannot validate Anthropic signatures), resulting in no thinking blocks at all.

## Fix

In `convert_messages_to_anthropic()`, skip extracting signed thinking blocks from `reasoning_details` when the target endpoint is DeepSeek `/anthropic`. This allows the `reasoning_content` path to create unsigned blocks that DeepSeek accepts.

Also widen the `_DEEPSEEK_V_SERIES_RE` regex from `^deepseek-v\d+([-.].+)?$` to `^deepseek-v\d+.*$` so model names with bracket suffixes (like `deepseek-v4-flash[1m]`) are correctly recognized as V-series models instead of being normalized to `deepseek-chat`.

## Test plan

- [x] Verified with DeepSeek `deepseek-v4-flash[1m]` via `/anthropic` endpoint — multi-turn conversations now work without HTTP 400
- [x] Verified model normalization: `deepseek-v4-flash[1m]` → `deepseek-v4-flash[1m]` (not `deepseek-chat`)