### PR TITLE
fix(api_server): wire decide_image_input_mode into chat completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -274,6 +274,32 @@ def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Respons
     )
 
 
+def _extract_image_urls_from_content(content: list) -> list:
+    """Extract image URLs from a normalized multimodal content list.
+
+    Returns the bare URL strings (http/https or data:image/...) from
+    ``image_url``/``input_image`` parts.  The list must already have been
+    through ``_normalize_multimodal_content`` — the shape is canonical.
+    """
+    urls = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") not in _IMAGE_PART_TYPES:
+            continue
+        img_ref = part.get("image_url")
+        # Handle both ``{"image_url": {"url": "..."}}`` (Chat Completions
+        # canonical shape) and ``{"image_url": "https://..."}`` (Responses
+        # input_image already rewritten to Chat style by the normalizer).
+        if isinstance(img_ref, dict):
+            url = img_ref.get("url")
+        else:
+            url = img_ref
+        if isinstance(url, str) and url.strip():
+            urls.append(url.strip())
+    return urls
+
+
 def check_api_server_requirements() -> bool:
     """Check if API server dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -705,6 +731,74 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("SessionDB unavailable for API server: %s", e)
         return self._session_db
 
+    async def _enrich_api_content_with_vision(self, content: list) -> str:
+        """Pre-analyze images in a multimodal content list via vision_analyze.
+
+        Called when ``decide_image_input_mode`` returns ``"text"`` for an
+        API server request.  Runs ``vision_analyze_tool`` on each image URL
+        (http, https, or data:image/...) and returns enriched text with
+        descriptions prepended — matching the gateway's
+        ``_enrich_message_with_vision`` output format.
+
+        Returns a plain string so downstream code (history, logging,
+        trajectory) sees the same shape as text-only turns.
+        """
+        from tools.vision_tools import vision_analyze_tool
+        from agent.memory_manager import sanitize_context
+
+        image_urls = _extract_image_urls_from_content(content)
+        if not image_urls:
+            # No images — collapse to text and return.
+            return _normalize_chat_content(content)
+
+        analysis_prompt = (
+            "Describe everything visible in this image in thorough detail. "
+            "Include any text, code, data, objects, people, layout, colors, "
+            "and any other notable visual information."
+        )
+
+        # Extract original user text from text parts.
+        original_text = ""
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in _TEXT_PART_TYPES:
+                original_text += str(part.get("text") or "")
+
+        enriched_parts = []
+        for url in image_urls:
+            try:
+                result_json = await vision_analyze_tool(
+                    image_url=url,
+                    user_prompt=analysis_prompt,
+                )
+                result = json.loads(result_json)
+                if result.get("success"):
+                    description = result.get("analysis", "")
+                    description = sanitize_context(description)
+                    enriched_parts.append(
+                        f"[The user sent an image. Here's what I can see:\n"
+                        f"{description}]\n"
+                        f"[If you need a closer look, use vision_analyze with "
+                        f"image_url: {url}]"
+                    )
+                else:
+                    enriched_parts.append(
+                        "[The user sent an image but I couldn't quite see it "
+                        "this time (>_<) You can try looking at it yourself "
+                        f"with vision_analyze using image_url: {url}]"
+                    )
+            except Exception as exc:
+                logger.warning("Vision auto-analysis failed for %s: %s", url, exc)
+                enriched_parts.append(
+                    "[The user sent an image but something went wrong when I "
+                    "tried to look at it. You can try examining it yourself "
+                    f"with vision_analyze using image_url: {url}]"
+                )
+
+        prefix = "\n\n".join(enriched_parts)
+        if original_text:
+            return f"{prefix}\n\n{original_text}"
+        return prefix
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
@@ -906,6 +1000,51 @@ class APIServerAdapter(BasePlatformAdapter):
         if conversation_messages:
             user_message = conversation_messages[-1].get("content", "")
             history = conversation_messages[:-1]
+
+        # ── Image routing: respect agent.image_input_mode config ──
+        # The api_server historically bypassed the gateway's per-turn
+        # image-routing decision (CLI/TUI/messaging platforms call
+        # _decide_image_input_mode before passing content to the agent).
+        # Match that behaviour here so users with non-vision primary
+        # models (DeepSeek, GLM, etc.) can still process images via
+        # auxiliary.vision.
+        if isinstance(user_message, list) and any(
+            isinstance(p, dict) and p.get("type") in _IMAGE_PART_TYPES
+            for p in user_message
+        ):
+            try:
+                from agent.image_routing import decide_image_input_mode
+                from agent.auxiliary_client import _read_main_model, _read_main_provider
+                from hermes_cli.config import load_config
+
+                cfg = load_config()
+                provider = _read_main_provider()
+                model = _read_main_model()
+                img_mode = decide_image_input_mode(provider, model, cfg)
+                img_count = sum(
+                    1 for p in user_message
+                    if isinstance(p, dict) and p.get("type") in _IMAGE_PART_TYPES
+                )
+                if img_mode == "text":
+                    logger.info(
+                        "Image routing: text (mode=%s). Pre-analyzing %d image(s) via vision_analyze.",
+                        img_mode, img_count,
+                    )
+                    user_message = await self._enrich_api_content_with_vision(user_message)
+                else:
+                    logger.info(
+                        "Image routing: native. %d image(s) attached inline.",
+                        img_count,
+                    )
+            except Exception as exc:
+                logger.debug(
+                    "Image routing: decision failed, passing images through unchanged — %s",
+                    exc,
+                )
+                # On failure, pass through unchanged.  Downstream
+                # _prepare_messages_for_non_vision_model will strip
+                # images from the wire format if the model can't handle
+                # them (best-effort fallback).
 
         if not _content_has_visible_payload(user_message):
             return web.json_response(

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -165,13 +165,21 @@ class TestChatCompletionsMultimodalHTTP:
                     )
                 mock_run.side_effect = _stub
 
-                resp = await cli.post(
-                    "/v1/chat/completions",
-                    json={
-                        "model": "hermes-agent",
-                        "messages": [{"role": "user", "content": image_payload}],
-                    },
-                )
+                # With image routing wired in, images only pass through when
+                # the routing decision returns "native" (vision-capable model
+                # or explicit config).  The routing decision is tested
+                # separately; this test verifies the native pass-through path.
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                    return_value="native",
+                ):
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": image_payload}],
+                        },
+                    )
 
             assert resp.status == 200, await resp.text()
             assert mock_run.captured["user_message"] == image_payload
@@ -306,3 +314,305 @@ class TestResponsesMultimodalHTTP:
             assert resp.status == 400
             body = await resp.json()
         assert body["error"]["code"] == "unsupported_content_type"
+
+
+# ---------------------------------------------------------------------------
+# Image routing: decide_image_input_mode wired into _handle_chat_completions
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsImageRouting:
+    """Tests for the image-routing decision wired into the API server.
+
+    The gateway (CLI/TUI/messaging) calls _decide_image_input_mode before
+    passing content to the agent.  These tests verify the api_server now
+    does the same — respecting agent.image_input_mode, auxiliary.vision
+    overrides, and model capability metadata.
+    """
+
+    IMAGE_PAYLOAD = [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_native_mode_preserves_image_parts(self, adapter):
+        """Vision-capable model (or explicit native config) → images pass through."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                    return_value="native",
+                ):
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": self.IMAGE_PAYLOAD}],
+                        },
+                    )
+
+            assert resp.status == 200, await resp.text()
+            user_msg = mock_run.captured["user_message"]
+            assert isinstance(user_msg, list)
+            assert any(
+                isinstance(p, dict) and p.get("type") == "image_url"
+                for p in user_msg
+            )
+
+    @pytest.mark.asyncio
+    async def test_text_mode_replaces_images_with_descriptions(self, adapter):
+        """Non-vision model (or explicit text config) → images replaced with text."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                    return_value="text",
+                ):
+                    with patch(
+                        "tools.vision_tools.vision_analyze_tool",
+                        return_value='{"success":true,"analysis":"a fluffy cat sitting on a couch"}',
+                    ):
+                        resp = await cli.post(
+                            "/v1/chat/completions",
+                            json={
+                                "model": "hermes-agent",
+                                "messages": [{"role": "user", "content": self.IMAGE_PAYLOAD}],
+                            },
+                        )
+
+            assert resp.status == 200, await resp.text()
+            user_msg = mock_run.captured["user_message"]
+            assert isinstance(user_msg, str)
+            assert "a fluffy cat sitting on a couch" in user_msg
+            assert "What's in this image?" in user_msg
+            assert "vision_analyze" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_auto_with_non_vision_model_uses_text_path(self, adapter):
+        """Auto mode + non-vision model caps → text path."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing._lookup_supports_vision",
+                    return_value=False,
+                ):
+                    with patch(
+                        "tools.vision_tools.vision_analyze_tool",
+                        return_value='{"success":true,"analysis":"a fluffy cat sitting on a couch"}',
+                    ):
+                        resp = await cli.post(
+                            "/v1/chat/completions",
+                            json={
+                                "model": "hermes-agent",
+                                "messages": [{"role": "user", "content": self.IMAGE_PAYLOAD}],
+                            },
+                        )
+
+            assert resp.status == 200, await resp.text()
+            user_msg = mock_run.captured["user_message"]
+            assert isinstance(user_msg, str)
+            assert "a fluffy cat sitting on a couch" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_auto_with_vision_model_uses_native_path(self, adapter):
+        """Auto mode + vision-capable model caps → native path."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing._lookup_supports_vision",
+                    return_value=True,
+                ):
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": self.IMAGE_PAYLOAD}],
+                        },
+                    )
+
+            assert resp.status == 200, await resp.text()
+            user_msg = mock_run.captured["user_message"]
+            assert isinstance(user_msg, list)
+            assert any(
+                isinstance(p, dict) and p.get("type") == "image_url"
+                for p in user_msg
+            )
+
+    @pytest.mark.asyncio
+    async def test_url_based_image_passed_to_vision_analyze(self, adapter):
+        """HTTPS image URL is forwarded to vision_analyze_tool correctly."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                calls = []
+
+                async def _fake_vision(image_url, user_prompt, model=None):
+                    calls.append({"image_url": image_url, "user_prompt": user_prompt})
+                    return '{"success":true,"analysis":"a cat"}'
+
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                    return_value="text",
+                ):
+                    with patch(
+                        "tools.vision_tools.vision_analyze_tool",
+                        side_effect=_fake_vision,
+                    ):
+                        resp = await cli.post(
+                            "/v1/chat/completions",
+                            json={
+                                "model": "hermes-agent",
+                                "messages": [{"role": "user", "content": self.IMAGE_PAYLOAD}],
+                            },
+                        )
+
+            assert resp.status == 200, await resp.text()
+            assert len(calls) == 1
+            assert calls[0]["image_url"] == "https://example.com/cat.png"
+
+    @pytest.mark.asyncio
+    async def test_text_only_message_skips_routing(self, adapter):
+        """Plain text messages never trigger image routing logic."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "Hi!", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                ) as mock_decide:
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": "Hello, world!"}],
+                        },
+                    )
+
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["user_message"] == "Hello, world!"
+            mock_decide.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_data_url_image_enrichment(self, adapter):
+        """data:image/... URLs are handled by the text path."""
+        app = _create_app(adapter)
+        data_url_payload = [
+            {"type": "text", "text": "What's this?"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                    return_value="text",
+                ):
+                    with patch(
+                        "tools.vision_tools.vision_analyze_tool",
+                        return_value='{"success":true,"analysis":"a pixel"}',
+                    ):
+                        resp = await cli.post(
+                            "/v1/chat/completions",
+                            json={
+                                "model": "hermes-agent",
+                                "messages": [{"role": "user", "content": data_url_payload}],
+                            },
+                        )
+
+            assert resp.status == 200, await resp.text()
+            user_msg = mock_run.captured["user_message"]
+            assert isinstance(user_msg, str)
+            assert "a pixel" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_routing_failure_passes_through_native(self, adapter):
+        """If decide_image_input_mode raises, images pass through unchanged."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                with patch(
+                    "agent.image_routing.decide_image_input_mode",
+                    side_effect=RuntimeError("config missing"),
+                ):
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [{"role": "user", "content": self.IMAGE_PAYLOAD}],
+                        },
+                    )
+
+            assert resp.status == 200, await resp.text()
+            user_msg = mock_run.captured["user_message"]
+            assert isinstance(user_msg, list)
+            assert any(
+                isinstance(p, dict) and p.get("type") == "image_url"
+                for p in user_msg
+            )


