### PR TITLE
feat(cron): enrich failure diagnostics + rolling failure history

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -536,6 +536,7 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "failure_history": [],  # Rolling last-5 failures: [{at, error, session_id}]
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -696,6 +697,16 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+
+                # Maintain rolling failure history (last 5 entries).
+                # On success, clear it so the counter resets.
+                if not success:
+                    _entry = {"at": now, "error": (error or "unknown")[:200]}
+                    _hist = list(job.get("failure_history") or [])
+                    _hist.append(_entry)
+                    job["failure_history"] = _hist[-5:]  # keep last 5
+                else:
+                    job["failure_history"] = []
                 
                 # Increment completed count
                 if job.get("repeat"):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -16,6 +16,7 @@ import logging
 import os
 import subprocess
 import sys
+import traceback
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -1194,22 +1195,52 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        
+
+        # Collect agent activity diagnostics if available
+        _diag_lines: list[str] = []
+        if agent is not None:
+            try:
+                _act = agent.get_activity_summary() if hasattr(agent, "get_activity_summary") else {}
+                _api_calls = _act.get("api_call_count", "?")
+                _max_iter = _act.get("max_iterations", "?")
+                _last_act = _act.get("last_activity_desc", "unknown")
+                _idle = _act.get("seconds_since_activity", 0)
+                _diag_lines.append(f"**Iterations:** {_api_calls}/{_max_iter}")
+                _diag_lines.append(f"**Last activity:** {_last_act} ({int(_idle)}s ago)")
+                if _act.get("current_tool"):
+                    _diag_lines.append(f"**Stuck on tool:** `{_act['current_tool']}`")
+            except Exception:
+                pass
+
+        _tb = traceback.format_exc()
+        _diag_block = ("\n".join(_diag_lines) + "\n\n") if _diag_lines else ""
+
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
+**Session:** `{_cron_session_id}`
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
-
-## Prompt
-
-{prompt}
 
 ## Error
 
 ```
 {error_msg}
 ```
+
+## Agent Diagnostics
+
+{_diag_block}**Session log:** `~/.hermes/sessions/session_{_cron_session_id}.json`
+
+## Traceback
+
+```
+{_tb}
+```
+
+## Prompt
+
+{prompt}
 """
         return False, output, "", error_msg
 
@@ -1340,7 +1371,28 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # Deliver the final response to the origin/target chat.
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                if success:
+                    deliver_content = final_response
+                else:
+                    # Build a structured failure notification with enough
+                    # context to diagnose without opening logs manually.
+                    _fail_lines = [
+                        f"❌ **Cron job failed:** `{job.get('name', job['id'])}`",
+                        f"**Error:** {error}",
+                    ]
+                    # Surface consecutive failure count if available
+                    _history = job.get("failure_history") or []
+                    if len(_history) > 1:
+                        _fail_lines.append(f"**Consecutive failures:** {len(_history)} (first: {_history[0].get('at', '?')[:16]})")
+                    # Include session log path for easy debugging
+                    _session_files = sorted(
+                        (f for f in (Path(_hermes_home) / "sessions").glob(f"session_cron_{job['id']}_*.json") if f.is_file()),
+                        key=lambda p: p.stat().st_mtime,
+                        reverse=True,
+                    )
+                    if _session_files:
+                        _fail_lines.append(f"**Session log:** `{_session_files[0]}`")
+                    deliver_content = "\n".join(_fail_lines)
                 should_deliver = bool(deliver_content)
                 if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -234,6 +234,14 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    # Surface failure history and last error only when there are failures —
+    # keeps the list output clean for healthy jobs.
+    if job.get("last_status") == "error" or job.get("failure_history"):
+        result["last_error"] = job.get("last_error")
+        _hist = job.get("failure_history") or []
+        if _hist:
+            result["failure_history"] = _hist
+            result["consecutive_failures"] = len(_hist)
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("enabled_toolsets"):


### PR DESCRIPTION
## Summary

Improves cron job failure diagnostics so failures are actionable without manually hunting through log files.

### Changes

**`cron/scheduler.py`**
- `run_job` failure output now includes: full Python traceback, session ID (links to the session JSON), agent iteration count, last activity description, and stuck-tool name when the agent was blocked on a specific tool call
- `_process_job` failure notification (delivered to Telegram/Discord/etc.) replaced the bare one-liner with a structured message: job name, error, consecutive failure count, and direct path to the session log

**`cron/jobs.py`**
- `mark_job_run` now maintains a rolling `failure_history` buffer (last 5 entries: `{at, error}`)
- Buffer is cleared on success so the consecutive-failure counter resets cleanly
- Field added to the job schema with default `[]` for new jobs

**`tools/cronjob_tools.py`**
- `cronjob(action='list')` now surfaces `last_error`, `failure_history`, and `consecutive_failures` when a job is in error state
- Healthy jobs are unaffected (fields omitted to keep output clean)

### Before / After

**Before** — failure notification:
```
⚠️ Cron job 'My Job' failed:
RuntimeError: agent reported failure
```

**After** — failure notification:
```
❌ Cron job failed: `My Job`
Error: RuntimeError: agent reported failure
Consecutive failures: 3 (first: 2026-04-30T07:00)
Session log: `/home/ubuntu/.hermes/sessions/session_cron_abc123_20260430_070025.json`
```

**After** — `cronjob(action='list')` for a failing job:
```json
{
  "last_status": "error",
  "last_error": "RuntimeError: ...",
  "consecutive_failures": 3,
  "failure_history": [
    {"at": "2026-04-28T07:00:25", "error": "..."},
    {"at": "2026-04-29T07:00:31", "error": "..."},
    {"at": "2026-04-30T07:00:25", "error": "..."}
  ]
}
```

### Motivation

This is groundwork for an autorecovery feature — the `failure_history` buffer lets a repair agent distinguish a transient fluke from a recurring structural problem before deciding whether to retry, patch the prompt, or escalate.
