### PR TITLE
fix(schema_sanitizer): strip pattern and format fields for llama.cpp compatibility

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -203,3 +203,50 @@ def test_empty_tools_list_returns_empty():
 
 def test_none_tools_returns_none():
     assert sanitize_tool_schemas(None) is None
+
+
+def test_string_pattern_stripped():
+    """llama.cpp's grammar converter chokes on regex escapes like \\d."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "date": {"type": "string", "pattern": "\\d{4,4}-\\d{2,2}-\\d{2,2}"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["date"]
+    assert "pattern" not in prop
+    assert prop["type"] == "string"
+
+
+def test_string_format_stripped():
+    """Format fields are also stripped — safe because runtime validation catches them."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "ts": {"type": "string", "format": "date-time"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["ts"]
+    assert "format" not in prop
+
+
+def test_nested_pattern_in_anyof_stripped():
+    """Pattern inside anyOf variants is also stripped."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "string", "pattern": "[A-Z]+"},
+                    {"type": "integer"},
+                ],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    variants = out[0]["function"]["parameters"]["properties"]["value"]["anyOf"]
+    assert "pattern" not in variants[0]
+    assert variants[0]["type"] == "string"
+

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -235,6 +235,18 @@ def _sanitize_node(node: Any, path: str) -> Any:
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged.
             out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
+        elif key in {"pattern", "format"}:
+            # Strip JSON Schema ``pattern`` and ``format`` fields entirely.
+            # llama.cpp's json-schema-to-grammar converter chokes on regex
+            # escapes in pattern strings (e.g. "\\d{4,4}") — it doesn't
+            # support standard PCRE/ECMAScript escape sequences.  These
+            # fields are purely descriptive hints for LLM prompting; the
+            # actual runtime validation happens on the Python side via the
+            # MCP tool's own type checking, so dropping them is safe.
+            logger.debug(
+                "schema_sanitizer[%s]: stripping %r (llama.cpp grammar incompatibility)",
+                path, key,
+            )
         else:
             out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
 


### PR DESCRIPTION
## What does this PR do?

Strip `pattern` and `format` fields from JSON Schema tool definitions before they reach llama.cpp's OAI-compatible server. These fields are purely descriptive hints for LLM prompting — the actual runtime validation happens on the Python side via MCP tool type checking.

llama.cpp's internal json-schema-to-grammar converter chokes on standard PCRE/ECMAScript regex escapes in pattern strings (e.g. `"\d{4,4}"`), causing HTTP 400 errors: `parse: error parsing grammar: unknown escape at \d"{4,4}"`. This is especially common with MCP servers that expose tool definitions containing date-time parameters, phone numbers, or other regex-constrained strings.

## Related Issue

Fixes # (no issue — this is a fix for an unreported bug)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/schema_sanitizer.py`: Added an `elif` branch in `_sanitize_node()` that strips `pattern` and `format` keys from JSON Schema nodes before they reach the llama.cpp grammar converter. Includes a debug log line for visibility.
- `tests/tools/test_schema_sanitizer.py`: Added 3 tests:
  - `test_string_pattern_stripped` — verifies date regex patterns like `\d{4,4}-\d{2,2}-\d{2,2}` get removed from properties
  - `test_string_format_stripped` — verifies `format: "date-time"` gets removed
  - `test_nested_pattern_in_anyof_stripped` — verifies patterns inside anyOf variant schemas are also stripped

## How to Test

1. Run the new tests: `pytest tests/tools/test_schema_sanitizer.py -v` (all 20 pass, including the 3 new ones)
2. Run all schema sanitizer tests: `pytest tests/tools/test_schema_sanitizer.py --tb=short` (all 20 pass)
3. Simulate the failure scenario: Create an MCP tool with a date-time parameter using `"pattern": "\d{4,4}-\d{2,2}-\d{2,2}"`, start a session with llama-cpp via Hermes, and confirm the grammar parsing error no longer occurs

## Checklist

### Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(schema-sanitizer): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [ ] N/A
