### PR TITLE
fix(environments): make remote snapshot stores atomic and race-safe

### DIFF
--- a/tests/tools/test_environment_json_store.py
+++ b/tests/tools/test_environment_json_store.py
@@ -1,0 +1,99 @@
+import threading
+import time
+from pathlib import Path
+
+from tools.environments import base as base_env
+from tools.environments import modal, singularity, vercel_sandbox
+
+
+def test_update_json_store_preserves_concurrent_updates(tmp_path):
+    store = tmp_path / "snapshots.json"
+    start = threading.Barrier(4)
+
+    def worker(index: int) -> None:
+        start.wait(timeout=5)
+
+        def _mutate(data: dict) -> bool:
+            time.sleep(0.01)
+            data[f"task-{index}"] = f"snap-{index}"
+            return True
+
+        base_env._update_json_store(store, _mutate)
+
+    threads = [
+        threading.Thread(target=worker, args=(index,))
+        for index in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert base_env._load_json_store(store) == {
+        f"task-{index}": f"snap-{index}"
+        for index in range(4)
+    }
+
+
+def test_modal_store_direct_snapshot_uses_locked_json_update(tmp_path, monkeypatch):
+    store = tmp_path / "modal_snapshots.json"
+    calls: list[Path] = []
+
+    def fake_update(path: Path, update_fn):
+        calls.append(path)
+        data = {"task-a": "im-legacy"}
+        changed = update_fn(data)
+        assert changed is True
+        assert data == {"direct:task-a": "im-fresh"}
+        return changed
+
+    monkeypatch.setattr(modal, "_SNAPSHOT_STORE", store)
+    monkeypatch.setattr(modal, "_update_json_store", fake_update)
+
+    modal._store_direct_snapshot("task-a", "im-fresh")
+
+    assert calls == [store]
+
+
+def test_vercel_store_snapshot_uses_locked_json_update(tmp_path, monkeypatch):
+    store = tmp_path / "vercel_snapshots.json"
+    calls: list[Path] = []
+
+    def fake_update(path: Path, update_fn):
+        calls.append(path)
+        data = {"task-a": "snap-old"}
+        changed = update_fn(data)
+        assert changed is True
+        assert data == {"task-a": "snap-new"}
+        return changed
+
+    monkeypatch.setattr(vercel_sandbox, "_snapshot_store_path", lambda: store)
+    monkeypatch.setattr(vercel_sandbox, "_update_json_store", fake_update)
+
+    vercel_sandbox._store_snapshot("task-a", "snap-new")
+
+    assert calls == [store]
+
+
+def test_singularity_store_snapshot_uses_locked_json_update(tmp_path, monkeypatch):
+    store = tmp_path / "singularity_snapshots.json"
+    calls: list[Path] = []
+
+    def fake_update(path: Path, update_fn):
+        calls.append(path)
+        data = {"other-task": "/scratch/keep"}
+        changed = update_fn(data)
+        assert changed is True
+        assert data == {
+            "other-task": "/scratch/keep",
+            "task-a": "/scratch/overlay-a",
+        }
+        return changed
+
+    monkeypatch.setattr(singularity, "_SNAPSHOT_STORE", store)
+    monkeypatch.setattr(singularity, "_update_json_store", fake_update)
+
+    singularity._store_snapshot("task-a", "/scratch/overlay-a")
+
+    assert calls == [store]

--- a/tests/tools/test_modal_snapshot_isolation.py
+++ b/tests/tools/test_modal_snapshot_isolation.py
@@ -107,6 +107,13 @@ def _install_modal_test_modules(
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(data, indent=2))
 
+    def _update_json_store(path, update_fn):
+        data = _load_json_store(path)
+        changed = update_fn(data)
+        if changed:
+            _save_json_store(path, data)
+        return changed
+
     def _file_mtime_key(host_path):
         try:
             st = Path(host_path).stat()
@@ -119,6 +126,7 @@ def _install_modal_test_modules(
         _ThreadedProcessHandle=_DummyThreadedProcessHandle,
         _load_json_store=_load_json_store,
         _save_json_store=_save_json_store,
+        _update_json_store=_update_json_store,
         _file_mtime_key=_file_mtime_key,
     )
     sys.modules["tools.interrupt"] = types.SimpleNamespace(is_interrupted=lambda: False)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -22,6 +22,7 @@ from typing import IO, Callable, Protocol
 
 from hermes_constants import get_hermes_home
 from tools.interrupt import is_interrupted
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ if _DEBUG_INTERRUPT:
 # Thread-local activity callback.  The agent sets this before a tool call so
 # long-running _wait_for_process loops can report liveness to the gateway.
 _activity_callback_local = threading.local()
+_json_store_locks_guard = threading.Lock()
+_json_store_locks: dict[str, threading.Lock] = {}
 
 
 def set_activity_callback(cb: Callable[[str], None] | None) -> None:
@@ -145,8 +148,32 @@ def _load_json_store(path: Path) -> dict:
 
 def _save_json_store(path: Path, data: dict) -> None:
     """Write *data* as pretty-printed JSON to *path*."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2))
+    atomic_json_write(path, data, indent=2)
+
+
+def _get_json_store_lock(path: Path) -> threading.Lock:
+    """Return a stable per-store lock for read-modify-write JSON updates."""
+    key = os.path.normcase(os.path.abspath(os.fspath(path)))
+    with _json_store_locks_guard:
+        lock = _json_store_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _json_store_locks[key] = lock
+        return lock
+
+
+def _update_json_store(path: Path, update_fn: Callable[[dict], bool]) -> bool:
+    """Apply a read-modify-write update to *path* under a per-store lock.
+
+    ``update_fn`` receives the loaded dict and must return ``True`` when the
+    caller mutated the data and it should be persisted.
+    """
+    with _get_json_store_lock(path):
+        data = _load_json_store(path)
+        changed = update_fn(data)
+        if changed:
+            _save_json_store(path, data)
+        return changed
 
 
 def _file_mtime_key(host_path: str) -> tuple[float, int] | None:

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -20,6 +20,7 @@ from tools.environments.base import (
     _ThreadedProcessHandle,
     _load_json_store,
     _save_json_store,
+    _update_json_store,
 )
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -60,24 +61,30 @@ def _get_snapshot_restore_candidate(task_id: str) -> tuple[str | None, bool]:
 
 
 def _store_direct_snapshot(task_id: str, snapshot_id: str) -> None:
-    snapshots = _load_snapshots()
-    snapshots[_direct_snapshot_key(task_id)] = snapshot_id
-    snapshots.pop(task_id, None)
-    _save_snapshots(snapshots)
+    key = _direct_snapshot_key(task_id)
+
+    def _mutate(snapshots: dict) -> bool:
+        changed = snapshots.get(key) != snapshot_id or task_id in snapshots
+        snapshots[key] = snapshot_id
+        snapshots.pop(task_id, None)
+        return changed
+
+    _update_json_store(_SNAPSHOT_STORE, _mutate)
 
 
 def _delete_direct_snapshot(task_id: str, snapshot_id: str | None = None) -> None:
-    snapshots = _load_snapshots()
-    updated = False
-    for key in (_direct_snapshot_key(task_id), task_id):
-        value = snapshots.get(key)
-        if value is None:
-            continue
-        if snapshot_id is None or value == snapshot_id:
-            snapshots.pop(key, None)
-            updated = True
-    if updated:
-        _save_snapshots(snapshots)
+    def _mutate(snapshots: dict) -> bool:
+        updated = False
+        for key in (_direct_snapshot_key(task_id), task_id):
+            value = snapshots.get(key)
+            if value is None:
+                continue
+            if snapshot_id is None or value == snapshot_id:
+                snapshots.pop(key, None)
+                updated = True
+        return updated
+
+    _update_json_store(_SNAPSHOT_STORE, _mutate)
 
 
 def _resolve_modal_image(image_spec: Any) -> Any:

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -20,6 +20,7 @@ from tools.environments.base import (
     _load_json_store,
     _popen_bash,
     _save_json_store,
+    _update_json_store,
 )
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,19 @@ def _load_snapshots() -> dict:
 
 def _save_snapshots(data: dict) -> None:
     _save_json_store(_SNAPSHOT_STORE, data)
+
+
+def _store_snapshot(task_id: str, overlay_dir: str) -> None:
+    if not task_id or not overlay_dir:
+        return
+
+    def _mutate(snapshots: dict) -> bool:
+        if snapshots.get(task_id) == overlay_dir:
+            return False
+        snapshots[task_id] = overlay_dir
+        return True
+
+    _update_json_store(_SNAPSHOT_STORE, _mutate)
 
 
 def _get_scratch_dir() -> Path:
@@ -257,6 +271,4 @@ class SingularityEnvironment(BaseEnvironment):
             self._instance_started = False
 
         if self._persistent and self._overlay_dir:
-            snapshots = _load_snapshots()
-            snapshots[self._task_id] = str(self._overlay_dir)
-            _save_snapshots(snapshots)
+            _store_snapshot(self._task_id, str(self._overlay_dir))

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -28,6 +28,7 @@ from tools.environments.base import (
     _ThreadedProcessHandle,
     _load_json_store,
     _save_json_store,
+    _update_json_store,
 )
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -161,22 +162,30 @@ def _get_snapshot_id(task_id: str) -> str | None:
 def _store_snapshot(task_id: str, snapshot_id: str) -> None:
     if not task_id or not snapshot_id:
         return
-    snapshots = _load_snapshots()
-    snapshots[task_id] = snapshot_id
-    _save_snapshots(snapshots)
+
+    def _mutate(snapshots: dict) -> bool:
+        if snapshots.get(task_id) == snapshot_id:
+            return False
+        snapshots[task_id] = snapshot_id
+        return True
+
+    _update_json_store(_snapshot_store_path(), _mutate)
 
 
 def _delete_snapshot(task_id: str, snapshot_id: str | None = None) -> None:
     if not task_id:
         return
-    snapshots = _load_snapshots()
-    existing = snapshots.get(task_id)
-    if existing is None:
-        return
-    if snapshot_id is not None and existing != snapshot_id:
-        return
-    snapshots.pop(task_id, None)
-    _save_snapshots(snapshots)
+
+    def _mutate(snapshots: dict) -> bool:
+        existing = snapshots.get(task_id)
+        if existing is None:
+            return False
+        if snapshot_id is not None and existing != snapshot_id:
+            return False
+        snapshots.pop(task_id, None)
+        return True
+
+    _update_json_store(_snapshot_store_path(), _mutate)
 
 
 def _extract_snapshot_id(snapshot: Any) -> str | None:


### PR DESCRIPTION
## Summary

This hardens the persistent snapshot stores used by the remote execution backends.

Before this change, snapshot metadata was written with plain `write_text()` and updated via unlocked read-modify-write sequences. Concurrent snapshot updates could overwrite each other, and interrupted writes could leave truncated JSON behind. On the next load, that corruption was treated as an empty store, silently dropping snapshot mappings.

This PR makes those stores atomic and race-safe.

## Problem

The Modal, Vercel Sandbox, and Singularity backends all persist task-scoped snapshot state in JSON files under `HERMES_HOME`.

Two failure modes existed:

1. Concurrent updates could lose entries because multiple writers performed `load -> mutate -> save` without a shared lock.
2. Partial/interrupted writes could leave invalid JSON on disk, causing the next load to fall back to `{}` and discard all stored snapshot mappings.

## Fix

- Switched the shared JSON store writer in `tools/environments/base.py` to `atomic_json_write()`.
- Added a per-store lock helper for read-modify-write JSON updates.
- Updated Modal, Vercel Sandbox, and Singularity snapshot persistence paths to use the locked update helper instead of ad hoc load/save cycles.

## Tests

Added/updated tests covering:

- concurrent JSON store updates preserving all entries
- Modal snapshot tests updated for the new helper import
- backend snapshot persistence paths routing through the locked update helper

## Verification

Ran:

- `tests/tools/test_environment_json_store.py`
- `tests/tools/test_modal_snapshot_isolation.py`

Result:

- `8 passed`
