### PR TITLE
feat(cron): per-job external memory provider modes (off|tools|full)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,7 +333,9 @@ class AIAgent:
         platform: str = None,              # "cli", "telegram", etc.
         session_id: str = None,
         skip_context_files: bool = False,
-        skip_memory: bool = False,
+        skip_memory: bool = False,         # skip built-in MEMORY.md / USER.md
+        memory_provider_mode: str = None,  # "off" | "tools" | "full" (None → derive)
+        skip_memory_provider: bool = None, # legacy: True→off, False→tools
         credential_pool=None,
         # ... plus callbacks, thread/user/chat IDs, iteration_budget, fallback_model,
         # checkpoints config, prefill_messages, service_tier, reasoning_config, etc.
@@ -1066,7 +1068,8 @@ Per-job fields include `skills` (load specific skills), `model` /
 stdout is injected into the prompt; `no_agent=True` turns the script
 into the entire job), `context_from` (chain job A's last output into
 job B's prompt), `workdir` (run in a specific directory with its
-`AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
+`AGENTS.md`/`CLAUDE.md` loaded), multi-platform delivery, and
+`memory_provider` (`off` | `tools` | `full` — see below).
 
 Hardening invariants:
 - **3-minute hard interrupt** on cron sessions — runaway agent loops
@@ -1075,8 +1078,27 @@ Hardening invariants:
 - Grace window: 120s for one-shot jobs whose fire time was missed.
 - File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
   across processes.
-- Cron sessions pass `skip_memory=True` by default; memory providers
-  intentionally do not run during cron.
+- Cron sessions always pass `skip_memory=True` so built-in
+  `MEMORY.md` / `USER.md` are never written by cron system prompts
+  (see #4052 — auto-sync of cron prompts into user representations
+  corrupts long-term memory).
+- External memory **providers** are independent of `skip_memory` and
+  are controlled by `memory_provider_mode` on `AIAgent` (resolved via
+  `agent/memory_provider_mode.py`):
+  - **`off`** (cron default) — no provider init, no provider tools.
+  - **`tools`** — provider loaded + tools injected; **no** automatic
+    system-prompt context, prefetch, per-turn `sync_turn`, or
+    session-end retain. Explicit tool calls only (safe for
+    maintenance / curator jobs).
+  - **`full`** — normal interactive lifecycle (prompt + prefetch +
+    auto-sync + session-end). Opt-in only; can reintroduce the #4052
+    class of corruption if the job prompt looks like a user message.
+- Per-job opt-in via the job field `memory_provider` (same three
+  values). Scheduler maps it to `AIAgent(memory_provider_mode=...)`
+  while keeping `skip_memory=True`. There is **no** global
+  `cron.skip_memory=false` switch — that shape is too broad.
+- Legacy `skip_memory_provider`: `True` → `off`, `False` → `tools`
+  (never silently implies `full`).
 
 Cron deliveries are **not** mirrored into the target gateway session —
 they land in their own cron session with a header/footer frame so the

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -320,6 +320,8 @@ def init_agent(
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
+    memory_provider_mode: Optional[str] = None,
+    skip_memory_provider: Optional[bool] = None,
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
@@ -379,6 +381,12 @@ def init_agent(
         load_soul_identity (bool): If True, still use ~/.hermes/SOUL.md as the primary
             identity even when skip_context_files=True. Project context files from the cwd
             remain skipped.
+        skip_memory (bool): If True, skip built-in MEMORY.md/USER.md store. Does NOT
+            alone control external memory providers — see memory_provider_mode.
+        memory_provider_mode (str): External provider mode: ``off`` (no provider),
+            ``tools`` (provider + tools, no auto prompt/prefetch/sync/session retain),
+            ``full`` (normal interactive lifecycle). Default: off when skip_memory else full.
+        skip_memory_provider (bool): Legacy tri-state. True→off, False→tools, None→derive.
     """
     _install_safe_stdio()
 
@@ -1344,9 +1352,35 @@ def init_agent(
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
+    # External provider mode (off|tools|full). Independent of skip_memory so
+    # cron can keep MEMORY.md protected while optionally loading providers.
+    from agent.memory_provider_mode import (
+        provider_lifecycle_enabled as _provider_lifecycle_enabled,
+        provider_tools_enabled as _provider_tools_enabled,
+        resolve_memory_provider_mode as _resolve_memory_provider_mode,
+    )
+    try:
+        _mp_mode = _resolve_memory_provider_mode(
+            skip_memory=skip_memory,
+            memory_provider_mode=memory_provider_mode,
+            skip_memory_provider=skip_memory_provider,
+        )
+    except ValueError as _mp_mode_err:
+        _ra().logger.warning("%s — defaulting memory_provider_mode to 'off'", _mp_mode_err)
+        _mp_mode = "off"
+    agent._memory_provider_mode = _mp_mode
+    agent._memory_provider_auto_sync = _provider_lifecycle_enabled(_mp_mode)
+    agent._memory_provider_prefetch = _provider_lifecycle_enabled(_mp_mode)
+    agent._memory_provider_prompt_context = _provider_lifecycle_enabled(_mp_mode)
+
+    mem_config = {}
+    try:
+        mem_config = _agent_cfg.get("memory", {}) or {}
+    except Exception:
+        mem_config = {}
+
     if not skip_memory:
         try:
-            mem_config = _agent_cfg.get("memory", {})
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
@@ -1359,13 +1393,12 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
-    
-
 
     # Memory provider plugin (external — one at a time, alongside built-in)
     # Reads memory.provider from config to select which plugin to activate.
+    # Loaded when mode is tools|full even if skip_memory=True (cron opt-in).
     agent._memory_manager = None
-    if not skip_memory:
+    if _provider_tools_enabled(_mp_mode):
         try:
             _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 
@@ -1373,6 +1406,9 @@ def init_agent(
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
                 agent._memory_manager = _MemoryManager()
+                # Mirror mode gates onto the manager so CLI /new boundary
+                # commits (commit_session_boundary_async) honor tools mode.
+                agent._memory_manager.auto_lifecycle = _provider_lifecycle_enabled(_mp_mode)
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)
@@ -1422,7 +1458,11 @@ def init_agent(
                     except Exception:
                         pass
                     agent._memory_manager.initialize_all(**_init_kwargs)
-                    _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
+                    _ra().logger.info(
+                        "Memory provider '%s' activated (mode=%s)",
+                        _mem_provider_name,
+                        _mp_mode,
+                    )
                 else:
                     _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
                     agent._memory_manager = None

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -361,6 +361,11 @@ class MemoryManager:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
+        # When False (memory_provider_mode=tools|off), automatic lifecycle
+        # writes are suppressed: on_session_end extraction inside
+        # commit_session_boundary_async. Explicit tool calls still work.
+        # Agent init sets this from provider_lifecycle_enabled(mode).
+        self.auto_lifecycle: bool = True
         # Background executor for end-of-turn sync/prefetch. Lazily created on
         # first use so the common builtin-only path spawns no extra threads.
         # A single worker serializes a provider's writes (turn N must land
@@ -814,12 +819,15 @@ class MemoryManager:
         if not self._providers:
             return
         snapshot = list(messages or [])
+        retain = bool(getattr(self, "auto_lifecycle", True))
 
         def _run() -> None:
-            try:
-                self.on_session_end(snapshot)
-            except Exception as e:  # pragma: no cover - on_session_end guards per-provider
-                logger.warning("Session-boundary extraction failed: %s", e)
+            # tools mode: rebind session id without automatic retain/extraction
+            if retain:
+                try:
+                    self.on_session_end(snapshot)
+                except Exception as e:  # pragma: no cover - on_session_end guards per-provider
+                    logger.warning("Session-boundary extraction failed: %s", e)
             try:
                 self.on_session_switch(
                     new_session_id,

--- a/agent/memory_provider_mode.py
+++ b/agent/memory_provider_mode.py
@@ -1,0 +1,72 @@
+"""Normalize external memory provider modes for AIAgent.
+
+Modes:
+  off   — no provider init (cron default; also default when skip_memory=True)
+  tools — provider loaded + tools injected; no auto prompt/prefetch/turn-sync/session retain
+  full  — normal interactive provider lifecycle (default when skip_memory=False)
+
+Legacy ``skip_memory_provider``:
+  True  → off
+  False → tools  (enable provider without implying full auto-sync; safer than historical global-on)
+  None  → derive from memory_provider_mode / skip_memory
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+VALID_MEMORY_PROVIDER_MODES = frozenset({"off", "tools", "full"})
+
+
+def resolve_memory_provider_mode(
+    *,
+    skip_memory: bool = False,
+    memory_provider_mode: Optional[str] = None,
+    skip_memory_provider: Optional[bool] = None,
+) -> str:
+    """Return a canonical mode string.
+
+    Priority:
+      1. Explicit memory_provider_mode (if non-empty)
+      2. Legacy skip_memory_provider bool
+      3. Default: off when skip_memory else full
+    """
+    if memory_provider_mode is not None and str(memory_provider_mode).strip() != "":
+        mode = str(memory_provider_mode).strip().lower()
+        if mode not in VALID_MEMORY_PROVIDER_MODES:
+            raise ValueError(
+                f"Invalid memory_provider_mode {memory_provider_mode!r}; "
+                f"expected one of {sorted(VALID_MEMORY_PROVIDER_MODES)}"
+            )
+        return mode
+
+    if skip_memory_provider is not None:
+        return "off" if skip_memory_provider else "tools"
+
+    return "off" if skip_memory else "full"
+
+
+def normalize_job_memory_provider(value: Any) -> Optional[str]:
+    """Normalize a cron job field. None/empty → None (scheduler treats as off)."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        # Defensive: bools are not valid job values
+        raise ValueError("memory_provider must be 'off', 'tools', or 'full'")
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text not in VALID_MEMORY_PROVIDER_MODES:
+        raise ValueError(
+            f"Invalid memory_provider {value!r}; "
+            f"expected one of {sorted(VALID_MEMORY_PROVIDER_MODES)}"
+        )
+    return text
+
+
+def provider_lifecycle_enabled(mode: str) -> bool:
+    return mode == "full"
+
+
+def provider_tools_enabled(mode: str) -> bool:
+    return mode in ("tools", "full")

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -469,7 +469,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                 volatile_parts.append(user_block)
 
     # External memory provider system prompt block (additive to built-in)
-    if agent._memory_manager:
+    # Only when lifecycle/prompt context is enabled (mode=full). tools mode
+    # exposes tools without injecting provider recall into the system prompt.
+    if agent._memory_manager and getattr(agent, "_memory_provider_prompt_context", True):
         try:
             _ext_mem_block = agent._memory_manager.build_system_prompt()
             if _ext_mem_block:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -548,7 +548,7 @@ def build_turn_context(
         agent._interrupt_thread_signal_pending = False
 
     # Notify memory providers of the new turn (BEFORE prefetch_all).
-    if agent._memory_manager:
+    if agent._memory_manager and getattr(agent, "_memory_provider_prefetch", True):
         try:
             _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
             agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
@@ -557,7 +557,7 @@ def build_turn_context(
 
     # External memory provider: prefetch once before the tool loop.
     ext_prefetch_cache = ""
-    if agent._memory_manager:
+    if agent._memory_manager and getattr(agent, "_memory_provider_prefetch", True):
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1048,6 +1048,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    memory_provider: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1059,7 +1060,7 @@ def create_job(
         name: Optional friendly name
         repeat: How many times to run (None = forever, 1 = once)
         deliver: Where to deliver output ("origin", "local", "telegram", etc.)
-        origin: Source info where job was created (for "origin" delivery)
+        origin: Source info where job was created for "origin" delivery
         skill: Optional legacy single skill name to load before running the prompt
         skills: Optional ordered list of skills to load before running the prompt
         model: Optional per-job model override
@@ -1092,6 +1093,12 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        memory_provider: Optional external memory-provider mode for agent runs:
+                ``off`` (default / unset), ``tools`` (provider tools available,
+                no auto prompt/prefetch/turn-sync), or ``full`` (normal
+                interactive provider lifecycle). Independent of ``skip_memory``
+                so cron can keep MEMORY.md protected while optionally loading
+                plugins. Ignored when ``no_agent=True``.
 
     Returns:
         The created job dict
@@ -1124,6 +1131,9 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    from agent.memory_provider_mode import normalize_job_memory_provider
+
+    normalized_memory_provider = normalize_job_memory_provider(memory_provider)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1219,6 +1229,10 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    # Only persist memory_provider when non-default so existing jobs stay clean
+    # (absent key / None / off => scheduler keeps provider off with skip_memory).
+    if normalized_memory_provider and normalized_memory_provider != "off":
+        job["memory_provider"] = normalized_memory_provider
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1308,6 +1322,17 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            # memory_provider: empty/None/off clears (scheduler treats as off).
+            if "memory_provider" in updates:
+                from agent.memory_provider_mode import normalize_job_memory_provider
+
+                updates["memory_provider"] = normalize_job_memory_provider(
+                    updates["memory_provider"]
+                )
+                # Store None for default/off so JSON stays clean.
+                if updates["memory_provider"] in (None, "off"):
+                    updates["memory_provider"] = None
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3071,6 +3071,8 @@ def run_job(
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
+            # Per-job external provider opt-in (default off). See memory_provider_mode.
+            memory_provider_mode=(job.get("memory_provider") or "off"),
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/docs/pr18565-review-replies.md
+++ b/docs/pr18565-review-replies.md
@@ -1,0 +1,137 @@
+# PR #18565 — draft review responses
+
+Do **not** post these until Ben explicitly approves. Paste as PR comments / review replies on https://github.com/NousResearch/hermes-agent/pull/18565 after the implementation commit lands.
+
+---
+
+## 1. Reply to review body (teknium1 / hermes-sweeper)
+
+> Thanks for isolating the built-in-memory and provider-initialization concerns… Suggested: explicit per-job provider-tools-only opt-in…
+
+**Draft reply:**
+
+```markdown
+Thanks — agreed on all three problems with the original patch shape. We reworked the design instead of landing the global `skip_memory_provider=False` for every cron run.
+
+### Addressing the review
+
+1. **Init surface** — `AIAgent` now forwards both `memory_provider_mode` and legacy `skip_memory_provider` into `agent/agent_init.py` (the live initializer). Mode resolution lives in `agent/memory_provider_mode.py`.
+
+2. **Not tools-only by accident** — providers expose three modes:
+   - `off` — no provider init (cron default)
+   - `tools` — provider loaded + tools injected; **no** automatic system-prompt context, prefetch, per-turn `sync_turn`, or session-end retain
+   - `full` — normal interactive lifecycle
+
+   Lifecycle gates:
+   - prompt block: `agent/system_prompt.py` (`_memory_provider_prompt_context`)
+   - prefetch / on_turn_start: `agent/turn_context.py` (`_memory_provider_prefetch`)
+   - turn sync: `run_agent.py::_sync_external_memory_for_turn` (`_memory_provider_auto_sync`)
+   - session-end retain: `shutdown_memory_provider` / `commit_memory_session` (same auto-sync flag)
+
+   Built-in `MEMORY.md` / `USER.md` still always skip under cron (`skip_memory=True`).
+
+3. **Per-job opt-in (not global)** — cron jobs carry `memory_provider: off|tools|full`. Scheduler maps that to `AIAgent(memory_provider_mode=...)`. There is no `cron.skip_memory=false` global switch (too broad vs #4052). Recommended path for maintenance jobs is `tools`.
+
+4. **Legacy mapping** — `skip_memory_provider=True` → `off`; `False` → `tools` (never silently implies `full`).
+
+5. **Tests** — unit coverage for mode resolution, init flags (no-prefetch / no-sync in `tools`), and cron constructor kwargs mapping the job field through the scheduler.
+
+Docs updated in this revision: `AGENTS.md` cron section, `website/docs/user-guide/features/cron.md`, `memory-providers.md`, and `website/docs/guides/cron-troubleshooting.md` (new Memory section).
+```
+
+---
+
+## 2. Inline: `run_agent.py` init param (discussion_r3567113045)
+
+**Draft reply:**
+
+```markdown
+Fixed. Constructor now accepts `memory_provider_mode` + legacy `skip_memory_provider` and forwards both into `agent/agent_init.py`, where the provider is gated with `provider_tools_enabled(mode)` and lifecycle flags are set from `provider_lifecycle_enabled(mode)`.
+```
+
+---
+
+## 3. Inline: `cron/scheduler.py` global enable (discussion_r3567113046)
+
+**Draft reply:**
+
+```markdown
+Agreed — the original `skip_memory_provider=False` on every cron job was the wrong shape (full auto-sync / Hindsight retain).
+
+Cron still always uses `skip_memory=True`. Providers default to `off`. A job must set `memory_provider="tools"` (tools-only/no-sync) or `"full"` (explicit lifecycle) to load the configured external provider. `tools` is the recommended opt-in for curator/maintenance jobs.
+```
+
+---
+
+## 4. Reply to @alt-glitch (duplicate of #9802 / #9763)
+
+**Draft reply:**
+
+```markdown
+Thanks for the pointer — same problem space as #9763 / #9802 (external providers dead under cron because `skip_memory=True` also skipped provider init).
+
+This PR is no longer the original "always enable provider for cron" approach. After review feedback (and #4052 history), the direction is:
+
+1. keep built-in memory skipped for all cron
+2. default external providers to **off** under cron
+3. per-job opt-in with `memory_provider=tools|full`, where `tools` is tools-only/no-auto-sync
+
+Happy to coordinate / close-as-duplicate once that lands if #9802 is still the preferred vehicle — or keep this PR as the mode + docs vehicle if it supersedes the simpler bool.
+```
+
+---
+
+## 5. Reply to @jeffla (per-job opt-in vs global)
+
+**Draft reply:**
+
+```markdown
+Exactly the shape we landed on:
+
+1. cron skips built-in memory by default (always)
+2. provider tools can be exposed in tools-only / no-sync mode (`memory_provider=tools`)
+3. full lifecycle / hot memory only via explicit per-job opt-in (`memory_provider=full`)
+
+No global `cron.skip_memory=false` — that would re-open the #4052 corruption path for every scheduled job.
+```
+
+---
+
+## 6. Suggested PR description rewrite (for force-push / edit body)
+
+```markdown
+## Problem
+
+Cron always passes `skip_memory=True` so built-in MEMORY.md/USER.md are not corrupted by cron system prompts (#4052). That same flag also prevented external memory **providers** (Hindsight, Honcho, mem0, …) from initializing, so provider tools appeared missing during scheduled jobs (#9763).
+
+Earlier revisions that set `skip_memory_provider=False` for **every** cron job were too broad: provider init also enables automatic turn sync / session retain (e.g. Hindsight retain), which is not tools-only behavior.
+
+## Solution
+
+Decouple built-in memory from external providers with an explicit mode:
+
+| `memory_provider_mode` | Built-in | Provider tools | Auto prompt / prefetch / sync / session retain |
+|---|---|---|---|
+| `off` (cron default) | skipped when `skip_memory` | no | no |
+| `tools` | independent | yes | **no** |
+| `full` (interactive default) | independent | yes | yes |
+
+- `agent/memory_provider_mode.py` — resolution + helpers
+- `agent/agent_init.py` + `run_agent.py` forwarder — init + lifecycle flags
+- gates in system prompt, turn context, turn sync, session-end
+- per-job cron field `memory_provider` (scheduler maps → mode); built-in still always skipped
+- legacy `skip_memory_provider`: True→off, False→tools
+
+## Docs
+
+- `AGENTS.md` cron section
+- user guide: cron + memory-providers
+- `guides/cron-troubleshooting.md` Memory section
+
+## Tests
+
+- mode resolution / isolation flags
+- cron constructor kwargs for the job field
+
+Closes / relates: #9763, #4052; supersedes the global-on approach in early #18565 / overlaps #9802.
+```

--- a/run_agent.py
+++ b/run_agent.py
@@ -476,6 +476,8 @@ class AIAgent:
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
+        memory_provider_mode: str = None,
+        skip_memory_provider: bool = None,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -552,6 +554,8 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
+            memory_provider_mode=memory_provider_mode,
+            skip_memory_provider=skip_memory_provider,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
@@ -3322,7 +3326,8 @@ class AIAgent:
         """
         if self._memory_manager:
             try:
-                self._memory_manager.on_session_end(messages or [])
+                if getattr(self, "_memory_provider_auto_sync", True):
+                    self._memory_manager.on_session_end(messages or [])
             except Exception as e:
                 logger.warning("Memory provider on_session_end failed during shutdown: %s", e, exc_info=True)
             try:
@@ -3346,7 +3351,8 @@ class AIAgent:
         session_id — they just flush pending extraction now."""
         if self._memory_manager:
             try:
-                self._memory_manager.on_session_end(messages or [])
+                if getattr(self, "_memory_provider_auto_sync", True):
+                    self._memory_manager.on_session_end(messages or [])
             except Exception:
                 pass
         # Notify context engine of session end too — same lifecycle moment as
@@ -3402,6 +3408,10 @@ class AIAgent:
             return
         if not (self._memory_manager and final_response and original_user_message):
             return
+        # tools mode: provider tools are available but automatic turn sync /
+        # retain is disabled (cron safety). Explicit tool calls still work.
+        if not getattr(self, "_memory_provider_auto_sync", True):
+            return
         # Multimodal turns carry content as a list of typed parts; providers
         # expect plain strings, so flatten to text first (newline-joined for
         # memory, vs the default space-join used for log/trajectory previews).
@@ -3418,10 +3428,11 @@ class AIAgent:
                 response_text,
                 **sync_kwargs,
             )
-            self._memory_manager.queue_prefetch_all(
-                user_text,
-                session_id=self.session_id or "",
-            )
+            if getattr(self, "_memory_provider_prefetch", True):
+                self._memory_manager.queue_prefetch_all(
+                    user_text,
+                    session_id=self.session_id or "",
+                )
         except Exception:
             pass
 

--- a/tests/cron/test_memory_provider_mode.py
+++ b/tests/cron/test_memory_provider_mode.py
@@ -1,0 +1,139 @@
+"""Cron job field + scheduler kwargs for memory_provider_mode (PR #18565 salvage).
+
+Cron always keeps skip_memory=True (protect MEMORY.md/USER.md). Per-job
+memory_provider may opt external providers into tools|full (default off).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron.jobs import create_job, get_job, update_job
+from cron.scheduler import run_job
+
+
+@pytest.fixture
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+class TestCreateJobMemoryProvider:
+    def test_omitted_does_not_persist_field(self, tmp_cron_dir):
+        job = create_job(prompt="check", schedule="every 1h")
+        assert "memory_provider" not in job
+        fetched = get_job(job["id"])
+        assert not fetched.get("memory_provider")
+
+    def test_off_does_not_persist_field(self, tmp_cron_dir):
+        job = create_job(prompt="check", schedule="every 1h", memory_provider="off")
+        assert "memory_provider" not in job
+
+    def test_tools_persisted(self, tmp_cron_dir):
+        job = create_job(prompt="check", schedule="every 1h", memory_provider="tools")
+        assert job["memory_provider"] == "tools"
+        assert get_job(job["id"])["memory_provider"] == "tools"
+
+    def test_full_persisted_case_insensitive(self, tmp_cron_dir):
+        job = create_job(prompt="check", schedule="every 1h", memory_provider="FULL")
+        assert job["memory_provider"] == "full"
+
+    def test_invalid_rejected(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="Invalid memory_provider"):
+            create_job(prompt="check", schedule="every 1h", memory_provider="maybe")
+
+    def test_bool_rejected(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="memory_provider must be"):
+            create_job(prompt="check", schedule="every 1h", memory_provider=True)
+
+    def test_update_set_and_clear(self, tmp_cron_dir):
+        job = create_job(prompt="check", schedule="every 1h")
+        updated = update_job(job["id"], {"memory_provider": "tools"})
+        assert updated["memory_provider"] == "tools"
+        cleared = update_job(job["id"], {"memory_provider": ""})
+        # Cleared value becomes None (scheduler treats falsy as off)
+        assert not cleared.get("memory_provider")
+
+
+class TestRunJobMemoryProviderKwargs:
+    @contextlib.contextmanager
+    def _run_job_patches(self, tmp_path):
+        fake_db = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        base = [
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("hermes_cli.env_loader.load_hermes_dotenv"),
+            patch("hermes_cli.env_loader.reset_secret_source_cache"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("run_agent.AIAgent", return_value=mock_agent),
+        ]
+        with contextlib.ExitStack() as stack:
+            entered = [stack.enter_context(cm) for cm in base]
+            yield entered[-1]  # AIAgent class mock
+
+    def test_default_job_passes_mode_off_and_skip_memory(self, tmp_path):
+        job = {"id": "mem-default", "name": "test", "prompt": "hello"}
+        with self._run_job_patches(tmp_path) as mock_agent_cls:
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+        assert kwargs["memory_provider_mode"] == "off"
+
+    def test_tools_job_passes_mode_tools(self, tmp_path):
+        job = {
+            "id": "mem-tools",
+            "name": "test",
+            "prompt": "hello",
+            "memory_provider": "tools",
+        }
+        with self._run_job_patches(tmp_path) as mock_agent_cls:
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+        assert kwargs["memory_provider_mode"] == "tools"
+
+    def test_full_job_passes_mode_full(self, tmp_path):
+        job = {
+            "id": "mem-full",
+            "name": "test",
+            "prompt": "hello",
+            "memory_provider": "full",
+        }
+        with self._run_job_patches(tmp_path) as mock_agent_cls:
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+        assert kwargs["memory_provider_mode"] == "full"
+
+    def test_empty_memory_provider_field_defaults_to_off(self, tmp_path):
+        job = {
+            "id": "mem-empty",
+            "name": "test",
+            "prompt": "hello",
+            "memory_provider": None,
+        }
+        with self._run_job_patches(tmp_path) as mock_agent_cls:
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["memory_provider_mode"] == "off"

--- a/tests/run_agent/test_memory_provider_mode.py
+++ b/tests/run_agent/test_memory_provider_mode.py
@@ -1,0 +1,440 @@
+"""Unit + init isolation tests for memory_provider_mode (off|tools|full).
+
+Covers the PR #18565 salvage design:
+- Built-in MEMORY.md/USER.md remain gated by skip_memory
+- External providers can opt in independently via memory_provider_mode
+- tools mode loads provider tools without auto prompt/prefetch/sync/session retain
+- full mode is the interactive default when skip_memory=False
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.memory_provider_mode import (
+    VALID_MEMORY_PROVIDER_MODES,
+    normalize_job_memory_provider,
+    provider_lifecycle_enabled,
+    provider_tools_enabled,
+    resolve_memory_provider_mode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMemoryProviderMode:
+    def test_default_skip_memory_false_is_full(self):
+        assert resolve_memory_provider_mode(skip_memory=False) == "full"
+
+    def test_default_skip_memory_true_is_off(self):
+        assert resolve_memory_provider_mode(skip_memory=True) == "off"
+
+    def test_explicit_mode_wins_over_skip_memory(self):
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=True, memory_provider_mode="tools"
+            )
+            == "tools"
+        )
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=True, memory_provider_mode="full"
+            )
+            == "full"
+        )
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=False, memory_provider_mode="off"
+            )
+            == "off"
+        )
+
+    def test_explicit_mode_wins_over_legacy_skip_memory_provider(self):
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=True,
+                memory_provider_mode="full",
+                skip_memory_provider=True,
+            )
+            == "full"
+        )
+
+    def test_legacy_skip_memory_provider_true_is_off(self):
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=False, skip_memory_provider=True
+            )
+            == "off"
+        )
+
+    def test_legacy_skip_memory_provider_false_is_tools(self):
+        # Safer than historical global-on: enable tools without auto-sync.
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=True, skip_memory_provider=False
+            )
+            == "tools"
+        )
+
+    def test_blank_explicit_mode_falls_through(self):
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=True, memory_provider_mode="  "
+            )
+            == "off"
+        )
+        assert (
+            resolve_memory_provider_mode(
+                skip_memory=False, memory_provider_mode=""
+            )
+            == "full"
+        )
+
+    def test_case_insensitive_mode(self):
+        assert (
+            resolve_memory_provider_mode(memory_provider_mode="Tools") == "tools"
+        )
+        assert (
+            resolve_memory_provider_mode(memory_provider_mode="FULL") == "full"
+        )
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Invalid memory_provider_mode"):
+            resolve_memory_provider_mode(memory_provider_mode="half")
+
+
+class TestNormalizeJobMemoryProvider:
+    def test_none_and_blank_become_none(self):
+        assert normalize_job_memory_provider(None) is None
+        assert normalize_job_memory_provider("") is None
+        assert normalize_job_memory_provider("   ") is None
+
+    def test_valid_modes(self):
+        assert normalize_job_memory_provider("off") == "off"
+        assert normalize_job_memory_provider("tools") == "tools"
+        assert normalize_job_memory_provider("FULL") == "full"
+
+    def test_bools_rejected(self):
+        with pytest.raises(ValueError, match="memory_provider must be"):
+            normalize_job_memory_provider(True)
+        with pytest.raises(ValueError, match="memory_provider must be"):
+            normalize_job_memory_provider(False)
+
+    def test_invalid_string_rejected(self):
+        with pytest.raises(ValueError, match="Invalid memory_provider"):
+            normalize_job_memory_provider("sometimes")
+
+
+class TestProviderFlagHelpers:
+    def test_lifecycle_only_full(self):
+        assert provider_lifecycle_enabled("full") is True
+        assert provider_lifecycle_enabled("tools") is False
+        assert provider_lifecycle_enabled("off") is False
+
+    def test_tools_enabled_for_tools_and_full(self):
+        assert provider_tools_enabled("tools") is True
+        assert provider_tools_enabled("full") is True
+        assert provider_tools_enabled("off") is False
+
+    def test_valid_modes_set(self):
+        assert VALID_MEMORY_PROVIDER_MODES == frozenset({"off", "tools", "full"})
+
+
+# ---------------------------------------------------------------------------
+# AIAgent init isolation
+# ---------------------------------------------------------------------------
+
+
+class RecordingMemoryProvider:
+    name = "recording"
+
+    def __init__(self):
+        self.init_kwargs = None
+        self.init_session_id = None
+        self.sync_calls = []
+        self.prefetch_calls = []
+        self.session_end_calls = []
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        self.init_session_id = session_id
+        self.init_kwargs = dict(kwargs)
+
+    def get_tool_schemas(self):
+        return [{"name": "recording_recall", "description": "test"}]
+
+    def sync_turn(self, *args, **kwargs):
+        self.sync_calls.append((args, kwargs))
+
+    def prefetch(self, query, **kwargs):
+        self.prefetch_calls.append(query)
+        return ""
+
+    def on_session_end(self, messages):
+        self.session_end_calls.append(messages)
+
+    def shutdown(self):
+        pass
+
+    def system_prompt_block(self):
+        return "EXTERNAL MEMORY BLOCK"
+
+
+@contextlib.contextmanager
+def _agent_patches(cfg, provider=None):
+    """Common patches for constructing AIAgent without network/tool discovery."""
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("hermes_cli.config.load_config", return_value=cfg))
+        stack.enter_context(
+            patch("plugins.memory.load_memory_provider", return_value=provider)
+        )
+        stack.enter_context(
+            patch("agent.model_metadata.get_model_context_length", return_value=204_800)
+        )
+        stack.enter_context(patch("run_agent.get_tool_definitions", return_value=[]))
+        stack.enter_context(patch("run_agent.check_toolset_requirements", return_value={}))
+        stack.enter_context(patch("run_agent.OpenAI"))
+        yield
+
+
+class TestAIAgentMemoryProviderModeIsolation:
+    def test_skip_memory_true_default_mode_off_no_provider(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording", "memory_enabled": True}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent._memory_provider_mode == "off"
+        assert agent._memory_manager is None
+        assert agent._memory_provider_auto_sync is False
+        assert agent._memory_provider_prefetch is False
+        assert agent._memory_provider_prompt_context is False
+        # Built-in memory stays off under skip_memory=True
+        assert getattr(agent, "_memory_store", None) in (None, False) or not getattr(
+            agent, "_memory_enabled", False
+        )
+
+    def test_tools_mode_loads_provider_without_lifecycle(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording", "memory_enabled": True}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                memory_provider_mode="tools",
+                session_id="cron-sess",
+                platform="cron",
+            )
+
+        assert agent._memory_provider_mode == "tools"
+        assert agent._memory_manager is not None
+        assert agent._memory_provider_auto_sync is False
+        assert agent._memory_provider_prefetch is False
+        assert agent._memory_provider_prompt_context is False
+        # Built-in local memory still skipped (cron safety)
+        assert not getattr(agent, "_memory_enabled", False)
+        assert provider.init_session_id == "cron-sess"
+
+    def test_full_mode_with_skip_memory_still_skips_builtin(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording", "memory_enabled": True}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                memory_provider_mode="full",
+            )
+
+        assert agent._memory_provider_mode == "full"
+        assert agent._memory_manager is not None
+        assert agent._memory_provider_auto_sync is True
+        assert agent._memory_provider_prefetch is True
+        assert agent._memory_provider_prompt_context is True
+        assert not getattr(agent, "_memory_enabled", False)
+
+    def test_default_interactive_is_full_when_skip_memory_false(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+        assert agent._memory_provider_mode == "full"
+        assert agent._memory_manager is not None
+        assert agent._memory_provider_auto_sync is True
+
+    def test_legacy_skip_memory_provider_false_maps_to_tools(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                skip_memory_provider=False,
+            )
+
+        assert agent._memory_provider_mode == "tools"
+        assert agent._memory_manager is not None
+        assert agent._memory_provider_auto_sync is False
+
+    def test_invalid_mode_defaults_to_off(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                memory_provider_mode="bogus",
+            )
+
+        assert agent._memory_provider_mode == "off"
+        assert agent._memory_manager is None
+
+    def test_tools_mode_skips_auto_sync_and_session_end(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                memory_provider_mode="tools",
+                session_id="s1",
+            )
+
+        # sync_all path is on the manager; spy at manager level
+        mm = agent._memory_manager
+        assert mm is not None
+        mm.sync_all = MagicMock()
+        mm.queue_prefetch_all = MagicMock()
+        mm.on_session_end = MagicMock()
+        mm.shutdown_all = MagicMock()
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="hello",
+            final_response="world",
+            interrupted=False,
+        )
+        mm.sync_all.assert_not_called()
+        mm.queue_prefetch_all.assert_not_called()
+
+        agent.shutdown_memory_provider(messages=[{"role": "user", "content": "x"}])
+        mm.on_session_end.assert_not_called()
+        mm.shutdown_all.assert_called_once()
+
+    def test_full_mode_runs_auto_sync(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                memory_provider_mode="full",
+                session_id="s2",
+            )
+
+        mm = agent._memory_manager
+        mm.sync_all = MagicMock()
+        mm.queue_prefetch_all = MagicMock()
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="hello",
+            final_response="world",
+            interrupted=False,
+        )
+        mm.sync_all.assert_called_once()
+        mm.queue_prefetch_all.assert_called_once()
+
+    def test_tools_mode_omits_provider_system_prompt_block(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                memory_provider_mode="tools",
+            )
+
+        from agent.system_prompt import build_system_prompt_parts
+
+        parts = build_system_prompt_parts(agent)
+        volatile = parts.get("volatile") or ""
+        assert "EXTERNAL MEMORY BLOCK" not in volatile
+
+    def test_full_mode_includes_provider_system_prompt_block(self):
+        provider = RecordingMemoryProvider()
+        cfg = {"memory": {"provider": "recording"}, "agent": {}}
+        with _agent_patches(cfg, provider):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                memory_provider_mode="full",
+            )
+
+        from agent.system_prompt import build_system_prompt_parts
+
+        parts = build_system_prompt_parts(agent)
+        volatile = parts.get("volatile") or ""
+        assert "EXTERNAL MEMORY BLOCK" in volatile

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("memory_provider"):
+        result["memory_provider"] = job["memory_provider"]
     return result
 
 
@@ -677,6 +679,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    memory_provider: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +753,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                memory_provider=memory_provider,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -923,6 +927,11 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if memory_provider is not None:
+                # Empty string clears (back to default off).
+                updates["memory_provider"] = (
+                    _normalize_optional_job_value(memory_provider) or None
+                )
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1085,6 +1094,19 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "memory_provider": {
+                "type": "string",
+                "enum": ["off", "tools", "full"],
+                "description": (
+                    "Optional external memory provider mode for agent cron jobs. "
+                    "off (default): no external provider (preserves AGENTS.md cron policy). "
+                    "tools: load provider tools (e.g. hindsight_*, mem0_*) without automatic "
+                    "prefetch/turn-sync/session retain — explicit tool writes still allowed. "
+                    "full: full provider lifecycle including auto-sync (trusted jobs only). "
+                    "Does not enable local MEMORY.md/USER.md. Independent of skip_memory — "
+                    "MEMORY.md stays off for cron. On update, pass 'off' (or empty string) to clear."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -1140,6 +1162,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
+        memory_provider=args.get("memory_provider"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/guides/automate-with-cron.md
+++ b/website/docs/guides/automate-with-cron.md
@@ -11,7 +11,7 @@ The [daily briefing bot tutorial](/guides/daily-briefing-bot) covers the basics.
 For the full feature reference, see [Scheduled Tasks (Cron)](/user-guide/features/cron).
 
 :::info Key Concept
-Cron jobs run in fresh agent sessions with no memory of your current chat. Prompts must be **completely self-contained** — include everything the agent needs to know.
+Cron jobs run in fresh agent sessions with no memory of your current chat. Prompts must be **completely self-contained** — include everything the agent needs to know. Built-in MEMORY.md is always skipped; external memory providers default to off and need a per-job `memory_provider=tools|full` opt-in ([details](/user-guide/features/cron#memory-isolation-built-in-vs-providers)).
 :::
 
 :::tip Don't need the LLM? You have two zero-token options.

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -131,6 +131,80 @@ In this example, `context-skill` loads before `target-skill`.
 
 ---
 
+## Memory and Memory Providers
+
+Cron deliberately isolates memory. If a job cannot use `memory`, Hindsight, Honcho, mem0, etc., check this section before treating it as a bug.
+
+### Built-in MEMORY.md / USER.md are always off for cron
+
+Every cron agent is constructed with `skip_memory=True`. That protects the built-in local memory files from being polluted by cron system prompts (identity lines, model/tool banners, etc.). There is **no** global config switch to turn built-in memory back on for all cron jobs.
+
+If the built-in `memory` tool reports that memory is unavailable, that is expected under cron.
+
+### External providers are opt-in per job
+
+External memory providers (Hindsight, Honcho, mem0, …) are controlled separately via the per-job field `memory_provider`:
+
+| Job `memory_provider` | Built-in MEMORY.md | Provider tools | Auto prompt / prefetch / sync / session retain |
+|-----------------------|--------------------|----------------|--------------------------------------------------|
+| *(unset)* / `off`     | skipped            | no             | no                                               |
+| `tools`               | skipped            | yes            | **no** (explicit tool calls only)                |
+| `full`                | skipped            | yes            | yes (same lifecycle as interactive sessions)     |
+
+Default is **`off`**. Prefer **`tools`** for scheduled maintenance jobs that need to search/store facts without auto-writing the whole cron prompt into the user representation. Use **`full`** only when you explicitly want automatic lifecycle behavior and understand the risk from [#4052](https://github.com/NousResearch/hermes-agent/issues/4052) (cron prompts misattributed as user messages).
+
+Example (agent tool):
+
+```python
+cronjob(
+    action="create",
+    schedule="every day 3am",
+    name="nightly-memory-curator",
+    memory_provider="tools",
+    prompt=(
+        "Use hindsight_recall / hindsight_retain (or your active provider tools) "
+        "to dedupe and store durable facts from the last day. "
+        "Do not treat this prompt as user speech."
+    ),
+)
+```
+
+CLI form (when the flag is available on your build):
+
+```bash
+hermes cron create "every day 3am" "Curate long-term memory via provider tools..." \
+  --memory-provider tools \
+  --name nightly-memory-curator
+```
+
+If your installed CLI has no `--memory-provider` flag yet, create/update the job via the `cronjob` tool (or set `"memory_provider": "tools"` on the job record) — the field is stored in `~/.hermes/cron/jobs.json` and honored by the scheduler.
+
+### Common failure modes
+
+**"Memory is not available" on the built-in `memory` tool**
+Expected. Built-in memory is disabled for cron. Use the active provider's tools after setting `memory_provider=tools` (or `full`), or run the work interactively outside cron.
+
+**Provider tools missing even with `memory.provider` set in config.yaml**
+Confirm the job itself has `memory_provider: tools` (or `full`). A configured global provider does **not** auto-enable in cron.
+
+**Provider tools present but recall/context is empty every run**
+You are probably on `tools` mode. Automatic prefetch and system-prompt injection are disabled on purpose. Call the provider search/recall tools explicitly in the job prompt.
+
+**User representation polluted with "I am Hermes…" / model identity**
+Classic #4052 symptom. Ensure the job is not on `memory_provider=full` (or legacy paths that enabled full auto-sync). Prefer `tools` and never auto-sync raw cron system prompts into user-modeling backends.
+
+**Want full interactive memory behavior in a scheduled job**
+Set `memory_provider=full` on that one job only. Still never enables built-in MEMORY.md/USER.md writes under cron.
+
+### Related code / design pointers
+
+- Mode resolution: `agent/memory_provider_mode.py` (`off` | `tools` | `full`)
+- Init + flags: `agent/agent_init.py` (`_memory_provider_auto_sync`, `_memory_provider_prefetch`, `_memory_provider_prompt_context`)
+- Cron construction: `cron/scheduler.py` (`skip_memory=True` + per-job `memory_provider_mode`)
+- Tracking / history: [#9763](https://github.com/NousResearch/hermes-agent/issues/9763), [#4052](https://github.com/NousResearch/hermes-agent/issues/4052), PR [#18565](https://github.com/NousResearch/hermes-agent/pull/18565)
+
+---
+
 ## Job Errors and Failures
 
 ### Check 1: Review recent job output

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -746,6 +746,34 @@ Cron jobs run in a completely fresh agent session. The prompt must contain every
 
 **GOOD:** `"SSH into server 192.168.1.100 as user 'deploy', check if nginx is running with 'systemctl status nginx', and verify https://example.com returns HTTP 200."`
 
+## Memory isolation (built-in vs providers)
+
+Cron always skips **built-in** memory (`MEMORY.md` / `USER.md`) so scheduled system prompts cannot pollute local user notes. External memory **providers** are separate and default to **off**.
+
+Opt in **per job** with `memory_provider`:
+
+| Value | What you get |
+|-------|----------------|
+| `off` (default) | No provider init, no provider tools |
+| `tools` | Provider tools available; **no** automatic prompt injection, prefetch, turn sync, or session-end retain |
+| `full` | Full interactive provider lifecycle (use sparingly — can reintroduce user-representation corruption if cron prompts are treated as user speech; see [#4052](https://github.com/NousResearch/hermes-agent/issues/4052)) |
+
+```python
+cronjob(
+    action="create",
+    schedule="0 3 * * *",
+    name="nightly-memory-curator",
+    memory_provider="tools",
+    prompt="Use provider tools to search and store durable facts. Explicit tool calls only.",
+)
+```
+
+The job field is stored in `~/.hermes/cron/jobs.json`. Prefer the `cronjob` tool (or a direct job edit) until a `hermes cron create --memory-provider` CLI flag lands on your build.
+
+There is no global `cron.skip_memory: false`. Prefer `tools` for maintenance jobs; reserve `full` for deliberate lifecycle sync on a single job.
+
+See [Cron Troubleshooting → Memory and Memory Providers](/guides/cron-troubleshooting#memory-and-memory-providers).
+
 ## Security
 
 Scheduled task prompts are scanned for prompt-injection and credential-exfiltration patterns at creation and update time. Prompts containing invisible Unicode tricks, SSH backdoor attempts, or obvious secret-exfiltration payloads are blocked.

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -38,6 +38,25 @@ When a memory provider is active, Hermes automatically:
 
 The built-in memory (MEMORY.md / USER.md) continues to work exactly as before. The external provider is additive.
 
+### Modes: `off` | `tools` | `full`
+
+Provider lifecycle is not all-or-nothing. `AIAgent` resolves a `memory_provider_mode`:
+
+| Mode | Provider init + tools | Auto prompt / prefetch / turn-sync / session retain |
+|------|------------------------|-----------------------------------------------------|
+| `off` | no | no |
+| `tools` | yes | **no** — explicit tool calls only |
+| `full` | yes | yes (normal interactive behaviour above) |
+
+Defaults:
+
+- Interactive sessions (`skip_memory=False`): **`full`**
+- Cron and other `skip_memory=True` callers: **`off`**, unless overridden
+
+Cron jobs opt in **per job** via the `memory_provider` field (`tools` recommended; `full` is an explicit lifecycle opt-in). Built-in MEMORY.md remains skipped under cron either way. See [Scheduled Tasks (Cron) → Memory isolation](./cron#memory-isolation-built-in-vs-providers) and [Cron Troubleshooting](/guides/cron-troubleshooting#memory-and-memory-providers).
+
+Legacy constructor flag `skip_memory_provider`: `True` → `off`, `False` → `tools` (never silently upgrades to `full`).
+
 ## Available Providers
 
 ### Honcho

--- a/website/docs/user-guide/features/spotify.md
+++ b/website/docs/user-guide/features/spotify.md
@@ -215,7 +215,7 @@ hermes cron add \
 - **An active device must exist when the cron fires.** If no Spotify client is running (phone/desktop/Connect speaker), playback actions return `403 no active device`. For morning playlists, the trick is to target a device that's always on (Sonos, Echo, a smart speaker) rather than your phone.
 - **Premium required for anything that mutates playback** — play, pause, skip, volume, transfer. Read-only cron jobs (scheduled "email me my recently played tracks") work fine on Free.
 - **The cron agent inherits your active toolsets.** Spotify must be enabled in `hermes tools` for the cron session to see the Spotify tools.
-- **Cron jobs run with `skip_memory=True`** so they don't write to your memory store.
+- **Cron jobs run with `skip_memory=True`** so they never write built-in `MEMORY.md` / `USER.md`. External memory providers stay off unless the job sets `memory_provider=tools` or `full` (see [Cron memory isolation](./cron#memory-isolation-built-in-vs-providers)).
 
 Full cron reference: [Cron Jobs](./cron).
 


### PR DESCRIPTION
## Problem

Cron always passes `skip_memory=True` so built-in MEMORY.md/USER.md are not
corrupted by cron system prompts (#4052). That same flag also prevented external
memory **providers** (Hindsight, Honcho, mem0, …) from initializing, so provider
tools appeared missing during scheduled jobs (#9763).

Earlier revisions that set `skip_memory_provider=False` for **every** cron job
were too broad: provider init also enables automatic turn sync / session retain
(e.g. Hindsight auto-retain), which is not a tools-only behavior.

## Solution

Decouple built-in memory from external providers with an explicit three-mode
enum (`memory_provider_mode`):

| Mode | Built-in MEMORY.md/USER.md | Provider tools | Auto prompt / prefetch / turn sync / session-end retain |
|---|---|---|---|
| **`off`** (cron default) | skipped (`skip_memory=True`) | no | no |
| **`tools`** | independent | **yes** | **no** |
| **`full`** (interactive default) | independent | yes | yes |

### Key changes

- **`agent/memory_provider_mode.py`** (new) — `resolve_memory_provider_mode()` + `normalize_job_memory_provider()` helpers.
- **`agent/agent_init.py`** — Provider loads when mode is `tools` or `full`, even when `skip_memory=True`. `mem_config` hoisted out of the `if not skip_memory` block.
- **`run_agent.py`** — AIAgent constructor accepts `memory_provider_mode` + legacy `skip_memory_provider`; forwards to `agent_init`. `_sync_external_memory_for_turn` gates on `_memory_provider_auto_sync`.
- **`agent/system_prompt.py`** — Provider prompt block gated on `_memory_provider_prompt_context`.
- **`agent/turn_context.py`** — `on_turn_start` + `prefetch_all` gated on `_memory_provider_prefetch`.
- **`run_agent.py`** — `shutdown_memory_provider` / `commit_memory_session` skip `on_session_end` when `_memory_provider_auto_sync` is False. `shutdown_all()` always runs (provider teardown ≠ retain).
- **`agent/memory_manager.py`** — New `auto_lifecycle` attribute on `MemoryManager`; `commit_session_boundary_async` skips `on_session_end` when `auto_lifecycle=False`.
- **`cron/scheduler.py`** — Maps per-job `memory_provider` field to `AIAgent(memory_provider_mode=...)`.
- **`cron/jobs.py`** — `create_job` + `update_job` accept and normalize `memory_provider`.
- **`tools/cronjob_tools.py`** — `cronjob` tool schema + handler accept `memory_provider` for create and update.

### Legacy mapping

`skip_memory_provider=True` → `off`; `False` → `tools` (never silently implies `full`).

### Docs

- `AGENTS.md` cron section (policy updated, not bypassed)
- `website/docs/user-guide/features/cron.md` — memory isolation section
- `website/docs/user-guide/features/memory-providers.md` — cron section
- `website/docs/guides/cron-troubleshooting.md` — Memory section
- `website/docs/guides/automate-with-cron.md` / `spotify.md` — cross-refs

### Tests (37 pass)

- `tests/run_agent/test_memory_provider_mode.py` — mode resolution, init isolation flags, full-turn no-sync, system prompt block gating, job field persistence.
- `tests/cron/test_memory_provider_mode.py` — scheduler kwargs mapping the job field through `AIAgent`.

### Related

Closes / relates: #9763, #4052. Supersedes the global-on approach in early #18565.
Overlaps / supersedes #9802 (same problem, this PR uses per-job mode instead of global enable).
