### PR TITLE
fix: auto-rollover degraded gateway sessions

### DIFF
--- a/.devlogs/2026-05-01-auto-rollover-context-compression.md
+++ b/.devlogs/2026-05-01-auto-rollover-context-compression.md
@@ -1,0 +1,45 @@
+# 2026-05-01 — auto-rollover after repeated context compression
+
+## Goal
+Prevent long-running Hermes gateway sessions from degrading through repeated lossy context compression by rolling over to a fresh session after a bounded number of successful compressions.
+
+## Worktree
+`/work/.hermes-data/worktrees/hermes-agent-auto-rollover`
+
+## Plan/spec
+`.hermes/plans/2026-05-01-auto-rollover-after-compaction.md`
+
+## No-ADR rationale
+This is a tactical reliability guard in existing gateway session/reset behavior, not a new architecture or cross-cutting design. The plan/spec plus regression tests document the decision.
+
+## Changes
+- Added durable `compression_count` metadata to `gateway.session.SessionEntry` serialization and update flow.
+- Added `GatewayConfig.max_context_compressions_before_reset`, default `3`, with `0` as disable.
+- Bridged root `config.yaml` key `max_context_compressions_before_reset` into `GatewayConfig` loading.
+- Added `compression_count` to `AIAgent.run_conversation()` result metadata.
+- Persisted returned agent compression count after each gateway turn.
+- Incremented compression count when gateway pre-agent hygiene compression rewrites a transcript.
+- Added `GatewayRunner._rollover_session_if_compression_limit_reached()` and called it before building the next turn's session context.
+- Auto-rollover cleans up the evicted cached agent before removing it from the cache so memory/tool/process resources do not leak.
+- Auto-rollover clears the `is_fresh_reset` marker immediately so the next inbound message does not duplicate session-start handling.
+- Added `GatewayRunner._sync_agent_compression_count()` so persisted gateway-side hygiene compression counts seed the cached/new agent compressor before the turn.
+- Added regression tests for session persistence/reset, config loading, and gateway rollover helper behavior.
+
+## Validation
+RED observed before production changes:
+- `python -m pytest tests/gateway/test_session.py::TestCompressionCount -q`
+- `python -m pytest tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q`
+- `python -m pytest tests/gateway/test_context_compression_rollover.py -q`
+
+GREEN:
+- `python -m pytest tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py::TestCompressionCount tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q` — 13 passed
+- `python -m pytest tests/gateway/test_session.py tests/gateway/test_config.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_agent_cache.py -q` — 185 passed, 20 warnings
+- `python -m py_compile gateway/session.py gateway/config.py gateway/run.py run_agent.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py tests/gateway/test_config.py` — passed
+
+## Risks / follow-up
+- The rollover occurs on the next inbound message, not mid-run, by design. This avoids dropping in-flight tool/process state.
+- There is no user-facing notice yet for compression-count rollover. Existing auto-expiry reset notices remain separate.
+- A future operator command like `/session status` could expose compression count and impending rollover.
+
+## Session-quality notes
+The work followed worktree/spec/TDD discipline. No commit was created per user preference.

--- a/.devlogs/2026-05-01-auto-rollover-context-compression.md
+++ b/.devlogs/2026-05-01-auto-rollover-context-compression.md
@@ -9,6 +9,9 @@ Prevent long-running Hermes gateway sessions from degrading through repeated los
 ## Plan/spec
 `.hermes/plans/2026-05-01-auto-rollover-after-compaction.md`
 
+## Pull request
+https://github.com/NousResearch/hermes-agent/pull/18563
+
 ## No-ADR rationale
 This is a tactical reliability guard in existing gateway session/reset behavior, not a new architecture or cross-cutting design. The plan/spec plus regression tests document the decision.
 
@@ -42,4 +45,4 @@ GREEN:
 - A future operator command like `/session status` could expose compression count and impending rollover.
 
 ## Session-quality notes
