### PR TITLE
fix(weixin): steer agent to images or list format for wide tables (#16951)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -787,7 +787,13 @@ PLATFORM_HINTS = {
         "include MEDIA:/absolute/path/to/file in your response. Images are sent as native "
         "photos, videos play inline when supported, and other files arrive as downloadable "
         "documents. You can also include image URLs in markdown format ![alt](url) and they "
-        "will be downloaded and sent as native media when possible."
+        "will be downloaded and sent as native media when possible.\n\n"
+        "Tables: the WeChat personal client clips the right-hand side of wide pipe-style "
+        "Markdown tables — columns beyond the initial viewport stay hidden even when the "
+        "user scrolls. Do NOT use pipe tables for 3+ columns or wide data. Instead, either "
+        "(a) render the table as an image (for example via the bundled table-image-generator "
+        "skill) and attach it with MEDIA:/absolute/path/to/table.png, or (b) for simple "
+        "rows, format as a key: value list. Two-column pipe tables render fine and are OK."
     ),
     "wecom": (
         "You are on WeCom (企业微信 / Enterprise WeChat). Markdown formatting is supported. "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -791,9 +791,10 @@ PLATFORM_HINTS = {
         "Tables: the WeChat personal client clips the right-hand side of wide pipe-style "
         "Markdown tables — columns beyond the initial viewport stay hidden even when the "
         "user scrolls. Do NOT use pipe tables for 3+ columns or wide data. Instead, either "
-        "(a) render the table as an image (for example via the bundled table-image-generator "
-        "skill) and attach it with MEDIA:/absolute/path/to/table.png, or (b) for simple "
-        "rows, format as a key: value list. Two-column pipe tables render fine and are OK."
+        "(a) render the table as an image using whatever image-generation tool is available "
+        "(or code that produces a table screenshot) and attach it with "
+        "MEDIA:/absolute/path/to/table.png, or (b) for simple rows, format as a key: value "
+        "list. Two-column pipe tables render fine and are OK."
     ),
     "wecom": (
         "You are on WeCom (企业微信 / Enterprise WeChat). Markdown formatting is supported. "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1128,6 +1128,32 @@ class TestPromptBuilderConstants:
         assert "Markdown" in hint
         assert "absolute" in hint
 
+    def test_platform_hints_weixin_discourages_wide_pipe_tables(self):
+        # Regression for #16951: the WeChat personal client clips the
+        # right-hand side of wide pipe-style Markdown tables, so the
+        # Weixin hint must steer the agent to images or key:value lists
+        # for 3+ column data instead of pipe tables.
+        hint = PLATFORM_HINTS["weixin"]
+        # Existing positive guidance remains.
+        assert "Weixin" in hint or "WeChat" in hint
+        assert "MEDIA:" in hint
+        # New negative guidance about wide pipe tables must be present.
+        lower = hint.lower()
+        assert "table" in lower, "weixin hint should mention tables"
+        assert "pipe" in lower, (
+            "weixin hint should explicitly call out pipe-style tables"
+        )
+        assert any(
+            marker in lower for marker in ("do not", "don't", "not use")
+        ), "weixin hint should explicitly discourage wide pipe tables"
+        # The recommended alternatives must be spelled out.
+        assert (
+            "image" in lower or "table-image-generator" in lower
+        ), "weixin hint should point to image rendering as an alternative"
+        assert "key: value" in lower or "key:value" in lower, (
+            "weixin hint should point to key:value list format as an alternative"
+        )
+
 
 # =========================================================================
 # Environment hints

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1147,9 +1147,9 @@ class TestPromptBuilderConstants:
             marker in lower for marker in ("do not", "don't", "not use")
         ), "weixin hint should explicitly discourage wide pipe tables"
         # The recommended alternatives must be spelled out.
-        assert (
-            "image" in lower or "table-image-generator" in lower
-        ), "weixin hint should point to image rendering as an alternative"
+        assert "image" in lower, (
+            "weixin hint should point to image rendering as an alternative"
+        )
         assert "key: value" in lower or "key:value" in lower, (
             "weixin hint should point to key:value list format as an alternative"
         )


### PR DESCRIPTION
## What does this PR do?

The WeChat personal client clips the right-hand side of wide pipe-style
Markdown tables — columns beyond the initial viewport stay hidden even
when the user horizontally scrolls. This is a client-side rendering bug
in the WeChat Webview engine, not a Hermes transport issue: since #11571
the Weixin adapter already preserves Markdown tables intact, so the
clipping happens after delivery.

Per the issue reporter's proposed mitigation, this PR extends the Weixin
platform hint (`PLATFORM_HINTS["weixin"]` in `agent/prompt_builder.py`)
so the agent proactively avoids wide pipe tables when chatting on Weixin
and instead either:

1. renders the table as an image using whatever image-generation tool is
   available (or code that produces a table screenshot) and attaches it
   with `MEDIA:/absolute/path/to/table.png`, or
2. formats the data as a simple `key: value` list.

Two-column pipe tables render fine on WeChat and remain permitted.

The change is scoped to the system-prompt string. There is no change to
the transport layer, to any gateway adapter, or to the `wecom`
(Enterprise WeChat) hint.

## Related Issue

Fixes #16951

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/prompt_builder.py`: append a "Tables:" paragraph to
  `PLATFORM_HINTS["weixin"]` that explicitly forbids 3+ column pipe
  tables on Weixin and points the agent at rendering the table as an image
  via whatever image-generation tool is available (or code that produces a
  table screenshot) with `MEDIA:`, or a `key: value` list format, as the
  two recommended alternatives.
- `tests/agent/test_prompt_builder.py`: add
  `test_platform_hints_weixin_discourages_wide_pipe_tables` to pin the
  new guidance (regression gate).

## How to Test

```bash
uv venv .venv --python 3.11
source .venv/bin/activate
uv pip install -e ".[all,dev]"
python -m pytest tests/agent/test_prompt_builder.py -q
```

All 116 tests in that module pass (1 pre-existing skip).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(weixin): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open PR referenced #16951 at the time of writing)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/agent/test_prompt_builder.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (prompt string only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — prompt string only, platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
