### PR TITLE
fix(tui): cap oversized tool outputs before model calls

### DIFF
--- a/tests/tui_gateway/test_tool_output_truncation.py
+++ b/tests/tui_gateway/test_tool_output_truncation.py
@@ -1,0 +1,106 @@
+"""Focused tests for tui_gateway.server._truncate_tool_messages."""
+
+import os
+
+from tui_gateway import server
+
+
+class TestTruncateToolMessages:
+    def test_passes_through_small_messages_unchanged(self) -> None:
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "tool", "content": "small output"},
+        ]
+        result = server._truncate_tool_messages(msgs, max_chars=100)
+        assert result == msgs
+
+    def test_truncates_oversized_tool_message(self) -> None:
+        big = "line\n" * 5000  # ~30k chars
+        msgs = [{"role": "tool", "content": big}]
+        result = server._truncate_tool_messages(msgs, max_chars=100)
+        assert len(result) == 1
+        text = result[0]["content"]
+        assert "[truncated," in text and "chars total]" in text
+        assert len(text) <= 200  # head (~100) + banner (~30)
+
+    def test_truncates_tool_text_field_without_adding_content(self) -> None:
+        big = "line\n" * 5000
+        msgs = [{"role": "tool", "text": big}]
+        result = server._truncate_tool_messages(msgs, max_chars=100)
+        assert "content" not in result[0]
+        assert "[truncated," in result[0]["text"]
+        assert len(result[0]["text"]) <= 200
+
+    def test_keeps_head_at_newline_boundary(self) -> None:
+        big = "a\nb\nc\nd\ne\n" * 30  # ~150 chars
+        msgs = [{"role": "tool", "content": big}]
+        result = server._truncate_tool_messages(msgs, max_chars=20)
+        text = result[0]["content"]
+        # Should break at a newline, not mid-word
+        assert text.startswith("a\nb\nc\n") or text.startswith("a\nb\n")
+        assert "[truncated" in text
+
+    def test_does_not_mutate_original_list(self) -> None:
+        big = "x" * 200
+        msgs = [{"role": "tool", "content": big}]
+        original_content = msgs[0]["content"]
+        server._truncate_tool_messages(msgs, max_chars=50)
+        assert msgs[0]["content"] == original_content
+
+    def test_non_dict_items_passthrough(self) -> None:
+        msgs = ["not a dict", {"role": "tool", "content": "ok"}]
+        result = server._truncate_tool_messages(msgs, max_chars=10)
+        assert result[0] == "not a dict"
+        assert result[1]["content"] == "ok"
+
+    def test_does_not_truncate_large_user_or_assistant_messages(self) -> None:
+        big = "y" * 500
+        msgs = [
+            {"role": "user", "content": big},
+            {"role": "assistant", "content": big},
+        ]
+        result = server._truncate_tool_messages(msgs, max_chars=50)
+        assert result == msgs
+
+    def test_heuristic_truncates_large_flat_roleless_content(self) -> None:
+        big = "y" * 500
+        msgs = [{"content": big}]
+        result = server._truncate_tool_messages(msgs, max_chars=50)
+        assert "[truncated" in result[0]["content"]
+
+    def test_empty_or_missing_content_unchanged(self) -> None:
+        msgs = [
+            {"role": "tool"},
+            {"role": "tool", "content": ""},
+            {"role": "user"},
+        ]
+        result = server._truncate_tool_messages(msgs, max_chars=10)
+        assert result == msgs
+
+    def test_env_override_changes_default(self) -> None:
+        old = os.environ.get("HERMES_TUI_MAX_TOOL_CHARS")
+        try:
+            os.environ["HERMES_TUI_MAX_TOOL_CHARS"] = "1234"
+            # Force re-import of the module-level constant by re-reading
+            max_chars = int(os.environ.get("HERMES_TUI_MAX_TOOL_CHARS", "8000"))
+            big = "z" * 5000
+            msgs = [{"role": "tool", "content": big}]
+            result = server._truncate_tool_messages(msgs, max_chars=max_chars)
+            assert len(result[0]["content"]) <= 1300
+        finally:
+            if old is None:
+                os.environ.pop("HERMES_TUI_MAX_TOOL_CHARS", None)
+            else:
+                os.environ["HERMES_TUI_MAX_TOOL_CHARS"] = old
+
+    def test_multiple_tools_total_under_threshold(self) -> None:
+        # Gateway-level fix caps *per-tool*, not total.  Verify each is
+        # truncated independently so a batch of 5x10k tools stays bounded.
+        msgs = [
+            {"role": "tool", "content": "a" * 10000},
+            {"role": "tool", "content": "b" * 10000},
+        ]
+        result = server._truncate_tool_messages(msgs, max_chars=100)
+        for m in result:
+            assert "[truncated" in m["content"]
+            assert len(m["content"]) <= 200

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1251,6 +1251,70 @@ def _sync_session_key_after_compress(sid: str, session: dict) -> None:
         pass
 
 