### PR DESCRIPTION
Closes the gap where api_server bypassed image routing while CLI/TUI/messaging gateway respected it.

**Problem**
The gateway (CLI, TUI, Telegram, Discord) calls `_decide_image_input_mode()` before passing content to the agent — non-vision models (DeepSeek, GLM, etc.) get images pre-analyzed via `vision_analyze_tool` and the result injected as text. The API server (`_handle_chat_completions`) normalized multimodal content but passed it straight through, bypassing the routing decision entirely. Users hitting the API server with images on a non-vision primary model (or with `auxiliary.vision` configured) would get model errors instead of text descriptions.

**Fix**
- Adds `_extract_image_urls_from_content()` — standalone helper to pull URL strings from normalized content parts
- Adds `_enrich_api_content_with_vision()` — async instance method on `APIServerAdapter` that runs `vision_analyze_tool` on each image URL and returns enriched text (matching the gateway's `_enrich_message_with_vision` output format)
- Wires `decide_image_input_mode()` into `_handle_chat_completions` after content normalization, before `_run_agent` is called
- Uses the same provider/model resolution as the gateway (`_read_main_provider()` / `_read_main_model()` from `agent.auxiliary_client`) — consistent with `_decide_image_input_mode`

**Behaviour**
| Config / Model | Image handling |
|---|---|
| `agent.image_input_mode: native` | Images pass through as OpenAI-style parts |
| `agent.image_input_mode: text` | Images replaced with `vision_analyze` text descriptions |
| `auto` + vision-capable model | Native pass-through |
| `auto` + non-vision model | Text enrichment via `vision_analyze_tool` |
| `auto` + explicit `auxiliary.vision` config | Text path (respects user's opt-in to dedicated vision backend) |
| Routing decision raises | Graceful passthrough — downstream falls back to model's native handling |
| Plain text (no images) | No routing overhead — `decide_image_input_mode` never called |

**Test Plan**
- 8 new tests in `tests/gateway/test_api_server_multimodal.py::TestChatCompletionsImageRouting`:
  - Native mode preserves image parts
  - Text mode replaces images with descriptions
  - Auto with non-vision model → text path
  - Auto with vision model → native path
  - URL-based image forwarded to `vision_analyze_tool` correctly
  - Text-only messages skip routing (assert_not_called)
  - `data:image/...` URLs handled by text path
  - Routing failure passes images through unchanged
- 1 adapted existing test: `test_inline_image_preserved_to_run_agent` now wraps in `patch("...decide_image_input_mode", return_value="native")` to account for routing being wired in
- 31/31 pass: `pytest tests/gateway/test_api_server_multimodal.py -v`

**Type of Change**
- [x] New feature (non-breaking change which adds functionality)

**References**
- Existing test pattern source: `tests/agent/test_image_routing.py`
- Gateway's image routing: `gateway/run.py:_decide_image_input_mode` / `gateway/run.py:_enrich_message_with_vision`


