### PR TITLE
fix: keep auxiliary credentials synced after pool exhaustion

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -1622,6 +1623,93 @@ def _is_auth_error(exc: Exception) -> bool:
         return True
     err_lower = str(exc).lower()
     return "error code: 401" in err_lower or "authenticationerror" in type(exc).__name__.lower()
+
+
+def _error_status_code(exc: Exception) -> Optional[int]:
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return status
+    return None
+
+
+def _error_context_from_exception(exc: Exception, *, reason: str) -> Dict[str, Any]:
+    """Build a credential-pool error context from provider exceptions."""
+    text = str(exc)
+    context: Dict[str, Any] = {"reason": reason, "message": text}
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error") if isinstance(body.get("error"), dict) else body
+        for key in ("reset_at", "resets_at", "retry_until"):
+            if key in err:
+                context["reset_at"] = err[key]
+                break
+        if isinstance(err.get("type"), str):
+            context["reason"] = err["type"]
+        if isinstance(err.get("message"), str):
+            context["message"] = err["message"]
+
+    if "reset_at" not in context:
+        # ChatGPT/Codex usage-limit errors often stringify a Python dict:
+        # {'error': {'type': 'usage_limit_reached', ..., 'resets_at': 1777712481}}
+        match = re.search(r"['\"]resets_at['\"]\s*:\s*(\d+(?:\.\d+)?)", text)
+        if match:
+            context["reset_at"] = match.group(1)
+
+    return context
+
+
+def _rotate_provider_pool_after_exhaustion(
+    provider: str,
+    exc: Exception,
+    *,
+    task: Optional[str] = None,
+    reason: str = "payment error",
+) -> bool:
+    """Mark the current same-provider pool entry exhausted and rotate.
+
+    Main chat already uses the credential pool for same-provider failover.
+    Auxiliary calls (compression/session-search/etc.) must do the same, not
+    wait for a cross-provider fallback.  Returns True when a new entry is
+    selected and cached clients were evicted so the next retry uses it.
+    """
+    normalized = _normalize_aux_provider(provider)
+    if normalized in ("auto", "", None):
+        return False
+    try:
+        pool = load_pool(normalized)
+    except Exception as load_err:
+        logger.debug(
+            "Auxiliary %s: could not load %s credential pool after %s: %s",
+            task or "call", normalized, reason, load_err,
+        )
+        return False
+    if not pool or not pool.has_credentials():
+        return False
+
+    status_code = _error_status_code(exc)
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=status_code,
+        error_context=_error_context_from_exception(exc, reason=reason),
+    )
+    if next_entry is None:
+        logger.warning(
+            "Auxiliary %s: %s on %s and same-provider credential pool has no usable next entry",
+            task or "call", reason, normalized,
+        )
+        return False
+
+    _evict_cached_clients(normalized)
+    label = getattr(next_entry, "label", None) or getattr(next_entry, "id", "")[:8]
+    logger.info(
+        "Auxiliary %s: %s on %s; rotated credential pool to %s and retrying",
+        task or "call", reason, normalized, label or "next entry",
+    )
+    return True
 
 
 def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
