### PR TITLE
fix(tts): filter emoji characters from text-to-speech input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8397,6 +8397,8 @@ class HermesCLI:
             tts_text = re.sub(r'^\s*[-*]\s+', '', tts_text, flags=re.MULTILINE)  # list items
             tts_text = re.sub(r'---+', '', tts_text)              # horizontal rules
             tts_text = re.sub(r'\n{3,}', '\n\n', tts_text)        # excessive newlines
+            # Strip emojis so TTS doesn't read out emoji descriptions
+            tts_text = re.sub(r'[\U0001F600-\U0001F64F\U0001F300-\U0001F5FF\U0001F680-\U0001F6FF\U0001F1E0-\U0001F1FF\U00002702-\U000027B0\U0000FE00-\U0000FE0F\U0001F900-\U0001F9FF\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF\U00002600-\U000026FF\U0000200D]+', '', tts_text)
             tts_text = tts_text.strip()
             if not tts_text:
                 return

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -494,6 +494,8 @@ def speak_text(text: str) -> None:
         tts_text = re.sub(r'^\s*[-*]\s+', '', tts_text, flags=re.MULTILINE)  # list bullets
         tts_text = re.sub(r'---+', '', tts_text)                        # horizontal rules
         tts_text = re.sub(r'\n{3,}', '\n\n', tts_text)                  # excess newlines
+        # Strip emojis so TTS doesn't read out emoji descriptions
+        tts_text = re.sub(r'[\U0001F600-\U0001F64F\U0001F300-\U0001F5FF\U0001F680-\U0001F6FF\U0001F1E0-\U0001F1FF\U00002702-\U000027B0\U0000FE00-\U0000FE0F\U0001F900-\U0001F9FF\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF\U00002600-\U000026FF\U0000200D]+', '', tts_text)
         tts_text = tts_text.strip()
         if not tts_text:
             return

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1910,6 +1910,19 @@ def _strip_markdown_for_tts(text: str) -> str:
     text = _MD_LIST_ITEM.sub('', text)
     text = _MD_HR.sub('', text)
     text = _MD_EXCESS_NL.sub('\n\n', text)
+    # Strip emojis so TTS doesn't read out emoji descriptions
+    text = re.sub(r'[\U0001F600-\U0001F64F'  # emoticons
+                  r'\U0001F300-\U0001F5FF'    # symbols & pictographs
+                  r'\U0001F680-\U0001F6FF'    # transport & map
+                  r'\U0001F1E0-\U0001F1FF'    # flags
+                  r'\U00002702-\U000027B0'    # dingbats
+                  r'\U0000FE00-\U0000FE0F'    # variation selectors
+                  r'\U0001F900-\U0001F9FF'    # supplemental symbols
+                  r'\U0001FA00-\U0001FA6F'    # chess symbols
+                  r'\U0001FA70-\U0001FAFF'    # symbols extended-A
+                  r'\U00002600-\U000026FF'    # misc symbols
+                  r'\U0000200D'               # zero-width joiner
+                  r']+', '', text)
     return text.strip()
 
 


### PR DESCRIPTION
## Summary

Add emoji regex filter to all TTS text preprocessing paths to prevent voice engines from attempting to pronounce emoji characters.

## Problem

When users send messages with emojis (😊, 👍, etc.), the text-to-speech engines (Edge TTS, ElevenLabs, MiniMax, etc.) attempt to pronounce them as literal characters (e.g., "smiling face with smiling eyes", "thumbs up"). This degrades voice output quality and creates awkward listening experiences.

## Solution

Add an emoji regex filter to all TTS text preprocessing functions:
- `tools/tts_tool.py`: `_strip_markdown_for_tts()`
- `cli.py`: `_voice_speak_response()`
- `hermes_cli/voice.py`: `speak_text()`

The regex pattern covers the full Unicode emoji range:
- Emoticons (U+1F600-U+1F64F)
- Symbols & Pictographs (U+1F300-U+1F5FF)
- Transport & Map (U+1F680-U+1F6FF)
- Flags (U+1F1E0-U+1F1FF)
- And other emoji blocks

## Testing

Verified locally:
1. Send message with emojis (e.g., "你好😊这个功能很棒👍")
2. TTS reads clean text without emoji pronunciations
3. All three TTS paths (CLI, TUI, gateway) work correctly

## Files Changed

- `cli.py`: +2 lines
- `hermes_cli/voice.py`: +2 lines
- `tools/tts_tool.py`: +13 lines

Total: 17 insertions, 0 deletions
