### PR TITLE
fix(discord): auto-thread free-response channels

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -100,6 +100,10 @@ def auto_title_session(
     - session_db is None
     - session already has a title (user-set or previously auto-generated)
     - title generation fails
+
+    ``on_title`` is invoked after the DB title is stored. Gateway adapters use
+    it for best-effort visible retitles (for example editing a Discord thread
+    name) without coupling this module to any platform SDK.
     """
     if not session_db or not session_id:
         return
@@ -119,7 +123,8 @@ def auto_title_session(
         return
 
     try:
-        session_db.set_session_title(session_id, title)
+        if not session_db.set_session_title(session_id, title):
+            return
         logger.debug("Auto-generated session title: %s", title)
         if title_callback is not None:
             try:
@@ -128,6 +133,7 @@ def auto_title_session(
                 logger.debug("Auto-title callback failed", exc_info=True)
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
+        return
 
 
 def maybe_auto_title(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -921,6 +921,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                if "smart_thread_titles" in discord_cfg and not os.getenv("DISCORD_SMART_THREAD_TITLES"):
+                    os.environ["DISCORD_SMART_THREAD_TITLES"] = str(discord_cfg["smart_thread_titles"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4591,7 +4591,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4043,6 +4043,28 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return None
 
+    async def rename_thread(self, thread_id: str, title: str) -> bool:
+        """Best-effort visible Discord thread rename used by auto-title hooks."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return False
+        clean_title = _truncate_thread_name(_strip_discord_noise(title or ""))
+        if not clean_title:
+            return False
+        try:
+            channel = self._client.get_channel(int(thread_id))
+            if channel is None:
+                channel = await self._client.fetch_channel(int(thread_id))
+            if not isinstance(channel, discord.Thread):
+                return False
+            if getattr(channel, "name", None) == clean_title:
+                return True
+            await channel.edit(name=clean_title, reason="Hermes auto-generated conversation title")
+            logger.info("[%s] Renamed Discord thread %s to %r", self.name, thread_id, clean_title)
+            return True
+        except Exception as e:
+            logger.warning("[%s] Failed to rename Discord thread %s: %s", self.name, thread_id, e)
+            return False
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -85,6 +85,69 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _discord_bool_env(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _truncate_thread_name(name: str, limit: int = 80) -> str:
+    if len(name) <= limit:
+        return name
+    return name[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _strip_discord_noise(content: str) -> str:
+    """Remove Discord syntax that makes terrible human-facing thread names."""
+    text = content or ""
+    text = re.sub(r"<@[!&]?\d+>", "", text)
+    text = re.sub(r"<#\d+>", "", text)
+    text = re.sub(r"https?://\S+", "", text)
+    text = re.sub(r"[`*_~>#]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip(" -–—:\t\n\r")
+    return text
+
+
+def _legacy_auto_thread_name(content: str) -> str:
+    text = _strip_discord_noise(content)
+    return _truncate_thread_name(text) if text else "Hermes"
+
+
+def _build_auto_thread_name(content: str) -> str:
+    """Build a deterministic smart title for Discord auto-created threads."""
+    text = _strip_discord_noise(content)
+    if not text:
+        return "Hermes"
+
+    # Prefer the first meaningful clause/sentence instead of the whole ramble.
+    clauses = [
+        p.strip(" -–—:")
+        for p in re.split(r"[\n.!?;]+|\s+[–—-]\s+", text)
+        if p.strip(" -–—:")
+    ]
+    if clauses:
+        text = clauses[0]
+
+    # Strip common request boilerplate, but never strip down to empty.
+    openers = [
+        r"^(?:hey|hi|hello)\s+(?:hermes|joi|bot)?[,\s:;-]*",
+        r"^(?:can|could|would)\s+you\s+",
+        r"^please\s+",
+        r"^(?:help\s+me|help)\s+(?:to\s+)?",
+        r"^what(?:'s| is)\s+the\s+next\s+step\s+for\s+",
+        r"^how\s+do\s+i\s+",
+        r"^i\s+need\s+(?:you\s+to\s+)?",
+    ]
+    candidate = text
+    for pattern in openers:
+        stripped = re.sub(pattern, "", candidate, flags=re.IGNORECASE).strip(" -–—:")
+        if stripped:
+            candidate = stripped
+
+    return _truncate_thread_name(candidate) if candidate else "Hermes"
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -3873,18 +3936,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Returns the created thread object, or ``None`` on failure.
         """
-        # Build a short thread name from the message. Strip Discord mention
-        # syntax (users / roles / channels) so thread titles don't end up
-        # showing raw <@id>, <@&id>, or <#id> markers — the ID isn't
-        # meaningful to humans glancing at the thread list (#6336).
-        content = (message.content or "").strip()
-        # <@123>, <@!123>, <@&123>, <#123> — collapse to empty; normalize spaces.
-        content = re.sub(r"<@[!&]?\d+>", "", content)
-        content = re.sub(r"<#\d+>", "", content)
-        content = re.sub(r"\s+", " ", content).strip()
-        thread_name = content[:80] if content else "Hermes"
-        if len(content) > 80:
-            thread_name = thread_name[:77] + "..."
+        content = message.content or ""
+        if _discord_bool_env("DISCORD_SMART_THREAD_TITLES", False):
+            thread_name = _build_auto_thread_name(content)
+        else:
+            thread_name = _legacy_auto_thread_name(content)
 
         try:
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15979,12 +15979,48 @@ class GatewayRunner:
                             "api_mode": getattr(agent, "api_mode", None),
                         } if agent else None,
                     }
+                    title_callbacks = []
                     if self._is_telegram_topic_lane(source):
-                        maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
-                            source,
-                            effective_session_id,
-                            title,
+                        title_callbacks.append(
+                            lambda title: self._schedule_telegram_topic_title_rename(
+                                source,
+                                effective_session_id,
+                                title,
+                            )
                         )
+                    _is_discord_thread = (
+                        getattr(getattr(source, "platform", None), "value", source.platform) == "discord"
+                        and getattr(source, "chat_type", None) == "thread"
+                        and _status_adapter is not None
+                        and getattr(type(_status_adapter), "rename_thread", None) is not None
+                        and str(os.getenv("DISCORD_SMART_THREAD_TITLES", "false")).lower()
+                        in ("true", "1", "yes", "on")
+                    )
+                    if _is_discord_thread:
+                        _title_thread_id = getattr(source, "thread_id", None) or getattr(source, "chat_id", None)
+
+                        def _schedule_discord_thread_title_rename(title: str) -> None:
+                            try:
+                                asyncio.run_coroutine_threadsafe(
+                                    _status_adapter.rename_thread(str(_title_thread_id), title),
+                                    _loop_for_step,
+                                ).result(timeout=15)
+                            except Exception as _e:
+                                logger.warning(
+                                    "Failed to run Discord thread retitle callback for %s: %s",
+                                    _title_thread_id,
+                                    _e,
+                                )
+
+                        title_callbacks.append(_schedule_discord_thread_title_rename)
+
+                    if title_callbacks:
+
+                        def _run_title_callbacks(title: str) -> None:
+                            for callback in title_callbacks:
+                                callback(title)
+
+                        maybe_auto_title_kwargs["title_callback"] = _run_title_callbacks
                     maybe_auto_title(
                         self._session_db,
                         effective_session_id,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1315,6 +1315,7 @@ DEFAULT_CONFIG = {
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        "smart_thread_titles": False,  # Summarize auto-thread titles instead of raw message slices
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -518,34 +518,35 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
-async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypatch):
-    """Free-response channels should reply inline, never spawn a new thread.
+async def test_discord_free_response_channel_auto_threads_by_default(adapter, monkeypatch):
+    """Free-response channels should still auto-thread when auto_thread is enabled.
 
-    Without this, every message in a free-response channel would auto-create
-    a fresh thread (since the channel bypasses the @mention gate, every
-    message looks like a fresh trigger).  That turns a "lightweight chat"
-    channel into a thread-spawning machine — see the docs at
-    website/docs/user-guide/messaging/discord.md which already describe
-    this as the intended behavior.
+    free_response_channels only bypasses the @mention gate. It should not also
+    act like no_thread_channels; operators can use DISCORD_NO_THREAD_CHANNELS
+    when they deliberately want inline replies.
     """
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
 
-    adapter._auto_create_thread = AsyncMock()
+    parent = FakeTextChannel(channel_id=789)
+    thread = FakeThread(channel_id=790, name="casual-chat", parent=parent)
+    adapter._auto_create_thread = AsyncMock(return_value=thread)
 
     message = make_message(
-        channel=FakeTextChannel(channel_id=789),
+        channel=parent,
         content="casual chat in free-response channel",
     )
 
     await adapter._handle_message(message)
 
-    adapter._auto_create_thread.assert_not_awaited()
+    adapter._auto_create_thread.assert_awaited_once_with(message)
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "casual chat in free-response channel"
-    assert event.source.chat_type == "group"
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "790"
+    assert event.source.parent_chat_id == "789"
 
 
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -691,6 +691,45 @@ def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza
 
 
 @pytest.mark.asyncio
+async def test_rename_thread_edits_discord_thread(adapter):
+    thread = _FakeThreadChannel(channel_id=777, name="raw first message")
+    thread.edit = AsyncMock()
+    adapter._client.get_channel = lambda _id: thread
+
+    result = await adapter.rename_thread("777", "Helpful Discord thread title")
+
+    assert result is True
+    thread.edit.assert_awaited_once_with(
+        name="Helpful Discord thread title",
+        reason="Hermes auto-generated conversation title",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_thread_fetches_when_not_cached(adapter):
+    thread = _FakeThreadChannel(channel_id=777, name="raw first message")
+    thread.edit = AsyncMock()
+    adapter._client.get_channel = lambda _id: None
+    adapter._client.fetch_channel = AsyncMock(return_value=thread)
+
+    result = await adapter.rename_thread("777", "Fetched title")
+
+    assert result is True
+    adapter._client.fetch_channel.assert_awaited_once_with(777)
+    thread.edit.assert_awaited_once_with(
+        name="Fetched title",
+        reason="Hermes auto-generated conversation title",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_thread_ignores_non_thread_channel(adapter):
+    adapter._client.get_channel = lambda _id: _FakeTextChannel(channel_id=777)
+
+    assert await adapter.rename_thread("777", "Nope") is False
+
+
+@pytest.mark.asyncio
 async def test_auto_thread_creates_thread_and_redirects(adapter, monkeypatch):
     """When DISCORD_AUTO_THREAD=true, a new thread is created and the event routes there."""
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -75,7 +75,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+from gateway.platforms.discord import (  # noqa: E402
+    DiscordAdapter,
+    _build_auto_thread_name,
+)
 
 
 class FakeTree:
@@ -97,7 +100,9 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -493,8 +498,40 @@ def test_build_slash_event_uses_group_context_for_channels(adapter):
 # ------------------------------------------------------------------
 
 
+def test_build_auto_thread_name_summarizes_request():
+    assert (
+        _build_auto_thread_name(
+            "Can you make yourself auto-retitle threads intelligently? "
+            "Based on the first message, give the thread a title that is a smart summary."
+        )
+        == "make yourself auto-retitle threads intelligently"
+    )
+
+
+def test_build_auto_thread_name_strips_polite_openers():
+    assert _build_auto_thread_name("<@123> please help me debug Discord auto-thread titles") == "debug Discord auto-thread titles"
+
+
 @pytest.mark.asyncio
-async def test_auto_create_thread_uses_message_content_as_name(adapter):
+async def test_auto_create_thread_uses_summarized_name_when_enabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SMART_THREAD_TITLES", "true")
+    thread = SimpleNamespace(id=999, name="summary")
+    message = SimpleNamespace(
+        content="Can you fix our Discord auto-thread titling? It keeps using the whole message.",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    assert message.create_thread.await_args[1]["name"] == "fix our Discord auto-thread titling"
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_uses_message_content_as_name(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_SMART_THREAD_TITLES", raising=False)
     thread = SimpleNamespace(id=999, name="Hello world")
     message = SimpleNamespace(
         content="Hello world, how are you?",

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -103,6 +103,9 @@ class FakeTree:
 def adapter(monkeypatch):
     monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
     monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_SMART_THREAD_TITLES", raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -763,6 +766,58 @@ async def test_auto_thread_can_be_disabled(adapter, monkeypatch):
     adapter._auto_create_thread.assert_not_awaited()
     assert len(captured_events) == 1
     assert captured_events[0].source.chat_id == "100"  # stays in channel
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_still_runs_in_free_response_channels(adapter, monkeypatch):
+    """Free-response means no mention required; it must not imply no-thread."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "100")
+
+    fake_thread = _FakeThreadChannel(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+
+    msg = _fake_message(_FakeTextChannel(channel_id=100), content="Did Joi's update work?")
+
+    await adapter._handle_message(msg)
+
+    adapter._auto_create_thread.assert_awaited_once_with(msg)
+    assert len(captured_events) == 1
+    assert captured_events[0].source.chat_id == "999"
+    assert captured_events[0].source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_respects_no_thread_channels(adapter, monkeypatch):
+    """no_thread_channels is the explicit opt-out from auto-threading."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "100")
+
+    adapter._auto_create_thread = AsyncMock()
+
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+
+    msg = _fake_message(_FakeTextChannel(channel_id=100), content="Stay in channel")
+
+    await adapter._handle_message(msg)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    assert len(captured_events) == 1
+    assert captured_events[0].source.chat_id == "100"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- adds deterministic smart names for Discord auto-created threads
- keeps `discord.free_response_channels` from disabling auto-thread creation
- preserves `discord.no_thread_channels` as the explicit auto-thread opt-out
- retitles Discord auto-thread sessions after the first exchange when smart thread titles are enabled
- hardens Discord auto-thread tests against host env leakage

## Runtime verification
- Confirmed in the live Discord gateway after restart: a newly created thread used the smarter title path instead of the raw first-message slice.

## Test plan
- [x] `python -m pytest tests/agent/test_title_generator.py tests/gateway/test_discord_slash_commands.py -q -o 'addopts='` — 62 passed
- [x] Discord live smoke test: new auto-created thread title looked correct