@@ -3525,6 +3613,46 @@ def call_llm(
                     return _validate_llm_response(
                         retry_client.chat.completions.create(**retry_kwargs), task)
 
+        # ── Same-provider credential-pool rotation ───────────────────
+        # Main chat can rotate between multiple credentials for the same
+        # provider (e.g. several ChatGPT/Codex accounts).  Auxiliary calls
+        # must stay in sync: if compression hits usage_limit_reached on the
+        # currently selected Codex account, mark that pool entry exhausted,
+        # evict the cached aux client, and retry with the next account before
+        # considering cross-provider fallback.
+        if _is_payment_error(first_err):
+            if _rotate_provider_pool_after_exhaustion(
+                resolved_provider,
+                first_err,
+                task=task,
+                reason="payment error",
+            ):
+                retry_client, retry_model = _get_cached_client(
+                    resolved_provider,
+                    resolved_model,
+                    base_url=resolved_base_url,
+                    api_key=resolved_api_key,
+                    api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
+                )
+                if retry_client is not None:
+                    retry_kwargs = _build_call_kwargs(
+                        resolved_provider,
+                        retry_model or final_model,
+                        messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(retry_client, "base_url", "") or resolved_base_url or ""),
+                    )
+                    _retry_base = str(getattr(retry_client, "base_url", "") or "")
+                    if _is_anthropic_compat_endpoint(resolved_provider, _retry_base):
+                        retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+                    return _validate_llm_response(
+                        retry_client.chat.completions.create(**retry_kwargs), task)
+
         # ── Payment / credit exhaustion fallback ──────────────────────
         # When the resolved provider returns 402 or a credit-related error,
         # try alternative providers instead of giving up.  This handles the
@@ -3809,6 +3937,49 @@ async def async_call_llm(
                         timeout=effective_timeout,
                         extra_body=effective_extra_body,
                         base_url=resolved_base_url,
+                    )
+                    _retry_base = str(getattr(retry_client, "base_url", "") or "")
+                    if _is_anthropic_compat_endpoint(resolved_provider, _retry_base):
+                        retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+                    return _validate_llm_response(
+                        await retry_client.chat.completions.create(**retry_kwargs), task)
+
+        # ── Same-provider credential-pool rotation ───────────────────
+        # Keep async auxiliary tasks (vision/session_search/etc.) aligned with
+        # the same credential-pool exhaustion semantics as main chat.
+        if _is_payment_error(first_err):
+            if _rotate_provider_pool_after_exhaustion(
+                resolved_provider,
+                first_err,
+                task=task,
+                reason="payment error",
+            ):
+                if task == "vision":
+                    _, retry_client, retry_model = resolve_vision_provider_client(
+                        provider=resolved_provider,
+                        model=resolved_model or final_model,
+                        async_mode=True,
+                    )
+                else:
+                    retry_client, retry_model = _get_cached_client(
+                        resolved_provider,
+                        resolved_model,
+                        async_mode=True,
+                        base_url=resolved_base_url,
+                        api_key=resolved_api_key,
+                        api_mode=resolved_api_mode,
+                    )
+                if retry_client is not None:
+                    retry_kwargs = _build_call_kwargs(
+                        resolved_provider,
+                        retry_model or final_model,
+                        messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(retry_client, "base_url", "") or resolved_base_url or ""),
                     )
                     _retry_base = str(getattr(retry_client, "base_url", "") or "")
                     if _is_anthropic_compat_endpoint(resolved_provider, _retry_base):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1583,7 +1583,8 @@ def _is_payment_error(exc: Exception) -> bool:
     if status in (402, 429, None):
         if any(kw in err_lower for kw in ("credits", "insufficient funds",
                                            "can only afford", "billing",
-                                           "payment required")):
+                                           "payment required", "usage_limit_reached",
+                                           "usage limit has been reached")):
             return True
     return False
 
