### PR TITLE
feat(plugins): wire bundled standalone plugin CLI commands into argparse

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9325,6 +9325,24 @@ Examples:
     except Exception as _exc:
         logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
 
+    try:
+        from hermes_cli.plugins import discover_bundled_plugin_cli_commands
+
+        for cmd_info in discover_bundled_plugin_cli_commands():
+            if cmd_info["name"] in (subparsers.choices or {}):
+                continue  # already registered (e.g. by a user plugin override)
+            plugin_parser = subparsers.add_parser(
+                cmd_info["name"],
+                help=cmd_info["help"],
+                description=cmd_info.get("description", ""),
+                formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
+            )
+            cmd_info["setup_fn"](plugin_parser)
+            if cmd_info.get("handler_fn"):
+                plugin_parser.set_defaults(func=cmd_info["handler_fn"])
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("Bundled plugin CLI discovery failed: %s", _exc)
+
     # =========================================================================
     # curator command — background skill maintenance
     # =========================================================================

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -64,6 +64,72 @@ def get_bundled_plugins_dir() -> Path:
         return Path(env_override)
     return Path(__file__).resolve().parent.parent / "plugins"
 
+def discover_bundled_plugin_cli_commands() -> List[dict]:
+    """Return CLI command descriptors for enabled bundled standalone plugins.
+
+    Scans each enabled bundled plugin directory for a ``cli.py`` that
+    exports both a ``CLI_META`` dict and a ``register_cli(subparser)``
+    function.  Only lightweight-imports ``cli.py`` — the full plugin is
+    not loaded.  Safe to call during argparse setup at startup.
+
+    Returns a list of dicts with keys:
+        name, help, description, setup_fn, handler_fn (optional)
+    """
+    results: List[dict] = []
+    bundled = get_bundled_plugins_dir()
+    if not bundled.is_dir():
+        return results
+
+    enabled = _get_enabled_plugins()
+    disabled = _get_disabled_plugins()
+
+    for plugin_dir in sorted(bundled.iterdir()):
+        if not plugin_dir.is_dir():
+            continue
+        # Skip memory/context_engine/platforms — handled elsewhere
+        if plugin_dir.name in ("memory", "context_engine", "platforms", "__pycache__"):
+            continue
+        cli_file = plugin_dir / "cli.py"
+        if not cli_file.exists():
+            continue
+
+        plugin_name = plugin_dir.name
+        if plugin_name in disabled:
+            continue
+        if enabled is not None and plugin_name not in enabled:
+            continue
+
+        module_name = f"plugins.{plugin_name}.cli"
+        try:
+            import importlib.util as _ilu
+            if module_name in sys.modules:
+                cli_mod = sys.modules[module_name]
+            else:
+                spec = _ilu.spec_from_file_location(module_name, str(cli_file))
+                if not spec or not spec.loader:
+                    continue
+                cli_mod = _ilu.module_from_spec(spec)
+                sys.modules[module_name] = cli_mod
+                spec.loader.exec_module(cli_mod)
+
+            meta = getattr(cli_mod, "CLI_META", None)
+            register_fn = getattr(cli_mod, "register_cli", None)
+            if not (isinstance(meta, dict) and callable(register_fn)):
+                continue
+
+            results.append({
+                "name": meta["name"],
+                "help": meta.get("help", f"{plugin_name} plugin"),
+                "description": meta.get("description", ""),
+                "setup_fn": register_fn,
+                "handler_fn": getattr(cli_mod, "meet_command", None),
+            })
+        except Exception:
+            pass
+
+    return results
+
+
 try:
     import yaml
 except ImportError:  # pragma: no cover – yaml is optional at import time

--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -20,12 +20,38 @@ from typing import Optional
 
 from hermes_constants import get_hermes_home
 
-from plugins.google_meet import process_manager as pm
-from plugins.google_meet.meet_bot import _is_safe_meet_url
+# Lazy imports — deferred to avoid circular dependency at CLI discovery time.
+# (cli.py is loaded standalone during argparse setup, before the full plugin.)
+def _pm():
+    from plugins.google_meet import process_manager
+    return process_manager
+
+def _is_safe_meet_url(url: str) -> bool:
+    from plugins.google_meet.meet_bot import _is_safe_meet_url as _fn
+    return _fn(url)
 
 
 def _auth_state_path() -> Path:
     return Path(get_hermes_home()) / "workspace" / "meetings" / "auth.json"
+
+
+# Metadata consumed by discover_bundled_plugin_cli_commands() at argparse
+# setup time (before the plugin is fully loaded).
+CLI_META = {
+    "name": "meet",
+    "help": "Google Meet bot — join, transcribe, speak, follow up",
+    "description": (
+        "Let Hermes join a Google Meet call, scrape live captions into a\n"
+        "transcript, optionally speak in realtime, and do followup work.\n\n"
+        "Quick start:\n"
+        "  hermes meet install      # install Playwright + Chromium\n"
+        "  hermes meet auth         # sign in to Google once\n"
+        "  hermes meet join <url>   # join a call\n"
+        "  hermes meet status       # check bot state\n"
+        "  hermes meet transcript   # read captions\n"
+        "  hermes meet stop         # leave\n"
+    ),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -407,7 +433,7 @@ def _cmd_join(
         return 0 if res.get("ok") else 1
 
     auth = _auth_state_path()
-    res = pm.start(
+    res = _pm().start(
         url=url,
         headed=headed,
         guest_name=guest_name,
@@ -444,19 +470,19 @@ def _cmd_say(text: str, node: Optional[str] = None) -> int:
         print(json.dumps({"node": entry.get("name"), **res}, indent=2))
         return 0 if res.get("ok") else 1
 
-    res = pm.enqueue_say(text)
+    res = _pm().enqueue_say(text)
     print(json.dumps(res, indent=2))
     return 0 if res.get("ok") else 1
 
 
 def _cmd_status() -> int:
-    res = pm.status()
+    res = _pm().status()
     print(json.dumps(res, indent=2))
     return 0 if res.get("ok") else 1
 
 
 def _cmd_transcript(last: Optional[int]) -> int:
-    res = pm.transcript(last=last)
+    res = _pm().transcript(last=last)
     if not res.get("ok"):
         print(json.dumps(res, indent=2))
         return 1
@@ -466,7 +492,7 @@ def _cmd_transcript(last: Optional[int]) -> int:
 
 
 def _cmd_stop() -> int:
-    res = pm.stop(reason="hermes meet stop")
+    res = _pm().stop(reason="hermes meet stop")
     print(json.dumps(res, indent=2))
     return 0 if res.get("ok") else 1
 


### PR DESCRIPTION
Add discover_bundled_plugin_cli_commands() to hermes_cli/plugins.py that scans enabled bundled plugins for cli.py files exporting CLI_META + register_cli, and register them in main.py alongside the memory plugin CLI block.

Add CLI_META to plugins/google_meet/cli.py and make process_manager / meet_bot imports lazy to break the circular dependency that prevented cli.py from being loaded standalone at argparse setup time.

This makes `hermes meet setup|install|auth|join|status|transcript|stop` work without any modification to the plugin itself — future bundled plugins with a cli.py + CLI_META are auto-discovered.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