-The work followed worktree/spec/TDD discipline. No commit was created per user preference.
+The work followed worktree/spec/TDD/review discipline. Commit created and PR opened at https://github.com/NousResearch/hermes-agent/pull/18563.

--- a/.devlogs/tdd-evidence-auto-rollover-context-compression.md
+++ b/.devlogs/tdd-evidence-auto-rollover-context-compression.md
@@ -1,0 +1,19 @@
+# TDD evidence — auto-rollover after repeated context compression
+
+## RED runs observed before production fixes
+- `python -m pytest tests/gateway/test_session.py::TestCompressionCount -q` — failed before `SessionEntry.compression_count` / `SessionStore.update_session(compression_count=...)` existed.
+- `python -m pytest tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q` — failed before `GatewayConfig.max_context_compressions_before_reset` and root YAML bridge existed.
+- `python -m pytest tests/gateway/test_context_compression_rollover.py -q` — failed before `GatewayRunner._rollover_session_if_compression_limit_reached()` existed.
+- `python -m pytest tests/gateway/test_context_compression_rollover.py::TestContextCompressionRollover::test_syncs_persisted_count_into_agent_before_turn -q` — failed before `GatewayRunner._sync_agent_compression_count()` existed.
+- `python -m pytest tests/gateway/test_context_compression_rollover.py::TestContextCompressionRollover::test_rolls_session_when_compression_limit_reached -q` — failed before auto-rollover cleaned up the evicted cached agent.
+
+## GREEN / regression validation
+- `python -m pytest tests/gateway/test_context_compression_rollover.py -q` — 4 passed.
+- `python -m pytest tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py::TestCompressionCount tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q` — 13 passed.
+- `python -m pytest tests/gateway/test_session.py tests/gateway/test_config.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_agent_cache.py -q` — 185 passed, 20 warnings.
+- `python -m py_compile gateway/session.py gateway/config.py gateway/run.py run_agent.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py tests/gateway/test_config.py` — passed.
+- `git diff --check` — passed.
+
+## Review gate
+- Delegated review found three real issues: gateway wrapper omitted `compression_count`, auto-rollover left `is_fresh_reset=True` for the next turn, and auto-rollover evicted cached agents without cleaning up their resources.
+- These findings were fixed and covered/validated by the final focused and regression commands above.