@@ -3324,6 +3325,7 @@ def call_llm(
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
+    vision_requested_auto = task == "vision" and resolved_provider in ("auto", "", None)
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
@@ -3539,7 +3541,7 @@ def call_llm(
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
-        is_auto = resolved_provider in ("auto", "", None)
+        is_auto = resolved_provider in ("auto", "", None) or vision_requested_auto
         if should_fallback and is_auto:
             reason = "payment error" if _is_payment_error(first_err) else "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -3637,6 +3639,7 @@ async def async_call_llm(
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
+    vision_requested_auto = task == "vision" and resolved_provider in ("auto", "", None)
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
@@ -3815,7 +3818,7 @@ async def async_call_llm(
 
         # ── Payment / connection fallback (mirrors sync call_llm) ─────
         should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
-        is_auto = resolved_provider in ("auto", "", None)
+        is_auto = resolved_provider in ("auto", "", None) or vision_requested_auto
         if should_fallback and is_auto:
             reason = "payment error" if _is_payment_error(first_err) else "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",

--- a/run_agent.py
+++ b/run_agent.py
@@ -6001,6 +6001,7 @@ class AIAgent:
         if not self._replace_primary_openai_client(reason="codex_credential_refresh"):
             return False
 
+        self._sync_context_compressor_runtime()
         return True
 
     def _try_refresh_nous_client_credentials(self, *, force: bool = True) -> bool:
@@ -6036,6 +6037,7 @@ class AIAgent:
         if not self._replace_primary_openai_client(reason="nous_credential_refresh"):
             return False
 
+        self._sync_context_compressor_runtime()
         return True
 
     def _try_refresh_copilot_client_credentials(self) -> bool:
@@ -6122,6 +6124,7 @@ class AIAgent:
         # identity-injection guard).
         from agent.anthropic_adapter import _is_oauth_token
         self._is_anthropic_oauth = _is_oauth_token(new_token) if self.provider == "anthropic" else False
+        self._sync_context_compressor_runtime()
         return True
 
     def _apply_client_headers_for_base_url(self, base_url: str) -> None:
@@ -6149,6 +6152,30 @@ class AIAgent:
         else:
             self._client_kwargs.pop("default_headers", None)
 
+    def _sync_context_compressor_runtime(self) -> None:
+        """Keep compression on the same live credential as the main agent."""
+        compressor = getattr(self, "context_compressor", None)
+        if not compressor or not hasattr(compressor, "update_model"):
+            return
+        try:
+            compressor.update_model(
+                model=self.model,
+                context_length=getattr(compressor, "context_length", 0),
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                provider=self.provider,
+                api_mode=getattr(self, "api_mode", None),
+            )
+        except TypeError:
+            # Third-party context engines may not accept api_mode yet.
+            compressor.update_model(
+                model=self.model,
+                context_length=getattr(compressor, "context_length", 0),
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                provider=self.provider,
+            )
+
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
@@ -6170,6 +6197,7 @@ class AIAgent:
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
             self.base_url = runtime_base
+            self._sync_context_compressor_runtime()
             return
 
         self.api_key = runtime_key
@@ -6178,6 +6206,7 @@ class AIAgent:
         self._client_kwargs["base_url"] = self.base_url
         self._apply_client_headers_for_base_url(self.base_url)
         self._replace_primary_openai_client(reason="credential_rotation")
+        self._sync_context_compressor_runtime()
 
     def _recover_with_credential_pool(
         self,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -684,6 +684,47 @@ class TestAuxiliaryPoolAwareness:
         assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
 
+    def test_call_llm_rotates_same_provider_pool_after_usage_limit(self):
+        class _UsageLimit429(Exception):
+            status_code = 429
+            body = {"error": {"type": "usage_limit_reached", "message": "The usage limit has been reached", "resets_at": 1777712481}}
+
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex/responses"
+        stale_client.chat.completions.create.side_effect = _UsageLimit429("usage_limit_reached")
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex/responses"
+        fresh_client.chat.completions.create.return_value = {"ok": True}
+
+        next_entry = MagicMock()
+        next_entry.label = "codex-alt"
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.5"), (fresh_client, "gpt-5.5")]),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients") as evict,
+            patch("agent.auxiliary_client._validate_llm_response", side_effect=lambda resp, _task: resp),
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == {"ok": True}
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        _, kwargs = pool.mark_exhausted_and_rotate.call_args
+        assert kwargs["status_code"] == 429
+        assert kwargs["error_context"]["reason"] == "usage_limit_reached"
+        assert kwargs["error_context"]["reset_at"] == 1777712481
+        evict.assert_called_once_with("openai-codex")
+        assert stale_client.chat.completions.create.call_count == 1
+        assert fresh_client.chat.completions.create.call_count == 1
+
     @pytest.mark.asyncio
     async def test_async_call_llm_retries_nous_after_401(self):
         class _Auth401(Exception):
@@ -712,6 +753,44 @@ class TestAuxiliaryPoolAwareness:
         assert result == {"ok": True}
         assert stale_client.chat.completions.create.await_count == 1
         assert fresh_async_client.chat.completions.create.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_rotates_same_provider_pool_after_usage_limit(self):
+        class _UsageLimit429(Exception):
+            status_code = 429
+            body = {"error": {"type": "usage_limit_reached", "message": "The usage limit has been reached", "resets_at": 1777712481}}
+
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex/responses"
+        stale_client.chat.completions.create = AsyncMock(side_effect=_UsageLimit429("usage_limit_reached"))
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex/responses"
+        fresh_client.chat.completions.create = AsyncMock(return_value={"ok": True})
+
+        next_entry = MagicMock()
+        next_entry.label = "codex-alt"
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.5"), (fresh_client, "gpt-5.5")]),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients") as evict,
+            patch("agent.auxiliary_client._validate_llm_response", side_effect=lambda resp, _task: resp),
+        ):
+            result = await async_call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == {"ok": True}
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        evict.assert_called_once_with("openai-codex")
+        assert stale_client.chat.completions.create.await_count == 1
+        assert fresh_client.chat.completions.create.await_count == 1
 
     def test_cached_gmi_client_keeps_explicit_slash_model_override(self):
         import agent.auxiliary_client as aux

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -768,6 +768,11 @@ class TestIsPaymentError:
         exc.status_code = 429
         assert _is_payment_error(exc) is True
 
+    def test_429_usage_limit_reached_is_payment(self):
+        exc = Exception("Error code: 429 - {'error': {'type': 'usage_limit_reached', 'message': 'The usage limit has been reached'}}")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
     def test_429_without_credits_message_is_not_payment(self):
         """Normal rate limits should NOT be treated as payment errors."""
         exc = Exception("Rate limit exceeded, try again in 2 seconds")
@@ -1334,6 +1339,16 @@ class _AuxAuth401(Exception):
         super().__init__(message)
 
 
+class _AuxUsageLimit(Exception):
+    status_code = 429
+
+    def __init__(self):
+        super().__init__(
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached'}}"
+        )
+
+
 class _DummyResponse:
     def __init__(self, text="ok"):
         self.choices = [MagicMock(message=MagicMock(content=text))]
@@ -1466,6 +1481,34 @@ class TestAuxiliaryAuthRefreshRetry:
 
         assert resp.choices[0].message.content == "fresh-async"
         mock_refresh.assert_called_once_with("openai-codex")
+
+    @pytest.mark.asyncio
+    async def test_async_auto_vision_falls_back_on_usage_limit_reached(self):
+        failing_client = MagicMock()
+        failing_client.base_url = "https://chatgpt.com/backend-api/codex"
+        failing_client.chat.completions.create = AsyncMock(side_effect=_AuxUsageLimit())
+
+        fallback_sync_client = MagicMock()
+        fallback_sync_client.base_url = "https://openrouter.ai/api/v1"
+        fallback_async_client = MagicMock()
+        fallback_async_client.base_url = "https://openrouter.ai/api/v1"
+        fallback_async_client.chat.completions.create = AsyncMock(return_value=_DummyResponse("fallback-vision"))
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("auto", None, None, None, None)),
+            patch("agent.auxiliary_client.resolve_vision_provider_client", return_value=("openai-codex", failing_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._try_payment_fallback", return_value=(fallback_sync_client, "google/gemini-flash", "openrouter")) as mock_fallback,
+            patch("agent.auxiliary_client._to_async_client", return_value=(fallback_async_client, "google/gemini-flash")),
+        ):
+            resp = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe"}],
+            )
+
+        assert resp.choices[0].message.content == "fallback-vision"
+        mock_fallback.assert_called_once_with("openai-codex", "vision", reason="payment error")
+        assert failing_client.chat.completions.create.await_count == 1
+        assert fallback_async_client.chat.completions.create.await_count == 1
 
     def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch):
         stale_client = MagicMock()

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -11,6 +11,8 @@ Covers:
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # 1. CLI _resolve_turn_agent_config includes credential_pool
@@ -232,3 +234,55 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+
+class TestCompressorCredentialSync:
+    """Compression must follow the active pooled credential after rotation."""
+
+    def _make_agent(self, *, provider, api_mode, base_url):
+        from run_agent import AIAgent
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+        agent.model = "gpt-test"
+        agent.provider = provider
+        agent.api_mode = api_mode
+        agent.base_url = base_url
+        agent.api_key = "old-key"
+        agent._client_kwargs = {"api_key": "***", "base_url": agent.base_url}
+        agent._replace_primary_openai_client = MagicMock(return_value=True)
+        agent._apply_client_headers_for_base_url = MagicMock()
+        agent.context_compressor = MagicMock()
+        agent.context_compressor.context_length = 200000
+        return agent
+
+    @pytest.mark.parametrize(
+        ("provider", "api_mode", "base_url"),
+        [
+            ("openai-codex", "codex_responses", "https://chatgpt.com/backend-api/codex/responses"),
+            ("openrouter", "chat_completions", "https://openrouter.ai/api/v1"),
+            ("nous", "chat_completions", "https://inference.nousresearch.com/v1"),
+        ],
+    )
+    def test_swap_credential_updates_context_compressor_for_pooled_provider(
+        self,
+        provider,
+        api_mode,
+        base_url,
+    ):
+        agent = self._make_agent(provider=provider, api_mode=api_mode, base_url=base_url)
+        entry = SimpleNamespace(
+            runtime_api_key="new-key",
+            runtime_base_url=base_url,
+        )
+
+        agent._swap_credential(entry)
+
+        agent.context_compressor.update_model.assert_called_once_with(
+            model="gpt-test",
+            context_length=200000,
+            base_url=base_url,
+            api_key="new-key",
+            provider=provider,
+            api_mode=api_mode,
+        )


