### PR TITLE
fix(gateway/slack): batch salvage — reserved commands, session isolation, delivery fixes

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -53,9 +53,10 @@ class DeliveryTarget:
         - "telegram" → Telegram home channel
         - "telegram:123456" → specific Telegram chat
         """
-        target = target.strip().lower()
+        target_stripped = target.strip()
+        target_lower = target_stripped.lower()
         
-        if target == "origin":
+        if target_lower == "origin":
             if origin:
                 return cls(
                     platform=origin.platform,
@@ -67,13 +68,14 @@ class DeliveryTarget:
                 # Fallback to local if no origin
                 return cls(platform=Platform.LOCAL, is_origin=True)
         
-        if target == "local":
+        if target_lower == "local":
             return cls(platform=Platform.LOCAL)
         
         # Check for platform:chat_id or platform:chat_id:thread_id format
-        if ":" in target:
-            parts = target.split(":", 2)
-            platform_str = parts[0]
+        # Use the original case for chat_id/thread_id to preserve case-sensitive IDs
+        if ":" in target_stripped:
+            parts = target_stripped.split(":", 2)
+            platform_str = parts[0].lower()  # Platform names are case-insensitive
             chat_id = parts[1] if len(parts) > 1 else None
             thread_id = parts[2] if len(parts) > 2 else None
             try:
@@ -85,7 +87,7 @@ class DeliveryTarget:
         
         # Just a platform name (use home channel)
         try:
-            platform = Platform(target)
+            platform = Platform(target_lower)
             return cls(platform=platform)
         except ValueError:
             # Unknown platform, treat as local

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2851,8 +2851,15 @@ class DiscordAdapter(BasePlatformAdapter):
             raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
-        if isinstance(raw, str) and raw.strip():
-            return {part.strip() for part in raw.split(",") if part.strip()}
+        # Coerce non-list scalars (str/int/float) to str before splitting.
+        # YAML parses a bare numeric value such as
+        # `free_response_channels: 1491973769726791812` as int, which was
+        # previously falling through the isinstance(str) branch and silently
+        # returning an empty set.  str() here accepts whatever scalar the YAML
+        # loader hands us without changing existing string/CSV semantics.
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
     def _thread_parent_channel(self, channel: Any) -> Any:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -734,6 +734,10 @@ class SlackAdapter(BasePlatformAdapter):
 
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
+            # Clear Slack Assistant status as soon as the final message is posted.
+            if thread_ts:
+                await self.stop_typing(chat_id)
+
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
@@ -811,6 +815,8 @@ class SlackAdapter(BasePlatformAdapter):
                 ts=message_id,
                 text=formatted,
             )
+            if finalize:
+                await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -851,7 +857,7 @@ class SlackAdapter(BasePlatformAdapter):
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
 
-    async def stop_typing(self, chat_id: str) -> None:
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Clear the assistant thread status indicator."""
         if not self._app:
             return

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2888,6 +2888,13 @@ class SlackAdapter(BasePlatformAdapter):
             raw = os.getenv("SLACK_FREE_RESPONSE_CHANNELS", "")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
-        if isinstance(raw, str) and raw.strip():
-            return {part.strip() for part in raw.split(",") if part.strip()}
+        # Coerce non-list scalars (str/int/float) to str before splitting.
+        # A bare numeric YAML value (`free_response_channels: 1234567890`) is
+        # loaded as int and was previously falling through the isinstance(str)
+        # branch to return an empty set.  str() here accepts whatever scalar
+        # the YAML loader hands us without changing existing string/CSV
+        # semantics.
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
         return set()

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2695,9 +2695,14 @@ class SlackAdapter(BasePlatformAdapter):
             # gateway command dispatcher by prepending the slash.
             text = f"/{slash_name} {text}".strip()
 
