### PR TITLE
fix: skip maybe_persist and subdir hints for blocked results (concurrent)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9682,16 +9682,17 @@ class AIAgent:
                 except Exception as cb_err:
                     logging.debug(f"Tool complete callback error: {cb_err}")
 
-            function_result = maybe_persist_tool_result(
-                content=function_result,
-                tool_name=name,
-                tool_use_id=tc.id,
-                env=get_active_env(effective_task_id),
-            )
+            if not blocked:
+                function_result = maybe_persist_tool_result(
+                    content=function_result,
+                    tool_name=name,
+                    tool_use_id=tc.id,
+                    env=get_active_env(effective_task_id),
+                )
 
-            subdir_hints = self._subdirectory_hints.check_tool_call(name, args)
-            if subdir_hints:
-                function_result += subdir_hints
+                subdir_hints = self._subdirectory_hints.check_tool_call(name, args)
+                if subdir_hints:
+                    function_result += subdir_hints
 
             tool_msg = {
                 "role": "tool",


### PR DESCRIPTION
Same fix as #18561 but in the concurrent execution path. `maybe_persist_tool_result()` and subdirectory hint appending ran unconditionally for blocked results.

Fix: wrap both operations in `if not blocked:`