### PR DESCRIPTION
## Summary

Keep auxiliary LLM calls on usable credentials after account-scoped quota exhaustion.

This fixes two shared auxiliary-runtime failure modes:

- context compression could keep using a stale exhausted credential after the main agent rotated or refreshed to a usable credential
- auto-selected vision calls could receive `usage_limit_reached` from the selected provider and fail without trying the configured fallback chain

## Root cause

`AIAgent` can rotate or refresh provider credentials after a pool error, but the `ContextCompressor` keeps its own provider, API key, base URL, and API mode fields. That allowed the main agent runtime to be healthy while compression still pointed at the old exhausted credential.

Separately, auxiliary vision fallback did not classify `usage_limit_reached` as quota exhaustion, and once `provider=auto` resolved to a concrete provider the call could be treated like an explicit provider constraint.

## Fix

- Sync the context compressor runtime after credential swaps and refreshes.
- Treat `usage_limit_reached` / “usage limit has been reached” as auxiliary quota exhaustion.
- Preserve fallback eligibility for auto-selected vision providers after auto resolution.

## Scope

- The runtime sync copies generic active provider fields.
- The quota classification is based on error type/message, not provider name.
- Auto vision fallback only changes calls that started as `provider=auto`; explicitly pinned providers remain constrained.

## Tests

```bash
python -m pytest \
  tests/agent/test_auxiliary_client.py \
  tests/agent/test_credential_pool_routing.py \
  tests/cron/test_scheduler.py \
  tests/run_agent/test_compression_boundary.py \
  tests/run_agent/test_compression_persistence.py \
  -q -o 'addopts='
```

Result:

```text
241 passed, 2 warnings
```

Regression coverage includes:

- compressor runtime sync across multiple pooled providers
- `usage_limit_reached` classification as auxiliary quota exhaustion
- async auto vision fallback after an auto-selected provider returns `usage_limit_reached`