+        # Slack slash commands can originate from DMs or shared channels.
+        # Preserve DM semantics only for DM channel IDs; shared channels must
+        # keep group semantics so different users do not collide into one
+        # session key.
+        is_dm = str(channel_id).startswith("D")
         source = self.build_source(
             chat_id=channel_id,
-            chat_type="dm",  # Slash commands are always in DM-like context
+            chat_type="dm" if is_dm else "group",
             user_id=user_id,
         )
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -838,6 +838,13 @@ def discord_skill_commands_by_category(
 _SLACK_MAX_SLASH_COMMANDS = 50
 _SLACK_NAME_LIMIT = 32
 _SLACK_INVALID_CHARS = re.compile(r"[^a-z0-9_\-]")
+_SLACK_RESERVED_COMMANDS = frozenset({
+    # Built-in Slack slash commands that cannot be registered by apps.
+    # https://slack.com/help/articles/201259356-Use-built-in-slash-commands
+    "me", "status", "away", "dnd", "shrug", "remind", "msg", "feed",
+    "who", "collapse", "expand", "leave", "join", "open", "search",
+    "topic", "mute", "pro", "shortcuts",
+})
 
 
 def _sanitize_slack_name(raw: str) -> str:
@@ -864,6 +871,10 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     documented form (e.g. ``/background``, ``/bg``, and ``/btw`` all work).
     Plugin-registered slash commands are included too.
 
+    Commands whose sanitized name collides with a Slack built-in
+    (e.g. ``/status``, ``/me``, ``/join``) are silently skipped.  Users
+    can still reach them via ``/hermes <command>``.
+
     Results are clamped to Slack's 50-command limit with duplicate-name
     avoidance. ``/hermes`` is always reserved as the first entry so the
     legacy ``/hermes <subcommand>`` form keeps working for anything that
@@ -880,6 +891,8 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     def _add(name: str, desc: str, hint: str) -> None:
         slack_name = _sanitize_slack_name(name)
         if not slack_name or slack_name in seen:
+            return
+        if slack_name in _SLACK_RESERVED_COMMANDS:
             return
         if len(entries) >= _SLACK_MAX_SLASH_COMMANDS:
             return

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -82,6 +82,11 @@ AUTHOR_MAP = {
     "rob@atlas.lan": "rmoen",
     # Slack ephemeral slash-ack salvage (May 2026)
     "probepark@users.noreply.github.com": "probepark",
+    # Slack batch salvage (May 2026)
+    "280484231+prive-fe-bot@users.noreply.github.com": "priveperfumes",
+    "amr@ghanem.sa": "amroessam",
+    "paperlantern.agent@gmail.com": "Hinotoi-agent",
+    "valda@underscore.jp": "valda",
     "162235745+0z1-ghb@users.noreply.github.com": "0z1-ghb",
     "yes999zc@163.com": "yes999zc",
     "343873859@qq.com": "DrStrangerUJN",

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -65,4 +65,62 @@ class TestTargetToStringRoundtrip:
         assert reparsed.chat_id == "999"
 
 
+class TestCaseSensitiveChatIdParsing:
+    """Test that chat IDs preserve their original case (issue #11768)."""
+    
+    def test_slack_uppercase_chat_id_preserved(self):
+        """Slack channel IDs like C123ABC should preserve case."""
+        target = DeliveryTarget.parse("slack:C123ABC")
+        assert target.platform == Platform.SLACK
+        assert target.chat_id == "C123ABC"  # Should NOT be lowercased to c123abc
+        assert target.is_explicit is True
+    
+    def test_slack_chat_id_with_thread_preserved(self):
+        """Slack channel:thread IDs should preserve case."""
+        target = DeliveryTarget.parse("slack:C123ABC:thread123")
+        assert target.platform == Platform.SLACK
+        assert target.chat_id == "C123ABC"
+        assert target.thread_id == "thread123"
+    
+    def test_matrix_room_id_preserved(self):
+        """Matrix room IDs like !RoomABC:example.org should preserve case.
+        
+        Note: Matrix room IDs contain colons (e.g., !RoomABC:example.org).
+        Due to the platform:chat_id:thread_id format, these are parsed as
+        chat_id=!RoomABC and thread_id=example.org. This is a known limitation
+        of the current format. The fix preserves case but doesn't change the
+        parsing structure.
+        """
+        target = DeliveryTarget.parse("matrix:!RoomABC:example.org")
+        assert target.platform == Platform.MATRIX
+        # The room ID is split at the first colon after the platform prefix
+        # This is a format limitation - the case is preserved but the structure is split
+        assert target.chat_id == "!RoomABC"
+        assert target.thread_id == "example.org"
+    
+    def test_mixed_case_chat_id_roundtrip(self):
+        """Mixed-case chat IDs should survive parse-to_string roundtrip."""
+        original = "telegram:ChatId123ABC"
+        target = DeliveryTarget.parse(original)
+        s = target.to_string()
+        reparsed = DeliveryTarget.parse(s)
+        assert reparsed.chat_id == "ChatId123ABC"
+
+
+class TestPlatformNameCaseInsensitivity:
+    """Test that platform names are case-insensitive."""
+    
+    def test_uppercase_platform_name(self):
+        """Platform names should be case-insensitive."""
+        target = DeliveryTarget.parse("TELEGRAM:12345")
+        assert target.platform == Platform.TELEGRAM
+        assert target.chat_id == "12345"
+    
+    def test_mixed_case_platform_name(self):
+        """Mixed-case platform names should work."""
+        target = DeliveryTarget.parse("TeleGram:12345")
+        assert target.platform == Platform.TELEGRAM
+        assert target.chat_id == "12345"
+
+
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -220,6 +220,26 @@ async def test_discord_free_response_channel_can_come_from_config_extra(adapter,
     assert event.text == "allowed from config"
 
 
+def test_discord_free_response_channels_bare_int(adapter, monkeypatch):
+    # YAML `discord.free_response_channels: 1491973769726791812` (single bare
+    # integer) is loaded as an int and previously fell through the
+    # isinstance(str) branch in _discord_free_response_channels, silently
+    # returning an empty set.  Scalar → str coercion makes single-channel
+    # config work without having to quote the ID in YAML.
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["free_response_channels"] = 1491973769726791812
+
+    assert adapter._discord_free_response_channels() == {"1491973769726791812"}
+
+
+def test_discord_free_response_channels_int_list(adapter, monkeypatch):
+    # YAML list form with bare numeric entries — each element should be coerced.
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["free_response_channels"] = [1491973769726791812, 99999]
+
+    assert adapter._discord_free_response_channels() == {"1491973769726791812", "99999"}
+
+
 @pytest.mark.asyncio
 async def test_discord_forum_parent_in_free_response_list_allows_forum_thread(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1153,6 +1153,104 @@ class TestSendTyping:
             status="is thinking...",
         )
 
+    @pytest.mark.asyncio
+    async def test_stop_typing_clears_tracked_thread(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list[1] == call(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_noop_without_tracked_thread(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.stop_typing("C123")
+
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_handles_api_error_gracefully(self, adapter):
+        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=Exception("missing_scope")
+        )
+
+        await adapter.stop_typing("C123")
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_send_clears_status_after_final_post(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = "parent_ts"
+
+        result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
+
+        assert result.success
+        adapter._app.client.chat_postMessage.assert_called_once()
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_streaming_final_edit_clears_status(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = "parent_ts"
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "done",
+            finalize=True,
+        )
+
+        assert result.success
+        adapter._app.client.chat_update.assert_called_once_with(
+            channel="C123",
+            ts="reply_ts",
+            text="done",
+        )
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_streaming_intermediate_edit_keeps_status(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = "parent_ts"
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "partial",
+            finalize=False,
+        )
+
+        assert result.success
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+        assert adapter._active_status_threads["C123"] == "parent_ts"
+
 
 # ---------------------------------------------------------------------------
 # TestFormatMessage — Markdown → mrkdwn conversion

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -93,6 +93,46 @@ def _redirect_cache(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# TestSlashCommandSessionIsolation
+# ---------------------------------------------------------------------------
+
+class TestSlashCommandSessionIsolation:
+    @pytest.mark.asyncio
+    async def test_channel_slash_command_uses_group_session_semantics(self, adapter):
+        command = {
+            "text": "hello",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.chat_type == "group"
+        assert event.source.chat_id == "C123"
+        assert event.source.user_id == "U123"
+
+    @pytest.mark.asyncio
+    async def test_dm_slash_command_keeps_dm_session_semantics(self, adapter):
+        command = {
+            "text": "hello",
+            "user_id": "U123",
+            "channel_id": "D123",
+            "team_id": "T123",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.chat_type == "dm"
+        assert event.source.chat_id == "D123"
+        assert event.source.user_id == "U123"
+
+
+# ---------------------------------------------------------------------------
 # TestAppMentionHandler
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -215,6 +215,23 @@ def test_free_response_channels_env_var_fallback(monkeypatch):
     assert OTHER_CHANNEL_ID in result
 
 
+def test_free_response_channels_bare_int():
+    # YAML `free_response_channels: 1491973769726791812` (single bare integer)
+    # is loaded as an int and would previously fall through the isinstance(str)
+    # branch to return an empty set.  Coerce scalar → str so single-channel
+    # config without quoting works as users expect.
+    adapter = _make_adapter(free_response_channels=1491973769726791812)
+    result = adapter._slack_free_response_channels()
+    assert result == {"1491973769726791812"}
+
+
+def test_free_response_channels_int_list():
+    # YAML list form with bare numeric entries — each element should be coerced.
+    adapter = _make_adapter(free_response_channels=[1491973769726791812, 99999])
+    result = adapter._slack_free_response_channels()
+    assert result == {"1491973769726791812", "99999"}
+
+
 # ---------------------------------------------------------------------------
 # Tests: mention gating integration (simulating _handle_slack_message logic)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -13,6 +13,7 @@ from hermes_cli.commands import (
     SlashCommandAutoSuggest,
     SlashCommandCompleter,
     _CMD_NAME_LIMIT,
+    _SLACK_RESERVED_COMMANDS,
     _TG_NAME_LIMIT,
     _clamp_command_names,
     _clamp_telegram_names,
@@ -299,8 +300,18 @@ class TestSlackNativeSlashes:
     def test_includes_canonical_commands(self):
         names = {n for n, _d, _h in slack_native_slashes()}
         # Sample of gateway-available canonical commands
-        for expected in ("new", "stop", "background", "model", "help", "status"):
+        for expected in ("new", "stop", "background", "model", "help"):
             assert expected in names, f"missing canonical /{expected}"
+
+    def test_excludes_slack_reserved_commands(self):
+        """Slack built-in commands (e.g. /status, /me, /join) cannot be
+        registered by apps and must be excluded from the manifest.
+        Users can still reach them via /hermes <command>."""
+        names = {n for n, _d, _h in slack_native_slashes()}
+        for reserved in _SLACK_RESERVED_COMMANDS:
+            assert reserved not in names, (
+                f"/{reserved} is a Slack built-in and must not appear in the manifest"
+            )
 
     def test_includes_aliases_as_first_class_slashes(self):
         """Aliases (/btw, /bg, /reset, /q) must be registered as standalone
@@ -319,6 +330,9 @@ class TestSlackNativeSlashes:
         Telegram but not Slack (because of Slack's 50-slash cap), this
         test fails loudly so we can curate the list rather than silently
         dropping parity.
+
+        Slack-reserved built-in commands (e.g. /status) are excluded
+        from parity checks since they cannot be registered on Slack.
         """
         slack_names = {n for n, _d, _h in slack_native_slashes()}
         tg_names = {n for n, _d in telegram_bot_commands()}
@@ -329,7 +343,8 @@ class TestSlackNativeSlashes:
 
         slack_norm = {_norm(n) for n in slack_names}
         tg_norm = {_norm(n) for n in tg_names}
-        missing = tg_norm - slack_norm
+        reserved_norm = {_norm(n) for n in _SLACK_RESERVED_COMMANDS}
+        missing = (tg_norm - slack_norm) - reserved_norm
         assert not missing, (
             f"commands on Telegram but missing from Slack native slashes: {sorted(missing)}"
         )


### PR DESCRIPTION
## Summary

Batch salvage of 5 focused Slack bug fixes from open community PRs. Each fix is a clean cherry-pick with original authorship preserved; no modifications needed.

## Salvaged PRs

| PR | Author | Priority | What it fixes |
|----|--------|----------|---------------|
| #18456 | @priveperfumes | P2 bug | Reserved Slack built-in commands (`/status`, `/me`, `/join`, etc.) included in the native slash manifest cause Slack API registration failures |
| #14932 | @valda | P2 bug | YAML `free_response_channels: 1234567890` loaded as `int` silently returns empty set — `isinstance(raw, str)` gate rejects it |
| #11893 | @nightq | P2 bug | `DeliveryTarget.parse()` calls `.lower()` on the entire target string including Slack channel IDs (`C0ABC123`) which are case-sensitive |
| #9361 | @Hinotoi-agent | P1 security | Slash commands hardcode `chat_type="dm"` for all channels — users in shared channels share one agent session (session collision) |
| #17798 | @amroessam | P2 bug | Slack "is thinking…" assistant status indicator lingers after the bot replies — no `stop_typing()` call in `send()`/`edit_message()` |

## Changes by file

| File | PRs | What |
|------|-----|------|
| `hermes_cli/commands.py` | #18456 | `_SLACK_RESERVED_COMMANDS` frozenset + filter in `_add()` to skip 19 reserved Slack built-ins |
| `gateway/platforms/slack.py` | #14932, #9361, #17798 | Coerce free_response_channels to str; detect DM vs group channel for slash commands; call `stop_typing()` after final send/edit |
| `gateway/platforms/discord.py` | #14932 | Same free_response_channels str coercion (Discord adapter has the identical bug) |
| `gateway/delivery.py` | #11893 | Only lowercase the platform prefix, preserve case for chat_id and thread_id |
| `scripts/release.py` | — | AUTHOR_MAP entries for 4 new contributors |
| `tests/` | all | Tests from each PR cherry-picked with the fix |

## PRs closed as redundant (in follow-up comments)

| PR | Reason |
|----|--------|
| #18453 | Redundant with #18456 — renames `/status` → `/status1` (worse UX vs clean exclusion) |
| #12193 | Already fixed in PR #18198 (app_mention forwarding) |
| #17081 | Incorrect — Slack API docs allow hyphens in command names |
| #10875 | Overlaps with #9361; riskier scope (thread_ts session key changes) |

## Test plan

- 429 tests passed across affected test files (0 failures)
- All changed `.py` files pass `py_compile`
- Each cherry-pick applied cleanly with zero conflicts
