### PR TITLE
feat(telegram): route forum topics to Hermes profiles

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -131,6 +131,7 @@ def init_agent(
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
     fallback_model: Dict[str, Any] = None,
+    runtime_env: Dict[str, Any] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20,
@@ -216,6 +217,7 @@ def init_agent(
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
     agent._credential_pool = credential_pool
+    agent._runtime_env = dict(runtime_env or {}) if runtime_env is not None else None
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -337,7 +339,7 @@ def init_agent(
     agent.status_callback = status_callback
     agent.tool_gen_callback = tool_gen_callback
 
-    
+
     # Tool execution state — allows _vprint during tool execution
     # even when stream consumers are registered (no tokens streaming then)
     agent._executing_tools = False
@@ -370,12 +372,12 @@ def init_agent(
     # their tids explicitly.
     agent._tool_worker_threads: set[int] = set()
     agent._tool_worker_threads_lock = threading.Lock()
-    
+
     # Subagent delegation state
     agent._delegate_depth = 0        # 0 = top-level agent, incremented for children
     agent._active_children = []      # Running child AIAgents (for interrupt propagation)
     agent._active_children_lock = threading.Lock()
-    
+
     # Store OpenRouter provider preferences
     agent.providers_allowed = providers_allowed
     agent.providers_ignored = providers_ignored
@@ -388,7 +390,7 @@ def init_agent(
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
-    
+
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
@@ -396,7 +398,7 @@ def init_agent(
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
-    
+
     # Anthropic prompt caching: auto-enabled for Claude models on native
     # Anthropic, OpenRouter, and third-party gateways that speak the
     # Anthropic protocol (``api_mode == 'anthropic_messages'``). Reduces
@@ -451,7 +453,7 @@ def init_agent(
     # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
     # (which creates a new AIAgent per message) won't duplicate handlers.
     from hermes_logging import setup_logging, setup_verbose_logging
-    setup_logging(hermes_home=_ra()._hermes_home)
+    setup_logging(hermes_home=get_hermes_home())
 
     if agent.verbose_logging:
         setup_verbose_logging()
@@ -468,7 +470,7 @@ def init_agent(
         # console. Any future noise reduction belongs at the
         # handler level inside hermes_logging.py, not here.
         pass
-    
+
     # Internal stream callback (set during streaming TTS).
     # Initialized here so _vprint can reference it before run_conversation.
     agent._stream_callback = None
@@ -659,7 +661,8 @@ def init_agent(
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client
             _routed_client, _ = resolve_provider_client(
-                agent.provider or "auto", model=agent.model, raw_codex=True)
+                agent.provider or "auto", model=agent.model, raw_codex=True,
+                env=runtime_env)
             if _routed_client is not None:
                 client_kwargs = {
                     "api_key": _routed_client.api_key,
@@ -705,14 +708,36 @@ def init_agent(
                     _fb_resolved = False
                     for _fb in _fb_entries:
                         _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
+                        _fb_key_env = ""
                         if not _fb_explicit_key:
                             _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
                             if _fb_key_env:
-                                _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
+                                if runtime_env is None:
+                                    _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
+                                else:
+                                    _fb_explicit_key = str(runtime_env.get(_fb_key_env, "")).strip() or None
+                        if runtime_env is not None and not _fb_explicit_key:
+                            _fb_env_names = []
+                            _fb_base_url = (_fb.get("base_url") or "").strip()
+                            if _fb["provider"] == "ollama" or base_url_host_matches(_fb_base_url, "ollama.com"):
+                                _fb_env_names.append("OLLAMA_API_KEY")
+                            try:
+                                from hermes_cli.auth import PROVIDER_REGISTRY as _fb_registry
+                                _fb_pcfg = _fb_registry.get(str(_fb["provider"]))
+                                if _fb_pcfg and _fb_pcfg.api_key_env_vars:
+                                    _fb_env_names.extend(_fb_pcfg.api_key_env_vars)
+                            except Exception:
+                                _fb_pcfg = None
+                            _fb_env_names.append(f"{str(_fb['provider']).upper().replace('-', '_')}_API_KEY")
+                            for _fb_env_name in _fb_env_names:
+                                _fb_explicit_key = str(runtime_env.get(_fb_env_name, "")).strip() or None
+                                if _fb_explicit_key:
+                                    break
                         _fb_client, _fb_model = resolve_provider_client(
                             _fb["provider"], model=_fb["model"], raw_codex=True,
                             explicit_base_url=_fb.get("base_url"),
                             explicit_api_key=_fb_explicit_key,
+                            env=runtime_env,
                         )
                         if _fb_client is not None:
                             agent.provider = _fb["provider"]
@@ -744,7 +769,7 @@ def init_agent(
                         "select a provider, or run `hermes setup` for first-time "
                         "configuration."
                     )
-        
+
         agent._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
         # Enable fine-grained tool streaming for Claude on OpenRouter.
@@ -788,7 +813,7 @@ def init_agent(
                     print("⚠️  Warning: API key appears invalid or missing")
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
-    
+
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
@@ -820,7 +845,7 @@ def init_agent(
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
     )
-    
+
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
     if agent.tools:
@@ -853,16 +878,16 @@ def init_agent(
         missing_reqs = [name for name, available in requirements.items() if not available]
         if missing_reqs:
             print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
-    
+
     # Show trajectory saving status
     if agent.save_trajectories and not agent.quiet_mode:
         print("📝 Trajectory saving enabled")
-    
+
     # Show ephemeral system prompt status
     if agent.ephemeral_system_prompt and not agent.quiet_mode:
         prompt_preview = agent.ephemeral_system_prompt[:60] + "..." if len(agent.ephemeral_system_prompt) > 60 else agent.ephemeral_system_prompt
         print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
-    
+
     # Show prompt caching status
     if agent._use_prompt_caching and not agent.quiet_mode:
         if agent._use_native_cache_layout and agent.provider == "anthropic":
@@ -872,7 +897,7 @@ def init_agent(
         else:
             source = "Claude via OpenRouter"
         print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
-    
+
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()
     if session_id:
@@ -919,10 +944,10 @@ def init_agent(
     agent._session_messages: List[Dict[str, Any]] = []
     agent._memory_write_origin = "assistant_tool"
     agent._memory_write_context = "foreground"
-    
+
     # Cached system prompt -- built once per session, only rebuilt on compression
     agent._cached_system_prompt: Optional[str] = None
-    
+
     # Filesystem checkpoint manager (transparent — not a tool)
     from tools.checkpoint_manager import CheckpointManager
     agent._checkpoint_mgr = CheckpointManager(
@@ -931,22 +956,24 @@ def init_agent(
         max_total_size_mb=checkpoint_max_total_size_mb,
         max_file_size_mb=checkpoint_max_file_size_mb,
     )
-    
+
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
     agent._session_db_created = False  # DB row deferred to run_conversation()
+    agent._system_prompt_identity_fingerprint = agent._system_prompt_identity_digest()
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,
+        "system_prompt_identity_digest": agent._system_prompt_identity_fingerprint,
     }
-    
+
     # In-memory todo list for task planning (one per agent/session)
     from tools.todo_tool import TodoStore
     agent._todo_store = TodoStore()
-    
+
     # Load config once for memory, skills, and compression sections
     try:
         from hermes_cli.config import load_config as _load_agent_config
@@ -988,7 +1015,7 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
-    
+
 
 
     # Memory provider plugin (external — one at a time, alongside built-in)
@@ -1346,6 +1373,10 @@ def init_agent(
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
         )
+    try:
+        agent.context_compressor.runtime_env = getattr(agent, "_runtime_env", None)
+    except Exception:
+        pass
     agent.compression_enabled = compression_enabled
 
     # Reject models whose context window is below the minimum required
@@ -1418,7 +1449,7 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -40,6 +40,7 @@ Payment / credit exhaustion fallback:
   their OpenRouter balance but has Codex OAuth or another provider available.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -67,6 +68,13 @@ if TYPE_CHECKING:
     from openai import OpenAI  # noqa: F401 — type hints only
 
 _OPENAI_CLS_CACHE: Optional[type] = None
+
+
+def _env_lookup(env: Optional[Dict[str, Any]], key: str, default: str = "") -> str:
+    if env is None:
+        return os.getenv(key, default)
+    value = env.get(key, default)
+    return "" if value is None else str(value)
 
 
 def _load_openai_cls() -> type:
@@ -428,8 +436,6 @@ _OPENROUTER_MODEL = "google/gemini-3-flash-preview"
 _NOUS_MODEL = "google/gemini-3-flash-preview"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
-_AUTH_JSON_PATH = get_hermes_home() / "auth.json"
-
 # Codex OAuth endpoint used when a caller explicitly requests
 # provider="openai-codex".  There is deliberately no hardcoded default
 # model: the set of models OpenAI accepts on this endpoint for
@@ -510,10 +516,67 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
+def _scoped_auth_store_allowed(env: Optional[Dict[str, Any]]) -> bool:
+    if env is None:
+        return True
+    try:
+        from gateway.session_context import get_session_env
+
+        if get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "").strip():
+            return True
+        if get_session_env("HERMES_SESSION_AGENT_PROFILE", "").strip():
+            return False
+    except Exception:
+        pass
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        profile_home = get_hermes_home().resolve(strict=False)
+        default_home = get_default_hermes_root().resolve(strict=False)
+        return profile_home != default_home
+    except Exception:
+        return False
+
+
+def _load_scoped_auth_store(env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not _scoped_auth_store_allowed(env):
+        return {}
+    auth_path = get_hermes_home() / "auth.json"
+    try:
+        if not auth_path.is_file():
+            return {}
+        data = json.loads(auth_path.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:
+        logger.debug("Auxiliary client: could not read scoped auth store %s: %s", auth_path, exc)
+        return {}
+
+
+def _load_scoped_pool(provider: str, env: Optional[Dict[str, Any]]):
+    if env is None:
+        return load_pool(provider)
+    store = _load_scoped_auth_store(env)
+    pool_data = store.get("credential_pool")
+    if not isinstance(pool_data, dict):
+        raw_entries = []
+    else:
+        raw_entries = pool_data.get(provider)
+        if not isinstance(raw_entries, list):
+            raw_entries = []
+    try:
+        from agent.credential_pool import CredentialPool, PooledCredential
+
+        entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+        return CredentialPool(provider, entries)
+    except Exception as exc:
+        logger.debug("Auxiliary client: could not load scoped pool for %s: %s", provider, exc)
+        return None
+
+
+def _select_pool_entry(provider: str, env: Optional[Dict[str, Any]] = None) -> Tuple[bool, Optional[Any]]:
     """Return (pool_exists_for_provider, selected_entry)."""
     try:
-        pool = load_pool(provider)
+        pool = _load_scoped_pool(provider, env)
     except Exception as exc:
         logger.debug("Auxiliary client: could not load pool for %s: %s", provider, exc)
         return False, None
@@ -526,10 +589,10 @@ def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
         return True, None
 
 
-def _peek_pool_entry(provider: str) -> Optional[Any]:
+def _peek_pool_entry(provider: str, env: Optional[Dict[str, Any]] = None) -> Optional[Any]:
     """Best-effort current/next pool entry without mutating selection order."""
     try:
-        pool = load_pool(provider)
+        pool = _load_scoped_pool(provider, env)
     except Exception as exc:
         logger.debug("Auxiliary client: could not load pool for %s (peek): %s", provider, exc)
         return None
@@ -1210,13 +1273,13 @@ def _maybe_wrap_anthropic(
     )
 
 
-def _read_nous_auth() -> Optional[dict]:
+def _read_nous_auth(env: Optional[Dict[str, Any]] = None) -> Optional[dict]:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
     Returns the provider state dict if Nous is active with tokens,
     otherwise None.
     """
-    pool_present, entry = _select_pool_entry("nous")
+    pool_present, entry = _select_pool_entry("nous", env=env)
     if pool_present:
         if entry is None:
             return None
@@ -1233,9 +1296,12 @@ def _read_nous_auth() -> Optional[dict]:
         }
 
     try:
-        if not _AUTH_JSON_PATH.is_file():
+        if env is not None and not _scoped_auth_store_allowed(env):
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text())
+        auth_json_path = get_hermes_home() / "auth.json"
+        if not auth_json_path.is_file():
+            return None
+        data = json.loads(auth_json_path.read_text())
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})
@@ -1253,9 +1319,9 @@ def _nous_api_key(provider: dict) -> str:
     return provider.get("agent_key") or provider.get("access_token", "")
 
 
-def _nous_base_url() -> str:
+def _nous_base_url(env: Optional[Dict[str, Any]] = None) -> str:
     """Resolve the Nous inference base URL from env or default."""
-    return os.getenv("NOUS_INFERENCE_BASE_URL", _NOUS_DEFAULT_BASE_URL)
+    return _env_lookup(env, "NOUS_INFERENCE_BASE_URL", _NOUS_DEFAULT_BASE_URL)
 
 
 def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[str, str]]:
@@ -1293,7 +1359,7 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
     return api_key, base_url
 
 
-def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
+def _resolve_xai_oauth_for_aux(env: Optional[Dict[str, Any]] = None) -> Optional[Tuple[str, str]]:
     """Resolve a fresh xAI OAuth (api_key, base_url) for auxiliary clients.
 
     Prefer the credential pool, matching the main runtime/provider status
@@ -1312,7 +1378,7 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
             _xai_validate_inference_base_url,
         )
 
-        pool = load_pool("xai-oauth")
+        pool = _load_scoped_pool("xai-oauth", env)
         if pool and pool.has_credentials():
             entry = pool.select()
             if entry is not None:
@@ -1322,8 +1388,8 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
                     or ""
                 ).strip()
                 base_url = _xai_validate_inference_base_url(
-                    os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
-                    or os.getenv("XAI_BASE_URL", "").strip().rstrip("/")
+                    _env_lookup(env, "HERMES_XAI_BASE_URL").strip().rstrip("/")
+                    or _env_lookup(env, "XAI_BASE_URL").strip().rstrip("/")
                     or str(getattr(entry, "runtime_base_url", None) or "").strip().rstrip("/")
                     or str(getattr(entry, "base_url", None) or "").strip().rstrip("/"),
                     fallback=DEFAULT_XAI_OAUTH_BASE_URL,
@@ -1336,6 +1402,8 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     try:
         from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
+        if env is not None and not _scoped_auth_store_allowed(env):
+            return None
         creds = resolve_xai_oauth_runtime_credentials()
     except Exception as exc:
         logger.debug("Auxiliary xAI OAuth runtime credential resolution failed: %s", exc)
@@ -1348,7 +1416,7 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     return api_key, base_url
 
 
-def _read_codex_access_token() -> Optional[str]:
+def _read_codex_access_token(env: Optional[Dict[str, Any]] = None) -> Optional[str]:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
     If a credential pool exists but currently has no selectable runtime entry
@@ -1357,13 +1425,15 @@ def _read_codex_access_token() -> Optional[str]:
     fallback-to-Codex working when the pool state is stale but the stored OAuth
     token is still valid.
     """
-    pool_present, entry = _select_pool_entry("openai-codex")
+    pool_present, entry = _select_pool_entry("openai-codex", env=env)
     if pool_present:
         token = _pool_runtime_api_key(entry)
         if token:
             return token
 
     try:
+        if env is not None and not _scoped_auth_store_allowed(env):
+            return None
         from hermes_cli.auth import _read_codex_tokens
         data = _read_codex_tokens()
         tokens = data.get("tokens", {})
@@ -1391,7 +1461,7 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_api_key_provider(env: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Try each API-key provider in PROVIDER_REGISTRY order.
 
     Returns (client, model) for the first provider with usable runtime
@@ -1416,9 +1486,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                     continue
             except ImportError:
                 pass
-            return _try_anthropic()
+                return _try_anthropic(env=env)
 
-        pool_present, entry = _select_pool_entry(provider_id)
+        pool_present, entry = _select_pool_entry(provider_id, env=env)
         if pool_present:
             api_key = _pool_runtime_api_key(entry)
             if not api_key:
@@ -1456,7 +1526,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             _client = _maybe_wrap_anthropic(_client, model, api_key, raw_base_url)
             return _client, model
 
-        creds = resolve_api_key_provider_credentials(provider_id)
+        creds = resolve_api_key_provider_credentials(provider_id, env=env)
         api_key = str(creds.get("api_key", "")).strip()
         if not api_key:
             continue
@@ -1500,8 +1570,12 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 
-def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
-    pool_present, entry = _select_pool_entry("openrouter")
+def _try_openrouter(
+    explicit_api_key: str = None,
+    model: str = None,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[OpenAI], Optional[str]]:
+    pool_present, entry = _select_pool_entry("openrouter", env=env)
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if not or_key:
@@ -1512,7 +1586,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         return OpenAI(api_key=or_key, base_url=base_url,
                        default_headers=build_or_headers()), model or _OPENROUTER_MODEL
 
-    or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
+    or_key = explicit_api_key or _env_lookup(env, "OPENROUTER_API_KEY").strip()
     if not or_key:
         _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
@@ -1521,20 +1595,23 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
                    default_headers=build_or_headers()), model or _OPENROUTER_MODEL
 
 
-def _describe_openrouter_unavailable() -> str:
+def _describe_openrouter_unavailable(env: Optional[Dict[str, Any]] = None) -> str:
     """Return a more precise OpenRouter auth failure reason for logs."""
-    pool_present, entry = _select_pool_entry("openrouter")
+    pool_present, entry = _select_pool_entry("openrouter", env=env)
     if pool_present:
         if entry is None:
             return "OpenRouter credential pool has no usable entries (credentials may be exhausted)"
         if not _pool_runtime_api_key(entry):
             return "OpenRouter credential pool entry is missing a runtime API key"
-    if not str(os.getenv("OPENROUTER_API_KEY") or "").strip():
+    if not _env_lookup(env, "OPENROUTER_API_KEY").strip():
         return "OPENROUTER_API_KEY not set"
     return "no usable OpenRouter credentials found"
 
 
-def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_nous(
+    vision: bool = False,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[OpenAI], Optional[str]]:
     # Check cross-session rate limit guard before attempting Nous —
     # if another session already recorded a 429, skip Nous entirely
     # to avoid piling more requests onto the tapped RPH bucket.
@@ -1551,8 +1628,12 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     except Exception:
         pass
 
-    nous = _read_nous_auth()
-    runtime = _resolve_nous_runtime_api(force_refresh=False)
+    nous = _read_nous_auth(env=env)
+    runtime = (
+        _resolve_nous_runtime_api(force_refresh=False)
+        if env is None or nous
+        else None
+    )
     if runtime is None and not nous:
         logger.warning(
             "Auxiliary Nous client unavailable: no Nous authentication found "
@@ -1605,7 +1686,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         api_key, base_url = runtime
     else:
         api_key = _nous_api_key(nous or {})
-        base_url = str((nous or {}).get("inference_base_url") or _nous_base_url()).rstrip("/")
+        base_url = str((nous or {}).get("inference_base_url") or _nous_base_url(env)).rstrip("/")
     return (
         OpenAI(
             api_key=api_key,
@@ -1696,7 +1777,7 @@ def clear_runtime_main() -> None:
     _RUNTIME_MAIN_MODEL = ""
 
 
-def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
+def _resolve_custom_runtime(env: Optional[Dict[str, Any]] = None) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
     This covers both env-driven OPENAI_BASE_URL setups and config-saved custom
@@ -1706,14 +1787,14 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested="custom")
+        runtime = resolve_runtime_provider(requested="custom", env=env)
     except Exception as exc:
         logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
         runtime = None
 
     if not isinstance(runtime, dict):
-        openai_base = os.getenv("OPENAI_BASE_URL", "").strip().rstrip("/")
-        openai_key = os.getenv("OPENAI_API_KEY", "").strip()
+        openai_base = _env_lookup(env, "OPENAI_BASE_URL").strip().rstrip("/")
+        openai_key = _env_lookup(env, "OPENAI_API_KEY").strip()
         if not openai_base:
             return None, None, None
         runtime = {
@@ -1798,8 +1879,8 @@ def _validate_base_url(base_url: str) -> None:
         ) from exc
 
 
-def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
-    runtime = _resolve_custom_runtime()
+def _try_custom_endpoint(env: Optional[Dict[str, Any]] = None) -> Tuple[Optional[Any], Optional[str]]:
+    runtime = _resolve_custom_runtime(env=env)
     if len(runtime) == 2:
         custom_base, custom_key = runtime
         custom_mode = None
@@ -1842,7 +1923,10 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     return _fallback_client, model
 
 
-def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_xai_oauth_aux_client(
+    model: str,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
 
     xAI's ``/v1/responses`` endpoint speaks the OpenAI Responses API, so we
@@ -1859,7 +1943,7 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    resolved = _resolve_xai_oauth_for_aux()
+    resolved = _resolve_xai_oauth_for_aux(env=env)
     if resolved is None:
         return None, None
     api_key, base_url = resolved
@@ -1868,7 +1952,10 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
-def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_codex_client(
+    model: str,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
     There is no auto-selection of the Codex model: the ChatGPT-account
@@ -1885,18 +1972,18 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
+    pool_present, entry = _select_pool_entry("openai-codex", env=env)
     if pool_present:
         codex_token = _pool_runtime_api_key(entry)
         if codex_token:
             base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
         else:
-            codex_token = _read_codex_access_token()
+            codex_token = _read_codex_access_token(env=env)
             if not codex_token:
                 return None, None
             base_url = _CODEX_AUX_BASE_URL
     else:
-        codex_token = _read_codex_access_token()
+        codex_token = _read_codex_access_token(env=env)
         if not codex_token:
             return None, None
         base_url = _CODEX_AUX_BASE_URL
@@ -1915,6 +2002,7 @@ def _try_azure_foundry(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Resolve an Azure Foundry auxiliary client via the runtime resolver.
 
@@ -1960,6 +2048,7 @@ def _try_azure_foundry(
             explicit_api_key=explicit_api_key,
             explicit_base_url=explicit_base_url,
             target_model=model,
+            env=env,
         )
     except AuthError as exc:
         logger.debug("Auxiliary azure-foundry: %s", exc)
@@ -2023,20 +2112,35 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic(
+    explicit_api_key: str = None,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
     except ImportError:
         return None, None
 
-    pool_present, entry = _select_pool_entry("anthropic")
+    pool_present, entry = _select_pool_entry("anthropic", env=env)
     if pool_present:
         if entry is None:
             return None, None
         token = explicit_api_key or _pool_runtime_api_key(entry)
     else:
         entry = None
-        token = explicit_api_key or resolve_anthropic_token()
+        token = explicit_api_key
+        if not token:
+            if env is None:
+                token = resolve_anthropic_token()
+            else:
+                try:
+                    from hermes_cli.auth import PROVIDER_REGISTRY
+                    for env_name in PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
+                        token = _env_lookup(env, env_name).strip()
+                        if token:
+                            break
+                except Exception:
+                    token = ""
     if not token:
         return None, None
 
@@ -2107,6 +2211,47 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     return normalized
 
 
+def _runtime_env_cache_key(env: Optional[Dict[str, Any]]) -> tuple:
+    if env is None:
+        return ()
+    try:
+        from hermes_constants import get_hermes_home
+        home = str(get_hermes_home())
+    except Exception:
+        home = ""
+    items = sorted((str(k), "" if v is None else str(v)) for k, v in env.items())
+    payload = json.dumps(items, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return (home, digest)
+
+
+def _effective_runtime_env(env: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if env is not None:
+        return env
+    try:
+        from gateway.session_context import get_runtime_env
+        runtime_env = get_runtime_env()
+        if runtime_env is not None:
+            return runtime_env
+    except Exception:
+        pass
+    try:
+        from gateway.session_context import get_session_env
+        profile_home = get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "").strip()
+        profile = get_session_env("HERMES_SESSION_AGENT_PROFILE", "").strip()
+        if profile_home:
+            from hermes_cli.env_loader import read_hermes_dotenv_values
+            runtime_env = read_hermes_dotenv_values(hermes_home=Path(profile_home))
+            runtime_env["HERMES_PROFILE_STRICT_AUTH"] = "1"
+            runtime_env["HERMES_HOME"] = profile_home
+            return runtime_env
+        if profile:
+            return {"HERMES_PROFILE_STRICT_AUTH": "1"}
+    except Exception:
+        pass
+    return None
+
+
 def _get_provider_chain() -> List[tuple]:
     """Return the ordered provider detection chain.
 
@@ -2126,6 +2271,15 @@ def _get_provider_chain() -> List[tuple]:
         ("local/custom", _try_custom_endpoint),
         ("api-key", _resolve_api_key_provider),
     ]
+
+
+_ENV_AWARE_PROVIDER_CHAIN_LABELS = {"openrouter", "nous", "local/custom", "api-key"}
+
+
+def _try_provider_chain_entry(label: str, try_fn, env: Optional[Dict[str, Any]] = None):
+    if env is None or label not in _ENV_AWARE_PROVIDER_CHAIN_LABELS:
+        return try_fn()
+    return try_fn(env=env)
 
 
 # ── Auxiliary "recently 402'd" unhealthy-provider cache ────────────────────
@@ -2453,6 +2607,7 @@ def _pool_cache_hint(
     provider: str,
     *,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Return a stable cache discriminator for pooled providers."""
     normalized = _normalize_aux_provider(provider)
@@ -2461,7 +2616,7 @@ def _pool_cache_hint(
         normalized = _normalize_aux_provider(runtime.get("provider") or _read_main_provider())
     if normalized in {"", "auto", "custom"}:
         return ""
-    entry = _peek_pool_entry(normalized)
+    entry = _peek_pool_entry(normalized, env=env)
     if entry is None:
         return ""
     entry_id = str(getattr(entry, "id", "") or "").strip()
@@ -2499,11 +2654,15 @@ def _recoverable_pool_provider(resolved_provider: str, client: Any) -> Optional[
     return None
 
 
-def _recover_provider_pool(provider: str, exc: Exception) -> bool:
+def _recover_provider_pool(
+    provider: str,
+    exc: Exception,
+    env: Optional[Dict[str, Any]] = None,
+) -> bool:
     """Try same-provider credential-pool recovery for auxiliary calls."""
     normalized = _normalize_aux_provider(provider)
     try:
-        pool = load_pool(normalized)
+        pool = _load_scoped_pool(normalized, env)
     except Exception as load_exc:
         logger.debug("Auxiliary client: could not load pool for %s recovery: %s", normalized, load_exc)
         return False
@@ -2548,6 +2707,7 @@ def _retry_same_provider_sync(
     resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str],
     main_runtime: Optional[Dict[str, Any]],
+    env: Optional[Dict[str, Any]],
     final_model: Optional[str],
     messages: list,
     temperature: Optional[float],
@@ -2563,6 +2723,7 @@ def _retry_same_provider_sync(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             async_mode=False,
+            env=env,
         )
     else:
         retry_client, retry_model = _get_cached_client(
@@ -2572,6 +2733,7 @@ def _retry_same_provider_sync(
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
             main_runtime=main_runtime,
+            env=env,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -2605,6 +2767,8 @@ async def _retry_same_provider_async(
     resolved_base_url: Optional[str],
     resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str],
+    main_runtime: Optional[Dict[str, Any]],
+    env: Optional[Dict[str, Any]],
     final_model: Optional[str],
     messages: list,
     temperature: Optional[float],
@@ -2620,6 +2784,7 @@ async def _retry_same_provider_async(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             async_mode=True,
+            env=env,
         )
     else:
         retry_client, retry_model = _get_cached_client(
@@ -2629,6 +2794,8 @@ async def _retry_same_provider_async(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            main_runtime=main_runtime,
+            env=env,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -2654,13 +2821,18 @@ async def _retry_same_provider_async(
     )
 
 
-def _refresh_provider_credentials(provider: str) -> bool:
+def _refresh_provider_credentials(
+    provider: str,
+    env: Optional[Dict[str, Any]] = None,
+) -> bool:
     """Refresh short-lived credentials for OAuth-backed auxiliary providers."""
     normalized = _normalize_aux_provider(provider)
     try:
         if normalized == "openai-codex":
             from hermes_cli.auth import resolve_codex_runtime_credentials
 
+            if env is not None and not _scoped_auth_store_allowed(env):
+                return False
             creds = resolve_codex_runtime_credentials(force_refresh=True)
             if not str(creds.get("api_key", "") or "").strip():
                 return False
@@ -2672,6 +2844,8 @@ def _refresh_provider_credentials(provider: str) -> bool:
                 resolve_nous_runtime_credentials,
             )
 
+            if env is not None and _read_nous_auth(env=env) is None:
+                return False
             creds = resolve_nous_runtime_credentials(
                 min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
                 timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
@@ -2684,9 +2858,9 @@ def _refresh_provider_credentials(provider: str) -> bool:
         if normalized == "anthropic":
             from agent.anthropic_adapter import read_claude_code_credentials, _refresh_oauth_token, resolve_anthropic_token
 
-            creds = read_claude_code_credentials()
+            creds = read_claude_code_credentials() if env is None else None
             token = _refresh_oauth_token(creds) if isinstance(creds, dict) and creds.get("refreshToken") else None
-            if not str(token or "").strip():
+            if not str(token or "").strip() and env is None:
                 token = resolve_anthropic_token()
             if not str(token or "").strip():
                 return False
@@ -2702,6 +2876,7 @@ def _try_payment_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "payment error",
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try alternative providers after a payment/credit or connection error.
 
@@ -2733,7 +2908,7 @@ def _try_payment_fallback(
             _log_skip_unhealthy(label, task)
             tried.append(f"{label} (unhealthy)")
             continue
-        client, model = try_fn()
+        client, model = _try_provider_chain_entry(label, try_fn, env=env)
         if client is not None:
             logger.info(
                 "Auxiliary %s: %s on %s — falling back to %s (%s)",
@@ -2753,6 +2928,7 @@ def _try_main_agent_model_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "error",
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Last-resort fallback to the user's main agent provider + model.
 
@@ -2783,6 +2959,7 @@ def _try_main_agent_model_fallback(
     try:
         client, resolved_model = resolve_provider_client(
             provider=main_provider, model=main_model,
+            env=env,
         )
     except Exception:
         client, resolved_model = None, None
@@ -2802,6 +2979,7 @@ def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
     reason: str = "error",
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
@@ -2837,7 +3015,7 @@ def _try_configured_fallback_chain(
 
         try:
             fb_client = _resolve_single_provider(
-                fb_provider, fb_model, fb_base_url, fb_api_key)
+                fb_provider, fb_model, fb_base_url, fb_api_key, env=env)
         except Exception:
             fb_client = None
 
@@ -2862,6 +3040,7 @@ def _resolve_single_provider(
     model: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Optional[Any]:
     """Resolve a single provider entry from fallback_chain to an OpenAI client.
 
@@ -2871,12 +3050,16 @@ def _resolve_single_provider(
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+        env=env,
     )
     return client
 
-def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_auto(
+    main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain.
 
     Priority:
@@ -2951,6 +3134,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                 explicit_base_url=explicit_base_url,
                 explicit_api_key=explicit_api_key,
                 api_mode=runtime_api_mode or None,
+                env=env,
             )
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
@@ -2964,7 +3148,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             _log_skip_unhealthy(label)
             tried.append(f"{label} (unhealthy)")
             continue
-        client, model = try_fn()
+        client, model = _try_provider_chain_entry(label, try_fn, env=env)
         if client is not None:
             if tried:
                 logger.info("Auxiliary auto-detect: using %s (%s) — skipped: %s",
@@ -3074,6 +3258,7 @@ def resolve_provider_client(
     explicit_api_key: str = None,
     api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
@@ -3106,6 +3291,7 @@ def resolve_provider_client(
     Returns:
         (client, resolved_model) or (None, None) if auth is unavailable.
     """
+    env = _effective_runtime_env(env)
     _validate_proxy_env_urls()
     # Preserve the original provider name before alias normalization so a
     # user-declared ``custom_providers`` entry whose name coincidentally
@@ -3167,7 +3353,7 @@ def resolve_provider_client(
 
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":
-        client, resolved = _resolve_auto(main_runtime=main_runtime)
+        client, resolved = _resolve_auto(main_runtime=main_runtime, env=env)
         if client is None:
             return None, None
         # When auto-detection lands on a non-OpenRouter provider (e.g. a
@@ -3185,11 +3371,11 @@ def resolve_provider_client(
 
     # ── OpenRouter ───────────────────────────────────────────
     if provider == "openrouter":
-        client, default = _try_openrouter(explicit_api_key=explicit_api_key)
+        client, default = _try_openrouter(explicit_api_key=explicit_api_key, env=env)
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",
-                _describe_openrouter_unavailable(),
+                _describe_openrouter_unavailable(env=env),
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
@@ -3204,7 +3390,7 @@ def resolve_provider_client(
             model in _PROVIDER_VISION_MODELS.values()
             or (model or "").strip().lower() == "mimo-v2-omni"
         )
-        client, default = _try_nous(vision=_is_vision)
+        client, default = _try_nous(vision=_is_vision, env=env)
         if client is None:
             logger.warning("resolve_provider_client: nous requested "
                            "but Nous Portal not configured (run: hermes auth)")
@@ -3225,7 +3411,7 @@ def resolve_provider_client(
         if raw_codex:
             # Return the raw OpenAI client for callers that need direct
             # access to responses.stream() (e.g., the main agent loop).
-            codex_token = _read_codex_access_token()
+            codex_token = _read_codex_access_token(env=env)
             if not codex_token:
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")
@@ -3238,7 +3424,7 @@ def resolve_provider_client(
             )
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
-        client, default = _build_codex_client(model)
+        client, default = _build_codex_client(model, env=env)
         if client is None:
             logger.warning("resolve_provider_client: openai-codex requested "
                            "but no Codex OAuth token found (run: hermes model)")
@@ -3256,7 +3442,7 @@ def resolve_provider_client(
     # OpenRouter / Nous bills for side tasks they thought were running on
     # their xAI subscription.
     if provider == "xai-oauth":
-        client, default = _build_xai_oauth_aux_client(model)
+        client, default = _build_xai_oauth_aux_client(model, env=env)
         if client is None:
             logger.warning(
                 "resolve_provider_client: xai-oauth requested but no xAI "
@@ -3271,17 +3457,21 @@ def resolve_provider_client(
     if provider == "custom":
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
-            custom_key = (
-                (explicit_api_key or "").strip()
-                or os.getenv("OPENAI_API_KEY", "").strip()
-                or "no-key-required"  # local servers don't need auth
-            )
+            custom_key = (explicit_api_key or "").strip()
             if not custom_base:
                 logger.warning(
                     "resolve_provider_client: explicit custom endpoint requested "
                     "but base_url is empty"
                 )
                 return None, None
+            if not custom_key and base_url_host_matches(custom_base, "ollama.com"):
+                custom_key = _env_lookup(env, "OLLAMA_API_KEY").strip()
+            if not custom_key:
+                custom_key = _env_lookup(env, "OPENAI_API_KEY").strip()
+            if not custom_key:
+                if base_url_host_matches(custom_base, "ollama.com"):
+                    return None, None
+                custom_key = "no-key-required"  # local servers don't need auth
             final_model = _normalize_resolved_model(
                 model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
                 provider,
@@ -3316,7 +3506,7 @@ def resolve_provider_client(
         # Try custom first, then API-key providers (Codex excluded here:
         # falling through to Codex with no model is a stale-constant trap).
         for try_fn in (_try_custom_endpoint, _resolve_api_key_provider):
-            client, default = try_fn()
+            client, default = try_fn(env=env)
             if client is not None:
                 final_model = _normalize_resolved_model(model or default, provider)
                 _cbase = str(getattr(client, "base_url", "") or "")
@@ -3344,15 +3534,23 @@ def resolve_provider_client(
         # still defer to the built-in per `_get_named_custom_provider`'s guard.
         custom_entry = None
         if original_provider and original_provider != provider:
-            custom_entry = _get_named_custom_provider(original_provider)
+            custom_entry = _get_named_custom_provider(original_provider, env=env)
         if custom_entry is None:
-            custom_entry = _get_named_custom_provider(provider)
+            custom_entry = _get_named_custom_provider(provider, env=env)
         if custom_entry:
             custom_base = custom_entry.get("base_url", "").strip()
             custom_key = custom_entry.get("api_key", "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+                custom_key = _env_lookup(env, custom_key_env).strip()
+            if env is not None and custom_key_env and not custom_key:
+                logger.debug(
+                    "resolve_provider_client: named custom provider %r skipped "
+                    "because key_env %s is absent from scoped runtime env",
+                    custom_entry.get("name") or provider,
+                    custom_key_env,
+                )
+                return None, None
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(
@@ -3458,6 +3656,7 @@ def resolve_provider_client(
             explicit_api_key=explicit_api_key,
             explicit_base_url=explicit_base_url,
             api_mode=api_mode,
+            env=env,
         )
         if client is None:
             logger.warning(
@@ -3488,14 +3687,14 @@ def resolve_provider_client(
 
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
-            client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
+            client, default_model = _try_anthropic(explicit_api_key=explicit_api_key, env=env)
             if client is None:
                 logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
                 return None, None
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
 
-        creds = resolve_api_key_provider_credentials(provider)
+        creds = resolve_api_key_provider_credentials(provider, env=env)
         api_key = str(creds.get("api_key", "")).strip()
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit
@@ -3663,11 +3862,11 @@ def resolve_provider_client(
     elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
         # OAuth providers — route through their specific try functions
         if provider == "nous":
-            return resolve_provider_client("nous", model, async_mode)
+            return resolve_provider_client("nous", model, async_mode, env=env)
         if provider == "openai-codex":
-            return resolve_provider_client("openai-codex", model, async_mode)
+            return resolve_provider_client("openai-codex", model, async_mode, env=env)
         if provider == "xai-oauth":
-            return resolve_provider_client("xai-oauth", model, async_mode)
+            return resolve_provider_client("xai-oauth", model, async_mode, env=env)
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)
@@ -3684,6 +3883,7 @@ def get_text_auxiliary_client(
     task: str = "",
     *,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Return (client, default_model_slug) for text-only auxiliary tasks.
 
@@ -3702,10 +3902,16 @@ def get_text_auxiliary_client(
         explicit_api_key=api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
+        env=env,
     )
 
 
-def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Dict[str, Any]] = None):
+def get_async_text_auxiliary_client(
+    task: str = "",
+    *,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
+):
     """Return (async_client, model_slug) for async consumers.
 
     For standard providers returns (AsyncOpenAI, model). For Codex returns
@@ -3721,6 +3927,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
         explicit_api_key=api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
+        env=env,
     )
 
 
@@ -3737,31 +3944,35 @@ def _normalize_vision_provider(provider: Optional[str]) -> str:
 def _resolve_strict_vision_backend(
     provider: str,
     model: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     provider = _normalize_vision_provider(provider)
     if provider == "copilot":
-        return resolve_provider_client("copilot", model, is_vision=True)
+        return resolve_provider_client("copilot", model, env=env, is_vision=True)
     if provider == "openrouter":
-        return _try_openrouter(model=model)
+        return _try_openrouter(model=model, env=env)
     if provider == "nous":
-        return _try_nous(vision=True)
+        return _try_nous(vision=True, env=env)
     if provider == "openai-codex":
         # Route through resolve_provider_client so the caller's explicit
         # model is used.  There is no safe default Codex model (shifting
         # allow-list); callers must specify via auxiliary.<task>.model.
-        return resolve_provider_client("openai-codex", model, is_vision=True)
+        return resolve_provider_client("openai-codex", model, env=env, is_vision=True)
     if provider == "anthropic":
-        return _try_anthropic()
+        return _try_anthropic(env=env)
     if provider == "custom":
-        return _try_custom_endpoint()
+        return _try_custom_endpoint(env=env)
     return None, None
 
 
-def _strict_vision_backend_available(provider: str) -> bool:
-    return _resolve_strict_vision_backend(provider)[0] is not None
+def _strict_vision_backend_available(
+    provider: str,
+    env: Optional[Dict[str, Any]] = None,
+) -> bool:
+    return _resolve_strict_vision_backend(provider, env=env)[0] is not None
 
 
-def get_available_vision_backends() -> List[str]:
+def get_available_vision_backends(env: Optional[Dict[str, Any]] = None) -> List[str]:
     """Return the currently available vision backends in auto-selection order.
 
     Order: active provider → OpenRouter → Nous → stop.  This is the single
@@ -3773,15 +3984,15 @@ def get_available_vision_backends() -> List[str]:
     main_provider = _read_main_provider()
     if main_provider and main_provider not in {"auto", ""}:
         if main_provider in _VISION_AUTO_PROVIDER_ORDER:
-            if _strict_vision_backend_available(main_provider):
+            if _strict_vision_backend_available(main_provider, env=env):
                 available.append(main_provider)
         else:
-            client, _ = resolve_provider_client(main_provider, _read_main_model())
+            client, _ = resolve_provider_client(main_provider, _read_main_model(), env=env)
             if client is not None:
                 available.append(main_provider)
     # 2. OpenRouter, 3. Nous — skip if already covered by main provider.
     for p in _VISION_AUTO_PROVIDER_ORDER:
-        if p not in available and _strict_vision_backend_available(p):
+        if p not in available and _strict_vision_backend_available(p, env=env):
             available.append(p)
     return available
 
@@ -3793,6 +4004,7 @@ def resolve_vision_provider_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     async_mode: bool = False,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
 
@@ -3826,6 +4038,7 @@ def resolve_vision_provider_client(
             explicit_base_url=resolved_base_url,
             explicit_api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            env=env,
         )
         if client is None:
             return provider_for_base_override, None, None
@@ -3849,7 +4062,7 @@ def resolve_vision_provider_client(
             vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
             if main_provider == "nous":
                 sync_client, default_model = _resolve_strict_vision_backend(
-                    main_provider, vision_model
+                    main_provider, vision_model, env=env
                 )
                 if sync_client is not None:
                     logger.info(
@@ -3874,6 +4087,7 @@ def resolve_vision_provider_client(
                 rpc_client, rpc_model = resolve_provider_client(
                     main_provider, vision_model,
                     api_mode=resolved_api_mode,
+                    env=env,
                     is_vision=True)
                 if rpc_client is not None:
                     logger.info(
@@ -3888,7 +4102,7 @@ def resolve_vision_provider_client(
         for candidate in _VISION_AUTO_PROVIDER_ORDER:
             if candidate == main_provider:
                 continue  # already tried above
-            sync_client, default_model = _resolve_strict_vision_backend(candidate)
+            sync_client, default_model = _resolve_strict_vision_backend(candidate, env=env)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)
 
@@ -3897,7 +4111,7 @@ def resolve_vision_provider_client(
 
     if requested in _VISION_AUTO_PROVIDER_ORDER:
         sync_client, default_model = _resolve_strict_vision_backend(
-            requested, resolved_model
+            requested, resolved_model, env=env
         )
         return _finalize(requested, sync_client, default_model)
 
@@ -3916,6 +4130,7 @@ def resolve_vision_provider_client(
                 base_url=_zai_url,
                 api_key=resolved_api_key or None,
                 api_mode="chat_completions",
+                env=env,
                 is_vision=True,
             )
             if client is not None:
@@ -3923,6 +4138,7 @@ def resolve_vision_provider_client(
         # Fallback: try without explicit base_url (old behavior)
         client, final_model = _get_cached_client(requested, resolved_model, async_mode,
                                                  api_mode=resolved_api_mode,
+                                                 env=env,
                                                  is_vision=True)
         if client is None:
             return requested, None, None
@@ -3930,6 +4146,7 @@ def resolve_vision_provider_client(
 
     client, final_model = _get_cached_client(requested, resolved_model, async_mode,
                                              api_mode=resolved_api_mode,
+                                             env=env,
                                              is_vision=True)
     if client is None:
         return requested, None, None
@@ -3976,7 +4193,7 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 # Every auxiliary LLM consumer should use these instead of manually
 # constructing clients and calling .chat.completions.create().
 
-# Client cache: (provider, async_mode, base_url, api_key, api_mode, runtime_key) -> (client, default_model, loop)
+# Client cache: (provider, async_mode, base_url, api_key, api_mode, runtime_key, env_key) -> (client, default_model, loop)
 # NOTE: loop identity is NOT part of the key.  On async cache hits we check
 # whether the cached loop is the *current* loop; if not, the stale entry is
 # replaced in-place.  This bounds cache growth to one entry per unique
@@ -3995,12 +4212,14 @@ def _client_cache_key(
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
-    runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
-    pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)
+    runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if runtime else ()
+    env_key = _runtime_env_cache_key(env)
+    pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime, env=env)
+    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, env_key, is_vision, pool_hint)
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -4026,9 +4245,12 @@ def _refresh_nous_auxiliary_client(
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Refresh Nous runtime creds, rebuild the client, and replace the cache entry."""
+    if env is not None and _read_nous_auth(env=env) is None:
+        return None, model
     runtime = _resolve_nous_runtime_api(force_refresh=True)
     if runtime is None:
         return None, model
@@ -4055,6 +4277,7 @@ def _refresh_nous_auxiliary_client(
         api_key=api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
+        env=env,
         is_vision=is_vision,
     )
     _store_cached_client(cache_key, client, final_model, bound_loop=current_loop)
@@ -4192,6 +4415,7 @@ def _get_cached_client(
     api_key: str = None,
     api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Get or create a cached client for the given provider.
@@ -4208,6 +4432,7 @@ def _get_cached_client(
     preventing the fd-exhaustion that previously occurred in long-running
     gateways where recycled worker threads created unbounded entries (#10200).
     """
+    env = _effective_runtime_env(env)
     # Resolve the current event loop for async clients so we can validate
     # cached entries.  Loop identity is NOT in the cache key — instead we
     # check at hit time whether the cached loop is still current and open.
@@ -4229,6 +4454,7 @@ def _get_cached_client(
         api_key=api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
+        env=env,
         is_vision=is_vision,
     )
     with _client_cache_lock:
@@ -4261,6 +4487,7 @@ def _get_cached_client(
         explicit_api_key=api_key,
         api_mode=api_mode,
         main_runtime=runtime,
+        env=env,
         is_vision=is_vision,
     )
     if client is not None:
@@ -4577,6 +4804,7 @@ def call_llm(
     base_url: str = None,
     api_key: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
     max_tokens: int = None,
@@ -4608,6 +4836,7 @@ def call_llm(
     Raises:
         RuntimeError: If no provider is configured.
     """
+    env = _effective_runtime_env(env)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
@@ -4620,6 +4849,7 @@ def call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=False,
+            env=env,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -4630,6 +4860,7 @@ def call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=False,
+                env=env,
             )
         if client is None:
             raise RuntimeError(
@@ -4645,6 +4876,7 @@ def call_llm(
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
             main_runtime=main_runtime,
+            env=env,
         )
         if client is None:
             # When the user explicitly chose a non-OpenRouter provider but no
@@ -4665,7 +4897,7 @@ def call_llm(
             if not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", main_runtime=main_runtime)
+                client, final_model = _get_cached_client("auto", main_runtime=main_runtime, env=env)
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -4769,6 +5001,7 @@ def call_llm(
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
                 main_runtime=main_runtime,
+                env=env,
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
@@ -4783,7 +5016,7 @@ def call_llm(
         if (_is_auth_error(first_err)
                 and resolved_provider not in {"auto", "", None}
                 and not client_is_nous):
-            if _refresh_provider_credentials(resolved_provider):
+            if _refresh_provider_credentials(resolved_provider, env=env):
                 logger.info(
                     "Auxiliary %s: refreshed %s credentials after auth error, retrying",
                     task or "call", resolved_provider,
@@ -4796,6 +5029,7 @@ def call_llm(
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
                     main_runtime=main_runtime,
+                    env=env,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -4817,7 +5051,7 @@ def call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err):
+            if _recover_provider_pool(pool_provider, recovery_err, env=env):
                 logger.info(
                     "Auxiliary %s: recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -4830,6 +5064,7 @@ def call_llm(
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
                     main_runtime=main_runtime,
+                    env=env,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -4897,13 +5132,13 @@ def call_llm(
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason=reason)
+                    resolved_provider, task, reason=reason, env=env)
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason, env=env)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason)
+                        resolved_provider, task, reason=reason, env=env)
 
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
@@ -4999,6 +5234,8 @@ async def async_call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
     max_tokens: int = None,
@@ -5010,6 +5247,7 @@ async def async_call_llm(
 
     Same as call_llm() but async. See call_llm() for full documentation.
     """
+    env = _effective_runtime_env(env)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
@@ -5022,6 +5260,7 @@ async def async_call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=True,
+            env=env,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -5032,6 +5271,7 @@ async def async_call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=True,
+                env=env,
             )
         if client is None:
             raise RuntimeError(
@@ -5047,6 +5287,8 @@ async def async_call_llm(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            main_runtime=main_runtime,
+            env=env,
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
@@ -5059,7 +5301,8 @@ async def async_call_llm(
             if not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", async_mode=True)
+                client, final_model = _get_cached_client(
+                    "auto", async_mode=True, main_runtime=main_runtime, env=env)
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -5149,6 +5392,8 @@ async def async_call_llm(
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
+                main_runtime=main_runtime,
+                env=env,
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
@@ -5163,7 +5408,7 @@ async def async_call_llm(
         if (_is_auth_error(first_err)
                 and resolved_provider not in {"auto", "", None}
                 and not client_is_nous):
-            if _refresh_provider_credentials(resolved_provider):
+            if _refresh_provider_credentials(resolved_provider, env=env):
                 logger.info(
                     "Auxiliary %s (async): refreshed %s credentials after auth error, retrying",
                     task or "call", resolved_provider,
@@ -5175,6 +5420,8 @@ async def async_call_llm(
                     resolved_base_url=resolved_base_url,
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
+                    env=env,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -5196,7 +5443,7 @@ async def async_call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err):
+            if _recover_provider_pool(pool_provider, recovery_err, env=env):
                 logger.info(
                     "Auxiliary %s (async): recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -5208,6 +5455,8 @@ async def async_call_llm(
                     resolved_base_url=resolved_base_url,
                     resolved_api_key=resolved_api_key,
                     resolved_api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
+                    env=env,
                     final_model=final_model,
                     messages=messages,
                     temperature=temperature,
@@ -5249,13 +5498,13 @@ async def async_call_llm(
             fb_client, fb_model, fb_label = (None, None, "")
             if is_auto:
                 fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason=reason)
+                    resolved_provider, task, reason=reason, env=env)
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason)
+                    task, resolved_provider or "auto", reason=reason, env=env)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason)
+                        resolved_provider, task, reason=reason, env=env)
 
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -752,21 +752,41 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # falling through to OpenRouter defaults.
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = (fb.get("api_key") or "").strip() or None
+        fb_key_env = ""
+        runtime_env = getattr(agent, "_runtime_env", None)
         if not fb_api_key_hint:
             # key_env and api_key_env are both documented aliases (see
             # _normalize_custom_provider_entry in hermes_cli/config.py).
             fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
             if fb_key_env:
-                fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
+                if runtime_env is None:
+                    fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
+                else:
+                    fb_api_key_hint = str(runtime_env.get(fb_key_env, "")).strip() or None
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
         # when no explicit key is in the fallback config. Host match
         # (not substring) — see GHSA-76xc-57q6-vm5m.
         if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+            if runtime_env is None:
+                fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+            else:
+                fb_api_key_hint = str(runtime_env.get("OLLAMA_API_KEY", "")).strip() or None
+        if runtime_env is not None and not fb_api_key_hint:
+            fb_provider_config = None
+            try:
+                from hermes_cli.auth import PROVIDER_REGISTRY
+                fb_provider_config = PROVIDER_REGISTRY.get(str(fb_provider))
+                for env_name in getattr(fb_provider_config, "api_key_env_vars", ()) or ():
+                    fb_api_key_hint = str(runtime_env.get(env_name, "")).strip() or None
+                    if fb_api_key_hint:
+                        break
+            except Exception:
+                fb_provider_config = None
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            env=runtime_env)
         if fb_client is None:
             logging.warning(
                 "Fallback to %s failed: provider not configured",

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1062,6 +1062,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     "api_key": self.api_key,
                     "api_mode": self.api_mode,
                 },
+                "env": getattr(self, "runtime_env", None),
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": int(summary_budget * 1.3),
                 # timeout resolved from auxiliary.compression.timeout config by call_llm

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -70,6 +70,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
         client, aux_model = get_text_auxiliary_client(
             "compression",
             main_runtime=agent._current_main_runtime(),
+            env=getattr(agent, "_runtime_env", None),
         )
         # Best-effort aux provider label for the warning message. The
         # configured provider may be "auto", in which case we fall back
@@ -313,6 +314,10 @@ def compress_context(
             pass
 
     try:
+        try:
+            agent.context_compressor.runtime_env = getattr(agent, "_runtime_env", None)
+        except Exception:
+            pass
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,6 +25,7 @@ import ssl
 import threading
 import time
 import uuid
+from functools import wraps
 from typing import Any, Dict, List, Optional
 
 from agent.anthropic_adapter import _is_oauth_token
@@ -231,7 +232,6 @@ def run_conversation(
         )
     except Exception:
         pass
-
     # Tag all log records on this thread with the session ID so
     # ``hermes logs --session <id>`` can filter a single conversation.
     from hermes_logging import set_session_context
@@ -270,7 +270,7 @@ def run_conversation(
     # state registry.  Set BEFORE any tool dispatch so snapshots taken at
     # child-launch time see the parent's real id, not None.
     agent._current_task_id = effective_task_id
-    
+
     # Reset retry counters and iteration budget at the start of each turn
     # so subagent usage from a previous turn doesn't eat into the next one.
     agent._invalid_tool_retries = 0
@@ -362,7 +362,7 @@ def run_conversation(
     # never stored in the messages list. This keeps them ephemeral: they won't
     # be saved to session DB, session logs, or batch trajectories, but they're
     # automatically re-applied on every API call (including session continuations).
-    
+
     # Track user turns for memory flush and periodic nudge logic
     agent._user_turn_count += 1
 
@@ -398,11 +398,11 @@ def run_conversation(
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
-    
+
     if not agent.quiet_mode:
         _print_preview = _summarize_user_message_for_log(user_message)
         agent._safe_print(f"💬 Starting conversation: '{_print_preview[:60]}{'...' if len(_print_preview) > 60 else ''}'")
-    
+
     # ── System prompt (cached per session for prefix caching) ──
     # Built once on first call, reused for all subsequent calls.
     # Only rebuilt after context compression events (which invalidate
@@ -541,7 +541,7 @@ def run_conversation(
     # present are surfaced in an advisory footer so the model cannot
     # over-claim success while the file is actually unchanged on disk.
     agent._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
-    
+
     # Record the execution thread so interrupt()/clear_interrupt() can
     # scope the tool-level interrupt signal to THIS agent's thread only.
     # Must be set before any thread-scoped interrupt syncing.
@@ -606,7 +606,7 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
-        
+
         api_call_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
@@ -655,7 +655,7 @@ def run_conversation(
         if (agent._skill_nudge_interval > 0
                 and "skill_manage" in agent.valid_tool_names):
             agent._iters_since_skill += 1
-        
+
         # ── Pre-API-call /steer drain ──────────────────────────────────
         # If a /steer arrived during the previous API call (while the model
         # was thinking), drain it now — before we build api_messages — so
@@ -883,10 +883,10 @@ def run_conversation(
         # Calculate approximate request size for logging
         total_chars = sum(len(str(msg)) for msg in api_messages)
         approx_tokens = estimate_messages_tokens_rough(api_messages)
-        
+
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
-        
+
         if not agent.quiet_mode:
             agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
             agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
@@ -905,13 +905,13 @@ def run_conversation(
                 spinner_type = random.choice(['brain', 'sparkle', 'pulse', 'moon', 'star'])
                 thinking_spinner = KawaiiSpinner(f"{face} {verb}...", spinner_type=spinner_type, print_fn=agent._print_fn)
                 thinking_spinner.start()
-        
+
         # Log request details if verbose
         if agent.verbose_logging:
             logging.debug(f"API Request - Model: {agent.model}, Messages: {len(messages)}, Tools: {len(agent.tools) if agent.tools else 0}")
             logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
             logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
-        
+
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
@@ -1076,9 +1076,9 @@ def run_conversation(
                     )
                 else:
                     response = agent._interruptible_api_call(api_kwargs)
-                
+
                 api_duration = time.time() - api_start_time
-                
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -1086,15 +1086,15 @@ def run_conversation(
                     thinking_spinner = None
                 if agent.thinking_callback:
                     agent.thinking_callback("")
-                
+
                 if not agent.quiet_mode:
                     agent._vprint(f"{agent.log_prefix}⏱️  API call completed in {api_duration:.2f}s")
-                
+
                 if agent.verbose_logging:
                     # Log response with provider info if available
                     resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
                     logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
-                
+
                 # Validate response shape before proceeding
                 response_invalid = False
                 error_details = []
@@ -1182,11 +1182,11 @@ def run_conversation(
                         thinking_spinner = None
                     if agent.thinking_callback:
                         agent.thinking_callback("")
-                    
+
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
-                    
+
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
@@ -1208,18 +1208,18 @@ def run_conversation(
                             provider_name = response.error.metadata.get('provider_name', 'Unknown')
                     elif response and hasattr(response, 'message') and response.message:
                         error_msg = str(response.message)
-                    
+
                     # Try to get provider from model field (OpenRouter often returns actual model used)
                     if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
                         provider_name = f"model={response.model}"
-                    
+
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
                         # Log all response attributes for debugging
                         resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
                         if agent.verbose_logging:
                             logging.debug(f"Response attributes for invalid response: {resp_attrs}")
-                    
+
                     # Extract error code from response for contextual diagnostics
                     _resp_error_code = None
                     if response and hasattr(response, 'error') and response.error:
@@ -1258,7 +1258,7 @@ def run_conversation(
                     cleaned_provider_error = agent._clean_error_message(error_msg)
                     agent._vprint(f"{agent.log_prefix}   📝 Provider message: {cleaned_provider_error}", force=True)
                     agent._vprint(f"{agent.log_prefix}   ⏱️  {_failure_hint}", force=True)
-                    
+
                     if retry_count >= max_retries:
                         # Try fallback before giving up
                         agent._emit_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
@@ -1277,12 +1277,12 @@ def run_conversation(
                             "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
                             "failed": True  # Mark as failure for filtering
                         }
-                    
+
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
                     wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
                     agent._vprint(f"{agent.log_prefix}⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...", force=True)
                     logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
-                    
+
                     # Sleep in small increments to stay responsive to interrupts
                     sleep_end = time.time() + wait_time
                     _backoff_touch_counter = 0
@@ -1525,7 +1525,7 @@ def run_conversation(
                             "failed": True,
                             "error": "First response truncated due to output length limit"
                         }
-                
+
                 # Track actual token usage from response for context management
                 if hasattr(response, 'usage') and response.usage:
                     canonical_usage = normalize_usage(
@@ -1630,10 +1630,10 @@ def run_conversation(
                                 "Token persistence failed (session=%s, tokens=%d): %s",
                                 agent.session_id, total_tokens, e,
                             )
-                    
+
                     if agent.verbose_logging:
                         logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                    
+
                     # Surface cache hit stats for any provider that reports
                     # them — not just those where we inject cache_control
                     # markers.  OpenAI/Kimi/DeepSeek/Qwen all do automatic
@@ -1655,7 +1655,7 @@ def run_conversation(
                             f"{cached:,}/{prompt:,} tokens "
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
-                
+
                 has_retried_429 = False  # Reset on success
                 # Clear Nous rate limit state on successful request —
                 # proves the limit has reset and other sessions can
@@ -2188,7 +2188,7 @@ def run_conversation(
                 agent._touch_activity(
                     f"API error recovery (attempt {retry_count}/{max_retries})"
                 )
-                
+
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
                 _error_summary = agent._summarize_api_error(api_error)
@@ -2254,7 +2254,7 @@ def run_conversation(
                         "completed": False,
                         "interrupted": True,
                     }
-                
+
                 # Check for 413 payload-too-large BEFORE generic 4xx handler.
                 # A 413 is a payload-size error — the correct response is to
                 # compress history and retry, not abort immediately.
@@ -2889,7 +2889,7 @@ def run_conversation(
                             f"error retry backoff ({retry_count}/{max_retries}), "
                             f"{int(sleep_end - time.time())}s remaining"
                         )
-        
+
         # If the API call was interrupted, skip response processing
         if interrupted:
             _turn_exit_reason = "interrupted_during_api_call"
@@ -2931,7 +2931,7 @@ def run_conversation(
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
-            
+
             # Normalize content to string — some OpenAI-compatible servers
             # (llama-server, etc.) return content as a dict or list instead
             # of a plain string, which crashes downstream .strip() calls.
@@ -3008,14 +3008,14 @@ def run_conversation(
                         agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
                     except Exception:
                         pass
-            
+
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times
             if has_incomplete_scratchpad(assistant_message.content or ""):
                 agent._incomplete_scratchpad_retries += 1
-                
+
                 agent._vprint(f"{agent.log_prefix}⚠️  Incomplete <REASONING_SCRATCHPAD> detected (opened but never closed)")
-                
+
                 if agent._incomplete_scratchpad_retries <= 2:
                     agent._vprint(f"{agent.log_prefix}🔄 Retrying API call ({agent._incomplete_scratchpad_retries}/2)...")
                     # Don't add the broken message, just retry
@@ -3024,11 +3024,11 @@ def run_conversation(
                     # Max retries - discard this turn and save as partial
                     agent._vprint(f"{agent.log_prefix}❌ Max retries (2) for incomplete scratchpad. Saving as partial.", force=True)
                     agent._incomplete_scratchpad_retries = 0
-                    
+
                     rolled_back_messages = agent._get_messages_up_to_last_assistant(messages)
                     agent._cleanup_task_resources(effective_task_id)
                     agent._persist_session(messages, conversation_history)
-                    
+
                     return {
                         "final_response": None,
                         "messages": rolled_back_messages,
@@ -3037,7 +3037,7 @@ def run_conversation(
                         "partial": True,
                         "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
                     }
-            
+
             # Reset incomplete scratchpad counter on clean response
             agent._incomplete_scratchpad_retries = 0
 
@@ -3099,16 +3099,16 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
-            
+
             # Check for tool calls
             if assistant_message.tool_calls:
                 if not agent.quiet_mode:
                     agent._vprint(f"{agent.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")
-                
+
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
                         logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
-                
+
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
                 for tc in assistant_message.tool_calls:
@@ -3160,7 +3160,7 @@ def run_conversation(
                     continue
                 # Reset retry counter on successful tool call validation
                 agent._invalid_tool_retries = 0
-                
+
                 # Validate tool call arguments are valid JSON
                 # Handle empty strings as empty objects (common model quirk)
                 invalid_json_args = []
@@ -3180,7 +3180,7 @@ def run_conversation(
                         json.loads(args)
                     except json.JSONDecodeError as e:
                         invalid_json_args.append((tc.function.name, str(e)))
-                
+
                 if invalid_json_args:
                     # Check if the invalid JSON is due to truncation rather
                     # than a model formatting mistake.  Routers sometimes
@@ -3226,11 +3226,11 @@ def run_conversation(
                         # Using tool results (not user messages) preserves role alternation.
                         agent._vprint(f"{agent.log_prefix}⚠️  Injecting recovery tool results for invalid JSON...")
                         agent._invalid_json_retries = 0  # Reset for next attempt
-                        
+
                         # Append the assistant message with its (broken) tool_calls
                         recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
                         messages.append(recovery_assistant)
-                        
+
                         # Respond with tool error results for each tool call
                         invalid_names = {name for name, _ in invalid_json_args}
                         for tc in assistant_message.tool_calls:
@@ -3250,7 +3250,7 @@ def run_conversation(
                                 "content": tool_result,
                             })
                         continue
-                
+
                 # Reset retry counter on successful JSON validation
                 agent._invalid_json_retries = 0
 
@@ -3263,7 +3263,7 @@ def run_conversation(
                 )
 
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                
+
                 # If this turn has both content AND tool_calls, capture the content
                 # as a fallback final response. Common pattern: model delivers its
                 # answer and calls memory/skill tools as a side-effect in the same
@@ -3290,7 +3290,7 @@ def run_conversation(
                         clean = agent._strip_think_blocks(turn_content).strip()
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
-                
+
                 # Pop thinking-only prefill message(s) before appending
                 # (tool-call path — same rationale as the final-response path).
                 _had_prefill = False
@@ -3363,7 +3363,7 @@ def run_conversation(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
-                
+
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the
                 # actual context size the provider reported plus the
@@ -3406,24 +3406,24 @@ def run_conversation(
                     # _flush_messages_to_session_db writes compressed messages
                     # to the new session (see preflight compression comment).
                     conversation_history = None
-                
+
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages
                 
                 # Continue loop for next response
                 continue
-            
+
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a
                 # prior housekeeping tool turn and should not silence the
                 # final response path.
                 agent._mute_post_response = False
-                
+
                 # Check if response only has think block with no actual content after it
                 if not agent._has_content_after_think_block(final_response):
                     # ── Partial stream recovery ─────────────────────
@@ -3679,7 +3679,7 @@ def run_conversation(
 
                     final_response = "(empty)"
                     break
-                
+
                 # Reset retry counter/signature on successful content
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
@@ -3716,9 +3716,9 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
-                
+
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
+
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
                 # Pop thinking-only prefill and empty-response retry
@@ -3737,21 +3737,21 @@ def run_conversation(
                     messages.pop()
 
                 messages.append(final_msg)
-                
+
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
-            
+
         except Exception as e:
             error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
                 logger.error(error_msg)
-            
+
             logger.debug("Outer loop error in API call #%d", api_call_count, exc_info=True)
-            
+
             # If an assistant message with tool_calls was already appended,
             # the API expects a role="tool" result for every tool_call_id.
             # Fill in error results for any that weren't answered yet.
@@ -3778,7 +3778,7 @@ def run_conversation(
                             }
                             messages.append(err_msg)
                 break
-            
+
             # Non-tool errors don't need a synthetic message injected.
             # The error is already printed to the user (line above), and
             # the retry loop continues.  Injecting a fake user/assistant
@@ -3793,7 +3793,7 @@ def run_conversation(
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})
                 break
-    
+
     if final_response is None and (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
@@ -4026,11 +4026,11 @@ def run_conversation(
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
     agent._response_was_previewed = False
-    
+
     # Include interrupt message if one triggered the interrupt
     if interrupted and agent._interrupt_message:
         result["interrupt_message"] = agent._interrupt_message
-    
+
     # Clear interrupt state after handling
     agent.clear_interrupt()
 
@@ -4089,6 +4089,33 @@ def run_conversation(
 
     return result
 
+
+
+_run_conversation_impl = run_conversation
+
+
+@wraps(_run_conversation_impl)
+def run_conversation(*args, **kwargs):
+    """Bind profile-scoped runtime env for one agent turn and restore it."""
+    agent = args[0] if args else kwargs.get("agent")
+    runtime_env_token = None
+    clear_runtime_env = None
+    try:
+        from gateway.session_context import clear_runtime_env, set_runtime_env
+        runtime_env_token = set_runtime_env(
+            getattr(agent, "_runtime_env", None) if agent is not None else None
+        )
+    except Exception:
+        runtime_env_token = None
+        clear_runtime_env = None
+    try:
+        return _run_conversation_impl(*args, **kwargs)
+    finally:
+        if runtime_env_token is not None and clear_runtime_env is not None:
+            try:
+                clear_runtime_env(runtime_env_token)
+            except Exception:
+                pass
 
 
 __all__ = ["run_conversation"]

--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -61,6 +61,7 @@ _BUNDLE_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 _bundles_cache: Dict[str, Dict[str, Any]] = {}
 _bundles_cache_mtime: Optional[float] = None
+_bundles_cache_dir: Optional[str] = None
 
 
 def _bundles_dir() -> Path:
@@ -172,8 +173,12 @@ def scan_bundles() -> Dict[str, Dict[str, Any]]:
     bundle info dict. Later bundles with a duplicate slug are skipped with
     a warning (first wins, alphabetical order).
     """
-    global _bundles_cache, _bundles_cache_mtime
+    global _bundles_cache, _bundles_cache_mtime, _bundles_cache_dir
     files = _iter_bundle_files()
+    try:
+        _bundles_cache_dir = str(_bundles_dir().expanduser().resolve(strict=False))
+    except Exception:
+        _bundles_cache_dir = str(_bundles_dir())
     out: Dict[str, Dict[str, Any]] = {}
     for f in files:
         info = _load_bundle_file(f)
@@ -200,7 +205,15 @@ def get_skill_bundles() -> Dict[str, Dict[str, Any]]:
     """
     files = _iter_bundle_files()
     current_mtime = _max_mtime(files)
-    if not _bundles_cache or _bundles_cache_mtime != current_mtime:
+    try:
+        current_dir = str(_bundles_dir().expanduser().resolve(strict=False))
+    except Exception:
+        current_dir = str(_bundles_dir())
+    if (
+        not _bundles_cache
+        or _bundles_cache_mtime != current_mtime
+        or _bundles_cache_dir != current_dir
+    ):
         scan_bundles()
     return _bundles_cache
 
@@ -228,7 +241,7 @@ def reload_bundles() -> Dict[str, Any]:
     def _snapshot(cmds: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
         return {k.lstrip("/"): (v or {}).get("description", "") for k, v in cmds.items()}
 
-    before = _snapshot(_bundles_cache)
+    before = _snapshot(get_skill_bundles())
     new = scan_bundles()
     after = _snapshot(new)
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_home: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -57,13 +58,15 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         return None
 
     try:
-        from tools.skills_tool import SKILLS_DIR, skill_view
+        from tools.skills_tool import get_skills_dir, skill_view
         from agent.skill_utils import get_external_skills_dirs
+
+        skills_dir = get_skills_dir()
 
         identifier_path = Path(raw_identifier).expanduser()
         if identifier_path.is_absolute():
             normalized = None
-            trusted_roots = [SKILLS_DIR]
+            trusted_roots = [skills_dir]
             try:
                 trusted_roots.extend(get_external_skills_dirs())
             except Exception:
@@ -84,7 +87,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
 
             if normalized is None:
                 try:
-                    normalized = str(identifier_path.resolve().relative_to(SKILLS_DIR.resolve()))
+                    normalized = str(identifier_path.resolve().relative_to(skills_dir.resolve()))
                 except Exception:
                     normalized = raw_identifier
         else:
@@ -111,7 +114,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         skill_dir = Path(abs_skill_dir)
     elif skill_path:
         try:
-            skill_dir = SKILLS_DIR / Path(skill_path).parent
+            skill_dir = get_skills_dir() / Path(skill_path).parent
         except Exception:
             skill_dir = None
 
@@ -166,9 +169,10 @@ def _build_skill_message(
     session_id: str | None = None,
 ) -> str:
     """Format a loaded skill into a user/system message payload."""
-    from tools.skills_tool import SKILLS_DIR
+    from tools.skills_tool import get_skills_dir
 
     content = str(loaded_skill.get("content") or "")
+    skills_dir = get_skills_dir()
 
     # ── Template substitution and inline-shell expansion ──
     # Done before anything else so downstream blocks (setup notes,
@@ -235,7 +239,7 @@ def _build_skill_message(
 
     if supporting and skill_dir:
         try:
-            skill_view_target = str(skill_dir.relative_to(SKILLS_DIR))
+            skill_view_target = str(skill_dir.relative_to(skills_dir))
         except ValueError:
             # Skill is from an external dir — use the skill name instead
             skill_view_target = skill_dir.name
@@ -266,19 +270,21 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_home
     _skill_commands_platform = _resolve_skill_commands_platform()
+    _skill_commands_home = str(get_hermes_home())
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
+        from tools.skills_tool import get_skills_dir, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
         # Scan local dir first, then external dirs
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        skills_dir = get_skills_dir()
+        if skills_dir.exists():
+            dirs_to_scan.append(skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -336,6 +342,7 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_home != str(get_hermes_home())
     ):
         scan_skill_commands()
     return _skill_commands

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -32,6 +32,7 @@ def generate_title(
     timeout: float = 30.0,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
+    env: dict = None,
 ) -> Optional[str]:
     """Generate a session title from the first exchange.
 
@@ -61,6 +62,7 @@ def generate_title(
             temperature=0.3,
             timeout=timeout,
             main_runtime=main_runtime,
+            env=env,
         )
         title = (response.choices[0].message.content or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
@@ -91,6 +93,7 @@ def auto_title_session(
     assistant_response: str,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
+    env: dict = None,
     title_callback: Optional[TitleCallback] = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
@@ -113,7 +116,8 @@ def auto_title_session(
         return
 
     title = generate_title(
-        user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
+        user_message, assistant_response, failure_callback=failure_callback,
+        main_runtime=main_runtime, env=env,
     )
     if not title:
         return
@@ -138,6 +142,7 @@ def maybe_auto_title(
     conversation_history: list,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
+    env: dict = None,
     title_callback: Optional[TitleCallback] = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
@@ -163,6 +168,7 @@ def maybe_auto_title(
         kwargs={
             "failure_callback": failure_callback,
             "main_runtime": main_runtime,
+            "env": env,
             "title_callback": title_callback,
         },
         daemon=True,

--- a/cli.py
+++ b/cli.py
@@ -11404,6 +11404,7 @@ class HermesCLI:
                             "api_key": self.api_key,
                             "api_mode": self.api_mode,
                         },
+                        env=getattr(self.agent, "_runtime_env", None) if self.agent else None,
                     )
                 except Exception:
                     pass

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -714,6 +714,26 @@ def load_gateway_config() -> GatewayConfig:
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
 
+            ui_cfg = yaml_cfg.get("ui")
+            ui_platforms = ui_cfg.get("platforms") if isinstance(ui_cfg, dict) else None
+            ui_telegram = ui_platforms.get("telegram") if isinstance(ui_platforms, dict) else None
+            ui_telegram_extra = ui_telegram.get("extra") if isinstance(ui_telegram, dict) else None
+            if (
+                isinstance(ui_telegram, dict)
+                and (
+                    "topic_profiles" in ui_telegram
+                    or (
+                        isinstance(ui_telegram_extra, dict)
+                        and "topic_profiles" in ui_telegram_extra
+                    )
+                )
+            ):
+                logger.warning(
+                    "Ignoring ui.platforms.telegram.topic_profiles; configure "
+                    "Telegram topic profiles under "
+                    "platforms.telegram.extra.topic_profiles or telegram.topic_profiles"
+                )
+
             # Map config.yaml keys → GatewayConfig.from_dict() schema.
             # Each key overwrites whatever gateway.json may have set.
             sr = yaml_cfg.get("session_reset")
@@ -868,6 +888,10 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "topic_profiles" in platform_cfg:
+                    bridged["topic_profiles"] = platform_cfg["topic_profiles"]
+                if "topic_profiles_safe_root" in platform_cfg:
+                    bridged["topic_profiles_safe_root"] = platform_cfg["topic_profiles_safe_root"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue
@@ -1285,6 +1309,16 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
                 )
                 pconfig.enabled = False
 
+    telegram_cfg = config.platforms.get(Platform.TELEGRAM)
+    if telegram_cfg and telegram_cfg.extra.get("topic_profiles"):
+        from gateway.platforms.base import normalize_topic_profile_routes
+
+        telegram_cfg.extra["topic_profiles"] = normalize_topic_profile_routes(
+            telegram_cfg.extra,
+            hermes_home=get_hermes_home(),
+            require_identity=True,
+        )
+
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
@@ -1310,6 +1344,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
         config.platforms[Platform.TELEGRAM].extra["fallback_ips"] = [
             ip.strip() for ip in telegram_fallback_ips.split(",") if ip.strip()
+        ]
+
+    telegram_allowed_topics = os.getenv("TELEGRAM_ALLOWED_TOPICS", "")
+    if telegram_allowed_topics:
+        if Platform.TELEGRAM not in config.platforms:
+            config.platforms[Platform.TELEGRAM] = PlatformConfig()
+        config.platforms[Platform.TELEGRAM].extra["allowed_topics"] = [
+            part.strip() for part in telegram_allowed_topics.split(",") if part.strip()
         ]
 
     telegram_home = os.getenv("TELEGRAM_HOME_CHANNEL")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import uuid
 from abc import ABC, abstractmethod
+from pathlib import Path
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
@@ -32,6 +33,40 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 # delivered as a regular document.
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
+_PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+class TopicProfileConfigError(ValueError):
+    """Raised when Telegram topic profile routing config is unsafe or invalid."""
+
+
+def _is_path_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _has_symlink_ancestor(path: Path, stop_at: Path | None = None) -> bool:
+    current = path
+    stop = stop_at.resolve(strict=False) if stop_at is not None else None
+    while True:
+        try:
+            if current.exists() and current.is_symlink():
+                return True
+        except OSError:
+            return True
+        if stop is not None:
+            try:
+                if current.resolve(strict=False) == stop:
+                    return False
+            except OSError:
+                return True
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
 
 
 def _platform_name(platform) -> str:
@@ -54,7 +89,8 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     if thread_id is None:
         return None
     metadata = {"thread_id": thread_id}
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    platform_name = _platform_name(getattr(source, "platform", None))
+    if platform_name == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
@@ -62,6 +98,9 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
+    routed_profile = str(getattr(source, "agent_profile", None) or "").strip()
+    if platform_name == "telegram" and routed_profile and routed_profile != "default":
+        metadata["disable_thread_fallback"] = True
     return metadata
 
 
@@ -981,6 +1020,10 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Optional profile routing chosen by a platform adapter.
+    agent_profile: Optional[str] = None
+    agent_hermes_home: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
@@ -1232,6 +1275,163 @@ def resolve_channel_prompt(
     return None
 
 
+def resolve_topic_profile(
+    config_extra: dict,
+    chat_id: str,
+    thread_id: str | None,
+) -> dict | None:
+    """Resolve Telegram topic-to-profile routing from platform config."""
+    routes = normalize_topic_profile_routes(config_extra)
+
+    chat_id_s = str(chat_id)
+    thread_id_s = str(thread_id) if thread_id is not None else None
+    for route in routes:
+        match = route["match"]
+        if str(match.get("chat_id", "")) != chat_id_s:
+            continue
+        expected_thread = str(match.get("thread_id"))
+        if expected_thread != thread_id_s:
+            continue
+        profile = route["profile"]
+        result = {"profile": profile}
+        home = route.get("profile_home")
+        if home:
+            result["profile_home"] = str(home)
+        return result
+    return None
+
+
+def normalize_topic_profile_routes(
+    config_extra: dict,
+    *,
+    hermes_home: str | Path | None = None,
+    require_identity: bool = False,
+) -> list[dict]:
+    """Validate and normalize Telegram topic-to-profile routing rules.
+
+    The public routing surface is deliberately small: exact chat/topic matches
+    map to existing Hermes profile names under a declared safe root.
+    """
+    routes = config_extra.get("topic_profiles") or []
+    if not routes:
+        return []
+    if not isinstance(routes, list):
+        raise TopicProfileConfigError("telegram.topic_profiles must be a list")
+
+    safe_root_raw = config_extra.get("topic_profiles_safe_root")
+    safe_root: Path | None = None
+    if not safe_root_raw:
+        raise TopicProfileConfigError(
+            "telegram.topic_profiles_safe_root is required when telegram.topic_profiles is set"
+        )
+    safe_root_candidate = Path(str(safe_root_raw)).expanduser()
+    if not safe_root_candidate.is_absolute():
+        base_home = Path(hermes_home).expanduser() if hermes_home else Path.cwd()
+        safe_root_candidate = base_home / safe_root_candidate
+    if safe_root_candidate.is_symlink() or _has_symlink_ancestor(safe_root_candidate):
+        raise TopicProfileConfigError(
+            "telegram.topic_profiles_safe_root must not be or contain a symlink"
+        )
+    safe_root = safe_root_candidate.resolve(strict=False)
+    default_home = (Path.home() / ".hermes").resolve(strict=False)
+    if safe_root == default_home:
+        raise TopicProfileConfigError(
+            "telegram.topic_profiles_safe_root must not be ~/.hermes"
+        )
+    if not safe_root.is_dir():
+        raise TopicProfileConfigError(
+            "telegram.topic_profiles_safe_root must exist and be a directory"
+        )
+    config_extra["topic_profiles_safe_root"] = str(safe_root)
+
+    normalized: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    allowed_topics_raw = config_extra.get("allowed_topics")
+    allowed_topics: set[str] = set()
+    if isinstance(allowed_topics_raw, str):
+        allowed_topics = {part.strip() for part in allowed_topics_raw.split(",") if part.strip()}
+    elif isinstance(allowed_topics_raw, (list, tuple, set)):
+        allowed_topics = {str(part).strip() for part in allowed_topics_raw if str(part).strip()}
+
+    for idx, route in enumerate(routes):
+        if not isinstance(route, dict):
+            raise TopicProfileConfigError(f"telegram.topic_profiles[{idx}] must be a mapping")
+        match = route.get("match")
+        if not isinstance(match, dict):
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}].match must be a mapping"
+            )
+
+        chat_id = str(match.get("chat_id") or "").strip()
+        thread_raw = match.get("thread_id")
+        thread_id = "" if thread_raw is None else str(thread_raw).strip()
+        if not chat_id or not thread_id:
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}] requires match.chat_id and match.thread_id"
+            )
+        if allowed_topics and thread_id not in allowed_topics:
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}] routes thread_id={thread_id!r}, "
+                "but telegram.allowed_topics would block it"
+            )
+
+        key = (chat_id, thread_id)
+        if key in seen:
+            raise TopicProfileConfigError(
+                f"Duplicate telegram.topic_profiles route for chat_id={chat_id!r} "
+                f"thread_id={thread_id!r}"
+            )
+        seen.add(key)
+
+        profile = str(route.get("profile") or "").strip()
+        if not profile or profile == "default" or not _PROFILE_ID_RE.match(profile):
+            raise TopicProfileConfigError(
+                f"Invalid telegram.topic_profiles[{idx}].profile: {profile!r}"
+            )
+
+        item = {"match": {"chat_id": chat_id, "thread_id": thread_id}, "profile": profile}
+
+        home_raw = route.get("profile_home") or route.get("home") or route.get("hermes_home")
+        if home_raw:
+            home_path = Path(str(home_raw)).expanduser()
+            if not home_path.is_absolute():
+                home_path = safe_root / home_path
+        else:
+            home_path = safe_root / profile
+
+        if home_path.is_symlink() or _has_symlink_ancestor(home_path, safe_root.parent):
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}].profile_home must not be or contain a symlink"
+            )
+        resolved_home = home_path.resolve(strict=False)
+        if not _is_path_relative_to(resolved_home, safe_root):
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}].profile_home must be inside "
+                "telegram.topic_profiles_safe_root"
+            )
+        if resolved_home == (Path.home() / ".hermes").resolve(strict=False):
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}].profile_home must not be ~/.hermes"
+            )
+        if not resolved_home.is_dir():
+            raise TopicProfileConfigError(
+                f"telegram.topic_profiles[{idx}].profile_home must exist"
+            )
+        if require_identity:
+            try:
+                from hermes_cli.profiles import validate_profile_identity
+                validate_profile_identity(profile, resolved_home, safe_root)
+            except Exception as exc:
+                raise TopicProfileConfigError(
+                    f"telegram.topic_profiles[{idx}] profile identity is invalid: {exc}"
+                ) from exc
+        item["profile_home"] = str(resolved_home)
+
+        normalized.append(item)
+
+    return normalized
+
+
 def resolve_channel_skills(
     config_extra: dict,
     channel_id: str,
@@ -1330,6 +1530,7 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        self._topic_profile_route_resolver: Optional[Callable[[MessageEvent], None]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
@@ -1348,6 +1549,12 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+
+    def _thread_metadata_for_event(self, event: MessageEvent) -> Optional[Dict[str, Any]]:
+        return _thread_metadata_for_source(
+            getattr(event, "source", None),
+            _reply_anchor_for_event(event),
+        )
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -1549,6 +1756,44 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_topic_profile_route_resolver(
+        self,
+        resolver: Optional[Callable[[MessageEvent], None]],
+    ) -> None:
+        """Set an optional resolver for adapter-early topic profile routing.
+
+        Adapters compute session keys before the gateway runner sees an event.
+        A runner-provided resolver lets those early keys include routed topic
+        profiles even when the platform adapter did not hydrate the source.
+        """
+        self._topic_profile_route_resolver = resolver
+
+    @staticmethod
+    def _copy_event_profile_to_source(event: MessageEvent) -> None:
+        source = getattr(event, "source", None)
+        if source is None:
+            return
+        if getattr(event, "agent_profile", None) and not getattr(source, "agent_profile", None):
+            source.agent_profile = event.agent_profile
+        if getattr(event, "agent_hermes_home", None) and not getattr(source, "agent_hermes_home", None):
+            source.agent_hermes_home = event.agent_hermes_home
+
+    def _hydrate_routed_event_source(self, event: MessageEvent) -> None:
+        """Ensure profile routing is present on ``event.source`` before keys.
+
+        The gateway runner also hydrates defensively, but adapter guards,
+        batching keys, and pending queues are all keyed before the runner gets
+        control. Keep this helper as the single adapter-side pre-key step.
+        """
+        source = getattr(event, "source", None)
+        if source is None:
+            return
+        self._copy_event_profile_to_source(event)
+        resolver = getattr(self, "_topic_profile_route_resolver", None)
+        if callable(resolver) and not getattr(source, "agent_profile", None):
+            resolver(event)
+            self._copy_event_profile_to_source(event)
     
     def set_session_store(self, session_store: Any) -> None:
         """
@@ -2875,6 +3120,7 @@ class BasePlatformAdapter(ABC):
             return
 
         coerce_plaintext_gateway_command(event)
+        self._hydrate_routed_event_source(event)
         
         session_key = build_session_key(
             event.source,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -674,6 +674,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not (metadata and metadata.get("telegram_dm_topic_reply_fallback")):
             return False
+        if metadata.get("disable_thread_fallback"):
+            return False
         if not cls._is_bad_request_error(error):
             return False
         err_lower = str(error).lower()
@@ -1703,6 +1705,9 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
+            disable_thread_fallback = bool(
+                isinstance(metadata, dict) and metadata.get("disable_thread_fallback")
+            )
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1797,6 +1802,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                         self.name, effective_thread_id,
                                     )
                                     continue
+                                if disable_thread_fallback:
+                                    logger.warning(
+                                        "[%s] Thread %s not found for routed profile; not retrying in main chat",
+                                        self.name, effective_thread_id,
+                                    )
+                                    raise
                                 # Second failure: the thread is genuinely gone.
                                 # Retry without ``message_thread_id`` so the
                                 # message still reaches the chat.
@@ -1810,6 +1821,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                             err_lower = str(send_err).lower()
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
+                                if disable_thread_fallback:
+                                    logger.warning(
+                                        "[%s] Reply target deleted for routed profile; not retrying in main chat",
+                                        self.name,
+                                    )
+                                    raise
                                 # Original message was deleted before we
                                 # could reply. For private-topic fallback
                                 # sends, message_thread_id is only valid with
@@ -2147,6 +2164,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
                 except Exception as send_err:
                     if "reply message not found" in str(send_err).lower():
+                        if metadata and metadata.get("disable_thread_fallback"):
+                            logger.warning(
+                                "[%s] Overflow continuation reply target deleted for routed profile; not retrying in main chat",
+                                self.name,
+                            )
+                            sent_msg = None
+                            break
                         # Drop the reply anchor and try again.  Private DM
                         # topic fallback needs the anchor and topic id together;
                         # forum topics can still safely keep message_thread_id.
@@ -2304,7 +2328,12 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=str(e))
 
-    async def _send_message_with_thread_fallback(self, **kwargs):
+    async def _send_message_with_thread_fallback(
+        self,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
         """Send a Telegram message, retrying once without message_thread_id
         if Telegram returns 'Message thread not found'.
 
@@ -2318,14 +2347,35 @@ class TelegramAdapter(BasePlatformAdapter):
             raise RuntimeError("Not connected")
 
         message_thread_id = kwargs.get("message_thread_id")
-        try:
-            return await self._bot.send_message(**kwargs)
-        except Exception as send_err:
-            if (
-                message_thread_id is not None
-                and self._is_bad_request_error(send_err)
-                and self._is_thread_not_found_error(send_err)
-            ):
+        disable_thread_fallback = bool(
+            metadata and metadata.get("disable_thread_fallback")
+        )
+        retried_same_thread = False
+        while True:
+            try:
+                return await self._bot.send_message(**kwargs)
+            except Exception as send_err:
+                if not (
+                    message_thread_id is not None
+                    and self._is_bad_request_error(send_err)
+                    and self._is_thread_not_found_error(send_err)
+                ):
+                    raise
+                if not retried_same_thread:
+                    retried_same_thread = True
+                    logger.warning(
+                        "[%s] Thread %s not found for control message, retrying once with same thread_id",
+                        self.name,
+                        message_thread_id,
+                    )
+                    continue
+                if disable_thread_fallback:
+                    logger.warning(
+                        "[%s] Thread %s not found for routed profile control message; not retrying in main chat",
+                        self.name,
+                        message_thread_id,
+                    )
+                    raise
                 logger.warning(
                     "[%s] Thread %s not found for control message, retrying without message_thread_id",
                     self.name,
@@ -2334,7 +2384,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 retry_kwargs = dict(kwargs)
                 retry_kwargs.pop("message_thread_id", None)
                 return await self._bot.send_message(**retry_kwargs)
-            raise
 
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
@@ -2360,6 +2409,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             msg = await self._send_message_with_thread_fallback(
+                metadata=metadata,
                 chat_id=int(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -2441,7 +2491,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(metadata=metadata, **kwargs)
 
             # Store session_key keyed by approval_id for the callback handler
             self._approval_state[approval_id] = session_key
@@ -2492,7 +2542,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(metadata=metadata, **kwargs)
             self._slash_confirm_state[confirm_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -2574,7 +2624,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(metadata=metadata, **kwargs)
             self._clarify_state[clarify_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -2635,6 +2685,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = metadata.get("thread_id") if metadata else None
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             msg = await self._send_message_with_thread_fallback(
+                metadata=metadata,
                 chat_id=int(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -3069,31 +3120,47 @@ class TelegramAdapter(BasePlatformAdapter):
                             str(ChatType.PRIVATE).lower(),
                             str(getattr(ChatType.PRIVATE, "value", ChatType.PRIVATE)).lower(),
                         }
+                        _session_key_parts = str(session_key or "").split(":", 2)
+                        _routed_profile_callback = (
+                            len(_session_key_parts) >= 2
+                            and _session_key_parts[0] == "agent"
+                            and _session_key_parts[1] not in {"", "main", "cron"}
+                        )
+                        followup_metadata = None
                         if thread_id is not None and is_private_chat and prompt_message_id is not None:
                             reply_to_id = int(prompt_message_id)
+                            followup_metadata = {
+                                "thread_id": str(thread_id),
+                                "telegram_dm_topic_reply_fallback": True,
+                            }
+                            if _routed_profile_callback:
+                                followup_metadata["disable_thread_fallback"] = True
                             send_kwargs["reply_to_message_id"] = reply_to_id
                             send_kwargs.update(
                                 self._thread_kwargs_for_send(
                                     str(query.message.chat_id),
                                     str(thread_id),
-                                    {
-                                        "thread_id": str(thread_id),
-                                        "telegram_dm_topic_reply_fallback": True,
-                                    },
+                                    followup_metadata,
                                     reply_to_message_id=reply_to_id,
                                     reply_to_mode=self._reply_to_mode
                                 )
                             )
                         elif thread_id is not None:
+                            followup_metadata = {"thread_id": str(thread_id)}
+                            if _routed_profile_callback:
+                                followup_metadata["disable_thread_fallback"] = True
                             send_kwargs.update(
                                 self._thread_kwargs_for_send(
                                     str(query.message.chat_id),
                                     str(thread_id),
-                                    {"thread_id": str(thread_id)},
+                                    followup_metadata,
                                     reply_to_mode=self._reply_to_mode
                                 )
                             )
-                        await self._send_message_with_thread_fallback(**send_kwargs)
+                        await self._send_message_with_thread_fallback(
+                            metadata=followup_metadata,
+                            **send_kwargs,
+                        )
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
             return
@@ -3934,6 +4001,8 @@ class TelegramAdapter(BasePlatformAdapter):
             _is_dm_topic: bool = False
             message_thread_id: Optional[int] = None
             try:
+                if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
+                    return
                 _typing_thread = self._metadata_thread_id(metadata)
                 _is_dm_topic = bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
@@ -4824,6 +4893,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
         from gateway.session import build_session_key
+        self._hydrate_routed_event_source(event)
         return build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
@@ -4913,6 +4983,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _photo_batch_key(self, event: MessageEvent, msg: Message) -> str:
         """Return a batching key for Telegram photos/albums."""
         from gateway.session import build_session_key
+        self._hydrate_routed_event_source(event)
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
@@ -5225,6 +5296,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
         await self.handle_message(event)
 
+    def _media_group_batch_key(self, event: MessageEvent, media_group_id: str) -> str:
+        """Return a session-scoped key for Telegram albums."""
+        from gateway.session import build_session_key
+        self._hydrate_routed_event_source(event)
+        session_key = build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+        return f"{session_key}:album:{media_group_id}"
+
     async def _queue_media_group_event(self, media_group_id: str, event: MessageEvent) -> None:
         """Buffer Telegram media-group items so albums arrive as one logical event.
 
@@ -5233,33 +5315,34 @@ class TelegramAdapter(BasePlatformAdapter):
         new user message and interrupts the first. We debounce briefly and merge the
         attachments into a single MessageEvent.
         """
-        existing = self._media_group_events.get(media_group_id)
+        batch_key = self._media_group_batch_key(event, media_group_id)
+        existing = self._media_group_events.get(batch_key)
         if existing is None:
-            self._media_group_events[media_group_id] = event
+            self._media_group_events[batch_key] = event
         else:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
 
-        prior_task = self._media_group_tasks.get(media_group_id)
+        prior_task = self._media_group_tasks.get(batch_key)
         if prior_task:
             prior_task.cancel()
 
-        self._media_group_tasks[media_group_id] = asyncio.create_task(
-            self._flush_media_group_event(media_group_id)
+        self._media_group_tasks[batch_key] = asyncio.create_task(
+            self._flush_media_group_event(batch_key)
         )
 
-    async def _flush_media_group_event(self, media_group_id: str) -> None:
+    async def _flush_media_group_event(self, batch_key: str) -> None:
         try:
             await asyncio.sleep(self.MEDIA_GROUP_WAIT_SECONDS)
-            event = self._media_group_events.pop(media_group_id, None)
+            event = self._media_group_events.pop(batch_key, None)
             if event is not None:
                 await self.handle_message(event)
         except asyncio.CancelledError:
             return
         finally:
-            self._media_group_tasks.pop(media_group_id, None)
+            self._media_group_tasks.pop(batch_key, None)
 
     async def _handle_sticker(self, msg: Message, event: "MessageEvent") -> None:
         """
@@ -5447,6 +5530,16 @@ class TelegramAdapter(BasePlatformAdapter):
         # python-telegram-bot enum values both work (``ChatType.CHANNEL`` is
         # string-like, but mocks often provide plain strings).
         telegram_chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        # Test doubles and older PTB enum representations may stringify as
+        # "<Mock ... SUPERGROUP ...>" rather than the raw Bot API value.
+        if "supergroup" in telegram_chat_type:
+            telegram_chat_type = "supergroup"
+        elif "group" in telegram_chat_type:
+            telegram_chat_type = "group"
+        elif "channel" in telegram_chat_type:
+            telegram_chat_type = "channel"
+        elif "private" in telegram_chat_type:
+            telegram_chat_type = "private"
         chat_type = "dm"
         if telegram_chat_type in {"group", "supergroup"}:
             chat_type = "group"
@@ -5553,14 +5646,21 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
 
-        # Per-channel/topic ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt
+        # Per-channel/topic ephemeral prompt and optional profile routing.
+        from gateway.platforms.base import resolve_channel_prompt, resolve_topic_profile
         _chat_id_str = str(chat.id)
         _channel_prompt = resolve_channel_prompt(
             self.config.extra,
             thread_id_str or _chat_id_str,
             _chat_id_str if thread_id_str else None,
         )
+        _topic_profile = resolve_topic_profile(self.config.extra, _chat_id_str, thread_id_str)
+        _agent_profile = (_topic_profile or {}).get("profile")
+        _agent_hermes_home = (_topic_profile or {}).get("profile_home")
+        if _agent_profile:
+            source.agent_profile = _agent_profile
+        if _agent_hermes_home:
+            source.agent_hermes_home = _agent_hermes_home
 
         return MessageEvent(
             text=message.text or "",
@@ -5573,6 +5673,8 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            agent_profile=_agent_profile,
+            agent_hermes_home=_agent_hermes_home,
             timestamp=message.date,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -548,7 +548,13 @@ _ensure_ssl_certs()
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    get_hermes_home_override,
+    hermes_home_context,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -799,9 +805,11 @@ from gateway.config import (
     GatewayConfig,
     HomeChannel,
     PlatformConfig,
+    _validate_gateway_config,
     load_gateway_config,
 )
 from gateway.session import (
+    _PROFILE_ID_RE,
     SessionStore,
     SessionSource,
     SessionContext,
@@ -817,7 +825,9 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     _reply_anchor_for_event,
+    _thread_metadata_for_source as _base_thread_metadata_for_source,
     merge_pending_message_event,
+    resolve_topic_profile,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -843,7 +853,37 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
+class TopicProfileRoutingError(RuntimeError):
+    """Raised when a routed topic profile cannot be safely resolved."""
+
+
+def _env_get(runtime_env: Optional[dict], key: str, default: str = "") -> str:
+    if runtime_env is None:
+        return os.getenv(key, default)
+    value = runtime_env.get(key, default)
+    return "" if value is None else str(value)
+
+
+def _resolve_max_iterations(
+    *,
+    user_config: Optional[dict] = None,
+    runtime_env: Optional[dict] = None,
+    default: int = 90,
+) -> int:
+    agent_cfg = user_config.get("agent") if isinstance(user_config, dict) else None
+    if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
+        try:
+            return int(agent_cfg["max_turns"])
+        except (TypeError, ValueError):
+            pass
+    raw = _env_get(runtime_env, "HERMES_MAX_ITERATIONS", str(default))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_runtime_agent_kwargs(runtime_env: Optional[dict] = None) -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
     If the primary provider fails with an authentication error, attempt to
@@ -856,15 +896,34 @@ def _resolve_runtime_agent_kwargs() -> dict:
     )
     from hermes_cli.auth import AuthError
 
-    try:
-        runtime = resolve_runtime_provider(
-            requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+    def _runtime_has_credentials(runtime: dict) -> bool:
+        try:
+            from hermes_cli.auth import has_usable_secret
+        except Exception:
+            has_usable_secret = lambda value: bool(str(value or "").strip())  # type: ignore[assignment]
+
+        api_key = str(runtime.get("api_key") or "").strip()
+        return bool(
+            runtime.get("credential_pool")
+            or runtime.get("command")
+            or api_key == "no-key-required"
+            or has_usable_secret(api_key)
         )
+
+    try:
+        runtime_kwargs = {"requested": _env_get(runtime_env, "HERMES_INFERENCE_PROVIDER")}
+        if runtime_env is not None:
+            runtime_kwargs["env"] = runtime_env
+        runtime = resolve_runtime_provider(**runtime_kwargs)
+        if not _runtime_has_credentials(runtime):
+            fb_config = _try_resolve_fallback_provider(runtime_env=runtime_env)
+            if fb_config is not None:
+                return fb_config
     except AuthError as auth_exc:
         # Primary provider auth failed (expired token, revoked key, etc.).
         # Try the fallback provider chain before raising.
         logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
-        fb_config = _try_resolve_fallback_provider()
+        fb_config = _try_resolve_fallback_provider(runtime_env=runtime_env)
         if fb_config is not None:
             return fb_config
         raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
@@ -882,12 +941,14 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
-def _try_resolve_fallback_provider() -> dict | None:
+def _try_resolve_fallback_provider(runtime_env: Optional[dict] = None) -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
     try:
         import yaml as _y
-        cfg_path = _hermes_home / "config.yaml"
+        cfg_path = get_hermes_home() / "config.yaml"
+        if not cfg_path.exists() and runtime_env is None:
+            cfg_path = _hermes_home / "config.yaml"
         if not cfg_path.exists():
             return None
         with open(cfg_path, encoding="utf-8") as _f:
@@ -901,11 +962,42 @@ def _try_resolve_fallback_provider() -> dict | None:
             if not isinstance(entry, dict):
                 continue
             try:
-                runtime = resolve_runtime_provider(
-                    requested=entry.get("provider"),
-                    explicit_base_url=entry.get("base_url"),
-                    explicit_api_key=entry.get("api_key"),
-                )
+                explicit_api_key = entry.get("api_key")
+                if not explicit_api_key:
+                    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+                    if key_env:
+                        explicit_api_key = _env_get(runtime_env, key_env).strip() or None
+                        if runtime_env is not None and not explicit_api_key:
+                            logger.debug(
+                                "Fallback entry %s skipped: key_env %s is not present in scoped runtime env",
+                                entry.get("provider"),
+                                key_env,
+                            )
+                            continue
+                runtime_args = {
+                    "requested": entry.get("provider"),
+                    "explicit_base_url": entry.get("base_url"),
+                    "explicit_api_key": explicit_api_key,
+                }
+                if runtime_env is not None:
+                    runtime_args["env"] = runtime_env
+                runtime = resolve_runtime_provider(**runtime_args)
+                try:
+                    from hermes_cli.auth import has_usable_secret
+                except Exception:
+                    has_usable_secret = lambda value: bool(str(value or "").strip())  # type: ignore[assignment]
+                api_key = str(runtime.get("api_key") or "").strip()
+                if not (
+                    runtime.get("credential_pool")
+                    or runtime.get("command")
+                    or api_key == "no-key-required"
+                    or has_usable_secret(api_key)
+                ):
+                    logger.debug(
+                        "Fallback entry %s skipped: no usable scoped credentials resolved",
+                        entry.get("provider"),
+                    )
+                    continue
                 logger.info(
                     "Fallback provider resolved: %s model=%s",
                     runtime.get("provider"),
@@ -1158,6 +1250,50 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _enabled_mcp_server_names(config: dict | None) -> set[str]:
+    servers = (config or {}).get("mcp_servers")
+    if not isinstance(servers, dict):
+        return set()
+    enabled: set[str] = set()
+    for name, server_cfg in servers.items():
+        if isinstance(server_cfg, dict) and server_cfg.get("enabled") is False:
+            continue
+        enabled.add(str(name))
+    return enabled
+
+
+def _has_explicit_platform_toolsets(config: dict | None, platform_key: str) -> bool:
+    toolsets = (config or {}).get("platform_toolsets")
+    return isinstance(toolsets, dict) and platform_key in toolsets
+
+
+def _topic_profile_tool_isolation_notice(
+    gateway_config: dict | None,
+    profile_config: dict | None,
+    platform_key: str,
+) -> Optional[str]:
+    """Return a diagnostic when gateway-only tool config will not be inherited."""
+    reasons: list[str] = []
+    if (
+        _has_explicit_platform_toolsets(gateway_config, platform_key)
+        and not _has_explicit_platform_toolsets(profile_config, platform_key)
+    ):
+        reasons.append(f"platform_toolsets.{platform_key}")
+
+    gateway_mcp = _enabled_mcp_server_names(gateway_config)
+    profile_mcp = _enabled_mcp_server_names(profile_config)
+    if gateway_mcp and not profile_mcp:
+        reasons.append("mcp_servers")
+
+    if not reasons:
+        return None
+    return (
+        "Routed profile tool isolation: gateway "
+        f"{', '.join(reasons)} config is not inherited by the routed profile. "
+        "Declare required toolsets or MCP servers in the profile config."
+    )
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -1167,14 +1303,19 @@ def _teams_pipeline_plugin_enabled() -> bool:
     return "teams_pipeline" in enabled or "teams-pipeline" in enabled
 
 
-def _load_gateway_config() -> dict:
+def _load_gateway_config(hermes_home: Path | None = None) -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error.
 
-    Uses the module-level ``_hermes_home`` (so tests that monkeypatch it
-    still see their fixture) and shares the mtime-keyed raw-yaml cache
-    from ``hermes_cli.config.read_raw_config`` when the paths match.
+    Uses the active ``get_hermes_home()`` value so topic-routed profile
+    contexts can read their own config while the gateway process stays in
+    its original home.
     """
-    config_path = _hermes_home / 'config.yaml'
+    if hermes_home is not None:
+        active_home = Path(hermes_home)
+    else:
+        override = get_hermes_home_override()
+        active_home = Path(override) if override else _hermes_home
+    config_path = active_home / 'config.yaml'
     try:
         from hermes_cli.config import get_config_path, read_raw_config
         # Fast path: if _hermes_home agrees with the canonical config
@@ -1243,7 +1384,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    ``agent:{profile}:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
     Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
@@ -1253,12 +1394,19 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if (
+        len(parts) >= 5
+        and parts[0] == "agent"
+        and parts[1] != "cron"
+        and _PROFILE_ID_RE.match(parts[1])
+    ):
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
             "chat_id": parts[4],
         }
+        if parts[1] != "main":
+            result["agent_profile"] = parts[1]
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]
         return result
@@ -1822,6 +1970,189 @@ class GatewayRunner:
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
+    def _hydrate_topic_profile_for_event(self, event: MessageEvent) -> None:
+        """Hydrate routed Telegram topic profile data before session-key use."""
+        source = getattr(event, "source", None)
+        if source is None:
+            return
+
+        BasePlatformAdapter._copy_event_profile_to_source(event)
+        if getattr(source, "agent_profile", None):
+            return
+        if source.platform != Platform.TELEGRAM:
+            return
+
+        config = getattr(self, "config", None)
+        try:
+            platform_cfg = config.platforms.get(Platform.TELEGRAM) if config else None
+        except Exception:
+            platform_cfg = None
+        if not platform_cfg:
+            return
+
+        extra = getattr(platform_cfg, "extra", None) or {}
+        if not isinstance(extra, dict) or not extra.get("topic_profiles"):
+            return
+
+        chat_id = str(getattr(source, "chat_id", "") or "").strip()
+        if not chat_id:
+            return
+
+        thread_id = getattr(source, "thread_id", None)
+        thread_id_s = str(thread_id).strip() if thread_id is not None else None
+        if not thread_id_s:
+            raw_message = getattr(event, "raw_message", None)
+            raw_thread_id = getattr(raw_message, "message_thread_id", None)
+            if raw_thread_id is not None:
+                thread_id_s = str(raw_thread_id)
+            if thread_id_s:
+                source.thread_id = thread_id_s
+
+        route = resolve_topic_profile(extra, chat_id, thread_id_s)
+        if not route:
+            return
+
+        profile = route.get("profile")
+        home = route.get("profile_home")
+        if profile and not getattr(source, "agent_profile", None):
+            source.agent_profile = profile
+            event.agent_profile = getattr(event, "agent_profile", None) or profile
+        if home and not getattr(source, "agent_hermes_home", None):
+            source.agent_hermes_home = home
+            event.agent_hermes_home = getattr(event, "agent_hermes_home", None) or home
+
+    def _topic_profile_homes(self) -> list[Path]:
+        """Return concrete Hermes homes configured for routed topic profiles."""
+        homes: list[Path] = []
+        seen: set[str] = set()
+        config = getattr(self, "config", None)
+        if not config:
+            return homes
+        try:
+            platform_items = list((config.platforms or {}).items())
+        except Exception:
+            return homes
+
+        for platform, platform_cfg in platform_items:
+            extra = getattr(platform_cfg, "extra", None) or {}
+            if not isinstance(extra, dict):
+                continue
+            routes = extra.get("topic_profiles") or []
+            if not isinstance(routes, list):
+                continue
+            for route in routes:
+                if not isinstance(route, dict):
+                    continue
+                profile = str(route.get("profile") or "").strip()
+                if not profile or profile == "default":
+                    continue
+                match = route.get("match") if isinstance(route.get("match"), dict) else {}
+                try:
+                    source = SessionSource(
+                        platform=platform,
+                        chat_id=str(match.get("chat_id") or ""),
+                        chat_type="group",
+                        thread_id=str(match.get("thread_id") or ""),
+                        agent_profile=profile,
+                        agent_hermes_home=str(route.get("profile_home") or "").strip() or None,
+                    )
+                    home = self._profile_home_for_source(source)
+                except Exception:
+                    logger.debug(
+                        "Could not resolve routed topic profile home for %r",
+                        profile,
+                        exc_info=True,
+                    )
+                    continue
+                if home is None:
+                    continue
+                key = str(home)
+                if key not in seen:
+                    seen.add(key)
+                    homes.append(home)
+        return homes
+
+    def _process_checkpoint_paths_for_topic_profiles(self) -> list[Path]:
+        """Return profile-scoped process checkpoint paths configured for topic routes."""
+        return [home / "processes.json" for home in self._topic_profile_homes()]
+
+    def _session_store_for_profile_home(self, profile_home: Path):
+        cache = getattr(self, "_profile_session_stores", None)
+        if cache is None:
+            self._profile_session_stores = {}
+            cache = self._profile_session_stores
+        key = str(profile_home)
+        if key not in cache:
+            with hermes_home_context(profile_home):
+                cache[key] = SessionStore(
+                    profile_home / "sessions",
+                    getattr(self, "config", GatewayConfig()),
+                )
+        return cache[key]
+
+    def _known_session_stores(self) -> list:
+        stores = []
+        seen: set[int] = set()
+
+        def add(store) -> None:
+            if store is None:
+                return
+            marker = id(store)
+            if marker in seen:
+                return
+            seen.add(marker)
+            stores.append(store)
+
+        add(getattr(self, "session_store", None))
+        for store in (getattr(self, "_profile_session_stores", None) or {}).values():
+            add(store)
+        for home in self._topic_profile_homes():
+            try:
+                add(self._session_store_for_profile_home(home))
+            except Exception:
+                logger.debug("Could not open routed profile session store for %s", home, exc_info=True)
+        return stores
+
+    def _session_store_for_session_key(self, session_key: str):
+        source = self._get_cached_session_source(session_key)
+        if source is not None:
+            try:
+                return self._session_store_for_source(source)
+            except Exception:
+                logger.debug(
+                    "Could not resolve session store from cached source for %s",
+                    session_key,
+                    exc_info=True,
+                )
+
+        primary = getattr(self, "session_store", None)
+        for store in self._known_session_stores():
+            entries = getattr(store, "_entries", None)
+            if isinstance(entries, dict) and session_key in entries:
+                return store
+            try:
+                lock = getattr(store, "_lock")
+                with lock:
+                    store._ensure_loaded_locked()  # noqa: SLF001
+                    entries = getattr(store, "_entries", None)
+                    if isinstance(entries, dict) and session_key in entries:
+                        return store
+            except Exception:
+                continue
+        return primary
+
+    def _mark_resume_pending_for_session_key(self, session_key: str, reason: str) -> bool:
+        store = self._session_store_for_session_key(session_key)
+        if store is None:
+            return False
+        return bool(store.mark_resume_pending(session_key, reason))
+
+    def _clear_resume_pending_for_session_key(self, session_key: str) -> bool:
+        store = self._session_store_for_session_key(session_key)
+        if store is None:
+            return False
+        return bool(store.clear_resume_pending(session_key))
+
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
 
@@ -1924,7 +2255,169 @@ class GatewayRunner:
             source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            profile=getattr(source, "agent_profile", None),
         )
+
+    def _profile_home_for_source(self, source: SessionSource) -> Optional[Path]:
+        profile = str(getattr(source, "agent_profile", None) or "").strip()
+        if not profile or profile == "default":
+            return None
+        try:
+            from hermes_cli.profiles import (
+                get_profile_dir,
+                profile_exists,
+                validate_profile_identity,
+                validate_profile_name,
+            )
+            validate_profile_name(profile)
+        except Exception as exc:
+            raise TopicProfileRoutingError(
+                f"Invalid routed Hermes profile name: {profile!r}"
+            ) from exc
+
+        safe_root = None
+        try:
+            platform_cfg = self.config.platforms.get(source.platform)
+            if platform_cfg:
+                safe_root_raw = platform_cfg.extra.get("topic_profiles_safe_root")
+                if safe_root_raw:
+                    safe_root = Path(str(safe_root_raw)).expanduser()
+                    if not safe_root.is_absolute():
+                        gateway_home = None
+                        try:
+                            sessions_dir = getattr(getattr(self, "session_store", None), "sessions_dir", None)
+                            if sessions_dir is not None:
+                                gateway_home = Path(sessions_dir).parent
+                        except Exception:
+                            gateway_home = None
+                        safe_root = (gateway_home or _hermes_home) / safe_root
+                    safe_root = safe_root.resolve(strict=False)
+        except Exception:
+            safe_root = None
+        if safe_root is None:
+            raise TopicProfileRoutingError(
+                "Routed topic profiles require telegram.topic_profiles_safe_root"
+            )
+        if safe_root == (Path.home() / ".hermes").resolve(strict=False):
+            raise TopicProfileRoutingError(
+                "telegram.topic_profiles_safe_root must not be ~/.hermes"
+            )
+
+        explicit = getattr(source, "agent_hermes_home", None)
+        if explicit:
+            explicit_path = Path(str(explicit)).expanduser()
+            if not explicit_path.is_absolute():
+                explicit_path = safe_root / explicit_path
+            if explicit_path.is_symlink():
+                raise TopicProfileRoutingError(
+                    f"Unsafe routed profile_home for {profile}: symlinks are not allowed"
+                )
+            try:
+                resolved = explicit_path.resolve(strict=False)
+                resolved.relative_to(safe_root)
+            except Exception as exc:
+                raise TopicProfileRoutingError(
+                    f"Unsafe routed profile_home for {profile}: path must stay inside "
+                    "topic_profiles_safe_root"
+                ) from exc
+            if resolved == (Path.home() / ".hermes").resolve(strict=False):
+                raise TopicProfileRoutingError(
+                    f"Unsafe routed profile_home for {profile}: ~/.hermes is forbidden"
+                )
+            if not resolved.is_dir():
+                raise TopicProfileRoutingError(
+                    f"Routed Hermes profile home does not exist for {profile}: {resolved}"
+                )
+            try:
+                validate_profile_identity(profile, resolved, safe_root)
+            except Exception as exc:
+                raise TopicProfileRoutingError(
+                    f"Routed Hermes profile identity failed for {profile}: {exc}"
+                ) from exc
+            return resolved
+
+        if not profile_exists(profile):
+            raise TopicProfileRoutingError(
+                f"Routed Hermes profile does not exist: {profile!r}. "
+                "Create it with `hermes profile create` or configure a safe profile_home."
+            )
+
+        resolved = get_profile_dir(profile).resolve(strict=False)
+        try:
+            resolved.relative_to(safe_root)
+        except Exception as exc:
+            raise TopicProfileRoutingError(
+                f"Routed Hermes profile home for {profile} is outside topic_profiles_safe_root"
+            ) from exc
+        try:
+            validate_profile_identity(profile, resolved, safe_root)
+        except Exception as exc:
+            raise TopicProfileRoutingError(
+                f"Routed Hermes profile identity failed for {profile}: {exc}"
+            ) from exc
+        return resolved
+
+    def _session_store_for_source(self, source: SessionSource):
+        profile_home = self._profile_home_for_source(source)
+        if profile_home is None:
+            store = getattr(self, "session_store", None)
+            if store is None:
+                store = SessionStore(_hermes_home / "sessions", getattr(self, "config", GatewayConfig()))
+                self.session_store = store
+            return store
+        return self._session_store_for_profile_home(profile_home)
+
+    def _session_db_for_source(self, source: SessionSource):
+        """Return the SQLite SessionDB associated with the source's active store."""
+        profile_home = self._profile_home_for_source(source)
+        if profile_home is None:
+            explicit = getattr(self, "_session_db", None)
+            if explicit is not None:
+                return explicit
+        try:
+            store = self._session_store_for_source(source)
+            db = getattr(store, "_db", None)
+            if db is not None:
+                return db
+        except Exception as exc:
+            if profile_home is not None:
+                raise TopicProfileRoutingError(
+                    f"Routed Hermes profile session DB is unavailable for {profile_home}"
+                ) from exc
+        if profile_home is not None:
+            raise TopicProfileRoutingError(
+                f"Routed Hermes profile session DB is unavailable for {profile_home}"
+            )
+        return getattr(self, "_session_db", None)
+
+    def _runtime_env_for_profile_home(self, profile_home: Path) -> dict:
+        """Read profile-local runtime env and mark auth fallbacks as forbidden."""
+        from hermes_cli.env_loader import read_hermes_dotenv_values
+        runtime_env = read_hermes_dotenv_values(hermes_home=profile_home)
+        runtime_env["HERMES_PROFILE_STRICT_AUTH"] = "1"
+        runtime_env["HERMES_HOME"] = str(profile_home)
+        return runtime_env
+
+    def _set_command_hermes_home_for_source(self, source: SessionSource):
+        """Install the routed profile HERMES_HOME for gateway-handled commands."""
+        profile_home = self._profile_home_for_source(source)
+        if profile_home is None:
+            return None
+        return set_hermes_home_override(profile_home)
+
+    def _resolved_agent_hermes_home_for_source(self, source: Optional[SessionSource]) -> str:
+        """Return the concrete routed HERMES_HOME for session-scoped tool context."""
+        if source is None:
+            return ""
+        try:
+            profile_home = self._profile_home_for_source(source)
+        except TopicProfileRoutingError:
+            raise
+        except Exception:
+            profile_home = None
+        if profile_home is not None:
+            return str(profile_home)
+        return str(getattr(source, "agent_hermes_home", None) or "")
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
@@ -2092,6 +2585,7 @@ class GatewayRunner:
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
+        runtime_env: Optional[dict] = None,
     ) -> tuple[str, dict]:
         """Resolve model/runtime for a session, honoring session-scoped /model overrides.
 
@@ -2105,6 +2599,17 @@ class GatewayRunner:
                 resolved_session_key = self._session_key_for_source(source)
             except Exception:
                 resolved_session_key = None
+
+        if runtime_env is None and source is not None and getattr(source, "agent_profile", None):
+            try:
+                profile_home = self._profile_home_for_source(source)
+                if profile_home is not None:
+                    runtime_env = self._runtime_env_for_profile_home(profile_home)
+            except TopicProfileRoutingError:
+                raise
+            except Exception as exc:
+                logger.debug("Could not read routed profile runtime env: %s", exc)
+                runtime_env = {}
 
         model = _resolve_gateway_model(user_config)
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
@@ -2136,7 +2641,12 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        try:
+            runtime_kwargs = _resolve_runtime_agent_kwargs(runtime_env=runtime_env)
+        except TypeError:
+            # Some tests monkeypatch this helper with the historical no-arg
+            # shape. Production helper accepts runtime_env.
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -2521,21 +3031,30 @@ class GatewayRunner:
         return True
 
     @staticmethod
-    def _load_prefill_messages() -> List[Dict[str, Any]]:
+    def _load_prefill_messages(
+        *,
+        config: Optional[dict] = None,
+        hermes_home: Optional[Path] = None,
+        include_env: bool = True,
+    ) -> List[Dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.
         
-        Checks HERMES_PREFILL_MESSAGES_FILE env var first, then falls back to
-        the prefill_messages_file key in ~/.hermes/config.yaml.
-        Relative paths are resolved from ~/.hermes/.
+        Checks HERMES_PREFILL_MESSAGES_FILE env var first when ``include_env``
+        is true, then falls back to the prefill_messages_file key in the active
+        profile's config. Relative paths are resolved from that profile home.
         """
-        file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
+        base_home = Path(hermes_home) if hermes_home is not None else _hermes_home
+        file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "") if include_env else ""
         if not file_path:
             try:
-                import yaml as _y
-                cfg_path = _hermes_home / "config.yaml"
-                if cfg_path.exists():
-                    with open(cfg_path, encoding="utf-8") as _f:
-                        cfg = _y.safe_load(_f) or {}
+                cfg = config
+                if cfg is None:
+                    import yaml as _y
+                    cfg_path = base_home / "config.yaml"
+                    if cfg_path.exists():
+                        with open(cfg_path, encoding="utf-8") as _f:
+                            cfg = _y.safe_load(_f) or {}
+                if isinstance(cfg, dict):
                     file_path = cfg.get("prefill_messages_file", "")
             except Exception:
                 pass
@@ -2543,7 +3062,7 @@ class GatewayRunner:
             return []
         path = Path(file_path).expanduser()
         if not path.is_absolute():
-            path = _hermes_home / path
+            path = base_home / path
         if not path.exists():
             logger.warning("Prefill messages file not found: %s", path)
             return []
@@ -2559,28 +3078,42 @@ class GatewayRunner:
             return []
 
     @staticmethod
-    def _load_ephemeral_system_prompt() -> str:
+    def _load_ephemeral_system_prompt(
+        *,
+        config: Optional[dict] = None,
+        hermes_home: Optional[Path] = None,
+        include_env: bool = True,
+    ) -> str:
         """Load ephemeral system prompt from config or env var.
         
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first when ``include_env``
+        is true, then falls back to agent.system_prompt in the active profile's
+        config.
         """
-        prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
+        prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "") if include_env else ""
         if prompt:
             return prompt
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
+            cfg = config
+            if cfg is None:
+                import yaml as _y
+                base_home = Path(hermes_home) if hermes_home is not None else _hermes_home
+                cfg_path = base_home / "config.yaml"
+                if cfg_path.exists():
+                    with open(cfg_path, encoding="utf-8") as _f:
+                        cfg = _y.safe_load(_f) or {}
+            if isinstance(cfg, dict):
                 return (cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
         except Exception:
             pass
         return ""
 
     @staticmethod
-    def _load_reasoning_config() -> dict | None:
+    def _load_reasoning_config(
+        *,
+        config: Optional[dict] = None,
+        hermes_home: Optional[Path] = None,
+    ) -> dict | None:
         """Load reasoning effort from config.yaml.
 
         Reads agent.reasoning_effort from config.yaml. Valid: "none",
@@ -2590,11 +3123,15 @@ class GatewayRunner:
         from hermes_constants import parse_reasoning_effort
         effort = ""
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
+            cfg = config
+            if cfg is None:
+                import yaml as _y
+                base_home = Path(hermes_home) if hermes_home is not None else _hermes_home
+                cfg_path = base_home / "config.yaml"
+                if cfg_path.exists():
+                    with open(cfg_path, encoding="utf-8") as _f:
+                        cfg = _y.safe_load(_f) or {}
+            if isinstance(cfg, dict):
                 effort = str(cfg_get(cfg, "agent", "reasoning_effort", default="") or "").strip()
         except Exception:
             pass
@@ -2634,6 +3171,8 @@ class GatewayRunner:
         *,
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
+        user_config: Optional[dict] = None,
+        hermes_home: Optional[Path] = None,
     ) -> dict | None:
         """Resolve reasoning effort for a session, honoring session overrides."""
         resolved_session_key = session_key
@@ -2646,7 +3185,7 @@ class GatewayRunner:
         overrides = getattr(self, "_session_reasoning_overrides", {}) or {}
         if resolved_session_key and resolved_session_key in overrides:
             return overrides[resolved_session_key]
-        return self._load_reasoning_config()
+        return self._load_reasoning_config(config=user_config, hermes_home=hermes_home)
 
     def _set_session_reasoning_override(
         self,
@@ -2664,7 +3203,11 @@ class GatewayRunner:
             self._session_reasoning_overrides[session_key] = dict(reasoning_config)
 
     @staticmethod
-    def _load_service_tier() -> str | None:
+    def _load_service_tier(
+        *,
+        config: Optional[dict] = None,
+        hermes_home: Optional[Path] = None,
+    ) -> str | None:
         """Load Priority Processing setting from config.yaml.
 
         Reads agent.service_tier from config.yaml. Accepted values mirror the CLI:
@@ -2673,11 +3216,15 @@ class GatewayRunner:
         """
         raw = ""
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
+            cfg = config
+            if cfg is None:
+                import yaml as _y
+                base_home = Path(hermes_home) if hermes_home is not None else _hermes_home
+                cfg_path = base_home / "config.yaml"
+                if cfg_path.exists():
+                    with open(cfg_path, encoding="utf-8") as _f:
+                        cfg = _y.safe_load(_f) or {}
+            if isinstance(cfg, dict):
                 raw = str(cfg_get(cfg, "agent", "service_tier", default="") or "").strip()
         except Exception:
             pass
@@ -2789,14 +3336,22 @@ class GatewayRunner:
         return mode
 
     @staticmethod
-    def _load_provider_routing() -> dict:
+    def _load_provider_routing(
+        *,
+        config: Optional[dict] = None,
+        hermes_home: Optional[Path] = None,
+    ) -> dict:
         """Load OpenRouter provider routing preferences from config.yaml."""
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
+            cfg = config
+            if cfg is None:
+                import yaml as _y
+                base_home = Path(hermes_home) if hermes_home is not None else _hermes_home
+                cfg_path = base_home / "config.yaml"
+                if cfg_path.exists():
+                    with open(cfg_path, encoding="utf-8") as _f:
+                        cfg = _y.safe_load(_f) or {}
+            if isinstance(cfg, dict):
                 return cfg.get("provider_routing", {}) or {}
         except Exception:
             pass
@@ -3095,9 +3650,10 @@ class GatewayRunner:
         for session_key in active:
             source = None
             try:
-                if getattr(self, "session_store", None) is not None:
-                    self.session_store._ensure_loaded()
-                    entry = self.session_store._entries.get(session_key)
+                store = self._session_store_for_session_key(session_key)
+                if store is not None:
+                    store._ensure_loaded()
+                    entry = store._entries.get(session_key)
                     source = getattr(entry, "origin", None) if entry else None
             except Exception as e:
                 logger.debug(
@@ -3515,16 +4071,18 @@ class GatewayRunner:
         message, or on the next gateway startup.
         """
         window = _auto_continue_freshness_window()
+        candidates = []
         try:
-            with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
-                self.session_store._ensure_loaded_locked()  # noqa: SLF001
-                candidates = [
-                    entry for entry in self.session_store._entries.values()  # noqa: SLF001
-                    if entry.resume_pending
-                    and not entry.suspended
-                    and entry.origin is not None
-                    and entry.resume_reason in self._AUTO_RESUME_REASONS
-                ]
+            for store in self._known_session_stores():
+                with store._lock:  # noqa: SLF001 — snapshot under lock
+                    store._ensure_loaded_locked()  # noqa: SLF001
+                    candidates.extend(
+                        entry for entry in store._entries.values()  # noqa: SLF001
+                        if entry.resume_pending
+                        and not entry.suspended
+                        and entry.origin is not None
+                        and entry.resume_reason in self._AUTO_RESUME_REASONS
+                    )
         except Exception as exc:
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
@@ -3777,7 +4335,9 @@ class GatewayRunner:
         # Recover background processes from checkpoint (crash recovery)
         try:
             from tools.process_registry import process_registry
-            recovered = process_registry.recover_from_checkpoint()
+            recovered = process_registry.recover_from_checkpoint(
+                checkpoint_paths=self._process_checkpoint_paths_for_topic_profiles()
+            )
             if recovered:
                 logger.info("Recovered %s background process(es) from previous run", recovered)
         except Exception as e:
@@ -3849,6 +4409,8 @@ class GatewayRunner:
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            if hasattr(adapter, "set_topic_profile_route_resolver"):
+                adapter.set_topic_profile_route_resolver(self._hydrate_topic_profile_for_event)
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -5456,6 +6018,8 @@ class GatewayRunner:
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    if hasattr(adapter, "set_topic_profile_route_resolver"):
+                        adapter.set_topic_profile_route_resolver(self._hydrate_topic_profile_for_event)
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
@@ -5617,7 +6181,7 @@ class GatewayRunner:
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
                 try:
-                    self.session_store.mark_resume_pending(
+                    self._mark_resume_pending_for_session_key(
                         _sk,
                         "restart_timeout" if self._restart_requested else "shutdown_timeout",
                     )
@@ -5644,7 +6208,7 @@ class GatewayRunner:
                 for _sk in _pre_drain_keys:
                     if _sk not in self._running_agents:
                         try:
-                            self.session_store.clear_resume_pending(_sk)
+                            self._clear_resume_pending_for_session_key(_sk)
                         except Exception as _e:
                             logger.debug(
                                 "clear_resume_pending after drain failed for %s: %s",
@@ -5685,7 +6249,7 @@ class GatewayRunner:
                     if _agent is _AGENT_PENDING_SENTINEL:
                         continue
                     try:
-                        self.session_store.mark_resume_pending(_sk, _resume_reason)
+                        self._mark_resume_pending_for_session_key(_sk, _resume_reason)
                     except Exception as _e:
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",
@@ -6431,6 +6995,12 @@ class GatewayRunner:
         7. Return response
         """
         source = event.source
+        self._hydrate_topic_profile_for_event(event)
+        source = event.source
+        routed_profile_topic = bool(
+            getattr(source, "agent_profile", None)
+            or getattr(source, "agent_hermes_home", None)
+        )
 
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
@@ -6443,7 +7013,7 @@ class GatewayRunner:
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
+        if not is_internal and not routed_profile_topic:
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
                 _hook_results = _invoke_hook(
@@ -7064,16 +7634,32 @@ class GatewayRunner:
         # don't depend on the exact alias the user typed.
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command
+        if isinstance(self.config, dict):
+            quick_commands = self.config.get("quick_commands", {}) or {}
+        else:
+            quick_commands = getattr(self.config, "quick_commands", {}) or {}
+        if not isinstance(quick_commands, dict):
+            quick_commands = {}
+
+        if (
+            command
+            and (getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None))
+            and command in quick_commands
+        ):
+            return (
+                f"`/{command}` is disabled in routed profile topics. "
+                "Quick commands run in the gateway process."
+            )
+        routed_profile_topic = bool(
+            getattr(source, "agent_profile", None)
+            or getattr(source, "agent_hermes_home", None)
+        )
 
         # Expand alias quick commands before built-in dispatch so targets like
-        # /model openai/gpt-5.5 --provider openrouter reach the /model handler.
+        # /model provider/example-model --provider example reach the /model handler.
         # Preserve built-in precedence; aliases only need early handling when
         # the typed command is not already known.
         if command and _cmd_def is None:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
             if isinstance(quick_commands, dict) and command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "alias":
@@ -7086,6 +7672,18 @@ class GatewayRunner:
                         command = target_command.split()[0] if target_command else target_command
                         _cmd_def = _resolve_cmd(command) if command else None
                         canonical = _cmd_def.name if _cmd_def else command
+
+        if command and routed_profile_topic:
+            try:
+                from hermes_cli.plugins import get_plugin_command_handler
+                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
+            except Exception:
+                plugin_handler = None
+            if plugin_handler:
+                return (
+                    f"`/{command}` is disabled in routed profile topics. "
+                    "Plugin slash commands run in the gateway process."
+                )
 
         # Per-platform slash command access control. Only kicks in when the
         # operator has set ``allow_admin_from`` for the source's scope (DM
@@ -7105,7 +7703,7 @@ class GatewayRunner:
         # the previous fire-and-forget emit(): return values are now
         # honored, but handlers that return nothing behave exactly as
         # before (telemetry-style hooks keep working).
-        if command and is_gateway_known_command(canonical):
+        if command and is_gateway_known_command(canonical) and not routed_profile_topic:
             raw_args = event.get_command_args().strip()
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
@@ -7317,12 +7915,6 @@ class GatewayRunner:
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if not isinstance(quick_commands, dict):
-                quick_commands = {}
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
@@ -7376,6 +7968,11 @@ class GatewayRunner:
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
+                    if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+                        return (
+                            f"`/{command}` is disabled in routed profile topics. "
+                            "Plugin slash commands run in the gateway process."
+                        )
                     user_args = event.get_command_args().strip()
                     result = plugin_handler(user_args)
                     if asyncio.iscoroutine(result):
@@ -7392,7 +7989,11 @@ class GatewayRunner:
             # Skill bundles take precedence over individual skill commands —
             # /<bundle> loads multiple skills at once. Mirrors CLI dispatch.
             _bundle_handled = False
+            _bundle_home_token = None
             try:
+                _bundle_profile_home = self._profile_home_for_source(source)
+                if _bundle_profile_home is not None:
+                    _bundle_home_token = set_hermes_home_override(_bundle_profile_home)
                 from agent.skill_bundles import (
                     build_bundle_invocation_message,
                     resolve_bundle_command_key,
@@ -7411,13 +8012,22 @@ class GatewayRunner:
                             logger.info(
                                 "Bundle %s skipped missing skills: %s",
                                 bundle_key, ", ".join(missing),
-                            )
+                        )
                         # Fall through to normal message processing with bundle content
+            except TopicProfileRoutingError as exc:
+                return f"⚠️ Topic profile routing failed: {exc}"
             except Exception as exc:
                 logger.debug("Bundle dispatch failed (non-fatal): %s", exc)
+            finally:
+                if _bundle_home_token is not None:
+                    reset_hermes_home_override(_bundle_home_token)
 
         if command and not locals().get("_bundle_handled", False):
+            _skill_home_token = None
             try:
+                _skill_profile_home = self._profile_home_for_source(source)
+                if _skill_profile_home is not None:
+                    _skill_home_token = set_hermes_home_override(_skill_profile_home)
                 from agent.skill_commands import (
                     get_skill_commands,
                     build_skill_invocation_message,
@@ -7473,8 +8083,14 @@ class GatewayRunner:
                             f"or resend without the leading slash to send "
                             f"as a regular message."
                         )
+            except TopicProfileRoutingError as e:
+                logger.error("Topic profile routing failed closed for skill command: %s", e)
+                return f"⚠️ Topic profile routing failed: {e}"
             except Exception as e:
                 logger.debug("Skill command check failed (non-fatal): %s", e)
+            finally:
+                if _skill_home_token is not None:
+                    reset_hermes_home_override(_skill_home_token)
         
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger
@@ -7517,7 +8133,8 @@ class GatewayRunner:
                 # on error. Let the user drive the next turn.
                 if _final_text.strip():
                     try:
-                        session_entry = self.session_store.get_or_create_session(source)
+                        session_store = self._session_store_for_source(source)
+                        session_entry = session_store.get_or_create_session(source)
                     except Exception:
                         session_entry = None
                     if session_entry is not None:
@@ -7823,13 +8440,30 @@ class GatewayRunner:
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
+        _session_env_tokens = []
+        self._hydrate_topic_profile_for_event(event)
+        source = event.source
+        try:
+            _profile_home = self._profile_home_for_source(source)
+        except TopicProfileRoutingError as exc:
+            logger.error("Topic profile routing failed closed: %s", exc)
+            return f"⚠️ Topic profile routing failed: {exc}"
+        _profile_home_token = (
+            set_hermes_home_override(_profile_home)
+            if _profile_home is not None
+            else None
+        )
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
         logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r",
+            "inbound message: platform=%s user=%s chat=%s profile=%s msg=%r",
             _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview,
+            source.chat_id or "unknown",
+            getattr(source, "agent_profile", None) or "main",
+            _msg_preview,
         )
 
         # Get or create session
@@ -7848,15 +8482,15 @@ class GatewayRunner:
             except Exception:
                 pass
 
-        session_entry = self.session_store.get_or_create_session(source)
+        session_entry = session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         self._cache_session_source(session_key, source)
         if self._is_telegram_topic_lane(source):
             try:
-                binding = self._session_db.get_telegram_topic_binding(
+                binding = session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
-                ) if self._session_db else None
+                ) if session_db else None
             except Exception:
                 logger.debug("Failed to read Telegram topic binding", exc_info=True)
                 binding = None
@@ -7868,7 +8502,7 @@ class GatewayRunner:
                     # lane session is ended cleanly. Mutating session_entry in
                     # place here created a split-brain state where the JSON
                     # index pointed at one id but code downstream used another.
-                    switched = self.session_store.switch_session(session_key, bound_session_id)
+                    switched = session_store.switch_session(session_key, bound_session_id)
                     if switched is not None:
                         session_entry = switched
             else:
@@ -7904,8 +8538,15 @@ class GatewayRunner:
                 "session_key": session_key,
             })
         
-        # Build session context
-        context = build_session_context(source, self.config, session_entry)
+        # Build session context. Routed profile turns must not inherit the
+        # gateway's global delivery/home-channel map into the agent prompt.
+        context_config = self.config
+        if _profile_home is not None:
+            context_config = dataclasses.replace(
+                self.config if not isinstance(self.config, dict) else GatewayConfig(),
+                platforms={},
+            )
+        context = build_session_context(source, context_config, session_entry)
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
@@ -7913,7 +8554,7 @@ class GatewayRunner:
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
         try:
-            _pcfg = _load_gateway_config()
+            _pcfg = _load_gateway_config(_profile_home) if _profile_home is not None else _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
         except Exception:
             pass
@@ -7938,7 +8579,7 @@ class GatewayRunner:
             # - the platform is excluded (e.g. api_server, webhook)
             # - the expired session had no activity (nothing was cleared)
             try:
-                policy = self.session_store.config.get_reset_policy(
+                policy = session_store.config.get_reset_policy(
                     platform=source.platform,
                     session_type=getattr(source, 'chat_type', 'dm'),
                 )
@@ -7970,7 +8611,7 @@ class GatewayRunner:
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
                         try:
-                            session_info = self._format_session_info()
+                            session_info = self._format_session_info(source)
                             if session_info:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
@@ -8022,7 +8663,7 @@ class GatewayRunner:
                 logger.warning("[Gateway] Failed to auto-load skill(s) %s: %s", _skill_names, e)
 
         # Load conversation history from transcript
-        history = self.session_store.load_transcript(session_entry.session_id)
+        history = session_store.load_transcript(session_entry.session_id)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -8062,8 +8703,15 @@ class GatewayRunner:
             _hyg_base_url = None
             _hyg_api_key = None
             _hyg_data = {}
+            _hyg_runtime_env = None
             try:
                 _hyg_data = _load_gateway_config()
+                if _profile_home is not None:
+                    try:
+                        _hyg_runtime_env = self._runtime_env_for_profile_home(_profile_home)
+                    except Exception as exc:
+                        logger.debug("Could not read routed profile .env for session hygiene: %s", exc)
+                        _hyg_runtime_env = {}
                 if _hyg_data:
                     # Resolve model name (same logic as run_sync)
                     _model_cfg = _hyg_data.get("model", {})
@@ -8105,6 +8753,7 @@ class GatewayRunner:
                         source=source,
                         session_key=session_key,
                         user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                        runtime_env=_hyg_runtime_env,
                     )
                     _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
                     _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
@@ -8208,8 +8857,22 @@ class GatewayRunner:
                             source=source,
                             session_key=session_key,
                             user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                            runtime_env=_hyg_runtime_env,
                         )
-                        if _hyg_runtime.get("api_key"):
+                        if _profile_home is not None:
+                            from hermes_cli.auth import has_usable_secret
+                            _hyg_has_provider = bool(
+                                _hyg_runtime.get("credential_pool")
+                                or _hyg_runtime.get("command")
+                                or has_usable_secret(str(_hyg_runtime.get("api_key") or ""))
+                            )
+                        else:
+                            _hyg_has_provider = bool(
+                                _hyg_runtime.get("api_key")
+                                or _hyg_runtime.get("credential_pool")
+                                or _hyg_runtime.get("command")
+                            )
+                        if _hyg_has_provider:
                             _hyg_msgs = [
                                 {"role": m.get("role"), "content": m.get("content")}
                                 for m in history
@@ -8226,13 +8889,18 @@ class GatewayRunner:
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=session_db,
+                                    fallback_model=(
+                                        _hyg_data.get("fallback_providers")
+                                        or _hyg_data.get("fallback_model")
+                                        or (None if _profile_home is not None else getattr(self, "_fallback_model", None))
+                                    ),
+                                    runtime_env=_hyg_runtime_env,
                                 )
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
-                                    loop = asyncio.get_running_loop()
-                                    _compressed, _ = await loop.run_in_executor(
-                                        None,
+                                    _compressed, _ = await self._run_in_executor_with_context(
                                         lambda: _hyg_agent._compress_context(
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
@@ -8246,9 +8914,9 @@ class GatewayRunner:
                                     _hyg_new_sid = _hyg_agent.session_id
                                     if _hyg_new_sid != session_entry.session_id:
                                         session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
+                                        session_store._save()
 
-                                    self.session_store.rewrite_transcript(
+                                    session_store.rewrite_transcript(
                                         session_entry.session_id, _compressed
                                     )
                                     # Reset stored token count — transcript was rewritten
@@ -8339,7 +9007,7 @@ class GatewayRunner:
                         )
 
         # First-message onboarding -- only on the very first interaction ever
-        if not history and not self.session_store.has_any_sessions():
+        if not history and not session_store.has_any_sessions():
             context_prompt += (
                 "\n\n[System note: This is the user's very first message ever. "
                 "Briefly introduce yourself and mention that /help shows available commands. "
@@ -8433,6 +9101,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                session_db=session_db,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -8493,7 +9162,7 @@ class GatewayRunner:
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
                 self._clear_restart_failure_count(session_key)
                 try:
-                    self.session_store.clear_resume_pending(session_key)
+                    session_store.clear_resume_pending(session_key)
                 except Exception as _e:
                     logger.debug(
                         "clear_resume_pending failed for %s: %s",
@@ -8655,7 +9324,7 @@ class GatewayRunner:
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
                 )
-                self.session_store.reset_session(session_key)
+                session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
                 self._set_session_reasoning_override(session_key, None)
@@ -8676,7 +9345,7 @@ class GatewayRunner:
                 pass  # Skip all transcript writes — don't grow a broken session
             elif not history:
                 tool_defs = agent_result.get("tools", [])
-                self.session_store.append_to_transcript(
+                session_store.append_to_transcript(
                     session_entry.session_id,
                     {
                         "role": "session_meta",
@@ -8701,7 +9370,7 @@ class GatewayRunner:
                 _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
-                self.session_store.append_to_transcript(
+                session_store.append_to_transcript(
                     session_entry.session_id,
                     _user_entry,
                 )
@@ -8714,12 +9383,12 @@ class GatewayRunner:
                     _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
-                    self.session_store.append_to_transcript(
+                    session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,
                     )
                     if response:
-                        self.session_store.append_to_transcript(
+                        session_store.append_to_transcript(
                             session_entry.session_id,
                             {"role": "assistant", "content": response, "timestamp": ts}
                         )
@@ -8728,7 +9397,7 @@ class GatewayRunner:
                     # _flush_messages_to_session_db(), so skip the DB write here
                     # to prevent the duplicate-write bug (#860).  We still write
                     # to JSONL for backward compatibility and as a backup.
-                    agent_persisted = self._session_db is not None
+                    agent_persisted = session_db is not None
                     # Attach the inbound platform message_id to the first user
                     # entry written this turn so platform-level quote-resolution
                     # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
@@ -8748,7 +9417,7 @@ class GatewayRunner:
                         ):
                             entry["message_id"] = str(event.message_id)
                             _user_msg_id_attached = True
-                        self.session_store.append_to_transcript(
+                        session_store.append_to_transcript(
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
                         )
@@ -8756,7 +9425,7 @@ class GatewayRunner:
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and
             # compression decisions.
-            self.session_store.update_session(
+            session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
@@ -8865,8 +9534,10 @@ class GatewayRunner:
         finally:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
+            if _profile_home_token is not None:
+                reset_hermes_home_override(_profile_home_token)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: Optional[SessionSource] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
@@ -8875,17 +9546,88 @@ class GatewayRunner:
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
-        model = _resolve_gateway_model()
+        def _providers_equivalent(config_provider: Optional[str], runtime_provider: Optional[str]) -> bool:
+            configured = (config_provider or "").strip().lower()
+            runtime_name = (runtime_provider or "").strip().lower()
+            if not configured or not runtime_name:
+                return False
+            if configured == runtime_name:
+                return True
+            return configured.startswith("custom:") and runtime_name == "custom"
+
+        profile_home = None
+        runtime_env = None
+        if source is not None:
+            profile_home = self._profile_home_for_source(source)
+            if profile_home is not None:
+                try:
+                    runtime_env = self._runtime_env_for_profile_home(profile_home)
+                except Exception as exc:
+                    logger.debug(
+                        "Could not read routed profile runtime env for session info: %s",
+                        exc,
+                    )
+                    runtime_env = {}
+
+        data = _load_gateway_config(profile_home) if profile_home is not None else _load_gateway_config(_hermes_home)
+        configured_model = _resolve_gateway_model(data)
+        model = configured_model
         config_context_length = None
+        config_provider = None
+        config_base_url = None
         provider = None
         base_url = None
         api_key = None
         custom_provs = None
-        data = None
 
         try:
-            data = _load_gateway_config()
             if data:
+                model_cfg = data.get("model", {})
+                if isinstance(model_cfg, dict):
+                    config_provider = model_cfg.get("provider") or None
+                    config_base_url = model_cfg.get("base_url") or None
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers
+                    custom_provs = get_compatible_custom_providers(data)
+                except Exception:
+                    custom_provs = data.get("custom_providers")
+        except Exception:
+            pass
+
+        # Resolve runtime credentials for probing. For routed profiles, keep
+        # all config/auth/fallback lookup under the profile's Hermes home so
+        # global gateway credentials cannot leak into the displayed session.
+        try:
+            if source is not None:
+                if profile_home is not None:
+                    with hermes_home_context(profile_home):
+                        model, runtime = self._resolve_session_agent_runtime(
+                            source=source,
+                            user_config=data,
+                            runtime_env=runtime_env,
+                        )
+                else:
+                    model, runtime = self._resolve_session_agent_runtime(
+                        source=source,
+                        user_config=data,
+                        runtime_env=runtime_env,
+                    )
+            else:
+                runtime = _resolve_runtime_agent_kwargs()
+            runtime_provider = runtime.get("provider")
+            provider = (
+                config_provider
+                if _providers_equivalent(config_provider, runtime_provider)
+                else (runtime_provider or config_provider)
+            )
+            base_url = runtime.get("base_url") or config_base_url
+            api_key = runtime.get("api_key")
+        except Exception:
+            provider = config_provider
+            base_url = config_base_url
+
+        try:
+            if data and model == configured_model:
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
                     raw_ctx = model_cfg.get("context_length")
@@ -8894,13 +9636,6 @@ class GatewayRunner:
                             config_context_length = int(raw_ctx)
                         except (TypeError, ValueError):
                             pass
-                    provider = model_cfg.get("provider") or None
-                    base_url = model_cfg.get("base_url") or None
-                try:
-                    from hermes_cli.config import get_compatible_custom_providers
-                    custom_provs = get_compatible_custom_providers(data)
-                except Exception:
-                    custom_provs = data.get("custom_providers")
         except Exception:
             pass
 
@@ -8938,15 +9673,6 @@ class GatewayRunner:
                                     pass
             except Exception:
                 pass
-
-        # Resolve runtime credentials for probing
-        try:
-            runtime = _resolve_runtime_agent_kwargs()
-            provider = provider or runtime.get("provider")
-            base_url = base_url or runtime.get("base_url")
-            api_key = runtime.get("api_key")
-        except Exception:
-            pass
 
         context_length = get_model_context_length(
             model,
@@ -8995,7 +9721,9 @@ class GatewayRunner:
 
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.
-        old_entry = self.session_store._entries.get(session_key)
+        active_session_store = self._session_store_for_source(source)
+        active_session_db = getattr(active_session_store, "_db", None)
+        old_entry = active_session_store._entries.get(session_key)
 
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.
@@ -9029,7 +9757,7 @@ class GatewayRunner:
             pass
 
         # Reset the session
-        new_entry = self.session_store.reset_session(session_key)
+        new_entry = active_session_store.reset_session(session_key)
 
         # Clear any session-scoped model/reasoning overrides so the next agent
         # picks up configured defaults instead of previous session switches.
@@ -9068,7 +9796,7 @@ class GatewayRunner:
 
         # Resolve session config info to surface to the user
         try:
-            session_info = self._format_session_info()
+            session_info = self._format_session_info(source)
         except Exception:
             session_info = ""
 
@@ -9076,13 +9804,13 @@ class GatewayRunner:
             header = self._telegram_topic_new_header(source) or t("gateway.reset.header_default")
         else:
             # No existing session, just create one
-            new_entry = self.session_store.get_or_create_session(source, force_new=True)
+            new_entry = active_session_store.get_or_create_session(source, force_new=True)
             header = self._telegram_topic_new_header(source) or t("gateway.reset.header_new")
 
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""
-        if _title_arg and self._session_db and new_entry:
+        if _title_arg and active_session_db and new_entry:
             from hermes_state import SessionDB
             try:
                 sanitized = SessionDB.sanitize_title(_title_arg)
@@ -9091,7 +9819,7 @@ class GatewayRunner:
                 _title_note = t("gateway.reset.title_rejected", error=str(e))
             if sanitized:
                 try:
-                    self._session_db.set_session_title(new_entry.session_id, sanitized)
+                    active_session_db.set_session_title(new_entry.session_id, sanitized)
                     header = t("gateway.reset.header_titled", title=sanitized)
                 except ValueError as e:
                     _title_note = t("gateway.reset.title_error_untitled", error=str(e))
@@ -9138,8 +9866,19 @@ class GatewayRunner:
         from hermes_constants import display_hermes_home
         from hermes_cli.profiles import get_active_profile_name
 
-        display = display_hermes_home()
-        profile_name = get_active_profile_name()
+        source = event.source
+        routed_profile = str(getattr(source, "agent_profile", "") or "").strip()
+        routed_home = str(getattr(source, "agent_hermes_home", "") or "").strip()
+        if routed_profile or routed_home:
+            try:
+                profile_home = self._profile_home_for_source(source)
+            except TopicProfileRoutingError as exc:
+                return f"⚠️ Topic profile routing failed: {exc}"
+            profile_name = routed_profile or "routed"
+            display = str(profile_home) if profile_home is not None else (routed_home or display_hermes_home())
+        else:
+            display = display_hermes_home()
+            profile_name = get_active_profile_name()
 
         lines = [
             t("gateway.profile.header", profile=profile_name),
@@ -9345,7 +10084,9 @@ class GatewayRunner:
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
+        session_entry = session_store.get_or_create_session(source)
 
         connected_platforms = [p.value for p in self.adapters.keys()]
 
@@ -9365,13 +10106,13 @@ class GatewayRunner:
         # single source of truth; reading it here keeps /status accurate
         # without duplicating token writes into two stores.
         db_total_tokens = 0
-        if self._session_db:
+        if session_db:
             try:
-                title = self._session_db.get_session_title(session_entry.session_id)
+                title = session_db.get_session_title(session_entry.session_id)
             except Exception:
                 title = None
             try:
-                row = self._session_db.get_session(session_entry.session_id)
+                row = session_db.get_session(session_entry.session_id)
                 if row:
                     db_total_tokens = (
                         (row.get("input_tokens") or 0)
@@ -9409,7 +10150,7 @@ class GatewayRunner:
         # one left off. Inspired by Claude Code 2.1.114's /recap.
         try:
             from hermes_cli.session_recap import build_recap
-            history = self.session_store.load_transcript(session_entry.session_id)
+            history = session_store.load_transcript(session_entry.session_id)
             recap = build_recap(
                 history,
                 session_title=title,
@@ -9428,13 +10169,17 @@ class GatewayRunner:
         from tools.process_registry import format_uptime_short, process_registry
 
         now = time.time()
-        current_session_key = self._session_key_for_source(event.source)
+        source = event.source
+        current_session_key = self._session_key_for_source(source)
+        current_prefix = ":".join(current_session_key.split(":", 2)[:2]) + ":"
 
         running_agents: dict = getattr(self, "_running_agents", {}) or {}
         running_started: dict = getattr(self, "_running_agents_ts", {}) or {}
 
         agent_rows: list[dict] = []
         for session_key, agent in running_agents.items():
+            if not str(session_key).startswith(current_prefix):
+                continue
             started = float(running_started.get(session_key, now))
             elapsed = max(0, int(now - started))
             is_pending = agent is _AGENT_PENDING_SENTINEL
@@ -9451,17 +10196,53 @@ class GatewayRunner:
         agent_rows.sort(key=lambda row: row["elapsed"], reverse=True)
 
         running_processes: list[dict] = []
+        _session_env_tokens = []
         try:
+            from gateway.session_context import set_session_vars, clear_session_vars
+            _session_env_tokens = set_session_vars(
+                platform=source.platform.value if source and source.platform else "",
+                chat_id=source.chat_id if source else "",
+                chat_name=source.chat_name or "" if source else "",
+                thread_id=str(source.thread_id) if source and source.thread_id else "",
+                user_id=str(source.user_id) if source and source.user_id else "",
+                user_name=str(source.user_name) if source and source.user_name else "",
+                session_key=current_session_key,
+                message_id=str(source.message_id) if source and source.message_id else "",
+                agent_profile=str(getattr(source, "agent_profile", None) or "") if source else "",
+                agent_hermes_home=self._resolved_agent_hermes_home_for_source(source) if source else "",
+                profile_strict_auth="1" if source and getattr(source, "agent_profile", None) else "",
+            )
             running_processes = [
                 p for p in process_registry.list_sessions()
                 if p.get("status") == "running"
             ]
         except Exception:
             running_processes = []
+        finally:
+            if _session_env_tokens:
+                try:
+                    clear_session_vars(_session_env_tokens)
+                except Exception:
+                    pass
+
+        current_profile = str(getattr(source, "agent_profile", "") or "")
+        current_home = self._resolved_agent_hermes_home_for_source(source)
+
+        def _background_task_in_scope(task) -> bool:
+            if not hasattr(task, "done") or task.done():
+                return False
+            task_profile = str(getattr(task, "_hermes_agent_profile", "") or "")
+            task_home = str(getattr(task, "_hermes_agent_hermes_home", "") or "")
+            if current_profile or current_home:
+                if current_home:
+                    return task_home == current_home
+                return bool(current_profile) and task_profile == current_profile
+            return not bool(task_profile or task_home)
 
         background_tasks = [
-            t for t in (getattr(self, "_background_tasks", set()) or set())
-            if hasattr(t, "done") and not t.done()
+            task
+            for task in (getattr(self, "_background_tasks", set()) or set())
+            if _background_task_in_scope(task)
         ]
 
         lines = [
@@ -9525,7 +10306,8 @@ class GatewayRunner:
         The session is preserved so the user can continue the conversation.
         """
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_store = self._session_store_for_source(source)
+        session_entry = session_store.get_or_create_session(source)
         session_key = session_entry.session_key
 
         agent = self._running_agents.get(session_key)
@@ -9784,7 +10566,9 @@ class GatewayRunner:
             t("gateway.help.header"),
             *gateway_help_lines(),
         ]
+        profile_home_token = None
         try:
+            profile_home_token = self._set_command_hermes_home_for_source(event.source)
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
             if skill_cmds:
@@ -9795,8 +10579,13 @@ class GatewayRunner:
                     lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
                 if len(sorted_cmds) > 10:
                     lines.append(t("gateway.help.more_use_commands", count=len(sorted_cmds) - 10))
+        except TopicProfileRoutingError as exc:
+            return f"⚠️ Topic profile routing failed: {exc}"
         except Exception:
             pass
+        finally:
+            if profile_home_token is not None:
+                reset_hermes_home_override(profile_home_token)
         return _telegramize_command_mentions(
             "\n".join(lines),
             getattr(getattr(event, "source", None), "platform", None),
@@ -9816,7 +10605,9 @@ class GatewayRunner:
 
         # Build combined entry list: built-in commands + skill commands
         entries = list(gateway_help_lines())
+        profile_home_token = None
         try:
+            profile_home_token = self._set_command_hermes_home_for_source(event.source)
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
             if skill_cmds:
@@ -9825,8 +10616,13 @@ class GatewayRunner:
                 for cmd in sorted(skill_cmds):
                     desc = skill_cmds[cmd].get("description", "").strip() or t("gateway.commands.default_desc")
                     entries.append(f"`{cmd}` — {desc}")
+        except TopicProfileRoutingError as exc:
+            return f"⚠️ Topic profile routing failed: {exc}"
         except Exception:
             pass
+        finally:
+            if profile_home_token is not None:
+                reset_hermes_home_override(profile_home_token)
 
         if not entries:
             return t("gateway.commands.none")
@@ -9876,6 +10672,12 @@ class GatewayRunner:
         from hermes_cli.providers import get_label
 
         raw_args = event.get_command_args().strip()
+        source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return (
+                "`/model` is disabled in routed profile topics. "
+                "Change the routed profile configuration directly."
+            )
 
         # Parse --provider and --global flags
         model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
@@ -9906,7 +10708,6 @@ class GatewayRunner:
             pass
 
         # Check for session override
-        source = event.source
         session_key = self._session_key_for_source(source)
         override = self._session_model_overrides.get(session_key, {})
         if override:
@@ -10231,6 +11032,13 @@ class GatewayRunner:
         (avoids prompt-cache invalidation mid-session)."""
         from hermes_cli import codex_runtime_switch as crs
 
+        source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return (
+                "`/codex-runtime` is disabled in routed profile topics. "
+                "Change the routed profile configuration directly."
+            )
+
         raw_args = event.get_command_args().strip() if event else ""
         new_value, errors = crs.parse_args(raw_args)
         if errors:
@@ -10267,6 +11075,11 @@ class GatewayRunner:
         from hermes_constants import display_hermes_home
 
         args = event.get_command_args().strip().lower()
+        if getattr(event.source, "agent_profile", None):
+            return (
+                "`/personality` is disabled in routed profile topics. "
+                "Edit that profile's SOUL.md or config.yaml directly."
+            )
         config_path = _hermes_home / 'config.yaml'
 
         try:
@@ -10334,8 +11147,9 @@ class GatewayRunner:
     async def _handle_retry_command(self, event: MessageEvent) -> str:
         """Handle /retry command - re-send the last user message."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(session_entry.session_id)
+        session_store = self._session_store_for_source(source)
+        session_entry = session_store.get_or_create_session(source)
+        history = session_store.load_transcript(session_entry.session_id)
         
         # Find the last user message
         last_user_msg = None
@@ -10351,7 +11165,7 @@ class GatewayRunner:
         
         # Truncate history to before the last user message and persist
         truncated = history[:last_user_idx]
-        self.session_store.rewrite_transcript(session_entry.session_id, truncated)
+        session_store.rewrite_transcript(session_entry.session_id, truncated)
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
         
@@ -10403,7 +11217,8 @@ class GatewayRunner:
             logger.debug("goal manager unavailable: %s", exc)
             return None, None
         try:
-            session_entry = self.session_store.get_or_create_session(event.source)
+            session_store = self._session_store_for_source(event.source)
+            session_entry = session_store.get_or_create_session(event.source)
         except Exception as exc:
             logger.debug("goal manager: session lookup failed: %s", exc)
             return None, None
@@ -10675,8 +11490,9 @@ class GatewayRunner:
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(session_entry.session_id)
+        session_store = self._session_store_for_source(source)
+        session_entry = session_store.get_or_create_session(source)
+        history = session_store.load_transcript(session_entry.session_id)
         
         # Find the last user message and remove everything from it onward
         last_user_idx = None
@@ -10690,7 +11506,7 @@ class GatewayRunner:
         
         removed_msg = history[last_user_idx].get("content", "")
         removed_count = len(history) - last_user_idx
-        self.session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
+        session_store.rewrite_transcript(session_entry.session_id, history[:last_user_idx])
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
         
@@ -10700,6 +11516,11 @@ class GatewayRunner:
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
         source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return (
+                "`/sethome` is disabled in routed profile topics. "
+                "Home-channel configuration belongs to the gateway profile."
+            )
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
@@ -11342,6 +12163,9 @@ class GatewayRunner:
                 media_types=media_types,
             )
         )
+        setattr(_task, "_hermes_session_key", self._session_key_for_source(source))
+        setattr(_task, "_hermes_agent_profile", str(getattr(source, "agent_profile", "") or ""))
+        setattr(_task, "_hermes_agent_hermes_home", self._resolved_agent_hermes_home_for_source(source))
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
 
@@ -11370,13 +12194,60 @@ class GatewayRunner:
 
         _thread_metadata = self._thread_metadata_for_source(source, event_message_id)
 
+        _profile_home: Optional[Path] = None
+        _profile_home_token = None
+        _session_env_tokens = []
         try:
-            user_config = _load_gateway_config()
+            try:
+                _profile_home = self._profile_home_for_source(source)
+            except TopicProfileRoutingError as exc:
+                logger.error("Topic profile routing failed closed for background task: %s", exc)
+                await adapter.send(
+                    source.chat_id,
+                    f"⚠️ Background task {task_id} failed: topic profile routing failed: {exc}",
+                    metadata=_thread_metadata,
+                )
+                return
+            if _profile_home is not None:
+                _profile_home_token = set_hermes_home_override(_profile_home)
+            try:
+                from gateway.session_context import set_session_vars
+                background_session_key = self._session_key_for_source(source)
+                _session_env_tokens = set_session_vars(
+                    platform=source.platform.value if source and source.platform else "",
+                    chat_id=source.chat_id if source else "",
+                    chat_name=source.chat_name or "" if source else "",
+                    thread_id=str(source.thread_id) if source and source.thread_id else "",
+                    user_id=str(source.user_id) if source and source.user_id else "",
+                    user_name=str(source.user_name) if source and source.user_name else "",
+                    session_key=background_session_key,
+                    message_id=str(event_message_id or ""),
+                    session_id=task_id,
+                    agent_profile=str(getattr(source, "agent_profile", None) or ""),
+                    agent_hermes_home=str(_profile_home or getattr(source, "agent_hermes_home", None) or ""),
+                    profile_strict_auth="1" if getattr(source, "agent_profile", None) else "",
+                )
+            except Exception:
+                _session_env_tokens = []
+
+            user_config = _load_gateway_config(_profile_home) if _profile_home is not None else _load_gateway_config()
+            runtime_env = None
+            if _profile_home is not None:
+                try:
+                    runtime_env = self._runtime_env_for_profile_home(_profile_home)
+                except Exception as exc:
+                    logger.debug("Could not read routed profile .env from %s: %s", _profile_home, exc)
+                    runtime_env = {}
             model, runtime_kwargs = self._resolve_session_agent_runtime(
                 source=source,
                 user_config=user_config,
+                runtime_env=runtime_env,
             )
-            if not runtime_kwargs.get("api_key"):
+            if not (
+                runtime_kwargs.get("api_key")
+                or runtime_kwargs.get("credential_pool")
+                or runtime_kwargs.get("command")
+            ):
                 await adapter.send(
                     source.chat_id,
                     f"❌ Background task {task_id} failed: no provider credentials configured.",
@@ -11391,12 +12262,32 @@ class GatewayRunner:
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
-            pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            reasoning_config = self._resolve_session_reasoning_config(source=source)
+            pr = (
+                self._load_provider_routing(config=user_config, hermes_home=_profile_home)
+                if _profile_home is not None
+                else self._provider_routing
+            )
+            max_iterations = _resolve_max_iterations(
+                user_config=user_config,
+                runtime_env=runtime_env,
+            )
+            reasoning_config = self._resolve_session_reasoning_config(
+                source=source,
+                user_config=user_config if _profile_home is not None else None,
+                hermes_home=_profile_home,
+            )
             self._reasoning_config = reasoning_config
-            self._service_tier = self._load_service_tier()
+            self._service_tier = (
+                self._load_service_tier(config=user_config, hermes_home=_profile_home)
+                if _profile_home is not None
+                else self._load_service_tier()
+            )
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            session_db = (
+                self._session_db_for_source(source)
+                if _profile_home is not None
+                else self._session_db
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -11441,8 +12332,13 @@ class GatewayRunner:
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
-                    session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    session_db=session_db,
+                    fallback_model=(
+                        user_config.get("fallback_providers")
+                        or user_config.get("fallback_model")
+                        or (None if _profile_home is not None else self._fallback_model)
+                    ),
+                    runtime_env=runtime_env,
                 )
                 try:
                     return agent.run_conversation(
@@ -11519,6 +12415,15 @@ class GatewayRunner:
                 )
             except Exception:
                 pass
+        finally:
+            if _session_env_tokens:
+                try:
+                    from gateway.session_context import clear_session_vars
+                    clear_session_vars(_session_env_tokens)
+                except Exception:
+                    pass
+            if _profile_home_token is not None:
+                reset_hermes_home_override(_profile_home_token)
 
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.
@@ -11535,11 +12440,17 @@ class GatewayRunner:
 
         raw_args = event.get_command_args().strip()
         args, persist_global = self._parse_reasoning_command_args(raw_args)
+        source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return (
+                "`/reasoning` is disabled in routed profile topics. "
+                "Change the routed profile configuration directly."
+            )
         config_path = _hermes_home / "config.yaml"
-        session_key = self._session_key_for_source(event.source)
+        session_key = self._session_key_for_source(source)
         self._show_reasoning = self._load_show_reasoning()
         self._reasoning_config = self._resolve_session_reasoning_config(
-            source=event.source,
+            source=source,
             session_key=session_key,
         )
 
@@ -11591,7 +12502,7 @@ class GatewayRunner:
             )
 
         # Display toggle (per-platform)
-        platform_key = _platform_config_key(event.source.platform)
+        platform_key = _platform_config_key(source.platform)
         if args in {"show", "on"}:
             self._show_reasoning = True
             _save_config_key(f"display.platforms.{platform_key}.show_reasoning", True)
@@ -11641,10 +12552,26 @@ class GatewayRunner:
         from hermes_cli.models import model_supports_fast_mode
 
         args = event.get_command_args().strip().lower()
-        config_path = _hermes_home / "config.yaml"
-        self._service_tier = self._load_service_tier()
-
-        user_config = _load_gateway_config()
+        source = event.source
+        profile_home = self._profile_home_for_source(source)
+        config_home = profile_home if profile_home is not None else _hermes_home
+        config_path = config_home / "config.yaml"
+        profile_home_token = None
+        if profile_home is not None:
+            profile_home_token = set_hermes_home_override(profile_home)
+        try:
+            user_config = (
+                _load_gateway_config(profile_home)
+                if profile_home is not None
+                else _load_gateway_config()
+            )
+        finally:
+            if profile_home_token is not None:
+                reset_hermes_home_override(profile_home_token)
+        self._service_tier = self._load_service_tier(
+            config=user_config,
+            hermes_home=profile_home,
+        )
         model = _resolve_gateway_model(user_config)
         if not model_supports_fast_mode(model):
             return t("gateway.fast.not_supported")
@@ -11715,8 +12642,14 @@ class GatewayRunner:
         have its own verbosity level independently.
         """
 
+        source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return (
+                "`/verbose` is disabled in routed profile topics. "
+                "Change the routed profile configuration directly."
+            )
         config_path = _hermes_home / "config.yaml"
-        platform_key = _platform_config_key(event.source.platform)
+        platform_key = _platform_config_key(source.platform)
 
         # --- check config gate ------------------------------------------------
         try:
@@ -11783,8 +12716,14 @@ class GatewayRunner:
         """
         from gateway.runtime_footer import resolve_footer_config
 
+        source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return (
+                "`/footer` is disabled in routed profile topics. "
+                "Change the routed profile configuration directly."
+            )
         config_path = _hermes_home / "config.yaml"
-        platform_key = _platform_config_key(event.source.platform)
+        platform_key = _platform_config_key(source.platform)
 
         # --- parse argument -------------------------------------------------
         arg = ""
@@ -11860,8 +12799,10 @@ class GatewayRunner:
         more aggressive about discarding everything else.
         """
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(session_entry.session_id)
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
+        session_entry = session_store.get_or_create_session(source)
+        history = session_store.load_transcript(session_entry.session_id)
 
         if not history or len(history) < 4:
             return t("gateway.compress.not_enough")
@@ -11875,29 +12816,97 @@ class GatewayRunner:
             from agent.model_metadata import estimate_request_tokens_rough
 
             session_key = self._session_key_for_source(source)
-            model, runtime_kwargs = self._resolve_session_agent_runtime(
-                source=source,
-                session_key=session_key,
-            )
-            if not runtime_kwargs.get("api_key"):
-                return t("gateway.compress.no_provider")
-
-            msgs = [
-                {"role": m.get("role"), "content": m.get("content")}
-                for m in history
-                if m.get("role") in {"user", "assistant"} and m.get("content")
-            ]
-
-            tmp_agent = AIAgent(
-                **runtime_kwargs,
-                model=model,
-                max_iterations=4,
-                quiet_mode=True,
-                skip_memory=True,
-                enabled_toolsets=["memory"],
-                session_id=session_entry.session_id,
-            )
+            profile_home = self._profile_home_for_source(source)
+            profile_home_token = None
+            runtime_env_token = None
+            session_env_tokens = []
+            tmp_agent = None
             try:
+                if profile_home is not None:
+                    profile_home_token = set_hermes_home_override(profile_home)
+                user_config = (
+                    _load_gateway_config(profile_home)
+                    if profile_home is not None
+                    else _load_gateway_config(_hermes_home)
+                )
+                runtime_env = None
+                if profile_home is not None:
+                    try:
+                        runtime_env = self._runtime_env_for_profile_home(profile_home)
+                    except Exception as exc:
+                        logger.debug("Could not read routed profile .env for /compress: %s", exc)
+                        runtime_env = {}
+                    try:
+                        from gateway.session_context import (
+                            clear_runtime_env,
+                            clear_session_vars,
+                            set_runtime_env,
+                            set_session_vars,
+                        )
+                        session_env_tokens = set_session_vars(
+                            platform=source.platform.value if source and source.platform else "",
+                            chat_id=getattr(source, "chat_id", "") or "",
+                            chat_name=getattr(source, "chat_name", "") or "",
+                            thread_id=getattr(source, "thread_id", "") or "",
+                            user_id=getattr(source, "user_id", "") or "",
+                            user_name=getattr(source, "user_name", "") or "",
+                            session_key=session_key or "",
+                            message_id=getattr(event, "message_id", "") or "",
+                            session_id=getattr(session_entry, "session_id", "") or "",
+                            agent_profile=getattr(source, "agent_profile", "") or "",
+                            agent_hermes_home=str(profile_home),
+                            profile_strict_auth="1",
+                        )
+                        runtime_env_token = set_runtime_env(runtime_env)
+                    except Exception:
+                        session_env_tokens = []
+                        runtime_env_token = None
+                model, runtime_kwargs = self._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=session_key,
+                    user_config=user_config,
+                    runtime_env=runtime_env,
+                )
+                if profile_home is not None:
+                    from hermes_cli.auth import has_usable_secret
+                    if (
+                        not runtime_kwargs.get("credential_pool")
+                        and not runtime_kwargs.get("command")
+                        and not has_usable_secret(str(runtime_kwargs.get("api_key") or ""))
+                    ):
+                        return t("gateway.compress.no_provider")
+                elif not (
+                    runtime_kwargs.get("api_key")
+                    or runtime_kwargs.get("credential_pool")
+                    or runtime_kwargs.get("command")
+                ):
+                    return t("gateway.compress.no_provider")
+
+                msgs = [
+                    {"role": m.get("role"), "content": m.get("content")}
+                    for m in history
+                    if m.get("role") in {"user", "assistant"} and m.get("content")
+                ]
+
+                def _build_tmp_agent():
+                    return AIAgent(
+                        **runtime_kwargs,
+                        model=model,
+                        max_iterations=4,
+                        quiet_mode=True,
+                        skip_memory=True,
+                        enabled_toolsets=["memory"],
+                        session_id=session_entry.session_id,
+                        session_db=session_db,
+                        fallback_model=(
+                            user_config.get("fallback_providers")
+                            or user_config.get("fallback_model")
+                            or (None if profile_home is not None else getattr(self, "_fallback_model", None))
+                        ),
+                        runtime_env=runtime_env,
+                    )
+
+                tmp_agent = _build_tmp_agent()
                 tmp_agent._print_fn = lambda *a, **kw: None
 
                 # Estimate with system prompt + tool schemas included so the
@@ -11914,10 +12923,14 @@ class GatewayRunner:
                 if not compressor.has_content_to_compress(msgs):
                     return t("gateway.compress.nothing_to_do")
 
-                loop = asyncio.get_running_loop()
-                compressed, _ = await loop.run_in_executor(
-                    None,
-                    lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True)
+                compressed, _ = await self._run_in_executor_with_context(
+                    lambda: tmp_agent._compress_context(
+                        msgs,
+                        "",
+                        approx_tokens=approx_tokens,
+                        focus_topic=focus_topic,
+                        force=True,
+                    )
                 )
 
                 # _compress_context already calls end_session() on the old session
@@ -11927,11 +12940,11 @@ class GatewayRunner:
                 new_session_id = tmp_agent.session_id
                 if new_session_id != session_entry.session_id:
                     session_entry.session_id = new_session_id
-                    self.session_store._save()
+                    session_store._save()
 
-                self.session_store.rewrite_transcript(new_session_id, compressed)
+                session_store.rewrite_transcript(new_session_id, compressed)
                 # Reset stored token count — transcript changed, old value is stale
-                self.session_store.update_session(
+                session_store.update_session(
                     session_entry.session_key, last_prompt_tokens=0
                 )
                 new_tokens = estimate_request_tokens_rough(
@@ -11961,7 +12974,20 @@ class GatewayRunner:
                 # Evict cached agent so next turn rebuilds system prompt
                 # from current files (SOUL.md, memory, etc.).
                 self._evict_cached_agent(session_key)
-                self._cleanup_agent_resources(tmp_agent)
+                if tmp_agent is not None:
+                    self._cleanup_agent_resources(tmp_agent)
+                if runtime_env_token is not None:
+                    try:
+                        clear_runtime_env(runtime_env_token)
+                    except Exception:
+                        pass
+                if session_env_tokens:
+                    try:
+                        clear_session_vars(session_env_tokens)
+                    except Exception:
+                        pass
+                if profile_home_token is not None:
+                    reset_hermes_home_override(profile_home_token)
             lines = [f"🗜️ {summary['headline']}"]
             if focus_topic:
                 lines.append(t("gateway.compress.focus_line", topic=focus_topic))
@@ -12502,20 +13528,22 @@ class GatewayRunner:
     async def _handle_title_command(self, event: MessageEvent) -> str:
         """Handle /title command — set or show the current session's title."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
+        session_entry = session_store.get_or_create_session(source)
         session_id = session_entry.session_id
 
-        if not self._session_db:
+        if not session_db:
             from hermes_state import format_session_db_unavailable
             return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
 
         # Ensure session exists in SQLite DB (it may only exist in session_store
         # if this is the first command in a new session)
-        existing_title = self._session_db.get_session_title(session_id)
+        existing_title = session_db.get_session_title(session_id)
         if existing_title is None:
             # Session doesn't exist in DB yet — create it
             try:
-                self._session_db.create_session(
+                session_db.create_session(
                     session_id=session_id,
                     source=source.platform.value if source.platform else "unknown",
                     user_id=source.user_id,
@@ -12527,14 +13555,14 @@ class GatewayRunner:
         if title_arg:
             # Sanitize the title before setting
             try:
-                sanitized = self._session_db.sanitize_title(title_arg)
+                sanitized = session_db.sanitize_title(title_arg)
             except ValueError as e:
                 return t("gateway.shared.warn_passthrough", error=e)
             if not sanitized:
                 return t("gateway.title.empty_after_clean")
             # Set the title
             try:
-                if self._session_db.set_session_title(session_id, sanitized):
+                if session_db.set_session_title(session_id, sanitized):
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")
@@ -12542,7 +13570,7 @@ class GatewayRunner:
                 return t("gateway.shared.warn_passthrough", error=e)
         else:
             # Show the current title and session ID
-            title = self._session_db.get_session_title(session_id)
+            title = session_db.get_session_title(session_id)
             if title:
                 return t("gateway.title.current_with_title", session_id=session_id, title=title)
             else:
@@ -12550,11 +13578,13 @@ class GatewayRunner:
 
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — switch to a previously-named session."""
-        if not self._session_db:
+        source = event.source
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
+        if not session_db:
             from hermes_state import format_session_db_unavailable
             return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
 
-        source = event.source
         session_key = self._session_key_for_source(source)
         name = event.get_command_args().strip()
 
@@ -12562,7 +13592,7 @@ class GatewayRunner:
             # List recent titled sessions for this user/platform
             try:
                 user_source = source.platform.value if source.platform else None
-                sessions = self._session_db.list_sessions_rich(
+                sessions = session_db.list_sessions_rich(
                     source=user_source, limit=10
                 )
                 titled = [s for s in sessions if s.get("title")]
@@ -12581,18 +13611,18 @@ class GatewayRunner:
                 return t("gateway.resume.list_failed", error=e)
 
         # Resolve the name to a session ID.
-        target_id = self._session_db.resolve_session_by_title(name)
+        target_id = session_db.resolve_session_by_title(name)
         if not target_id:
             return t("gateway.resume.not_found", name=name)
         # Compression creates child continuations that hold the live transcript.
         # Follow that chain so gateway /resume matches CLI behavior (#15000).
         try:
-            target_id = self._session_db.resolve_resume_session_id(target_id)
+            target_id = session_db.resolve_resume_session_id(target_id)
         except Exception as e:
             logger.debug("Failed to resolve resume continuation for %s: %s", target_id, e)
 
         # Check if already on that session
-        current_entry = self.session_store.get_or_create_session(source)
+        current_entry = session_store.get_or_create_session(source)
         if current_entry.session_id == target_id:
             return t("gateway.resume.already_on", name=name)
 
@@ -12600,7 +13630,7 @@ class GatewayRunner:
         self._release_running_agent_state(session_key)
 
         # Switch the session entry to point at the old session
-        new_entry = self.session_store.switch_session(session_key, target_id)
+        new_entry = session_store.switch_session(session_key, target_id)
         if not new_entry:
             return t("gateway.resume.switch_failed")
         self._clear_session_boundary_security_state(session_key)
@@ -12613,10 +13643,10 @@ class GatewayRunner:
         self._evict_cached_agent(session_key)
 
         # Get the title for confirmation
-        title = self._session_db.get_session_title(target_id) or name
+        title = session_db.get_session_title(target_id) or name
 
         # Count messages for context
-        history = self.session_store.load_transcript(target_id)
+        history = session_store.load_transcript(target_id)
         msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
         if not msg_count:
             return t("gateway.resume.resumed_no_count", title=title)
@@ -12633,16 +13663,17 @@ class GatewayRunner:
         """
         import uuid as _uuid
 
-        if not self._session_db:
+        source = event.source
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
+        if not session_db:
             from hermes_state import format_session_db_unavailable
             return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
-
-        source = event.source
         session_key = self._session_key_for_source(source)
 
         # Load the current session and its transcript
-        current_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(current_entry.session_id)
+        current_entry = session_store.get_or_create_session(source)
+        history = session_store.load_transcript(current_entry.session_id)
         if not history:
             return t("gateway.branch.no_conversation")
 
@@ -12659,15 +13690,15 @@ class GatewayRunner:
         if branch_name:
             branch_title = branch_name
         else:
-            current_title = self._session_db.get_session_title(current_entry.session_id)
+            current_title = session_db.get_session_title(current_entry.session_id)
             base = current_title or "branch"
-            branch_title = self._session_db.get_next_title_in_lineage(base)
+            branch_title = session_db.get_next_title_in_lineage(base)
 
         parent_session_id = current_entry.session_id
 
         # Create the new session with parent link
         try:
-            self._session_db.create_session(
+            session_db.create_session(
                 session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
@@ -12680,7 +13711,7 @@ class GatewayRunner:
         # Copy conversation history to the new session
         for msg in history:
             try:
-                self._session_db.append_message(
+                session_db.append_message(
                     session_id=new_session_id,
                     role=msg.get("role", "user"),
                     content=msg.get("content"),
@@ -12699,12 +13730,12 @@ class GatewayRunner:
 
         # Set title
         try:
-            self._session_db.set_session_title(new_session_id, branch_title)
+            session_db.set_session_title(new_session_id, branch_title)
         except Exception:
             pass
 
         # Switch the session store entry to the new session
-        new_entry = self.session_store.switch_session(session_key, new_session_id)
+        new_entry = session_store.switch_session(session_key, new_session_id)
         if not new_entry:
             return t("gateway.branch.switch_failed")
         self._clear_session_boundary_security_state(session_key)
@@ -12724,6 +13755,8 @@ class GatewayRunner:
         available whenever the user asks, not only while the agent is running.
         """
         source = event.source
+        session_store = self._session_store_for_source(source)
+        session_db = self._session_db_for_source(source)
         session_key = self._session_key_for_source(source)
 
         # Try running agent first (mid-turn), then cached agent (between turns)
@@ -12744,10 +13777,10 @@ class GatewayRunner:
         provider = getattr(agent, "provider", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         base_url = getattr(agent, "base_url", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         api_key = getattr(agent, "api_key", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
-        if not provider and getattr(self, "_session_db", None) is not None:
+        if not provider and session_db is not None:
             try:
-                _entry_for_billing = self.session_store.get_or_create_session(source)
-                persisted = self._session_db.get_session(_entry_for_billing.session_id) or {}
+                _entry_for_billing = session_store.get_or_create_session(source)
+                persisted = session_db.get_session(_entry_for_billing.session_id) or {}
             except Exception:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
@@ -12833,8 +13866,8 @@ class GatewayRunner:
             return "\n".join(lines)
 
         # No agent at all -- check session history for a rough count
-        session_entry = self.session_store.get_or_create_session(source)
-        history = self.session_store.load_transcript(session_entry.session_id)
+        session_entry = session_store.get_or_create_session(source)
+        history = session_store.load_transcript(session_entry.session_id)
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough
             msgs = [m for m in history if m.get("role") in {"user", "assistant"} and m.get("content")]
@@ -12861,7 +13894,7 @@ class GatewayRunner:
         args = re.sub(r'[\u2012\u2013\u2014\u2015](days|source)', r'--\1', args)
 
         days = 30
-        source = None
+        source_filter = None
 
         # Parse simple args: /insights 7  or  /insights --days 7
         if args:
@@ -12875,7 +13908,7 @@ class GatewayRunner:
                         return t("gateway.insights.invalid_days", value=parts[i + 1])
                     i += 2
                 elif parts[i] == "--source" and i + 1 < len(parts):
-                    source = parts[i + 1]
+                    source_filter = parts[i + 1]
                     i += 2
                 elif parts[i].isdigit():
                     days = int(parts[i])
@@ -12884,17 +13917,18 @@ class GatewayRunner:
                     i += 1
 
         try:
-            from hermes_state import SessionDB
             from agent.insights import InsightsEngine
 
             loop = asyncio.get_running_loop()
+            session_db = self._session_db_for_source(event.source)
+            if not session_db:
+                from hermes_state import format_session_db_unavailable
+                return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
 
             def _run_insights():
-                db = SessionDB()
-                engine = InsightsEngine(db)
-                report = engine.generate(days=days, source=source)
+                engine = InsightsEngine(session_db)
+                report = engine.generate(days=days, source=source_filter)
                 result = engine.format_gateway(report)
-                db.close()
                 return result
 
             return await loop.run_in_executor(None, _run_insights)
@@ -12919,6 +13953,8 @@ class GatewayRunner:
         Users can also skip the confirm by flipping the config key directly.
         """
         source = event.source
+        if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+            return "⚠️ /reload-mcp is disabled in routed profile topics because MCP connections are process-global."
         session_key = self._session_key_for_source(source)
 
         # Read the gate fresh from disk so a prior "always" click takes
@@ -12973,7 +14009,9 @@ class GatewayRunner:
         button, text reply, or has the confirm gate disabled.
         """
         loop = asyncio.get_running_loop()
+        profile_home_token = None
         try:
+            profile_home_token = self._set_command_hermes_home_for_source(event.source)
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
 
             # Capture old server names before shutdown
@@ -12985,7 +14023,8 @@ class GatewayRunner:
             await loop.run_in_executor(None, shutdown_mcp_servers)
 
             # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+            ctx = copy_context()
+            new_tools = await loop.run_in_executor(None, lambda: ctx.run(discover_mcp_tools))
 
             # Compute what changed
             with _lock:
@@ -13024,8 +14063,9 @@ class GatewayRunner:
                 "content": f"[IMPORTANT: MCP servers have been reloaded. {change_detail}{tool_summary}. The tool list for this conversation has been updated accordingly.]",
             }
             try:
-                session_entry = self.session_store.get_or_create_session(event.source)
-                self.session_store.append_to_transcript(
+                session_store = self._session_store_for_source(event.source)
+                session_entry = session_store.get_or_create_session(event.source)
+                session_store.append_to_transcript(
                     session_entry.session_id, reload_msg
                 )
             except Exception:
@@ -13036,6 +14076,9 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("MCP reload failed: %s", e)
             return t("gateway.reload_mcp.failed", error=e)
+        finally:
+            if profile_home_token is not None:
+                reset_hermes_home_override(profile_home_token)
 
     async def _handle_reload_skills_command(self, event: MessageEvent) -> str:
         """Handle /reload-skills — rescan skills dir, queue a note for next turn.
@@ -13053,10 +14096,13 @@ class GatewayRunner:
         alternation is preserved.
         """
         loop = asyncio.get_running_loop()
+        profile_home_token = None
         try:
+            profile_home_token = self._set_command_hermes_home_for_source(event.source)
             from agent.skill_commands import reload_skills
 
-            result = await loop.run_in_executor(None, reload_skills)
+            ctx = copy_context()
+            result = await loop.run_in_executor(None, lambda: ctx.run(reload_skills))
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)
@@ -13136,6 +14182,9 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Skills reload failed: %s", e)
             return t("gateway.reload_skills.failed", error=e)
+        finally:
+            if profile_home_token is not None:
+                reset_hermes_home_override(profile_home_token)
 
     async def _handle_bundles_command(self, event: MessageEvent) -> str:
         """Handle /bundles — list installed skill bundles.
@@ -13144,33 +14193,39 @@ class GatewayRunner:
         message suitable for any gateway adapter; bundles are loaded by
         invoking the bundle's own ``/<slug>`` command, not by this one.
         """
+        profile_home_token = None
         try:
-            from agent.skill_bundles import list_bundles, _bundles_dir
-        except Exception as exc:
-            logger.warning("Bundles command unavailable: %s", exc)
-            return f"Bundles subsystem unavailable: {exc}"
+            profile_home_token = self._set_command_hermes_home_for_source(event.source)
+            try:
+                from agent.skill_bundles import list_bundles, _bundles_dir
+            except Exception as exc:
+                logger.warning("Bundles command unavailable: %s", exc)
+                return f"Bundles subsystem unavailable: {exc}"
 
-        bundles = list_bundles()
-        if not bundles:
-            return (
-                "No skill bundles installed.\n"
-                "Create one on the host with:\n"
-                "  `hermes bundles create <name> --skill <s1> --skill <s2>`\n"
-                f"Directory: `{_bundles_dir()}`"
-            )
+            bundles = list_bundles()
+            if not bundles:
+                return (
+                    "No skill bundles installed.\n"
+                    "Create one on the host with:\n"
+                    "  `hermes bundles create <name> --skill <s1> --skill <s2>`\n"
+                    f"Directory: `{_bundles_dir()}`"
+                )
 
-        lines = [f"**Skill Bundles** ({len(bundles)} installed):", ""]
-        for info in bundles:
-            skill_count = len(info.get("skills", []))
-            desc = info.get("description") or f"Load {skill_count} skills"
-            lines.append(
-                f"• `/{info['slug']}` — {desc} _({skill_count} skills)_"
-            )
-            for s in info.get("skills", []):
-                lines.append(f"    · {s}")
-        lines.append("")
-        lines.append("Invoke a bundle with `/<slug>` to load all its skills.")
-        return "\n".join(lines)
+            lines = [f"**Skill Bundles** ({len(bundles)} installed):", ""]
+            for info in bundles:
+                skill_count = len(info.get("skills", []))
+                desc = info.get("description") or f"Load {skill_count} skills"
+                lines.append(
+                    f"• `/{info['slug']}` — {desc} _({skill_count} skills)_"
+                )
+                for s in info.get("skills", []):
+                    lines.append(f"    · {s}")
+            lines.append("")
+            lines.append("Invoke a bundle with `/<slug>` to load all its skills.")
+            return "\n".join(lines)
+        finally:
+            if profile_home_token is not None:
+                reset_hermes_home_override(profile_home_token)
 
     # ------------------------------------------------------------------
     # Slash-command confirmation primitive (generic)
@@ -13362,25 +14417,7 @@ class GatewayRunner:
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
-        thread_id = getattr(source, "thread_id", None)
-        if thread_id is None:
-            return None
-        metadata: Dict[str, Any] = {"thread_id": thread_id}
-        if (
-            getattr(source, "platform", None) == Platform.TELEGRAM
-            and getattr(source, "chat_type", None) == "dm"
-        ):
-            metadata["telegram_dm_topic_reply_fallback"] = True
-            # Telegram DM topic lanes need direct_messages_topic_id in metadata
-            # so synthetic/queued messages (goal continuations, status notices)
-            # route to the correct topic even when reply anchor is unavailable.
-            tid = str(thread_id)
-            if tid and tid not in {"", "1"}:
-                metadata["direct_messages_topic_id"] = tid
-            anchor = reply_to_message_id or getattr(source, "message_id", None)
-            if anchor is not None:
-                metadata["telegram_reply_to_message_id"] = str(anchor)
-        return metadata
+        return _base_thread_metadata_for_source(source, reply_to_message_id)
 
     @staticmethod
     def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
@@ -14148,6 +15185,10 @@ class GatewayRunner:
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
+            session_id=context.session_id or "",
+            agent_profile=str(getattr(context.source, "agent_profile", None) or ""),
+            agent_hermes_home=self._resolved_agent_hermes_home_for_source(context.source),
+            profile_strict_auth="1" if getattr(context.source, "agent_profile", None) else "",
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -14409,7 +15450,7 @@ class GatewayRunner:
             )
             return None
 
-        return SessionSource(
+        source = SessionSource(
             platform=platform,
             chat_id=chat_id,
             chat_type=chat_type,
@@ -14417,6 +15458,9 @@ class GatewayRunner:
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
         )
+        source.agent_profile = str(evt.get("agent_profile") or "").strip() or None
+        source.agent_hermes_home = str(evt.get("agent_hermes_home") or "").strip() or None
+        return source
 
     async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
         """Inject a watch-pattern notification as a synthetic message event.
@@ -14481,6 +15525,8 @@ class GatewayRunner:
         user_id = watcher.get("user_id", "")
         user_name = watcher.get("user_name", "")
         message_id = str(watcher.get("message_id") or "").strip() or None
+        agent_profile = watcher.get("agent_profile", "")
+        agent_hermes_home = watcher.get("agent_hermes_home", "")
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
 
@@ -14543,6 +15589,8 @@ class GatewayRunner:
                         "thread_id": thread_id,
                         "user_id": user_id,
                         "user_name": user_name,
+                        "agent_profile": agent_profile,
+                        "agent_hermes_home": agent_hermes_home,
                     })
                     if not source:
                         logger.warning(
@@ -14589,15 +15637,46 @@ class GatewayRunner:
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
                     )
+                    source = self._build_process_event_source({
+                        "session_id": session_id,
+                        "session_key": session_key,
+                        "platform": platform_name,
+                        "chat_id": chat_id,
+                        "thread_id": thread_id,
+                        "user_id": user_id,
+                        "user_name": user_name,
+                        "agent_profile": agent_profile,
+                        "agent_hermes_home": agent_hermes_home,
+                    })
+                    if not source and (agent_profile or agent_hermes_home):
+                        logger.warning(
+                            "Dropping routed completion notification with no routing metadata for process %s",
+                            session_id,
+                        )
+                        break
                     adapter = None
-                    for p, a in self.adapters.items():
-                        if p.value == platform_name:
-                            adapter = a
-                            break
-                    if adapter and chat_id:
+                    if source:
+                        for p, a in self.adapters.items():
+                            if p == source.platform:
+                                adapter = a
+                                break
+                    else:
+                        for p, a in self.adapters.items():
+                            if p.value == platform_name:
+                                adapter = a
+                                break
+                    if adapter and (source.chat_id if source else chat_id):
                         try:
-                            send_meta = {"thread_id": thread_id} if thread_id else None
-                            await adapter.send(chat_id, message_text, metadata=send_meta)
+                            send_meta = (
+                                self._thread_metadata_for_source(source, message_id)
+                                if source
+                                else ({"thread_id": thread_id} if thread_id else None)
+                            )
+                            await adapter.send(
+                                source.chat_id if source else chat_id,
+                                message_text,
+                                metadata=send_meta,
+                            )
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)
                 break
@@ -14610,15 +15689,46 @@ class GatewayRunner:
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"
                 )
+                source = self._build_process_event_source({
+                    "session_id": session_id,
+                    "session_key": session_key,
+                    "platform": platform_name,
+                    "chat_id": chat_id,
+                    "thread_id": thread_id,
+                    "user_id": user_id,
+                    "user_name": user_name,
+                    "agent_profile": agent_profile,
+                    "agent_hermes_home": agent_hermes_home,
+                })
+                if not source and (agent_profile or agent_hermes_home):
+                    logger.warning(
+                        "Dropping routed progress notification with no routing metadata for process %s",
+                        session_id,
+                    )
+                    continue
                 adapter = None
-                for p, a in self.adapters.items():
-                    if p.value == platform_name:
-                        adapter = a
-                        break
-                if adapter and chat_id:
+                if source:
+                    for p, a in self.adapters.items():
+                        if p == source.platform:
+                            adapter = a
+                            break
+                else:
+                    for p, a in self.adapters.items():
+                        if p.value == platform_name:
+                            adapter = a
+                            break
+                if adapter and (source.chat_id if source else chat_id):
                     try:
-                        send_meta = {"thread_id": thread_id} if thread_id else None
-                        await adapter.send(chat_id, message_text, metadata=send_meta)
+                        send_meta = (
+                            self._thread_metadata_for_source(source, message_id)
+                            if source
+                            else ({"thread_id": thread_id} if thread_id else None)
+                        )
+                        await adapter.send(
+                            source.chat_id if source else chat_id,
+                            message_text,
+                            metadata=send_meta,
+                        )
                     except Exception as e:
                         logger.error("Watcher delivery error: %s", e)
 
@@ -14642,6 +15752,7 @@ class GatewayRunner:
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
+        ("agent", "max_turns"),
     )
 
     @classmethod
@@ -14673,6 +15784,29 @@ class GatewayRunner:
         except Exception:
             out["tools.registry_generation"] = None
         return out
+
+    @staticmethod
+    def _stable_config_digest(value: Any) -> str:
+        """Return a stable short digest for cache-sensitive config fragments."""
+        import hashlib
+
+        try:
+            payload = json.dumps(value, sort_keys=True, default=str)
+        except Exception:
+            payload = repr(value)
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _file_content_digest(path: Path) -> str:
+        """Return a cache-safe digest for a file that may not exist."""
+        import hashlib
+
+        try:
+            if not path.is_file():
+                return "missing"
+            return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+        except Exception as exc:
+            return f"error:{type(exc).__name__}"
 
     @staticmethod
     def _agent_config_signature(
@@ -15202,7 +16336,7 @@ class GatewayRunner:
             _scfg = StreamingConfig()
 
         platform_key = _platform_config_key(source.platform)
-        user_config = _load_gateway_config()
+        user_config = _load_gateway_config(_hermes_home)
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
             user_config, platform_key, "streaming"
@@ -15406,6 +16540,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        session_db: Any = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -15419,8 +16554,30 @@ class GatewayRunner:
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        # Resolve the routed profile's SessionStore/SessionDB once so every
+        # post-turn write inside _run_agent (compression split entry update,
+        # auto-title, resume_pending lookup) targets the profile that owns
+        # this conversation. Without this, lines below silently fell back
+        # to self.session_store / self._session_db — the gateway-global
+        # stores — which caused routed compressed sessions to become
+        # unreachable on the next turn and routed auto-titles to land in
+        # the wrong DB (bug E in the topic-profile-routing review).
+        session_store = self._session_store_for_source(source)
+        if session_db is None:
+            session_db = self._session_db_for_source(source)
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
+            if getattr(source, "agent_profile", None) or getattr(source, "agent_hermes_home", None):
+                return {
+                    "final_response": (
+                        "⚠️ Proxy mode is disabled in routed profile topics because "
+                        "the remote API does not carry profile-scoped runtime state."
+                    ),
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                }
             return await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,
@@ -15439,9 +16596,47 @@ class GatewayRunner:
             if run_generation is None or not session_key:
                 return True
             return self._is_session_run_current(session_key, run_generation)
-        
-        user_config = _load_gateway_config()
+
+        try:
+            _profile_home = self._profile_home_for_source(source)
+        except TopicProfileRoutingError as exc:
+            logger.error("Topic profile routing failed closed before agent run: %s", exc)
+            return {
+                "final_response": f"⚠️ Topic profile routing failed: {exc}",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+
+        user_config = _load_gateway_config(_profile_home or _hermes_home)
         platform_key = _platform_config_key(source.platform)
+
+        if _profile_home is not None:
+            try:
+                gateway_sessions = getattr(
+                    getattr(self, "session_store", None),
+                    "sessions_dir",
+                    None,
+                )
+                gateway_home = (
+                    gateway_sessions.parent
+                    if gateway_sessions is not None
+                    else _hermes_home
+                )
+                notice = _topic_profile_tool_isolation_notice(
+                    _load_gateway_config(gateway_home),
+                    user_config,
+                    platform_key,
+                )
+                if notice:
+                    logger.info(
+                        "%s profile=%s home=%s",
+                        notice,
+                        getattr(source, "agent_profile", ""),
+                        _profile_home,
+                    )
+            except Exception:
+                logger.debug("Could not evaluate routed profile tool isolation notice", exc_info=True)
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -15665,7 +16860,6 @@ class GatewayRunner:
             if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
             else None
         )
-
         async def send_progress_messages():
             if not progress_queue:
                 return
@@ -16098,9 +17292,6 @@ class GatewayRunner:
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
@@ -16111,20 +17302,67 @@ class GatewayRunner:
             event_channel_prompt = (channel_prompt or "").strip()
             if event_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
-            if self._ephemeral_system_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
+            turn_ephemeral_prompt = self._ephemeral_system_prompt
+            if _profile_home is not None:
+                turn_ephemeral_prompt = self._load_ephemeral_system_prompt(
+                    config=user_config,
+                    hermes_home=_profile_home,
+                    include_env=True,
+                )
+            if turn_ephemeral_prompt:
+                combined_ephemeral = (combined_ephemeral + "\n\n" + turn_ephemeral_prompt).strip()
 
-            # Re-read .env and config for fresh credentials (gateway is long-lived,
-            # keys may change without restart). Keep config.yaml authoritative for
-            # runtime budget settings bridged into env vars.
-            _reload_runtime_env_preserving_config_authority()
+            pr = (
+                self._load_provider_routing(config=user_config, hermes_home=_profile_home)
+                if _profile_home is not None
+                else self._provider_routing
+            )
+            turn_prefill_messages = (
+                self._load_prefill_messages(
+                    config=user_config,
+                    hermes_home=_profile_home,
+                    include_env=False,
+                )
+                if _profile_home is not None
+                else self._prefill_messages
+            )
+
+            runtime_env = None
+            if _profile_home is not None:
+                try:
+                    runtime_env = self._runtime_env_for_profile_home(_profile_home)
+                except Exception as exc:
+                    logger.debug("Could not read routed profile .env from %s: %s", _profile_home, exc)
+                    runtime_env = {}
+            else:
+                # Re-read .env and config for fresh credentials (gateway is long-lived,
+                # keys may change without restart). Keep config.yaml authoritative for
+                # runtime budget settings bridged into env vars.
+                _reload_runtime_env_preserving_config_authority()
+            max_iterations = _resolve_max_iterations(
+                user_config=user_config,
+                runtime_env=runtime_env,
+            )
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
                     source=source,
                     session_key=session_key,
                     user_config=user_config,
+                    runtime_env=runtime_env,
                 )
+                if _profile_home is not None:
+                    from hermes_cli.auth import has_usable_secret
+                    if (
+                        not runtime_kwargs.get("credential_pool")
+                        and not runtime_kwargs.get("command")
+                        and not has_usable_secret(str(runtime_kwargs.get("api_key") or ""))
+                    ):
+                        raise RuntimeError(
+                            f"Routed profile {getattr(source, 'agent_profile', '')!r} has no "
+                            "profile-scoped provider credentials. Add the API key to that "
+                            "profile's .env/config/auth store; gateway credentials are not reused."
+                        )
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",
                     model, runtime_kwargs.get("provider"), session_key or "",
@@ -16137,13 +17375,18 @@ class GatewayRunner:
                     "tools": [],
                 }
 
-            pr = self._provider_routing
             reasoning_config = self._resolve_session_reasoning_config(
                 source=source,
                 session_key=session_key,
+                user_config=user_config if _profile_home is not None else None,
+                hermes_home=_profile_home,
             )
             self._reasoning_config = reasoning_config
-            self._service_tier = self._load_service_tier()
+            self._service_tier = (
+                self._load_service_tier(config=user_config, hermes_home=_profile_home)
+                if _profile_home is not None
+                else self._load_service_tier()
+            )
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None
             _stream_delta_cb = None
@@ -16207,11 +17450,11 @@ class GatewayRunner:
                             chat_type=getattr(source, "chat_type", "") or "",
                         )
                         _stream_consumer = GatewayStreamConsumer(
-                            adapter=_adapter,
-                            chat_id=source.chat_id,
-                            config=_consumer_cfg,
-                            metadata=_status_thread_metadata,
-                            on_new_message=(
+                        adapter=_adapter,
+                        chat_id=source.chat_id,
+                        config=_consumer_cfg,
+                        metadata=_status_thread_metadata,
+                        on_new_message=(
                                 (lambda: progress_queue.put(("__reset__",)))
                                 if progress_queue is not None
                                 else None
@@ -16249,6 +17492,19 @@ class GatewayRunner:
                 )
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            cache_keys = self._extract_cache_busting_config(user_config)
+            active_home = _profile_home or get_hermes_home()
+            cache_keys["hermes_home"] = str(active_home)
+            cache_keys["soul_md.digest"] = self._file_content_digest(active_home / "SOUL.md")
+            cache_keys["provider_routing.digest"] = self._stable_config_digest(pr)
+            cache_keys["prefill_messages.digest"] = self._stable_config_digest(
+                turn_prefill_messages or []
+            )
+            cache_keys["fallback.digest"] = self._stable_config_digest(
+                user_config.get("fallback_providers") or user_config.get("fallback_model")
+            )
+            if runtime_env is not None:
+                cache_keys["runtime_env.digest"] = self._stable_config_digest(runtime_env)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -16258,7 +17514,7 @@ class GatewayRunner:
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
-                cache_keys=self._extract_cache_busting_config(user_config),
+                cache_keys=cache_keys,
             )
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
@@ -16289,7 +17545,7 @@ class GatewayRunner:
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,
-                    prefill_messages=self._prefill_messages or None,
+                    prefill_messages=turn_prefill_messages or None,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
@@ -16308,8 +17564,13 @@ class GatewayRunner:
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
-                    session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    session_db=session_db if session_db is not None else self._session_db,
+                    fallback_model=(
+                        user_config.get("fallback_providers")
+                        or user_config.get("fallback_model")
+                        or (None if _profile_home is not None else self._fallback_model)
+                    ),
+                    runtime_env=runtime_env,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
@@ -16652,7 +17913,7 @@ class GatewayRunner:
             _resume_entry = None
             if session_key:
                 try:
-                    _resume_entry = self.session_store._entries.get(session_key)
+                    _resume_entry = session_store._entries.get(session_key)
                 except Exception:
                     _resume_entry = None
             _is_resume_pending = bool(
@@ -16849,10 +18110,10 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
+                entry = session_store._entries.get(session_key)
                 if entry:
                     entry.session_id = agent.session_id
-                    self.session_store._save()
+                    session_store._save()
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it
@@ -16865,10 +18126,10 @@ class GatewayRunner:
                     getattr(source, "platform", None) == Platform.TELEGRAM
                     and getattr(source, "chat_type", None) == "dm"
                     and getattr(source, "thread_id", None) is None
-                    and self._session_db is not None
+                    and session_db is not None
                 ):
                     try:
-                        _binding = self._session_db.get_telegram_topic_binding_by_session(
+                        _binding = session_db.get_telegram_topic_binding_by_session(
                             session_id=agent.session_id,
                         )
                         if _binding and _binding.get("thread_id"):
@@ -16895,7 +18156,7 @@ class GatewayRunner:
             _effective_history_offset = 0 if _session_was_split else len(agent_history)
 
             # Auto-generate session title after first exchange (non-blocking)
-            if final_response and self._session_db:
+            if final_response and session_db:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
@@ -16918,6 +18179,7 @@ class GatewayRunner:
                             "api_key": getattr(agent, "api_key", None),
                             "api_mode": getattr(agent, "api_mode", None),
                         } if agent else None,
+                        "env": getattr(agent, "_runtime_env", None) if agent else None,
                     }
                     if self._is_telegram_topic_lane(source):
                         maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
@@ -16926,7 +18188,7 @@ class GatewayRunner:
                             title,
                         )
                     maybe_auto_title(
-                        self._session_db,
+                        session_db,
                         effective_session_id,
                         message,
                         final_response,
@@ -17507,6 +18769,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    session_db=session_db,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
@@ -18169,6 +19432,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     return True
 
 
+def _load_gateway_config_from_file(path: str | Path) -> GatewayConfig:
+    import yaml
+
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    config = GatewayConfig.from_dict(data)
+    _validate_gateway_config(config)
+    return config
+
+
 def main():
     """CLI entry point for the gateway."""
     # Force UTF-8 stdio on Windows — gateway logs and startup banner would
@@ -18189,10 +19462,7 @@ def main():
     
     config = None
     if args.config:
-        import yaml
-        with open(args.config, encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-            config = GatewayConfig.from_dict(data)
+        config = _load_gateway_config_from_file(args.config)
     
     # Run the gateway - exit with code 1 if no platforms connected,
     # so systemd Restart=on-failure will retry on transient errors (e.g. DNS)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import json
+import re
 import threading
 import uuid
 from pathlib import Path
@@ -20,6 +21,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
+_PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 
 def _now() -> datetime:
@@ -64,6 +66,7 @@ from .whatsapp_identity import (
     canonical_whatsapp_identifier,
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
+from hermes_constants import get_hermes_home
 from utils import atomic_replace
 
 
@@ -91,6 +94,8 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    agent_profile: Optional[str] = None  # Logical Hermes profile for routed gateway messages.
+    agent_hermes_home: Optional[str] = None  # Optional explicit HERMES_HOME for that profile.
     
     @property
     def description(self) -> str:
@@ -134,6 +139,10 @@ class SessionSource:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
             d["message_id"] = self.message_id
+        if self.agent_profile:
+            d["agent_profile"] = self.agent_profile
+        if self.agent_hermes_home:
+            d["agent_hermes_home"] = self.agent_hermes_home
         return d
 
     @classmethod
@@ -152,6 +161,8 @@ class SessionSource:
             guild_id=data.get("guild_id"),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            agent_profile=data.get("agent_profile"),
+            agent_hermes_home=data.get("agent_hermes_home"),
         )
     
 
@@ -601,6 +612,7 @@ def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
     thread_sessions_per_user: bool = False,
+    profile: Optional[str] = None,
 ) -> str:
     """Build a deterministic session key from a message source.
 
@@ -625,6 +637,15 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
+    resolved_profile = str(profile or getattr(source, "agent_profile", None) or "").strip()
+    if resolved_profile and resolved_profile != "default" and not _PROFILE_ID_RE.match(resolved_profile):
+        logger.warning("Ignoring invalid agent profile for session key: %r", resolved_profile)
+        resolved_profile = ""
+    prefix = (
+        "agent:main"
+        if not resolved_profile or resolved_profile == "default"
+        else f"agent:{resolved_profile}"
+    )
     platform = source.platform.value
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
@@ -633,11 +654,11 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_chat_id}"
+                return f"{prefix}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+            return f"{prefix}:{platform}:dm:{dm_chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{prefix}:{platform}:dm:{source.thread_id}"
+        return f"{prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -645,7 +666,7 @@ def build_session_key(
         # single group member gets two isolated per-user sessions when the
         # bridge reshuffles alias forms.
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)
@@ -686,7 +707,10 @@ class SessionStore:
         self._db = None
         try:
             from hermes_state import SessionDB
-            self._db = SessionDB()
+            # Resolve the DB path at SessionStore construction time.  The
+            # hermes_state.DEFAULT_DB_PATH constant is evaluated at import time,
+            # so passing an explicit path is required for context-routed profiles.
+            self._db = SessionDB(db_path=get_hermes_home() / "state.db")
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
     
@@ -747,6 +771,7 @@ class SessionStore:
             source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            profile=getattr(source, "agent_profile", None),
         )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -37,7 +37,7 @@ needs to replace the import + call site:
 """
 
 from contextvars import ContextVar
-from typing import Any
+from typing import Any, Optional
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
@@ -60,6 +60,10 @@ _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
+_SESSION_AGENT_PROFILE: ContextVar = ContextVar("HERMES_SESSION_AGENT_PROFILE", default=_UNSET)
+_SESSION_AGENT_HERMES_HOME: ContextVar = ContextVar("HERMES_SESSION_AGENT_HERMES_HOME", default=_UNSET)
+_SESSION_PROFILE_STRICT_AUTH: ContextVar = ContextVar("HERMES_PROFILE_STRICT_AUTH", default=_UNSET)
+_SESSION_RUNTIME_ENV: ContextVar = ContextVar("HERMES_SESSION_RUNTIME_ENV", default=_UNSET)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
@@ -77,6 +81,9 @@ _VAR_MAP = {
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
+    "HERMES_SESSION_AGENT_PROFILE": _SESSION_AGENT_PROFILE,
+    "HERMES_SESSION_AGENT_HERMES_HOME": _SESSION_AGENT_HERMES_HOME,
+    "HERMES_PROFILE_STRICT_AUTH": _SESSION_PROFILE_STRICT_AUTH,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -92,6 +99,10 @@ def set_session_vars(
     user_name: str = "",
     session_key: str = "",
     message_id: str = "",
+    session_id: str = "",
+    agent_profile: str = "",
+    agent_hermes_home: str = "",
+    profile_strict_auth: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -110,6 +121,10 @@ def set_session_vars(
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
         _SESSION_MESSAGE_ID.set(message_id),
+        _SESSION_ID.set(session_id),
+        _SESSION_AGENT_PROFILE.set(agent_profile),
+        _SESSION_AGENT_HERMES_HOME.set(agent_hermes_home),
+        _SESSION_PROFILE_STRICT_AUTH.set(profile_strict_auth),
     ]
     return tokens
 
@@ -134,8 +149,13 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_NAME,
         _SESSION_KEY,
         _SESSION_MESSAGE_ID,
+        _SESSION_ID,
+        _SESSION_AGENT_PROFILE,
+        _SESSION_AGENT_HERMES_HOME,
+        _SESSION_PROFILE_STRICT_AUTH,
     ):
         var.set("")
+    _SESSION_RUNTIME_ENV.set({})
 
 
 def get_session_env(name: str, default: str = "") -> str:
@@ -162,3 +182,32 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def set_runtime_env(runtime_env: Optional[dict[str, Any]]) -> Any:
+    """Set the current turn's scoped runtime env and return a reset token."""
+    value = None if runtime_env is None else dict(runtime_env)
+    return _SESSION_RUNTIME_ENV.set(value)
+
+
+def clear_runtime_env(token: Any = None) -> None:
+    """Clear the runtime env without falling back to process-global secrets."""
+    if token is not None:
+        try:
+            _SESSION_RUNTIME_ENV.reset(token)
+            return
+        except Exception:
+            pass
+    _SESSION_RUNTIME_ENV.set({})
+
+
+def get_runtime_env(default: Optional[dict[str, Any]] = None) -> Optional[dict[str, Any]]:
+    """Return the scoped runtime env for this context, if one was set."""
+    value = _SESSION_RUNTIME_ENV.get()
+    if value is _UNSET:
+        return default
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    return default

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -68,6 +68,7 @@ except Exception:
 
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
+STRICT_PROFILE_AUTH_ENV = "HERMES_PROFILE_STRICT_AUTH"
 
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
@@ -102,6 +103,15 @@ MINIMAX_OAUTH_GLOBAL_BASE = "https://api.minimax.io"
 MINIMAX_OAUTH_CN_BASE = "https://api.minimaxi.com"
 MINIMAX_OAUTH_GLOBAL_INFERENCE = "https://api.minimax.io/anthropic"
 MINIMAX_OAUTH_CN_INFERENCE = "https://api.minimaxi.com/anthropic"
+
+
+def _env_get(env: Optional[Dict[str, Any]], key: str, default: str = "") -> str:
+    if env is None:
+        return os.getenv(key, default)
+    value = env.get(key, default)
+    return "" if value is None else str(value)
+
+
 MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
@@ -575,7 +585,7 @@ def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
 
 
 def _resolve_api_key_provider_secret(
-    provider_id: str, pconfig: ProviderConfig
+    provider_id: str, pconfig: ProviderConfig, env: Optional[Dict[str, Any]] = None
 ) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
     if provider_id == "copilot":
@@ -591,26 +601,32 @@ def _resolve_api_key_provider_secret(
             pass
         return "", ""
 
-    from hermes_cli.config import get_env_value
     for env_var in pconfig.api_key_env_vars:
-        # Check both os.environ and ~/.hermes/.env file
-        val = (get_env_value(env_var) or "").strip()
+        if env is None:
+            from hermes_cli.config import get_env_value
+            # Check both os.environ and ~/.hermes/.env file
+            val = (get_env_value(env_var) or "").strip()
+        else:
+            val = _env_get(env, env_var).strip()
         if has_usable_secret(val):
             return val, env_var
 
-    # Fallback: try credential pool (e.g. zai key stored via auth.json)
-    try:
-        from agent.credential_pool import load_pool
-        pool = load_pool(provider_id)
-        if pool and pool.has_credentials():
-            entry = pool.peek()
-            if entry:
-                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
-                key = str(key).strip()
-                if has_usable_secret(key):
-                    return key, f"credential_pool:{provider_id}"
-    except Exception:
-        pass
+    # Fallback: try credential pool (e.g. zai key stored via auth.json).
+    # Scoped callers pass an explicit env mapping; they must not inherit the
+    # process/global pool after their scoped env misses.
+    if env is None:
+        try:
+            from agent.credential_pool import load_pool
+            pool = load_pool(provider_id)
+            if pool and pool.has_credentials():
+                entry = pool.peek()
+                if entry:
+                    key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                    key = str(key).strip()
+                    if has_usable_secret(key):
+                        return key, f"credential_pool:{provider_id}"
+        except Exception:
+            pass
 
     return "", ""
 
@@ -830,6 +846,8 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
+    if profile_strict_auth_enabled():
+        return None
     try:
         from hermes_constants import get_default_hermes_root
         global_root = get_default_hermes_root()
@@ -849,6 +867,28 @@ def _global_auth_file_path() -> Optional[Path]:
     # belongs (that's what protects the real user's auth store from being
     # corrupted by a mis-configured test).
     return global_root / "auth.json"
+
+
+def profile_strict_auth_enabled(env: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True when routed-profile auth must not use global fallbacks."""
+    if isinstance(env, dict) and is_truthy_value(
+        str(env.get(STRICT_PROFILE_AUTH_ENV, "") or "")
+    ):
+        return True
+    if is_truthy_value(os.getenv(STRICT_PROFILE_AUTH_ENV, "")):
+        return True
+    try:
+        from gateway.session_context import get_runtime_env, get_session_env
+        if is_truthy_value(get_session_env(STRICT_PROFILE_AUTH_ENV, "")):
+            return True
+        runtime_env = get_runtime_env()
+        if isinstance(runtime_env, dict) and is_truthy_value(
+            str(runtime_env.get(STRICT_PROFILE_AUTH_ENV, "") or "")
+        ):
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def _load_global_auth_store() -> Dict[str, Any]:
@@ -1387,6 +1427,7 @@ def resolve_provider(
     *,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Determine which inference provider to use.
@@ -1480,7 +1521,7 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    if has_usable_secret(_env_get(env, "OPENAI_API_KEY")) or has_usable_secret(_env_get(env, "OPENROUTER_API_KEY")):
         return "openrouter"
 
     # Auto-detect API-key providers by checking their env vars
@@ -1496,17 +1537,18 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(_env_get(env, env_var)):
                 return pid
 
     # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).
     # This runs after API-key providers so explicit keys always win.
-    try:
-        from agent.bedrock_adapter import has_aws_credentials
-        if has_aws_credentials():
-            return "bedrock"
-    except ImportError:
-        pass  # boto3 not installed — skip Bedrock auto-detection
+    if env is None or any(_env_get(env, key).strip() for key in ("AWS_ACCESS_KEY_ID", "AWS_PROFILE")):
+        try:
+            from agent.bedrock_adapter import has_aws_credentials
+            if has_aws_credentials():
+                return "bedrock"
+        except ImportError:
+            pass  # boto3 not installed — skip Bedrock auto-detection
 
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
@@ -3256,6 +3298,8 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     Returns tokens dict if valid and not expired, None otherwise.
     Does NOT write to the shared file.
     """
+    if profile_strict_auth_enabled():
+        return None
     codex_home = os.getenv("CODEX_HOME", "").strip()
     if not codex_home:
         codex_home = str(Path.home() / ".codex")
@@ -4095,6 +4139,8 @@ def _nous_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
 
 def _merge_shared_nous_oauth_state(state: Dict[str, Any]) -> bool:
     """Copy fresher shared OAuth tokens into a profile-local Nous state."""
+    if profile_strict_auth_enabled():
+        return False
     shared = _read_shared_nous_state()
     if not shared:
         return False
@@ -4139,6 +4185,8 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     (either an invoke JWT or legacy opaque session key) — only OAuth tokens
     are cross-profile useful.
     """
+    if profile_strict_auth_enabled():
+        return
     refresh_token = state.get("refresh_token")
     access_token = state.get("access_token")
     if not (isinstance(refresh_token, str) and refresh_token.strip()):
@@ -4203,6 +4251,8 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     lacks required fields. Callers should treat ``None`` as "no shared
     credentials available — fall through to device-code".
     """
+    if profile_strict_auth_enabled():
+        return None
     try:
         path = _nous_shared_store_path()
     except RuntimeError:
@@ -4228,6 +4278,8 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
 
 def _clear_shared_nous_state(reason: str) -> None:
     """Remove the shared Nous OAuth store after a terminal token failure."""
+    if profile_strict_auth_enabled():
+        return
     try:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
@@ -4373,6 +4425,8 @@ def _try_import_shared_nous_state(
     etc.) — caller should then fall through to the normal device-code
     flow.
     """
+    if profile_strict_auth_enabled():
+        return None
     try:
         with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
             shared = _read_shared_nous_state()
@@ -5745,7 +5799,11 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     return info
 
 
-def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
+def resolve_api_key_provider_credentials(
+    provider_id: str,
+    *,
+    env: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Resolve API key and base URL for an API-key provider.
 
     Returns dict with: provider, api_key, base_url, source.
@@ -5760,7 +5818,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     api_key = ""
     key_source = ""
-    api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
+    api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig, env=env)
 
     # No-auth LM Studio: substitute a placeholder so runtime / auxiliary_client
     # see the local server as configured. doctor still reports unconfigured
@@ -5771,7 +5829,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = _env_get(env, pconfig.base_url_env_var).strip()
 
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -5790,8 +5848,20 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str, Any]:
+def resolve_external_process_provider_credentials(
+    provider_id: str,
+    *,
+    env: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Resolve runtime details for local subprocess-backed providers."""
+    if profile_strict_auth_enabled(env):
+        raise AuthError(
+            "External-process providers are disabled for strict routed profiles. "
+            "Configure provider credentials inside the routed profile instead.",
+            provider=provider_id,
+            code="profile_strict_external_process_disabled",
+        )
+
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         raise AuthError(
@@ -5800,16 +5870,16 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = _env_get(env, pconfig.base_url_env_var).strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
+        _env_get(env, "HERMES_COPILOT_ACP_COMMAND").strip()
+        or _env_get(env, "COPILOT_CLI_PATH").strip()
         or "copilot"
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+    raw_args = _env_get(env, "HERMES_COPILOT_ACP_ARGS").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from utils import atomic_replace
 
 
@@ -79,6 +79,54 @@ def _sanitize_loaded_credentials() -> None:
             ".env file in a plain-text editor).",
             file=sys.stderr,
         )
+
+
+def _sanitize_env_mapping_credentials(values: dict[str, str]) -> dict[str, str]:
+    """Return a copy with non-ASCII credential characters stripped in memory."""
+    cleaned_values = dict(values)
+    for key, value in list(cleaned_values.items()):
+        if not any(key.endswith(suffix) for suffix in _CREDENTIAL_SUFFIXES):
+            continue
+        try:
+            value.encode("ascii")
+            continue
+        except UnicodeEncodeError:
+            pass
+        cleaned = value.encode("ascii", errors="ignore").decode("ascii")
+        cleaned_values[key] = cleaned
+        if key in _WARNED_KEYS:
+            continue
+        _WARNED_KEYS.add(key)
+        stripped = len(value) - len(cleaned)
+        detail = _format_offending_chars(value) or "non-printable"
+        print(
+            f"  Warning: {key} contained {stripped} non-ASCII character"
+            f"{'s' if stripped != 1 else ''} ({detail}) — stripped in memory so "
+            f"the key can be sent as an HTTP header.",
+            file=sys.stderr,
+        )
+    return cleaned_values
+
+
+def read_hermes_dotenv_values(
+    *,
+    hermes_home: str | os.PathLike | None = None,
+) -> dict[str, str]:
+    """Read a Hermes .env file without mutating ``os.environ``."""
+    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    env_path = home_path / ".env"
+    if not env_path.exists():
+        return {}
+    try:
+        values = dotenv_values(dotenv_path=env_path, encoding="utf-8")
+    except UnicodeDecodeError:
+        values = dotenv_values(dotenv_path=env_path, encoding="latin-1")
+    parsed = {
+        str(key): str(value)
+        for key, value in values.items()
+        if key is not None and value is not None
+    }
+    return _sanitize_env_mapping_credentials(parsed)
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9621,6 +9621,9 @@ def cmd_profile(args):
         check_alias_collision,
         create_wrapper_script,
         remove_wrapper_script,
+        audit_profile_isolation,
+        format_profile_isolation_audit,
+        write_profile_identity_marker,
         _is_wrapper_dir_in_path,
         _get_wrapper_dir,
     )
@@ -9920,6 +9923,28 @@ def cmd_profile(args):
         if not all_flag:
             sys.exit(0 if ok_count == 1 else 1)
         sys.exit(0 if ok_count > 0 else 1)
+
+    elif action == "audit-isolation":
+        name = args.profile_name
+        try:
+            if getattr(args, "write_marker", False):
+                from hermes_cli.profiles import get_profile_dir
+                profile_dir = get_profile_dir(name)
+                safe_root = Path(getattr(args, "safe_root", None)).expanduser() if getattr(args, "safe_root", None) else profile_dir.parent
+                write_profile_identity_marker(name, profile_dir, safe_root, overwrite=True)
+            report = audit_profile_isolation(
+                name,
+                safe_root=getattr(args, "safe_root", None),
+            )
+            if getattr(args, "json", False):
+                print(json.dumps(report, indent=2, sort_keys=True))
+            else:
+                print(format_profile_isolation_audit(report))
+            if report.get("status") == "FAIL":
+                sys.exit(1)
+        except Exception as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
 
     elif action == "show":
         name = args.profile_name
@@ -13015,6 +13040,27 @@ Examples:
         dest="all_missing",
         action="store_true",
         help="With --auto, run on every profile missing a description",
+    )
+
+    profile_audit = profile_subparsers.add_parser(
+        "audit-isolation",
+        help="Audit routed profile isolation without printing secrets",
+    )
+    profile_audit.add_argument("profile_name", help="Profile to audit")
+    profile_audit.add_argument(
+        "--safe-root",
+        default=None,
+        help="Expected topic_profiles_safe_root for routed profiles",
+    )
+    profile_audit.add_argument(
+        "--write-marker",
+        action="store_true",
+        help="Write or refresh .hermes_profile.json before auditing",
+    )
+    profile_audit.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable audit output",
     )
 
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -27,8 +27,10 @@ import stat
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -104,6 +106,444 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 # `hermes skills install` or drop SKILL.md files into the profile's skills/.
 # Delete the marker file to opt back in.
 NO_BUNDLED_SKILLS_MARKER = ".no-bundled-skills"
+PROFILE_IDENTITY_FILENAME = ".hermes_profile.json"
+PROFILE_IDENTITY_VERSION = 1
+
+_AUDIT_SECRET_KEY_PARTS = (
+    "API",
+    "AUTH",
+    "BEARER",
+    "COOKIE",
+    "CREDENTIAL",
+    "KEY",
+    "PASSWORD",
+    "SECRET",
+    "TOKEN",
+)
+_AUDIT_SENSITIVE_ROOTS = (
+    ".env",
+    "auth.json",
+    "config.yaml",
+    "SOUL.md",
+    "memories",
+    "sessions",
+    "logs",
+    "plugins",
+    "hooks",
+    "mcp",
+    "cron",
+)
+_AUDIT_MEMORY_FILES = (
+    "SOUL.md",
+    "memories/MEMORY.md",
+    "memories/USER.md",
+)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _has_symlink_ancestor(path: Path, stop_at: Path | None = None) -> bool:
+    """Return True when path or an existing ancestor is a symlink."""
+    current = path
+    stop = stop_at.resolve(strict=False) if stop_at is not None else None
+    while True:
+        try:
+            if current.exists() and current.is_symlink():
+                return True
+        except OSError:
+            return True
+        if stop is not None:
+            try:
+                if current.resolve(strict=False) == stop:
+                    return False
+            except OSError:
+                return True
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+
+
+def _profile_identity_payload(
+    profile_id: str,
+    profile_dir: Path,
+    profiles_root: Path | None = None,
+) -> Dict[str, Any]:
+    root = profiles_root or profile_dir.parent
+    return {
+        "version": PROFILE_IDENTITY_VERSION,
+        "profile_id": profile_id,
+        "home_realpath": str(profile_dir.resolve(strict=False)),
+        "profiles_root_realpath": str(root.resolve(strict=False)),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def write_profile_identity_marker(
+    profile_name: str,
+    profile_dir: Path | None = None,
+    profiles_root: Path | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Write a non-secret identity marker for a routed profile."""
+    canon = normalize_profile_name(profile_name)
+    validate_profile_name(canon)
+    profile_dir = (profile_dir or get_profile_dir(canon)).expanduser()
+    marker = profile_dir / PROFILE_IDENTITY_FILENAME
+    if marker.is_symlink():
+        raise ValueError(f"{PROFILE_IDENTITY_FILENAME} must not be a symlink")
+    if marker.exists() and not overwrite:
+        return marker
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"Profile '{canon}' does not exist at {profile_dir}")
+    payload = _profile_identity_payload(canon, profile_dir, profiles_root)
+    tmp = marker.with_name(f"{marker.name}.tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        tmp.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+    tmp.replace(marker)
+    return marker
+
+
+def load_profile_identity_marker(profile_dir: Path) -> Dict[str, Any]:
+    marker = profile_dir / PROFILE_IDENTITY_FILENAME
+    if marker.is_symlink():
+        raise ValueError(f"{PROFILE_IDENTITY_FILENAME} must not be a symlink")
+    if not marker.is_file():
+        raise FileNotFoundError(f"Missing {PROFILE_IDENTITY_FILENAME}")
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Invalid {PROFILE_IDENTITY_FILENAME}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid {PROFILE_IDENTITY_FILENAME}: expected object")
+    return data
+
+
+def validate_profile_identity(
+    profile_name: str,
+    profile_dir: Path,
+    profiles_root: Path,
+) -> None:
+    """Fail closed unless the routed profile identity matches the filesystem."""
+    canon = normalize_profile_name(profile_name)
+    validate_profile_name(canon)
+    profile_dir = profile_dir.expanduser()
+    profiles_root = profiles_root.expanduser()
+    if _has_symlink_ancestor(profile_dir, profiles_root.parent):
+        raise ValueError("profile home ancestry must not contain symlinks")
+    if _has_symlink_ancestor(profiles_root, profiles_root.parent):
+        raise ValueError("profiles root ancestry must not contain symlinks")
+    home_real = profile_dir.resolve(strict=False)
+    root_real = profiles_root.resolve(strict=False)
+    if not _is_relative_to(home_real, root_real):
+        raise ValueError("profile home must stay inside profiles root")
+    if home_real == (Path.home() / ".hermes").resolve(strict=False):
+        raise ValueError("profile home must not be ~/.hermes")
+    if not home_real.is_dir():
+        raise FileNotFoundError(f"profile home does not exist: {home_real}")
+    marker = load_profile_identity_marker(home_real)
+    if marker.get("version") != PROFILE_IDENTITY_VERSION:
+        raise ValueError(f"{PROFILE_IDENTITY_FILENAME} version mismatch")
+    if marker.get("profile_id") != canon:
+        raise ValueError(f"{PROFILE_IDENTITY_FILENAME} profile_id mismatch")
+    if str(marker.get("home_realpath") or "") != str(home_real):
+        raise ValueError(f"{PROFILE_IDENTITY_FILENAME} home_realpath mismatch")
+    if str(marker.get("profiles_root_realpath") or "") != str(root_real):
+        raise ValueError(f"{PROFILE_IDENTITY_FILENAME} profiles_root_realpath mismatch")
+
+
+def _read_env_keyset_and_secret_flag(path: Path) -> tuple[list[str], bool]:
+    keys: list[str] = []
+    secret_bearing = False
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return keys, False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, raw_value = stripped.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        keys.append(key)
+        value = raw_value.strip().strip("'\"")
+        if _is_secret_key_name(key) and _looks_secret_value(value):
+            secret_bearing = True
+    return sorted(set(keys)), secret_bearing
+
+
+def _is_secret_key_name(key: str) -> bool:
+    lowered = str(key or "").strip().lower()
+    if lowered in {"auth_type", "record_key"} or lowered.endswith("_key_env"):
+        return False
+    if lowered in {"url", "base_url", "api_url", "endpoint"} or lowered.endswith("_url"):
+        return False
+    upper = lowered.upper()
+    return any(part in upper for part in _AUDIT_SECRET_KEY_PARTS)
+
+
+def _looks_secret_value(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip().strip("'\"")
+    if not text:
+        return False
+    if text.lower() in {
+        "true",
+        "false",
+        "none",
+        "null",
+        "default",
+        "changeme",
+        "change-me",
+        "placeholder",
+    }:
+        return False
+    if re.fullmatch(r"[0-9_.,:-]+", text):
+        return False
+    return True
+
+
+def _secret_fingerprint(value: Any) -> str | None:
+    if not _looks_secret_value(value):
+        return None
+    text = str(value or "").strip()
+    return sha256(text.encode("utf-8")).hexdigest()
+
+
+def _read_env_secret_fingerprints(path: Path) -> tuple[set[str], list[str]]:
+    fingerprints: set[str] = set()
+    keys: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return fingerprints, keys
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, raw_value = stripped.split("=", 1)
+        key = key.strip()
+        if not key or not _is_secret_key_name(key):
+            continue
+        value = raw_value.strip().strip("'\"")
+        fp = _secret_fingerprint(value)
+        if fp:
+            fingerprints.add(fp)
+            keys.append(key)
+    return fingerprints, sorted(set(keys))
+
+
+def _json_secret_fingerprints(value: Any, key_path: tuple[str, ...] = ()) -> set[str]:
+    fingerprints: set[str] = set()
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            fingerprints |= _json_secret_fingerprints(nested, (*key_path, str(key)))
+        return fingerprints
+    if isinstance(value, list):
+        for nested in value:
+            fingerprints |= _json_secret_fingerprints(nested, key_path)
+        return fingerprints
+    if key_path and isinstance(value, str) and _is_secret_key_name(key_path[-1]):
+        fp = _secret_fingerprint(value)
+        if fp:
+            fingerprints.add(fp)
+    return fingerprints
+
+
+def _read_json_secret_fingerprints(path: Path) -> set[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return set()
+    return _json_secret_fingerprints(data)
+
+
+def _read_yaml_secret_fingerprints(path: Path) -> set[str]:
+    try:
+        import yaml
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return set()
+    return _json_secret_fingerprints(data)
+
+
+def _file_sha256(path: Path) -> str | None:
+    try:
+        return sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _audit_add(findings: list[dict], status: str, relpath: str, message: str, **extra: Any) -> None:
+    item = {"status": status, "path": relpath, "message": message}
+    item.update(extra)
+    findings.append(item)
+
+
+def audit_profile_isolation(
+    profile_name: str,
+    *,
+    safe_root: str | Path | None = None,
+) -> Dict[str, Any]:
+    """Audit routed profile isolation without printing secret values."""
+    canon = normalize_profile_name(profile_name)
+    validate_profile_name(canon)
+    profiles_root = Path(safe_root).expanduser().resolve(strict=False) if safe_root else _get_profiles_root().resolve(strict=False)
+    profile_dir = (profiles_root / canon).resolve(strict=False)
+    default_home = _get_default_hermes_home().resolve(strict=False)
+    main_home = profiles_root.parent.resolve(strict=False) if default_home == profile_dir else default_home
+    findings: list[dict] = []
+
+    try:
+        validate_profile_identity(canon, profile_dir, profiles_root)
+        _audit_add(findings, "OK", PROFILE_IDENTITY_FILENAME, "identity marker matches profile home")
+    except Exception as exc:
+        _audit_add(findings, "FAIL", PROFILE_IDENTITY_FILENAME, str(exc))
+
+    for rel in _AUDIT_SENSITIVE_ROOTS:
+        target = profile_dir / rel
+        if not target.exists() and not target.is_symlink():
+            continue
+        try:
+            if target.is_symlink():
+                resolved = target.resolve(strict=False)
+                if not _is_relative_to(resolved, profile_dir):
+                    _audit_add(findings, "FAIL", rel, "symlink points outside profile home")
+                continue
+            if target.is_file() and target.stat().st_nlink > 1:
+                _audit_add(findings, "FAIL", rel, "hardlink count is greater than one")
+        except OSError as exc:
+            _audit_add(findings, "FAIL", rel, f"cannot stat path: {exc}")
+            continue
+        if target.is_dir():
+            for child in target.rglob("*"):
+                child_rel = child.relative_to(profile_dir).as_posix()
+                try:
+                    if child.is_symlink():
+                        resolved = child.resolve(strict=False)
+                        if not _is_relative_to(resolved, profile_dir):
+                            _audit_add(findings, "FAIL", child_rel, "symlink points outside profile home")
+                        continue
+                    if child.is_file() and child.stat().st_nlink > 1:
+                        _audit_add(findings, "FAIL", child_rel, "hardlink count is greater than one")
+                except OSError as exc:
+                    _audit_add(findings, "FAIL", child_rel, f"cannot inspect path: {exc}")
+
+    env_path = profile_dir / ".env"
+    main_env = main_home / ".env"
+    if env_path.is_file() and main_env.is_file():
+        keys, secret_bearing = _read_env_keyset_and_secret_flag(env_path)
+        keyset_hash = sha256("\n".join(keys).encode("utf-8")).hexdigest()[:16]
+        profile_secret_fps, _profile_secret_keys = _read_env_secret_fingerprints(env_path)
+        main_secret_fps, _main_secret_keys = _read_env_secret_fingerprints(main_env)
+        shared_secret_fps = profile_secret_fps & main_secret_fps
+        if shared_secret_fps:
+            _audit_add(
+                findings,
+                "FAIL",
+                ".env",
+                "profile .env shares secret values with main .env",
+                keyset_hash=keyset_hash,
+                shared_secret_count=len(shared_secret_fps),
+            )
+        elif _file_sha256(env_path) == _file_sha256(main_env):
+            status = "FAIL" if secret_bearing else "WARN"
+            _audit_add(
+                findings,
+                status,
+                ".env",
+                "profile .env is byte-identical to main .env",
+                keyset_hash=keyset_hash,
+            )
+
+    auth_path = profile_dir / "auth.json"
+    main_auth = main_home / "auth.json"
+    if auth_path.is_file() and main_auth.is_file() and auth_path.stat().st_size > 0:
+        shared_secret_fps = (
+            _read_json_secret_fingerprints(auth_path)
+            & _read_json_secret_fingerprints(main_auth)
+        )
+        if shared_secret_fps:
+            _audit_add(
+                findings,
+                "FAIL",
+                "auth.json",
+                "profile auth.json shares secret values with main auth.json",
+                shared_secret_count=len(shared_secret_fps),
+            )
+        elif _file_sha256(auth_path) == _file_sha256(main_auth):
+            _audit_add(findings, "FAIL", "auth.json", "profile auth.json is byte-identical to main auth.json")
+
+    config_path = profile_dir / "config.yaml"
+    main_config = main_home / "config.yaml"
+    if config_path.is_file() and main_config.is_file() and config_path.stat().st_size > 0:
+        shared_secret_fps = (
+            _read_yaml_secret_fingerprints(config_path)
+            & _read_yaml_secret_fingerprints(main_config)
+        )
+        if shared_secret_fps:
+            _audit_add(
+                findings,
+                "FAIL",
+                "config.yaml",
+                "profile config.yaml shares secret values with main config.yaml",
+                shared_secret_count=len(shared_secret_fps),
+            )
+
+    for rel in _AUDIT_MEMORY_FILES:
+        path = profile_dir / rel
+        main_path = main_home / rel
+        if not (path.is_file() and main_path.is_file()):
+            continue
+        try:
+            if path.stat().st_size == 0:
+                continue
+        except OSError:
+            continue
+        if _file_sha256(path) == _file_sha256(main_path):
+            _audit_add(findings, "FAIL", rel, "profile identity/memory file is non-empty and identical to main")
+
+    if not any(f["status"] in {"FAIL", "WARN"} for f in findings):
+        _audit_add(findings, "OK", ".", "no isolation issues detected")
+
+    overall = "FAIL" if any(f["status"] == "FAIL" for f in findings) else (
+        "WARN" if any(f["status"] == "WARN" for f in findings) else "OK"
+    )
+    return {
+        "profile": canon,
+        "home": profile_dir.name,
+        "profiles_root": profiles_root.name,
+        "status": overall,
+        "findings": findings,
+    }
+
+
+def format_profile_isolation_audit(report: Dict[str, Any]) -> str:
+    lines = [
+        f"Profile isolation audit: {report.get('profile')}",
+        f"Status: {report.get('status')}",
+    ]
+    for finding in report.get("findings", []):
+        extra = ""
+        if finding.get("keyset_hash"):
+            extra = f" keyset_hash={finding['keyset_hash']}"
+        lines.append(
+            f"- {finding.get('status')}: {finding.get('path')}: {finding.get('message')}{extra}"
+        )
+    return "\n".join(lines)
 
 
 def has_bundled_skills_opt_out(profile_dir: Path) -> bool:
@@ -773,6 +1213,8 @@ def create_profile(
             )
         except Exception:
             pass  # non-fatal — user can describe later with `hermes profile describe`
+
+    write_profile_identity_marker(canon, profile_dir, profile_dir.parent, overwrite=True)
 
     return profile_dir
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import json
 import os
 import re
 from typing import Any, Dict, Optional
@@ -30,8 +31,90 @@ from hermes_cli.auth import (
     has_usable_secret,
 )
 from hermes_cli.config import get_compatible_custom_providers, load_config
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_constants import OPENROUTER_BASE_URL, get_default_hermes_root, get_hermes_home
 from utils import base_url_host_matches, base_url_hostname
+
+
+def _env_get(env: Optional[Dict[str, Any]], key: str, default: str = "") -> str:
+    if env is None:
+        return os.getenv(key, default)
+    value = env.get(key, default)
+    return "" if value is None else str(value)
+
+
+def _resolve_api_key_credentials(provider: str, env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if env is None:
+        return resolve_api_key_provider_credentials(provider)
+    return resolve_api_key_provider_credentials(provider, env=env)
+
+
+def _scoped_auth_store_allowed(env: Optional[Dict[str, Any]]) -> bool:
+    if env is None:
+        return True
+    try:
+        profile_home = get_hermes_home().resolve(strict=False)
+        default_home = get_default_hermes_root().resolve(strict=False)
+        return profile_home != default_home
+    except Exception:
+        return False
+
+
+def _load_pool_for_env(provider: str, env: Optional[Dict[str, Any]]) -> Optional[CredentialPool]:
+    if env is None:
+        return load_pool(provider)
+    if not _scoped_auth_store_allowed(env):
+        return None
+    auth_path = get_hermes_home() / "auth.json"
+    try:
+        if not auth_path.is_file():
+            return CredentialPool(provider, [])
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+        pools = data.get("credential_pool") if isinstance(data, dict) else None
+        raw_entries = pools.get(provider) if isinstance(pools, dict) else []
+        if not isinstance(raw_entries, list):
+            raw_entries = []
+        entries = [PooledCredential.from_dict(provider, entry) for entry in raw_entries]
+        return CredentialPool(provider, entries)
+    except Exception as exc:
+        logger.debug("Runtime provider: could not load scoped pool for %s: %s", provider, exc)
+        return CredentialPool(provider, [])
+
+
+def _scoped_provider_state_exists(provider: str, env: Optional[Dict[str, Any]]) -> bool:
+    if env is None:
+        return True
+    if not _scoped_auth_store_allowed(env):
+        return False
+    auth_path = get_hermes_home() / "auth.json"
+    try:
+        if not auth_path.is_file():
+            return False
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("Runtime provider: could not inspect scoped auth state for %s: %s", provider, exc)
+        return False
+    providers = data.get("providers") if isinstance(data, dict) else None
+    state = providers.get(provider) if isinstance(providers, dict) else None
+    return isinstance(state, dict) and bool(state)
+
+
+def _scoped_auth_unavailable(provider: str) -> AuthError:
+    return AuthError(
+        f"Provider '{provider}' has no profile-scoped auth credentials. "
+        "Configure credentials in the routed profile instead of relying on "
+        "gateway/global auth state.",
+        provider=provider,
+        code="no_scoped_credentials",
+    )
+
+
+def _get_named_custom_provider_for_env(
+    requested_provider: str,
+    env: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    if env is None:
+        return _get_named_custom_provider(requested_provider)
+    return _get_named_custom_provider(requested_provider, env=env)
 
 
 def _normalize_custom_provider_name(value: str) -> str:
@@ -100,7 +183,7 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
-def _host_derived_api_key(base_url: str) -> str:
+def _host_derived_api_key(base_url: str, env: Optional[Dict[str, Any]] = None) -> str:
     """Look up `<VENDOR>_API_KEY` in the env, derived from the base URL host.
 
     Examples:
@@ -154,7 +237,7 @@ def _host_derived_api_key(base_url: str) -> str:
     if sanitized in ("OPENAI", "OPENROUTER", "OLLAMA"):
         return ""
     env_name = f"{sanitized}_API_KEY"
-    return (os.getenv(env_name, "") or "").strip()
+    return _env_get(env, env_name).strip()
 
 
 def _auto_detect_local_model(base_url: str) -> str:
@@ -423,7 +506,11 @@ def _resolve_runtime_from_pool_entry(
     }
 
 
-def resolve_requested_provider(requested: Optional[str] = None) -> str:
+def resolve_requested_provider(
+    requested: Optional[str] = None,
+    *,
+    env: Optional[Dict[str, Any]] = None,
+) -> str:
     """Resolve provider request from explicit arg, config, then env."""
     if requested and requested.strip():
         return requested.strip().lower()
@@ -435,7 +522,7 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
 
     # Prefer the persisted config selection over any stale shell/.env
     # provider override so chat uses the endpoint the user last saved.
-    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+    env_provider = _env_get(env, "HERMES_INFERENCE_PROVIDER").strip().lower()
     if env_provider:
         return env_provider
 
@@ -447,13 +534,14 @@ def _try_resolve_from_custom_pool(
     provider_label: str,
     api_mode_override: Optional[str] = None,
     provider_name: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
         return None
     try:
-        pool = load_pool(pool_key)
+        pool = _load_pool_for_env(pool_key, env)
         if not pool.has_credentials():
             return None
         entry = pool.select()
@@ -474,7 +562,11 @@ def _try_resolve_from_custom_pool(
         return None
 
 
-def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
+def _get_named_custom_provider(
+    requested_provider: str,
+    *,
+    env: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm or requested_norm == "custom":
         return None
@@ -486,7 +578,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         return None
     if not requested_norm.startswith("custom:"):
         try:
-            canonical = auth_mod.resolve_provider(requested_norm)
+            canonical = auth_mod.resolve_provider(requested_norm, env=env)
         except AuthError:
             pass
         else:
@@ -512,8 +604,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+            resolved_api_key = _env_get(env, key_env).strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
@@ -528,6 +620,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    if key_env:
+                        result["key_env"] = key_env
                     # The v11→v12 migration writes the API mode under the new
                     # ``transport`` field, but hand-edited configs may still
                     # use the legacy ``api_mode`` spelling.  Accept both —
@@ -553,6 +647,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
+                        if key_env:
+                            result["key_env"] = key_env
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
@@ -612,6 +708,7 @@ def _resolve_named_custom_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     # Bare `provider="custom"` with an explicit base_url (e.g. propagated
     # from a `model_aliases:` direct-alias resolution) — build a runtime
@@ -635,7 +732,7 @@ def _resolve_named_custom_runtime(
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None, env=env)
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result
@@ -644,12 +741,12 @@ def _resolve_named_custom_runtime(
         api_key_candidates = [
             (explicit_api_key or "").strip(),
             # Gate env key fallbacks on authoritative hosts (#28660)
-            (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
-            (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
+            (_env_get(env, "OPENAI_API_KEY").strip()     if _da_is_openai_url else ""),
+            (_env_get(env, "OPENROUTER_API_KEY").strip() if _da_is_openrouter  else ""),
             # Bonus (#28660): derive `<VENDOR>_API_KEY` from the host so users
             # who set DEEPSEEK_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY get the
             # intuitive match without configuring `custom_providers` first.
-            _host_derived_api_key(base_url),
+            _host_derived_api_key(base_url, env),
         ]
         api_key = next(
             (c for c in api_key_candidates if has_usable_secret(c)),
@@ -664,7 +761,7 @@ def _resolve_named_custom_runtime(
             "requested_provider": requested_provider,
         }
 
-    custom_provider = _get_named_custom_provider(requested_provider)
+    custom_provider = _get_named_custom_provider_for_env(requested_provider, env)
     if not custom_provider:
         return None
 
@@ -676,7 +773,13 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    pool_result = _try_resolve_from_custom_pool(
+        base_url,
+        "custom",
+        custom_provider.get("api_mode"),
+        provider_name=custom_provider.get("name"),
+        env=env,
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -687,17 +790,29 @@ def _resolve_named_custom_runtime(
 
     _cp_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
+    explicit_key = (explicit_api_key or "").strip()
+    inline_key = str(custom_provider.get("api_key", "") or "").strip()
+    key_env = str(custom_provider.get("key_env", "") or "").strip()
+    key_env_value = _env_get(env, key_env).strip() if key_env else ""
+    if env is not None and key_env and not explicit_key and not inline_key and not key_env_value:
+        logger.debug(
+            "Named custom provider %s skipped: key_env %s is not present in scoped runtime env",
+            custom_provider.get("name", requested_provider),
+            key_env,
+        )
+        return None
+
     api_key_candidates = [
-        (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        explicit_key,
+        inline_key,
+        key_env_value,
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
-        (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),
-        (os.getenv("OPENROUTER_API_KEY", "").strip() if _cp_is_openrouter  else ""),
+        (_env_get(env, "OPENAI_API_KEY").strip()     if _cp_is_openai_url  else ""),
+        (_env_get(env, "OPENROUTER_API_KEY").strip() if _cp_is_openrouter  else ""),
         # Bonus (#28660): derive `<VENDOR>_API_KEY` from the host as a final
         # fallback when key_env wasn't set explicitly.
-        _host_derived_api_key(base_url),
+        _host_derived_api_key(base_url, env),
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
@@ -722,6 +837,7 @@ def _resolve_openrouter_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
@@ -748,8 +864,8 @@ def _resolve_openrouter_runtime(
         except Exception:
             pass
 
-    env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
-    env_custom_base_url = os.getenv("CUSTOM_BASE_URL", "").strip()
+    env_openrouter_base_url = _env_get(env, "OPENROUTER_BASE_URL").strip()
+    env_custom_base_url = _env_get(env, "CUSTOM_BASE_URL").strip()
 
     # Use config base_url when available and the provider context matches.
     # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
@@ -789,8 +905,8 @@ def _resolve_openrouter_runtime(
     if _is_openrouter_context:
         api_key_candidates = [
             explicit_api_key,
-            os.getenv("OPENROUTER_API_KEY"),
-            os.getenv("OPENAI_API_KEY"),
+            _env_get(env, "OPENROUTER_API_KEY"),
+            _env_get(env, "OPENAI_API_KEY"),
         ]
     else:
         # Custom endpoint: use api_key from config when using config base_url (#1760).
@@ -810,14 +926,14 @@ def _resolve_openrouter_runtime(
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
-            (os.getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
-            (os.getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
-            (os.getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),
+            (_env_get(env, "OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
+            (_env_get(env, "OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
+            (_env_get(env, "OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),
             # Bonus (#28660): derive `<VENDOR>_API_KEY` from the host so users
             # who set DEEPSEEK_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY get the
             # intuitive match. Helper returns "" for IPs/loopback and for env
             # vars already handled by the explicit host-gated paths above.
-            _host_derived_api_key(base_url),
+            _host_derived_api_key(base_url, env),
         ]
     api_key = next(
         (str(candidate or "").strip() for candidate in api_key_candidates if has_usable_secret(candidate)),
@@ -839,6 +955,7 @@ def _resolve_openrouter_runtime(
         pool_result = _try_resolve_from_custom_pool(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
             provider_name=requested_provider if requested_norm != "custom" else None,
+            env=env,
         )
         if pool_result:
             return pool_result
@@ -864,6 +981,7 @@ def _resolve_azure_foundry_runtime(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     target_model: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Resolve an Azure Foundry runtime entry.
 
@@ -915,7 +1033,7 @@ def _resolve_azure_foundry_runtime(
         if inferred:
             cfg_api_mode = inferred
 
-    env_base_url = os.getenv("AZURE_FOUNDRY_BASE_URL", "").strip().rstrip("/")
+    env_base_url = _env_get(env, "AZURE_FOUNDRY_BASE_URL").strip().rstrip("/")
     base_url = explicit_base_url_clean or cfg_base_url or env_base_url
     if not base_url:
         raise AuthError(
@@ -997,14 +1115,14 @@ def _resolve_azure_foundry_runtime(
 
     # ── Static API key (legacy / default) ──────────────────────────────
     api_key = explicit_api_key
-    if not api_key:
+    if not api_key and env is None:
         try:
             from hermes_cli.config import get_env_value
             api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or ""
         except Exception:
             api_key = ""
     if not api_key:
-        api_key = os.getenv("AZURE_FOUNDRY_API_KEY", "").strip()
+        api_key = _env_get(env, "AZURE_FOUNDRY_API_KEY").strip()
     if not api_key:
         raise AuthError(
             "Azure Foundry requires an API key. Set AZURE_FOUNDRY_API_KEY in "
@@ -1033,6 +1151,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1047,9 +1166,15 @@ def _resolve_explicit_runtime(
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
         api_key = explicit_api_key
         if not api_key:
-            from agent.anthropic_adapter import resolve_anthropic_token
-
-            api_key = resolve_anthropic_token()
+            if env is None:
+                from agent.anthropic_adapter import resolve_anthropic_token
+                api_key = resolve_anthropic_token()
+            else:
+                api_key = (
+                    _env_get(env, "ANTHROPIC_API_KEY").strip()
+                    or _env_get(env, "ANTHROPIC_TOKEN").strip()
+                    or _env_get(env, "CLAUDE_CODE_OAUTH_TOKEN").strip()
+                )
             if not api_key:
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
@@ -1121,25 +1246,26 @@ def _resolve_explicit_runtime(
             model_cfg=model_cfg,
             explicit_api_key=explicit_api_key,
             explicit_base_url=explicit_base_url,
+            env=env,
         )
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+            env_url = _env_get(env, pconfig.base_url_env_var).strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:
             if provider in {"kimi-coding", "kimi-coding-cn"}:
-                creds = resolve_api_key_provider_credentials(provider)
+                creds = _resolve_api_key_credentials(provider, env)
                 base_url = creds.get("base_url", "").rstrip("/")
             else:
                 base_url = env_url or pconfig.inference_base_url
 
         api_key = explicit_api_key
         if not api_key:
-            creds = resolve_api_key_provider_credentials(provider)
+            creds = _resolve_api_key_credentials(provider, env)
             api_key = creds.get("api_key", "")
             if not base_url:
                 base_url = creds.get("base_url", "").rstrip("/")
@@ -1178,6 +1304,7 @@ def resolve_runtime_provider(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     target_model: Optional[str] = None,
+    env: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution.
 
@@ -1189,7 +1316,7 @@ def resolve_runtime_provider(
     persisted default. Other callers can leave it None to preserve existing
     behavior (api_mode derived from config).
     """
-    requested_provider = resolve_requested_provider(requested)
+    requested_provider = resolve_requested_provider(requested, env=env)
 
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
@@ -1199,8 +1326,8 @@ def resolve_runtime_provider(
     if requested_provider == "anthropic" and "azure.com" in _eff_base:
         _azure_key = (
             (explicit_api_key or "").strip()
-            or os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
-            or os.getenv("ANTHROPIC_API_KEY", "").strip()
+            or _env_get(env, "AZURE_ANTHROPIC_KEY").strip()
+            or _env_get(env, "ANTHROPIC_API_KEY").strip()
         )
         return {
             "provider": "anthropic",
@@ -1223,6 +1350,7 @@ def resolve_runtime_provider(
             explicit_api_key=explicit_api_key,
             explicit_base_url=explicit_base_url,
             target_model=target_model,
+            env=env,
         )
         return azure_runtime
 
@@ -1230,6 +1358,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        env=env,
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider
@@ -1239,6 +1368,7 @@ def resolve_runtime_provider(
         requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        env=env,
     )
     model_cfg = _get_model_config()
     explicit_runtime = _resolve_explicit_runtime(
@@ -1247,6 +1377,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        env=env,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1255,8 +1386,8 @@ def resolve_runtime_provider(
     if provider == "openrouter":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
-        env_openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
-        env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
+        env_openai_base_url = _env_get(env, "OPENAI_BASE_URL").strip()
+        env_openrouter_base_url = _env_get(env, "OPENROUTER_BASE_URL").strip()
         has_custom_endpoint = bool(
             explicit_base_url
             or env_openai_base_url
@@ -1272,7 +1403,7 @@ def resolve_runtime_provider(
         )
 
     try:
-        pool = load_pool(provider) if should_use_pool else None
+        pool = _load_pool_for_env(provider, env) if should_use_pool else None
     except Exception:
         pool = None
     if pool and pool.has_credentials():
@@ -1312,6 +1443,8 @@ def resolve_runtime_provider(
 
     if provider == "nous":
         try:
+            if not _scoped_provider_state_exists(provider, env):
+                raise _scoped_auth_unavailable(provider)
             creds = resolve_nous_runtime_credentials(
                 min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
                 timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
@@ -1335,6 +1468,8 @@ def resolve_runtime_provider(
 
     if provider == "openai-codex":
         try:
+            if not _scoped_provider_state_exists(provider, env):
+                raise _scoped_auth_unavailable(provider)
             creds = resolve_codex_runtime_credentials()
             return {
                 "provider": "openai-codex",
@@ -1355,6 +1490,8 @@ def resolve_runtime_provider(
 
     if provider == "xai-oauth":
         try:
+            if not _scoped_provider_state_exists(provider, env):
+                raise _scoped_auth_unavailable(provider)
             creds = resolve_xai_oauth_runtime_credentials()
             return {
                 "provider": "xai-oauth",
@@ -1373,6 +1510,8 @@ def resolve_runtime_provider(
 
     if provider == "qwen-oauth":
         try:
+            if not _scoped_provider_state_exists(provider, env):
+                raise _scoped_auth_unavailable(provider)
             creds = resolve_qwen_runtime_credentials()
             return {
                 "provider": "qwen-oauth",
@@ -1392,19 +1531,27 @@ def resolve_runtime_provider(
     if provider == "minimax-oauth":
         pconfig = PROVIDER_REGISTRY.get(provider)
         if pconfig and pconfig.auth_type == "oauth_minimax":
-            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
-            creds = resolve_minimax_oauth_runtime_credentials()
-            return {
-                "provider": provider,
-                "api_mode": "anthropic_messages",
-                "base_url": creds["base_url"],
-                "api_key": creds["api_key"],
-                "source": creds.get("source", "oauth"),
-                "requested_provider": requested_provider,
-            }
+            if not _scoped_provider_state_exists(provider, env):
+                if requested_provider != "auto":
+                    raise _scoped_auth_unavailable(provider)
+                logger.info("MiniMax OAuth credentials not available in scoped profile; "
+                            "falling through to next provider.")
+            else:
+                from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+                creds = resolve_minimax_oauth_runtime_credentials()
+                return {
+                    "provider": provider,
+                    "api_mode": "anthropic_messages",
+                    "base_url": creds["base_url"],
+                    "api_key": creds["api_key"],
+                    "source": creds.get("source", "oauth"),
+                    "requested_provider": requested_provider,
+                }
 
     if provider == "google-gemini-cli":
         try:
+            if not _scoped_provider_state_exists(provider, env):
+                raise _scoped_auth_unavailable(provider)
             creds = resolve_gemini_oauth_runtime_credentials()
             return {
                 "provider": "google-gemini-cli",
@@ -1424,7 +1571,7 @@ def resolve_runtime_provider(
                         "falling through to next provider.")
 
     if provider == "copilot-acp":
-        creds = resolve_external_process_provider_credentials(provider)
+        creds = resolve_external_process_provider_credentials(provider, env=env)
         return {
             "provider": "copilot-acp",
             "api_mode": "chat_completions",
@@ -1467,7 +1614,7 @@ def resolve_runtime_provider(
             for hint_key in ("key_env", "api_key_env"):
                 env_var = str(model_cfg.get(hint_key) or "").strip()
                 if env_var:
-                    token = os.getenv(env_var, "").strip()
+                    token = _env_get(env, env_var).strip()
                     if token:
                         break
             # Next: an inline api_key on the model config (useful in multi-profile
@@ -1477,8 +1624,8 @@ def resolve_runtime_provider(
             # Finally fall back to the historical fixed names.
             if not token:
                 token = (
-                    os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
-                    or os.getenv("ANTHROPIC_API_KEY", "").strip()
+                    _env_get(env, "AZURE_ANTHROPIC_KEY").strip()
+                    or _env_get(env, "ANTHROPIC_API_KEY").strip()
                 )
             if not token:
                 raise AuthError(
@@ -1487,8 +1634,15 @@ def resolve_runtime_provider(
                     "config.yaml model section at a custom env var."
                 )
         else:
-            from agent.anthropic_adapter import resolve_anthropic_token
-            token = resolve_anthropic_token()
+            if env is None:
+                from agent.anthropic_adapter import resolve_anthropic_token
+                token = resolve_anthropic_token()
+            else:
+                token = (
+                    _env_get(env, "ANTHROPIC_API_KEY").strip()
+                    or _env_get(env, "ANTHROPIC_TOKEN").strip()
+                    or _env_get(env, "CLAUDE_CODE_OAUTH_TOKEN").strip()
+                )
             if not token:
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
@@ -1516,7 +1670,16 @@ def resolve_runtime_provider(
         # Lambda execution roles, SSO, and other implicit sources that our
         # env-var check can't detect.
         is_explicit = requested_provider in {"bedrock", "aws", "aws-bedrock", "amazon-bedrock", "amazon"}
-        if not is_explicit and not has_aws_credentials():
+        scoped_aws_source = resolve_aws_auth_env_var(env) if env is not None else None
+        if env is not None and not scoped_aws_source:
+            raise AuthError(
+                "No profile-scoped AWS credentials found for Bedrock. Add AWS_ACCESS_KEY_ID + "
+                "AWS_SECRET_ACCESS_KEY, AWS_PROFILE, AWS_BEARER_TOKEN_BEDROCK, or another "
+                "Bedrock-supported AWS credential hint to the routed profile .env.",
+                provider=provider,
+                code="no_scoped_aws_credentials",
+            )
+        if env is None and not is_explicit and not has_aws_credentials():
             raise AuthError(
                 "No AWS credentials found for Bedrock. Configure one of:\n"
                 "  - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY\n"
@@ -1528,8 +1691,8 @@ def resolve_runtime_provider(
         # Read bedrock-specific config from config.yaml
         _bedrock_cfg = load_config().get("bedrock", {})
         # Region priority: config.yaml bedrock.region → env var → us-east-1
-        region = (_bedrock_cfg.get("region") or "").strip() or resolve_bedrock_region()
-        auth_source = resolve_aws_auth_env_var() or "aws-sdk-default-chain"
+        region = (_bedrock_cfg.get("region") or "").strip() or resolve_bedrock_region(env)
+        auth_source = scoped_aws_source or resolve_aws_auth_env_var() or "aws-sdk-default-chain"
         # Build guardrail config if configured
         _gr = _bedrock_cfg.get("guardrail", {})
         guardrail_config = None
@@ -1576,7 +1739,7 @@ def resolve_runtime_provider(
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
-        creds = resolve_api_key_provider_credentials(provider)
+        creds = _resolve_api_key_credentials(provider, env)
         # Honour model.base_url from config.yaml when the configured provider
         # matches this provider — mirrors the Anthropic path above.  Without
         # this, users who set model.base_url to e.g. api.minimaxi.com/anthropic
@@ -1632,6 +1795,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        env=env,
     )
     runtime["requested_provider"] = requested_provider
     return runtime

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -6,9 +6,9 @@ without risk of circular imports.
 
 import os
 import sysconfig
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from pathlib import Path
-
 
 _profile_fallback_warned: bool = False
 _UNSET = object()
@@ -101,6 +101,16 @@ def get_hermes_home() -> Path:
     return Path.home() / ".hermes"
 
 
+@contextmanager
+def hermes_home_context(path: str | Path | None):
+    """Context manager for task/thread-local Hermes home routing."""
+    token = set_hermes_home_override(path)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
+
 def get_default_hermes_root() -> Path:
     """Return the root Hermes directory for profile-level operations.
 
@@ -118,12 +128,12 @@ def get_default_hermes_root() -> Path:
     Import-safe — no dependencies beyond stdlib.
     """
     native_home = Path.home() / ".hermes"
+    active_home = get_hermes_home()
     env_home = os.environ.get("HERMES_HOME", "")
-    if not env_home:
+    if not env_home and get_hermes_home_override() is None:
         return native_home
-    env_path = Path(env_home)
     try:
-        env_path.resolve().relative_to(native_home.resolve())
+        active_home.resolve().relative_to(native_home.resolve())
         # HERMES_HOME is under ~/.hermes (normal or profile mode)
         return native_home
     except ValueError:
@@ -133,11 +143,11 @@ def get_default_hermes_root() -> Path:
     # Check if this is a profile path: <root>/profiles/<name>
     # If the immediate parent dir is named "profiles", the root is
     # the grandparent — this covers Docker profiles correctly.
-    if env_path.parent.name == "profiles":
-        return env_path.parent.parent
+    if active_home.parent.name == "profiles":
+        return active_home.parent.parent
 
     # Not a profile path — HERMES_HOME itself is the root
-    return env_path
+    return active_home
 
 
 def _get_packaged_data_dir(name: str) -> Path | None:
@@ -272,10 +282,8 @@ def get_subprocess_home() -> str | None:
     Activation is directory-based: if the ``home/`` subdirectory doesn't
     exist, returns ``None`` and behavior is unchanged.
     """
-    hermes_home = get_hermes_home_override() or os.getenv("HERMES_HOME")
-    if not hermes_home:
-        return None
-    profile_home = os.path.join(hermes_home, "home")
+    active_home = get_hermes_home()
+    profile_home = os.path.join(str(active_home), "home")
     if os.path.isdir(profile_home):
         return profile_home
     return None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -764,6 +764,15 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_model_config(self, session_id: str, model_config: Dict[str, Any]) -> None:
+        """Store updated model/session configuration metadata."""
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps(model_config) if model_config else None, session_id),
+            )
+        self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,

--- a/run_agent.py
+++ b/run_agent.py
@@ -406,6 +406,7 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        runtime_env: Dict[str, Any] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,
@@ -475,6 +476,7 @@ class AIAgent:
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
             fallback_model=fallback_model,
+            runtime_env=runtime_env,
             credential_pool=credential_pool,
             checkpoints_enabled=checkpoints_enabled,
             checkpoint_max_snapshots=checkpoint_max_snapshots,
@@ -523,6 +525,49 @@ class AIAgent:
             logger.warning(
                 "Session DB creation failed (will retry next turn): %s", e
             )
+
+    @staticmethod
+    def _system_prompt_identity_digest() -> str:
+        """Fingerprint profile files that affect persisted system prompt reuse."""
+        home = get_hermes_home()
+        h = hashlib.sha256()
+        h.update(str(home).encode("utf-8", errors="ignore"))
+        for name in ("SOUL.md", "config.yaml"):
+            path = home / name
+            h.update(b"\0")
+            h.update(name.encode("utf-8"))
+            try:
+                if path.is_file():
+                    h.update(b"\0present\0")
+                    h.update(path.read_bytes())
+                else:
+                    h.update(b"\0missing")
+            except Exception as exc:
+                h.update(f"\0error\0{type(exc).__name__}".encode("utf-8"))
+        return h.hexdigest()[:16]
+
+    def _stored_system_prompt_identity_matches(self, session_row: Optional[Dict[str, Any]]) -> bool:
+        """Return whether a stored prompt snapshot matches current identity."""
+        if not session_row:
+            return False
+        try:
+            cfg_raw = session_row.get("model_config") or ""
+            cfg = json.loads(cfg_raw) if isinstance(cfg_raw, str) and cfg_raw else {}
+        except Exception:
+            cfg = {}
+        stored = cfg.get("system_prompt_identity_digest") if isinstance(cfg, dict) else None
+        current = getattr(self, "_system_prompt_identity_fingerprint", None)
+        return bool(stored and current and stored == current)
+
+    def _persist_current_system_prompt_identity(self) -> None:
+        """Persist current identity digest in the session's model_config metadata."""
+        if not self._session_db:
+            return
+        try:
+            if hasattr(self._session_db, "update_model_config"):
+                self._session_db.update_model_config(self.session_id, self._session_init_model_config)
+        except Exception as exc:
+            logger.debug("Session DB update_model_config failed: %s", exc)
 
     def reset_session_state(self):
         """Reset all session-scoped token counters to 0 for a fresh session.

--- a/scripts/setup_topic_routing_sandbox.sh
+++ b/scripts/setup_topic_routing_sandbox.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Create a disposable Hermes topic-routing sandbox.
+#
+# This script never writes into ~/.hermes. It prepares a gateway home plus two
+# profile homes with non-sensitive marker data so forum-topic routing can be
+# tested against isolated SOUL/config/memory/session trees.
+
+set -euo pipefail
+
+GATEWAY_HOME="${HERMES_TOPIC_ROUTING_GATEWAY_HOME:-/tmp/hermes-topic-routing-gateway}"
+PROFILES_ROOT="${HERMES_TOPIC_ROUTING_PROFILES_ROOT:-/tmp/hermes-topic-routing-profiles}"
+ALPHA_HOME="$PROFILES_ROOT/alpha-test"
+BETA_HOME="$PROFILES_ROOT/beta-test"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+case "$GATEWAY_HOME:$PROFILES_ROOT" in
+  *"$HOME/.hermes"*|*"~/.hermes"*)
+    echo "Refusing to use ~/.hermes for a sandbox." >&2
+    exit 1
+    ;;
+esac
+
+for path in "$GATEWAY_HOME" "$ALPHA_HOME" "$BETA_HOME"; do
+  if [ -L "$path" ]; then
+    echo "Refusing symlink sandbox path: $path" >&2
+    exit 1
+  fi
+done
+
+if [ "${1:-}" = "--clean" ]; then
+  if command -v trash >/dev/null 2>&1; then
+    [ ! -e "$GATEWAY_HOME" ] || trash "$GATEWAY_HOME"
+    [ ! -e "$PROFILES_ROOT" ] || trash "$PROFILES_ROOT"
+  else
+    echo "Refusing to delete without the 'trash' command installed." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p \
+  "$GATEWAY_HOME/sessions" \
+  "$ALPHA_HOME/memories" "$ALPHA_HOME/sessions" "$ALPHA_HOME/logs" \
+  "$BETA_HOME/memories" "$BETA_HOME/sessions" "$BETA_HOME/logs"
+
+cat > "$GATEWAY_HOME/config.yaml" <<EOF
+model:
+  provider: openai-compatible
+  default: sandbox-fake-model
+  base_url: http://127.0.0.1:18099/v1
+telegram:
+  enabled: true
+  topic_profiles_safe_root: "$PROFILES_ROOT"
+  topic_profiles:
+    - match:
+        chat_id: "-1000000000000"
+        thread_id: 101
+      profile: alpha-test
+      profile_home: "$ALPHA_HOME"
+    - match:
+        chat_id: "-1000000000000"
+        thread_id: 202
+      profile: beta-test
+      profile_home: "$BETA_HOME"
+EOF
+
+cat > "$GATEWAY_HOME/.env" <<'EOF'
+# Sandbox only. Do not put production tokens here.
+OPENAI_API_KEY=test-key-only
+TELEGRAM_BOT_TOKEN=
+EOF
+
+cat > "$ALPHA_HOME/config.yaml" <<'EOF'
+model:
+  provider: openai-compatible
+  default: sandbox-alpha-model
+  base_url: http://127.0.0.1:18099/v1
+EOF
+cat > "$ALPHA_HOME/.env" <<'EOF'
+OPENAI_API_KEY=test-key-only
+EOF
+cat > "$ALPHA_HOME/SOUL.md" <<'EOF'
+# Alpha Test Soul
+
+SANDBOX_PROFILE_MARKER=alpha-test
+EOF
+cat > "$ALPHA_HOME/memories/MEMORY.md" <<'EOF'
+SANDBOX_MEMORY_MARKER=alpha-test
+EOF
+
+cat > "$BETA_HOME/config.yaml" <<'EOF'
+model:
+  provider: openai-compatible
+  default: sandbox-beta-model
+  base_url: http://127.0.0.1:18099/v1
+EOF
+cat > "$BETA_HOME/.env" <<'EOF'
+OPENAI_API_KEY=test-key-only
+EOF
+cat > "$BETA_HOME/SOUL.md" <<'EOF'
+# Beta Test Soul
+
+SANDBOX_PROFILE_MARKER=beta-test
+EOF
+cat > "$BETA_HOME/memories/MEMORY.md" <<'EOF'
+SANDBOX_MEMORY_MARKER=beta-test
+EOF
+
+cat <<EOF
+Sandbox ready:
+  Gateway home: $GATEWAY_HOME
+  Alpha profile: $ALPHA_HOME
+  Beta profile: $BETA_HOME
+
+Offline tests:
+  HERMES_HOME=$GATEWAY_HOME PYTHONPATH=$REPO_ROOT scripts/run_tests.sh tests/gateway/test_topic_profile_routing.py
+
+Manual gateway sandbox:
+  HERMES_HOME=$GATEWAY_HOME PYTHONPATH=$REPO_ROOT python -m hermes_cli.main gateway run
+EOF

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import shutil
 import tempfile
 from pathlib import Path
+
+import pytest
 
 from acp_adapter.edit_approval import (
     EditProposal,
@@ -18,6 +21,15 @@ from model_tools import handle_function_call
 
 def teardown_function() -> None:
     clear_edit_approval_requester()
+
+
+@pytest.fixture
+def safe_write_dir():
+    root = Path(tempfile.mkdtemp(prefix=".acp-edit-", dir=Path.cwd()))
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
 
 
 def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
@@ -41,8 +53,8 @@ def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
     assert diff.newText == "new\n"
 
 
-def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
-    target = tmp_path / "sample.txt"
+def test_write_file_rejection_does_not_mutate_existing_file(safe_write_dir):
+    target = safe_write_dir / "sample.txt"
     target.write_text("before\n", encoding="utf-8")
 
     set_edit_approval_requester(lambda _proposal: False)
@@ -60,8 +72,8 @@ def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
     assert target.read_text(encoding="utf-8") == "before\n"
 
 
-def test_write_file_approval_mutates_and_request_includes_diff(tmp_path):
-    target = tmp_path / "sample.txt"
+def test_write_file_approval_mutates_and_request_includes_diff(safe_write_dir):
+    target = safe_write_dir / "sample.txt"
     target.write_text("before\n", encoding="utf-8")
     proposals = []
 
@@ -89,8 +101,8 @@ def test_write_file_approval_mutates_and_request_includes_diff(tmp_path):
     assert proposal.new_text == "after\n"
 
 
-def test_write_file_new_file_request_has_empty_old_text(tmp_path):
-    target = tmp_path / "new.txt"
+def test_write_file_new_file_request_has_empty_old_text(safe_write_dir):
+    target = safe_write_dir / "new.txt"
     proposals = []
 
     set_edit_approval_requester(lambda proposal: proposals.append(proposal) or True)
@@ -109,8 +121,8 @@ def test_write_file_new_file_request_has_empty_old_text(tmp_path):
     assert proposals[0].new_text == "created\n"
 
 
-def test_requester_exception_denies_and_does_not_mutate(tmp_path):
-    target = tmp_path / "sample.txt"
+def test_requester_exception_denies_and_does_not_mutate(safe_write_dir):
+    target = safe_write_dir / "sample.txt"
     target.write_text("before\n", encoding="utf-8")
 
     def boom(_proposal):
@@ -131,8 +143,8 @@ def test_requester_exception_denies_and_does_not_mutate(tmp_path):
     assert target.read_text(encoding="utf-8") == "before\n"
 
 
-def test_patch_replace_rejection_does_not_mutate(tmp_path):
-    target = tmp_path / "sample.txt"
+def test_patch_replace_rejection_does_not_mutate(safe_write_dir):
+    target = safe_write_dir / "sample.txt"
     target.write_text("alpha\nbeta\n", encoding="utf-8")
 
     set_edit_approval_requester(lambda _proposal: False)
@@ -155,8 +167,8 @@ def test_patch_replace_rejection_does_not_mutate(tmp_path):
     assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
 
 
-def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
-    target = tmp_path / "sample.txt"
+def test_patch_replace_approval_request_includes_full_file_diff(safe_write_dir):
+    target = safe_write_dir / "sample.txt"
     target.write_text("alpha\nbeta\n", encoding="utf-8")
     proposals = []
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1092,6 +1092,44 @@ class TestTryPaymentFallback:
         assert model is None
         assert label == ""
 
+    def test_uses_profile_env_for_env_aware_chain_entries(self, monkeypatch):
+        """Payment fallback must use routed profile env, not process env."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+        with patch("agent.auxiliary_client._read_main_provider", return_value="nous"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value.base_url = "https://openrouter.ai/api/v1"
+            client, model, label = _try_payment_fallback(
+                "nous",
+                task="compression",
+                env={"OPENROUTER_API_KEY": "profile-openrouter"},
+            )
+
+        assert client is mock_openai.return_value
+        assert label == "openrouter"
+        assert mock_openai.call_args.kwargs["api_key"] == "profile-openrouter"
+
+    def test_empty_profile_env_blocks_global_env_chain_entries(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+        with patch("agent.auxiliary_client._read_main_provider", return_value="nous"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy"), \
+             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model, label = _try_payment_fallback(
+                "nous",
+                task="compression",
+                env={},
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
+        mock_openai.assert_not_called()
+
 
 class TestCallLlmPaymentFallback:
     """call_llm() retries with a different provider on 402 / payment / rate-limit errors."""
@@ -1159,6 +1197,46 @@ class TestAuxiliaryFallbackLayering:
         exc = Exception("Payment Required: insufficient credits")
         exc.status_code = 402
         return exc
+
+    def test_configured_chain_uses_profile_env(self, monkeypatch):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={
+            "fallback_chain": [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        }), patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value.base_url = "https://openrouter.ai/api/v1"
+            client, model, label = _try_configured_fallback_chain(
+                "compression",
+                "zai",
+                env={"OPENROUTER_API_KEY": "profile-openrouter"},
+            )
+
+        assert client is mock_openai.return_value
+        assert model == "anthropic/claude-sonnet-4"
+        assert label == "fallback_chain[0](openrouter)"
+        assert mock_openai.call_args.kwargs["api_key"] == "profile-openrouter"
+
+    def test_configured_chain_ignores_global_env_when_profile_env_empty(self, monkeypatch):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={
+            "fallback_chain": [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        }), patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy"), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model, label = _try_configured_fallback_chain(
+                "compression",
+                "zai",
+                env={},
+            )
+
+        assert client is None
+        assert model is None
+        assert label == ""
+        mock_openai.assert_not_called()
 
     def test_explicit_provider_uses_configured_chain_first(self, monkeypatch, caplog):
         """When a user has fallback_chain configured, it's tried BEFORE the main agent model."""
@@ -1786,7 +1864,7 @@ class TestAuxiliaryAuthRefreshRetry:
             )
 
         assert resp.choices[0].message.content == "fresh-sync"
-        mock_refresh.assert_called_once_with("openai-codex")
+        mock_refresh.assert_called_once_with("openai-codex", env=None)
 
     def test_call_llm_refreshes_codex_on_401_for_non_vision(self):
         stale_client = MagicMock()
@@ -1810,7 +1888,7 @@ class TestAuxiliaryAuthRefreshRetry:
             )
 
         assert resp.choices[0].message.content == "fresh-non-vision"
-        mock_refresh.assert_called_once_with("openai-codex")
+        mock_refresh.assert_called_once_with("openai-codex", env=None)
         assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
 
@@ -1836,7 +1914,7 @@ class TestAuxiliaryAuthRefreshRetry:
             )
 
         assert resp.choices[0].message.content == "fresh-anthropic"
-        mock_refresh.assert_called_once_with("anthropic")
+        mock_refresh.assert_called_once_with("anthropic", env=None)
         assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
 
@@ -1865,7 +1943,7 @@ class TestAuxiliaryAuthRefreshRetry:
             )
 
         assert resp.choices[0].message.content == "fresh-async"
-        mock_refresh.assert_called_once_with("openai-codex")
+        mock_refresh.assert_called_once_with("openai-codex", env=None)
 
     def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch):
         stale_client = MagicMock()
@@ -1897,6 +1975,56 @@ class TestAuxiliaryAuthRefreshRetry:
         mock_write.assert_called_once_with("fresh-token", "refresh-token-2", 9999999999999)
         stale_client.close.assert_called_once()
 
+    def test_refresh_provider_credentials_scoped_nous_ignores_default_auth_store(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "auth.json").write_text(json.dumps({
+            "version": 2,
+            "active_provider": "nous",
+            "providers": {
+                "nous": {
+                    "access_token": "global-access",
+                    "agent_key": "global-agent-key",
+                },
+            },
+        }))
+
+        from agent.auxiliary_client import _refresh_provider_credentials
+
+        with patch(
+            "hermes_cli.auth.resolve_nous_runtime_credentials",
+            side_effect=AssertionError("scoped refresh must not use default/global auth"),
+        ):
+            assert _refresh_provider_credentials("nous", env={}) is False
+
+    def test_refresh_provider_credentials_scoped_nous_uses_profile_auth_store(self, monkeypatch, tmp_path):
+        profile_home = tmp_path / "profiles" / "profile-a"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        (profile_home / "auth.json").write_text(json.dumps({
+            "version": 2,
+            "active_provider": "nous",
+            "providers": {
+                "nous": {
+                    "access_token": "profile-access",
+                    "agent_key": "profile-agent-key",
+                },
+            },
+        }))
+
+        from agent.auxiliary_client import _refresh_provider_credentials
+
+        with (
+            patch("hermes_cli.auth.resolve_nous_runtime_credentials", return_value={
+                "api_key": "fresh-profile-key",
+                "base_url": "https://inference-api.nousresearch.com/v1",
+            }) as mock_refresh,
+            patch("agent.auxiliary_client._evict_cached_clients") as mock_evict,
+        ):
+            assert _refresh_provider_credentials("nous", env={}) is True
+
+        mock_refresh.assert_called_once()
+        mock_evict.assert_called_once_with("nous")
+
     @pytest.mark.asyncio
     async def test_async_call_llm_refreshes_anthropic_on_401_for_non_vision(self):
         stale_client = MagicMock()
@@ -1920,7 +2048,7 @@ class TestAuxiliaryAuthRefreshRetry:
             )
 
         assert resp.choices[0].message.content == "fresh-async-anthropic"
-        mock_refresh.assert_called_once_with("anthropic")
+        mock_refresh.assert_called_once_with("anthropic", env=None)
         assert stale_client.chat.completions.create.await_count == 1
         assert fresh_client.chat.completions.create.await_count == 1
 
@@ -2215,7 +2343,7 @@ class TestVisionAutoSkipsKimiCoding:
             "agent.auxiliary_client.resolve_provider_client", rpc_mock,
         )
 
-        def fake_strict(provider, model=None):
+        def fake_strict(provider, model=None, **kwargs):
             if provider == "openrouter":
                 return fake_or_client, "google/gemini-3-flash-preview"
             if provider == "nous":
@@ -2251,7 +2379,7 @@ class TestVisionAutoSkipsKimiCoding:
         )
         monkeypatch.setattr(
             "agent.auxiliary_client._resolve_strict_vision_backend",
-            lambda p, m=None: (fake_or_client, "gemini")
+            lambda p, m=None, **kwargs: (fake_or_client, "gemini")
             if p == "openrouter"
             else (None, None),
         )
@@ -2401,6 +2529,45 @@ class TestAuxiliaryClientPoisonedCacheEviction:
         finally:
             with _client_cache_lock:
                 _client_cache.clear()
+
+    def test_cache_key_separates_profile_runtime_env(self):
+        from agent.auxiliary_client import (
+            _client_cache, _client_cache_lock, _get_cached_client,
+        )
+
+        def _fake_resolve(provider, model=None, async_mode=False, **kwargs):
+            env = kwargs.get("env") or {}
+            return SimpleNamespace(
+                api_key=env.get("OPENROUTER_API_KEY", ""),
+                base_url="https://openrouter.ai/api/v1",
+                close=lambda: None,
+            ), "fallback-model"
+
+        with _client_cache_lock:
+            _client_cache.clear()
+        try:
+            with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_fake_resolve) as mock_resolve:
+                first, _ = _get_cached_client(
+                    "openrouter",
+                    env={"OPENROUTER_API_KEY": "profile-one"},
+                )
+                second, _ = _get_cached_client(
+                    "openrouter",
+                    env={"OPENROUTER_API_KEY": "profile-two"},
+                )
+                first_again, _ = _get_cached_client(
+                    "openrouter",
+                    env={"OPENROUTER_API_KEY": "profile-one"},
+                )
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
+        assert first is not second
+        assert first_again is first
+        assert first.api_key == "profile-one"
+        assert second.api_key == "profile-two"
+        assert mock_resolve.call_count == 2
 
     def test_evict_cached_client_instance_walks_codex_wrapper(self):
         """Closing the underlying OpenAI client must evict the Codex shim."""

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -394,7 +394,7 @@ class TestResolveVisionMainFirst:
 
         # Explicit "nous" override → uses strict backend, NOT main model path
         assert provider == "nous"
-        mock_strict.assert_called_once_with("nous", None)
+        mock_strict.assert_called_once_with("nous", None, env=None)
 
 
 # ── Constant cleanup ────────────────────────────────────────────────────────

--- a/tests/agent/test_nous_rate_guard.py
+++ b/tests/agent/test_nous_rate_guard.py
@@ -234,7 +234,7 @@ class TestAuxiliaryClientIntegration:
 
         # Mock _read_nous_auth to return valid creds (would normally succeed)
         import agent.auxiliary_client as aux
-        monkeypatch.setattr(aux, "_read_nous_auth", lambda: {
+        monkeypatch.setattr(aux, "_read_nous_auth", lambda *args, **kwargs: {
             "access_token": "test-token",
             "inference_base_url": "https://api.nous.test/v1",
         })
@@ -248,7 +248,7 @@ class TestAuxiliaryClientIntegration:
         # No rate limit recorded — _try_nous should proceed normally
         # (will return None because no real creds, but won't be blocked
         # by the rate guard)
-        monkeypatch.setattr(aux, "_read_nous_auth", lambda: None)
+        monkeypatch.setattr(aux, "_read_nous_auth", lambda *args, **kwargs: None)
         result = aux._try_nous()
         assert result == (None, None)
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -203,6 +203,7 @@ class TestMaybeAutoTitle:
                 "hi there",
                 failure_callback=None,
                 main_runtime=None,
+                env=None,
                 title_callback=None,
             )
 
@@ -229,6 +230,7 @@ class TestMaybeAutoTitle:
                 "hi there",
                 failure_callback=_cb,
                 main_runtime=None,
+                env=None,
                 title_callback=None,
             )
 

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -78,6 +78,7 @@ class TestGatewayPersonalityNone:
         event = MagicMock()
         event.get_command.return_value = "personality"
         event.get_command_args.return_value = args
+        event.source = MagicMock(agent_profile=None)
         return event
 
     def _make_runner(self, personalities=None):

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -218,12 +218,12 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
-    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda *args, **kwargs: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",
-        lambda: {
+        lambda runtime_env=None: {
             "provider": "openrouter",
             "api_mode": "chat_completions",
             "base_url": "https://openrouter.ai/api/v1",

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -126,7 +126,7 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
-    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda hermes_home=None: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
 
     response = await runner._handle_fast_command(_make_event("/fast fast"))
@@ -139,6 +139,42 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_handle_fast_command_persists_profile_config(monkeypatch, tmp_path):
+    runner = _make_runner()
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    (gateway_home / "config.yaml").write_text("agent:\n  service_tier: normal\n", encoding="utf-8")
+    (profile_home / "config.yaml").write_text("agent:\n  model: gpt-5.4\n", encoding="utf-8")
+
+    source = _make_source()
+    source.agent_profile = "alpha-test"
+    source.agent_hermes_home = str(profile_home)
+    event = MessageEvent(text="/fast fast", source=source, message_id="m1")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", gateway_home)
+    monkeypatch.setattr(runner, "_profile_home_for_source", lambda _source: profile_home)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda hermes_home=None: yaml.safe_load(
+            ((hermes_home or gateway_home) / "config.yaml").read_text(encoding="utf-8")
+        ) or {},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: config["agent"]["model"])
+
+    response = await runner._handle_fast_command(event)
+
+    assert "FAST" in response
+    assert runner._service_tier == "priority"
+    profile_saved = yaml.safe_load((profile_home / "config.yaml").read_text(encoding="utf-8"))
+    gateway_saved = yaml.safe_load((gateway_home / "config.yaml").read_text(encoding="utf-8"))
+    assert profile_saved["agent"]["service_tier"] == "fast"
+    assert gateway_saved["agent"]["service_tier"] == "normal"
+
+
+@pytest.mark.asyncio
 async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch, tmp_path):
     _install_fake_agent(monkeypatch)
     runner = _make_runner()
@@ -147,7 +183,7 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
-    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda hermes_home=None: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -165,9 +165,10 @@ class TestTelegramExecApproval:
         )
 
         assert result.success is True
-        assert len(call_log) == 2
+        assert len(call_log) == 3
         assert call_log[0]["message_thread_id"] == 999
-        assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
+        assert call_log[1]["message_thread_id"] == 999
+        assert "message_thread_id" not in call_log[2] or call_log[2]["message_thread_id"] is None
 
     @pytest.mark.asyncio
     async def test_not_connected(self):

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -484,8 +484,9 @@ class TestMediaGroups:
         with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/one.jpg"):
             await adapter._handle_media_message(_make_update(msg), MagicMock())
 
-        assert "album-2" in adapter._media_group_events
-        assert "album-2" in adapter._media_group_tasks
+        batch_key = "agent:main:telegram:dm:100:album:album-2"
+        assert batch_key in adapter._media_group_events
+        assert batch_key in adapter._media_group_tasks
 
         await adapter.disconnect()
         await asyncio.sleep(adapter.MEDIA_GROUP_WAIT_SECONDS + 0.05)

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -174,6 +174,7 @@ class TestTelegramModelPicker:
         )
 
         assert result.success is True
-        assert len(call_log) == 2
+        assert len(call_log) == 3
         assert call_log[0]["message_thread_id"] == 99999
-        assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
+        assert call_log[1]["message_thread_id"] == 99999
+        assert "message_thread_id" not in call_log[2] or call_log[2]["message_thread_id"] is None

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -11,6 +11,7 @@ avoid retrying with a partial topic route that can render outside the lane.
 import sys
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -300,15 +301,8 @@ async def test_send_typing_does_not_fall_back_to_root_for_dm_topic():
 
 
 @pytest.mark.asyncio
-async def test_send_typing_attempts_api_call_for_dm_topic_reply_fallback():
-    """Hermes-created DM topic lanes should still attempt scoped typing.
-
-    Some private DM topic lanes route message sends through reply-anchor
-    fallback, but live Telegram testing shows sendChatAction accepts the lane's
-    message_thread_id. If Telegram rejects a stale or invalid thread later,
-    send_typing now falls back to sending typing without thread_id so the
-    indicator at least appears in the main DM view.
-    """
+async def test_send_typing_skips_dm_topic_reply_fallback():
+    """Hermes-created DM topic fallback lanes cannot safely scope chat actions."""
     adapter = _make_adapter()
     call_log = []
 
@@ -326,14 +320,12 @@ async def test_send_typing_attempts_api_call_for_dm_topic_reply_fallback():
         },
     )
 
-    assert call_log == [
-        {"chat_id": 12345, "action": "typing", "message_thread_id": 20197},
-    ]
+    assert call_log == []
 
 
 @pytest.mark.asyncio
 async def test_send_typing_falls_back_without_thread_on_bad_request():
-    """When DM topic typing with message_thread_id fails, retry without it."""
+    """Typing thread failures are non-fatal and do not fall back to root."""
     adapter = _make_adapter()
 
     call_log = []
@@ -349,25 +341,14 @@ async def test_send_typing_falls_back_without_thread_on_bad_request():
 
     await adapter.send_typing(
         "12345",
-        metadata={
-            "thread_id": "20197",
-            "telegram_dm_topic_reply_fallback": True,
-            "telegram_reply_to_message_id": "462",
-        },
+        metadata={"thread_id": "20197"},
     )
 
-    # First call: with message_thread_id (failed)
-    # Second call: fallback without message_thread_id (succeeded)
-    assert len(call_log) == 2
-    assert call_log[0] == {
+    assert call_log == [{
         "chat_id": 12345,
         "action": "typing",
         "message_thread_id": 20197,
-    }
-    assert call_log[1] == {
-        "chat_id": 12345,
-        "action": "typing",
-    }
+    }]
 
 
 @pytest.mark.asyncio
@@ -434,6 +415,31 @@ async def test_send_retries_transient_thread_not_found_before_fallback():
 
 
 @pytest.mark.asyncio
+async def test_send_does_not_fallback_to_main_chat_when_routed_topic_missing():
+    """Routed profile replies must not leak into the parent chat."""
+    adapter = _make_adapter()
+
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="test message",
+        metadata={"thread_id": "99999", "disable_thread_fallback": True},
+    )
+
+    assert result.success is False
+    assert len(call_log) == 2
+    assert call_log[0]["message_thread_id"] == 99999
+    assert call_log[1]["message_thread_id"] == 99999
+
+
+@pytest.mark.asyncio
 async def test_send_private_dm_topic_uses_direct_messages_topic_id():
     """Private Telegram topics route sends via direct_messages_topic_id."""
     adapter = _make_adapter()
@@ -475,6 +481,7 @@ def test_base_gateway_metadata_marks_telegram_dm_topics_as_reply_fallback():
 
 def test_base_gateway_metadata_for_resumed_telegram_dm_topic_uses_direct_topic():
     """Resumed/synthetic DM-topic events may have no reply anchor."""
+
     source = SimpleNamespace(
         platform=Platform.TELEGRAM,
         chat_type="dm",
@@ -487,6 +494,41 @@ def test_base_gateway_metadata_for_resumed_telegram_dm_topic_uses_direct_topic()
         "thread_id": "20189",
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20189",
+    }
+
+
+def test_base_gateway_metadata_marks_routed_telegram_profiles_no_fallback():
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        thread_id="20189",
+        agent_profile="shopping",
+    )
+
+    metadata = _thread_metadata_for_source(source, "462")
+
+    assert metadata == {
+        "thread_id": "20189",
+        "disable_thread_fallback": True,
+    }
+
+
+def test_base_gateway_metadata_combines_routed_dm_profile_flags():
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        thread_id="20189",
+        agent_profile="shopping",
+    )
+
+    metadata = _thread_metadata_for_source(source, "462")
+
+    assert metadata == {
+        "thread_id": "20189",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "20189",
+        "telegram_reply_to_message_id": "462",
+        "disable_thread_fallback": True,
     }
 
 
@@ -744,6 +786,168 @@ async def test_send_dm_topic_reply_not_found_retry_drops_thread_id():
     assert call_log[1]["reply_to_message_id"] is None
     assert "message_thread_id" not in call_log[1]
     assert "direct_messages_topic_id" not in call_log[1]
+
+
+@pytest.mark.asyncio
+async def test_routed_dm_topic_reply_not_found_does_not_fallback_to_main_chat():
+    """Routed profile DM-topic replies must not drop the topic anchor."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message to be replied not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="anchor disappeared",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+            "disable_thread_fallback": True,
+        },
+    )
+
+    assert result.success is False
+    assert len(call_log) == 1
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+
+
+@pytest.mark.asyncio
+async def test_routed_dm_topic_media_reply_not_found_does_not_fallback_to_main_chat(tmp_path):
+    adapter = _make_adapter()
+    media_path = tmp_path / "report.txt"
+    media_path.write_text("report", encoding="utf-8")
+    call_log = []
+
+    async def mock_send_document(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message to be replied not found")
+
+    adapter._bot = SimpleNamespace(send_document=mock_send_document)
+
+    result = await adapter.send_document(
+        chat_id="123",
+        file_path=str(media_path),
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+            "disable_thread_fallback": True,
+        },
+    )
+
+    assert result.success is False
+    assert len(call_log) == 1
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "kwargs"),
+    [
+        ("send_update_prompt", {"prompt": "Proceed?", "default": "yes"}),
+        ("send_exec_approval", {"command": "ls", "session_key": "agent:alpha-test:telegram:group:123:999"}),
+        (
+            "send_slash_confirm",
+            {
+                "title": "Confirm",
+                "message": "Proceed?",
+                "session_key": "agent:alpha-test:telegram:group:123:999",
+                "confirm_id": "confirm-alpha",
+            },
+        ),
+        (
+            "send_clarify",
+            {
+                "question": "Pick one",
+                "choices": ["A", "B"],
+                "clarify_id": "clarify-alpha",
+                "session_key": "agent:alpha-test:telegram:group:123:999",
+            },
+        ),
+        (
+            "send_model_picker",
+            {
+                "providers": [
+                    {
+                        "slug": "example",
+                        "name": "Example",
+                        "total_models": 1,
+                        "models": ["example/model"],
+                        "is_current": True,
+                    }
+                ],
+                "current_model": "example/model",
+                "current_provider": "example",
+                "session_key": "agent:alpha-test:telegram:group:123:999",
+                "on_model_selected": AsyncMock(),
+            },
+        ),
+    ],
+)
+async def test_routed_control_messages_do_not_fallback_to_main_chat(method_name, kwargs):
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**send_kwargs):
+        call_log.append(dict(send_kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await getattr(adapter, method_name)(
+        chat_id="123",
+        metadata={"thread_id": "99999", "disable_thread_fallback": True},
+        **kwargs,
+    )
+
+    assert result.success is False
+    assert len(call_log) == 2
+    assert call_log[0]["message_thread_id"] == 99999
+    assert call_log[1]["message_thread_id"] == 99999
+
+
+@pytest.mark.asyncio
+async def test_routed_overflow_split_reply_not_found_does_not_fallback_to_main_chat():
+    adapter = _make_adapter()
+    send_log = []
+
+    async def mock_edit_message_text(**kwargs):
+        return SimpleNamespace(message_id=700)
+
+    async def mock_send_message(**kwargs):
+        send_log.append(dict(kwargs))
+        raise FakeBadRequest("reply message not found")
+
+    adapter._bot = SimpleNamespace(
+        edit_message_text=mock_edit_message_text,
+        send_message=mock_send_message,
+    )
+
+    result = await adapter._edit_overflow_split(
+        chat_id="123",
+        message_id="700",
+        content="x" * 5000,
+        finalize=False,
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+            "disable_thread_fallback": True,
+        },
+    )
+
+    assert result.success is True
+    assert result.continuation_message_ids == ()
+    assert len(send_log) == 1
+    assert send_log[0]["reply_to_message_id"] == 700
+    assert send_log[0]["message_thread_id"] == 20197
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_topic_profile_routing.py
+++ b/tests/gateway/test_topic_profile_routing.py
@@ -1,0 +1,3812 @@
+import asyncio
+import json
+import os
+import sys
+import threading
+import types
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    TopicProfileConfigError,
+    resolve_topic_profile,
+)
+from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_constants import get_hermes_home, hermes_home_context
+from hermes_cli.profiles import write_profile_identity_marker
+
+
+def _mark_profile(profile_home, profile_name=None, profiles_root=None):
+    profile_home.mkdir(parents=True, exist_ok=True)
+    write_profile_identity_marker(
+        profile_name or profile_home.name,
+        profile_home,
+        profiles_root or profile_home.parent,
+        overwrite=True,
+    )
+    return profile_home
+
+
+class _CapturingAgent:
+    last_init = None
+    last_user_message = None
+    inits = []
+    _lock = threading.Lock()
+
+    def __init__(self, *args, **kwargs):
+        from agent.prompt_builder import load_soul_md
+        from tools.memory_tool import get_memory_dir
+
+        record = dict(kwargs)
+        record["hermes_home_at_init"] = str(get_hermes_home())
+        record["soul"] = load_soul_md() or ""
+        record["memory_dir"] = str(get_memory_dir())
+        try:
+            from gateway.session_context import get_session_env
+            record["session_env_agent_profile"] = get_session_env("HERMES_SESSION_AGENT_PROFILE", "")
+            record["session_env_agent_hermes_home"] = get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "")
+        except Exception:
+            record["session_env_agent_profile"] = ""
+            record["session_env_agent_hermes_home"] = ""
+        with self._lock:
+            type(self).last_init = record
+            type(self).inits.append(record)
+        self.tools = []
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+        type(self).last_user_message = user_message
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    _CapturingAgent.last_init = None
+    _CapturingAgent.last_user_message = None
+    _CapturingAgent.inits = []
+
+
+def _make_runner(config=None, *, gateway_prompt="Gateway prompt"):
+    from gateway import run as gateway_run
+    from gateway.session import SessionStore
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = gateway_prompt
+    runner._prefill_messages = [{"role": "system", "content": "gateway prefill"}]
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {"order": ["gateway-provider"], "sort": "latency"}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_model_notes = {}
+    runner._update_prompt_pending = {}
+    runner._background_tasks = set()
+    runner._pending_native_image_paths_by_session = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._draining = False
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+    runner.config = config or GatewayConfig()
+    runner.session_store = SessionStore(get_hermes_home() / "sessions", runner.config)
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _provider_runtime(runtime_env=None):
+    return {
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": (runtime_env or {}).get("OPENROUTER_API_KEY", "sk-test-gateway-key"),
+    }
+
+
+def _write_profile_config(profile_home, *, prompt, model, toolsets=None, disabled=None, provider_routing=None, prefill=None):
+    _mark_profile(profile_home)
+    prefill_line = f'prefill_messages_file: "{prefill}"\n' if prefill else ""
+    provider_lines = ""
+    if provider_routing:
+        provider_lines = "provider_routing:\n" + "\n".join(
+            f"  {key}: {json.dumps(value)}" for key, value in provider_routing.items()
+        ) + "\n"
+    disabled_lines = ""
+    if disabled:
+        disabled_lines = "  disabled_toolsets:\n" + "\n".join(f"    - {item}" for item in disabled) + "\n"
+    toolset_lines = ""
+    if toolsets:
+        toolset_lines = "platform_toolsets:\n  telegram:\n" + "\n".join(f"    - {item}" for item in toolsets) + "\n"
+    (profile_home / "config.yaml").write_text(
+        (
+            "model:\n"
+            "  provider: openrouter\n"
+            f"  default: {model}\n"
+            "agent:\n"
+            f"  system_prompt: {json.dumps(prompt)}\n"
+            "  reasoning_effort: high\n"
+            "  service_tier: priority\n"
+            f"{disabled_lines}"
+            f"{prefill_line}"
+            f"{provider_lines}"
+            f"{toolset_lines}"
+        ),
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text("OPENROUTER_API_KEY=sk-test-profile-key\n", encoding="utf-8")
+
+
+def _write_skill(home, name, description):
+    skill_dir = home / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\n{description}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_bundle(home, slug, skills):
+    bundle_dir = home / "skill-bundles"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / f"{slug}.yaml").write_text(
+        f"name: {slug}\nskills:\n" + "\n".join(f"  - {skill}" for skill in skills) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _source(**overrides):
+    home = overrides.get("agent_hermes_home")
+    profile = overrides.get("agent_profile")
+    if home and profile:
+        home_path = Path(str(home))
+        if home_path.is_absolute():
+            _mark_profile(home_path, str(profile))
+    data = {
+        "platform": Platform.TELEGRAM,
+        "chat_id": "-1001",
+        "chat_type": "group",
+        "thread_id": "101",
+        "user_id": "42",
+    }
+    data.update(overrides)
+    return SessionSource(**data)
+
+
+class _KeyCapturingAdapter(BasePlatformAdapter):
+    def __init__(self, config=None):
+        super().__init__(config or PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.captured_session_key = None
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    def _start_session_processing(self, event, session_key, *, interrupt_event=None):
+        self.captured_session_key = session_key
+        return True
+
+
+def test_topic_profile_resolver_matches_exact_topic_and_home(tmp_path):
+    profile_home = tmp_path / "profiles" / "alpha-test"
+    _mark_profile(profile_home)
+    route = resolve_topic_profile(
+        {
+            "topic_profiles_safe_root": str(tmp_path / "profiles"),
+            "topic_profiles": [
+                {
+                    "match": {"chat_id": "-1001", "thread_id": 101},
+                    "profile": "alpha-test",
+                    "profile_home": str(profile_home),
+                }
+            ]
+        },
+        "-1001",
+        "101",
+    )
+
+    assert route == {"profile": "alpha-test", "profile_home": str(profile_home)}
+
+
+def test_topic_profile_resolver_handles_general_topic_and_absent_topic_falls_back(tmp_path):
+    profile_home = _mark_profile(tmp_path / "profiles" / "general-test")
+    general = resolve_topic_profile(
+        {
+            "topic_profiles_safe_root": str(profile_home.parent),
+            "topic_profiles": [
+                {"match": {"chat_id": "-1001", "thread_id": "1"}, "profile": "general-test"},
+            ]
+        },
+        "-1001",
+        "1",
+    )
+    no_topic = resolve_topic_profile(
+        {
+            "topic_profiles_safe_root": str(profile_home.parent),
+            "topic_profiles": [
+                {"match": {"chat_id": "-1001", "thread_id": "1"}, "profile": "general-test"},
+            ]
+        },
+        "-1001",
+        None,
+    )
+
+    assert general == {"profile": "general-test", "profile_home": str(profile_home)}
+    assert no_topic is None
+
+
+def test_topic_profile_resolver_rejects_allowed_topics_mismatch(tmp_path):
+    profile_home = _mark_profile(tmp_path / "profiles" / "topic-test")
+    with pytest.raises(TopicProfileConfigError, match="allowed_topics would block"):
+        resolve_topic_profile(
+            {
+                "allowed_topics": ["202"],
+                "topic_profiles_safe_root": str(profile_home.parent),
+                "topic_profiles": [
+                    {"match": {"chat_id": "-1001", "thread_id": "101"}, "profile": "topic-test"},
+                ],
+            },
+            "-1001",
+            "101",
+        )
+
+
+def test_topic_profile_resolver_rejects_default_profile(tmp_path):
+    profiles_root = tmp_path / "profiles"
+    profiles_root.mkdir()
+    with pytest.raises(TopicProfileConfigError, match="Invalid .*profile"):
+        resolve_topic_profile(
+            {
+                "topic_profiles_safe_root": str(profiles_root),
+                "topic_profiles": [
+                    {"match": {"chat_id": "-1001", "thread_id": "101"}, "profile": "default"},
+                ],
+            },
+            "-1001",
+            "101",
+        )
+
+
+def test_topic_profiles_reject_env_allowed_topics_mismatch(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    profile_home = hermes_home / "profiles" / "alpha-test"
+    _mark_profile(profile_home)
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        f"  topic_profiles_safe_root: {hermes_home / 'profiles'}\n"
+        "  topic_profiles:\n"
+        "    - match:\n"
+        "        chat_id: '-1001'\n"
+        "        thread_id: 101\n"
+        "      profile: alpha-test\n"
+        f"      profile_home: {profile_home}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_TOPICS", "202")
+
+    with pytest.raises(TopicProfileConfigError, match="allowed_topics would block"):
+        load_gateway_config()
+
+
+def test_topic_profile_resolver_rejects_invalid_profile_names(tmp_path):
+    profiles_root = tmp_path / "profiles"
+    profiles_root.mkdir()
+    with pytest.raises(TopicProfileConfigError, match="Invalid .*profile"):
+        resolve_topic_profile(
+            {
+                "topic_profiles_safe_root": str(profiles_root),
+                "topic_profiles": [
+                    {
+                        "match": {"chat_id": "-1001", "thread_id": "101"},
+                        "profile": "bad:profile",
+                    }
+                ]
+            },
+            "-1001",
+            "101",
+        )
+
+
+def test_topic_profile_resolver_rejects_missing_thread_id(tmp_path):
+    profiles_root = tmp_path / "profiles"
+    profiles_root.mkdir()
+    with pytest.raises(TopicProfileConfigError, match="requires match.chat_id and match.thread_id"):
+        resolve_topic_profile(
+            {
+                "topic_profiles_safe_root": str(profiles_root),
+                "topic_profiles": [
+                    {"match": {"chat_id": "-1001"}, "profile": "no-topic-test"},
+                ]
+            },
+            "-1001",
+            None,
+        )
+
+
+def test_topic_profile_resolver_rejects_duplicate_routes(tmp_path):
+    profiles_root = tmp_path / "profiles"
+    profiles_root.mkdir()
+    (profiles_root / "a").mkdir()
+    (profiles_root / "b").mkdir()
+    with pytest.raises(TopicProfileConfigError, match="Duplicate"):
+        resolve_topic_profile(
+            {
+                "topic_profiles_safe_root": str(profiles_root),
+                "topic_profiles": [
+                    {"match": {"chat_id": "-1001", "thread_id": 101}, "profile": "a"},
+                    {"match": {"chat_id": "-1001", "thread_id": "101"}, "profile": "b"},
+                ]
+            },
+            "-1001",
+            "101",
+        )
+
+
+def test_topic_profile_resolver_rejects_profile_home_without_safe_root(tmp_path):
+    with pytest.raises(TopicProfileConfigError, match="topic_profiles_safe_root is required"):
+        resolve_topic_profile(
+            {
+                "topic_profiles": [
+                    {
+                        "match": {"chat_id": "-1001", "thread_id": "101"},
+                        "profile": "alpha-test",
+                        "profile_home": str(tmp_path / "alpha-test"),
+                    }
+                ]
+            },
+            "-1001",
+            "101",
+        )
+
+
+def test_session_key_includes_valid_profile_and_ignores_invalid_profile():
+    routed = build_session_key(_source(agent_profile="alpha-test"))
+    invalid = build_session_key(_source(agent_profile="bad:profile"))
+
+    assert routed == "agent:alpha-test:telegram:group:-1001:101"
+    assert invalid == "agent:main:telegram:group:-1001:101"
+
+
+def test_parse_session_key_accepts_routed_profiles():
+    from gateway.run import _parse_session_key
+
+    parsed = _parse_session_key("agent:alpha-test:telegram:group:-1001:101")
+
+    assert parsed is not None
+    assert parsed["agent_profile"] == "alpha-test"
+    assert parsed["platform"] == "telegram"
+    assert parsed["chat_type"] == "group"
+    assert parsed["chat_id"] == "-1001"
+
+
+def test_session_key_treats_empty_profile_as_main_without_warning(caplog):
+    source = _source(agent_profile="")
+
+    assert build_session_key(source) == "agent:main:telegram:group:-1001:101"
+    assert "Ignoring invalid agent profile" not in caplog.text
+
+
+def test_session_source_roundtrip_preserves_agent_profile_fields(tmp_path):
+    source = _source(
+        agent_profile="beta-test",
+        agent_hermes_home=str(tmp_path / "beta-test"),
+    )
+
+    restored = SessionSource.from_dict(source.to_dict())
+
+    assert restored.agent_profile == "beta-test"
+    assert restored.agent_hermes_home == str(tmp_path / "beta-test")
+
+
+def test_completion_event_rebuilds_source_with_routed_profile(tmp_path):
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.session_store = SessionStore(gateway_home / "sessions", runner.config)
+
+        source = runner._build_process_event_source(
+            {
+                "session_id": "proc_alpha",
+                "session_key": "agent:alpha-test:telegram:group:-1001:101",
+                "platform": "telegram",
+                "chat_type": "group",
+                "chat_id": "-1001",
+                "thread_id": "101",
+                "user_id": "42",
+                "agent_profile": "alpha-test",
+                "agent_hermes_home": str(profile_home),
+            }
+        )
+
+    assert source is not None
+    assert source.agent_profile == "alpha-test"
+    assert source.agent_hermes_home == str(profile_home)
+    assert source.thread_id == "101"
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_reads_profile_cli_config_for_routed_topic(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+    from tools import mcp_tool
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    captured_homes = []
+
+    def fake_discover_mcp_tools():
+        captured_homes.append(str(get_hermes_home()))
+        mcp_tool._servers["profile-server"] = object()
+        return [{"name": "profile_tool"}]
+
+    monkeypatch.setattr(mcp_tool, "_servers", {})
+    monkeypatch.setattr(mcp_tool, "_lock", threading.Lock())
+    monkeypatch.setattr(mcp_tool, "shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", fake_discover_mcp_tools)
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    extra={"topic_profiles_safe_root": str(profiles_root)}
+                )
+            }
+        )
+        runner.session_store = SessionStore(gateway_home / "sessions", runner.config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        event = MessageEvent(
+            text="/reload-mcp",
+            message_type=MessageType.COMMAND,
+            source=source,
+        )
+        result = await runner._execute_mcp_reload(event)
+
+    assert captured_homes == [str(profile_home)]
+    assert "profile-server" in result
+
+
+@pytest.mark.asyncio
+async def test_reload_skills_reads_profile_home_for_routed_topic(monkeypatch, tmp_path):
+    from agent import skill_commands
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    captured_homes = []
+
+    def fake_reload_skills():
+        captured_homes.append(str(get_hermes_home()))
+        return {"added": [], "removed": [], "total": 0}
+
+    monkeypatch.setattr(skill_commands, "reload_skills", fake_reload_skills)
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    extra={"topic_profiles_safe_root": str(profiles_root)}
+                )
+            }
+        )
+        runner.adapters = {}
+        runner.session_store = SessionStore(gateway_home / "sessions", runner.config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        event = MessageEvent(
+            text="/reload-skills",
+            message_type=MessageType.COMMAND,
+            source=source,
+        )
+        result = await runner._handle_reload_skills_command(event)
+
+    assert captured_homes == [str(profile_home)]
+    assert "Skills Reloaded" in result
+
+
+def test_profile_session_store_uses_routed_home_without_changing_global_home(tmp_path):
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(tmp_path / "profiles")}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner.session_store = SessionStore(gateway_home / "sessions", config)
+        source = _source(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+
+        profile_store = runner._session_store_for_source(source)
+
+        assert profile_store.sessions_dir == profile_home / "sessions"
+        assert profile_store._db.db_path == profile_home / "state.db"
+        assert get_hermes_home() == gateway_home
+        assert runner._session_key_for_source(source) == (
+            "agent:alpha-test:telegram:group:-1001:101"
+        )
+
+
+def test_named_profile_without_explicit_home_stays_isolated_under_profiles_root(tmp_path):
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = _mark_profile(gateway_home / "profiles" / "alpha-test")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profile_home.parent)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner.session_store = SessionStore(gateway_home / "sessions", config)
+        source = _source(agent_profile="alpha-test")
+
+        profile_store = runner._session_store_for_source(source)
+
+        assert profile_store.sessions_dir == gateway_home / "profiles" / "alpha-test" / "sessions"
+        assert profile_store._db.db_path == gateway_home / "profiles" / "alpha-test" / "state.db"
+        assert profile_store is not runner.session_store
+
+
+@pytest.mark.asyncio
+async def test_resume_pending_shutdown_mark_uses_routed_profile_store(tmp_path):
+    from tests.gateway.restart_test_helpers import make_restart_runner
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="test",
+                extra={
+                    "topic_profiles_safe_root": str(gateway_home / "profiles"),
+                    "topic_profiles": [
+                        {
+                            "match": {"chat_id": "-1001", "thread_id": "101"},
+                            "profile": "alpha-test",
+                            "profile_home": str(profile_home),
+                        }
+                    ],
+                },
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner, adapter = make_restart_runner()
+        runner.config = config
+        runner.session_store = SessionStore(gateway_home / "sessions", config)
+        runner._restart_drain_timeout = 0.05
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        entry = profile_store.get_or_create_session(source)
+        runner._running_agents = {entry.session_key: MagicMock()}
+        adapter.disconnect = AsyncMock()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gateway.status.remove_pid_file", lambda: None)
+            mp.setattr("gateway.status.write_runtime_status", lambda *args, **kwargs: None)
+            await runner.stop()
+
+        profile_store._ensure_loaded()
+        runner.session_store._ensure_loaded()
+
+    assert profile_store._entries[entry.session_key].resume_pending is True
+    assert entry.session_key not in runner.session_store._entries
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_scans_routed_profile_store(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="test",
+                extra={
+                    "topic_profiles_safe_root": str(gateway_home / "profiles"),
+                    "topic_profiles": [
+                        {
+                            "match": {"chat_id": "-1001", "thread_id": "101"},
+                            "profile": "alpha-test",
+                            "profile_home": str(profile_home),
+                        }
+                    ],
+                },
+            )
+        }
+    )
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    with hermes_home_context(gateway_home):
+        seed_runner = _make_runner(config)
+        profile_store = seed_runner._session_store_for_source(source)
+        entry = profile_store.get_or_create_session(source)
+        profile_store.mark_resume_pending(entry.session_key, "restart_timeout")
+
+        runner = _make_runner(config)
+        adapter = _KeyCapturingAdapter()
+        adapter.handle_message = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        scheduled = runner._schedule_resume_pending_sessions()
+        await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.internal is True
+    assert event.source.agent_profile == "alpha-test"
+    assert event.source.agent_hermes_home == str(profile_home)
+
+
+def test_relative_explicit_profile_home_is_resolved_inside_safe_root(tmp_path):
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "relative-home"
+    _mark_profile(profile_home, "alpha-test")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner.session_store = SessionStore(gateway_home / "sessions", config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home="relative-home")
+
+        profile_store = runner._session_store_for_source(source)
+
+        assert profile_store.sessions_dir == profile_home / "sessions"
+
+
+def test_missing_named_profile_fails_closed(tmp_path):
+    from gateway.run import GatewayRunner, TopicProfileRoutingError
+
+    gateway_home = tmp_path / "gateway"
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(gateway_home / "profiles")}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner.session_store = SessionStore(gateway_home / "sessions", config)
+        source = _source(agent_profile="missing-profile")
+
+        with pytest.raises(TopicProfileRoutingError, match="does not exist"):
+            runner._session_store_for_source(source)
+
+
+def test_routed_profile_runtime_env_is_loaded_without_mutating_process_env(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    _mark_profile(profile_home)
+    (profile_home / ".env").write_text("OPENROUTER_API_KEY=profile-key\n", encoding="utf-8")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profile_home.parent)}
+            )
+        }
+    )
+    captured = {}
+
+    def _capture_runtime(runtime_env=None):
+        captured["runtime_env"] = dict(runtime_env or {})
+        return {
+            "api_key": runtime_env.get("OPENROUTER_API_KEY"),
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "main-key")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _capture_runtime)
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner.session_store = SessionStore(gateway_home / "sessions", config)
+        runner._session_model_overrides = {}
+        runner._pending_model_notes = {}
+        source = _source(agent_profile="alpha-test")
+
+        model, runtime = runner._resolve_session_agent_runtime(
+            source=source,
+            user_config={"model": {"default": "test-model"}},
+        )
+
+    assert model == "test-model"
+    assert runtime["api_key"] == "profile-key"
+    assert captured["runtime_env"]["OPENROUTER_API_KEY"] == "profile-key"
+    assert captured["runtime_env"]["HERMES_PROFILE_STRICT_AUTH"] == "1"
+    assert captured["runtime_env"]["HERMES_HOME"] == str(profile_home)
+    assert os.environ["OPENROUTER_API_KEY"] == "main-key"
+
+
+@pytest.mark.asyncio
+async def test_hermes_home_context_is_task_local(tmp_path):
+    import asyncio
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profile"
+
+    async def read_home(path):
+        with hermes_home_context(path):
+            await asyncio.sleep(0)
+            return get_hermes_home()
+
+    first, second = await asyncio.gather(read_home(gateway_home), read_home(profile_home))
+
+    assert first == gateway_home
+    assert second == profile_home
+
+
+def test_config_yaml_bridges_telegram_topic_profiles(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    profile_home = _mark_profile(tmp_path / "profiles" / "alpha-test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        f"""
+telegram:
+  enabled: true
+  token: test-token
+  topic_profiles_safe_root: {profile_home.parent}
+  topic_profiles:
+    - match:
+        chat_id: "-1001"
+        thread_id: 101
+      profile: alpha-test
+""",
+        encoding="utf-8",
+    )
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.TELEGRAM].extra["topic_profiles"][0]["profile"] == "alpha-test"
+
+
+def test_config_yaml_relative_safe_root_survives_runtime_cwd_change(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    profile_home = _mark_profile(tmp_path / "profiles" / "alpha-test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        """
+telegram:
+  enabled: true
+  token: test-token
+  topic_profiles_safe_root: profiles
+  topic_profiles:
+    - match:
+        chat_id: "-1001"
+        thread_id: 101
+      profile: alpha-test
+""",
+        encoding="utf-8",
+    )
+
+    config = load_gateway_config()
+    other_cwd = tmp_path / "service-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+
+    route = resolve_topic_profile(
+        config.platforms[Platform.TELEGRAM].extra,
+        "-1001",
+        "101",
+    )
+
+    assert route == {"profile": "alpha-test", "profile_home": str(profile_home)}
+
+
+def test_config_yaml_warns_for_ui_platforms_topic_profiles(monkeypatch, tmp_path, caplog):
+    from gateway.config import load_gateway_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        """
+ui:
+  platforms:
+    telegram:
+      topic_profiles:
+        - match:
+            chat_id: "-1001"
+            thread_id: 101
+          profile: alpha-test
+""",
+        encoding="utf-8",
+    )
+
+    config = load_gateway_config()
+
+    assert Platform.TELEGRAM not in config.platforms
+    assert "Ignoring ui.platforms.telegram.topic_profiles" in caplog.text
+
+
+def test_telegram_synthetic_message_event_sets_profile_on_event_and_source(tmp_path):
+    pytest.importorskip("telegram")
+    from telegram.constants import ChatType
+    from gateway.platforms.telegram import TelegramAdapter
+
+    profile_home = tmp_path / "alpha-test"
+    profile_home.mkdir()
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={
+                "topic_profiles_safe_root": str(tmp_path),
+                "topic_profiles": [
+                    {
+                        "match": {"chat_id": "-1001", "thread_id": "101"},
+                        "profile": "alpha-test",
+                        "profile_home": str(profile_home),
+                    }
+                ]
+            },
+        )
+    )
+    message = SimpleNamespace(
+        chat=SimpleNamespace(
+            id=-1001,
+            type="supergroup",
+            is_forum=True,
+            title="Sandbox Forum",
+        ),
+        from_user=SimpleNamespace(id=42, full_name="Ayo Test"),
+        message_thread_id=101,
+        is_topic_message=True,
+        text="hello",
+        caption=None,
+        message_id=7,
+        reply_to_message=None,
+        date=datetime(2026, 5, 1),
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.agent_profile == "alpha-test"
+    assert event.agent_hermes_home == str(profile_home)
+    assert event.source.agent_profile == "alpha-test"
+    assert event.source.agent_hermes_home == str(profile_home)
+
+
+@pytest.mark.asyncio
+async def test_base_handle_message_hydrates_event_profile_before_session_key(tmp_path):
+    adapter = _KeyCapturingAdapter()
+    adapter.set_message_handler(AsyncMock(return_value=None))
+    event = MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=_source(thread_id="10", agent_profile=None, agent_hermes_home=None),
+        agent_profile="atlas",
+        agent_hermes_home=str(tmp_path / "atlas"),
+    )
+
+    await adapter.handle_message(event)
+
+    assert adapter.captured_session_key == "agent:atlas:telegram:group:-1001:10"
+    assert event.source.agent_profile == "atlas"
+    assert event.source.agent_hermes_home == str(tmp_path / "atlas")
+
+
+@pytest.mark.asyncio
+async def test_runner_fallback_hydrates_topic_profile_before_quick_key(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "atlas"
+    _mark_profile(profile_home)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={
+                    "topic_profiles_safe_root": str(profiles_root),
+                    "topic_profiles": [
+                        {
+                            "match": {"chat_id": "-1001", "thread_id": "10"},
+                            "profile": "atlas",
+                            "profile_home": str(profile_home),
+                        }
+                    ],
+                }
+            )
+        }
+    )
+    captured = {}
+
+    async def fake_inner(event, source, quick_key, run_generation):
+        captured["quick_key"] = quick_key
+        captured["source"] = source
+        return "ok"
+
+    with hermes_home_context(tmp_path / "gateway"):
+        runner = _make_runner(config)
+        runner._is_user_authorized = lambda _source: True
+        monkeypatch.setattr(runner, "_handle_message_with_agent", fake_inner)
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=_source(thread_id="10", agent_profile=None, agent_hermes_home=None),
+        )
+        response = await runner._handle_message(event)
+
+    assert response == "ok"
+    assert captured["quick_key"] == "agent:atlas:telegram:group:-1001:10"
+    assert captured["source"].agent_profile == "atlas"
+    assert captured["source"].agent_hermes_home == str(profile_home)
+
+
+@pytest.mark.asyncio
+async def test_runner_fallback_no_topic_profile_match_stays_main(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    _mark_profile(profiles_root / "atlas")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={
+                    "topic_profiles_safe_root": str(profiles_root),
+                    "topic_profiles": [
+                        {"match": {"chat_id": "-1001", "thread_id": "10"}, "profile": "atlas"}
+                    ],
+                }
+            )
+        }
+    )
+    captured = {}
+
+    async def fake_inner(event, source, quick_key, run_generation):
+        captured["quick_key"] = quick_key
+        captured["source"] = source
+        return "ok"
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._is_user_authorized = lambda _source: True
+        monkeypatch.setattr(runner, "_handle_message_with_agent", fake_inner)
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=_source(thread_id="11", agent_profile=None, agent_hermes_home=None),
+        )
+        response = await runner._handle_message(event)
+
+    assert response == "ok"
+    assert captured["quick_key"] == "agent:main:telegram:group:-1001:11"
+    assert captured["source"].agent_profile is None
+
+
+def test_runner_fallback_normalizes_forum_general_topic_from_raw_message(tmp_path):
+    from gateway.run import GatewayRunner
+
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "atlas"
+    profile_home.mkdir(parents=True)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={
+                    "topic_profiles_safe_root": str(profiles_root),
+                    "topic_profiles": [
+                        {
+                            "match": {"chat_id": "-1001", "thread_id": "1"},
+                            "profile": "atlas",
+                            "profile_home": str(profile_home),
+                        }
+                    ],
+                }
+            )
+        }
+    )
+    event = MessageEvent(
+        text="general",
+        message_type=MessageType.TEXT,
+        source=_source(thread_id=None, agent_profile=None, agent_hermes_home=None),
+        raw_message=SimpleNamespace(
+            message_thread_id=None,
+            chat=SimpleNamespace(is_forum=True),
+        ),
+    )
+
+    runner._hydrate_topic_profile_for_event(event)
+
+    assert event.source.thread_id is None
+    assert event.source.agent_profile is None
+    assert event.source.agent_hermes_home is None
+
+
+def test_try_resolve_fallback_provider_uses_scoped_key_env(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n"
+        "    key_env: PROFILE_FALLBACK_KEY\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PROFILE_FALLBACK_KEY", "global-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+
+    with hermes_home_context(profile_home):
+        resolved = gateway_run._try_resolve_fallback_provider(
+            runtime_env={"PROFILE_FALLBACK_KEY": "profile-secret"}
+        )
+
+    assert resolved is not None
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "profile-secret"
+    assert resolved["model"] == "fallback-model"
+
+
+def test_try_resolve_fallback_provider_fails_closed_when_scoped_key_env_missing(
+    monkeypatch, tmp_path
+):
+    from gateway import run as gateway_run
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n"
+        "    key_env: PROFILE_FALLBACK_KEY\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PROFILE_FALLBACK_KEY", "global-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+
+    with hermes_home_context(profile_home):
+        resolved = gateway_run._try_resolve_fallback_provider(runtime_env={})
+
+    assert resolved is None
+
+
+def test_resolve_runtime_agent_kwargs_uses_scoped_fallback_when_primary_has_no_key(
+    monkeypatch, tmp_path
+):
+    from gateway import run as gateway_run
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n"
+        "    key_env: PROFILE_FALLBACK_KEY\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+    monkeypatch.setenv("PROFILE_FALLBACK_KEY", "global-fallback")
+
+    with hermes_home_context(profile_home):
+        resolved = gateway_run._resolve_runtime_agent_kwargs(
+            runtime_env={"PROFILE_FALLBACK_KEY": "profile-fallback"}
+        )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "profile-fallback"
+    assert resolved["model"] == "fallback-model"
+
+
+def test_resolve_runtime_agent_kwargs_fails_closed_when_scoped_primary_and_fallback_missing(
+    monkeypatch, tmp_path
+):
+    from gateway import run as gateway_run
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n"
+        "    key_env: PROFILE_FALLBACK_KEY\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+    monkeypatch.setenv("PROFILE_FALLBACK_KEY", "global-fallback")
+
+    with hermes_home_context(profile_home):
+        resolved = gateway_run._resolve_runtime_agent_kwargs(runtime_env={})
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == ""
+
+
+@pytest.mark.asyncio
+async def test_run_agent_returns_visible_auth_failure_for_routed_profile_without_credentials(
+    monkeypatch, tmp_path
+):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    gateway_home.mkdir()
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  default: routed-model\n",
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter-should-not-be-used")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    _install_fake_agent(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(tmp_path)}
+            )
+        }
+    )
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(
+        agent_profile="profile",
+        agent_hermes_home=str(profile_home),
+    )
+
+    with hermes_home_context(profile_home):
+        result = await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-auth-fail",
+            session_key=build_session_key(source),
+        )
+
+    assert "Provider authentication failed" in result["final_response"]
+    assert "profile-scoped provider credentials" in result["final_response"]
+    assert _CapturingAgent.last_init is None
+
+
+def test_telegram_batch_keys_are_profile_aware_from_event(tmp_path):
+    pytest.importorskip("telegram")
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    event = MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=_source(thread_id="10", agent_profile=None),
+        agent_profile="atlas",
+    )
+    msg = SimpleNamespace(media_group_id=None)
+
+    assert adapter._text_batch_key(event) == "agent:atlas:telegram:group:-1001:10"
+    assert adapter._photo_batch_key(event, msg) == "agent:atlas:telegram:group:-1001:10:photo-burst"
+    assert adapter._media_group_batch_key(event, "album-1") == (
+        "agent:atlas:telegram:group:-1001:10:album:album-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_resolver_hydrates_profile_before_adapter_session_key(tmp_path):
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "atlas"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={
+                    "topic_profiles_safe_root": str(profiles_root),
+                    "topic_profiles": [
+                        {
+                            "match": {"chat_id": "-1001", "thread_id": "10"},
+                            "profile": "atlas",
+                            "profile_home": str(profile_home),
+                        }
+                    ],
+                }
+            )
+        }
+    )
+    with hermes_home_context(tmp_path / "gateway"):
+        runner = _make_runner(config)
+    adapter = _KeyCapturingAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    adapter.set_message_handler(AsyncMock(return_value=None))
+    adapter.set_topic_profile_route_resolver(runner._hydrate_topic_profile_for_event)
+    event = MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=_source(thread_id="10", agent_profile=None, agent_hermes_home=None),
+    )
+
+    await adapter.handle_message(event)
+
+    assert adapter.captured_session_key == "agent:atlas:telegram:group:-1001:10"
+    assert event.source.agent_profile == "atlas"
+    assert event.source.agent_hermes_home == str(profile_home)
+
+
+@pytest.mark.asyncio
+async def test_real_telegram_adapter_handle_message_routes_full_turn_to_profile(
+    monkeypatch,
+    tmp_path,
+):
+    pytest.importorskip("telegram")
+    from telegram.constants import ChatType
+    from gateway import run as gateway_run
+    from gateway.platforms.telegram import TelegramAdapter
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "atlas"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    (gateway_home / "SOUL.md").write_text("Gateway SOUL", encoding="utf-8")
+    (profile_home / "SOUL.md").write_text("Atlas SOUL", encoding="utf-8")
+    _write_profile_config(
+        profile_home,
+        prompt="Atlas prompt",
+        model="openrouter/atlas-model",
+        toolsets=["web"],
+    )
+    route_extra = {
+        "topic_profiles_safe_root": str(profiles_root),
+        "topic_profiles": [
+            {
+                "match": {"chat_id": "-1001", "thread_id": "10"},
+                "profile": "atlas",
+                "profile_home": str(profile_home),
+            }
+        ],
+    }
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(extra=route_extra)
+        }
+    )
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._is_user_authorized = lambda _source: True
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra=route_extra)
+        )
+        adapter.set_message_handler(runner._handle_message)
+        adapter.set_topic_profile_route_resolver(runner._hydrate_topic_profile_for_event)
+        adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="99"))
+        adapter.send_typing = AsyncMock()
+        adapter.stop_typing = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        message = SimpleNamespace(
+            chat=SimpleNamespace(
+                id=-1001,
+                type="supergroup",
+                is_forum=True,
+                title="Sandbox Forum",
+            ),
+            from_user=SimpleNamespace(id=42, full_name="Ayo Test"),
+            message_thread_id=10,
+            is_topic_message=True,
+            text="hello",
+            caption=None,
+            message_id=7,
+            reply_to_message=None,
+            date=datetime(2026, 5, 1),
+        )
+        event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+        await adapter.handle_message(event)
+        await asyncio.gather(*list(adapter._background_tasks))
+
+    captured = _CapturingAgent.last_init
+    assert captured is not None
+    assert captured["gateway_session_key"] == "agent:atlas:telegram:group:-1001:10"
+    assert captured["hermes_home_at_init"] == str(profile_home)
+    assert captured["soul"] == "Atlas SOUL"
+    assert captured["model"] == "openrouter/atlas-model"
+    assert "web" in set(captured["enabled_toolsets"])
+
+
+async def _run_captured_agent(monkeypatch, runner, source, hermes_home, *, context_prompt="", channel_prompt=None):
+    from gateway import run as gateway_run
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(hermes_home):
+        result = await runner._run_agent(
+            message="hi",
+            context_prompt=context_prompt,
+            history=[],
+            source=source,
+            session_id=f"session-{source.thread_id or 'main'}",
+            session_key=build_session_key(source),
+            channel_prompt=channel_prompt,
+        )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    return _CapturingAgent.last_init
+
+
+class _CompressingAgent(_CapturingAgent):
+    """Capturing agent that mutates ``session_id`` mid-turn to simulate the
+    auto-compression code path: when ``run_conversation`` finishes, the
+    agent's ``session_id`` differs from the one ``_run_agent`` was invoked
+    with, which triggers the compression-split entry update at
+    ``gateway/run.py:13041`` (bug E)."""
+
+    new_session_id = "session-after-compression"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Constructor is invoked with ``session_id=...``; rewrite to a
+        # different value so the post-result block sees a split.
+        self.session_id = self.new_session_id
+
+
+@pytest.mark.asyncio
+async def test_run_agent_compression_split_writes_to_profile_session_store(
+    monkeypatch, tmp_path
+):
+    """Bug E regression: when auto-compression mid-turn rotates the
+    agent's ``session_id``, ``_run_agent`` must update the entry on the
+    routed profile's SessionStore — not the gateway-global store.
+
+    Before the fix, ``self.session_store._entries.get(...)`` and
+    ``self.session_store._save()`` (gateway/run.py:13041 + :13044) wrote
+    to the gateway store, leaving the profile entry stuck on the old
+    ``session_id`` and making the compressed transcript unreachable on
+    the next routed turn.
+    """
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CompressingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    _CompressingAgent.last_init = None
+    _CompressingAgent.inits = []
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(
+            chat_type="dm",
+            thread_id=None,
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        session_key = build_session_key(source)
+
+        profile_store = runner._session_store_for_source(source)
+        gateway_store = runner.session_store
+
+        original_session_id = "session-before-compression"
+        profile_entry = profile_store.get_or_create_session(source)
+        profile_entry.session_id = original_session_id
+        profile_store._save()
+        monkeypatch.setattr(
+            profile_store._db,
+            "get_telegram_topic_binding_by_session",
+            lambda *, session_id: (
+                {"thread_id": "303"}
+                if session_id == _CompressingAgent.new_session_id
+                else None
+            ),
+        )
+        gateway_entry = gateway_store.get_or_create_session(source)
+        gateway_entry.session_id = "gateway-untouched"
+        gateway_store._save()
+
+        with hermes_home_context(profile_home):
+            result = await runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id=original_session_id,
+                session_key=session_key,
+            )
+
+    assert result["final_response"] == "ok"
+
+    # Profile store entry must reflect the post-compression session id.
+    profile_entry_after = profile_store._entries.get(session_key)
+    assert profile_entry_after is not None
+    assert profile_entry_after.session_id == _CompressingAgent.new_session_id
+    assert source.thread_id == "303"
+
+    # Gateway store must NOT have been written. Its entry, if present, keeps
+    # the original placeholder id; either the entry is absent or untouched.
+    gw_entry_after = gateway_store._entries.get(session_key)
+    if gw_entry_after is not None:
+        assert gw_entry_after.session_id == "gateway-untouched"
+
+
+def test_routed_profile_session_db_fail_closed_without_profile_db(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profile_home.parent)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._is_user_authorized = lambda _source: True
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        runner._session_db = SimpleNamespace(name="global-db")
+        runner._session_store_for_source = lambda _source: SimpleNamespace(_db=None)
+        with pytest.raises(Exception, match="session DB is unavailable"):
+            runner._session_db_for_source(source)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_auto_title_writes_to_profile_session_db(
+    monkeypatch, tmp_path
+):
+    """Bug E regression: auto-title generation at ``gateway/run.py:13056``
+    must call ``maybe_auto_title`` with the routed profile's SessionDB,
+    not ``self._session_db`` (which is the gateway-global one)."""
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    captured_dbs = []
+
+    def _fake_maybe_auto_title(session_db, session_id, message, final_response, all_msgs, **kwargs):
+        captured_dbs.append(session_db)
+
+    import agent.title_generator as title_module
+    monkeypatch.setattr(title_module, "maybe_auto_title", _fake_maybe_auto_title)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        # Force the gateway-global _session_db to a sentinel so any leak is
+        # observable in the captured arguments.
+        gateway_db_sentinel = MagicMock(name="gateway_session_db")
+        runner._session_db = gateway_db_sentinel
+
+        source = _source(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        profile_store = runner._session_store_for_source(source)
+        profile_db = profile_store._db
+        assert profile_db is not gateway_db_sentinel
+
+        with hermes_home_context(profile_home):
+            await runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="session-init",
+                session_key=build_session_key(source),
+            )
+
+    assert captured_dbs, "maybe_auto_title was never called"
+    assert captured_dbs[0] is profile_db
+    assert captured_dbs[0] is not gateway_db_sentinel
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_system_prompt_uses_profile_config_not_gateway_config(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    (gateway_home / "config.yaml").write_text(
+        'agent:\n  system_prompt: "Gateway config prompt"\n',
+        encoding="utf-8",
+    )
+    _write_profile_config(
+        profile_home,
+        prompt="Profile config prompt",
+        model="anthropic/claude-sonnet-4",
+        toolsets=["web"],
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config, gateway_prompt="Gateway runtime prompt")
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    captured = await _run_captured_agent(
+        monkeypatch,
+        runner,
+        source,
+        profile_home,
+        context_prompt="Context prompt",
+        channel_prompt="Channel prompt",
+    )
+
+    assert captured["ephemeral_system_prompt"] == (
+        "Context prompt\n\nChannel prompt\n\nProfile config prompt"
+    )
+    assert "Gateway" not in captured["ephemeral_system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_non_routed_system_prompt_keeps_existing_gateway_behavior(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    gateway_home.mkdir()
+    (gateway_home / "config.yaml").write_text(
+        'agent:\n  system_prompt: "Gateway config prompt"\n',
+        encoding="utf-8",
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(gateway_prompt="Gateway runtime prompt")
+    source = _source(agent_profile=None, agent_hermes_home=None)
+
+    captured = await _run_captured_agent(
+        monkeypatch,
+        runner,
+        source,
+        gateway_home,
+        context_prompt="Context prompt",
+        channel_prompt="Channel prompt",
+    )
+
+    assert captured["ephemeral_system_prompt"] == (
+        "Context prompt\n\nChannel prompt\n\nGateway runtime prompt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_soul_identity_is_loaded_from_profile_home(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    (gateway_home / "SOUL.md").write_text("Gateway SOUL", encoding="utf-8")
+    (profile_home / "SOUL.md").write_text("Profile SOUL", encoding="utf-8")
+    _write_profile_config(profile_home, prompt="Profile prompt", model="profile-model", toolsets=["web"])
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    captured = await _run_captured_agent(monkeypatch, runner, source, profile_home)
+
+    assert captured["soul"] == "Profile SOUL"
+    assert captured["hermes_home_at_init"] == str(profile_home)
+
+
+@pytest.mark.asyncio
+async def test_handle_message_routes_full_turn_through_topic_profile(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    (gateway_home / "SOUL.md").write_text("Gateway SOUL", encoding="utf-8")
+    (profile_home / "SOUL.md").write_text("Profile SOUL", encoding="utf-8")
+    _write_profile_config(
+        profile_home,
+        prompt="Profile prompt",
+        model="openrouter/profile-model",
+        toolsets=["web"],
+    )
+    (profile_home / ".env").write_text(
+        "OPENROUTER_API_KEY=sk-test-profile-key\nHERMES_MAX_ITERATIONS=7\n",
+        encoding="utf-8",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="gateway-token",
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="-100999",
+                    name="GatewayHome",
+                ),
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "99")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._detect_stale_code = lambda: False
+        runner._trigger_stale_code_restart = lambda: None
+        runner._is_user_authorized = lambda _source: True
+        source = _source(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source)
+
+        response = await runner._handle_message(event)
+
+        assert get_hermes_home() == gateway_home
+
+    assert response == "ok"
+    captured = _CapturingAgent.last_init
+    assert captured is not None
+    assert captured["hermes_home_at_init"] == str(profile_home)
+    assert captured["soul"] == "Profile SOUL"
+    assert captured["model"] == "openrouter/profile-model"
+    assert captured["max_iterations"] == 7
+    assert "web" in set(captured["enabled_toolsets"])
+    assert "GatewayHome" not in captured["ephemeral_system_prompt"]
+    assert "Home Channels" not in captured["ephemeral_system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_quick_and_plugin_commands_disabled_for_routed_profile_topics(monkeypatch, tmp_path):
+    from hermes_cli import plugins
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    executed = {"quick": False, "plugin": False}
+
+    async def fake_subprocess_shell(*_args, **_kwargs):
+        executed["quick"] = True
+        raise AssertionError("quick command should not execute")
+
+    def fake_plugin_handler(_name):
+        def _handler(_args):
+            executed["plugin"] = True
+            return "plugin result"
+
+        return _handler
+
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_subprocess_shell)
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_commands",
+        lambda: {"plugin-test": {"description": "Plugin test", "handler": fake_plugin_handler("plugin-test")}},
+    )
+    monkeypatch.setattr(plugins, "get_plugin_command_handler", fake_plugin_handler)
+
+    config = GatewayConfig(
+        quick_commands={
+            "limits": {"type": "exec", "command": "echo gateway"},
+            "status-alias": {"type": "alias", "target": "/status"},
+        },
+    )
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner.hooks.emit_collect = AsyncMock(
+            side_effect=AssertionError("plugin hooks should not run in routed profile topics")
+        )
+        runner._is_user_authorized = lambda _source: True
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+        quick_response = await runner._handle_message(
+            MessageEvent(text="/limits", message_type=MessageType.TEXT, source=source)
+        )
+        alias_response = await runner._handle_message(
+            MessageEvent(text="/status-alias", message_type=MessageType.TEXT, source=source)
+        )
+        plugin_response = await runner._handle_message(
+            MessageEvent(text="/plugin-test", message_type=MessageType.TEXT, source=source)
+        )
+
+    assert "disabled in routed profile topics" in quick_response
+    assert "disabled in routed profile topics" in alias_response
+    assert "disabled in routed profile topics" in plugin_response
+    assert executed == {"quick": False, "plugin": False}
+
+
+@pytest.mark.asyncio
+async def test_sethome_disabled_for_routed_profile_topics(monkeypatch, tmp_path):
+    from hermes_cli import config as hermes_config
+    from hermes_cli import plugins
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+
+    def fail_save_env_value(*_args, **_kwargs):
+        raise AssertionError("/sethome must not write gateway env from a routed topic")
+
+    monkeypatch.setattr(hermes_config, "save_env_value", fail_save_env_value)
+    monkeypatch.setattr(
+        plugins,
+        "invoke_hook",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pre_gateway_dispatch must not run in routed profile topics")
+        ),
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(
+            GatewayConfig(
+                platforms={
+                    Platform.TELEGRAM: PlatformConfig(
+                        extra={"topic_profiles_safe_root": str(gateway_home / "profiles")}
+                    )
+                }
+            )
+        )
+        runner.hooks.emit_collect = AsyncMock(
+            side_effect=AssertionError("command hooks must not run in routed profile topics")
+        )
+        runner._detect_stale_code = lambda: False
+        runner._trigger_stale_code_restart = lambda: None
+        runner._is_user_authorized = lambda _source: True
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        event = MessageEvent(text="/sethome", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_message(event)
+
+    assert "disabled in routed profile topics" in response
+
+
+@pytest.mark.asyncio
+async def test_insights_command_uses_profile_session_db_for_routed_topic(monkeypatch, tmp_path):
+    from agent import insights as insights_module
+
+    class _FakeInsightsEngine:
+        captured_db = None
+        captured_source = None
+
+        def __init__(self, db):
+            type(self).captured_db = db
+
+        def generate(self, *, days, source=None):
+            type(self).captured_source = source
+            return {"days": days}
+
+        def format_gateway(self, report):
+            return f"profile insights {report['days']}"
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(insights_module, "InsightsEngine", _FakeInsightsEngine)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(
+            GatewayConfig(
+                platforms={
+                    Platform.TELEGRAM: PlatformConfig(
+                        extra={"topic_profiles_safe_root": str(gateway_home / "profiles")}
+                    )
+                }
+            )
+        )
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        runner._session_db = runner.session_store._db
+        event = MessageEvent(
+            text="/insights --days 7 --source telegram",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+        response = await runner._handle_insights_command(event)
+
+    assert response == "profile insights 7"
+    assert _FakeInsightsEngine.captured_db is profile_store._db
+    assert _FakeInsightsEngine.captured_source == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_auto_compression_hygiene_uses_profile_runtime_home_and_session_db(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    class _HygieneAgent:
+        inits = []
+        home_at_compress = None
+
+        def __init__(self, *args, **kwargs):
+            self.session_id = kwargs["session_id"]
+            self.context_compressor = SimpleNamespace(
+                _last_compress_aborted=False,
+                _last_summary_error=None,
+                _last_aux_model_failure_model=None,
+                _last_aux_model_failure_error=None,
+            )
+            type(self).inits.append(
+                {
+                    **kwargs,
+                    "hermes_home_at_init": str(get_hermes_home()),
+                }
+            )
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            type(self).home_at_compress = str(get_hermes_home())
+            self.session_id = "hygiene-compressed-session"
+            return ([messages[0], messages[-1]], "")
+
+        def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+            return {
+                "final_response": "ok",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+            }
+
+        def shutdown_memory_provider(self):
+            return None
+
+        def close(self):
+            return None
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    _write_profile_config(profile_home, prompt="Profile prompt", model="profile-model")
+    with (profile_home / "config.yaml").open("a", encoding="utf-8") as fh:
+        fh.write("compression:\n  enabled: true\n  hygiene_hard_message_limit: 4\n")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _HygieneAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._detect_stale_code = lambda: False
+        runner._trigger_stale_code_restart = lambda: None
+        runner._is_user_authorized = lambda _source: True
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        profile_store.rewrite_transcript(
+            profile_entry.session_id,
+            [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "two"},
+                {"role": "user", "content": "three"},
+                {"role": "assistant", "content": "four"},
+            ],
+        )
+        profile_entry.last_prompt_tokens = 10
+        profile_store._save()
+
+        event = MessageEvent(text="continue", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_message(event)
+
+    assert response == "ok"
+    hygiene_init = _HygieneAgent.inits[0]
+    assert hygiene_init["hermes_home_at_init"] == str(profile_home)
+    assert _HygieneAgent.home_at_compress == str(profile_home)
+    assert hygiene_init["runtime_env"]["OPENROUTER_API_KEY"] == "sk-test-profile-key"
+    assert hygiene_init["runtime_env"]["HERMES_PROFILE_STRICT_AUTH"] == "1"
+    assert hygiene_init["runtime_env"]["HERMES_HOME"] == str(profile_home)
+    assert hygiene_init["session_db"] is profile_store._db
+    assert hygiene_init["api_key"] == "sk-test-profile-key"
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_skill_slash_command_uses_profile_skills(monkeypatch, tmp_path):
+    from agent import skill_commands
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _write_skill(gateway_home, "gateway-only", "gateway skill body")
+    _write_skill(profile_home, "profile-only", "profile skill body")
+    _write_profile_config(
+        profile_home,
+        prompt="Profile prompt",
+        model="openrouter/profile-model",
+        toolsets=["web"],
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_home", None, raising=False)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        # Prime the process-global slash-command cache with gateway skills.
+        assert "/gateway-only" in skill_commands.get_skill_commands()
+        runner = _make_runner(config)
+        runner._detect_stale_code = lambda: False
+        runner._trigger_stale_code_restart = lambda: None
+        runner._is_user_authorized = lambda _source: True
+        source = _source(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        event = MessageEvent(
+            text="/profile-only use profile-local instructions",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+
+        response = await runner._handle_message(event)
+
+    assert response == "ok"
+    assert _CapturingAgent.last_user_message is not None
+    assert "profile skill body" in _CapturingAgent.last_user_message
+    assert "gateway skill body" not in _CapturingAgent.last_user_message
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_skill_bundle_uses_profile_bundle_and_skills(monkeypatch, tmp_path):
+    from agent import skill_bundles
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _write_skill(gateway_home, "gateway-only", "gateway skill body")
+    _write_skill(profile_home, "profile-only", "profile skill body")
+    _write_bundle(gateway_home, "research", ["gateway-only"])
+    _write_bundle(profile_home, "research", ["profile-only"])
+    _write_profile_config(profile_home, prompt="Profile prompt", model="openrouter/profile-model")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_BUNDLES_DIR", raising=False)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache", {}, raising=False)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None, raising=False)
+
+    with hermes_home_context(gateway_home):
+        assert skill_bundles.resolve_bundle_command_key("research") == "/research"
+        runner = _make_runner(config)
+        runner._detect_stale_code = lambda: False
+        runner._trigger_stale_code_restart = lambda: None
+        runner._is_user_authorized = lambda _source: True
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        event = MessageEvent(
+            text="/research use bundle instructions",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+
+        response = await runner._handle_message(event)
+
+    assert response == "ok"
+    assert _CapturingAgent.last_user_message is not None
+    assert "profile skill body" in _CapturingAgent.last_user_message
+    assert "gateway skill body" not in _CapturingAgent.last_user_message
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_help_and_commands_list_profile_skills(monkeypatch, tmp_path):
+    from agent import skill_commands
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _write_skill(gateway_home, "gateway-only", "gateway skill body")
+    _write_skill(profile_home, "profile-only", "profile skill body")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    monkeypatch.setattr(skill_commands, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_home", None, raising=False)
+
+    with hermes_home_context(gateway_home):
+        assert "/gateway-only" in skill_commands.get_skill_commands()
+        runner = _make_runner(config)
+        source = _source(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        help_text = await runner._handle_help_command(
+            MessageEvent(text="/help", message_type=MessageType.TEXT, source=source)
+        )
+        commands_text = await runner._handle_commands_command(
+            MessageEvent(text="/commands 999", message_type=MessageType.TEXT, source=source)
+        )
+
+    assert "/profile_only" in help_text
+    assert "/gateway_only" not in help_text
+    assert "/profile_only" in commands_text
+    assert "/gateway_only" not in commands_text
+
+
+@pytest.mark.asyncio
+async def test_background_task_uses_routed_profile_config_env_and_session_db(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    (gateway_home / "SOUL.md").write_text("Gateway SOUL", encoding="utf-8")
+    (profile_home / "SOUL.md").write_text("Profile SOUL", encoding="utf-8")
+    _write_profile_config(
+        profile_home,
+        prompt="Profile prompt",
+        model="openrouter/profile-background-model",
+        toolsets=["web"],
+        provider_routing={"order": ["profile-provider"], "sort": "throughput"},
+    )
+    (profile_home / ".env").write_text(
+        "OPENROUTER_API_KEY=sk-test-profile-key\nHERMES_MAX_ITERATIONS=7\n",
+        encoding="utf-8",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "99")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "ok"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "ok"))
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+        source = _source(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        profile_db = runner._session_store_for_source(source)._db
+
+        await runner._run_background_task("background prompt", source, "bg_profile")
+
+    captured = _CapturingAgent.last_init
+    assert captured is not None
+    assert captured["hermes_home_at_init"] == str(profile_home)
+    assert captured["soul"] == "Profile SOUL"
+    assert captured["model"] == "openrouter/profile-background-model"
+    assert captured["runtime_env"]["OPENROUTER_API_KEY"] == "sk-test-profile-key"
+    assert captured["runtime_env"]["HERMES_MAX_ITERATIONS"] == "7"
+    assert captured["max_iterations"] == 7
+    assert captured["session_db"] is profile_db
+    assert captured["session_env_agent_profile"] == "alpha-test"
+    assert captured["session_env_agent_hermes_home"] == str(profile_home)
+    assert "web" in set(captured["enabled_toolsets"])
+    assert captured["providers_order"] == ["profile-provider"]
+    assert captured["provider_sort"] == "throughput"
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_model_toolsets_and_disabled_toolsets_come_from_profile_config(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    _write_profile_config(
+        profile_home,
+        prompt="Profile prompt",
+        model="openrouter/profile-model",
+        toolsets=["web"],
+        disabled=["memory"],
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    captured = await _run_captured_agent(monkeypatch, runner, source, profile_home)
+
+    assert captured["model"] == "openrouter/profile-model"
+    assert "web" in set(captured["enabled_toolsets"])
+    assert captured["disabled_toolsets"] == ["memory"]
+
+
+def test_routed_profile_tool_isolation_diagnostic_for_gateway_only_tools():
+    from gateway.run import _topic_profile_tool_isolation_notice
+
+    notice = _topic_profile_tool_isolation_notice(
+        {
+            "platform_toolsets": {"telegram": ["web", "browser"]},
+            "mcp_servers": {"search": {"command": "npx", "args": ["server"]}},
+        },
+        {},
+        "telegram",
+    )
+
+    assert notice is not None
+    assert "platform_toolsets.telegram" in notice
+    assert "mcp_servers" in notice
+    assert "not inherited" in notice
+
+    no_notice = _topic_profile_tool_isolation_notice(
+        {
+            "platform_toolsets": {"telegram": ["web", "browser"]},
+            "mcp_servers": {"search": {"command": "npx", "args": ["server"]}},
+        },
+        {
+            "platform_toolsets": {"telegram": ["memory"]},
+            "mcp_servers": {"profile-search": {"command": "npx"}},
+        },
+        "telegram",
+    )
+    assert no_notice is None
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_provider_routing_comes_from_profile_config(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    _write_profile_config(
+        profile_home,
+        prompt="Profile prompt",
+        model="openrouter/profile-model",
+        toolsets=["web"],
+        provider_routing={
+            "only": ["anthropic"],
+            "ignore": ["deepinfra"],
+            "order": ["anthropic", "google"],
+            "sort": "throughput",
+            "require_parameters": True,
+            "data_collection": "deny",
+        },
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    captured = await _run_captured_agent(monkeypatch, runner, source, profile_home)
+
+    assert captured["providers_allowed"] == ["anthropic"]
+    assert captured["providers_ignored"] == ["deepinfra"]
+    assert captured["providers_order"] == ["anthropic", "google"]
+    assert captured["provider_sort"] == "throughput"
+    assert captured["provider_require_parameters"] is True
+    assert captured["provider_data_collection"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_prefill_file_resolves_relative_to_profile_home(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    profile_prefill = [{"role": "system", "content": "profile prefill"}]
+    gateway_prefill = [{"role": "system", "content": "gateway prefill"}]
+    (profile_home / "prefill.json").write_text(json.dumps(profile_prefill), encoding="utf-8")
+    _write_profile_config(
+        profile_home,
+        prompt="Profile prompt",
+        model="openrouter/profile-model",
+        toolsets=["web"],
+        prefill="prefill.json",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._prefill_messages = gateway_prefill
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    captured = await _run_captured_agent(monkeypatch, runner, source, profile_home)
+
+    assert captured["prefill_messages"] == profile_prefill
+    assert captured["prefill_messages"] != gateway_prefill
+
+
+def test_agent_cache_signature_changes_when_profile_prompt_provider_or_prefill_changes():
+    from gateway.run import GatewayRunner
+
+    runtime = {
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+        "api_key": "***",
+    }
+    base_keys = {
+        "provider_routing.digest": GatewayRunner._stable_config_digest({"order": ["anthropic"]}),
+        "prefill_messages.digest": GatewayRunner._stable_config_digest(
+            [{"role": "system", "content": "prefill-a"}]
+        ),
+    }
+    base = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys=base_keys,
+    )
+    changed_prompt = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-b",
+        cache_keys=base_keys,
+    )
+    changed_provider = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            **base_keys,
+            "provider_routing.digest": GatewayRunner._stable_config_digest({"order": ["google"]}),
+        },
+    )
+    changed_prefill = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            **base_keys,
+            "prefill_messages.digest": GatewayRunner._stable_config_digest(
+                [{"role": "system", "content": "prefill-b"}]
+            ),
+        },
+    )
+    changed_fallback = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            **base_keys,
+            "fallback.digest": GatewayRunner._stable_config_digest(
+                [{"provider": "openrouter", "model": "fallback-b"}]
+            ),
+        },
+    )
+    changed_runtime_env = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            **base_keys,
+            "runtime_env.digest": GatewayRunner._stable_config_digest(
+                {"PROFILE_FALLBACK_KEY": "fallback-b"}
+            ),
+        },
+    )
+
+    assert changed_prompt != base
+    assert changed_provider != base
+    assert changed_prefill != base
+    assert changed_fallback != base
+    assert changed_runtime_env != base
+
+
+def test_agent_cache_signature_changes_when_profile_home_or_soul_changes(tmp_path):
+    from gateway.run import GatewayRunner
+
+    profile_a = tmp_path / "profiles" / "alpha-test"
+    profile_b = tmp_path / "profiles" / "beta-test"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    (profile_a / "SOUL.md").write_text("SOUL A", encoding="utf-8")
+    (profile_b / "SOUL.md").write_text("SOUL A", encoding="utf-8")
+    runtime = {"provider": "openrouter", "base_url": "", "api_mode": "chat_completions", "api_key": "***"}
+
+    base = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            "hermes_home": str(profile_a),
+            "soul_md.digest": GatewayRunner._file_content_digest(profile_a / "SOUL.md"),
+        },
+    )
+    changed_home = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            "hermes_home": str(profile_b),
+            "soul_md.digest": GatewayRunner._file_content_digest(profile_b / "SOUL.md"),
+        },
+    )
+    (profile_a / "SOUL.md").write_text("SOUL B", encoding="utf-8")
+    changed_soul = GatewayRunner._agent_config_signature(
+        "model-a",
+        runtime,
+        ["web"],
+        "prompt-a",
+        cache_keys={
+            "hermes_home": str(profile_a),
+            "soul_md.digest": GatewayRunner._file_content_digest(profile_a / "SOUL.md"),
+        },
+    )
+
+    assert changed_home != base
+    assert changed_soul != base
+
+
+def test_agent_max_turns_config_is_cache_busting():
+    from gateway.run import GatewayRunner
+
+    base = GatewayRunner._extract_cache_busting_config({"agent": {"max_turns": 7}})
+    changed = GatewayRunner._extract_cache_busting_config({"agent": {"max_turns": 9}})
+
+    assert base["agent.max_turns"] == 7
+    assert changed["agent.max_turns"] == 9
+    assert GatewayRunner._stable_config_digest(base) != GatewayRunner._stable_config_digest(changed)
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_soul_change_busts_cached_agent(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    _write_profile_config(profile_home, prompt="Profile prompt", model="profile-model", toolsets=["web"])
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    from gateway import run as gateway_run
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(profile_home):
+        await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=f"session-{source.thread_id or 'main'}",
+            session_key=build_session_key(source),
+        )
+    (profile_home / "SOUL.md").write_text("Profile SOUL after first turn", encoding="utf-8")
+    with hermes_home_context(profile_home):
+        await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=f"session-{source.thread_id or 'main'}",
+            session_key=build_session_key(source),
+        )
+
+    assert len(_CapturingAgent.inits) == 2
+    assert _CapturingAgent.inits[-1]["soul"] == "Profile SOUL after first turn"
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_runtime_env_change_busts_cached_agent(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    _write_profile_config(profile_home, prompt="Profile prompt", model="profile-model", toolsets=["web"])
+    profile_cfg = (profile_home / "config.yaml").read_text(encoding="utf-8")
+    (profile_home / "config.yaml").write_text(
+        profile_cfg
+        + "fallback_providers:\n"
+        + "  - provider: openrouter\n"
+        + "    model: anthropic/claude-sonnet-4\n"
+        + "    key_env: PROFILE_FALLBACK_KEY\n",
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text(
+        "OPENROUTER_API_KEY=stable-primary\nPROFILE_FALLBACK_KEY=fallback-one\n",
+        encoding="utf-8",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    from gateway import run as gateway_run
+
+    def stable_primary_runtime(runtime_env=None):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "stable-primary",
+        }
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", stable_primary_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(profile_home):
+        await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=f"session-{source.thread_id or 'main'}",
+            session_key=build_session_key(source),
+        )
+    (profile_home / ".env").write_text(
+        "OPENROUTER_API_KEY=stable-primary\nPROFILE_FALLBACK_KEY=fallback-two\n",
+        encoding="utf-8",
+    )
+    with hermes_home_context(profile_home):
+        await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=f"session-{source.thread_id or 'main'}",
+            session_key=build_session_key(source),
+        )
+
+    assert len(_CapturingAgent.inits) == 2
+    assert _CapturingAgent.inits[0]["runtime_env"]["PROFILE_FALLBACK_KEY"] == "fallback-one"
+    assert _CapturingAgent.inits[1]["runtime_env"]["PROFILE_FALLBACK_KEY"] == "fallback-two"
+
+
+@pytest.mark.asyncio
+async def test_reset_command_uses_profile_session_store_for_routed_topic(tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(gateway_home / "profiles")}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        old_entry = profile_store.get_or_create_session(source)
+        gateway_store = runner.session_store
+        gateway_run._hermes_home = gateway_home
+
+        event = MessageEvent(text="/new", message_type=MessageType.TEXT, source=source)
+        await runner._handle_reset_command(event)
+
+    profile_entry = profile_store.get_or_create_session(source)
+    assert profile_entry.session_id != old_entry.session_id
+    assert runner._session_key_for_source(source) not in gateway_store._entries
+
+
+@pytest.mark.asyncio
+async def test_reset_command_displays_routed_profile_model_info(tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    gateway_home.mkdir(exist_ok=True)
+    (gateway_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openai-codex\n"
+        "  default: routed-model\n"
+        "  context_length: 272000\n",
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom:routed-proxy\n"
+        "  default: claude-opus-4-7\n"
+        "custom_providers:\n"
+        "  - name: routed-proxy\n"
+        "    base_url: http://127.0.0.1:8318/v1\n"
+        "    key_env: ROUTED_PROXY_API_KEY\n"
+        "    model: claude-opus-4-7\n"
+        "    context_length: 200000\n",
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text("ROUTED_PROXY_API_KEY=sk-test-profile\n", encoding="utf-8")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    gateway_run._hermes_home = gateway_home
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        runner._session_store_for_source(source).get_or_create_session(source)
+        event = MessageEvent(text="/new", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_reset_command(event)
+
+    text = str(response)
+    assert "claude-opus-4-7" in text
+    assert "custom:routed-proxy" in text
+    assert "127.0.0.1:8318" in text
+    assert "200K" in text
+    assert "routed-model" not in text
+    assert "openai-codex" not in text
+
+
+@pytest.mark.asyncio
+async def test_reset_command_session_info_does_not_borrow_global_credentials(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    gateway_home.mkdir(exist_ok=True)
+    (gateway_home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: routed-model\n",
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom:routed-proxy\n"
+        "  default: claude-opus-4-7\n"
+        "custom_providers:\n"
+        "  - name: routed-proxy\n"
+        "    base_url: http://127.0.0.1:8318/v1\n"
+        "    key_env: ROUTED_PROXY_API_KEY\n"
+        "    model: claude-opus-4-7\n",
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-global-must-not-leak")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    gateway_run._hermes_home = gateway_home
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        runner._session_store_for_source(source).get_or_create_session(source)
+        event = MessageEvent(text="/new", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_reset_command(event)
+
+    text = str(response)
+    assert "claude-opus-4-7" in text
+    assert "custom:routed-proxy" in text
+    assert "routed-model" not in text
+    assert "openai-codex" not in text
+
+
+@pytest.mark.asyncio
+async def test_reset_command_displays_profile_scoped_fallback_model(tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    gateway_home.mkdir(exist_ok=True)
+    (gateway_home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: routed-model\n",
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom:routed-proxy\n"
+        "  default: claude-opus-4-7\n"
+        "custom_providers:\n"
+        "  - name: routed-proxy\n"
+        "    base_url: http://127.0.0.1:8318/v1\n"
+        "    key_env: ROUTED_PROXY_API_KEY\n"
+        "    model: claude-opus-4-7\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: openrouter/fallback-model\n"
+        "    key_env: OPENROUTER_API_KEY\n",
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text("OPENROUTER_API_KEY=sk-profile-fallback\n", encoding="utf-8")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    gateway_run._hermes_home = gateway_home
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        runner._session_store_for_source(source).get_or_create_session(source)
+        event = MessageEvent(text="/new", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_reset_command(event)
+
+    text = str(response)
+    assert "openrouter/fallback-model" in text
+    assert "Provider: openrouter" in text
+    assert "routed-model" not in text
+    assert "openai-codex" not in text
+
+
+def test_reset_session_info_call_sites_preserve_source_context():
+    import inspect
+
+    from gateway.run import GatewayRunner
+
+    message_handler = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    reset_handler = inspect.getsource(GatewayRunner._handle_reset_command)
+
+    assert "_format_session_info(source)" in message_handler
+    assert "_format_session_info(source)" in reset_handler
+    assert "_format_session_info()" not in message_handler
+    assert "_format_session_info()" not in reset_handler
+
+
+@pytest.mark.asyncio
+async def test_undo_command_rewrites_profile_transcript_only_for_routed_topic(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        gateway_entry = runner.session_store.get_or_create_session(source)
+        profile_store.rewrite_transcript(
+            profile_entry.session_id,
+            [
+                {"role": "user", "content": "profile keep"},
+                {"role": "assistant", "content": "profile kept"},
+                {"role": "user", "content": "profile remove"},
+                {"role": "assistant", "content": "profile removed"},
+            ],
+        )
+        runner.session_store.rewrite_transcript(
+            gateway_entry.session_id,
+            [
+                {"role": "user", "content": "gateway keep"},
+                {"role": "assistant", "content": "gateway kept"},
+                {"role": "user", "content": "gateway remove"},
+                {"role": "assistant", "content": "gateway removed"},
+            ],
+        )
+
+        event = MessageEvent(text="/undo", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_undo_command(event)
+
+    assert "profile remove" in response
+    assert [m["content"] for m in profile_store.load_transcript(profile_entry.session_id)] == [
+        "profile keep",
+        "profile kept",
+    ]
+    assert [m["content"] for m in runner.session_store.load_transcript(gateway_entry.session_id)] == [
+        "gateway keep",
+        "gateway kept",
+        "gateway remove",
+        "gateway removed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_command_rewrites_profile_transcript_only_for_routed_topic(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        runner._handle_message = AsyncMock(return_value="retried")
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        gateway_entry = runner.session_store.get_or_create_session(source)
+        profile_store.rewrite_transcript(
+            profile_entry.session_id,
+            [
+                {"role": "user", "content": "profile keep"},
+                {"role": "assistant", "content": "profile kept"},
+                {"role": "user", "content": "profile retry"},
+                {"role": "assistant", "content": "profile answer"},
+            ],
+        )
+        runner.session_store.rewrite_transcript(
+            gateway_entry.session_id,
+            [
+                {"role": "user", "content": "gateway keep"},
+                {"role": "assistant", "content": "gateway kept"},
+                {"role": "user", "content": "gateway retry"},
+                {"role": "assistant", "content": "gateway answer"},
+            ],
+        )
+
+        event = MessageEvent(text="/retry", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_retry_command(event)
+
+    assert response == "retried"
+    retry_event = runner._handle_message.await_args.args[0]
+    assert retry_event.text == "profile retry"
+    assert [m["content"] for m in profile_store.load_transcript(profile_entry.session_id)] == [
+        "profile keep",
+        "profile kept",
+    ]
+    assert [m["content"] for m in runner.session_store.load_transcript(gateway_entry.session_id)] == [
+        "gateway keep",
+        "gateway kept",
+        "gateway retry",
+        "gateway answer",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_title_command_uses_profile_session_db_for_routed_topic(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        gateway_entry = runner.session_store.get_or_create_session(source)
+        runner._session_db = runner.session_store._db
+
+        event = MessageEvent(text="/title Profile Title", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_title_command(event)
+
+    assert "Profile Title" in response
+    assert profile_store._db.get_session_title(profile_entry.session_id) == "Profile Title"
+    assert runner.session_store._db.get_session_title(gateway_entry.session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_status_command_reads_profile_session_db_for_routed_topic(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        profile_store._db.set_session_title(profile_entry.session_id, "Profile DB Title")
+        runner._session_db = runner.session_store._db
+
+        event = MessageEvent(text="/status", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_status_command(event)
+
+    assert "Profile DB Title" in response
+
+
+@pytest.mark.asyncio
+async def test_status_command_recap_reads_profile_transcript_only(monkeypatch, tmp_path):
+    from hermes_cli import session_recap
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+    captured = {}
+
+    def fake_recap(history, **kwargs):
+        captured["history"] = list(history)
+        return "profile recap"
+
+    monkeypatch.setattr(session_recap, "build_recap", fake_recap)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        gateway_entry = runner.session_store.get_or_create_session(source)
+        profile_entry = profile_store.switch_session(profile_entry.session_key, "same-session")
+        gateway_entry = runner.session_store.switch_session(gateway_entry.session_key, "same-session")
+        assert profile_entry is not None
+        assert gateway_entry is not None
+        profile_store._db.create_session(session_id="same-session", source="telegram", user_id="42")
+        runner.session_store._db.create_session(session_id="same-session", source="telegram", user_id="42")
+        profile_store.rewrite_transcript(
+            "same-session",
+            [{"role": "user", "content": "profile transcript only"}],
+        )
+        runner.session_store.rewrite_transcript(
+            "same-session",
+            [{"role": "user", "content": "gateway transcript leak"}],
+        )
+        runner._session_db = runner.session_store._db
+
+        event = MessageEvent(text="/status", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_status_command(event)
+
+    assert "profile recap" in response
+    assert captured["history"] == [{"role": "user", "content": "profile transcript only"}]
+
+
+@pytest.mark.asyncio
+async def test_compress_command_uses_profile_runtime_home_and_session_db(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    class _ManualCompressAgent:
+        last_init = None
+        home_at_compress = None
+
+        def __init__(self, *args, **kwargs):
+            self.session_id = kwargs["session_id"]
+            self._cached_system_prompt = "profile prompt"
+            self.tools = []
+            self.context_compressor = SimpleNamespace(
+                has_content_to_compress=lambda messages: True,
+                _last_compress_aborted=False,
+                _last_summary_error=None,
+                _last_aux_model_failure_model=None,
+                _last_aux_model_failure_error=None,
+            )
+            type(self).last_init = {
+                **kwargs,
+                "hermes_home_at_init": str(get_hermes_home()),
+            }
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            type(self).home_at_compress = str(get_hermes_home())
+            self.session_id = "profile-compressed-session"
+            return ([messages[0], messages[-1]], "")
+
+        def shutdown_memory_provider(self):
+            return None
+
+        def close(self):
+            return None
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    gateway_home.mkdir(exist_ok=True)
+    (gateway_home / ".env").write_text("OPENROUTER_API_KEY=sk-test-gateway-key\n", encoding="utf-8")
+    _write_profile_config(profile_home, prompt="Profile prompt", model="profile-model")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _ManualCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    captured_runtime = {}
+
+    def _capturing_provider_runtime(runtime_env=None):
+        from hermes_cli.auth import profile_strict_auth_enabled
+        from gateway.session_context import get_session_env
+
+        captured_runtime["resolver_home"] = str(get_hermes_home())
+        captured_runtime["runtime_env"] = runtime_env
+        captured_runtime["strict_auth"] = profile_strict_auth_enabled()
+        captured_runtime["session_home"] = get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "")
+        return _provider_runtime(runtime_env=runtime_env)
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _capturing_provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        profile_store = runner._session_store_for_source(source)
+        profile_entry = profile_store.get_or_create_session(source)
+        profile_store.rewrite_transcript(
+            profile_entry.session_id,
+            [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "two"},
+                {"role": "user", "content": "three"},
+                {"role": "assistant", "content": "four"},
+            ],
+        )
+        runner._session_db = runner.session_store._db
+
+        event = MessageEvent(text="/compress", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_compress_command(event)
+
+    assert "Compressed:" in response
+    init = _ManualCompressAgent.last_init
+    assert init["hermes_home_at_init"] == str(profile_home)
+    assert _ManualCompressAgent.home_at_compress == str(profile_home)
+    assert init["runtime_env"]["OPENROUTER_API_KEY"] == "sk-test-profile-key"
+    assert init["runtime_env"]["HERMES_PROFILE_STRICT_AUTH"] == "1"
+    assert init["runtime_env"]["HERMES_HOME"] == str(profile_home)
+    assert init["session_db"] is profile_store._db
+    assert init["api_key"] == "sk-test-profile-key"
+    assert captured_runtime["resolver_home"] == str(profile_home)
+    assert captured_runtime["runtime_env"]["OPENROUTER_API_KEY"] == "sk-test-profile-key"
+    assert captured_runtime["runtime_env"]["HERMES_PROFILE_STRICT_AUTH"] == "1"
+    assert captured_runtime["runtime_env"]["HERMES_HOME"] == str(profile_home)
+    assert captured_runtime["strict_auth"] is True
+    assert captured_runtime["session_home"] == str(profile_home)
+
+
+def test_gateway_config_file_loader_validates_topic_profile_identity(tmp_path):
+    from gateway.run import _load_gateway_config_from_file
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config_path = tmp_path / "gateway-config.yaml"
+    config_path.write_text(
+        "platforms:\n"
+        "  telegram:\n"
+        "    enabled: true\n"
+        "    token: test-token\n"
+        "    extra:\n"
+        f"      topic_profiles_safe_root: {profiles_root}\n"
+        "      topic_profiles:\n"
+        "        - match:\n"
+        "            chat_id: '-1001'\n"
+        "            thread_id: '101'\n"
+        "          profile: alpha-test\n",
+        encoding="utf-8",
+    )
+
+    with hermes_home_context(gateway_home), pytest.raises(
+        TopicProfileConfigError,
+        match="Missing .hermes_profile.json",
+    ):
+        _load_gateway_config_from_file(config_path)
+
+
+@pytest.mark.asyncio
+async def test_profile_command_reports_routed_profile_home(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        event = MessageEvent(text="/profile", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_profile_command(event)
+
+    assert "alpha-test" in response
+    assert str(profile_home) in response
+
+
+def test_relative_safe_root_resolves_against_gateway_home_under_profile_override(tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": "profiles"}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        token = set_hermes_home_override(profile_home)
+        try:
+            assert runner._profile_home_for_source(source) == profile_home
+        finally:
+            reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_is_disabled_for_routed_profile_topics(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        event = MessageEvent(text="/reload-mcp", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_reload_mcp_command(event)
+
+    assert "disabled" in response
+    assert "process-global" in response
+
+
+@pytest.mark.asyncio
+async def test_proxy_mode_is_disabled_for_routed_profile_topics(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+    monkeypatch.setenv("GATEWAY_PROXY_URL", "http://example.invalid:8642")
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        result = await runner._run_agent(
+            message="hello",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-profile",
+            session_key=build_session_key(source),
+        )
+
+    assert result["api_calls"] == 0
+    assert "Proxy mode is disabled" in result["final_response"]
+
+
+@pytest.mark.asyncio
+async def test_global_config_commands_disabled_for_routed_profile_topics(tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    gateway_config_path = gateway_home / "config.yaml"
+    gateway_config = (
+        "agent:\n"
+        "  reasoning_effort: medium\n"
+        "display:\n"
+        "  tool_progress_command: true\n"
+        "  runtime_footer:\n"
+        "    enabled: false\n"
+    )
+    gateway_config_path.write_text(gateway_config, encoding="utf-8")
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(GatewayConfig())
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+        model_response = await runner._handle_model_command(
+            MessageEvent(text="/model sandbox-alpha-model", message_type=MessageType.TEXT, source=source)
+        )
+        runtime_response = await runner._handle_codex_runtime_command(
+            MessageEvent(text="/codex-runtime auto", message_type=MessageType.TEXT, source=source)
+        )
+        reasoning_response = await runner._handle_reasoning_command(
+            MessageEvent(text="/reasoning high --global", message_type=MessageType.TEXT, source=source)
+        )
+        verbose_response = await runner._handle_verbose_command(
+            MessageEvent(text="/verbose", message_type=MessageType.TEXT, source=source)
+        )
+        footer_response = await runner._handle_footer_command(
+            MessageEvent(text="/footer on", message_type=MessageType.TEXT, source=source)
+        )
+
+    assert "disabled in routed profile topics" in model_response
+    assert "disabled in routed profile topics" in runtime_response
+    assert "disabled in routed profile topics" in reasoning_response
+    assert "disabled in routed profile topics" in verbose_response
+    assert "disabled in routed profile topics" in footer_response
+    assert gateway_config_path.read_text(encoding="utf-8") == gateway_config
+
+
+@pytest.mark.asyncio
+async def test_bundles_command_uses_routed_profile_home(monkeypatch, tmp_path):
+    from agent import skill_bundles
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profile_home.parent)}
+            )
+        }
+    )
+    _write_bundle(gateway_home, "global-bundle", ["global-skill"])
+    _write_bundle(profile_home, "profile-bundle", ["profile-skill"])
+
+    monkeypatch.delenv("HERMES_BUNDLES_DIR", raising=False)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache", {}, raising=False)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None, raising=False)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache_dir", None, raising=False)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+        response = await runner._handle_bundles_command(
+            MessageEvent(text="/bundles", message_type=MessageType.TEXT, source=source)
+        )
+
+    assert "profile-bundle" in response
+    assert "global-bundle" not in response
+
+
+@pytest.mark.asyncio
+async def test_agents_command_filters_agents_and_processes_to_profile_scope(monkeypatch, tmp_path):
+    from tools import process_registry as process_registry_module
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    alpha_home = profiles_root / "alpha-test"
+    beta_home = profiles_root / "beta-test"
+    _mark_profile(alpha_home)
+    _mark_profile(beta_home)
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    def fake_list_sessions(task_id=None):
+        from gateway.session_context import get_session_env
+
+        active_profile = get_session_env("HERMES_SESSION_AGENT_PROFILE", "")
+        active_home = get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "")
+        if active_profile == "beta-test":
+            assert active_home == str(beta_home)
+            return [
+                {
+                    "session_id": "proc-beta",
+                    "command": "beta command",
+                    "uptime_seconds": 1,
+                    "status": "running",
+                }
+            ]
+        return [
+            {
+                "session_id": "proc-alpha",
+                "command": "alpha command",
+                "uptime_seconds": 1,
+                "status": "running",
+            }
+        ]
+
+    monkeypatch.setattr(process_registry_module.process_registry, "list_sessions", fake_list_sessions)
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        alpha_source = _source(agent_profile="alpha-test", agent_hermes_home=str(alpha_home))
+        beta_source = _source(agent_profile="beta-test")
+        alpha_key = build_session_key(alpha_source)
+        beta_key = build_session_key(beta_source)
+        main_key = build_session_key(_source(agent_profile=None, agent_hermes_home=None))
+        runner._running_agents = {
+            alpha_key: SimpleNamespace(session_id="sess-alpha", model="alpha-model"),
+            beta_key: SimpleNamespace(session_id="sess-beta", model="beta-model"),
+            main_key: SimpleNamespace(session_id="sess-main", model="main-model"),
+        }
+        runner._running_agents_ts = {alpha_key: 1.0, beta_key: 1.0, main_key: 1.0}
+
+        class _FakeTask:
+            def __init__(self, *, profile="", home=""):
+                self._hermes_agent_profile = profile
+                self._hermes_agent_hermes_home = home
+
+            def done(self):
+                return False
+
+        runner._background_tasks = {
+            _FakeTask(profile="alpha-test", home=str(alpha_home)),
+            _FakeTask(profile="beta-test", home=str(beta_home)),
+            _FakeTask(),
+        }
+
+        event = MessageEvent(text="/agents", message_type=MessageType.TEXT, source=beta_source)
+        response = await runner._handle_agents_command(event)
+
+    assert "sess-beta" in response
+    assert "proc-beta" in response
+    assert "**Gateway async jobs:** 1" in response
+    assert "sess-alpha" not in response
+    assert "proc-alpha" not in response
+    assert "sess-main" not in response
+
+
+@pytest.mark.asyncio
+async def test_personality_command_is_disabled_for_routed_profile_topics(tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = gateway_home / "profiles" / "alpha-test"
+    profile_home.mkdir(parents=True)
+    gateway_home.mkdir(exist_ok=True)
+    gateway_config = gateway_home / "config.yaml"
+    gateway_config.write_text('agent:\n  system_prompt: "Gateway prompt"\n', encoding="utf-8")
+    (profile_home / "config.yaml").write_text(
+        "agent:\n"
+        "  personalities:\n"
+        "    analyst: Routed analyst prompt\n",
+        encoding="utf-8",
+    )
+    config = GatewayConfig()
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        gateway_run._hermes_home = gateway_home
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+    event = MessageEvent(text="/personality analyst", message_type=MessageType.TEXT, source=source)
+
+    with hermes_home_context(profile_home):
+        response = await runner._handle_personality_command(event)
+
+    assert "disabled" in response.lower()
+    assert "Gateway prompt" in gateway_config.read_text(encoding="utf-8")
+    assert "Routed analyst prompt" not in gateway_config.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_personality_command_still_works_for_non_routed_gateway_sessions(tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    gateway_home.mkdir()
+    gateway_config = gateway_home / "config.yaml"
+    gateway_config.write_text(
+        "agent:\n"
+        "  personalities:\n"
+        "    analyst: Gateway analyst prompt\n",
+        encoding="utf-8",
+    )
+    config = GatewayConfig()
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+        gateway_run._hermes_home = gateway_home
+        source = _source(agent_profile=None, agent_hermes_home=None)
+        event = MessageEvent(text="/personality analyst", message_type=MessageType.TEXT, source=source)
+        response = await runner._handle_personality_command(event)
+
+    assert "set to" in response.lower()
+    assert "Gateway analyst prompt" in gateway_config.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_routed_profile_memory_store_uses_profile_memories_dir(monkeypatch, tmp_path):
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_home = profiles_root / "alpha-test"
+    profile_home.mkdir(parents=True)
+    _write_profile_config(profile_home, prompt="Profile prompt", model="profile-model", toolsets=["web"])
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+    source = _source(agent_profile="alpha-test", agent_hermes_home=str(profile_home))
+
+    captured = await _run_captured_agent(monkeypatch, runner, source, profile_home)
+
+    assert captured["memory_dir"] == str(profile_home / "memories")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_routed_profiles_do_not_cross_contaminate_prompt_env_or_toolsets(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    gateway_home = tmp_path / "gateway"
+    profiles_root = gateway_home / "profiles"
+    profile_a = profiles_root / "alpha-test"
+    profile_b = profiles_root / "beta-test"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    _write_profile_config(profile_a, prompt="Prompt A", model="model-a", toolsets=["web"])
+    _write_profile_config(profile_b, prompt="Prompt B", model="model-b", toolsets=["todo"])
+    (profile_a / ".env").write_text("OPENROUTER_API_KEY=sk-test-profile-a\n", encoding="utf-8")
+    (profile_b / ".env").write_text("OPENROUTER_API_KEY=sk-test-profile-b\n", encoding="utf-8")
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"topic_profiles_safe_root": str(profiles_root)}
+            )
+        }
+    )
+
+    _install_fake_agent(monkeypatch)
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _provider_runtime)
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    with hermes_home_context(gateway_home):
+        runner = _make_runner(config)
+
+    source_a = _source(
+        thread_id="101",
+        agent_profile="alpha-test",
+        agent_hermes_home=str(profile_a),
+    )
+    source_b = _source(
+        thread_id="202",
+        agent_profile="beta-test",
+        agent_hermes_home=str(profile_b),
+    )
+
+    async def run_one(source, home):
+        with hermes_home_context(home):
+            return await runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id=f"session-{source.agent_profile}",
+                session_key=build_session_key(source),
+            )
+
+    result_a, result_b = await asyncio.gather(
+        run_one(source_a, profile_a),
+        run_one(source_b, profile_b),
+    )
+
+    assert result_a["final_response"] == "ok"
+    assert result_b["final_response"] == "ok"
+    by_key = {item["gateway_session_key"]: item for item in _CapturingAgent.inits}
+    captured_a = by_key["agent:alpha-test:telegram:group:-1001:101"]
+    captured_b = by_key["agent:beta-test:telegram:group:-1001:202"]
+    assert captured_a["model"] == "model-a"
+    assert captured_b["model"] == "model-b"
+    assert captured_a["ephemeral_system_prompt"] == "Prompt A"
+    assert captured_b["ephemeral_system_prompt"] == "Prompt B"
+    assert captured_a["api_key"] == "sk-test-profile-a"
+    assert captured_b["api_key"] == "sk-test-profile-b"
+    assert "web" in set(captured_a["enabled_toolsets"])
+    assert "todo" in set(captured_b["enabled_toolsets"])
+
+
+@pytest.mark.asyncio
+async def test_two_routed_topics_concurrent_background_processes_route_correctly(tmp_path):
+    from gateway.run import GatewayRunner
+    from tools.process_registry import ProcessSession, process_registry
+
+    gateway_home = tmp_path / "gateway"
+    profile_a = tmp_path / "profiles" / "alpha-test"
+    profile_b = tmp_path / "profiles" / "beta-test"
+    for home in (gateway_home, profile_a, profile_b):
+        home.mkdir(parents=True)
+
+    delivered = []
+
+    class _Adapter:
+        async def handle_message(self, event):
+            delivered.append(event)
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.session_store = SessionStore(gateway_home / "sessions", runner.config)
+        runner.adapters = {Platform.TELEGRAM: _Adapter()}
+        runner._load_background_notifications_mode = lambda: "result"
+
+    process_registry._running.clear()
+    process_registry._finished.clear()
+    process_registry._completion_consumed.clear()
+
+    session_a = ProcessSession(
+        id="proc_alpha",
+        command="printf alpha",
+        task_id="default",
+        session_key="agent:alpha-test:telegram:group:-1001:101",
+        agent_profile="alpha-test",
+        agent_hermes_home=str(profile_a),
+        pid=111,
+        started_at=1.0,
+        exited=True,
+        exit_code=0,
+        output_buffer="alpha done",
+        notify_on_complete=True,
+    )
+    session_b = ProcessSession(
+        id="proc_beta",
+        command="printf beta",
+        task_id="default",
+        session_key="agent:beta-test:telegram:group:-1001:202",
+        agent_profile="beta-test",
+        agent_hermes_home=str(profile_b),
+        pid=222,
+        started_at=1.0,
+        exited=True,
+        exit_code=0,
+        output_buffer="beta done",
+        notify_on_complete=True,
+    )
+    process_registry._running[session_a.id] = session_a
+    process_registry._running[session_b.id] = session_b
+
+    watcher_a = {
+        "session_id": session_a.id,
+        "check_interval": 0,
+        "session_key": session_a.session_key,
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "thread_id": "101",
+        "user_id": "42",
+        "user_name": "alice",
+        "agent_profile": "alpha-test",
+        "agent_hermes_home": str(profile_a),
+        "notify_on_complete": True,
+    }
+    watcher_b = {
+        "session_id": session_b.id,
+        "check_interval": 0,
+        "session_key": session_b.session_key,
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "thread_id": "202",
+        "user_id": "43",
+        "user_name": "bob",
+        "agent_profile": "beta-test",
+        "agent_hermes_home": str(profile_b),
+        "notify_on_complete": True,
+    }
+
+    await asyncio.gather(
+        runner._run_process_watcher(watcher_a),
+        runner._run_process_watcher(watcher_b),
+    )
+
+    by_profile = {event.source.agent_profile: event for event in delivered}
+    assert set(by_profile) == {"alpha-test", "beta-test"}
+    assert by_profile["alpha-test"].source.thread_id == "101"
+    assert by_profile["alpha-test"].source.agent_hermes_home == str(profile_a)
+    assert "alpha done" in by_profile["alpha-test"].text
+    assert by_profile["beta-test"].source.thread_id == "202"
+    assert by_profile["beta-test"].source.agent_hermes_home == str(profile_b)
+    assert "beta done" in by_profile["beta-test"].text
+
+
+@pytest.mark.asyncio
+async def test_routed_process_text_notifications_use_profile_thread_metadata(tmp_path):
+    from gateway.run import GatewayRunner
+    from tools.process_registry import ProcessSession, process_registry
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "alpha-test"
+    for home in (gateway_home, profile_home):
+        home.mkdir(parents=True)
+
+    sent = []
+
+    class _Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            sent.append((chat_id, content, metadata))
+
+    with hermes_home_context(gateway_home):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.session_store = SessionStore(gateway_home / "sessions", runner.config)
+        runner.adapters = {Platform.TELEGRAM: _Adapter()}
+        runner._load_background_notifications_mode = lambda: "result"
+
+    process_registry._running.clear()
+    process_registry._finished.clear()
+    process_registry._completion_consumed.clear()
+
+    session = ProcessSession(
+        id="proc_alpha",
+        command="printf alpha",
+        task_id="default",
+        session_key="agent:alpha-test:telegram:group:-1001:101",
+        agent_profile="alpha-test",
+        agent_hermes_home=str(profile_home),
+        pid=111,
+        started_at=1.0,
+        exited=True,
+        exit_code=0,
+        output_buffer="alpha done",
+        notify_on_complete=False,
+    )
+    process_registry._running[session.id] = session
+
+    watcher = {
+        "session_id": session.id,
+        "check_interval": 0,
+        "session_key": session.session_key,
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "thread_id": "101",
+        "user_id": "42",
+        "user_name": "alice",
+        "agent_profile": "alpha-test",
+        "agent_hermes_home": str(profile_home),
+        "notify_on_complete": False,
+    }
+
+    await runner._run_process_watcher(watcher)
+
+    assert len(sent) == 1
+    assert sent[0][0] == "-1001"
+    assert sent[0][2]["thread_id"] == "101"
+    assert sent[0][2]["disable_thread_fallback"] is True

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -358,3 +358,50 @@ def test_write_credential_pool_targets_profile_not_global(profile_env):
 
     # Subsequent read returns profile (shadows global).
     assert [e["id"] for e in read_credential_pool("openrouter")] == ["prof-new"]
+
+
+def test_strict_profile_auth_disables_global_pool_fallback(profile_env, monkeypatch):
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "glob-1",
+            "auth_type": "api_key",
+            "access_token": "sk-global",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+    monkeypatch.setenv("HERMES_PROFILE_STRICT_AUTH", "1")
+
+    assert read_credential_pool("openrouter") == []
+    assert read_credential_pool(None) == {}
+
+
+def test_strict_profile_auth_disables_global_provider_state_fallback(profile_env, monkeypatch):
+    from hermes_cli.auth import get_provider_auth_state
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "nous": {"access_token": "global-token", "refresh_token": "global-refresh"},
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+    monkeypatch.setenv("HERMES_PROFILE_STRICT_AUTH", "1")
+
+    assert get_provider_auth_state("nous") is None
+
+
+def test_strict_profile_auth_disables_external_process_credentials(profile_env):
+    from hermes_cli.auth import (
+        AuthError,
+        resolve_external_process_provider_credentials,
+    )
+
+    with pytest.raises(AuthError) as exc_info:
+        resolve_external_process_provider_credentials(
+            "copilot-acp",
+            env={
+                "HERMES_PROFILE_STRICT_AUTH": "1",
+                "HERMES_COPILOT_ACP_COMMAND": "/bin/echo",
+            },
+        )
+
+    assert exc_info.value.code == "profile_strict_external_process_disabled"

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -34,6 +34,10 @@ from hermes_cli.profiles import (
     seed_profile_skills,
     has_bundled_skills_opt_out,
     NO_BUNDLED_SKILLS_MARKER,
+    PROFILE_IDENTITY_FILENAME,
+    audit_profile_isolation,
+    validate_profile_identity,
+    write_profile_identity_marker,
 )
 
 
@@ -1181,3 +1185,247 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+
+class TestProfileIsolationAudit:
+    def test_create_profile_writes_identity_marker(self, profile_env):
+        tmp_path = profile_env
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        marker = profile_dir / PROFILE_IDENTITY_FILENAME
+
+        assert marker.is_file()
+        validate_profile_identity(
+            "alpha-test",
+            profile_dir,
+            tmp_path / ".hermes" / "profiles",
+        )
+
+    def test_audit_fails_for_secret_env_identical_to_main(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        env_text = "OPENROUTER_API_KEY=sk-test\n"
+        (main_home / ".env").write_text(env_text, encoding="utf-8")
+        (profile_dir / ".env").write_text(env_text, encoding="utf-8")
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(f["path"] == ".env" and f["status"] == "FAIL" for f in report["findings"])
+
+    def test_audit_fails_for_shared_env_secret_value_even_when_not_identical(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / ".env").write_text(
+            "OPENROUTER_API_KEY=shared-secret\nOTHER=main\n",
+            encoding="utf-8",
+        )
+        (profile_dir / ".env").write_text(
+            "# reordered copy\nOTHER=profile\nOPENROUTER_API_KEY=shared-secret\n",
+            encoding="utf-8",
+        )
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == ".env"
+            and f["status"] == "FAIL"
+            and f.get("shared_secret_count") == 1
+            for f in report["findings"]
+        )
+
+    def test_audit_fails_for_shared_alphabetic_env_secret_value(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / ".env").write_text(
+            "OPENROUTER_API_KEY=supersecretvalue\n",
+            encoding="utf-8",
+        )
+        (profile_dir / ".env").write_text(
+            "OPENROUTER_API_KEY=supersecretvalue\nOTHER=profile\n",
+            encoding="utf-8",
+        )
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == ".env"
+            and f["status"] == "FAIL"
+            and f.get("shared_secret_count") == 1
+            for f in report["findings"]
+        )
+
+    def test_audit_fails_for_shared_auth_secret_value_even_when_json_differs(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / "auth.json").write_text(
+            json.dumps({"providers": {"nous": {"access_token": "shared-token"}}}),
+            encoding="utf-8",
+        )
+        (profile_dir / "auth.json").write_text(
+            json.dumps(
+                {
+                    "providers": {
+                        "nous": {
+                            "label": "profile",
+                            "refresh_token": "different-refresh",
+                            "access_token": "shared-token",
+                        }
+                    }
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == "auth.json"
+            and f["status"] == "FAIL"
+            and f.get("shared_secret_count") == 1
+            for f in report["findings"]
+        )
+
+    def test_audit_fails_for_shared_alphabetic_auth_secret_value(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / "auth.json").write_text(
+            json.dumps({"providers": {"nous": {"access_token": "supersecretvalue"}}}),
+            encoding="utf-8",
+        )
+        (profile_dir / "auth.json").write_text(
+            json.dumps({"providers": {"nous": {"access_token": "supersecretvalue"}}}),
+            encoding="utf-8",
+        )
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == "auth.json"
+            and f["status"] == "FAIL"
+            and f.get("shared_secret_count") == 1
+            for f in report["findings"]
+        )
+
+    def test_audit_fails_for_shared_config_secret_value_even_when_yaml_differs(
+        self, profile_env
+    ):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / "config.yaml").write_text(
+            "model:\n"
+            "  provider: custom\n"
+            "  api_key: shared-inline-secret\n"
+            "  default: main-model\n",
+            encoding="utf-8",
+        )
+        (profile_dir / "config.yaml").write_text(
+            "model:\n"
+            "  default: profile-model\n"
+            "  api_key: shared-inline-secret\n"
+            "  provider: custom\n",
+            encoding="utf-8",
+        )
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == "config.yaml"
+            and f["status"] == "FAIL"
+            and f.get("shared_secret_count") == 1
+            for f in report["findings"]
+        )
+
+    def test_audit_fails_for_shared_alphabetic_config_secret_value(
+        self, profile_env
+    ):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / "config.yaml").write_text(
+            "providers:\n  custom:\n    api_key: supersecretvalue\n",
+            encoding="utf-8",
+        )
+        (profile_dir / "config.yaml").write_text(
+            "providers:\n  custom:\n    api_key: supersecretvalue\n",
+            encoding="utf-8",
+        )
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == "config.yaml"
+            and f["status"] == "FAIL"
+            and f.get("shared_secret_count") == 1
+            for f in report["findings"]
+        )
+
+    def test_audit_safe_root_uses_profile_under_safe_root_and_main_home_from_env(
+        self, profile_env
+    ):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        external_root = tmp_path / "external-profiles"
+        profile_dir = external_root / "alpha-test"
+        profile_dir.mkdir(parents=True)
+        write_profile_identity_marker(
+            "alpha-test",
+            profile_dir,
+            external_root,
+            overwrite=True,
+        )
+        (main_home / ".env").write_text("OPENROUTER_API_KEY=main-secret\n", encoding="utf-8")
+        (profile_dir / ".env").write_text("OPENROUTER_API_KEY=main-secret\n", encoding="utf-8")
+
+        report = audit_profile_isolation("alpha-test", safe_root=external_root)
+
+        assert report["status"] == "FAIL"
+        assert any(f["path"] == ".env" and f["status"] == "FAIL" for f in report["findings"])
+
+    def test_audit_fails_for_nonempty_memory_identical_to_main(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        (main_home / "memories").mkdir(exist_ok=True)
+        (profile_dir / "memories").mkdir(exist_ok=True)
+        text = "shared memory should not be cloned into routed profile\n"
+        (main_home / "memories" / "MEMORY.md").write_text(text, encoding="utf-8")
+        (profile_dir / "memories" / "MEMORY.md").write_text(text, encoding="utf-8")
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == "memories/MEMORY.md" and f["status"] == "FAIL"
+            for f in report["findings"]
+        )
+
+    def test_audit_fails_for_outgoing_plugin_symlink(self, profile_env):
+        tmp_path = profile_env
+        main_home = tmp_path / ".hermes"
+        profile_dir = create_profile("alpha-test", no_alias=True)
+        shared_plugin = main_home / "plugins" / "shared-plugin"
+        shared_plugin.mkdir(parents=True)
+        profile_plugins = profile_dir / "plugins"
+        profile_plugins.mkdir(exist_ok=True)
+        (profile_plugins / "shared-plugin").symlink_to(shared_plugin, target_is_directory=True)
+
+        report = audit_profile_isolation("alpha-test")
+
+        assert report["status"] == "FAIL"
+        assert any(
+            f["path"] == "plugins/shared-plugin" and f["status"] == "FAIL"
+            for f in report["findings"]
+        )

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,6 +1,10 @@
+import os
+import json
+
 import pytest
 
 from hermes_cli import runtime_provider as rp
+from hermes_constants import hermes_home_context
 
 
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
@@ -25,6 +29,165 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["api_key"] == "pool-token"
     assert resolved["credential_pool"] is not None
     assert resolved["source"] == "manual"
+
+
+def test_scoped_openrouter_runtime_ignores_global_env_and_pool(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openrouter", "default": "openrouter/model"},
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+    monkeypatch.setenv("OPENAI_API_KEY", "global-openai")
+
+    def _unexpected_global_pool(provider):
+        raise AssertionError(f"global pool should not be loaded for {provider}")
+
+    monkeypatch.setattr(rp, "load_pool", _unexpected_global_pool)
+
+    with hermes_home_context(tmp_path):
+        resolved = rp.resolve_runtime_provider(requested="openrouter", env={})
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == ""
+
+
+def test_scoped_openrouter_runtime_uses_profile_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openrouter", "default": "openrouter/model"},
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+
+    with hermes_home_context(tmp_path):
+        resolved = rp.resolve_runtime_provider(
+            requested="openrouter",
+            env={"OPENROUTER_API_KEY": "profile-openrouter"},
+        )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "profile-openrouter"
+
+
+def test_scoped_api_key_provider_ignores_global_credential_pool(monkeypatch, tmp_path):
+    class _Entry:
+        access_token = "global-zai-pool-token"
+        runtime_api_key = ""
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def peek(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "zai")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "zai", "default": "zai/model"},
+    )
+    monkeypatch.setattr(rp, "_load_pool_for_env", lambda provider, env: None)
+
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(credential_pool, "load_pool", lambda provider: _Pool())
+
+    with hermes_home_context(tmp_path):
+        resolved = rp.resolve_runtime_provider(requested="zai", env={})
+
+    assert resolved["provider"] == "zai"
+    assert resolved["api_key"] == ""
+
+
+def test_scoped_api_key_provider_uses_profile_auth_pool(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "zai-profile"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "zai")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "zai", "default": "zai/model"},
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: pytest.fail("global pool should not be loaded"),
+    )
+    (profile_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "credential_pool": {
+                    "zai": [
+                        {
+                            "id": "profile-zai",
+                            "source": "manual",
+                            "access_token": "profile-zai-pool-token",
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with hermes_home_context(profile_home):
+        resolved = rp.resolve_runtime_provider(requested="zai", env={})
+
+    assert resolved["provider"] == "zai"
+    assert resolved["api_key"] == "profile-zai-pool-token"
+    assert resolved["credential_pool"] is not None
+
+
+def test_scoped_oauth_provider_fails_closed_without_profile_auth(monkeypatch, tmp_path):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openai-codex", "default": "codex/model"},
+    )
+    monkeypatch.setattr(rp, "_load_pool_for_env", lambda provider, env: None)
+    monkeypatch.setattr(
+        rp,
+        "resolve_codex_runtime_credentials",
+        lambda: pytest.fail("global Codex auth resolver should not be called"),
+    )
+
+    with hermes_home_context(tmp_path), pytest.raises(rp.AuthError):
+        rp.resolve_runtime_provider(requested="openai-codex", env={})
+
+
+def test_scoped_bedrock_fails_closed_without_profile_aws_credentials(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bedrock")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "bedrock", "default": "amazon.nova-lite-v1:0"},
+    )
+
+    with pytest.raises(rp.AuthError):
+        rp.resolve_runtime_provider(requested="bedrock", env={})
+
+
+def test_strict_profile_runtime_rejects_external_process_provider(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot-acp")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "copilot-acp", "default": "copilot/model"},
+    )
+
+    with pytest.raises(rp.AuthError) as exc_info:
+        rp.resolve_runtime_provider(
+            requested="copilot-acp",
+            env={
+                "HERMES_PROFILE_STRICT_AUTH": "1",
+                "HERMES_COPILOT_ACP_COMMAND": "/bin/echo",
+            },
+        )
+
+    assert exc_info.value.code == "profile_strict_external_process_disabled"
 
 
 def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkeypatch):
@@ -400,6 +563,44 @@ def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
     assert resolved["api_key"] == "test-key"
     assert resolved["base_url"] == "https://example.com/v1"
     assert resolved["source"] == "explicit"
+
+
+def test_resolve_runtime_provider_env_mapping_overrides_process_env(monkeypatch):
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "main-gateway-key")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openrouter"})
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openrouter",
+        env={"OPENROUTER_API_KEY": "profile-key"},
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "profile-key"
+    assert os.environ["OPENROUTER_API_KEY"] == "main-gateway-key"
+
+
+def test_resolve_runtime_provider_env_mapping_does_not_inherit_main_env(monkeypatch):
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "main-gateway-key")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openrouter"})
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openrouter",
+        env={},
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == ""
+    assert os.environ["OPENROUTER_API_KEY"] == "main-gateway-key"
 
 
 def test_resolve_runtime_provider_auto_uses_openrouter_pool(monkeypatch):
@@ -835,6 +1036,72 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["requested_provider"] == "mycorp-proxy"
     assert resolved["source"] == "custom_provider:MyCorp Proxy"
     assert resolved["model"] == "acme-large"
+
+
+def test_named_custom_provider_uses_scoped_key_env_from_providers_dict(monkeypatch):
+    monkeypatch.setenv("MYCORP_API_KEY", "global-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="mycorp-proxy",
+        env={"MYCORP_API_KEY": "profile-secret"},
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "profile-secret"
+    assert resolved["requested_provider"] == "mycorp-proxy"
+
+
+def test_named_custom_provider_with_scoped_env_fails_closed_when_key_env_missing(monkeypatch):
+    monkeypatch.setenv("MYCORP_API_KEY", "global-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "global-openai")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "global-openrouter")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            rp.AuthError("unknown provider", provider="mycorp-proxy")
+        ),
+    )
+
+    with pytest.raises(rp.AuthError):
+        rp.resolve_runtime_provider(requested="mycorp-proxy", env={})
 
 
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):

--- a/tests/run_agent/test_async_httpx_del_neuter.py
+++ b/tests/run_agent/test_async_httpx_del_neuter.py
@@ -178,11 +178,12 @@ class TestClientCacheBoundedGrowth:
         """When the loop changes, the old entry should be replaced, not duplicated."""
         from agent.auxiliary_client import (
             _client_cache,
+            _client_cache_key,
             _client_cache_lock,
             _get_cached_client,
         )
 
-        key = ("test_replace", True, "", "", "", (), False, "")
+        key = _client_cache_key("test_replace", async_mode=True)
 
         # Simulate a stale entry from a closed loop
         old_loop = asyncio.new_event_loop()
@@ -214,10 +215,11 @@ class TestClientCacheBoundedGrowth:
         """Multiple event loops for the same provider should NOT create multiple entries."""
         from agent.auxiliary_client import (
             _client_cache,
+            _client_cache_key,
             _client_cache_lock,
         )
 
-        key = ("test_no_grow", True, "", "", "", (), False)
+        key = _client_cache_key("test_no_grow", async_mode=True)
 
         loops = []
         try:

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -168,6 +168,7 @@ def test_feasibility_check_passes_live_main_runtime():
             "api_key": "codex-token",
             "api_mode": "codex_responses",
         },
+        env=None,
     )
 
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -5,8 +5,12 @@ the new list-based ``fallback_providers`` config format and chain
 advancement through multiple providers.
 """
 
+import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from hermes_constants import hermes_home_context
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -181,6 +185,302 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
+
+    def test_init_time_fallback_uses_profile_runtime_env_key_env(self):
+        """Routed profiles must not read fallback keys from process env."""
+        fallback = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "key_env": "PROFILE_FALLBACK_KEY",
+        }
+        fallback_keys = []
+
+        def fake_resolve(provider, **kwargs):
+            if provider == "zai":
+                return None, None
+            fallback_keys.append(kwargs.get("explicit_api_key"))
+            return _mock_client(api_key=kwargs.get("explicit_api_key")), fallback["model"]
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+        ):
+            agent = AIAgent(
+                provider="zai",
+                model="primary-model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=fallback,
+                runtime_env={"PROFILE_FALLBACK_KEY": "profile-secret"},
+            )
+
+        assert "profile-secret" in fallback_keys
+        assert "global-secret" not in fallback_keys
+        assert agent.provider == "openrouter"
+        assert agent.api_key == "profile-secret"
+
+    def test_init_time_fallback_fails_closed_without_profile_key(self):
+        fallback = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "key_env": "PROFILE_FALLBACK_KEY",
+        }
+        attempted_fallback = False
+
+        def fake_resolve(provider, **kwargs):
+            nonlocal attempted_fallback
+            if provider == "zai":
+                return None, None
+            attempted_fallback = True
+            assert kwargs.get("env") == {}
+            assert kwargs.get("explicit_api_key") in {None, ""}
+            return None, None
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+            pytest.raises(RuntimeError, match="Provider 'zai'.*no API key"),
+        ):
+            AIAgent(
+                provider="zai",
+                model="primary-model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=fallback,
+                runtime_env={},
+            )
+
+        assert attempted_fallback is True
+
+    def test_runtime_fallback_uses_profile_runtime_env_key_env(self):
+        """Runtime fallback must use the routed profile env, not process env."""
+        fbs = [
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "key_env": "PROFILE_FALLBACK_KEY",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {"PROFILE_FALLBACK_KEY": "profile-secret"}
+
+        with (
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(api_key="profile-secret"), fbs[0]["model"]),
+            ) as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert mock_rpc.call_args.kwargs["explicit_api_key"] == "profile-secret"
+        assert agent.api_key == "profile-secret"
+
+    def test_runtime_fallback_fails_closed_without_profile_key(self):
+        """A routed profile must not activate fallback using global env keys."""
+        fbs = [
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "key_env": "PROFILE_FALLBACK_KEY",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {}
+
+        with (
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)) as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is False
+
+        assert mock_rpc.call_args.kwargs["env"] == {}
+        assert mock_rpc.call_args.kwargs["explicit_api_key"] in {None, ""}
+
+    def test_runtime_fallback_skips_missing_profile_key_and_tries_next_entry(self):
+        fbs = [
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "key_env": "PROFILE_FALLBACK_KEY",
+            },
+            {
+                "provider": "custom",
+                "model": "fallback-model",
+                "base_url": "https://fallback.example/v1",
+                "api_key": "explicit-second-key",
+            },
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {}
+
+        def fake_resolve(provider, **kwargs):
+            if provider == "openrouter":
+                assert kwargs.get("env") == {}
+                assert kwargs.get("explicit_api_key") in {None, ""}
+                return None, None
+            assert provider == "custom"
+            return (
+                _mock_client(
+                    base_url="https://fallback.example/v1",
+                    api_key="explicit-second-key",
+                ),
+                "fallback-model",
+            )
+
+        with (
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=fake_resolve,
+            ) as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert mock_rpc.call_count == 2
+        assert mock_rpc.call_args.args[:2] == ("custom",)
+        assert mock_rpc.call_args.kwargs["explicit_api_key"] == "explicit-second-key"
+        assert "global-secret" not in {
+            call.kwargs.get("explicit_api_key") for call in mock_rpc.call_args_list
+        }
+
+    def test_runtime_bare_openrouter_fallback_ignores_global_env_when_profile_env_empty(self):
+        fbs = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {}
+
+        with (
+            patch.dict(os.environ, {"OPENROUTER_API_KEY": "global-openrouter"}, clear=False),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch("agent.auxiliary_client._mark_provider_unhealthy"),
+            patch("agent.credential_pool.load_pool", return_value=None),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            assert agent._try_activate_fallback() is False
+
+        mock_openai.assert_not_called()
+
+    def test_runtime_auto_fallback_ignores_global_env_when_profile_env_empty(self):
+        fbs = [{"provider": "auto", "model": "anthropic/claude-sonnet-4"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {}
+
+        with (
+            patch.dict(os.environ, {"OPENROUTER_API_KEY": "global-openrouter"}, clear=False),
+            patch("agent.auxiliary_client._read_main_provider", return_value=""),
+            patch("agent.auxiliary_client._read_main_model", return_value=""),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch("agent.auxiliary_client._mark_provider_unhealthy"),
+            patch("agent.auxiliary_client._try_nous", return_value=(None, None)),
+            patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)),
+            patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            assert agent._try_activate_fallback() is False
+
+        mock_openai.assert_not_called()
+
+    def test_runtime_auto_fallback_uses_profile_env_openrouter_key(self):
+        fbs = [{"provider": "auto", "model": "anthropic/claude-sonnet-4"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {"OPENROUTER_API_KEY": "profile-openrouter"}
+
+        with (
+            patch.dict(os.environ, {"OPENROUTER_API_KEY": "global-openrouter"}, clear=False),
+            patch("agent.auxiliary_client._read_main_provider", return_value=""),
+            patch("agent.auxiliary_client._read_main_model", return_value=""),
+            patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch("agent.auxiliary_client._try_nous", return_value=(None, None)),
+            patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)),
+            patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value.base_url = "https://openrouter.ai/api/v1"
+            mock_openai.return_value.api_key = "profile-openrouter"
+            assert agent._try_activate_fallback() is True
+
+        assert mock_openai.call_args.kwargs["api_key"] == "profile-openrouter"
+        assert agent.api_key == "profile-openrouter"
+
+    def test_runtime_named_custom_fallback_uses_profile_key_env(self, tmp_path):
+        home = tmp_path / "profile"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "providers:\n"
+            "  profile-local:\n"
+            "    base_url: http://127.0.0.1:1234/v1\n"
+            "    key_env: PROFILE_FALLBACK_KEY\n"
+            "    default_model: fallback-model\n",
+            encoding="utf-8",
+        )
+        fbs = [{"provider": "profile-local", "model": "fallback-model"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {"PROFILE_FALLBACK_KEY": "profile-secret"}
+
+        with (
+            hermes_home_context(home),
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value.base_url = "http://127.0.0.1:1234/v1"
+            mock_openai.return_value.api_key = "profile-secret"
+            assert agent._try_activate_fallback() is True
+
+        assert mock_openai.call_args.kwargs["api_key"] == "profile-secret"
+        assert agent.api_key == "profile-secret"
+
+    def test_runtime_named_custom_fallback_ignores_global_key_env_when_profile_env_empty(self, tmp_path):
+        home = tmp_path / "profile"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "providers:\n"
+            "  profile-local:\n"
+            "    base_url: http://127.0.0.1:1234/v1\n"
+            "    key_env: PROFILE_FALLBACK_KEY\n"
+            "    default_model: fallback-model\n",
+            encoding="utf-8",
+        )
+        fbs = [{"provider": "profile-local", "model": "fallback-model"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {}
+
+        with (
+            hermes_home_context(home),
+            patch.dict(os.environ, {"PROFILE_FALLBACK_KEY": "global-secret"}, clear=False),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            assert agent._try_activate_fallback() is False
+
+        mock_openai.assert_not_called()
+        assert agent.api_key == "test-key"
+
+    def test_runtime_custom_ollama_fallback_requires_profile_ollama_key(self):
+        fbs = [
+            {
+                "provider": "custom",
+                "model": "nemotron-3-nano:30b",
+                "base_url": "https://ollama.com/v1",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._runtime_env = {}
+
+        with (
+            patch.dict(os.environ, {"OPENAI_API_KEY": "global-openai"}, clear=False),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            assert agent._try_activate_fallback() is False
+
+        mock_openai.assert_not_called()
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -7,9 +7,11 @@ and Path.home() remain unchanged.
 See: https://github.com/NousResearch/hermes-agent/issues/4426
 """
 
+import json
 import os
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -113,6 +115,21 @@ class TestGetSubprocessHome:
         assert seen == [str(root)]
         assert get_hermes_home() == root
 
+    def test_honors_context_override_when_process_env_points_at_gateway_home(self, tmp_path, monkeypatch):
+        """Topic-routed subprocess HOME must follow the active profile context."""
+        gateway_home = tmp_path / "gateway"
+        profile_dir = tmp_path / "profiles" / "alpha-test"
+        gateway_home.mkdir()
+        profile_dir.mkdir(parents=True)
+        (gateway_home / "home").mkdir()
+        (profile_dir / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        from hermes_constants import get_subprocess_home, hermes_home_context
+
+        with hermes_home_context(profile_dir):
+            assert get_subprocess_home() == str(profile_dir / "home")
+
 
 # ---------------------------------------------------------------------------
 # _make_run_env() injection
@@ -179,6 +196,26 @@ class TestMakeRunEnvHomeInjection:
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
 
+    def test_injects_profile_hermes_home_when_context_override_is_active(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_dir = tmp_path / "profiles" / "alpha-test"
+        gateway_home.mkdir()
+        profile_dir.mkdir(parents=True)
+        (gateway_home / "home").mkdir()
+        (profile_dir / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from hermes_constants import hermes_home_context
+        from tools.environments.local import _make_run_env
+
+        with hermes_home_context(profile_dir):
+            result = _make_run_env({})
+
+        assert result["HERMES_HOME"] == str(profile_dir)
+        assert result["HOME"] == str(profile_dir / "home")
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_subprocess_env() injection
@@ -230,6 +267,541 @@ class TestSanitizeSubprocessEnvHomeInjection:
 
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
+
+    def test_injects_profile_hermes_home_when_context_override_is_active(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_dir = tmp_path / "profiles" / "alpha-test"
+        gateway_home.mkdir()
+        profile_dir.mkdir(parents=True)
+        (gateway_home / "home").mkdir()
+        (profile_dir / "home").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        base_env = {"HOME": "/root", "PATH": "/usr/bin"}
+        from hermes_constants import hermes_home_context
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with hermes_home_context(profile_dir):
+            result = _sanitize_subprocess_env(base_env)
+
+        assert result["HERMES_HOME"] == str(profile_dir)
+        assert result["HOME"] == str(profile_dir / "home")
+
+
+# ---------------------------------------------------------------------------
+# Terminal/process runtime cache isolation
+# ---------------------------------------------------------------------------
+
+class TestTerminalRuntimeProfileIsolation:
+    """Regression tests for profile-scoped terminal/process runtime caches."""
+
+    def test_environment_cache_key_returns_tuple(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / "profiles" / "alpha"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "gateway"))
+
+        from hermes_constants import hermes_home_context
+        from tools.terminal_tool import _environment_cache_key
+
+        with hermes_home_context(profile_home):
+            key = _environment_cache_key("default")
+
+        assert key == (str(profile_home), "default")
+
+    def test_file_ops_cache_isolated_per_profile(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_a = tmp_path / "profiles" / "alpha"
+        profile_b = tmp_path / "profiles" / "beta"
+        for home in (gateway_home, profile_a, profile_b):
+            home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        from hermes_constants import hermes_home_context
+        from tools import file_tools
+        from tools import terminal_tool
+
+        terminal_tool._active_environments.clear()
+        terminal_tool._last_activity.clear()
+        terminal_tool._creation_locks.clear()
+        file_tools._file_ops_cache.clear()
+
+        created = []
+
+        def fake_create_environment(**kwargs):
+            env = SimpleNamespace(
+                cwd=f"/workspace/{len(created)}",
+                execute=lambda *args, **kw: {"output": "", "returncode": 0},
+            )
+            created.append((kwargs, env))
+            return env
+
+        monkeypatch.setattr(terminal_tool, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+        with hermes_home_context(profile_a):
+            ops_a = file_tools._get_file_ops("default")
+        with hermes_home_context(profile_b):
+            ops_b = file_tools._get_file_ops("default")
+
+        assert ops_a is not ops_b
+        assert set(file_tools._file_ops_cache) == {
+            (str(profile_a), "default"),
+            (str(profile_b), "default"),
+        }
+
+    def test_file_tracking_cwd_does_not_use_main_legacy_cache_for_routed_profile(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_home = tmp_path / "profiles" / "alpha-test"
+        gateway_home.mkdir(parents=True)
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from hermes_constants import hermes_home_context
+        from tools import file_tools
+
+        file_tools._file_ops_cache.clear()
+        file_tools._file_ops_cache["default"] = SimpleNamespace(
+            env=SimpleNamespace(cwd="/workspace/main")
+        )
+
+        assert file_tools._get_live_tracking_cwd("default") == "/workspace/main"
+
+        tokens = set_session_vars(
+            agent_profile="alpha-test",
+            agent_hermes_home=str(profile_home),
+        )
+        try:
+            with hermes_home_context(profile_home):
+                assert file_tools._get_live_tracking_cwd("default") is None
+        finally:
+            clear_session_vars(tokens)
+            file_tools._file_ops_cache.clear()
+
+    def test_execute_code_env_isolated_per_profile(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_a = tmp_path / "profiles" / "alpha"
+        profile_b = tmp_path / "profiles" / "beta"
+        for home in (gateway_home, profile_a, profile_b):
+            home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        from hermes_constants import hermes_home_context
+        from tools import code_execution_tool
+        from tools import terminal_tool
+
+        terminal_tool._active_environments.clear()
+        terminal_tool._last_activity.clear()
+        terminal_tool._creation_locks.clear()
+
+        created = []
+
+        def fake_create_environment(**kwargs):
+            env = SimpleNamespace(cwd=f"/workspace/{len(created)}")
+            created.append((kwargs, env))
+            return env
+
+        monkeypatch.setattr(terminal_tool, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+        with hermes_home_context(profile_a):
+            env_a, _ = code_execution_tool._get_or_create_env("default")
+        with hermes_home_context(profile_b):
+            env_b, _ = code_execution_tool._get_or_create_env("default")
+
+        assert env_a is not env_b
+        assert set(terminal_tool._active_environments) == {
+            (str(profile_a), "default"),
+            (str(profile_b), "default"),
+        }
+
+    def test_legacy_string_cache_key_does_not_crash_eviction_loop(self, tmp_path):
+        from tools import terminal_tool
+        from tools.process_registry import process_registry
+
+        cleaned = []
+        legacy_key = f"{tmp_path / 'legacy'}::default"
+        env = SimpleNamespace(cleanup=lambda: cleaned.append(True))
+        terminal_tool._active_environments.clear()
+        terminal_tool._last_activity.clear()
+        terminal_tool._creation_locks.clear()
+        process_registry._running.clear()
+        terminal_tool._active_environments[legacy_key] = env
+        terminal_tool._last_activity[legacy_key] = 0.0
+
+        terminal_tool._cleanup_inactive_envs(lifetime_seconds=1)
+
+        assert cleaned == [True]
+        assert legacy_key not in terminal_tool._active_environments
+
+    def test_process_registry_writes_profile_scoped_checkpoints(
+        self, tmp_path, monkeypatch
+    ):
+        gateway_home = tmp_path / "gateway"
+        profile_a = tmp_path / "profiles" / "alpha"
+        profile_b = tmp_path / "profiles" / "beta"
+        gateway_home.mkdir()
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        from hermes_constants import hermes_home_context
+        from tools.process_registry import ProcessRegistry, ProcessSession
+
+        registry = ProcessRegistry()
+        with hermes_home_context(profile_a):
+            registry._running["proc_alpha"] = ProcessSession(
+                id="proc_alpha",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:alpha:telegram:group:-1001:101",
+                agent_profile="alpha",
+                agent_hermes_home=str(profile_a),
+                pid=12345,
+                started_at=1.0,
+            )
+        with hermes_home_context(profile_b):
+            registry._running["proc_beta"] = ProcessSession(
+                id="proc_beta",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:beta:telegram:group:-1001:202",
+                agent_profile="beta",
+                agent_hermes_home=str(profile_b),
+                pid=23456,
+                started_at=2.0,
+            )
+            registry._write_checkpoint()
+
+        gateway_rows = json.loads((gateway_home / "processes.json").read_text(encoding="utf-8"))
+        alpha_rows = json.loads((profile_a / "processes.json").read_text(encoding="utf-8"))
+        beta_rows = json.loads((profile_b / "processes.json").read_text(encoding="utf-8"))
+
+        assert gateway_rows == []
+        assert [row["session_id"] for row in alpha_rows] == ["proc_alpha"]
+        assert [row["session_id"] for row in beta_rows] == ["proc_beta"]
+        assert alpha_rows[0]["agent_hermes_home"] == str(profile_a)
+        assert beta_rows[0]["agent_hermes_home"] == str(profile_b)
+
+    def test_process_registry_recovers_routed_processes_after_crash(
+        self, tmp_path, monkeypatch
+    ):
+        gateway_home = tmp_path / "gateway"
+        profile_a = tmp_path / "profiles" / "alpha"
+        profile_b = tmp_path / "profiles" / "beta"
+        gateway_home.mkdir()
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        from tools.process_registry import ProcessRegistry, ProcessSession
+
+        before = ProcessRegistry()
+        before._running["proc_alpha"] = ProcessSession(
+            id="proc_alpha",
+            command="sleep 60",
+            task_id="default",
+            session_key="agent:alpha:telegram:group:-1001:101",
+            agent_profile="alpha",
+            agent_hermes_home=str(profile_a),
+            pid=12345,
+            started_at=1.0,
+            watcher_platform="telegram",
+            watcher_chat_id="-1001",
+            watcher_thread_id="101",
+            watcher_interval=5,
+            notify_on_complete=True,
+        )
+        before._running["proc_beta"] = ProcessSession(
+            id="proc_beta",
+            command="sleep 60",
+            task_id="default",
+            session_key="agent:beta:telegram:group:-1001:202",
+            agent_profile="beta",
+            agent_hermes_home=str(profile_b),
+            pid=23456,
+            started_at=2.0,
+            watcher_platform="telegram",
+            watcher_chat_id="-1001",
+            watcher_thread_id="202",
+            watcher_interval=5,
+            notify_on_complete=True,
+        )
+        before._write_checkpoint()
+
+        after = ProcessRegistry()
+        monkeypatch.setattr(after, "_is_host_pid_alive", lambda _pid: True)
+
+        assert after.recover_from_checkpoint(
+            checkpoint_paths=[
+                profile_a / "processes.json",
+                profile_b / "processes.json",
+            ]
+        ) == 2
+        assert set(after._running) == {"proc_alpha", "proc_beta"}
+        assert after._running["proc_alpha"].agent_hermes_home == str(profile_a)
+        assert after._running["proc_beta"].agent_hermes_home == str(profile_b)
+        assert {w["agent_hermes_home"] for w in after.pending_watchers} == {
+            str(profile_a),
+            str(profile_b),
+        }
+
+    def test_session_context_propagates_routed_profile_to_terminal_tool(
+        self, tmp_path, monkeypatch
+    ):
+        gateway_home = tmp_path / "gateway"
+        profile_home = tmp_path / "profiles" / "alpha"
+        for home in (gateway_home, profile_home):
+            (home / "home").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_LOCAL_PERSISTENT", "false")
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import process_registry
+        from tools.terminal_tool import cleanup_all_environments, terminal_tool
+
+        process_registry._running.clear()
+        process_registry._finished.clear()
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id="-1001",
+            thread_id="101",
+            session_key="agent:alpha:telegram:group:-1001:101",
+            agent_profile="alpha",
+            agent_hermes_home=str(profile_home),
+        )
+        try:
+            started = json.loads(
+                terminal_tool("printf ok", background=True, notify_on_complete=True, timeout=5)
+            )
+            session = process_registry.get(started["session_id"])
+        finally:
+            clear_session_vars(tokens)
+            cleanup_all_environments()
+
+        assert session is not None
+        assert session.agent_profile == "alpha"
+        assert session.agent_hermes_home == str(profile_home)
+
+    def test_process_action_rejects_cross_profile_session_id(
+        self, tmp_path
+    ):
+        profile_a = tmp_path / "profiles" / "alpha"
+        profile_b = tmp_path / "profiles" / "beta"
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir(parents=True)
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import ProcessSession, _handle_process, process_registry
+
+        try:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+            process_registry._running["proc_alpha"] = ProcessSession(
+                id="proc_alpha",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:alpha:telegram:group:-1001:101",
+                agent_profile="alpha",
+                agent_hermes_home=str(profile_a),
+                pid=12345,
+                started_at=1.0,
+            )
+
+            tokens = set_session_vars(agent_profile="beta", agent_hermes_home=str(profile_b))
+            try:
+                for action in ("poll", "log", "wait", "kill", "write", "submit", "close"):
+                    result = json.loads(
+                        _handle_process(
+                            {
+                                "action": action,
+                                "session_id": "proc_alpha",
+                                "data": "x",
+                                "timeout": 0,
+                            }
+                        )
+                    )
+                    assert result["status"] == "not_found"
+            finally:
+                clear_session_vars(tokens)
+        finally:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+
+    def test_routed_profile_rejects_legacy_process_without_profile_home(
+        self, tmp_path
+    ):
+        profile_home = tmp_path / "profiles" / "beta"
+        profile_home.mkdir(parents=True)
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import ProcessSession, _handle_process, process_registry
+
+        try:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+            process_registry._running["proc_legacy"] = ProcessSession(
+                id="proc_legacy",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:main:telegram:group:-1001:101",
+                pid=12345,
+                started_at=1.0,
+            )
+
+            tokens = set_session_vars(agent_profile="beta", agent_hermes_home=str(profile_home))
+            try:
+                result = json.loads(
+                    _handle_process({"action": "log", "session_id": "proc_legacy"})
+                )
+                assert result["status"] == "not_found"
+            finally:
+                clear_session_vars(tokens)
+        finally:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+
+    def test_main_context_rejects_routed_process_session_id(
+        self, tmp_path
+    ):
+        profile_home = tmp_path / "profiles" / "alpha"
+        profile_home.mkdir(parents=True)
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import ProcessSession, _handle_process, process_registry
+
+        try:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+            process_registry._running["proc_alpha"] = ProcessSession(
+                id="proc_alpha",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:alpha:telegram:group:-1001:101",
+                agent_profile="alpha",
+                agent_hermes_home=str(profile_home),
+                pid=12345,
+                started_at=1.0,
+            )
+
+            tokens = set_session_vars(agent_profile="", agent_hermes_home="")
+            try:
+                result = json.loads(
+                    _handle_process({"action": "log", "session_id": "proc_alpha"})
+                )
+                assert result["status"] == "not_found"
+            finally:
+                clear_session_vars(tokens)
+        finally:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+
+    def test_process_list_filters_to_current_profile_scope(
+        self, tmp_path
+    ):
+        profile_a = tmp_path / "profiles" / "alpha"
+        profile_b = tmp_path / "profiles" / "beta"
+        profile_a.mkdir(parents=True)
+        profile_b.mkdir(parents=True)
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import ProcessSession, _handle_process, process_registry
+
+        try:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+            process_registry._running["proc_main"] = ProcessSession(
+                id="proc_main",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:main:telegram:group:-1001:1",
+                pid=111,
+                started_at=1.0,
+            )
+            process_registry._running["proc_alpha"] = ProcessSession(
+                id="proc_alpha",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:alpha:telegram:group:-1001:101",
+                agent_profile="alpha",
+                agent_hermes_home=str(profile_a),
+                pid=222,
+                started_at=2.0,
+            )
+            process_registry._running["proc_beta"] = ProcessSession(
+                id="proc_beta",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:beta:telegram:group:-1001:202",
+                agent_profile="beta",
+                agent_hermes_home=str(profile_b),
+                pid=333,
+                started_at=3.0,
+            )
+
+            tokens = set_session_vars(agent_profile="beta", agent_hermes_home=str(profile_b))
+            try:
+                routed = json.loads(_handle_process({"action": "list"}))
+                assert [p["session_id"] for p in routed["processes"]] == ["proc_beta"]
+            finally:
+                clear_session_vars(tokens)
+
+            main = json.loads(_handle_process({"action": "list"}))
+            assert [p["session_id"] for p in main["processes"]] == ["proc_main"]
+        finally:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+
+    def test_process_scope_requires_home_match_when_active_home_is_known(
+        self,
+    ):
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.process_registry import ProcessSession, _handle_process, process_registry
+
+        try:
+            process_registry._running.clear()
+            process_registry._finished.clear()
+            process_registry._running["proc_main"] = ProcessSession(
+                id="proc_main",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:main:telegram:group:-1001:1",
+                pid=111,
+                started_at=1.0,
+            )
+            process_registry._running["proc_alpha_legacy"] = ProcessSession(
+                id="proc_alpha_legacy",
+                command="sleep 60",
+                task_id="default",
+                session_key="agent:alpha-test:telegram:group:-1001:101",
+                agent_hermes_home="",
+                pid=222,
+                started_at=2.0,
+            )
+
+            tokens = set_session_vars(agent_profile="alpha-test", agent_hermes_home="/tmp/alpha-test")
+            try:
+                routed = json.loads(_handle_process({"action": "list"}))
+                assert routed["processes"] == []
+
+                result = json.loads(
+                    _handle_process({"action": "log", "session_id": "proc_main"})
+                )
+                assert result["status"] == "not_found"
+            finally:
+                clear_session_vars(tokens)
+
+            main = json.loads(_handle_process({"action": "list"}))
+            assert [p["session_id"] for p in main["processes"]] == ["proc_main"]
+
+            result = json.loads(
+                _handle_process({"action": "log", "session_id": "proc_alpha_legacy"})
+            )
+            assert result["status"] == "not_found"
+        finally:
+            process_registry._running.clear()
+            process_registry._finished.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_prompt_identity_digest.py
+++ b/tests/test_system_prompt_identity_digest.py
@@ -1,0 +1,67 @@
+import json
+
+from hermes_constants import hermes_home_context
+
+
+def test_system_prompt_identity_digest_changes_when_soul_changes(tmp_path):
+    from run_agent import AIAgent
+
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+
+    with hermes_home_context(hermes_home):
+        missing = AIAgent._system_prompt_identity_digest()
+        (hermes_home / "SOUL.md").write_text("Identity v1", encoding="utf-8")
+        v1 = AIAgent._system_prompt_identity_digest()
+        (hermes_home / "SOUL.md").write_text("Identity v2", encoding="utf-8")
+        v2 = AIAgent._system_prompt_identity_digest()
+
+    assert missing != v1
+    assert v1 != v2
+
+
+def test_system_prompt_identity_digest_changes_when_config_changes(tmp_path):
+    from run_agent import AIAgent
+
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+
+    with hermes_home_context(hermes_home):
+        missing = AIAgent._system_prompt_identity_digest()
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  system_prompt: Profile v1\n",
+            encoding="utf-8",
+        )
+        v1 = AIAgent._system_prompt_identity_digest()
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  system_prompt: Profile v2\n",
+            encoding="utf-8",
+        )
+        v2 = AIAgent._system_prompt_identity_digest()
+
+    assert missing != v1
+    assert v1 != v2
+
+
+def test_stored_system_prompt_identity_requires_matching_digest(tmp_path):
+    from run_agent import AIAgent
+
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    (hermes_home / "SOUL.md").write_text("Identity v1", encoding="utf-8")
+
+    with hermes_home_context(hermes_home):
+        agent = object.__new__(AIAgent)
+        agent._system_prompt_identity_fingerprint = AIAgent._system_prompt_identity_digest()
+        matching = {
+            "model_config": json.dumps(
+                {"system_prompt_identity_digest": agent._system_prompt_identity_fingerprint}
+            )
+        }
+        stale = {
+            "model_config": json.dumps({"system_prompt_identity_digest": "stale-digest"})
+        }
+
+        assert agent._stored_system_prompt_identity_matches(matching) is True
+        assert agent._stored_system_prompt_identity_matches(stale) is False
+        assert agent._stored_system_prompt_identity_matches({"model_config": "{}"}) is False

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -100,6 +100,35 @@ class TestRegisterCredentialFiles:
         mounts = get_credential_file_mounts()
         assert "real.json" in mounts[0]["container_path"]
 
+    def test_config_cache_is_keyed_by_hermes_home(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_home = tmp_path / "profiles" / "alpha-test"
+        gateway_home.mkdir()
+        profile_home.mkdir(parents=True)
+        (gateway_home / "global.json").write_text("{}")
+        (profile_home / "profile.json").write_text("{}")
+        (gateway_home / "config.yaml").write_text(
+            "terminal:\n  credential_files:\n    - global.json\n",
+            encoding="utf-8",
+        )
+        (profile_home / "config.yaml").write_text(
+            "terminal:\n  credential_files:\n    - profile.json\n",
+            encoding="utf-8",
+        )
+
+        from hermes_constants import hermes_home_context
+
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+        gateway_mounts = get_credential_file_mounts()
+        assert any(m["host_path"].endswith("global.json") for m in gateway_mounts)
+        assert not any(m["host_path"].endswith("profile.json") for m in gateway_mounts)
+
+        with hermes_home_context(profile_home):
+            profile_mounts = get_credential_file_mounts()
+
+        assert any(m["host_path"].endswith("profile.json") for m in profile_mounts)
+        assert not any(m["host_path"].endswith("global.json") for m in profile_mounts)
+
 
 class TestSkillsDirectoryMount:
     def test_returns_mount_when_skills_dir_exists(self, tmp_path):

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -105,6 +105,30 @@ class TestConfigPassthrough:
         assert "CONFIG_KEY" in all_pt
         assert "SKILL_KEY" in all_pt
 
+    def test_config_cache_is_keyed_by_hermes_home(self, tmp_path, monkeypatch):
+        gateway_home = tmp_path / "gateway"
+        profile_home = tmp_path / "profiles" / "alpha-test"
+        gateway_home.mkdir()
+        profile_home.mkdir(parents=True)
+        (gateway_home / "config.yaml").write_text(
+            yaml.dump({"terminal": {"env_passthrough": ["GLOBAL_ONLY"]}}),
+            encoding="utf-8",
+        )
+        (profile_home / "config.yaml").write_text(
+            yaml.dump({"terminal": {"env_passthrough": ["PROFILE_ONLY"]}}),
+            encoding="utf-8",
+        )
+
+        from hermes_constants import hermes_home_context
+
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+        assert is_env_passthrough("GLOBAL_ONLY")
+        assert not is_env_passthrough("PROFILE_ONLY")
+
+        with hermes_home_context(profile_home):
+            assert is_env_passthrough("PROFILE_ONLY")
+            assert not is_env_passthrough("GLOBAL_ONLY")
+
 
 class TestExecuteCodeIntegration:
     """Verify that the passthrough is checked in execute_code's env filtering."""

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -707,6 +707,39 @@ class TestCheckpoint:
             assert w["thread_id"] == "42"
             assert w["check_interval"] == 60
 
+    def test_recover_legacy_profile_without_home_does_not_rearm_watcher(
+        self, registry, tmp_path
+    ):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_legacy_profile",
+            "command": "sleep 999",
+            "pid": os.getpid(),
+            "task_id": "t1",
+            "session_key": "agent:alpha-test:telegram:u:dm:c",
+            "agent_profile": "alpha-test",
+            "agent_hermes_home": "",
+            "watcher_platform": "telegram",
+            "watcher_chat_id": "123",
+            "watcher_user_id": "u123",
+            "watcher_thread_id": "42",
+            "watcher_interval": 60,
+            "notify_on_complete": True,
+            "watch_patterns": ["done"],
+        }]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            recovered = registry.recover_from_checkpoint()
+
+        assert recovered == 1
+        assert registry.pending_watchers == []
+        session = registry.get("proc_legacy_profile")
+        assert session is not None
+        assert session.agent_profile == ""
+        assert session.agent_hermes_home == ""
+        assert session.watcher_interval == 0
+        assert session.notify_on_complete is False
+
     def test_recover_skips_watcher_when_no_interval(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
         checkpoint.write_text(json.dumps([{

--- a/tests/tools/test_skills_profile_isolation.py
+++ b/tests/tools/test_skills_profile_isolation.py
@@ -1,0 +1,163 @@
+import json
+import textwrap
+
+from hermes_constants import hermes_home_context
+
+
+def _write_skill(home, name, description):
+    skill_dir = home / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            name: {name}
+            description: {description}
+            ---
+
+            # {name}
+
+            {description}
+            """
+        ),
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _simulate_import_under_gateway(monkeypatch, gateway_home):
+    from tools import skill_manager_tool, skills_tool
+
+    for module in (skills_tool, skill_manager_tool):
+        monkeypatch.setattr(module, "HERMES_HOME", gateway_home, raising=False)
+        monkeypatch.setattr(module, "SKILLS_DIR", gateway_home / "skills", raising=False)
+        monkeypatch.setattr(
+            module,
+            "_IMPORT_SKILLS_DIR",
+            gateway_home / "skills",
+            raising=False,
+        )
+
+
+def test_skills_tools_resolve_active_profile_after_gateway_import(monkeypatch, tmp_path):
+    from tools import skills_tool
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "shopping"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _write_skill(gateway_home, "gateway-only", "gateway skill")
+    _write_skill(profile_home, "profile-only", "profile skill")
+    _simulate_import_under_gateway(monkeypatch, gateway_home)
+
+    with hermes_home_context(profile_home):
+        assert skills_tool.get_skills_dir() == profile_home / "skills"
+        listed = json.loads(skills_tool.skills_list())
+        names = {item["name"] for item in listed["skills"]}
+        assert names == {"profile-only"}
+
+        viewed = json.loads(skills_tool.skill_view("profile-only"))
+        assert viewed["success"] is True
+        assert viewed["skill_dir"] == str(profile_home / "skills" / "profile-only")
+
+        gateway_view = json.loads(skills_tool.skill_view("gateway-only"))
+        assert gateway_view["success"] is False
+
+
+def test_skill_manage_creates_under_active_profile_after_gateway_import(monkeypatch, tmp_path):
+    from tools.skill_manager_tool import skill_manage
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "shopping"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _simulate_import_under_gateway(monkeypatch, gateway_home)
+
+    content = textwrap.dedent(
+        """\
+        ---
+        name: profile-created
+        description: created in the routed profile
+        ---
+
+        # Profile Created
+        """
+    )
+
+    with hermes_home_context(profile_home):
+        result = json.loads(
+            skill_manage(action="create", name="profile-created", content=content)
+        )
+
+    assert result["success"] is True
+    assert (profile_home / "skills" / "profile-created" / "SKILL.md").exists()
+    assert not (gateway_home / "skills" / "profile-created" / "SKILL.md").exists()
+
+
+def test_skill_command_reload_scans_active_profile_after_gateway_import(monkeypatch, tmp_path):
+    from agent import skill_commands
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "shopping"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _write_skill(gateway_home, "gateway-only", "gateway skill")
+    _write_skill(profile_home, "profile-only", "profile skill")
+    _simulate_import_under_gateway(monkeypatch, gateway_home)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None, raising=False)
+
+    with hermes_home_context(profile_home):
+        commands = skill_commands.scan_skill_commands()
+
+    assert "/profile-only" in commands
+    assert "/gateway-only" not in commands
+
+
+def test_skill_command_cache_rescans_when_active_profile_changes(monkeypatch, tmp_path):
+    from agent import skill_commands
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "shopping"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    _write_skill(gateway_home, "gateway-only", "gateway skill")
+    _write_skill(profile_home, "profile-only", "profile skill")
+    _simulate_import_under_gateway(monkeypatch, gateway_home)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None, raising=False)
+    monkeypatch.setattr(skill_commands, "_skill_commands_home", None, raising=False)
+
+    with hermes_home_context(gateway_home):
+        gateway_commands = skill_commands.get_skill_commands()
+    with hermes_home_context(profile_home):
+        profile_commands = skill_commands.get_skill_commands()
+
+    assert "/gateway-only" in gateway_commands
+    assert "/profile-only" not in gateway_commands
+    assert "/profile-only" in profile_commands
+    assert "/gateway-only" not in profile_commands
+
+
+def test_explicit_skills_dir_monkeypatch_still_wins(monkeypatch, tmp_path):
+    from tools import skills_tool
+
+    gateway_home = tmp_path / "gateway"
+    profile_home = tmp_path / "profiles" / "shopping"
+    custom_skills = tmp_path / "custom-skills"
+    gateway_home.mkdir()
+    profile_home.mkdir(parents=True)
+    custom_skill = custom_skills / "custom-only"
+    custom_skill.mkdir(parents=True)
+    (custom_skill / "SKILL.md").write_text(
+        "---\nname: custom-only\ndescription: custom skill\n---\n\n# Custom\n",
+        encoding="utf-8",
+    )
+    _simulate_import_under_gateway(monkeypatch, gateway_home)
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", custom_skills, raising=False)
+
+    with hermes_home_context(profile_home):
+        assert skills_tool.get_skills_dir() == custom_skills
+        listed = json.loads(skills_tool.skills_list())
+
+    assert {item["name"] for item in listed["skills"]} == {"custom-only"}

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -571,28 +571,31 @@ def _get_or_create_env(task_id: str):
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
+        EnvCacheKey,
+        _environment_cache_key,
         _resolve_container_task_id,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
+    cache_key: EnvCacheKey = _environment_cache_key(task_id)
 
     # Fast path: environment already exists
     with _env_lock:
-        if effective_task_id in _active_environments:
-            _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+        if cache_key in _active_environments:
+            _last_activity[cache_key] = time.time()
+            return _active_environments[cache_key], _get_env_config()["env_type"]
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
-        if effective_task_id not in _creation_locks:
-            _creation_locks[effective_task_id] = threading.Lock()
-        task_lock = _creation_locks[effective_task_id]
+        if cache_key not in _creation_locks:
+            _creation_locks[cache_key] = threading.Lock()
+        task_lock = _creation_locks[cache_key]
 
     with task_lock:
         with _env_lock:
-            if effective_task_id in _active_environments:
-                _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+            if cache_key in _active_environments:
+                _last_activity[cache_key] = time.time()
+                return _active_environments[cache_key], _get_env_config()["env_type"]
 
         config = _get_env_config()
         env_type = config["env_type"]
@@ -654,8 +657,8 @@ def _get_or_create_env(task_id: str):
         )
 
         with _env_lock:
-            _active_environments[effective_task_id] = env
-            _last_activity[effective_task_id] = time.time()
+            _active_environments[cache_key] = env
+            _last_activity[cache_key] = time.time()
 
         _start_cleanup_thread()
         logger.info("%s environment ready for execute_code task %s",
@@ -1213,9 +1216,11 @@ def execute_code(
             child_env["TZ"] = _tz_name
         child_env.pop("HERMES_TIMEZONE", None)
 
-        # Per-profile HOME isolation: redirect system tool configs into
-        # {HERMES_HOME}/home/ when that directory exists.
-        from hermes_constants import get_subprocess_home
+        # Per-profile HOME/HERMES_HOME isolation: redirect system tool configs into
+        # {HERMES_HOME}/home/ when that directory exists and ensure child scripts
+        # see the active ContextVar-scoped HERMES_HOME.
+        from hermes_constants import get_hermes_home, get_subprocess_home
+        child_env["HERMES_HOME"] = str(get_hermes_home())
         _profile_home = get_subprocess_home()
         if _profile_home:
             child_env["HOME"] = _profile_home

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -44,13 +44,20 @@ def _get_registered() -> Dict[str, str]:
         return val
 
 
-# Cache for config-based file list (loaded once per process).
-_config_files: List[Dict[str, str]] | None = None
+# Cache for config-based file lists, keyed by active HERMES_HOME.
+_config_files: Dict[str, List[Dict[str, str]]] | None = {}
 
 
 def _resolve_hermes_home() -> Path:
     from hermes_constants import get_hermes_home
     return get_hermes_home()
+
+
+def _config_cache_key() -> str:
+    try:
+        return str(_resolve_hermes_home().expanduser().resolve(strict=False))
+    except Exception:
+        return ""
 
 
 def register_credential_file(
@@ -131,8 +138,11 @@ def register_credential_files(
 def _load_config_files() -> List[Dict[str, str]]:
     """Load ``terminal.credential_files`` from config.yaml (cached)."""
     global _config_files
-    if _config_files is not None:
-        return _config_files
+    if not isinstance(_config_files, dict):
+        _config_files = {}
+    cache_key = _config_cache_key()
+    if cache_key in _config_files:
+        return _config_files[cache_key]
 
     result: List[Dict[str, str]] = []
     try:
@@ -169,8 +179,8 @@ def _load_config_files() -> List[Dict[str, str]]:
     except Exception as e:
         logger.warning("Could not read terminal.credential_files from config: %s", e)
 
-    _config_files = result
-    return _config_files
+    _config_files[cache_key] = result
+    return result
 
 
 def get_credential_file_mounts() -> List[Dict[str, str]]:
@@ -432,5 +442,4 @@ def iter_cache_files(
 def clear_credential_files() -> None:
     """Reset the skill-scoped registry (e.g. on session reset)."""
     _get_registered().clear()
-
 

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -41,8 +41,16 @@ def _get_allowed() -> set[str]:
         return val
 
 
-# Cache for the config-based allowlist (loaded once per process).
-_config_passthrough: frozenset[str] | None = None
+# Cache for the config-based allowlist, keyed by active HERMES_HOME.
+_config_passthrough: dict[str, frozenset[str]] | None = {}
+
+
+def _config_cache_key() -> str:
+    try:
+        from hermes_constants import get_hermes_home
+        return str(get_hermes_home().expanduser().resolve(strict=False))
+    except Exception:
+        return ""
 
 
 def _is_hermes_provider_credential(name: str) -> bool:
@@ -103,8 +111,11 @@ def register_env_passthrough(var_names: Iterable[str]) -> None:
 def _load_config_passthrough() -> frozenset[str]:
     """Load ``tools.env_passthrough`` from config.yaml (cached)."""
     global _config_passthrough
-    if _config_passthrough is not None:
-        return _config_passthrough
+    if not isinstance(_config_passthrough, dict):
+        _config_passthrough = {}
+    cache_key = _config_cache_key()
+    if cache_key in _config_passthrough:
+        return _config_passthrough[cache_key]
 
     result: set[str] = set()
     try:
@@ -118,8 +129,9 @@ def _load_config_passthrough() -> frozenset[str]:
     except Exception as e:
         logger.debug("Could not read tools.env_passthrough from config: %s", e)
 
-    _config_passthrough = frozenset(result)
-    return _config_passthrough
+    cached = frozenset(result)
+    _config_passthrough[cache_key] = cached
+    return cached
 
 
 def is_env_passthrough(var_name: str) -> bool:
@@ -141,5 +153,4 @@ def get_all_passthrough() -> frozenset[str]:
 def clear_env_passthrough() -> None:
     """Reset the skill-scoped allowlist (e.g. on session reset)."""
     _get_allowed().clear()
-
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -207,8 +207,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
     _inject_context_hermes_home(sanitized)
 
-    # Per-profile HOME isolation for background processes (same as _make_run_env).
-    from hermes_constants import get_subprocess_home
+    # Per-profile HOME/HERMES_HOME isolation for background processes (same as _make_run_env).
+    from hermes_constants import get_hermes_home, get_subprocess_home
+    _active_hermes_home = str(get_hermes_home())
+    sanitized["HERMES_HOME"] = _active_hermes_home
     _profile_home = get_subprocess_home()
     if _profile_home:
         sanitized["HOME"] = _profile_home
@@ -309,10 +311,11 @@ def _make_run_env(env: dict) -> dict:
 
     _inject_context_hermes_home(run_env)
 
-    # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
+    # Per-profile HOME/HERMES_HOME isolation: redirect system tool configs (git, ssh, gh,
     # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
     # subprocess sees the override — the Python process keeps the real HOME.
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_hermes_home, get_subprocess_home
+    run_env["HERMES_HOME"] = str(get_hermes_home())
     _profile_home = get_subprocess_home()
     if _profile_home:
         run_env["HOME"] = _profile_home

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -87,14 +87,29 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path:
 
 def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
     """Return the task's live terminal cwd for bookkeeping when available."""
+    routed_context = False
     try:
-        from tools.terminal_tool import _resolve_container_task_id
-        container_key = _resolve_container_task_id(task_id)
+        from gateway.session_context import get_session_env
+
+        routed_context = bool(
+            str(get_session_env("HERMES_SESSION_AGENT_PROFILE", "") or "").strip()
+            or str(get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "") or "").strip()
+        )
     except Exception:
-        container_key = task_id
+        routed_context = False
+
+    try:
+        from tools.terminal_tool import EnvCacheKey, _environment_cache_key, _resolve_container_task_id
+        cache_key: EnvCacheKey = _environment_cache_key(task_id)
+        legacy_key = _resolve_container_task_id(task_id)
+    except Exception:
+        cache_key = task_id
+        legacy_key = task_id
 
     with _file_ops_lock:
-        cached = _file_ops_cache.get(container_key) or _file_ops_cache.get(task_id)
+        cached = _file_ops_cache.get(cache_key)
+        if cached is None and not routed_context:
+            cached = _file_ops_cache.get(legacy_key)
     if cached is not None:
         live_cwd = getattr(getattr(cached, "env", None), "cwd", None) or getattr(
             cached, "cwd", None
@@ -106,7 +121,9 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
         from tools.terminal_tool import _active_environments, _env_lock
 
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(cache_key)
+            if env is None and not routed_context:
+                env = _active_environments.get(legacy_key)
             live_cwd = getattr(env, "cwd", None) if env is not None else None
         if live_cwd:
             return live_cwd
@@ -322,39 +339,42 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks,
         _creation_locks_lock,
+        EnvCacheKey,
+        _environment_cache_key,
         _resolve_container_task_id,
     )
     import time
 
     task_id = _resolve_container_task_id(task_id)
+    cache_key: EnvCacheKey = _environment_cache_key(task_id)
 
     # Fast path: check cache -- but also verify the underlying environment
     # is still alive (it may have been killed by the cleanup thread).
     with _file_ops_lock:
-        cached = _file_ops_cache.get(task_id)
+        cached = _file_ops_cache.get(cache_key)
     if cached is not None:
         with _env_lock:
-            if task_id in _active_environments:
-                _last_activity[task_id] = time.time()
+            if cache_key in _active_environments:
+                _last_activity[cache_key] = time.time()
                 return cached
             else:
                 # Environment was cleaned up -- invalidate stale cache entry
                 with _file_ops_lock:
-                    _file_ops_cache.pop(task_id, None)
+                    _file_ops_cache.pop(cache_key, None)
 
     # Need to ensure the environment exists before building file_ops.
     # Acquire per-task lock so only one thread creates the sandbox.
     with _creation_locks_lock:
-        if task_id not in _creation_locks:
-            _creation_locks[task_id] = threading.Lock()
-        task_lock = _creation_locks[task_id]
+        if cache_key not in _creation_locks:
+            _creation_locks[cache_key] = threading.Lock()
+        task_lock = _creation_locks[cache_key]
 
     with task_lock:
         # Double-check: another thread may have created it while we waited
         with _env_lock:
-            if task_id in _active_environments:
-                _last_activity[task_id] = time.time()
-                terminal_env = _active_environments[task_id]
+            if cache_key in _active_environments:
+                _last_activity[cache_key] = time.time()
+                terminal_env = _active_environments[cache_key]
             else:
                 terminal_env = None
 
@@ -422,8 +442,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             )
 
             with _env_lock:
-                _active_environments[task_id] = terminal_env
-                _last_activity[task_id] = time.time()
+                _active_environments[cache_key] = terminal_env
+                _last_activity[cache_key] = time.time()
 
             _start_cleanup_thread()
             logger.info("%s environment ready for task %s", env_type, task_id[:8])
@@ -431,7 +451,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)
     with _file_ops_lock:
-        _file_ops_cache[task_id] = file_ops
+        _file_ops_cache[cache_key] = file_ops
     return file_ops
 
 
@@ -439,6 +459,16 @@ def clear_file_ops_cache(task_id: str = None):
     """Clear the file operations cache."""
     with _file_ops_lock:
         if task_id:
+            try:
+                from tools.terminal_tool import _environment_cache_key, _normalize_cache_key
+                cache_key = (
+                    _normalize_cache_key(task_id)
+                    if isinstance(task_id, tuple) or (isinstance(task_id, str) and "::" in task_id)
+                    else _environment_cache_key(task_id)
+                )
+                _file_ops_cache.pop(cache_key, None)
+            except Exception:
+                pass
             _file_ops_cache.pop(task_id, None)
         else:
             _file_ops_cache.clear()

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -39,6 +39,7 @@ import subprocess
 import threading
 import time
 import uuid
+from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
@@ -53,6 +54,7 @@ logger = logging.getLogger(__name__)
 
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
+_IMPORT_CHECKPOINT_PATH = CHECKPOINT_PATH
 
 # Limits
 MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer
@@ -75,6 +77,24 @@ WATCH_GLOBAL_WINDOW_SECONDS = 10
 WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 
 
+def _checkpoint_path_for_home(home: str | Path | None = None) -> Path:
+    """Return the checkpoint path for the active Hermes home.
+
+    Tests historically monkeypatch ``CHECKPOINT_PATH`` directly.  Preserve
+    that contract; otherwise derive the path from the current/profile home so
+    routed profile process metadata is not persisted in the gateway home.
+    """
+    configured = Path(CHECKPOINT_PATH)
+    if configured != _IMPORT_CHECKPOINT_PATH:
+        return configured
+    base = Path(home).expanduser() if home else get_hermes_home()
+    return base / "processes.json"
+
+
+def _checkpoint_path_overridden() -> bool:
+    return Path(CHECKPOINT_PATH) != _IMPORT_CHECKPOINT_PATH
+
+
 def format_uptime_short(seconds: int) -> str:
     s = max(0, int(seconds))
     if s < 60:
@@ -93,6 +113,8 @@ class ProcessSession:
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
     session_key: str = ""                       # Gateway session key (for reset protection)
+    agent_profile: str = ""                     # Routed gateway profile name
+    agent_hermes_home: str = ""                 # Routed profile HERMES_HOME
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
     env_ref: Any = None                         # Reference to the environment object
@@ -179,6 +201,7 @@ class ProcessRegistry:
         self._global_watch_window_hits: int = 0
         self._global_watch_tripped_until: float = 0.0
         self._global_watch_suppressed_during_trip: int = 0
+        self._checkpoint_paths: set[Path] = {_checkpoint_path_for_home()}
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
@@ -272,6 +295,8 @@ class ProcessRegistry:
                 self.completion_queue.put({
                     "session_id": session.id,
                     "session_key": session.session_key,
+                    "agent_profile": session.agent_profile,
+                    "agent_hermes_home": session.agent_hermes_home,
                     "command": session.command,
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
@@ -303,6 +328,8 @@ class ProcessRegistry:
         self.completion_queue.put({
             "session_id": session.id,
             "session_key": session.session_key,
+            "agent_profile": session.agent_profile,
+            "agent_hermes_home": session.agent_hermes_home,
             "command": session.command,
             "type": "watch_match",
             "pattern": matched_pattern,
@@ -479,6 +506,8 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        agent_profile: str = "",
+        agent_hermes_home: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -495,6 +524,8 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            agent_profile=agent_profile,
+            agent_hermes_home=agent_hermes_home,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
@@ -615,6 +646,8 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        agent_profile: str = "",
+        agent_hermes_home: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -632,6 +665,8 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            agent_profile=agent_profile,
+            agent_hermes_home=agent_hermes_home,
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
@@ -822,6 +857,9 @@ class ProcessRegistry:
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
+                "session_key": session.session_key,
+                "agent_profile": session.agent_profile,
+                "agent_hermes_home": session.agent_hermes_home,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "output": output_tail,
@@ -858,6 +896,51 @@ class ProcessRegistry:
         with self._lock:
             session = self._running.get(session_id) or self._finished.get(session_id)
         return self._refresh_detached_session(session)
+
+    @staticmethod
+    def _normalize_home(value: str) -> str:
+        value = str(value or "").strip()
+        if not value:
+            return ""
+        try:
+            return str(Path(value).expanduser().resolve(strict=False))
+        except Exception:
+            return value
+
+    def _current_scope(self) -> tuple[bool, str, str]:
+        try:
+            from gateway.session_context import get_session_env
+            active_profile = get_session_env("HERMES_SESSION_AGENT_PROFILE", "")
+            active_home = get_session_env("HERMES_SESSION_AGENT_HERMES_HOME", "")
+        except Exception:
+            active_profile = ""
+            active_home = ""
+
+        active_home = self._normalize_home(active_home)
+        active_profile = str(active_profile or "").strip()
+        is_routed = bool(active_profile or active_home)
+        return is_routed, active_home, active_profile
+
+    def _in_current_scope(self, session: ProcessSession) -> bool:
+        is_routed, active_home, active_profile = self._current_scope()
+        session_home = self._normalize_home(session.agent_hermes_home)
+        session_profile = str(session.agent_profile or "").strip()
+        if not session_profile:
+            parts = str(session.session_key or "").split(":", 2)
+            if len(parts) >= 2 and parts[0] == "agent" and parts[1] not in {"", "main", "cron"}:
+                session_profile = parts[1]
+        if is_routed:
+            if active_home:
+                return bool(session_home and session_home == active_home)
+            return False
+        return not bool(session_home or session_profile)
+
+    def _get_for_current_scope(self, session_id: str) -> Optional[ProcessSession]:
+        """Return a process only when it belongs to the active profile scope."""
+        session = self.get(session_id)
+        if session is None or not self._in_current_scope(session):
+            return None
+        return session
 
     def _reconcile_local_exit(self, session: "ProcessSession") -> None:
         """Reconcile session.exited against the real child process state.
@@ -1200,6 +1283,7 @@ class ProcessRegistry:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
+        all_sessions = [s for s in all_sessions if self._in_current_scope(s)]
 
         if task_id:
             all_sessions = [s for s in all_sessions if s.task_id == task_id]
@@ -1299,14 +1383,20 @@ class ProcessRegistry:
 
     # ----- Checkpoint (crash recovery) -----
 
+    @staticmethod
+    def _checkpoint_path_for_session(session: ProcessSession) -> Path:
+        home = str(session.agent_hermes_home or "").strip()
+        return _checkpoint_path_for_home(home or None)
+
     def _write_checkpoint(self):
         """Write running process metadata to checkpoint file atomically."""
         try:
             with self._lock:
-                entries = []
+                entries_by_path: Dict[Path, list[dict]] = {}
                 for s in self._running.values():
                     if not s.exited:
-                        entries.append({
+                        path = self._checkpoint_path_for_session(s)
+                        entries_by_path.setdefault(path, []).append({
                             "session_id": s.id,
                             "command": s.command,
                             "pid": s.pid,
@@ -1315,6 +1405,8 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "agent_profile": s.agent_profile,
+                            "agent_hermes_home": s.agent_hermes_home,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -1325,26 +1417,51 @@ class ProcessRegistry:
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
                         })
+                if _checkpoint_path_overridden():
+                    paths = set(entries_by_path) or {Path(CHECKPOINT_PATH)}
+                else:
+                    paths = set(self._checkpoint_paths) | set(entries_by_path)
+                if not paths:
+                    paths = {_checkpoint_path_for_home()}
+                self._checkpoint_paths = paths
             
             # Atomic write to avoid corruption on crash
             from utils import atomic_json_write
-            atomic_json_write(CHECKPOINT_PATH, entries)
+            for path in paths:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                atomic_json_write(path, entries_by_path.get(path, []))
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
 
-    def recover_from_checkpoint(self) -> int:
+    def recover_from_checkpoint(self, checkpoint_paths: list[str | Path] | None = None) -> int:
         """
         On gateway startup, probe PIDs from checkpoint file.
 
         Returns the number of processes recovered as detached.
         """
-        if not CHECKPOINT_PATH.exists():
+        paths: list[Path] = [_checkpoint_path_for_home()]
+        if checkpoint_paths and not _checkpoint_path_overridden():
+            paths.extend(Path(path) for path in checkpoint_paths)
+
+        seen_paths: set[Path] = set()
+        entries: list[dict] = []
+        for path in paths:
+            if path in seen_paths:
+                continue
+            seen_paths.add(path)
+            if not path.exists():
+                continue
+            try:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if isinstance(loaded, list):
+                entries.extend(entry for entry in loaded if isinstance(entry, dict))
+
+        if not entries:
             return 0
 
-        try:
-            entries = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
-        except Exception:
-            return 0
+        self._checkpoint_paths |= seen_paths
 
         recovered = 0
         for entry in entries:
@@ -1369,25 +1486,30 @@ class ProcessRegistry:
             alive = self._is_host_pid_alive(pid)
 
             if alive:
+                raw_agent_profile = str(entry.get("agent_profile", "") or "").strip()
+                raw_agent_home = str(entry.get("agent_hermes_home", "") or "").strip()
+                legacy_profile_without_home = bool(raw_agent_profile and not raw_agent_home)
                 session = ProcessSession(
                     id=entry["session_id"],
                     command=entry.get("command", "unknown"),
                     task_id=entry.get("task_id", ""),
                     session_key=entry.get("session_key", ""),
+                    agent_profile="" if legacy_profile_without_home else raw_agent_profile,
+                    agent_hermes_home=raw_agent_home,
                     pid=pid,
                     pid_scope=pid_scope,
                     cwd=entry.get("cwd"),
                     started_at=entry.get("started_at", time.time()),
                     detached=True,  # Can't read output, but can report status + kill
-                    watcher_platform=entry.get("watcher_platform", ""),
-                    watcher_chat_id=entry.get("watcher_chat_id", ""),
-                    watcher_user_id=entry.get("watcher_user_id", ""),
-                    watcher_user_name=entry.get("watcher_user_name", ""),
-                    watcher_thread_id=entry.get("watcher_thread_id", ""),
-                    watcher_message_id=entry.get("watcher_message_id", ""),
-                    watcher_interval=entry.get("watcher_interval", 0),
-                    notify_on_complete=entry.get("notify_on_complete", False),
-                    watch_patterns=entry.get("watch_patterns", []),
+                    watcher_platform="" if legacy_profile_without_home else entry.get("watcher_platform", ""),
+                    watcher_chat_id="" if legacy_profile_without_home else entry.get("watcher_chat_id", ""),
+                    watcher_user_id="" if legacy_profile_without_home else entry.get("watcher_user_id", ""),
+                    watcher_user_name="" if legacy_profile_without_home else entry.get("watcher_user_name", ""),
+                    watcher_thread_id="" if legacy_profile_without_home else entry.get("watcher_thread_id", ""),
+                    watcher_message_id="" if legacy_profile_without_home else entry.get("watcher_message_id", ""),
+                    watcher_interval=0 if legacy_profile_without_home else entry.get("watcher_interval", 0),
+                    notify_on_complete=False if legacy_profile_without_home else entry.get("notify_on_complete", False),
+                    watch_patterns=[] if legacy_profile_without_home else entry.get("watch_patterns", []),
                 )
                 with self._lock:
                     self._running[session.id] = session
@@ -1400,6 +1522,8 @@ class ProcessRegistry:
                         "session_id": session.id,
                         "check_interval": session.watcher_interval,
                         "session_key": session.session_key,
+                        "agent_profile": session.agent_profile,
+                        "agent_hermes_home": session.agent_hermes_home,
                         "platform": session.watcher_platform,
                         "chat_id": session.watcher_chat_id,
                         "user_id": session.watcher_user_id,
@@ -1517,6 +1641,12 @@ def _handle_process(args, **kw):
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
         if not session_id:
             return tool_error(f"session_id is required for {action}")
+        scoped = process_registry._get_for_current_scope(session_id)
+        if scoped is None:
+            return json.dumps({
+                "status": "not_found",
+                "error": "No process with ID in current profile scope",
+            }, ensure_ascii=False)
         if action == "poll":
             return json.dumps(process_registry.poll(session_id), ensure_ascii=False)
         elif action == "log":

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -39,7 +39,11 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    display_hermes_home,
+    get_skills_dir as _active_skills_dir,
+)
 from typing import Dict, Any, Optional, Tuple
 
 from utils import atomic_replace, is_truthy_value
@@ -107,6 +111,15 @@ import yaml
 # All skills live in ~/.hermes/skills/ (single source of truth)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
+_IMPORT_SKILLS_DIR = SKILLS_DIR
+
+
+def get_skills_dir() -> Path:
+    """Return the active profile's skills dir, preserving SKILLS_DIR monkeypatches."""
+    configured = Path(SKILLS_DIR)
+    if configured != _IMPORT_SKILLS_DIR:
+        return configured
+    return _active_skills_dir()
 
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
@@ -131,7 +144,7 @@ def _containing_skills_root(skill_path: Path) -> Path:
             return root
         except (ValueError, OSError):
             continue
-    return SKILLS_DIR
+    return get_skills_dir()
 
 
 def _pinned_guard(name: str) -> Optional[str]:
@@ -270,9 +283,10 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
     """Build the directory path for a new skill, optionally under a category."""
+    skills_dir = get_skills_dir()
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return skills_dir / category / name
+    return skills_dir / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -415,7 +429,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": str(skill_dir.relative_to(get_skills_dir())),
         "skill_md": str(skill_md),
     }
     if category:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,7 +69,11 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    display_hermes_home,
+    get_skills_dir as _active_skills_dir,
+)
 import os
 import re
 from enum import Enum
@@ -88,6 +92,15 @@ logger = logging.getLogger(__name__)
 # skills all coexist here without polluting the git repo.
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
+_IMPORT_SKILLS_DIR = SKILLS_DIR
+
+
+def get_skills_dir() -> Path:
+    """Return the active profile's skills dir, preserving SKILLS_DIR monkeypatches."""
+    configured = Path(SKILLS_DIR)
+    if configured != _IMPORT_SKILLS_DIR:
+        return configured
+    return _active_skills_dir()
 
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
@@ -451,9 +464,9 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
+    # Try the local skills dir first (respects monkeypatching in tests),
     # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
+    dirs_to_check = [get_skills_dir()]
     try:
         from agent.skill_utils import get_external_skills_dirs
         dirs_to_check.extend(get_external_skills_dirs())
@@ -568,8 +581,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     # Scan local dir first, then external dirs (local takes precedence)
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
+    skills_dir = get_skills_dir()
+    if skills_dir.exists():
+        dirs_to_scan.append(skills_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
@@ -687,8 +701,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
-        if not SKILLS_DIR.exists():
-            SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        skills_dir = get_skills_dir()
+        if not skills_dir.exists():
+            skills_dir.mkdir(parents=True, exist_ok=True)
             return json.dumps(
                 {
                     "success": True,
@@ -941,8 +956,9 @@ def skill_view(
 
         # Build list of all skill directories to search
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
+        skills_dir = get_skills_dir()
+        if skills_dir.exists():
+            all_dirs.append(skills_dir)
         all_dirs.extend(get_external_skills_dirs())
 
         if not all_dirs:
@@ -1062,7 +1078,7 @@ def skill_view(
         # Security: warn if skill is loaded from outside trusted directories
         # (local skills dir + configured external_dirs are all trusted)
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = [skills_dir.resolve()]
         try:
             _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
         except Exception:
@@ -1291,7 +1307,7 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(SKILLS_DIR))
+            rel_path = str(skill_md.relative_to(skills_dir))
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
             rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
@@ -1565,4 +1581,3 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
-

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -917,10 +917,11 @@ Do NOT use vim/nano/interactive tools without pty=true — they hang without a p
 """
 
 # Global state for environment lifecycle management
-_active_environments: Dict[str, Any] = {}
-_last_activity: Dict[str, float] = {}
+EnvCacheKey = tuple[str, str]
+_active_environments: Dict[EnvCacheKey | str, Any] = {}
+_last_activity: Dict[EnvCacheKey | str, float] = {}
 _env_lock = threading.Lock()
-_creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
+_creation_locks: Dict[EnvCacheKey | str, threading.Lock] = {}  # Per-task locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
@@ -986,6 +987,32 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     if task_id and task_id in _task_env_overrides:
         return task_id
     return "default"
+
+
+def _active_hermes_home_key() -> str:
+    try:
+        from hermes_constants import get_hermes_home
+        return str(get_hermes_home().expanduser().resolve(strict=False))
+    except Exception:
+        return os.environ.get("HERMES_HOME", "") or str(Path.home() / ".hermes")
+
+
+def _environment_cache_key(task_id: Optional[str]) -> EnvCacheKey:
+    logical_task_id = _resolve_container_task_id(task_id)
+    return (_active_hermes_home_key(), logical_task_id)
+
+
+def _normalize_cache_key(key: EnvCacheKey | str | None) -> EnvCacheKey:
+    if isinstance(key, tuple) and len(key) == 2:
+        return (str(key[0]), str(key[1]) or "default")
+    if isinstance(key, str) and "::" in key:
+        home, logical_task_id = key.split("::", 1)
+        return (home, logical_task_id or "default")
+    return ("", str(key or "default"))
+
+
+def _logical_task_id_from_cache_key(key: EnvCacheKey | str | None) -> str:
+    return _normalize_cache_key(key)[1]
 
 
 # Configuration from environment variables
@@ -1262,9 +1289,10 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     # background processes (their _last_activity gets refreshed to keep them alive).
     try:
         from tools.process_registry import process_registry
-        for task_id in list(_last_activity.keys()):
+        for cache_key in list(_last_activity.keys()):
+            task_id = _logical_task_id_from_cache_key(cache_key)
             if process_registry.has_active_processes(task_id):
-                _last_activity[task_id] = current_time  # Keep sandbox alive
+                _last_activity[cache_key] = current_time  # Keep sandbox alive
     except ImportError:
         pass
 
@@ -1275,21 +1303,22 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     envs_to_stop = []  # list of (task_id, env) pairs
 
     with _env_lock:
-        for task_id, last_time in list(_last_activity.items()):
+        for cache_key, last_time in list(_last_activity.items()):
             if current_time - last_time > lifetime_seconds:
-                env = _active_environments.pop(task_id, None)
-                _last_activity.pop(task_id, None)
+                env = _active_environments.pop(cache_key, None)
+                _last_activity.pop(cache_key, None)
                 if env is not None:
-                    envs_to_stop.append((task_id, env))
+                    envs_to_stop.append((cache_key, env))
 
         # Also purge per-task creation locks for cleaned-up tasks
         with _creation_locks_lock:
-            for task_id, _ in envs_to_stop:
-                _creation_locks.pop(task_id, None)
+            for cache_key, _ in envs_to_stop:
+                _creation_locks.pop(cache_key, None)
 
     # Phase 2: stop the actual sandboxes OUTSIDE the lock so other tool calls
     # are not blocked while Modal/Docker sandboxes shut down.
-    for task_id, env in envs_to_stop:
+    for cache_key, env in envs_to_stop:
+        task_id = _logical_task_id_from_cache_key(cache_key)
         # Invalidate stale file_ops cache entry (Bug fix: prevents
         # ShellFileOperations from referencing a dead sandbox)
         try:
@@ -1356,8 +1385,12 @@ def _stop_cleanup_thread():
 def get_active_env(task_id: str):
     """Return the active BaseEnvironment for *task_id*, or None."""
     lookup = _resolve_container_task_id(task_id)
+    cache_key = _environment_cache_key(task_id)
     with _env_lock:
-        return _active_environments.get(lookup) or _active_environments.get(task_id)
+        return (
+            _active_environments.get(cache_key)
+            or _active_environments.get(lookup)
+        )
 
 
 def is_persistent_env(task_id: str) -> bool:
@@ -1406,24 +1439,36 @@ def cleanup_all_environments():
     return cleaned
 
 
-def cleanup_vm(task_id: str):
+def cleanup_vm(task_id: EnvCacheKey | str):
     """Manually clean up a specific environment by task_id."""
     # Remove from tracking dicts while holding the lock, but defer the
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.
+    cache_key = (
+        _normalize_cache_key(task_id)
+        if isinstance(task_id, tuple) or (isinstance(task_id, str) and "::" in task_id)
+        else _environment_cache_key(task_id)
+    )
+    legacy_key = _logical_task_id_from_cache_key(cache_key)
     env = None
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        for key in (task_id, cache_key, legacy_key):
+            if env is None:
+                env = _active_environments.pop(key, None)
+            else:
+                _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        for key in (task_id, cache_key, legacy_key):
+            _creation_locks.pop(key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
+        clear_file_ops_cache(cache_key)
+        clear_file_ops_cache(legacy_key)
     except ImportError:
         pass
 
@@ -1719,6 +1764,7 @@ def terminal_tool(
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
         effective_task_id = _resolve_container_task_id(task_id)
+        effective_cache_key = _environment_cache_key(task_id)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config
@@ -1771,9 +1817,9 @@ def terminal_tool(
         # task_id wait for the first one to finish creating the sandbox,
         # instead of each creating their own (wasting Modal resources).
         with _env_lock:
-            if effective_task_id in _active_environments:
-                _last_activity[effective_task_id] = time.time()
-                env = _active_environments[effective_task_id]
+            if effective_cache_key in _active_environments:
+                _last_activity[effective_cache_key] = time.time()
+                env = _active_environments[effective_cache_key]
                 needs_creation = False
             else:
                 needs_creation = True
@@ -1781,16 +1827,16 @@ def terminal_tool(
         if needs_creation:
             # Per-task lock: only one thread creates the sandbox, others wait
             with _creation_locks_lock:
-                if effective_task_id not in _creation_locks:
-                    _creation_locks[effective_task_id] = threading.Lock()
-                task_lock = _creation_locks[effective_task_id]
+                if effective_cache_key not in _creation_locks:
+                    _creation_locks[effective_cache_key] = threading.Lock()
+                task_lock = _creation_locks[effective_cache_key]
 
             with task_lock:
                 # Double-check after acquiring the per-task lock
                 with _env_lock:
-                    if effective_task_id in _active_environments:
-                        _last_activity[effective_task_id] = time.time()
-                        env = _active_environments[effective_task_id]
+                    if effective_cache_key in _active_environments:
+                        _last_activity[effective_cache_key] = time.time()
+                        env = _active_environments[effective_cache_key]
                         needs_creation = False
 
                 if needs_creation:
@@ -1851,8 +1897,8 @@ def terminal_tool(
                         }, ensure_ascii=False)
 
                     with _env_lock:
-                        _active_environments[effective_task_id] = new_env
-                        _last_activity[effective_task_id] = time.time()
+                        _active_environments[effective_cache_key] = new_env
+                        _last_activity[effective_cache_key] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
@@ -1925,9 +1971,12 @@ def terminal_tool(
             # For non-local backends: runs inside the sandbox via env.execute().
             from tools.approval import get_current_session_key
             from tools.process_registry import process_registry
+            from gateway.session_context import get_session_env as _gse
 
             session_key = get_current_session_key(default="")
             effective_cwd = workdir or cwd
+            agent_profile = _gse("HERMES_SESSION_AGENT_PROFILE", "")
+            agent_hermes_home = _gse("HERMES_SESSION_AGENT_HERMES_HOME", "")
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -1937,6 +1986,8 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        agent_profile=agent_profile,
+                        agent_hermes_home=agent_hermes_home,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -1945,6 +1996,8 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        agent_profile=agent_profile,
+                        agent_hermes_home=agent_hermes_home,
                     )
 
                 result_data = {
@@ -1963,7 +2016,6 @@ def terminal_tool(
                 # watch-pattern and completion notifications can be
                 # routed back to the correct chat/thread.
                 if background and (notify_on_complete or watch_patterns):
-                    from gateway.session_context import get_session_env as _gse
                     _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
                     if _gw_platform:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
@@ -2008,6 +2060,8 @@ def terminal_tool(
                             "session_id": proc_session.id,
                             "check_interval": 5,
                             "session_key": session_key,
+                            "agent_profile": proc_session.agent_profile,
+                            "agent_hermes_home": proc_session.agent_hermes_home,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
                             "user_id": proc_session.watcher_user_id,
@@ -2022,6 +2076,7 @@ def terminal_tool(
                     proc_session.watch_patterns = list(watch_patterns)
                     result_data["watch_patterns"] = proc_session.watch_patterns
 
+                process_registry._write_checkpoint()
                 return json.dumps(result_data, ensure_ascii=False)
             except Exception as e:
                 return json.dumps({

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -569,6 +569,29 @@ Messages in Telegram topics `31` and `42` are always ignored before the mention 
 - Invalid regex patterns are ignored with a warning in the gateway logs rather than crashing the bot
 - If you want a pattern to match only at the start of a message, anchor it with `^`
 
+## Routing Topics to Profiles
+
+Operators can route specific Telegram forum topics to isolated Hermes profiles. This is useful when one bot serves several specialized agents in the same Telegram group.
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      topic_profiles_safe_root: ~/.hermes-topic-profiles
+      topic_profiles:
+        - match:
+            chat_id: "-1001234567890"
+            thread_id: 101
+          profile: shopping
+          profile_home: ~/.hermes-topic-profiles/shopping
+```
+
+For a routed topic, Hermes reads `SOUL.md`, `config.yaml`, `.env`, sessions, memory files, and skills from the routed profile home.
+Each routed profile should include its own provider/model settings in `config.yaml` and its own API keys in `.env`; these are not inherited from the gateway profile.
+Configure `topic_profiles` under `platforms.telegram.extra` as shown above, or under the legacy top-level `telegram.topic_profiles` bridge. `ui.platforms.telegram.topic_profiles` is ignored.
+Gateway-level custom `platform_toolsets` and `mcp_servers` are not inherited by the routed profile.
+If a topic profile needs custom tools or MCP servers, declare them in that profile's own `config.yaml`; otherwise it uses the normal Hermes defaults for that profile.
+
 ## Private Chat Topics (Bot API 9.4)
 
 Telegram Bot API 9.4 (February 2026) introduced **Private Chat Topics** — bots can create forum-style topic threads directly in 1-on-1 DM chats, no supergroup needed. This lets you run multiple isolated workspaces within your existing DM with Hermes.
@@ -577,7 +600,7 @@ Telegram Bot API 9.4 (February 2026) introduced **Private Chat Topics** — bots
 
 If you work on several long-running projects, topics keep their context separate:
 
-- **Topic "Website"** — work on your production web service
+- **Topic "Workspace"** — work on a dedicated project context
 - **Topic "Research"** — literature review and paper exploration
 - **Topic "General"** — miscellaneous tasks and quick questions
 


### PR DESCRIPTION
## What does this PR do?

Adds Telegram forum topic routing to existing Hermes profiles.

A single Telegram bot can now route `chat_id + message_thread_id` to a named Hermes profile, so each topic can use its own profile config, model, `SOUL.md`, system prompt, toolsets, `.env`, memory, sessions, and state.

Unconfigured chats/topics keep the current behavior.

## Related Issue

Fixes #10143 and #4321. Refs #9514 and #7517.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: resolve Telegram forum `message_thread_id` to a routed profile.
- `gateway/platforms/base.py`: add validation/normalization for `telegram.topic_profiles`.
- `gateway/run.py`: run routed messages under the target profile home/config/env.
- `gateway/session.py`: include profile in Telegram session keys.
- `hermes_cli/*`, `run_agent.py`: allow profile-scoped env/runtime provider resolution without mutating global `os.environ`.
- `scripts/setup_topic_routing_sandbox.sh`: add safe local sandbox helper.
- Tests for routing, profile isolation, env isolation, memory/session separation, provider config, and Telegram fallback behavior.

Example:

```yaml
telegram:
  topic_profiles:
    - match:
        chat_id: "-1001234567890"
        thread_id: 42
      profile: research
```

## How to Test

```bash
python -m pytest \
  tests/gateway/test_topic_profile_routing.py \
  tests/gateway/test_telegram_thread_fallback.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/gateway/test_discord_channel_prompts.py \
  -q
```

Result: `158 passed`.

Manual sandbox validation was also run with a separate Telegram test bot:
- General topic -> main gateway profile
- topic A -> profile A with its own OpenRouter model
- topic B -> profile B with its own OpenRouter model
- profile memory writes landed in each profile's own `memories/MEMORY.md`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, sandbox `HERMES_HOME`, Telegram test bot

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact
- [ ] I've updated tool descriptions/schemas — N/A
