### PR TITLE
feat(agent): per-operation retry limit and consecutive call circuit breaker

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -76,12 +76,25 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    # Per-operation retry limit: blocks when the exact same tool+args call has
+    # been made (regardless of outcome) more than this many consecutive times.
+    # 0 = disabled.  When set via the ``max_consecutive_identical_calls`` alias,
+    # hard_stop_enabled is auto-enabled.
+    consecutive_identical_block_after: int = 0
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "ToolCallGuardrailConfig":
-        """Build config from the `tool_loop_guardrails` config.yaml section."""
+        """Build config from the `tool_loop_guardrails` config.yaml section.
+
+        Supports user-friendly aliases (from issue #18504):
+        - ``max_retries_per_operation``: sets ``exact_failure_block_after`` and
+          auto-enables ``hard_stop_enabled`` when present.
+        - ``max_consecutive_identical_calls``: sets
+          ``consecutive_identical_block_after`` and auto-enables
+          ``hard_stop_enabled`` when present.
+        """
         if not isinstance(data, Mapping):
             return cls()
 
@@ -93,9 +106,33 @@ class ToolCallGuardrailConfig:
             hard_stop_after = {}
 
         defaults = cls()
+
+        # --- user-friendly aliases from issue #18504 ---
+        max_retries = _nonneg_int_or_none(data.get("max_retries_per_operation"))
+        max_consec = _nonneg_int_or_none(data.get("max_consecutive_identical_calls"))
+
+        hard_stop = _as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled)
+        if max_retries is not None or max_consec is not None:
+            hard_stop = True
+
+        exact_failure_block = _positive_int(
+            hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
+            defaults.exact_failure_block_after,
+        )
+        if max_retries is not None and max_retries > 0:
+            exact_failure_block = max_retries
+
+        consec_block = _nonneg_int_or_none(
+            hard_stop_after.get("consecutive_identical", data.get("consecutive_identical_block_after"))
+        )
+        if consec_block is None:
+            consec_block = defaults.consecutive_identical_block_after
+        if max_consec is not None:
+            consec_block = max_consec
+
         return cls(
             warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
-            hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
+            hard_stop_enabled=hard_stop,
             exact_failure_warn_after=_positive_int(
                 warn_after.get("exact_failure", data.get("exact_failure_warn_after")),
                 defaults.exact_failure_warn_after,
@@ -108,10 +145,7 @@ class ToolCallGuardrailConfig:
                 warn_after.get("idempotent_no_progress", data.get("no_progress_warn_after")),
                 defaults.no_progress_warn_after,
             ),
-            exact_failure_block_after=_positive_int(
-                hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
-                defaults.exact_failure_block_after,
-            ),
+            exact_failure_block_after=exact_failure_block,
             same_tool_failure_halt_after=_positive_int(
                 hard_stop_after.get("same_tool_failure", data.get("same_tool_failure_halt_after")),
                 defaults.same_tool_failure_halt_after,
@@ -120,6 +154,7 @@ class ToolCallGuardrailConfig:
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
             ),
+            consecutive_identical_block_after=consec_block,
         )
 
 
@@ -229,6 +264,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._consecutive_calls: list[ToolCallSignature] = []
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -277,6 +313,31 @@ class ToolCallGuardrailController:
                     self._halt_decision = decision
                     return decision
 
+        # Consecutive identical call circuit breaker (issue #18504)
+        consec_limit = self.config.consecutive_identical_block_after
+        if consec_limit > 0:
+            run_length = 0
+            for prev in reversed(self._consecutive_calls):
+                if prev == signature:
+                    run_length += 1
+                else:
+                    break
+            if run_length >= consec_limit:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="consecutive_identical_call_block",
+                    message=(
+                        f"Blocked {tool_name}: the same tool call has been made "
+                        f"{run_length} times consecutively. Stop retrying and report "
+                        "the failure to the user, or change your approach."
+                    ),
+                    tool_name=tool_name,
+                    count=run_length,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
     def after_call(
@@ -289,6 +350,10 @@ class ToolCallGuardrailController:
     ) -> ToolGuardrailDecision:
         args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, args)
+
+        # Track consecutive identical calls (issue #18504)
+        self._consecutive_calls.append(signature)
+
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
 
