### PR TITLE
Fix/api server slash commands extras

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -965,7 +965,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return str(e)
             if not sanitized:
                 return "Title must have printable characters."
-            db.set_session_title(session_id, sanitized)
+            try:
+                db.set_session_title(session_id, sanitized)
+            except ValueError as e:
+                return f"⚠️  {e}"
             return f"Title set: {sanitized}"
 
         title = db.get_session_title(session_id)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -61,6 +61,19 @@ CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
+# Slash commands supported over the API server (subset of gateway commands).
+# Commands NOT in this set fall through to the LLM as normal user messages.
+_API_SERVER_SLASH_COMMANDS: frozenset[str] = frozenset({
+    "help",
+    "new",
+    "reset",
+    "title",
+    "status",
+    "usage",
+    "retry",
+    "undo",
+})
+
 
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
@@ -857,6 +870,262 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         })
 
+    # ------------------------------------------------------------------
+    # Slash command dispatch (API server subset)
+    # ------------------------------------------------------------------
+
+    async def _try_slash_command(
+        self, user_message: str, session_id: str, body: dict
+    ) -> Optional[dict]:
+        """Try to handle *user_message* as a slash command.
+
+        Returns:
+            ``{"handled": True, "response": str}`` — return as chat completion
+            ``{"handled": True, "rewrite_message": str}`` — replace message, fall through to agent
+            ``None`` — not a slash command, normal processing
+        """
+        if not isinstance(user_message, str) or not user_message.startswith("/"):
+            return None
+
+        from gateway.platforms.base import MessageEvent
+
+        # Reuse the same parser the gateway uses — /title my session
+        # tokenizes identically over SMS-via-API as it does over Telegram.
+        event = MessageEvent(text=user_message)
+        command = event.get_command()
+        if not command:
+            return None  # "/ " or "/path/to/file" — not a command
+
+        args = event.get_command_args().strip()
+
+        # Only intercept commands we explicitly support.  Telegram-style
+        # commands (/personality, /voice, /model, …) fall through to the
+        # LLM as normal user messages.
+        if command not in _API_SERVER_SLASH_COMMANDS:
+            return None
+
+        if command in ("help",):
+            return {"handled": True, "response": self._slash_help()}
+
+        if command in ("new", "reset"):
+            return {"handled": True, "response": self._slash_reset(session_id)}
+
+        if command == "title":
+            return {"handled": True, "response": self._slash_title(session_id, args)}
+
+        if command == "status":
+            return {"handled": True, "response": self._slash_status(session_id, body)}
+
+        if command == "usage":
+            return {"handled": True, "response": self._slash_usage(session_id)}
+
+        if command == "undo":
+            return {"handled": True, "response": self._slash_undo(session_id)}
+
+        if command == "retry":
+            recovered = self._slash_retry(session_id)
+            if recovered is None:
+                return {"handled": True, "response": "No previous message to retry."}
+            return {"handled": True, "rewrite_message": recovered}
+
+        return None  # Shouldn't reach here, but be safe
+
+    # -- individual command handlers -------------------------------------
+
+    def _slash_help(self) -> str:
+        """Return a plain-text list of API-server-supported slash commands."""
+        return (
+            "Available commands: "
+            "/new (reset session), "
+            "/title <name> (set session title), "
+            "/status (session info), "
+            "/usage (token counts), "
+            "/retry (rerun last message), "
+            "/undo (remove last exchange), "
+            "/help (this list)"
+        )
+
+    def _slash_reset(self, session_id: str) -> str:
+        """Clear all messages for *session_id*."""
+        db = self._ensure_session_db()
+        if db is not None:
+            db.clear_messages(session_id)
+        return "Session reset. Starting fresh."
+
+    def _slash_title(self, session_id: str, args: str) -> str:
+        """Set or show the session title."""
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        if args:
+            try:
+                sanitized = db.sanitize_title(args)
+            except ValueError as e:
+                return str(e)
+            if not sanitized:
+                return "Title must have printable characters."
+            db.set_session_title(session_id, sanitized)
+            return f"Title set: {sanitized}"
+
+        title = db.get_session_title(session_id)
+        if title:
+            return f"Title: {title}"
+        return "No title set. Usage: /title My Session Name"
+
+    def _slash_status(self, session_id: str, body: dict) -> str:
+        """Return a single-line session summary: messages, tokens, model, age."""
+        db = self._ensure_session_db()
+        model = body.get("model", self._model_name) if body else self._model_name
+
+        msg_count = db.message_count(session_id) if db else 0
+        parts = [f"{msg_count} msgs"]
+
+        if db is not None:
+            session = db.get_session(session_id)
+            if session:
+                inp = session.get("input_tokens", 0) or 0
+                out = session.get("output_tokens", 0) or 0
+                total = inp + out
+                if total:
+                    if total >= 1000:
+                        parts.append(f"{total / 1000:.0f}k tokens")
+                    else:
+                        parts.append(f"{total} tokens")
+                started = session.get("started_at")
+                if started:
+                    age_s = time.time() - started
+                    if age_s < 3600:
+                        parts.append(f"{max(1, age_s / 60):.0f}m old")
+                    elif age_s < 86400:
+                        parts.append(f"{age_s / 3600:.0f}h old")
+                    else:
+                        parts.append(f"{age_s / 86400:.0f}d old")
+
+        parts.append(model)
+        return f"session: {', '.join(parts)}"
+
+    def _slash_usage(self, session_id: str) -> str:
+        """Return token counts for the session."""
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        session = db.get_session(session_id)
+        if not session:
+            return "Session not found."
+
+        inp = session.get("input_tokens", 0) or 0
+        out = session.get("output_tokens", 0) or 0
+        total = inp + out
+        return f"{inp:,} in / {out:,} out / {total:,} total tokens"
+
+    def _slash_undo(self, session_id: str) -> str:
+        """Remove the last user/assistant exchange, transactionally."""
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        messages = db.get_messages(session_id)
+        if not messages:
+            return "Nothing to undo."
+
+        # Find the last user message index
+        last_user_idx = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+
+        if last_user_idx is None:
+            return "Nothing to undo."
+
+        removed_msg = messages[last_user_idx].get("content", "") or ""
+        removed_count = len(messages) - last_user_idx
+        old_count = len(messages)
+        new_count = last_user_idx
+
+        # Delete the tail rows in a single transaction
+        ids_to_delete = [messages[j]["id"] for j in range(last_user_idx, len(messages))]
+        placeholders = ",".join("?" for _ in ids_to_delete)
+
+        def _do(conn):
+            conn.execute(
+                f"DELETE FROM messages WHERE id IN ({placeholders})",
+                ids_to_delete,
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ? WHERE id = ?",
+                (new_count, session_id),
+            )
+
+        db._execute_write(_do)
+
+        logger.info(
+            "Rebuilt session %s: %d → %d messages (/undo)",
+            session_id, old_count, new_count,
+        )
+
+        preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
+        return f'Removed last {removed_count} message(s): "{preview}"'
+
+    def _slash_retry(self, session_id: str) -> Optional[str]:
+        """Return the last user message for re-processing, or None.
+
+        Truncates history so the retry doesn't duplicate context.
+        Caller is responsible for passing the returned message through
+        the normal agent run path.
+        """
+        db = self._ensure_session_db()
+        if db is None:
+            return None
+
+        messages = db.get_messages(session_id)
+        if not messages:
+            return None
+
+        # Find the last user message
+        last_user_idx = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+
+        if last_user_idx is None:
+            return None
+
+        last_user_content = messages[last_user_idx].get("content", "") or ""
+        if not last_user_content:
+            return None
+
+        old_count = len(messages)
+        new_count = last_user_idx  # keep everything BEFORE the last user msg
+
+        # Delete the tail (last user msg + everything after) in one transaction
+        ids_to_delete = [
+            messages[j]["id"] for j in range(last_user_idx, len(messages))
+        ]
+        placeholders = ",".join("?" for _ in ids_to_delete)
+
+        def _do(conn):
+            conn.execute(
+                f"DELETE FROM messages WHERE id IN ({placeholders})",
+                ids_to_delete,
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ? WHERE id = ?",
+                (new_count, session_id),
+            )
+
+        db._execute_write(_do)
+
+        logger.info(
+            "Rebuilt session %s: %d → %d messages (/retry)",
+            session_id, old_count, new_count,
+        )
+
+        return last_user_content
+
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
@@ -961,6 +1230,52 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
             session_id = _derive_chat_session_id(system_prompt, first_user)
             # history already set from request body above
