### PR TITLE
fix(auth): allow Codex CLI auth reuse

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -22,13 +22,16 @@ from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     _auth_store_lock,
     _codex_access_token_is_expiring,
+    _codex_use_cli_auth_enabled,
     _decode_jwt_claims,
+    _read_codex_cli_auth_payload,
     _load_auth_store,
     _load_provider_state,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
     _save_auth_store,
     _save_provider_state,
+    _write_codex_cli_tokens,
     read_credential_pool,
     write_credential_pool,
 )
@@ -796,6 +799,15 @@ class CredentialPool:
         # _seed_from_singletons() on the next load_pool() sees fresh state
         # instead of re-seeding stale/consumed tokens.
         self._sync_device_code_entry_to_auth_store(updated)
+        if self.provider == "openai-codex" and entry.source == "codex-cli-auth" and updated.refresh_token:
+            try:
+                _write_codex_cli_tokens(
+                    updated.access_token,
+                    updated.refresh_token,
+                    last_refresh=updated.last_refresh,
+                )
+            except Exception as wexc:
+                logger.debug("Failed to write refreshed Codex CLI token from pool: %s", wexc)
         return updated
 
     def _entry_needs_refresh(self, entry: PooledCredential) -> bool:
@@ -1348,6 +1360,27 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # the Hermes auth store.  Without this gate the removal is instantly
         # undone on the next load_pool() call.
         if _is_suppressed(provider, "device_code"):
+            return changed, active_sources
+
+        if _codex_use_cli_auth_enabled():
+            cli_payload = _read_codex_cli_auth_payload(allow_expired=True)
+            cli_tokens = cli_payload.get("tokens") if isinstance(cli_payload, dict) else None
+            if isinstance(cli_tokens, dict) and cli_tokens.get("access_token"):
+                active_sources.add("codex-cli-auth")
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    "codex-cli-auth",
+                    {
+                        "source": "codex-cli-auth",
+                        "auth_type": AUTH_TYPE_OAUTH,
+                        "access_token": cli_tokens.get("access_token", ""),
+                        "refresh_token": cli_tokens.get("refresh_token"),
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_refresh": cli_payload.get("last_refresh") if isinstance(cli_payload, dict) else None,
+                        "label": label_from_token(cli_tokens.get("access_token", ""), "codex-cli-auth"),
+                    },
+                )
             return changed, active_sources
 
         state = _load_provider_state(auth_store, "openai-codex")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -91,6 +91,9 @@ model:
 #       claude-opus-4.6:
 #         timeout_seconds: 600       # Longer timeout for extended-thinking Opus calls
 #   openai-codex:
