### PR TITLE
fix(file-ops): allow grep content search in hidden roots (#18473)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -336,6 +336,88 @@ class TestSearchPathValidation:
         assert "search failed" in result.error.lower() or "Search error" in result.error
 
 
+class TestSearchContentFallbackHiddenPaths:
+    """Regression: _search_with_grep must return matches when the search root
+    is under a hidden ancestor (e.g. ~/.hermes/notes/). GNU grep's
+    --exclude-dir matches every directory component in the traversal — including
+    the search root itself — so a bare '.*' silently drops every result when
+    the caller explicitly searched a hidden tree. See issue #18473."""
+
+    def _make_env(self, captured: list):
+        env = MagicMock()
+        env.cwd = "/"
+
+        def execute(command, **kwargs):
+            captured.append(command)
+            return {"output": "", "returncode": 1}  # exit 1 = no matches (clean)
+
+        env.execute.side_effect = execute
+        return env
+
+    def test_hidden_root_omits_exclude_dir_in_grep_fallback(self, monkeypatch):
+        """When search root has a hidden ancestor, the grep cmd must NOT
+        carry --exclude-dir='.*' (it would match the root and drop all results)."""
+        captured: list = []
+        ops = ShellFileOperations(self._make_env(captured))
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+        ops._search_content(
+            "NEEDLE", "/home/user/.hermes/notes", None, limit=50, offset=0,
+            output_mode="content", context=0,
+        )
+
+        grep_cmds = [c for c in captured if c.startswith("grep ")]
+        assert grep_cmds, "expected a grep invocation"
+        assert "--exclude-dir='.*'" not in grep_cmds[0], grep_cmds[0]
+
+    def test_normal_root_keeps_exclude_dir_in_grep_fallback(self, monkeypatch):
+        """When search root is non-hidden, the grep cmd must keep
+        --exclude-dir='.*' to skip .git/, .cache/, etc. during recursion."""
+        captured: list = []
+        ops = ShellFileOperations(self._make_env(captured))
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+        ops._search_content(
+            "NEEDLE", "/home/user/repo", None, limit=50, offset=0,
+            output_mode="content", context=0,
+        )
+
+        grep_cmds = [c for c in captured if c.startswith("grep ")]
+        assert grep_cmds, "expected a grep invocation"
+        assert "--exclude-dir='.*'" in grep_cmds[0], grep_cmds[0]
+
+    def test_relative_hidden_root_omits_exclude_dir(self, monkeypatch):
+        """Relative paths with a hidden component (e.g. '.hermes/notes')
+        are also recognized as hidden roots."""
+        captured: list = []
+        ops = ShellFileOperations(self._make_env(captured))
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+        ops._search_content(
+            "NEEDLE", ".hermes/notes", None, limit=50, offset=0,
+            output_mode="content", context=0,
+        )
+
+        grep_cmds = [c for c in captured if c.startswith("grep ")]
+        assert grep_cmds, "expected a grep invocation"
+        assert "--exclude-dir='.*'" not in grep_cmds[0], grep_cmds[0]
+
+    def test_dot_only_components_do_not_count_as_hidden(self, monkeypatch):
+        """Search root '.' (cwd) or '..' must NOT be treated as a hidden ancestor."""
+        captured: list = []
+        ops = ShellFileOperations(self._make_env(captured))
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+        ops._search_content(
+            "NEEDLE", ".", None, limit=50, offset=0,
+            output_mode="content", context=0,
+        )
+
+        grep_cmds = [c for c in captured if c.startswith("grep ")]
+        assert grep_cmds, "expected a grep invocation"
+        assert "--exclude-dir='.*'" in grep_cmds[0], grep_cmds[0]
+
+
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):
         result = file_ops.write_file("~/.ssh/authorized_keys", "evil key")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1163,10 +1163,20 @@ class ShellFileOperations(FileOperations):
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""
         cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