+
+        # ── slash command interception ──────────────────────────────────
+        slash_result = await self._try_slash_command(
+            user_message, session_id, body
+        )
+        if slash_result is not None:
+            if slash_result.get("rewrite_message"):
+                # /retry — replace message and fall through to normal agent run.
+                # The command already truncated history so the retry doesn't
+                # duplicate context.  Reload history from DB to pick up the
+                # truncated state (history was loaded before our truncation).
+                user_message = slash_result["rewrite_message"]
+                db = self._ensure_session_db()
+                if db is not None:
+                    try:
+                        history = db.get_messages_as_conversation(session_id)
+                    except Exception:
+                        pass
+            else:
+                # Simple command response — return immediately, no LLM call.
+                response_text = slash_result.get("response", "")
+                return web.json_response(
+                    {
+                        "id": f"chatcmpl-{uuid.uuid4().hex[:29]}",
+                        "object": "chat.completion",
+                        "created": int(time.time()),
+                        "model": body.get("model", self._model_name),
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": response_text,
+                                },
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 0,
+                            "completion_tokens": 0,
+                            "total_tokens": 0,
+                        },
+                    },
+                    headers={"X-Hermes-Session-Id": session_id},
+                )
+        # ─────────────────────────────────────────────────────────────────
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -72,6 +72,9 @@ _API_SERVER_SLASH_COMMANDS: frozenset[str] = frozenset({
     "usage",
     "retry",
     "undo",
+    "profile",
+    "branch",
+    "resume",
 })
 
 
