### PR TITLE
fix(plugins): unregister stale image-gen providers on forced rediscovery

### DIFF
--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -57,6 +57,24 @@ def register_provider(provider: ImageGenProvider) -> None:
         logger.debug("Registered image gen provider '%s' (%s)", name, type(provider).__name__)
 
 
+def unregister_provider(name: str) -> bool:
+    """Remove the provider registered under *name*.
+
+    Returns True when a provider existed and was removed.
+    """
+    if not isinstance(name, str):
+        return False
+    clean = name.strip()
+    if not clean:
+        return False
+    with _lock:
+        removed = _providers.pop(clean, None)
+    if removed is not None:
+        logger.debug("Unregistered image gen provider '%s' (%s)", clean, type(removed).__name__)
+        return True
+    return False
+
+
 def list_providers() -> List[ImageGenProvider]:
     """Return all registered providers, sorted by name."""
     with _lock:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -462,6 +462,7 @@ class PluginContext:
             )
             return
         register_provider(provider)
+        self._manager._plugin_image_gen_provider_names.add(provider.name)
         logger.info(
             "Plugin '%s' registered image_gen provider: %s",
             self.manifest.name, provider.name,
@@ -601,6 +602,7 @@ class PluginManager:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
+        self._plugin_image_gen_provider_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
@@ -624,9 +626,11 @@ class PluginManager:
         if self._discovered and not force:
             return
         if force:
+            self._unregister_plugin_image_gen_providers()
             self._plugins.clear()
             self._hooks.clear()
             self._plugin_tool_names.clear()
+            self._plugin_image_gen_provider_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
             self._plugin_skills.clear()
@@ -752,6 +756,22 @@ class PluginManager:
     # -----------------------------------------------------------------------
     # Directory scanning
     # -----------------------------------------------------------------------
+
+    def _unregister_plugin_image_gen_providers(self) -> None:
+        """Drop plugin-provided image generation backends before a forced rescan."""
+        if not self._plugin_image_gen_provider_names:
+            return
+        from agent.image_gen_registry import unregister_provider
+
+        for name in tuple(self._plugin_image_gen_provider_names):
+            try:
+                unregister_provider(name)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to unregister plugin image_gen provider '%s' during refresh: %s",
+                    name,
+                    exc,
+                )
 
     def _scan_directory(
         self,

--- a/tests/hermes_cli/test_plugin_scanner_recursion.py
+++ b/tests/hermes_cli/test_plugin_scanner_recursion.py
@@ -248,6 +248,47 @@ class TestBackendGate:
 
         assert mgr._plugins["image_gen/fancy"].enabled is True
 
+    def test_forced_rediscovery_removes_deleted_image_gen_provider(self, tmp_path, monkeypatch):
+        from agent import image_gen_registry
+
+        image_gen_registry._reset_for_tests()
+        import os
+        hermes_home = Path(os.environ["HERMES_HOME"])  # set by hermetic conftest fixture
+        user_plugins = hermes_home / "plugins"
+        plugin_dir = _write_plugin(
+            user_plugins,
+            ["image_gen", "fancy"],
+            manifest_extra={"kind": "backend"},
+            register_body=(
+                "from agent.image_gen_provider import ImageGenProvider\n"
+                "    class P(ImageGenProvider):\n"
+                "        @property\n"
+                "        def name(self): return 'stale-test-provider'\n"
+                "        def generate(self, prompt, aspect_ratio='landscape', **kw):\n"
+                "            return {'success': True, 'image': 'x://y'}\n"
+                "    ctx.register_image_gen_provider(P())"
+            ),
+        )
+        _enable(hermes_home, "image_gen/fancy")
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert image_gen_registry.get_provider("stale-test-provider") is not None
+
+        import shutil
+
+        shutil.rmtree(plugin_dir)
+        if not any(plugin_dir.parent.iterdir()):
+            plugin_dir.parent.rmdir()
+
+        mgr.discover_and_load(force=True)
+
+        assert "image_gen/fancy" not in mgr._plugins
+        assert image_gen_registry.get_provider("stale-test-provider") is None
+
+        image_gen_registry._reset_for_tests()
+
     def test_exclusive_kind_skipped(self, tmp_path, monkeypatch):
         """``kind: exclusive`` plugins are recorded but not loaded — the
         category's own discovery system handles them (memory today)."""


### PR DESCRIPTION
## Summary

Forced plugin rediscovery was clearing `PluginManager` state but leaving plugin-registered image generation providers in `agent.image_gen_registry`.

That meant a removed or disabled image-gen plugin could still leave a stale provider behind after `discover_and_load(force=True)`, which defeats the purpose of a refresh in long-lived sessions.

This patch fixes that by:

- tracking image-gen provider names registered through `PluginContext`
- unregistering those providers before a forced rediscovery
- adding a regression test that deletes a backend plugin and verifies the provider no longer remains registered after `force=True`

## Why

`image_generate` explicitly uses forced rediscovery as a recovery path when a configured provider is missing. If stale providers survive refresh, plugin lifecycle state becomes inconsistent and removed backends can still appear available.

## Testing

- `bash scripts/run_tests.sh tests/hermes_cli/test_plugin_scanner_recursion.py -k forced_rediscovery_removes_deleted_image_gen_provider`
- `bash scripts/run_tests.sh tests/hermes_cli/test_plugin_scanner_recursion.py`

## Notes

- Scope is intentionally small: no behavior changes for non-plugin providers
- The test cleanup uses recursive removal so it works on Windows after `__pycache__` is created