-        
-        # Exclude hidden directories (matching ripgrep's default behavior).
-        # This prevents searching inside .hub/index-cache/, .git/, etc.
-        cmd_parts.append("--exclude-dir='.*'")
+
+        # Exclude hidden descendant directories (matching ripgrep's default
+        # behavior) — but only when the search root is not itself under a
+        # hidden ancestor. GNU grep's --exclude-dir matches every directory
+        # component in the traversal, including the search root, so a bare
+        # '.*' silently drops all results when the caller explicitly searched
+        # inside ~/.hermes/, .git/, etc. Mirrors the _search_files find
+        # fallback's hidden-ancestor handling.
+        has_hidden_path_ancestor = any(
+            part not in (".", "..") and part.startswith(".")
+            for part in Path(path).parts
+        )
+        if not has_hidden_path_ancestor:
+            cmd_parts.append("--exclude-dir='.*'")
         
         # Add context if requested
         if context > 0:


### PR DESCRIPTION
## Summary

- `search_files(target='content')` returned `total_count: 0` when the search path contained a hidden ancestor component (e.g. `~/.hermes/workspace/notes/`)
- root cause: GNU grep's `--exclude-dir='.*'` matches **every** directory component in the traversal — including the search root — so the bare `'.*'` glob silently dropped all results when the caller explicitly searched a hidden tree
- skip the filter only when the search root is under a hidden ancestor; non-hidden roots keep it so `.git/`, `.cache/`, etc. are still excluded

## The bug

From issue #18473:

```python
# Pattern exists in files; grep finds nothing
search_files(pattern="NAS", path="/home/user/.hermes/workspace/notes/", target="content")
# → {"total_count": 0}

# Same pattern, no hidden ancestor — works
search_files(pattern="NAS", path="/home/user/workspace/notes/", target="content")
# → returns matches
```

`_search_with_grep()` in `tools/file_operations.py` unconditionally appended `--exclude-dir='.*'`. GNU grep matches that glob against each directory component grep would recurse into, **including the explicit search root**. When the root is `/home/user/.hermes/notes/`, the `.hermes` component matches and the entire tree is excluded.

## The fix

Detect a hidden ancestor on the search root via `Path(path).parts` and only pass `--exclude-dir='.*'` when there is no hidden ancestor. This mirrors the hidden-ancestor handling already proposed for the sibling `_search_files` find fallback in #16672 (different function, different code path; this PR only touches `_search_with_grep`).

## Test plan

- [x] Focused regression tests added: `tests/tools/test_file_operations.py::TestSearchContentFallbackHiddenPaths` (4 cases — hidden absolute root, normal root, hidden relative root, dot-only components)
- [x] Regression guard verified: with `tools/file_operations.py` reverted, the two hidden-root assertions fail with the unmodified `grep -rnH --exclude-dir='.*' ...` command in the captured output; with the fix in place all 4 pass
- [x] Adjacent suite: `pytest tests/tools/test_file_operations.py -v` — 54 passed
- Tests assert command construction via a captured-cmd mock rather than running grep against `tmp_path`, because BSD grep on macOS doesn't reproduce the GNU-grep `--exclude-dir` matching against the search root

## Related / Positioning

| PR     | Function          | target        | Bug it covers                                         |
|--------|-------------------|---------------|-------------------------------------------------------|
| #16672 | `_search_files`   | `'files'`     | `find -not -path '*/.*'` excludes hidden-root paths   |
| this   | `_search_with_grep` | `'content'` | `grep --exclude-dir='.*'` excludes hidden-root paths  |

#16672 fixes the file-search fallback (find); this fixes the content-search fallback (grep). Same root-cause class, different execution paths, different bug surface — issue #18473 explicitly calls out the content path as still broken because `_search_with_grep` was not updated when `_search_files` was.

## Related

- Fixes #18473
- Sibling: #16672 (still open; orthogonal — only touches `_search_files`)