### PR TITLE
fix(prompt): stabilize system prompt prefix for KV cache reuse

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4946,9 +4946,10 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
-        from hermes_time import now as _hermes_now
-        now = _hermes_now()
-        timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
+        # Use session_start timestamp for stability across turns within the same session.
+        # Regenerating the timestamp on every API call would invalidate the KV cache
+        # prefix even though the session hasn't actually started at a different time.
+        timestamp_line = f"Conversation started: {self.session_start.strftime('%A, %B %d, %Y %I:%M %p')}"
         if self.pass_session_id and self.session_id:
             timestamp_line += f"\nSession ID: {self.session_id}"
         if self.model:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -391,19 +391,21 @@ class MemoryStore:
         return resp
 
     def _render_block(self, target: str, entries: List[str]) -> str:
-        """Render a system prompt block with header and usage indicator."""
+        """Render a system prompt block with stable header (no volatile indicators).
+
+        Headers are kept stable to preserve KV cache across turns. Percentage
+        indicators that change with memory size would invalidate the cache
+        prefix even when content is identical.
+        """
         if not entries:
             return ""
 
-        limit = self._char_limit(target)
         content = ENTRY_DELIMITER.join(entries)
-        current = len(content)
-        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
 
         if target == "user":
-            header = f"USER PROFILE (who the user is) [{pct}% — {current:,}/{limit:,} chars]"
+            header = "USER PROFILE (who the user is)"
         else:
-            header = f"MEMORY (your personal notes) [{pct}% — {current:,}/{limit:,} chars]"
+            header = "MEMORY (your personal notes)"
 
         separator = "═" * 46
         return f"{separator}\n{header}\n{separator}\n{content}"


### PR DESCRIPTION
# fix(prompt): stabilize system prompt prefix for KV cache reuse

## Summary

Two small changes to system prompt construction eliminate spurious KV cache invalidation between turns. The volatile content being removed has no semantic value to the model and was forcing unnecessary cold re-prefill on every turn it changed.

Particularly impactful on llama.cpp servers running hybrid attention models (e.g., Qwen3.5 family with Gated DeltaNet) where `--cache-reuse` is unavailable and cache restoration relies on byte-identical prefix matching against stored checkpoints.

## Root Cause

llama.cpp's KV cache checkpoint restoration matches the new prompt's prefix against existing checkpoints. When the prefix mutates — even by a single character — the matched span shrinks and downstream tokens have to be re-prefilled from the divergence point.

Two pieces of system prompt content were mutating between turns despite no semantic change:

**1. `tools/memory_tool.py:_render_block()`** included character-count usage indicators in section headers:
```
MEMORY (your personal notes) [49% — 1,085/2,200 chars]
```
Any memory write that bumped the percentage by one point, or shifted the comma position in the character count, invalidated all downstream cache.

