### PR TITLE
fix(kanban): normalize profile names to lowercase in assign_task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_cli.profiles import normalize_profile_name
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -818,7 +820,12 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 
     Refuses to reassign a task that's currently running (claim_lock set).
     Reassign after the current run completes if needed.
+
+    Profile names are normalized to lowercase before storage so that
+    mixed-case inputs from the dashboard UI (e.g. ``Jules``) resolve
+    correctly during dispatch.  See GH #18498.
     """
+    profile = normalize_profile_name(profile)
     with write_txn(conn):
         row = conn.execute(
             "SELECT status, claim_lock FROM tasks WHERE id = ?", (task_id,)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -190,6 +190,24 @@ def validate_profile_name(name: str) -> None:
         )
 
 
+def normalize_profile_name(name: str | None) -> str | None:
+    """Lowercase a profile name so mixed-case inputs resolve correctly.
+
+    The dashboard UI and CLI may pass title-cased or upper-cased profile
+    names (e.g. ``Jules``, ``LIBRARIAN``), but profile directories and
+    the validation regex are strictly lowercase.  This helper normalizes
+    the name before validation / storage so the dispatcher does not hit
+    ``Invalid profile name`` errors at runtime.
+
+    * ``"default"`` is preserved as-is (special alias for ``~/.hermes``).
+    * ``None`` passes through (used for unassign).
+    * Empty string passes through (caller handles).
+    """
+    if name is None or name == "" or name == "default":
+        return name
+    return name.lower()
+
+
 def get_profile_dir(name: str) -> Path:
     """Resolve a profile name to its HERMES_HOME directory."""
     if name == "default":

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -436,3 +436,56 @@ def test_tenant_propagates_to_events(kanban_home):
     # The "created" event should have tenant in its payload.
     created = [e for e in events if e.kind == "created"]
     assert created and created[0].payload.get("tenant") == "biz-a"
+
+
+# ---------------------------------------------------------------------------
+# Profile name normalization in assign_task
+# ---------------------------------------------------------------------------
+
+def test_assign_task_normalizes_profile_to_lowercase(kanban_home):
+    """assign_task() should normalize mixed-case profile names to lowercase.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/18498
+    The dashboard UI may pass title-cased profile names (e.g. 'Jules'), but
+    the profile validation regex only accepts lowercase.  Normalizing on write
+    prevents the dispatcher from hitting 'Invalid profile name' errors.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x")
+        # Assign with mixed case
+        assert kb.assign_task(conn, t, "Jules")
+        task = kb.get_task(conn, t)
+        # Should be normalized to lowercase
+        assert task.assignee == "jules"
+
+
+def test_assign_task_normalizes_title_case_profile(kanban_home):
+    """Title-cased profile names like 'Librarian' become 'librarian'."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x")
+        assert kb.assign_task(conn, t, "Librarian")
+        assert kb.get_task(conn, t).assignee == "librarian"
+
+
+def test_assign_task_preserves_already_lowercase(kanban_home):
+    """Already-lowercase names should pass through unchanged."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x")
+        assert kb.assign_task(conn, t, "jules")
+        assert kb.get_task(conn, t).assignee == "jules"
+
+
+def test_assign_task_preserves_default_special_case(kanban_home):
+    """'default' should not be lowercased (it's a special alias)."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x")
+        assert kb.assign_task(conn, t, "default")
+        assert kb.get_task(conn, t).assignee == "default"
+
+
+def test_assign_task_normalizes_none_passthrough(kanban_home):
+    """Unassigning (None) should still work after normalization."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="someone")
+        assert kb.assign_task(conn, t, None)
+        assert kb.get_task(conn, t).assignee is None

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -16,6 +16,7 @@ import pytest
 
 from hermes_cli.profiles import (
     validate_profile_name,
+    normalize_profile_name,
     get_profile_dir,
     create_profile,
     delete_profile,
@@ -88,6 +89,34 @@ class TestValidateProfileName:
     def test_empty_string_rejected(self):
         with pytest.raises(ValueError):
             validate_profile_name("")
+
+
+class TestNormalizeProfileName:
+    """Tests for normalize_profile_name()."""
+
+    def test_lowercase_unchanged(self):
+        assert normalize_profile_name("jules") == "jules"
+
+    def test_title_case_lowered(self):
+        assert normalize_profile_name("Jules") == "jules"
+
+    def test_uppercase_lowered(self):
+        assert normalize_profile_name("LIBRARIAN") == "librarian"
+
+    def test_mixed_case_lowered(self):
+        assert normalize_profile_name("MyAgent") == "myagent"
+
+    def test_default_preserved(self):
+        assert normalize_profile_name("default") == "default"
+
+    def test_none_passthrough(self):
+        assert normalize_profile_name(None) is None
+
+    def test_empty_string_passthrough(self):
+        assert normalize_profile_name("") == ""
+
+    def test_hyphenated_preserved(self):
+        assert normalize_profile_name("Work-Bot") == "work-bot"
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Normalize mixed-case profile names to lowercase in `assign_task()` so the Kanban dispatcher does not hit `Invalid profile name` errors when the dashboard UI passes title-cased assignees.

## Root Cause

The dashboard UI may pass profile names with mixed case (e.g. `Jules`, `Librarian`) to `kanban_db.assign_task()`. These are stored as-is in the DB. Later, when `dispatch_once()` spawns a worker via `hermes -p <assignee>`, the CLI's `validate_profile_name()` rejects the name because the regex `_PROFILE_ID_RE = r"^[a-z0-9][a-z0-9_-]{0,63}$"` only accepts lowercase.

The task is never claimed, and the dispatcher error is:
> Invalid profile name 'Jules'. Must match [a-z0-9][a-z0-9_-]{0,63}

## Fix

- Add `normalize_profile_name()` in `hermes_cli/profiles.py` that lowercases names (preserving `"default"` and `None`).
- Call it in `assign_task()` before storing the assignee in the DB.

This is a one-line change in the hot path (`profile = normalize_profile_name(profile)`) plus the helper function.

## Regression Coverage

- `test_assign_task_normalizes_profile_to_lowercase` — core regression: `"Jules"` → `"jules"`
- `test_assign_task_normalizes_title_case_profile` — `"Librarian"` → `"librarian"`
- `test_assign_task_preserves_already_lowercase` — idempotent for lowercase
- `test_assign_task_preserves_default_special_case` — `"default"` preserved
- `test_assign_task_normalizes_none_passthrough` — unassign still works
- 8 unit tests for `normalize_profile_name()` covering edge cases

## Testing

```
scripts/run_tests.sh tests/hermes_cli/test_profiles.py tests/hermes_cli/test_kanban_db.py
# 143 passed
```

Closes #18498
