### PR TITLE
fix(constants): raise ValueError when HERMES_HOME unset in profile mode

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -13,9 +13,31 @@ def get_hermes_home() -> Path:
 
     Reads HERMES_HOME env var, falls back to ~/.hermes.
     This is the single source of truth — all other copies should import this.
+
+    Raises ValueError when HERMES_HOME is unset but an ``active_profile``
+    file indicates a non-default profile is active.  In that case the
+    fallback to ``~/.hermes`` would silently corrupt the other profile's
+    data — the caller must set HERMES_HOME explicitly.
+    See https://github.com/NousResearch/hermes-agent/issues/18594.
     """
     val = os.environ.get("HERMES_HOME", "").strip()
-    return Path(val) if val else Path.home() / ".hermes"
+    if not val:
+        # Guard: if a non-default profile is active, falling back to
+        # ~/.hermes would write into the wrong profile's data directory.
+        active_profile_path = Path.home() / ".hermes" / "active_profile"
+        try:
+            active = active_profile_path.read_text().strip()
+        except (FileNotFoundError, UnicodeDecodeError, OSError):
+            active = ""
+        if active and active != "default":
+            raise ValueError(
+                f"HERMES_HOME is not set, but active profile is '{active}'. "
+                f"Profile mode requires HERMES_HOME to be set to the profile "
+                f"directory (e.g. ~/.hermes/profiles/{active}). "
+                f"This prevents silent cross-profile data corruption."
+            )
+        return Path.home() / ".hermes"
+    return Path(val)
 
 
 def get_default_hermes_root() -> Path:

--- a/tests/hermes_cli/test_get_hermes_home_profile_fallback.py
+++ b/tests/hermes_cli/test_get_hermes_home_profile_fallback.py
@@ -1,0 +1,71 @@
+"""Tests for get_hermes_home() profile-mode fallback safety.
+
+Validates that when HERMES_HOME is unset but an active_profile file exists
+(indicating profile mode), get_hermes_home() raises ValueError instead of
+silently falling back to ~/.hermes — which would cause cross-profile data
+corruption.
+
+Regression test for https://github.com/NousResearch/hermes-agent/issues/18594
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+class TestGetHermesHomeProfileFallback:
+    """get_hermes_home() should raise in profile mode when HERMES_HOME is unset."""
+
+    def test_classic_mode_no_active_profile_returns_default(self, tmp_path, monkeypatch):
+        """Classic mode: no HERMES_HOME, no active_profile → returns ~/.hermes."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # No active_profile file exists — classic mode
+        from hermes_constants import get_hermes_home
+        result = get_hermes_home()
+        assert result == tmp_path / ".hermes"
+
+    def test_profile_mode_raises_when_hermes_home_unset(self, tmp_path, monkeypatch):
+        """Profile mode: active_profile exists but HERMES_HOME is unset → ValueError."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Create active_profile file indicating a named profile is active
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "active_profile").write_text("coder\n")
+        from hermes_constants import get_hermes_home
+        with pytest.raises(ValueError, match="HERMES_HOME.*profile"):
+            get_hermes_home()
+
+    def test_profile_mode_default_profile_returns_ok(self, tmp_path, monkeypatch):
+        """Profile mode with 'default' active_profile → returns ~/.hermes (safe)."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "active_profile").write_text("default\n")
+        from hermes_constants import get_hermes_home
+        result = get_hermes_home()
+        assert result == tmp_path / ".hermes"
+
+    def test_hermes_home_env_set_returns_env_value(self, tmp_path, monkeypatch):
+        """When HERMES_HOME is set, returns it regardless of active_profile."""
+        profile_dir = tmp_path / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from hermes_constants import get_hermes_home
+        result = get_hermes_home()
+        assert result == profile_dir
+
+    def test_profile_mode_empty_active_profile_returns_ok(self, tmp_path, monkeypatch):
+        """Empty active_profile file → treated as classic mode, returns default."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "active_profile").write_text("")
+        from hermes_constants import get_hermes_home
+        result = get_hermes_home()
+        assert result == tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

When a non-default profile is active (`~/.hermes/active_profile` exists with a non-`default` value) but `HERMES_HOME` is not inherited by a sub-process, `get_hermes_home()` now raises `ValueError` instead of silently returning `~/.hermes`.

**Problem:** In profile mode, the CLI launcher sets `HERMES_HOME=<root>/profiles/<name>` before spawning sub-processes (cron jobs, skills, sub-agents). These sub-processes do not inherit the parent's environment variables. When `get_hermes_home()` is called without `HERMES_HOME`, it falls back to `~/.hermes` — the default profile — causing silent cross-profile data corruption.

**Real incident (May 1 2026):** A holographic-memory cron job ran SQL queries against `~/.hermes/memory_store.db` instead of the profile's database because `HERMES_HOME` was not inherited, contaminating the default profile with personal data.

## Fix

Reads `~/.hermes/active_profile` when `HERMES_HOME` is unset. If a non-default profile is active, raises `ValueError` with a clear message directing the operator to set `HERMES_HOME`. Classic mode (no `active_profile` file or `default` value) is unaffected — the fallback to `~/.hermes` remains correct.

## Test Plan

- [x] RED: `test_profile_mode_raises_when_hermes_home_unset` fails on current main (DID NOT RAISE)
- [x] GREEN: All 5 new tests pass after fix
- [x] Regression: `tests/hermes_cli/test_profiles.py` — 94 passed
- [x] Regression: `tests/test_subprocess_home_isolation.py` — all passed
- [x] Regression: Full `hermes_cli/` test suite — 0 new failures vs main

## Diff Stats

- `hermes_constants.py`: +23 lines (guard clause in `get_hermes_home()`)
- `tests/hermes_cli/test_get_hermes_home_profile_fallback.py`: +71 lines (5 test cases)

Closes #18594