@@ -928,6 +931,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 return {"handled": True, "response": "No previous message to retry."}
             return {"handled": True, "rewrite_message": recovered}
 
+        if command == "profile":
+            return {"handled": True, "response": self._slash_profile()}
+
+        if command == "branch":
+            return {"handled": True, "response": self._slash_branch(session_id, args)}
+
+        if command == "resume":
+            return {"handled": True, "response": self._slash_resume(args)}
+
         return None  # Shouldn't reach here, but be safe
 
     # -- individual command handlers -------------------------------------
@@ -942,6 +954,9 @@ class APIServerAdapter(BasePlatformAdapter):
             "/usage (token counts), "
             "/retry (rerun last message), "
             "/undo (remove last exchange), "
+            "/profile (show active profile), "
+            "/branch [name] (fork session), "
+            "/resume [name] (resume named session), "
             "/help (this list)"
         )
 
@@ -1128,6 +1143,188 @@ class APIServerAdapter(BasePlatformAdapter):
         )
 
         return last_user_content
+
+    def _slash_profile(self) -> str:
+        """Return the active profile name and home directory.
+
+        Mirrors ``_handle_profile_command`` in gateway/run.py.
+        """
+        from hermes_constants import display_hermes_home
+        from hermes_cli.profiles import get_active_profile_name
+
+        display = display_hermes_home()
+        profile_name = get_active_profile_name()
+
+        lines = [
+            f"👤 Profile: `{profile_name}`",
+            f"📂 Home: `{display}`",
+        ]
+        return "\n".join(lines)
+
+    def _slash_branch(self, session_id: str, args: str) -> str:
+        """Fork the current session into a new independent copy.
+
+        Copies conversation history to a new session so callers can explore
+        a different path without losing the original.  Returns the new
+        session_id for the caller to use via ``X-Hermes-Session-Id`` on
+        subsequent requests.
+
+        Mirrors ``_handle_branch_command`` in gateway/run.py.
+        """
+        import uuid as _uuid
+        from datetime import datetime as _dt
+
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        # Load current session transcript
+        messages = db.get_messages(session_id)
+        if not messages:
+            return "No conversation to branch — send a message first."
+
+        branch_name = args
+
+        # Generate new session_id — same format as gateway/run.py:9141
+        now = _dt.now()
+        timestamp_str = now.strftime("%Y%m%d_%H%M%S")
+        short_uuid = _uuid.uuid4().hex[:6]
+        new_session_id = f"{timestamp_str}_{short_uuid}"
+
+        # Determine branch title
+        if branch_name:
+            branch_title = branch_name
+        else:
+            current_title = db.get_session_title(session_id)
+            base = current_title or "branch"
+            branch_title = db.get_next_title_in_lineage(base)
+
+        # Create the new session with parent link
+        try:
+            db.create_session(
+                session_id=new_session_id,
+                source="api_server",
+                parent_session_id=session_id,
+            )
+        except Exception as e:
+            logger.error("Failed to create branch session: %s", e)
+            return f"Failed to create branch: {e}"
+
+        # Copy conversation history to the new session
+        for msg in messages:
+            try:
+                db.append_message(
+                    session_id=new_session_id,
+                    role=msg.get("role", "user"),
+                    content=msg.get("content"),
+                    tool_name=msg.get("tool_name") or msg.get("name"),
+                    tool_calls=msg.get("tool_calls"),
+                    tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
+                    reasoning=msg.get("reasoning"),
+                    reasoning_content=msg.get("reasoning_content"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
+                    codex_message_items=msg.get("codex_message_items"),
+                )
+            except Exception:
+                pass  # Best-effort copy
+
+        # Set title
+        try:
+            db.set_session_title(new_session_id, branch_title)
+        except Exception:
+            pass
+
+        user_msg_count = len([m for m in messages if m.get("role") == "user"])
+        return (
+            f"⑂ Branched to **{branch_title}**\n"
+            f"Session ID: `{new_session_id}` ({user_msg_count} msg)"
+        )
+
+    def _slash_resume(self, args: str) -> str:
+        """Resolve a session title to its session_id.
+
+        ``/resume`` with no arguments lists recently titled sessions.
+        ``/resume <name>`` resolves *name* to a session_id via
+        ``SessionDB.resolve_session_by_title()``.
+
+        The api_server has no server-side session state to switch — the
+        returned session_id is for the caller to use on subsequent requests
+        via ``X-Hermes-Session-Id``.  This mirrors the gateway's
+        ``_handle_resume_command``, adapted for the stateless HTTP model.
+
+        Mirrors ``_handle_resume_command`` in gateway/run.py.
+        """
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        if not args:
+            # List recent titled sessions
+            try:
+                sessions = db.list_sessions_rich(source="api_server", limit=10)
+                # Also include sessions without an explicit source (bridge
+                # sessions created via X-Hermes-Session-Id may have source="")
+                all_sessions = db.list_sessions_rich(limit=20)
+                titled: list[dict] = []
+                seen: set[str] = set()
+                for s in sessions + all_sessions:
+                    sid = s.get("id", "")
+                    title = s.get("title")
+                    if title and sid not in seen:
+                        seen.add(sid)
+                        titled.append(s)
+                titled = titled[:10]
+
+                if not titled:
+                    return (
+                        "No named sessions found.\n"
+                        "Use `/title My Session` to name your current "
+                        "session, then `/resume My Session` to return to "
+                        "it later."
+                    )
+
+                lines = ["📋 **Named Sessions**\n"]
+                for s in titled:
+                    title = s["title"]
+                    msg_count = s.get("message_count", 0) or 0
+                    lines.append(f"• **{title}** — {msg_count} msg")
+                lines.append("\nUsage: `/resume <name>`")
+                return "\n".join(lines)
+            except Exception as e:
+                logger.debug("Failed to list titled sessions: %s", e)
+                return f"Could not list sessions: {e}"
+
+        name = args
+
+        # Resolve the name to a session ID
+        target_id = db.resolve_session_by_title(name)
+        if not target_id:
+            return (
+                f"No session found matching '{name}'.\n"
+                "Use `/resume` with no arguments to see available sessions."
+            )
+
+        # Follow compression chain — resolves continuation IDs
+        try:
+            target_id = db.resolve_resume_session_id(target_id)
+        except Exception as e:
+            logger.debug(
+                "Failed to resolve resume continuation for %s: %s",
+                target_id, e,
+            )
+
+        # Get title for confirmation
+        title = db.get_session_title(target_id) or name
+
+        # Count messages
+        msg_count = db.message_count(target_id) or 0
+
+        return (
+            f"↻ Resumed **{title}**\n"
+            f"Session ID: `{target_id}` ({msg_count} msg)"
+        )
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2619,6 +2619,29 @@ class TestSlashCommandInterception:
             assert data["usage"]["total_tokens"] == 0
 
     @pytest.mark.asyncio
+    async def test_title_duplicate_returns_warning_not_500(self, adapter):
+        """/title returns a ⚠️ warning (not 500) when set_session_title raises ValueError."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.sanitize_title = lambda t: t.strip() if t else None
+        mock_db.set_session_title = MagicMock(side_effect=ValueError("A session with this title already exists"))
+        mock_db.get_session_title = MagicMock(return_value=None)
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/title My Duped Title"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "⚠️" in content
+            assert "already exists" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
     async def test_retry_triggers_agent_rerun(self, auth_adapter):
         """/retry rewrites the message and reruns the agent."""
         mock_result = {"final_response": "Fresh answer!", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2711,3 +2711,357 @@ class TestSlashCommandInterception:
             data = await resp.json()
             assert "Nothing to undo" in data["choices"][0]["message"]["content"]
             assert data["usage"]["total_tokens"] == 0
+
+    # ── /profile ────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_profile_returns_active_profile(self, adapter):
+        """/profile returns the active profile name and home directory."""
+        app = _create_app(adapter)
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="my-profile"), \
+             patch("hermes_constants.display_hermes_home", return_value="/home/user/.hermes"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/profile"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                content = data["choices"][0]["message"]["content"]
+                assert "👤" in content
+                assert "my-profile" in content
+                assert "/home/user/.hermes" in content
+                assert data["usage"]["total_tokens"] == 0
+
+    # ── /branch ─────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_branch_clones_with_default_title(self, auth_adapter):
+        """/branch with no name auto-generates a title and returns new session ID."""
+        app = _create_app(auth_adapter)
+        session_id = "test-branch-session-001"
+
+        mock_messages = [
+            {"role": "user", "content": "hello", "id": 1},
+            {"role": "assistant", "content": "hi", "id": 2},
+            {"role": "user", "content": "how are you", "id": 3},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages.return_value = mock_messages
+        mock_db.get_session_title.return_value = "Old Title"
+        mock_db.get_next_title_in_lineage.return_value = "Old Title #2"
+        mock_db.create_session = MagicMock()
+        mock_db.append_message = MagicMock()
+        mock_db.set_session_title = MagicMock()
+        auth_adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Id": session_id, "Authorization": "Bearer sk-secret"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/branch"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "⑂" in content
+            assert "Old Title #2" in content
+            assert "Session ID:" in content
+            assert "2 msg" in content
+            assert data["usage"]["total_tokens"] == 0
+            mock_db.create_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_branch_with_custom_title(self, auth_adapter):
+        """/branch My Name uses the provided name as the title."""
+        app = _create_app(auth_adapter)
+        session_id = "test-branch-session-002"
+
+        mock_messages = [
+            {"role": "user", "content": "test", "id": 1},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages.return_value = mock_messages
+        mock_db.create_session = MagicMock()
+        mock_db.append_message = MagicMock()
+        mock_db.set_session_title = MagicMock()
+        auth_adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Id": session_id, "Authorization": "Bearer sk-secret"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/branch My Custom Branch"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "My Custom Branch" in content
+            assert "1 msg" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_branch_no_history_returns_error(self, adapter):
+        """/branch with an empty session returns a helpful message."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.get_messages.return_value = []
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/branch"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "No conversation to branch" in data["choices"][0]["message"]["content"]
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_branch_copies_all_message_fields(self, auth_adapter):
+        """/branch copies tool_calls, reasoning, and metadata to the new session."""
+        app = _create_app(auth_adapter)
+        session_id = "test-branch-rich-003"
+
+        mock_messages = [
+            {"role": "user", "content": "run test", "id": 1},
+            {"role": "assistant", "content": None, "tool_calls": "[{\"id\":\"t1\"}]", "id": 2},
+            {"role": "tool", "content": "result", "tool_call_id": "t1", "tool_name": "terminal", "id": 3},
+            {"role": "assistant", "content": "done", "reasoning": "thought here", "id": 4},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages.return_value = mock_messages
+        mock_db.get_session_title.return_value = None
+        mock_db.get_next_title_in_lineage.return_value = "branch"
+        mock_db.create_session = MagicMock()
+        mock_db.append_message = MagicMock()
+        mock_db.set_session_title = MagicMock()
+        auth_adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Id": session_id, "Authorization": "Bearer sk-secret"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/branch"}]},
+            )
+            assert resp.status == 200
+            # All 4 messages should be copied
+            assert mock_db.append_message.call_count == 4
+            # First message is plain user text
+            first_call = mock_db.append_message.call_args_list[0].kwargs
+            assert first_call["role"] == "user"
+            assert first_call["content"] == "run test"
+            # Tool message should carry tool_call_id and tool_name
+            tool_call = mock_db.append_message.call_args_list[2].kwargs
+            assert tool_call["tool_call_id"] == "t1"
+            assert tool_call["tool_name"] == "terminal"
+
+    # ── /resume ─────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_resume_no_args_lists_titled_sessions(self, adapter):
+        """/resume with no arguments lists recent titled sessions."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = [
+            {"id": "s1", "title": "Research", "message_count": 12},
+            {"id": "s2", "title": "Debug Session", "message_count": 5},
+        ]
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "📋" in content
+            assert "Research" in content
+            assert "12 msg" in content
+            assert "Debug Session" in content
+            assert "5 msg" in content
+            assert "/resume" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_no_args_empty_result(self, adapter):
+        """/resume with no titled sessions returns usage guidance."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "No named sessions" in content
+            assert "/title" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_valid_title_returns_session_id(self, adapter):
+        """/resume <name> resolves the title and returns the session ID."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.resolve_session_by_title.return_value = "20260428_120000_abc123"
+        mock_db.resolve_resume_session_id.return_value = "20260428_120000_abc123"
+        mock_db.get_session_title.return_value = "My Session"
+        mock_db.message_count.return_value = 42
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume My Session"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "↻" in content
+            assert "My Session" in content
+            assert "20260428_120000_abc123" in content
+            assert "42 msg" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_invalid_title_returns_error(self, adapter):
+        """/resume NonExistent returns a clear error message."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.resolve_session_by_title.return_value = None
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume Bad Name"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "No session found" in content
+            assert "Bad Name" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_follows_compression_chain(self, adapter):
+        """/resume follows the compression chain via resolve_resume_session_id."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.resolve_session_by_title.return_value = "old-session-001"
+        # Compression created a continuation — resume should return the latest
+        mock_db.resolve_resume_session_id.return_value = "old-session-001-cont-2"
+        mock_db.get_session_title.return_value = "My Session"
+        mock_db.message_count.return_value = 15
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume My Session"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            # Should return the continuation ID, not the original
+            assert "old-session-001-cont-2" in content
+            mock_db.resolve_resume_session_id.assert_called_once_with("old-session-001")
+
+    @pytest.mark.asyncio
+    async def test_resume_deduplicates_listed_sessions(self, adapter):
+        """/resume listing deduplicates sessions with the same ID."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        # First call returns api_server sessions, second returns all
+        mock_db.list_sessions_rich.side_effect = [
+            [{"id": "s1", "title": "Alpha", "message_count": 3}],
+            [{"id": "s1", "title": "Alpha", "message_count": 3},
+             {"id": "s2", "title": "Beta", "message_count": 7}],
+        ]
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            # Both appear, Alpha only once
+            assert content.count("Alpha") == 1
+            assert "Beta" in content
+
+    # ── Dispatcher integration ───────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_profile_intercepted_before_llm(self, adapter):
+        """/profile never reaches the agent — zero tokens consumed."""
+        app = _create_app(adapter)
+        with patch.object(adapter, "_slash_profile", return_value="Profile: default"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/profile"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_branch_intercepted_before_llm(self, auth_adapter):
+        """/branch never reaches the agent — zero tokens consumed."""
+        app = _create_app(auth_adapter)
+        session_id = "test-intercept-branch-001"
+        mock_db = MagicMock()
+        mock_db.get_messages.return_value = [{"role": "user", "content": "hi", "id": 1}]
+        mock_db.get_session_title.return_value = None
+        mock_db.get_next_title_in_lineage.return_value = "branch"
+        mock_db.create_session = MagicMock()
+        mock_db.append_message = MagicMock()
+        mock_db.set_session_title = MagicMock()
+        auth_adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Id": session_id, "Authorization": "Bearer sk-secret"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/branch"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resume_intercepted_before_llm(self, adapter):
+        """/resume never reaches the agent — zero tokens consumed."""
+        app = _create_app(adapter)
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = [
+            {"id": "s1", "title": "Test", "message_count": 1},
+        ]
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/resume"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["usage"]["total_tokens"] == 0

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2491,3 +2491,200 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+# ---------------------------------------------------------------------------
+# Slash command interception
+# ---------------------------------------------------------------------------
+
+
+class TestSlashCommandInterception:
+    """Slash commands are intercepted before the LLM call."""
+
+    @pytest.mark.asyncio
+    async def test_help_command_returns_formatted_list(self, adapter):
+        """/help returns the command list without hitting the LLM."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/help"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "/new" in content
+            assert "/help" in content
+            assert "/status" in content
+            # Must be a slash response, not an LLM response — no tokens consumed
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_new_reset_clears_session(self, adapter):
+        """/new and /reset both clear the session and return confirmation."""
+        for cmd in ("/new", "/reset"):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": cmd}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert "Session reset" in data["choices"][0]["message"]["content"]
+                assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_non_slash_message_passes_through_to_llm(self, adapter):
+        """A non-slash message is NOT intercepted — it reaches the agent."""
+        mock_result = {"final_response": "Hello, human!", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 50, "output_tokens": 20, "total_tokens": 70}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Hello"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            # The agent ran and produced a response
+            assert data["choices"][0]["message"]["content"] == "Hello, human!"
+            assert data["usage"]["total_tokens"] == 70
+            mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slash_command_passes_through_to_llm(self, adapter):
+        """/xyz123 (not in supported set) falls through to the LLM."""
+        mock_result = {"final_response": "I don't know that command", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/xyz123"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            # The agent ran (not intercepted)
+            assert data["choices"][0]["message"]["content"] == "I don't know that command"
+            mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_malformed_slash_not_treated_as_command(self, adapter):
+        """/path/to/file (contains extra slashes) is not parsed as a command."""
+        mock_result = {"final_response": "That looks like a path", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/path/to/file"}]},
+                )
+            assert resp.status == 200
+            # Falls through to LLM — not treated as a command
+            mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_title_set_and_show(self, adapter):
+        """/title sets the session title via SessionDB."""
+        app = _create_app(adapter)
+        session_id = "test-title-session-002"
+
+        # Mock SessionDB to store/retrieve title
+        mock_db = MagicMock()
+        mock_db.sanitize_title = lambda t: t.strip() if t else None
+        mock_db.set_session_title = MagicMock(return_value=True)
+        mock_db.get_session_title = MagicMock(return_value=None)
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            # Set title
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/title hello world"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "hello world" in data["choices"][0]["message"]["content"]
+            mock_db.set_session_title.assert_called_once()
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_triggers_agent_rerun(self, auth_adapter):
+        """/retry rewrites the message and reruns the agent."""
+        mock_result = {"final_response": "Fresh answer!", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 100, "output_tokens": 30, "total_tokens": 130}
+
+        app = _create_app(auth_adapter)
+        session_id = "test-retry-session-004"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_slash_retry", return_value="recovered question"), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": session_id, "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/retry"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["choices"][0]["message"]["content"] == "Fresh answer!"
+                assert data["usage"]["total_tokens"] == 130
+                # Verify agent was called with the recovered message
+                mock_run.assert_awaited_once()
+                call_kwargs = mock_run.call_args.kwargs
+                assert call_kwargs["user_message"] == "recovered question"
+
+    @pytest.mark.asyncio
+    async def test_undo_removes_last_exchange(self, adapter):
+        """/undo returns a confirmation message."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_slash_undo", return_value="Removed 2 message(s): \"test\""):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/undo"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                content = data["choices"][0]["message"]["content"]
+                assert "Removed" in content or "Undid" in content
+                assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_with_no_history_returns_error(self, adapter):
+        """/retry with no prior messages returns a helpful message."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/retry"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "No previous message" in data["choices"][0]["message"]["content"]
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_undo_with_no_history_returns_error(self, adapter):
+        """/undo with nothing to undo returns a helpful message."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/undo"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "Nothing to undo" in data["choices"][0]["message"]["content"]
+            assert data["usage"]["total_tokens"] == 0


