### PR TITLE
feat(deepseek): add deepseek-v4-pro[1m] and deepseek-v4-flash[1m] to canonical models

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -130,10 +130,12 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
 })
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-chat",       # V3 on DeepSeek direct and most aggregators
-    "deepseek-reasoner",   # R1-family reasoning model
-    "deepseek-v4-pro",     # V4 Pro — first-class model ID
-    "deepseek-v4-flash",   # V4 Flash — first-class model ID
+    "deepseek-chat",             # V3 on DeepSeek direct and most aggregators
+    "deepseek-reasoner",         # R1-family reasoning model
+    "deepseek-v4-pro",           # V4 Pro — first-class model ID
+    "deepseek-v4-pro[1m]",       # V4 Pro — 1M context window variant
+    "deepseek-v4-flash",         # V4 Flash — first-class model ID
+    "deepseek-v4-flash[1m]",     # V4 Flash — 1M context window variant
 })
 
 # First-class V-series IDs (``deepseek-v4-pro``, ``deepseek-v4-flash``,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -311,7 +311,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "deepseek": [
         "deepseek-v4-pro",
+        "deepseek-v4-pro[1m]",
         "deepseek-v4-flash",
+        "deepseek-v4-flash[1m]",
         "deepseek-chat",
         "deepseek-reasoner",
     ],


### PR DESCRIPTION
## Summary

Add `deepseek-v4-pro[1m]` and `deepseek-v4-flash[1m]` (1M context window variants) to `_DEEPSEEK_CANONICAL_MODELS` and `_PROVIDER_MODELS` so these model IDs resolve explicitly rather than relying on the V-series regex fallback.

## Changes

- `_DEEPSEEK_CANONICAL_MODELS` — added `deepseek-v4-pro[1m]` and `deepseek-v4-flash[1m]`
- `_PROVIDER_MODELS["deepseek"]` — added the same two variants

## Verification

```
deepseek-v4-pro[1m]  → deepseek-v4-pro[1m]  (canonical match)
deepseek-v4-flash[1m] → deepseek-v4-flash[1m] (canonical match)
deepseek-v4-flash[1M] → deepseek-v4-flash[1m] (case-insensitive)
```