**2. `run_agent.py:_build_system_prompt()`** regenerated the conversation timestamp via `now()` on every API call, despite the value semantically representing session start (which doesn't change within a session). Each minute rollover invalidated the cache.

## Changes

### `run_agent.py`
Use `self.session_start` for the timestamp instead of `now()`:

```diff
-        from hermes_time import now as _hermes_now
-        now = _hermes_now()
-        timestamp_line = f"Conversation started: {now.strftime(...)}"
+        # Use session_start timestamp for stability across turns within the same session.
+        # Regenerating the timestamp on every API call would invalidate the KV cache
+        # prefix even though the session hasn't actually started at a different time.
+        timestamp_line = f"Conversation started: {self.session_start.strftime(...)}"
```

`session_start` is what the line semantically claims to display anyway — this is also a correctness fix.

### `tools/memory_tool.py`
Remove volatile usage indicators from memory block headers:

```diff
-        limit = self._char_limit(target)
         content = ENTRY_DELIMITER.join(entries)
-        current = len(content)
-        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
-
         if target == "user":
-            header = f"USER PROFILE (who the user is) [{pct}% — {current:,}/{limit:,} chars]"
+            header = "USER PROFILE (who the user is)"
         else:
-            header = f"MEMORY (your personal notes) [{pct}% — {current:,}/{limit:,} chars]"
+            header = "MEMORY (your personal notes)"
```

Usage statistics remain available in the memory tool's response payload via `_success_response()` — they're just no longer surfaced in the system prompt where they cost cache stability.

## Evidence

Tested on a llama.cpp `b8683-d0a6dfeb2` server running Qwen3.5-27B-UD-Q5_K_XL on a Tesla V100-SXM2-32GB.

**Before:** `llama-server` logs during multi-turn conversations showed prefix similarity collapsing whenever a memory write or minute rollover shifted bytes in the prompt, despite no semantic change in the conversation:

```
srv  load: looking for better prompt, base f_keep = 0.000, sim = 0.012
slot update_slots: n_tokens = 0, memory_seq_rm [0, end)
```

That's a full cold prefill — for a 22K-token conversation prefix on the V100, roughly 24-30 seconds of wasted work per turn.

**After:** Successive turns in agentic tool-call chains maintain near-perfect prefix similarity:

```
sim_best = 0.987, f_keep = 0.987    ← turn 2
sim_best = 0.998, f_keep = 1.000    ← turn 3
sim_best = 0.999, f_keep = 1.000    ← turn 4
sim_best = 0.992, f_keep = 1.000    ← turn 5
sim_best = 0.994, f_keep = 1.000    ← turn 6
sim_best = 0.997, f_keep = 1.000    ← turn 7
```

Partial invalidation still occurs at semantically meaningful boundaries — e.g., a tool-category switch from email search to OCR dropped similarity to 0.683, which is correct behavior because the recent context genuinely changed.

## Scope and Related Concerns

This PR addresses **prompt-construction sources** of cache invalidation only.

A related but architecturally distinct issue exists in `agent/auxiliary_client.py`: auxiliary tasks (title generation, summarization) default to `provider: "auto"`, which routes them through the main model endpoint. On local llama.cpp deployments this destroys the main conversation's checkpoint state on every call (~1.2% prefix similarity between the title generation prompt and a typical conversation context). That's a separate concern that warrants its own PR — the right fix is probably to default `auxiliary.*` tasks to `provider: none` or to a separate endpoint when one is configured, with a logged warning if they're routed to the main endpoint.

In real-world combined testing on the test setup — applying both these prompt fixes and the workaround `auxiliary.title_generation.provider: none` — multi-turn tool-call chain runtime dropped from roughly 7-9 minutes to 3-4 minutes on equivalent workloads. The split between the two fixes hasn't been isolated, but both contribute meaningfully and both should land.

## Backwards Compatibility

No breaking changes:
- Memory headers remain present and human-readable, just without inline usage stats
- Timestamp still displays (using `session_start`, which is what the line says it represents)
- Tool response payloads unchanged
- Memory usage stats remain available via the memory tool's response

## Testing

Manual verification confirms the fixes are correctly applied:

```bash
# Confirm volatile counters removed from memory headers
grep -A15 "def _render_block" tools/memory_tool.py

# Confirm timestamp uses session_start
grep -B3 "timestamp_line = f\"Conversation started" run_agent.py
```

End-to-end validation via `llama-server` log analysis on multi-turn tool-call chains over a 26K-token context. Post-fix, cache invalidation occurs only at legitimate context boundaries (tool category change, context truncation), not on semantically inert prompt mutations.

To observe cache behaviour live on a running llama-server instance:

```bash
tail -f /var/log/llama-server.log | grep -E "memory_seq_rm|found better|f_keep|sim =|erased invalidated"
```

Healthy indicators: `sim_best > 0.95` on consecutive turns, `memory_seq_rm` positions advancing rather than resetting to `[0, end)`. Pathological indicator: `sim = 0.0xx` or `memory_seq_rm [0, end)` on turns where no semantic context shift occurred.

## Files Changed

- `tools/memory_tool.py` — 6 lines removed, 5 lines added (header simplification + docstring)
- `run_agent.py` — 3 lines removed, 4 lines added (timestamp source + comment)