--- a/.hermes/plans/2026-05-01-auto-rollover-after-compaction.md
+++ b/.hermes/plans/2026-05-01-auto-rollover-after-compaction.md
@@ -1,0 +1,50 @@
+# Auto-rollover gateway sessions after repeated context compaction
+
+## Problem
+Long-running gateway sessions can survive for many turns and repeatedly compress their context. Each compression is lossy. After several rounds, the leading context becomes a summary-of-summary and starts degrading task fidelity. Operators need the gateway to start a fresh command/session lane automatically before degraded summaries become the dominant context.
+
+## Decision
+Add a bounded automatic rollover trigger based on successful compression count per gateway session.
+
+Default policy:
+- Track successful context compressions in `gateway.session.SessionEntry` as durable metadata.
+- Increment the counter whenever gateway hygiene compression rewrites a transcript, and after a normal agent turn if the agent reports its context engine compressed during that turn.
+- Before running the agent for a new inbound message, if the session has reached the configured compression limit, auto-reset it into a new session id and run the message there.
+- Do not reset in the middle of an active agent run; wait until the next inbound message. This avoids dropping in-flight tool/process state.
+- Default limit: 3 successful compressions. `0` disables the guard.
+
+## No-ADR rationale
+This is a tactical reliability guard inside existing gateway session hygiene/reset policy rather than a new architecture. The repo does not appear to have an ADR convention. The implementation plan plus tests document the decision sufficiently.
+
+## Acceptance criteria
+- `SessionEntry` persists `compression_count` through `to_dict`/`from_dict`.
+- `SessionStore.update_session()` can update compression count atomically after a turn.
+- Manual reset creates a fresh entry with compression count reset to 0.
+- Gateway auto-rolls over before an inbound message when `compression_count >= max_context_compressions_before_reset`.
+- Gateway increments compression count after successful preflight/hygiene compression.
+- Gateway increments/sets compression count after `_run_agent()` returns a higher `compression_count` from the agent context engine.
+- AIAgent result includes context engine `compression_count`.
+- Tests observe RED before production changes and GREEN after.
+
+## Likely files
+- `gateway/config.py`
+- `gateway/session.py`
+- `gateway/run.py`
+- `run_agent.py`
+- `tests/gateway/test_session.py`
+- `tests/gateway/test_session_hygiene.py`
+
+## Test strategy
+Targeted tests first:
+1. Session persistence/update/reset coverage for `compression_count`.
+2. Gateway handler test for auto-reset before agent run when threshold reached.
+3. Gateway hygiene test that successful preflight compression increments the counter.
+4. Existing gateway hygiene/session regression tests.
+
+Validation commands:
+- `python -m pytest tests/gateway/test_session.py::TestCompressionCount -q` (RED before production change, GREEN after)
+- `python -m pytest tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q` (RED before production change, GREEN after)
+- `python -m pytest tests/gateway/test_context_compression_rollover.py -q` (RED before production change, GREEN after)
+- `python -m pytest tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py::TestCompressionCount tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q` — 13 passed
+- `python -m pytest tests/gateway/test_session.py tests/gateway/test_config.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_agent_cache.py -q` — 185 passed, 20 warnings
+- `python -m py_compile gateway/session.py gateway/config.py gateway/run.py run_agent.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py tests/gateway/test_config.py` — passed

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -426,6 +426,12 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # After this many successful lossy context compressions in one gateway
+    # session lane, start a fresh session before the next agent turn. 0 disables
+    # this rollover. The default of 3 keeps one useful compressed history while
+    # avoiding repeated summary-of-summary drift in long-running gateways.
+    max_context_compressions_before_reset: int = 3
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -519,6 +525,7 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
+            "max_context_compressions_before_reset": self.max_context_compressions_before_reset,
         }
     
     @classmethod
