### PR TITLE
fix: set is_error=False for blocked tool results in concurrent path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9456,7 +9456,7 @@ class AIAgent:
         results = [None] * num_tools
         for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
             if block_result is not None:
-                results[i] = (name, args, block_result, 0.0, True, True)
+                results[i] = (name, args, block_result, 0.0, False, True)
 
         # Touch activity before launching workers so the gateway knows
         # we're executing tools (not stuck).


### PR DESCRIPTION
Blocked tool results (guardrail/dedup) in the concurrent execution path were hardcoded with `is_error=True`, triggering spurious WARNING logs like `"Tool my_tool returned error"` even when the block was intentional.

Since these are intentional blocks — not tool failures — the error flag should be `False`.