### PR DESCRIPTION
Depends on #17178.

Extend the api_server slash command support with three new commands mirroring the gateway's existing handlers. All three are intercepted before the LLM call — zero token cost.

- `/profile` — show active profile name and home directory
- `/branch [name]` — fork the current session into a new independent copy. Copies full conversation history (including tool calls, reasoning, and metadata). Returns the new session_id for use via X-Hermes-Session-Id.
- `/resume [name]` — resolve a session title to its session_id. With no arguments, lists recently titled sessions. With a name, resolves via SessionDB.resolve_session_by_title() and returns the session_id.

**/resume design note:** /resume is intentionally a lookup-and-return, not a server-side session switch. The api_server's session routing is client-managed via X-Hermes-Session-Id — there is no "current session" to mutate. This is the correct shape for a stateless HTTP API, parallel to the gateway's stateful /resume that switches the server-side session. Clients receive the resolved session_id and use it on subsequent requests.

**Scope:** Adds three entries to _API_SERVER_SLASH_COMMANDS, three dispatch cases in _try_slash_command(), and three handler methods. All use existing SessionDB methods — no new DB code.

**Tests:** 14 new test methods in TestSlashCommandInterception, mirroring the existing slash command test patterns. Full gateway suite: 4068 passed, 1 pre-existing WhatsApp failure.

---

## What does this PR do?

Add /profile, /branch, and /resume slash commands to the api_server platform, extending the slash command infrastructure from #17178.

## Related Issue

Depends on #17178 — builds on the _try_slash_command() dispatcher and _API_SERVER_SLASH_COMMANDS frozenset introduced there.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ⚠️ Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactor
- [ ] ⚡ Performance

## Changes Made

- `gateway/platforms/api_server.py`: Added `_slash_profile()`, `_slash_branch()`, `_slash_resume()` handler methods on `APIServerAdapter`. Updated `_API_SERVER_SLASH_COMMANDS` frozenset and `_try_slash_command()` dispatcher.
- `tests/gateway/test_api_server.py`: 14 new tests in `TestSlashCommandInterception`.

## How to Test

`pytest tests/gateway/test_api_server.py::TestSlashCommandInterception -v`

25 tests pass (11 existing + 14 new). Full gateway suite shows no regressions (4068 passed).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run pytest tests/ and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: api_server

### Documentation & Housekeeping

- [x] N/A — no doc changes needed
- [x] N/A — no config keys changed
- [x] N/A — no architecture changes
- [x] N/A — cross-platform compatibility unaffected
- [x] N/A — no tool behavior changes

