### PR TITLE
fix(agent): skip persist/subdir hints for blocked tool results

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -557,7 +557,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     results = [None] * num_tools
     for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         if block_result is not None:
-            results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
+            # Intentional block (guardrail / plugin / scope) — not a tool
+            # failure. Keep is_error=False so post-processing does not log a
+            # spurious WARNING for a synthetic blocked result.
+            results[i] = (name, args, block_result, 0.0, False, True, middleware_trace)
 
     # Touch activity before launching workers so the gateway knows
     # we're executing tools (not stuck).
@@ -943,22 +946,26 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=name,
-            tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        # Blocked calls never executed — skip persistence and subdirectory
+        # discovery so synthetic results are not written to disk and hints
+        # are not appended onto blocked JSON (which can corrupt it).
+        if not blocked:
+            function_result = maybe_persist_tool_result(
+                content=function_result,
+                tool_name=name,
+                tool_use_id=tc.id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            ) if not _is_multimodal_tool_result(function_result) else function_result
 
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
-        if subdir_hints:
-            if _is_multimodal_tool_result(function_result):
-                # Append the hint to the text summary part so the model
-                # still sees it; don't touch the image blocks.
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
-            else:
-                function_result += subdir_hints
+            subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
+            if subdir_hints:
+                if _is_multimodal_tool_result(function_result):
+                    # Append the hint to the text summary part so the model
+                    # still sees it; don't touch the image blocks.
+                    _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                else:
+                    function_result += subdir_hints
 
         # Unwrap _multimodal dicts to an OpenAI-style content list so any
         # vision-capable provider receives [{type:text},{type:image_url}]
@@ -1559,7 +1566,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
-        _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        # Intentional blocks are not tool failures — keep is_error=False so
+        # they do not emit a WARNING for a synthetic blocked result.
+        if _execution_blocked:
+            _is_error_result = False
+        else:
+            _is_error_result, _ = _detect_tool_failure(function_name, function_result)
         # The agent-runtime tools above (todo, session_search, memory,
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the
@@ -1634,21 +1646,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=function_name,
-            tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        # Blocked calls never executed — skip persistence and subdirectory
+        # discovery so synthetic results are not written to disk and hints
+        # are not appended onto blocked JSON (which can corrupt it).
+        if not _execution_blocked:
+            function_result = maybe_persist_tool_result(
+                content=function_result,
+                tool_name=function_name,
+                tool_use_id=tool_call.id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            ) if not _is_multimodal_tool_result(function_result) else function_result
 
