### PR TITLE
fix: guard against stale /restart redelivery on gateway startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -878,6 +878,7 @@ class GatewayRunner:
         self._restart_task_started = False
         self._restart_detached = False
         self._restart_via_service = False
+        self._startup_time: float = time.time()
         self._stop_task: Optional[asyncio.Task] = None
         
         # Track running agents per session for interrupt support
@@ -6916,6 +6917,15 @@ class GatewayRunner:
         try:
             marker_path = _hermes_home / ".restart_last_processed.json"
             if not marker_path.exists():
+                # No dedup marker — if the gateway just started (within
+                # the first 60 seconds), treat this as a stale /restart
+                # redelivery.  A legitimate /restart cannot arrive before
+                # the gateway has finished booting plus the adapter
+                # handshake; anything arriving this early is a re-delivery
+                # from the previous gateway cycle.
+                if hasattr(self, "_startup_time"):
+                    if time.time() - self._startup_time < 60:
+                        return True
                 return False
             data = json.loads(marker_path.read_text())
         except Exception:


### PR DESCRIPTION
## Problem

When the `.restart_last_processed.json` dedup marker is missing (e.g. cleaned up manually or lost due to a filesystem issue), a stale `/restart` command re-delivered by Telegram's polling can trigger an **infinite restart loop**: each fresh gateway instance processes the re-delivered `/restart` and immediately restarts itself again. No Telegram messages are processed during this loop because the polling connection never stays alive long enough.

Hit this in production today — gateway had been restarting every ~2 minutes all day, zero messages processed since April 14.

## Fix

Adds a **startup-time guard** inside `_is_stale_restart_redelivery()`:

- When the dedup marker file is missing **AND** the gateway process is less than 60 seconds old, treat the `/restart` as stale and return `True`
- A legitimate `/restart` cannot arrive before the gateway has finished its boot sequence plus adapter handshake; anything arriving this early is a re-delivery from the previous gateway cycle

## Changes

1. Added `self._startup_time: float = time.time()` in `GatewayRunner.__init__`
2. Added early-return guard: when marker missing + uptime < 60s → return `True`

The existing marker-file dedup mechanism is the right primary defense; this is belt-and-suspenders for when that file goes missing.