@@ -449,6 +514,17 @@ def _positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= 1 else default
+
+
+def _nonneg_int_or_none(value: Any) -> int | None:
+    """Parse a non-negative integer, returning None if absent or unparseable."""
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
 
 
 def _sha256(value: str) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -296,9 +296,15 @@ browser:
 # or non-progressing tool results but still let the tool execute. Hard stops are
 # opt-in circuit breakers for autonomous/cron sessions where stopping a loop is
 # preferable to spending the full iteration budget.
+#
+# User-friendly aliases (auto-enable hard_stop_enabled when set):
+#   max_retries_per_operation: 3         # block same tool+args after 3 failures
+#   max_consecutive_identical_calls: 3   # block after 3 identical calls in a row
 tool_loop_guardrails:
   warnings_enabled: true
   hard_stop_enabled: false
+  # max_retries_per_operation: 3         # alias for hard_stop_after.exact_failure
+  # max_consecutive_identical_calls: 3   # consecutive identical call circuit breaker
   warn_after:
     exact_failure: 2
     same_tool_failure: 3
@@ -307,6 +313,7 @@ tool_loop_guardrails:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    consecutive_identical: 0             # 0 = disabled
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -23,6 +23,14 @@ from typing import Any, Dict, List, Optional, Set
 from model_tools import handle_function_call
 from tools.terminal_tool import get_active_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
+from agent.tool_guardrails import (
+    ToolCallGuardrailConfig,
+    ToolCallGuardrailController,
+    ToolGuardrailDecision,
+    append_toolguard_guidance,
+    classify_tool_failure,
+    toolguard_synthetic_result,
+)
 
 # Thread pool for running sync tool calls that internally use asyncio.run()
 # (e.g., the Modal/Docker/Daytona terminal backends). Running them in a separate
@@ -141,6 +149,7 @@ class HermesAgentLoop:
         max_tokens: Optional[int] = None,
         extra_body: Optional[Dict[str, Any]] = None,
         budget_config: Optional["BudgetConfig"] = None,
+        guardrail_config: Optional[ToolCallGuardrailConfig] = None,
     ):
         """
         Initialize the agent loop.
@@ -160,6 +169,10 @@ class HermesAgentLoop:
             budget_config: Tool result persistence budget. Controls per-tool
                         thresholds, per-turn aggregate budget, and preview size.
                         If None, uses DEFAULT_BUDGET (current hardcoded values).
+            guardrail_config: Per-turn tool-call loop guardrail config.  Controls
+                        repeated-failure blocking and consecutive-call circuit
+                        breakers.  If None, uses ToolCallGuardrailConfig defaults
+                        (soft warnings only).
         """
         from tools.budget_config import DEFAULT_BUDGET
         self.server = server
@@ -171,6 +184,7 @@ class HermesAgentLoop:
         self.max_tokens = max_tokens
         self.extra_body = extra_body
         self.budget_config = budget_config or DEFAULT_BUDGET
+        self.guardrail_config = guardrail_config
 
     async def run(self, messages: List[Dict[str, Any]]) -> AgentResult:
         """
@@ -185,6 +199,7 @@ class HermesAgentLoop:
         """
         reasoning_per_turn = []
         tool_errors: List[ToolError] = []
+        guardrails = ToolCallGuardrailController(self.guardrail_config)
 
         # Per-loop TodoStore for the todo tool (ephemeral, dies with the loop)
         from tools.todo_tool import TodoStore, todo_tool as _todo_tool
@@ -375,68 +390,88 @@ class HermesAgentLoop:
 
                         # Dispatch tool only if arguments parsed successfully
                         if args is not None:
