### PR TITLE
fix(honcho): dedupe repeated message flushes

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import queue
+import hashlib
 import re
 import logging
 import threading
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, TYPE_CHECKING
@@ -19,6 +21,17 @@ logger = logging.getLogger(__name__)
 
 # Sentinel to signal the async writer thread to shut down
 _ASYNC_SHUTDOWN = object()
+_RECENT_BATCH_FINGERPRINT_LIMIT = 128
+
+
+def _batch_fingerprint(messages: list[dict[str, Any]]) -> str:
+    digest = hashlib.blake2s(digest_size=16)
+    for msg in messages:
+        digest.update((msg.get("role") or "").encode("utf-8", errors="replace"))
+        digest.update(b"\0")
+        digest.update((msg.get("content") or "").encode("utf-8", errors="replace"))
+        digest.update(b"\0\0")
+    return digest.hexdigest()
 
 
 @dataclass
@@ -98,6 +111,7 @@ class HonchoSessionManager:
         self._cache_lock = threading.RLock()
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
+        self._synced_batch_fingerprints: dict[str, tuple[set[str], deque[str]]] = {}
 
         # Write frequency state
         write_frequency = (config.write_frequency if config else "async")
@@ -364,6 +378,15 @@ class HonchoSessionManager:
         if not new_messages:
             return True
 
+        recent_set, recent_order = self._synced_batch_fingerprints.setdefault(
+            session.key, (set(), deque())
+        )
+        batch_fp = _batch_fingerprint(new_messages)
+        if batch_fp in recent_set:
+            for msg in new_messages:
+                msg["_synced"] = True
+            return True
+
         honcho_messages = []
         for msg in new_messages:
             peer = user_peer if msg["role"] == "user" else assistant_peer
@@ -373,6 +396,10 @@ class HonchoSessionManager:
             honcho_session.add_messages(honcho_messages)
             for msg in new_messages:
                 msg["_synced"] = True
+            recent_set.add(batch_fp)
+            recent_order.append(batch_fp)
+            while len(recent_order) > _RECENT_BATCH_FINGERPRINT_LIMIT:
+                recent_set.discard(recent_order.popleft())
             logger.debug("Synced %d messages to Honcho for %s", len(honcho_messages), session.key)
             with self._cache_lock:
                 self._cache[session.key] = session

--- a/tests/honcho_plugin/test_honcho_idempotency.py
+++ b/tests/honcho_plugin/test_honcho_idempotency.py
@@ -1,0 +1,49 @@
+"""Regression tests for Honcho duplicate flush guards."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class RecordingPeer:
+    def __init__(self, peer_id: str):
+        self.peer_id = peer_id
+
+    def message(self, content: str):
+        return SimpleNamespace(peer_id=self.peer_id, content=content)
+
+
+def test_honcho_flush_skips_recently_synced_duplicate_batch():
+    mgr = HonchoSessionManager()
+    session = HonchoSession(
+        key="cli:test",
+        user_peer_id="eri",
+        assistant_peer_id="hermes",
+        honcho_session_id="cli-test",
+    )
+    session.add_message("user", "same prompt")
+    session.add_message("assistant", "same answer")
+
+    user_peer = RecordingPeer("eri")
+    assistant_peer = RecordingPeer("hermes")
+    honcho_session = MagicMock()
+    mgr._peers_cache["eri"] = user_peer
+    mgr._peers_cache["hermes"] = assistant_peer
+    mgr._sessions_cache["cli-test"] = honcho_session
+
+    assert mgr._flush_session(session) is True
+    assert honcho_session.add_messages.call_count == 1
+
+    duplicate = HonchoSession(
+        key="cli:test",
+        user_peer_id="eri",
+        assistant_peer_id="hermes",
+        honcho_session_id="cli-test",
+    )
+    duplicate.add_message("user", "same prompt")
+    duplicate.add_message("assistant", "same answer")
+
+    assert mgr._flush_session(duplicate) is True
+    assert honcho_session.add_messages.call_count == 1
+    assert all(msg.get("_synced") for msg in duplicate.messages)


### PR DESCRIPTION
## Summary
- add bounded per-session batch fingerprints inside the Honcho session manager
- skip repeated Honcho uploads from stale async queue/retry/session-end flush paths after a successful sync
- keep the fix scoped to the Honcho plugin only

## Test Plan
- scripts/run_tests.sh tests/honcho_plugin/test_honcho_idempotency.py tests/honcho_plugin/test_session.py::TestConcludeToolDispatch::test_sync_turn_strips_leaked_memory_context_before_honcho_ingest tests/honcho_plugin/test_async_memory.py -q
