### PR TITLE
fix(approval): tighten 'delete in root path' regex to system roots only

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -259,6 +259,81 @@ class TestRmRecursiveFlagVariants:
         assert key is not None
 
 
+class TestRmAbsolutePathNotFalseFlagged:
+    """Issue #18083: `rm /path` must only fire 'delete in root path' for
+    genuine system-root targets (/, /*, /etc, /var, /usr, ...), not for
+    every absolute path. Routine cleanups in the user's home, /tmp, and
+    /mnt should not be flagged as root-path deletes."""
+
+    def test_rm_user_home_not_root_path(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "rm -f /home/scott/hermes-home/fawn_lily_temp.html"
+        )
+        if is_dangerous:
+            assert desc != "delete in root path"
+
+    def test_rm_tmp_path_not_root_path(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm /tmp/x")
+        assert is_dangerous is False or desc != "delete in root path"
+
+    def test_rm_mnt_wsl_path_not_root_path(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "rm -rf /mnt/c/Users/user/foo"
+        )
+        if is_dangerous:
+            assert desc != "delete in root path"
+
+    def test_rm_home_recursive_still_caught_as_recursive(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /home/user/.cache")
+        assert is_dangerous is True
+        assert desc != "delete in root path"
+        assert "recursive" in desc.lower() or "delete" in desc.lower()
+
+    def test_rm_lookalike_etc_bak_not_flagged_as_root(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm /etc.bak/file")
+        assert is_dangerous is False or desc != "delete in root path"
+
+    def test_rm_root_slash_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_root_glob_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /*")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_root_dotglob_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /.*")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_etc_passwd_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /etc/passwd")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_var_log_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /var/log")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_usr_bin_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm /usr/bin/something")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_etc_bare_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm /etc")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+    def test_rm_lib64_still_caught(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm /lib64/critical.so")
+        assert is_dangerous is True
+        assert desc == "delete in root path"
+
+
 class TestMultilineBypass:
     """Newlines in commands must not bypass dangerous pattern detection."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -212,7 +212,11 @@ def _hardline_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
-    (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
+    (
+        r'\brm\s+(-[^\s]*\s+)*/(\s|\*|$|\.\*|'
+        r'(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/|\s|$))',
+        "delete in root path",
+    ),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),


### PR DESCRIPTION
## Problem

`tools/approval.py:215` defines `DANGEROUS_PATTERNS[0]` as:

```python
(r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
```

Because `/` only requires a single forward-slash to match, **every absolute-path `rm` is flagged "delete in root path"** — including routine cleanups in the user's home, `/tmp`, `/mnt`, etc.

Real example from the issue report:

```
rm -f /home/scott/hermes-home/fawn_lily_temp.html
↳ Reason: delete in root path
```

That command deletes one file in the user's home directory — nowhere near the system root.

## Fix

Replace the over-broad pattern with one that only fires on actual system-root targets:

```python
(
    r'\brm\s+(-[^\s]*\s+)*/(\s|\*|$|\.\*|'
    r'(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/|\s|$))',
    "delete in root path",
),
```

This matches:
- bare `/`, root globs `/*`, `/.*`
- system top-level directories (`/bin`, `/boot`, `/dev`, `/etc`, `/lib`, `/lib64`, `/opt`, `/proc`, `/root`, `/run`, `/sbin`, `/srv`, `/sys`, `/usr`, `/var`) followed by `/`, whitespace, or end of string

The boundary requirement prevents false matches on look-alike paths (`/etc.bak/...`, `/var-something/...`, `/opting/...`).

## Verification

| Command | Before | After |
|---|---|---|
| `rm -rf /` | flagged | flagged |
| `rm -rf /*` | flagged | flagged |
| `rm -rf /.*` | flagged | flagged |
| `rm -rf /etc/passwd` | flagged | flagged |
| `rm -rf /var/log` | flagged | flagged |
| `rm /usr/bin/something` | flagged | flagged |
| `rm /home/user/foo` | **flagged (false +)** | not flagged |
| `rm -f /home/scott/hermes-home/x.html` | **flagged (false +)** | not flagged |
| `rm /tmp/x` | **flagged (false +)** | not flagged |
| `rm -rf /mnt/c/Users/u/foo` | **flagged (false +)** | not flagged |
| `rm -rf /home/user/.cache` | **flagged (false +)** | not flagged |
| `rm /etc.bak/file` (look-alike) | flagged (false +) | not flagged |

Recursive deletes on user paths (e.g. `rm -rf /home/user`) continue to be flagged correctly via the separate "recursive delete" pattern — they just lose the misleading "root path" label.

## Tests

New `TestRmAbsolutePathNotFalseFlagged` class in `tests/tools/test_approval.py` covers:
- The exact real-world false positive from the issue
- `/tmp`, `/mnt/c/...` user-space paths
- `/etc.bak` look-alike path
- `/`, `/*`, `/.*`, `/etc/passwd`, `/var/log`, `/usr/bin/...`, `/etc`, `/lib64/...` still flagged

Existing `TestDetectDangerousRm` and `TestRmRecursiveFlagVariants` continue to pass — recursive-flag commands fall through to the "recursive delete" pattern, which still satisfies their `"delete" in desc.lower()` assertions. Full suite: **145 passed**.

Fixes #18083

---

*Note: same author has two other open PRs ready for review — #12584 (fixes #6133) and #12592 (fixes #5861). Both apply cleanly to current main.*