-                            try:
-                                if tool_name == "terminal":
-                                    backend = os.getenv("TERMINAL_ENV", "local")
-                                    cmd_preview = args.get("command", "")[:80]
-                                    logger.info(
-                                        "[%s] $ %s", self.task_id[:8], cmd_preview,
-                                    )
-
-                                tool_submit_time = _time.monotonic()
-
-                                # Todo tool -- handle locally (needs per-loop TodoStore)
-                                if tool_name == "todo":
-                                    tool_result = _todo_tool(
-                                        todos=args.get("todos"),
-                                        merge=args.get("merge", False),
-                                        store=_todo_store,
-                                    )
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-                                elif tool_name == "memory":
-                                    tool_result = json.dumps({"error": "Memory is not available in RL environments."})
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-                                elif tool_name == "session_search":
-                                    tool_result = json.dumps({"error": "Session search is not available in RL environments."})
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-                                else:
-                                    # Run tool calls in a thread pool so backends that
-                                    # use asyncio.run() internally (modal, docker, daytona) get
-                                    # a clean event loop instead of deadlocking.
-                                    loop = asyncio.get_event_loop()
-                                    # Capture current tool_name/args for the lambda
-                                    _tn, _ta, _tid = tool_name, args, self.task_id
-                                    tool_result = await loop.run_in_executor(
-                                        _tool_executor,
-                                        lambda: handle_function_call(
-                                            _tn, _ta, task_id=_tid,
-                                            user_task=_user_task,
-                                        ),
-                                    )
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-
-                                # Log slow tools and thread pool stats for debugging
-                                pool_active = _tool_executor._work_queue.qsize()
-                                if tool_elapsed > 30:
-                                    logger.warning(
-                                        "[%s] turn %d: %s took %.1fs (pool queue=%d)",
-                                        self.task_id[:8], turn + 1, tool_name,
-                                        tool_elapsed, pool_active,
-                                    )
-                            except Exception as e:
-                                tool_result = json.dumps(
-                                    {"error": f"Tool execution failed: {type(e).__name__}: {str(e)}"}
+                            # Pre-execution guardrail check
+                            guard_decision = guardrails.before_call(tool_name, args)
+                            if not guard_decision.allows_execution:
+                                tool_result = toolguard_synthetic_result(guard_decision)
+                                logger.info(
+                                    "[%s] turn %d: guardrail blocked %s (%s)",
+                                    self.task_id[:8], turn + 1,
+                                    tool_name, guard_decision.code,
                                 )
-                                tool_errors.append(ToolError(
-                                    turn=turn + 1, tool_name=tool_name,
-                                    arguments=tool_args_raw[:200],
-                                    error=f"{type(e).__name__}: {str(e)}",
-                                    tool_result=tool_result,
-                                ))
-                                logger.error(
-                                    "Tool '%s' execution failed on turn %d: %s",
-                                    tool_name, turn + 1, e,
+                            else:
+                                try:
+                                    if tool_name == "terminal":
+                                        backend = os.getenv("TERMINAL_ENV", "local")
+                                        cmd_preview = args.get("command", "")[:80]
+                                        logger.info(
+                                            "[%s] $ %s", self.task_id[:8], cmd_preview,
+                                        )
+
+                                    tool_submit_time = _time.monotonic()
+
+                                    # Todo tool -- handle locally (needs per-loop TodoStore)
+                                    if tool_name == "todo":
+                                        tool_result = _todo_tool(
+                                            todos=args.get("todos"),
+                                            merge=args.get("merge", False),
+                                            store=_todo_store,
+                                        )
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+                                    elif tool_name == "memory":
+                                        tool_result = json.dumps({"error": "Memory is not available in RL environments."})
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+                                    elif tool_name == "session_search":
+                                        tool_result = json.dumps({"error": "Session search is not available in RL environments."})
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+                                    else:
+                                        # Run tool calls in a thread pool so backends that
+                                        # use asyncio.run() internally (modal, docker, daytona) get
+                                        # a clean event loop instead of deadlocking.
+                                        loop = asyncio.get_event_loop()
+                                        # Capture current tool_name/args for the lambda
+                                        _tn, _ta, _tid = tool_name, args, self.task_id
+                                        tool_result = await loop.run_in_executor(
+                                            _tool_executor,
+                                            lambda: handle_function_call(
+                                                _tn, _ta, task_id=_tid,
+                                                user_task=_user_task,
+                                            ),
+                                        )
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+
+                                    # Log slow tools and thread pool stats for debugging
+                                    pool_active = _tool_executor._work_queue.qsize()
+                                    if tool_elapsed > 30:
+                                        logger.warning(
+                                            "[%s] turn %d: %s took %.1fs (pool queue=%d)",
+                                            self.task_id[:8], turn + 1, tool_name,
+                                            tool_elapsed, pool_active,
+                                        )
+                                except Exception as e:
+                                    tool_result = json.dumps(
+                                        {"error": f"Tool execution failed: {type(e).__name__}: {str(e)}"}
+                                    )
+                                    tool_errors.append(ToolError(
+                                        turn=turn + 1, tool_name=tool_name,
+                                        arguments=tool_args_raw[:200],
+                                        error=f"{type(e).__name__}: {str(e)}",
+                                        tool_result=tool_result,
+                                    ))
+                                    logger.error(
+                                        "Tool '%s' execution failed on turn %d: %s",
+                                        tool_name, turn + 1, e,
+                                    )
+
+                                # Post-execution guardrail observation
+                                failed, _ = classify_tool_failure(tool_name, tool_result)
+                                after_decision = guardrails.after_call(
+                                    tool_name, args, tool_result, failed=failed,
                                 )
+                                if after_decision.action in {"warn", "halt"}:
+                                    tool_result = append_toolguard_guidance(
+                                        tool_result, after_decision,
+                                    )
 
                         # Also check if the tool returned an error in its JSON result
                         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -610,6 +610,11 @@ DEFAULT_CONFIG = {
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
+    #
+    # User-friendly aliases (see issue #18504):
+    #   max_retries_per_operation: 3         # → exact_failure hard stop after 3
+    #   max_consecutive_identical_calls: 3   # → consecutive call circuit breaker
+    # Setting either alias auto-enables hard_stop_enabled.
     "tool_loop_guardrails": {
         "warnings_enabled": True,
         "hard_stop_enabled": False,
@@ -622,6 +627,7 @@ DEFAULT_CONFIG = {
             "exact_failure": 5,
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
+            "consecutive_identical": 0,
         },
     },
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -236,3 +236,147 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+# ── Consecutive identical call tests (issue #18504) ──────────────────────
+
+
+def test_consecutive_identical_calls_disabled_by_default():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args = {"command": "git pull"}
+    for _ in range(20):
+        assert controller.before_call("terminal", args).action == "allow"
+        controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+
+
+def test_consecutive_identical_calls_blocks_after_limit():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=3,
+            exact_failure_block_after=99,
+        )
+    )
+    args = {"command": "git pull"}
+
+    for _ in range(3):
+        assert controller.before_call("terminal", args).action == "allow"
+        controller.after_call("terminal", args, '{"exit_code":1}', failed=True)
+
+    blocked = controller.before_call("terminal", args)
+    assert blocked.action == "block"
+    assert blocked.code == "consecutive_identical_call_block"
+    assert blocked.count == 3
+
+
+def test_consecutive_identical_calls_resets_on_different_call():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=3,
+            exact_failure_block_after=99,
+        )
+    )
+    args_a = {"command": "git pull"}
+    args_b = {"command": "git status"}
+
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+    # Interrupt the streak with a different call
+    controller.after_call("terminal", args_b, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+
+    # Only 2 consecutive identical calls (after the interruption)
+    assert controller.before_call("terminal", args_a).action == "allow"
+
+
+def test_consecutive_identical_calls_counts_success_too():
+    """max_consecutive_identical_calls blocks regardless of outcome."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=3,
+            exact_failure_block_after=99,
+        )
+    )
+    args = {"query": "weather"}
+
+    for _ in range(3):
+        assert controller.before_call("web_search", args).action == "allow"
+        controller.after_call("web_search", args, '{"result":"sunny"}', failed=False)
+
+    blocked = controller.before_call("web_search", args)
+    assert blocked.action == "block"
+    assert blocked.code == "consecutive_identical_call_block"
+
+
+def test_consecutive_identical_calls_cleared_by_reset_for_turn():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=2,
+        )
+    )
+    args = {"command": "git pull"}
+
+    controller.after_call("terminal", args, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", args, '{"exit_code":1}', failed=True)
+    assert controller.before_call("terminal", args).action == "block"
+
+    controller.reset_for_turn()
+    assert controller.before_call("terminal", args).action == "allow"
+
+
+# ── Config alias tests (issue #18504) ────────────────────────────────────
+
+
+def test_max_retries_per_operation_alias_sets_exact_failure_block_and_enables_hard_stop():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 3,
+    })
+    assert cfg.hard_stop_enabled is True
+    assert cfg.exact_failure_block_after == 3
+
+
+def test_max_consecutive_identical_calls_alias_sets_field_and_enables_hard_stop():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_consecutive_identical_calls": 4,
+    })
+    assert cfg.hard_stop_enabled is True
+    assert cfg.consecutive_identical_block_after == 4
+
+
+def test_both_aliases_together():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 2,
+        "max_consecutive_identical_calls": 3,
+    })
+    assert cfg.hard_stop_enabled is True
+    assert cfg.exact_failure_block_after == 2
+    assert cfg.consecutive_identical_block_after == 3
+
+
+def test_aliases_zero_disables():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 0,
+        "max_consecutive_identical_calls": 0,
+    })
+    # hard_stop still auto-enabled since the keys are present
+    assert cfg.hard_stop_enabled is True
+    # but 0 means the exact_failure_block stays at default (alias val=0 → keep default)
+    assert cfg.exact_failure_block_after == 5  # default
+    assert cfg.consecutive_identical_block_after == 0  # 0 = disabled
+
+
+def test_explicit_hard_stop_after_overrides_alias():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 3,
+        "hard_stop_after": {
+            "same_tool_failure": 5,
+        },
+    })
+    assert cfg.exact_failure_block_after == 3  # from alias
+    assert cfg.same_tool_failure_halt_after == 5  # from explicit


### PR DESCRIPTION
## What does this PR do?

Extends the existing `tool_loop_guardrails` system with two user-friendly config aliases requested in #18504, adding per-operation retry limits and a consecutive identical call circuit breaker.

When a tool call fails repeatedly with the same arguments, or the agent makes the same call N times in a row, the guardrail blocks further attempts and forces the agent to report the failure to the user instead of burning through its iteration budget.

## Related Issue

Fixes #18504

## Type of Change

- [ ] ≡ƒÉ¢ Bug fix (non-breaking change that fixes an issue)
- [x] Γ£¿ New feature (non-breaking change that adds functionality)
- [ ] ≡ƒöÆ Security fix
- [ ] ≡ƒô¥ Documentation update
- [ ] Γ£à Tests (adding or improving test coverage)
- [ ] ΓÖ╗∩╕Å Refactor (no behavior change)
- [ ] ≡ƒÄ» New skill (bundled or hub)

## Changes Made

- `agent/tool_guardrails.py`: Added `consecutive_identical_block_after` config field, consecutive call tracking in `before_call`/`after_call`, alias parsing in `from_mapping()`, `_nonneg_int_or_none` helper
- `hermes_cli/config.py`: Documented aliases in `DEFAULT_CONFIG` comments, added `consecutive_identical` to `hard_stop_after` defaults
- `environments/agent_loop.py`: Wired `ToolCallGuardrailController` into RL agent loop (preflight blocks, post-call observation, failure classification)
- `cli-config.yaml.example`: Added commented-out aliases and `consecutive_identical` key
- `tests/agent/test_tool_guardrails.py`: 10 new tests covering consecutive call blocking, reset, config aliases, zero-disables

## How to Test

1. Add to `~/.hermes/config.yaml`:
   ```yaml
   tool_loop_guardrails:
     max_retries_per_operation: 3
     max_consecutive_identical_calls: 3
   ```
2. Start a session and trigger a failing tool call (e.g., `terminal` with a bad command)
3. After 3 identical failures, the agent should stop retrying and report the blocker
4. Unit tests: `pytest tests/agent/test_tool_guardrails.py -v`

## Config Options

### `max_retries_per_operation: N`
Maps to `exact_failure_block_after` and auto-enables `hard_stop_enabled`. Blocks when the exact same tool+args call has failed N times.

### `max_consecutive_identical_calls: N`
New guardrail that blocks when the same tool+args call has been made N times consecutively (regardless of success/failure). Prevents stuck retry loops.

Both aliases auto-enable `hard_stop_enabled` when present, so users get circuit-breaker behavior without needing to understand the full guardrail config schema.

## Design Decisions

- **Builds on existing guardrail framework** rather than introducing a parallel retry tracker. The `ToolCallGuardrailController` already has `before_call`/`after_call` hooks, `ToolCallSignature` hashing, and halt/block/warn decision flow.
- **Consecutive identical call tracking** counts calls regardless of success/failure (the issue's `max_consecutive_identical_calls` spec). Different from the existing `no_progress` check which only applies to idempotent tools with same results.
- **0 = disabled** for `consecutive_identical_block_after` (default). The existing `_positive_int` helper rejects 0, so added `_nonneg_int_or_none` for fields where 0 has meaning.
- **RL environment wiring**: `agent_loop.py` now accepts an optional `guardrail_config` parameter and runs the full before/after guardrail cycle around tool dispatch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (10 new tests)
- [x] I've tested on my platform: Windows 11 (WSL2)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) ΓÇö or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows ΓÇö or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) ΓÇö pure Python, no platform-specific code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior ΓÇö or N/A

Closes #18504