@@ -573,6 +580,15 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        try:
+            max_context_compressions_before_reset = int(
+                data.get("max_context_compressions_before_reset", 3)
+            )
+            if max_context_compressions_before_reset < 0:
+                max_context_compressions_before_reset = 0
+        except (TypeError, ValueError):
+            max_context_compressions_before_reset = 3
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -588,6 +604,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            max_context_compressions_before_reset=max_context_compressions_before_reset,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -684,6 +701,11 @@ def load_gateway_config() -> GatewayConfig:
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
+
+            if "max_context_compressions_before_reset" in yaml_cfg:
+                gw_data["max_context_compressions_before_reset"] = yaml_cfg[
+                    "max_context_compressions_before_reset"
+                ]
 
             if "unauthorized_dm_behavior" in yaml_cfg:
                 gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -495,6 +495,7 @@ from gateway.config import (
 from gateway.session import (
     SessionStore,
     SessionSource,
+    SessionEntry,
     SessionContext,
     build_session_context,
     build_session_context_prompt,
@@ -5541,6 +5542,17 @@ class GatewayRunner:
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
+
+        session_entry, _compression_rollover = self._rollover_session_if_compression_limit_reached(session_entry)
+        if _compression_rollover:
+            session_key = session_entry.session_key
+            _is_new_session = True
+            await self.hooks.emit("session:start", {
+                "platform": source.platform.value if source.platform else "",
+                "user_id": source.user_id,
+                "session_id": session_entry.session_id,
+                "session_key": session_key,
+            })
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
@@ -5891,6 +5903,10 @@ class GatewayRunner:
                                     )
                                     # Reset stored token count — transcript was rewritten
                                     session_entry.last_prompt_tokens = 0
+                                    session_entry.compression_count = (
+                                        int(getattr(session_entry, "compression_count", 0) or 0) + 1
+                                    )
+                                    self.session_store._save()
                                     history = _compressed
                                     _new_count = len(_compressed)
                                     _new_tokens = estimate_messages_tokens_rough(
@@ -6392,6 +6408,10 @@ class GatewayRunner:
             self.session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                compression_count=agent_result.get(
+                    "compression_count",
+                    getattr(session_entry, "compression_count", 0),
+                ),
             )
 
             # Auto voice reply: send TTS audio before the text response
@@ -11125,6 +11145,62 @@ class GatewayRunner:
             with _lock:
                 self._agent_cache.pop(session_key, None)
 
+    def _rollover_session_if_compression_limit_reached(self, session_entry: SessionEntry) -> tuple[SessionEntry, bool]:
+        """Start a fresh session once lossy context compression has run too often."""
+        try:
+            limit = int(getattr(self.config, "max_context_compressions_before_reset", 3) or 0)
+        except (TypeError, ValueError):
+            limit = 3
+        if limit <= 0:
+            return session_entry, False
+
+        compression_count = int(getattr(session_entry, "compression_count", 0) or 0)
+        if compression_count < limit:
+            return session_entry, False
+
+        session_key = session_entry.session_key
+        old_session_id = session_entry.session_id
+        old_agent = None
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock:
+            with _cache_lock:
+                _cached = self._agent_cache.get(session_key)
+                old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
+        if old_agent is not None:
+            self._cleanup_agent_resources(old_agent)
+        self._evict_cached_agent(session_key)
+        new_entry = self.session_store.reset_session(session_key)
+        # This automatic rollover is consumed by the current inbound message;
+        # do not make the next message look like another fresh reset.
+        new_entry.is_fresh_reset = False
+        self.session_store._save()
+        self._clear_session_boundary_security_state(session_key)
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
+        logger.info(
+            "Session %s auto-rolled over after %d context compression(s): %s -> %s",
+            session_key,
+            compression_count,
+            old_session_id,
+            new_entry.session_id,
+        )
+        return new_entry, True
+
+    @staticmethod
+    def _sync_agent_compression_count(session_entry: SessionEntry, agent: Any) -> None:
+        """Seed the agent compressor with persisted gateway compression count."""
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is None:
+            return
+        try:
+            persisted = int(getattr(session_entry, "compression_count", 0) or 0)
+            current = int(getattr(compressor, "compression_count", 0) or 0)
+        except (TypeError, ValueError):
+            return
+        compressor.compression_count = max(current, persisted)
+
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
@@ -12320,6 +12396,7 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            self._sync_agent_compression_count(session_entry, agent)
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []
@@ -12665,12 +12742,14 @@ class GatewayRunner:
             _input_toks = 0
             _output_toks = 0
             _context_length = 0
+            _compression_count = 0
             _agent = agent_holder[0]
             if _agent and hasattr(_agent, "context_compressor"):
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
+                _compression_count = getattr(_agent.context_compressor, "compression_count", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
@@ -12684,6 +12763,7 @@ class GatewayRunner:
                     "tools": tools_holder[0] or [],
                     "history_offset": len(agent_history),
                     "last_prompt_tokens": _last_prompt_toks,
+                    "compression_count": _compression_count,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
@@ -12789,6 +12869,7 @@ class GatewayRunner:
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "last_prompt_tokens": _last_prompt_toks,
+                "compression_count": _compression_count,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -452,6 +452,11 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Successful lossy context compressions applied to this session lane.
+    # Used by the gateway to roll over before summary-of-summary drift becomes
+    # the dominant context.  Reset/session switch starts a fresh count.
+    compression_count: int = 0
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -506,6 +511,7 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "compression_count": self.compression_count,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -559,6 +565,7 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            compression_count=data.get("compression_count", 0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),
@@ -952,6 +959,7 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        compression_count: int = None,
     ) -> None:
         """Update lightweight session metadata after an interaction."""
         with self._lock:
@@ -962,6 +970,8 @@ class SessionStore:
                 entry.updated_at = _now()
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
+                if compression_count is not None:
+                    entry.compression_count = max(0, int(compression_count))
                 self._save()
 
     def suspend_session(self, session_key: str) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -13755,6 +13755,7 @@ class AIAgent:
             "completion_tokens": self.session_completion_tokens,
             "total_tokens": self.session_total_tokens,
             "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
+            "compression_count": getattr(self.context_compressor, "compression_count", 0) or 0,
             "estimated_cost_usd": self.session_estimated_cost_usd,
             "cost_status": self.session_cost_status,
             "cost_source": self.session_cost_source,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -122,6 +122,34 @@ class TestGetConnectedPlatforms:
         assert Platform.DINGTALK not in config.get_connected_platforms()
 
 
+class TestGatewayConfigCompressionRollover:
+    def test_default_max_context_compressions_before_reset_is_three(self):
+        config = GatewayConfig()
+        assert config.max_context_compressions_before_reset == 3
+
+    def test_from_dict_accepts_zero_to_disable_compression_rollover(self):
+        config = GatewayConfig.from_dict({"max_context_compressions_before_reset": 0})
+        assert config.max_context_compressions_before_reset == 0
+
+    def test_from_dict_clamps_negative_compression_rollover(self):
+        config = GatewayConfig.from_dict({"max_context_compressions_before_reset": -5})
+        assert config.max_context_compressions_before_reset == 0
+
+    def test_bridges_compression_rollover_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "max_context_compressions_before_reset: 2\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.max_context_compressions_before_reset == 2
+
+
 class TestSessionResetPolicy:
     def test_roundtrip(self):
         policy = SessionResetPolicy(mode="idle", at_hour=6, idle_minutes=120)

--- a/tests/gateway/test_context_compression_rollover.py
+++ b/tests/gateway/test_context_compression_rollover.py
@@ -1,0 +1,80 @@
+"""Tests for gateway rollover after repeated lossy context compression."""
+
+import threading
+from unittest.mock import MagicMock
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+
+
+def _source():
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", user_id="user-1")
+
+
+def _runner(tmp_path, max_compressions=3):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        max_context_compressions_before_reset=max_compressions,
+    )
+    runner.session_store = SessionStore(tmp_path, runner.config)
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+class TestContextCompressionRollover:
+    def test_rolls_session_when_compression_limit_reached(self, tmp_path):
+        runner = _runner(tmp_path, max_compressions=3)
+        entry = runner.session_store.get_or_create_session(_source())
+        old_session_id = entry.session_id
+        runner.session_store.update_session(
+            entry.session_key,
+            last_prompt_tokens=123,
+            compression_count=3,
+        )
+        old_agent = MagicMock()
+        runner._agent_cache[entry.session_key] = (old_agent, "sig")
+        runner._cleanup_agent_resources = MagicMock()
+
+        new_entry, did_rollover = runner._rollover_session_if_compression_limit_reached(entry)
+
+        assert did_rollover is True
+        assert new_entry.session_key == entry.session_key
+        assert new_entry.session_id != old_session_id
+        assert new_entry.compression_count == 0
+        assert new_entry.last_prompt_tokens == 0
+        assert new_entry.is_fresh_reset is False
+        runner._cleanup_agent_resources.assert_called_once_with(old_agent)
+        assert entry.session_key not in runner._agent_cache
+
+    def test_does_not_roll_before_limit(self, tmp_path):
+        runner = _runner(tmp_path, max_compressions=3)
+        entry = runner.session_store.get_or_create_session(_source())
+        runner.session_store.update_session(entry.session_key, compression_count=2)
+
+        same_entry, did_rollover = runner._rollover_session_if_compression_limit_reached(entry)
+
+        assert did_rollover is False
+        assert same_entry.session_id == entry.session_id
+
+    def test_zero_disables_compression_rollover(self, tmp_path):
+        runner = _runner(tmp_path, max_compressions=0)
+        entry = runner.session_store.get_or_create_session(_source())
+        runner.session_store.update_session(entry.session_key, compression_count=99)
+
+        same_entry, did_rollover = runner._rollover_session_if_compression_limit_reached(entry)
+
+        assert did_rollover is False
+        assert same_entry.session_id == entry.session_id
+
+    def test_syncs_persisted_count_into_agent_before_turn(self, tmp_path):
+        runner = _runner(tmp_path, max_compressions=3)
+        entry = runner.session_store.get_or_create_session(_source())
+        runner.session_store.update_session(entry.session_key, compression_count=2)
+        agent = MagicMock()
+        agent.context_compressor.compression_count = 0
+
+        runner._sync_agent_compression_count(entry, agent)
+
+        assert agent.context_compressor.compression_count == 2

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1198,6 +1198,101 @@ class TestLastPromptTokens:
         store.update_session("k1", last_prompt_tokens=0)
         assert entry.last_prompt_tokens == 0
 
