### PR TITLE
fix(feishu): preserve reply context from root_id

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2760,8 +2760,12 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
+            # Some Lark reply/topic payloads omit parent_id but still carry root_id.
+            or getattr(message, "root_id", None)
             or None
         )
+        if reply_to_message_id == message_id:
+            reply_to_message_id = None
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
         sender_primary = (

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,6 +83,7 @@ AUTHOR_MAP = {
     # Slack ephemeral slash-ack salvage (May 2026)
     "probepark@users.noreply.github.com": "probepark",
     # Slack batch salvage (May 2026)
+    "me@promplate.dev": "CNSeniorious000",
     "280484231+prive-fe-bot@users.noreply.github.com": "priveperfumes",
     "amr@ghanem.sa": "amroessam",
     "paperlantern.agent@gmail.com": "Hinotoi-agent",

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1819,29 +1819,26 @@ class TestAdapterBehavior(unittest.TestCase):
         event = adapter._dispatch_inbound_event.await_args.args[0]
         self.assertEqual(event.source.chat_type, "group")
 
-    @patch.dict(os.environ, {}, clear=True)
-    def test_process_inbound_message_fetches_reply_to_text(self):
+    def _process_feishu_text_message(self, *, fetched_text="引用消息内容", **message_overrides):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
         adapter._dispatch_inbound_event = AsyncMock()
-        adapter.get_chat_info = AsyncMock(
-            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
-        )
-        adapter._resolve_sender_profile = AsyncMock(
-            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
-        )
-        adapter._fetch_message_text = AsyncMock(return_value="父消息内容")
-        message = SimpleNamespace(
-            chat_id="oc_chat",
-            thread_id=None,
-            parent_id="om_parent",
-            upper_message_id=None,
-            message_type="text",
-            content='{"text":"reply"}',
-            message_id="om_reply",
-        )
+        adapter.get_chat_info = AsyncMock(return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"})
+        adapter._resolve_sender_profile = AsyncMock(return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None})
+        adapter._fetch_message_text = AsyncMock(return_value=fetched_text)
+        message_fields = {
+            "chat_id": "oc_chat",
+            "thread_id": None,
+            "parent_id": None,
+            "upper_message_id": None,
+            "message_type": "text",
+            "content": '{"text":"reply"}',
+            "message_id": "om_reply",
+        }
+        message_fields.update(message_overrides)
+        message = SimpleNamespace(**message_fields)
 
         asyncio.run(
             adapter._process_inbound_message(
@@ -1850,13 +1847,31 @@ class TestAdapterBehavior(unittest.TestCase):
                 sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
                 is_bot=False,
                 chat_type="p2p",
-                message_id="om_reply",
+                message_id=message.message_id,
             )
         )
+        return adapter, adapter._dispatch_inbound_event.await_args.args[0]
 
-        event = adapter._dispatch_inbound_event.await_args.args[0]
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_fetches_reply_to_text(self):
+        adapter, event = self._process_feishu_text_message(parent_id="om_parent", fetched_text="父消息内容")
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
+        adapter._fetch_message_text.assert_awaited_once_with("om_parent")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_fetches_reply_to_text_from_root_id(self):
+        adapter, event = self._process_feishu_text_message(root_id="om_root", fetched_text="根消息内容")
+        self.assertEqual(event.reply_to_message_id, "om_root")
+        self.assertEqual(event.reply_to_text, "根消息内容")
+        adapter._fetch_message_text.assert_awaited_once_with("om_root")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_ignores_self_root_id(self):
+        adapter, event = self._process_feishu_text_message(root_id="om_reply")
+        self.assertIsNone(event.reply_to_message_id)
+        self.assertIsNone(event.reply_to_text)
+        adapter._fetch_message_text.assert_not_awaited()
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):


### PR DESCRIPTION
Fixes #18566.

Summary

Treat Feishu/Lark `root_id` as a fallback inbound reply target after `parent_id` and `upper_message_id`.
Avoid treating a message as replying to itself when `root_id` equals the current `message_id`.
Add Feishu adapter regression coverage for parent-id, root-id-only, and self-root reply context handling.
Add the commit author's `AUTHOR_MAP` entry so the contributor audit can pass once fork workflows are approved.

Scope

This PR is limited to inbound reply-to context: it only uses `root_id` as a fallback for `MessageEvent.reply_to_message_id`. It does not change outbound Feishu topic/thread routing or `source.thread_id` behavior, which are covered separately by #16131 and #8656.

Test Plan

```bash
uv run pytest tests/gateway/test_feishu.py -q -o 'addopts='
uv run python scripts/contributor_audit.py --since-tag v2026.4.30 --diff-base origin/main --strict
```

Review

Codex read-only correctness review: no blockers.
Codex simplify/atomicity review: no blockers; confirmed no interactive-card changes.

CI

GitHub Actions are currently `ACTION_REQUIRED` for this fork PR and need maintainer approval before running.