### PR TITLE
fix(api): honor explicit empty conversation_history overrides

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1799,10 +1799,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
-        # Precedence: explicit conversation_history > previous_response_id.
+        # Precedence: explicit conversation_history > previous_response_id,
+        # including an explicit empty list that means "start fresh".
         conversation_history: List[Dict[str, Any]] = []
+        explicit_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
-        if raw_history:
+        if explicit_history_provided:
             if not isinstance(raw_history, list):
                 return web.json_response(
                     _openai_error("'conversation_history' must be an array of message objects"),
@@ -1823,7 +1825,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
-        if not conversation_history and previous_response_id:
+        if not explicit_history_provided and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
@@ -2465,10 +2467,12 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
 
         # Accept explicit conversation_history from the request body.
-        # Precedence: explicit conversation_history > previous_response_id.
+        # Precedence: explicit conversation_history > previous_response_id,
+        # including an explicit empty list that means "start fresh".
         conversation_history: List[Dict[str, str]] = []
+        explicit_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
-        if raw_history:
+        if explicit_history_provided:
             if not isinstance(raw_history, list):
                 return web.json_response(
                     _openai_error("'conversation_history' must be an array of message objects"),
@@ -2485,7 +2489,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
-        if not conversation_history and previous_response_id:
+        if not explicit_history_provided and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))
@@ -2496,7 +2500,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+        if not explicit_history_provided and isinstance(raw_input, list) and len(raw_input) > 1:
             for msg in raw_input[:-1]:
                 if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
                     content = msg["content"]

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1355,6 +1355,30 @@ class TestResponsesEndpoint:
             assert first_session_id == second_session_id
 
     @pytest.mark.asyncio
+    async def test_explicit_empty_conversation_history_overrides_previous_response_id(self, adapter):
+        """An explicit empty history must bypass previous_response_id chaining."""
+        mock_result = {"final_response": "fresh", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "fresh turn",
+                        "previous_response_id": "resp_nonexistent",
+                        "conversation_history": [],
+                    },
+                )
+
+        assert resp.status == 200
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["conversation_history"] == []
+        assert call_kwargs["user_message"] == "fresh turn"
+
+    @pytest.mark.asyncio
     async def test_invalid_previous_response_id_returns_404(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -1367,6 +1391,51 @@ class TestResponsesEndpoint:
                 },
             )
             assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_explicit_empty_conversation_history_skips_run_fallbacks(self, adapter):
+        """An explicit empty history must bypass previous_response_id and input-array fallback in /v1/runs."""
+        app = _create_app(adapter)
+        app.router.add_post("/v1/runs", adapter._handle_runs)
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        adapter._response_store.put("resp_prev", {
+            "response": {"id": "resp_prev", "object": "response"},
+            "conversation_history": [{"role": "user", "content": "stale history"}],
+            "instructions": "stale instructions",
+            "session_id": "stale-session",
+        })
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {"role": "user", "content": "prior message"},
+                            {"role": "user", "content": "fresh turn"},
+                        ],
+                        "previous_response_id": "resp_prev",
+                        "conversation_history": [],
+                    },
+                )
+                assert resp.status == 202
+                run_data = await resp.json()
+                await asyncio.sleep(0)
+                task = adapter._active_run_tasks.get(run_data["run_id"])
+                if task is not None:
+                    await asyncio.wait_for(asyncio.shield(task), timeout=5)
+
+        mock_agent.run_conversation.assert_called_once()
+        call_kwargs = mock_agent.run_conversation.call_args.kwargs
+        assert call_kwargs["user_message"] == "fresh turn"
+        assert call_kwargs["conversation_history"] == []
+        assert str(call_kwargs["task_id"]).startswith("run_")
 
     @pytest.mark.asyncio
     async def test_store_false_does_not_store(self, adapter):


### PR DESCRIPTION
## Summary

Fix `conversation_history=[]` handling in the API server so an explicit empty history is treated as an override instead of falling through to server-side history reconstruction.

## Problem

Both `/v1/responses` and `/v1/runs` documented `conversation_history` as taking precedence over `previous_response_id`, but the implementation used truthiness checks.

That meant an explicit empty list was treated as “no history provided”, which caused unintended fallback behavior:

- `/v1/responses` could still chain from `previous_response_id`
- `/v1/runs` could still rebuild history from `previous_response_id`
- `/v1/runs` could also still derive history from multi-message input arrays

Clients trying to explicitly start fresh with `conversation_history=[]` could therefore inherit stale context.

## Changes

- Track whether `conversation_history` was explicitly provided, even when it is an empty list
- Skip `previous_response_id` fallback when explicit history is present
- Skip `/v1/runs` multi-message input history derivation when explicit history is present
- Clarify inline comments to document that an explicit empty list means “start fresh”

## Tests

Added regression coverage for:
- `/v1/responses` with `conversation_history=[]` plus `previous_response_id`
- `/v1/runs` with `conversation_history=[]` plus both `previous_response_id` and multi-message input

## Verification

Passed locally:

- `uv run pytest tests/gateway/test_api_server.py -k explicit_empty_conversation_history -v`
- `uv run pytest tests/gateway/test_api_server.py -v`