+
+class TestCompressionCount:
+    """Tests for lossy context-compression rollover tracking."""
+
+    def test_session_entry_default(self):
+        """New sessions should have compression_count=0."""
+        from gateway.session import SessionEntry
+        from datetime import datetime
+
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        assert entry.compression_count == 0
+
+    def test_session_entry_roundtrip(self):
+        """compression_count should survive serialization/deserialization."""
+        from gateway.session import SessionEntry
+        from datetime import datetime
+
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            compression_count=2,
+        )
+
+        d = entry.to_dict()
+        assert d["compression_count"] == 2
+        restored = SessionEntry.from_dict(d)
+        assert restored.compression_count == 2
+
+    def test_session_entry_from_old_data_defaults_to_zero(self):
+        """Old session data without compression_count should default to 0."""
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry.from_dict({
+            "session_key": "test",
+            "session_id": "s1",
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+        })
+
+        assert entry.compression_count == 0
+
+    def test_update_session_sets_compression_count(self, tmp_path):
+        """update_session should persist the latest compression depth."""
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = None
+        store._save = MagicMock()
+
+        from gateway.session import SessionEntry
+        from datetime import datetime
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        store._entries = {"k1": entry}
+
+        store.update_session("k1", compression_count=2)
+        assert entry.compression_count == 2
+        store._save.assert_called()
+
+    def test_reset_session_resets_compression_count(self, tmp_path):
+        """A fresh reset session should not inherit lossy compression depth."""
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = None
+        store._save = MagicMock()
+
+        from gateway.session import SessionEntry
+        from datetime import datetime
+        old = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            compression_count=3,
+        )
+        store._entries = {"k1": old}
+
+        new = store.reset_session("k1")
+        assert new.compression_count == 0
+
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""
 


### PR DESCRIPTION
## Summary
- Persist per-session `compression_count` and propagate it from agent/gateway compression paths.
- Auto-roll over gateway sessions after repeated lossy context compression, defaulting to 3 compressions; `0` disables the policy.
- Clean up cached agent resources during auto-rollover and reset session-boundary state safely.

## Test Plan
- `python -m pytest tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py::TestCompressionCount tests/gateway/test_config.py::TestGatewayConfigCompressionRollover -q` — 13 passed
- `python -m pytest tests/gateway/test_session.py tests/gateway/test_config.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_agent_cache.py -q` — 185 passed, 20 warnings
- `python -m py_compile gateway/session.py gateway/config.py gateway/run.py run_agent.py tests/gateway/test_context_compression_rollover.py tests/gateway/test_session.py tests/gateway/test_config.py` — passed
- `git diff --check` — passed
- Static diff scan — passed
- Independent review — passed after fixing resource cleanup issue

## Process
- Plan: `.hermes/plans/2026-05-01-auto-rollover-after-compaction.md`
- Devlog: `.devlogs/2026-05-01-auto-rollover-context-compression.md`
- TDD evidence: `.devlogs/tdd-evidence-auto-rollover-context-compression.md`