+
+# ---- Tool-output truncation -------------------------------------------------
+
+# Per-turn safety valve: when a single tool (or a batch of parallel tools)
+# dumps a huge stdout, the raw text inflates the request tokens sent to the
+# model and can exceed the context window mid-turn.  _compress_context runs
+# *between* turns, so it never gets a chance to act.  Truncating tool results
+# here keeps the gateway-side history under a hard ceiling before the
+# agent assembles the LLM payload.
+#
+# Default threshold is tuned for qwen3.6-27b (~32k context).  Each tool
+# message is capped at 8k chars (≈2k tokens), which leaves room for system
+# prompt + prior history + response headroom.
+_MAX_TOOL_CHARS = int(os.environ.get("HERMES_TUI_MAX_TOOL_CHARS", "8000"))
+
+
+def _truncate_tool_messages(
+    messages: list[dict],
+    max_chars: int = _MAX_TOOL_CHARS,
+) -> list[dict]:
+    """Return a shallow copy of *messages* with oversized tool texts truncated.
+
+    Only tool messages, or flat role-less messages that look like normalized
+    tool output, are rewritten.  A trailing ``... [truncated, N chars total]``
+    banner is appended so the model still knows data was dropped.
+    """
+    out: list[dict] = []
+    protected_roles = {"user", "assistant", "system"}
+    flat_text_keys = {"role", "content", "text"}
+
+    for m in messages:
+        if not isinstance(m, dict):
+            out.append(m)
+            continue
+
+        role = str(m.get("role", "")).lower()
+        field = ""
+        text = ""
+        if role == "tool":
+            for candidate in ("content", "text"):
+                value = m.get(candidate)
+                if isinstance(value, str) and value:
+                    field = candidate
+                    text = value
+                    break
+        elif role not in protected_roles and set(m).issubset(flat_text_keys):
+            for candidate in ("content", "text"):
+                value = m.get(candidate)
+                if isinstance(value, str) and value:
+                    field = candidate
+                    text = value
+                    break
+
+        if text and len(text) > max_chars:
+            head = text[:max_chars]
+            # Break at last newline to avoid splitting a word / ANSI code.
+            if "\n" in head:
+                head = head.rsplit("\n", 1)[0]
+            banner = f"\n... [truncated, {len(text)} chars total]"
+            m = dict(m)
+            m[field] = head + banner
+        out.append(m)
+    return out
+
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
@@ -2939,9 +3003,14 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
 
+            # Safety valve: truncate oversized tool outputs before the agent
+            # assembles the LLM payload, preventing mid-turn context-window
+            # stalls when parallel tools dump large stdout.
+            safe_history = _truncate_tool_messages(history)
+
             result = agent.run_conversation(
                 run_message,
-                conversation_history=list(history),
+                conversation_history=safe_history,
                 stream_callback=_stream,
             )
 


### PR DESCRIPTION
## Summary
- truncates oversized tool outputs before they enter TUI gateway model payloads
- preserves user, assistant, and system messages unchanged
- adds regression coverage for role-less normalized tool output and non-tool large messages

## Validation
- python3 -m pytest tests/tui_gateway/test_tool_output_truncation.py -q -o addopts=''
- python3 -m ruff check tests/tui_gateway/test_tool_output_truncation.py

## Notes
- reviewed locally from clean worktree /tmp/hermes-agent-tui-truncation-2026-05-01