-        # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
-        if subdir_hints:
-            if _is_multimodal_tool_result(function_result):
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
-            else:
-                function_result += subdir_hints
+            # Discover subdirectory context files from tool arguments
+            subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
+            if subdir_hints:
+                if _is_multimodal_tool_result(function_result):
+                    _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                else:
+                    function_result += subdir_hints
 
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1669,7 +1669,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        # Match concurrent path: intentional blocks mark disposition none so
+        # session/replay treat them as non-executed synthetic results.
+        tool_message = make_tool_result_message(
+            function_name,
+            _tool_content,
+            tool_call.id,
+            effect_disposition="none" if _execution_blocked else None,
+        )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if (

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -353,3 +353,112 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_sequential_blocked_call_skips_persist_and_subdir_hints():
+    """Blocked sequential calls must not persist results or run subdir discovery."""
+    agent = _make_agent("web_search", config=_hard_stop_config())
+    args = {"query": "same"}
+    _seed_exact_failures(agent, "web_search", args)
+    tc = _mock_tool_call("web_search", json.dumps(args), "c-block-persist")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    agent._subdirectory_hints = MagicMock()
+    agent._subdirectory_hints.check_tool_call.return_value = "\n[subdir hint]"
+
+    with (
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc,
+        patch("agent.tool_executor.maybe_persist_tool_result") as mock_persist,
+    ):
+        mock_persist.side_effect = lambda content, **kwargs: content
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_not_called()
+    mock_persist.assert_not_called()
+    agent._subdirectory_hints.check_tool_call.assert_not_called()
+    assert len(messages) == 1
+    assert messages[0]["tool_call_id"] == "c-block-persist"
+    assert "repeated_exact_failure_block" in messages[0]["content"]
+    assert "[subdir hint]" not in messages[0]["content"]
+
+
+def test_concurrent_blocked_call_skips_persist_and_subdir_hints():
+    """Blocked concurrent calls must not persist results or run subdir discovery."""
+    agent = _make_agent("web_search", config=_hard_stop_config())
+    blocked_args = {"query": "blocked"}
+    allowed_args = {"query": "allowed"}
+    _seed_exact_failures(agent, "web_search", blocked_args)
+    calls = [
+        _mock_tool_call("web_search", json.dumps(blocked_args), "c-block"),
+        _mock_tool_call("web_search", json.dumps(allowed_args), "c-allow"),
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages = []
+    agent._subdirectory_hints = MagicMock()
+    agent._subdirectory_hints.check_tool_call.return_value = "\n[subdir hint]"
+
+    def fake_handle(name, args, task_id, **kwargs):
+        return json.dumps({"ok": args["query"]})
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=fake_handle),
+        patch("agent.tool_executor.maybe_persist_tool_result") as mock_persist,
+    ):
+        mock_persist.side_effect = lambda content, **kwargs: content
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    # Only the allowed (executed) call may hit persist / subdir discovery.
+    assert mock_persist.call_count == 1
+    assert mock_persist.call_args.kwargs["tool_name"] == "web_search"
+    assert mock_persist.call_args.kwargs["tool_use_id"] == "c-allow"
+
+    assert agent._subdirectory_hints.check_tool_call.call_count == 1
+    assert agent._subdirectory_hints.check_tool_call.call_args[0][0] == "web_search"
+    assert agent._subdirectory_hints.check_tool_call.call_args[0][1] == allowed_args
+
+    assert [m["tool_call_id"] for m in messages] == ["c-block", "c-allow"]
+    assert "repeated_exact_failure_block" in messages[0]["content"]
+    assert "[subdir hint]" not in messages[0]["content"]
+    assert "[subdir hint]" in messages[1]["content"]
+
+
+def test_sequential_blocked_call_is_not_logged_as_tool_error(caplog):
+    """Intentional sequential blocks must not emit tool-error WARNINGs."""
+    import logging
+
+    agent = _make_agent("web_search", config=_hard_stop_config())
+    args = {"query": "same"}
+    _seed_exact_failures(agent, "web_search", args)
+    tc = _mock_tool_call("web_search", json.dumps(args), "c-block-log")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN"),
+        caplog.at_level(logging.WARNING, logger="agent.tool_executor"),
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not any("returned error" in m for m in warning_msgs), warning_msgs
+
+
+def test_concurrent_blocked_call_is_not_logged_as_tool_error(caplog):
+    """Intentional concurrent blocks must not emit tool-error WARNINGs."""
+    import logging
+
+    agent = _make_agent("web_search", config=_hard_stop_config())
+    args = {"query": "same"}
+    _seed_exact_failures(agent, "web_search", args)
+    tc = _mock_tool_call("web_search", json.dumps(args), "c-block-log-c")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN"),
+        caplog.at_level(logging.WARNING, logger="agent.tool_executor"),
+    ):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not any("returned error" in m for m in warning_msgs), warning_msgs

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -380,6 +380,7 @@ def test_sequential_blocked_call_skips_persist_and_subdir_hints():
     assert messages[0]["tool_call_id"] == "c-block-persist"
     assert "repeated_exact_failure_block" in messages[0]["content"]
     assert "[subdir hint]" not in messages[0]["content"]
+    assert messages[0].get("effect_disposition") == "none"
 
 
 def test_concurrent_blocked_call_skips_persist_and_subdir_hints():
@@ -420,6 +421,8 @@ def test_concurrent_blocked_call_skips_persist_and_subdir_hints():
     assert "repeated_exact_failure_block" in messages[0]["content"]
     assert "[subdir hint]" not in messages[0]["content"]
     assert "[subdir hint]" in messages[1]["content"]
+    assert messages[0].get("effect_disposition") == "none"
+    assert "effect_disposition" not in messages[1]
 
 
 def test_sequential_blocked_call_is_not_logged_as_tool_error(caplog):


### PR DESCRIPTION
## Summary

When a tool call is **blocked** (guardrail hard-stop, plugin pre-tool block, or tool-scope block), post-processing still ran `maybe_persist_tool_result` and subdirectory-hint discovery. That wastes I/O on synthetic results and can corrupt blocked JSON by appending hint text.

Also: intentional blocks were classified as tool errors (`is_error=True` / `_detect_tool_failure`), producing spurious WARNING logs for policy blocks that never executed.

## Changes (`agent/tool_executor.py`)

After the executor extraction out of `run_agent.py`, both paths live here:

1. **Sequential + concurrent** — skip `maybe_persist_tool_result` and `_subdirectory_hints.check_tool_call` when blocked
2. **Concurrent** — intentional blocks store `is_error=False` (not a tool failure)
3. **Sequential** — skip `_detect_tool_failure` for intentional blocks so they do not emit tool-error WARNINGs
4. **Tests** — regression coverage in `tests/run_agent/test_tool_call_guardrail_runtime.py` for both paths (persist/hint skip + no error log)

## Test plan

- [x] `pytest tests/run_agent/test_tool_call_guardrail_runtime.py` (13 passed locally)
- [ ] CI green