+#     # Optional compatibility mode: reuse the Codex CLI session in ~/.codex/auth.json
+#     # instead of creating a separate Hermes device-code session.
+#     # use_cli_auth: true
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2289,6 +2289,104 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         _save_auth_store(auth_store)
 
 
+def _codex_cli_auth_path() -> Path:
+    codex_home = os.getenv("CODEX_HOME", "").strip()
+    if not codex_home:
+        codex_home = str(Path.home() / ".codex")
+    return Path(codex_home).expanduser() / "auth.json"
+
+
+def _config_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _codex_use_cli_auth_enabled() -> bool:
+    """Return True when Codex should use the Codex CLI auth file directly."""
+    env_value = _config_bool(os.getenv("HERMES_CODEX_USE_CLI_AUTH"))
+    if env_value is not None:
+        return env_value
+    try:
+        raw = read_raw_config()
+        providers = raw.get("providers")
+        provider_cfg = providers.get("openai-codex") if isinstance(providers, dict) else None
+        if isinstance(provider_cfg, dict):
+            cfg_value = _config_bool(provider_cfg.get("use_cli_auth"))
+            if cfg_value is not None:
+                return cfg_value
+            auth_source = str(provider_cfg.get("auth_source") or "").strip().lower()
+            if auth_source in {"codex-cli", "cli", "shared"}:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _read_codex_cli_auth_payload(*, allow_expired: bool = False) -> Optional[Dict[str, Any]]:
+    """Read Codex CLI auth.json and return tokens plus metadata."""
+    auth_path = _codex_cli_auth_path()
+    if not auth_path.is_file():
+        return None
+    try:
+        payload = json.loads(auth_path.read_text())
+        tokens = payload.get("tokens")
+        if not isinstance(tokens, dict):
+            return None
+        access_token = tokens.get("access_token")
+        refresh_token = tokens.get("refresh_token")
+        if not access_token or not refresh_token:
+            return None
+        if not allow_expired and _codex_access_token_is_expiring(access_token, 0):
+            logger.debug(
+                "Codex CLI tokens at %s are expired — skipping import.", auth_path,
+            )
+            return None
+        return {
+            "tokens": dict(tokens),
+            "last_refresh": payload.get("last_refresh"),
+            "auth_path": str(auth_path),
+        }
+    except Exception:
+        return None
+
+
+def _write_codex_cli_tokens(
+    access_token: str,
+    refresh_token: str,
+    *,
+    last_refresh: Optional[str] = None,
+) -> None:
+    """Write rotated Codex OAuth tokens back to the Codex CLI auth file."""
+    auth_path = _codex_cli_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        payload = json.loads(auth_path.read_text()) if auth_path.is_file() else {}
+        if not isinstance(payload, dict):
+            payload = {}
+    except Exception:
+        payload = {}
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        tokens = {}
+    tokens["access_token"] = access_token
+    tokens["refresh_token"] = refresh_token
+    payload["tokens"] = tokens
+    if last_refresh:
+        payload["last_refresh"] = last_refresh
+    auth_path.write_text(json.dumps(payload, indent=2) + "\n")
+    try:
+        auth_path.chmod(0o600)
+    except OSError:
+        pass
+
+
 def refresh_codex_oauth_pure(
     access_token: str,
     refresh_token: str,
@@ -2420,32 +2518,88 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     Returns tokens dict if valid and not expired, None otherwise.
     Does NOT write to the shared file.
     """
-    codex_home = os.getenv("CODEX_HOME", "").strip()
-    if not codex_home:
-        codex_home = str(Path.home() / ".codex")
-    auth_path = Path(codex_home).expanduser() / "auth.json"
-    if not auth_path.is_file():
+    payload = _read_codex_cli_auth_payload(allow_expired=False)
+    if not payload:
         return None
-    try:
-        payload = json.loads(auth_path.read_text())
-        tokens = payload.get("tokens")
-        if not isinstance(tokens, dict):
-            return None
-        access_token = tokens.get("access_token")
-        refresh_token = tokens.get("refresh_token")
-        if not access_token or not refresh_token:
-            return None
-        # Reject expired tokens — importing stale tokens from ~/.codex/
-        # that can't be refreshed leaves the user stuck with "Login successful!"
-        # but no working credentials.
-        if _codex_access_token_is_expiring(access_token, 0):
-            logger.debug(
-                "Codex CLI tokens at %s are expired — skipping import.", auth_path,
-            )
-            return None
-        return dict(tokens)
-    except Exception:
-        return None
+    return dict(payload["tokens"])
+
+
+def _refresh_codex_cli_auth_tokens(
+    tokens: Dict[str, str],
+    timeout_seconds: float,
+) -> Dict[str, str]:
+    refreshed = refresh_codex_oauth_pure(
+        str(tokens.get("access_token", "") or ""),
+        str(tokens.get("refresh_token", "") or ""),
+        timeout_seconds=timeout_seconds,
+    )
+    updated_tokens = dict(tokens)
+    updated_tokens["access_token"] = refreshed["access_token"]
+    updated_tokens["refresh_token"] = refreshed["refresh_token"]
+    _write_codex_cli_tokens(
+        refreshed["access_token"],
+        refreshed["refresh_token"],
+        last_refresh=refreshed.get("last_refresh"),
+    )
+    return updated_tokens
+
+
+def _resolve_codex_cli_runtime_credentials(
+    *,
+    force_refresh: bool,
+    refresh_if_expiring: bool,
+    refresh_skew_seconds: int,
+) -> Dict[str, Any]:
+    payload = _read_codex_cli_auth_payload(allow_expired=True)
+    if not payload:
+        raise AuthError(
+            "Codex CLI credentials were not found. Run `codex` to sign in, or disable providers.openai-codex.use_cli_auth.",
+            provider="openai-codex",
+            code="codex_cli_auth_missing",
+            relogin_required=True,
+        )
+
+    tokens = dict(payload["tokens"])
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+
+    should_refresh = bool(force_refresh)
+    if (not should_refresh) and refresh_if_expiring:
+        should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+    if should_refresh:
+        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+            payload = _read_codex_cli_auth_payload(allow_expired=True)
+            if not payload:
+                raise AuthError(
+                    "Codex CLI credentials disappeared while refreshing.",
+                    provider="openai-codex",
+                    code="codex_cli_auth_missing",
+                    relogin_required=True,
+                )
+            tokens = dict(payload["tokens"])
+            access_token = str(tokens.get("access_token", "") or "").strip()
+            should_refresh = bool(force_refresh)
+            if (not should_refresh) and refresh_if_expiring:
+                should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+            if should_refresh:
+                tokens = _refresh_codex_cli_auth_tokens(tokens, refresh_timeout_seconds)
+                access_token = str(tokens.get("access_token", "") or "").strip()
+                payload = _read_codex_cli_auth_payload(allow_expired=True) or payload
+
+    base_url = (
+        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CODEX_BASE_URL
+    )
+
+    return {
+        "provider": "openai-codex",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "codex-cli-auth",
+        "last_refresh": payload.get("last_refresh"),
+        "auth_store": payload.get("auth_path"),
+        "auth_mode": "chatgpt",
+    }
 
 
 def resolve_codex_runtime_credentials(
@@ -2455,6 +2609,13 @@ def resolve_codex_runtime_credentials(
     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> Dict[str, Any]:
     """Resolve runtime credentials from Hermes's own Codex token store."""
+    if _codex_use_cli_auth_enabled():
+        return _resolve_codex_cli_runtime_credentials(
+            force_refresh=force_refresh,
+            refresh_if_expiring=refresh_if_expiring,
+            refresh_skew_seconds=refresh_skew_seconds,
+        )
+
     data = _read_codex_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
@@ -3627,6 +3788,27 @@ def get_codex_auth_status() -> Dict[str, Any]:
     Checks the credential pool first (where `hermes auth` stores credentials),
     then falls back to the legacy provider state.
     """
+    if _codex_use_cli_auth_enabled():
+        auth_path = _codex_cli_auth_path()
+        try:
+            creds = resolve_codex_runtime_credentials()
+            return {
+                "logged_in": True,
+                "auth_store": str(auth_path),
+                "last_refresh": creds.get("last_refresh"),
+                "auth_mode": creds.get("auth_mode"),
+                "source": creds.get("source"),
+                "api_key": creds.get("api_key"),
+            }
+        except AuthError as exc:
+            return {
+                "logged_in": False,
+                "auth_store": str(auth_path),
+                "error": str(exc),
+                "code": exc.code,
+                "relogin_required": exc.relogin_required,
+            }
+
     # Check credential pool first — this is where `hermes auth` and
     # `hermes model` store device_code tokens.
     try:
@@ -4184,6 +4366,16 @@ def _login_openai_codex(
     """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
 
     del args, pconfig  # kept for parity with other provider login helpers
+
+    if _codex_use_cli_auth_enabled():
+        existing = resolve_codex_runtime_credentials()
+        config_path = _update_config_for_provider("openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL))
+        print()
+        print("Login successful!")
+        print(f"  Auth state: {existing.get('auth_store') or _codex_cli_auth_path()}")
+        print("  Source: Codex CLI auth.json")
+        print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+        return
 
     # Check for existing Hermes-owned credentials
     if not force_new_login:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2613,6 +2613,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
+        "use_cli_auth", "auth_source",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -15,6 +15,7 @@ from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     _read_codex_tokens,
     _save_codex_tokens,
+    _write_codex_cli_tokens,
     _import_codex_cli_tokens,
     _login_openai_codex,
     get_codex_auth_status,
@@ -182,6 +183,75 @@ def test_codex_tokens_not_written_to_shared_file(tmp_path, monkeypatch):
     # Hermes auth store should have the tokens
     data = _read_codex_tokens()
     assert data["tokens"]["access_token"] == "hermes-at"
+
+
+def test_write_codex_cli_tokens_preserves_existing_payload(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-cli"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    auth_path = codex_home / "auth.json"
+    auth_path.write_text(json.dumps({
+        "tokens": {"access_token": "old-at", "refresh_token": "old-rt", "extra": "keep"},
+        "custom": "preserve",
+    }))
+
+    _write_codex_cli_tokens("new-at", "new-rt", last_refresh="2026-04-13T00:00:00Z")
+
+    payload = json.loads(auth_path.read_text())
+    assert payload["tokens"]["access_token"] == "new-at"
+    assert payload["tokens"]["refresh_token"] == "new-rt"
+    assert payload["tokens"]["extra"] == "keep"
+    assert payload["custom"] == "preserve"
+    assert payload["last_refresh"] == "2026-04-13T00:00:00Z"
+    assert (auth_path.stat().st_mode & 0o777) == 0o600
+
+
+def test_resolve_codex_runtime_credentials_can_use_codex_cli_auth(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    (hermes_home / "config.yaml").write_text(yaml.safe_dump({
+        "providers": {"openai-codex": {"use_cli_auth": True}},
+    }))
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
+        "last_refresh": "2026-04-12T00:00:00Z",
+    }))
+
+    creds = resolve_codex_runtime_credentials()
+
+    assert creds["api_key"] == "cli-at"
+    assert creds["source"] == "codex-cli-auth"
+    assert creds["auth_store"] == str(codex_home / "auth.json")
+
+
+def test_resolve_codex_cli_auth_refreshes_and_writes_back(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("HERMES_CODEX_USE_CLI_AUTH", "1")
+    expiring_token = _jwt_with_exp(int(time.time()) - 10)
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {"access_token": expiring_token, "refresh_token": "old-rt"},
+    }))
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", lambda *a, **kw: {
+        "access_token": "new-at",
+        "refresh_token": "new-rt",
+        "last_refresh": "2026-04-13T00:00:00Z",
+    })
+
+    creds = resolve_codex_runtime_credentials()
+
+    assert creds["api_key"] == "new-at"
+    payload = json.loads((codex_home / "auth.json").read_text())
+    assert payload["tokens"]["access_token"] == "new-at"
+    assert payload["tokens"]["refresh_token"] == "new-rt"
 
 
 def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):


### PR DESCRIPTION
https://github.com/NousResearch/hermes-agent/pull/6874 is great, however it replaces the previous auth with one that requires either an API key or an Oauth login.  That Oauth login requires device-key support - which is disabled by my admin.

This MR enables the old approach as a fall back for those who can't use the new system.

## Summary
- add an opt-in Codex CLI auth compatibility mode via providers.openai-codex.use_cli_auth or HERMES_CODEX_USE_CLI_AUTH
- read runtime Codex credentials from CODEX_HOME/auth.json / ~/.codex/auth.json when enabled
- write refreshed rotated tokens back to the Codex CLI auth file so the shared session stays usable
- seed the credential pool from the shared Codex CLI auth source in compatibility mode

## Validation
- scripts/run_tests.sh tests/hermes_cli/test_auth_codex_provider.py
- scripts/run_tests.sh tests/agent/test_credential_pool.py
- venv/bin/python -m py_compile hermes_cli/auth.py agent/credential_pool.py hermes_cli/config.py tests/hermes_cli/test_auth_codex_provider.py
- git diff --check
