### PR TITLE
fix(context-compression): fallback to main model when summary_model_override is None and provider returns 413

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -903,17 +903,23 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 or "does not exist" in _err_str
                 or "no available channel" in _err_str
             )
+            _is_rate_limited = (
+                _status == 413
+                or "rate limit" in _err_str
+                or "tpm" in _err_str
+                or "tokens per minute" in _err_str
+            )
             if (
                 _is_model_not_found
-                and self.summary_model
-                and self.summary_model != self.model
                 and not getattr(self, "_summary_model_fallen_back", False)
+                and (not self.summary_model or self.summary_model != self.model)
             ):
                 self._summary_model_fallen_back = True
+                _had_aux_model = bool(self.summary_model)
                 logging.warning(
                     "Summary model '%s' not available (%s). "
                     "Falling back to main model '%s' for compression.",
-                    self.summary_model, e, self.model,
+                    self.summary_model or "(default)", e, self.model,
                 )
                 # Record the aux-model failure so callers can warn the user
                 # even if the retry-on-main succeeds — a misconfigured aux
@@ -922,8 +928,15 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 if len(_err_text) > 220:
                     _err_text = _err_text[:217].rstrip() + "..."
                 self._last_aux_model_failure_error = _err_text
-                self._last_aux_model_failure_model = self.summary_model
-                self.summary_model = ""  # empty = use main model
+                self._last_aux_model_failure_model = self.summary_model or "(default)"
+                # When summary_model was explicitly set to a different model,
+                # clear it so the retry uses the default (main) provider.
+                # When it was empty (no override configured), the default
+                # provider may differ from self.model — set it explicitly.
+                if _had_aux_model:
+                    self.summary_model = ""
+                else:
+                    self.summary_model = self.model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
 
@@ -937,15 +950,18 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # aggregator rejections, etc.) where auto-retry is still safer
             # than dropping the turns.
             if (
-                self.summary_model
-                and self.summary_model != self.model
-                and not getattr(self, "_summary_model_fallen_back", False)
+                not getattr(self, "_summary_model_fallen_back", False)
+                and (
+                    (self.summary_model and self.summary_model != self.model)
+                    or (not self.summary_model and (_is_rate_limited or _is_model_not_found))
+                )
             ):
                 self._summary_model_fallen_back = True
+                _had_aux_model = bool(self.summary_model)
                 logging.warning(
                     "Summary model '%s' failed (%s). "
                     "Retrying on main model '%s' before giving up.",
-                    self.summary_model, e, self.model,
+                    self.summary_model or "(default)", e, self.model,
                 )
                 # Record the aux-model failure (see 404 branch above) — user
                 # should know their configured model is broken even if main
@@ -954,8 +970,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 if len(_err_text) > 220:
                     _err_text = _err_text[:217].rstrip() + "..."
                 self._last_aux_model_failure_error = _err_text
-                self._last_aux_model_failure_model = self.summary_model
-                self.summary_model = ""  # empty = use main model
+                self._last_aux_model_failure_model = self.summary_model or "(default)"
+                if _had_aux_model:
+                    self.summary_model = ""
+                else:
+                    self.summary_model = self.model
                 self._summary_failure_cooldown_until = 0.0
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -376,6 +376,44 @@ class TestSummaryFallbackToMainModel:
         assert result is None
         assert c._summary_model_fallen_back is True
 
+    def test_empty_summary_model_413_falls_back_to_main(self):
+        """When summary_model_override is None (default), self.summary_model
+        is empty.  If the default provider returns a 413 rate-limit error,
+        the compressor should fall back to the main model explicitly."""
+        mock_ok = MagicMock()
+        mock_ok.choices = [MagicMock()]
+        mock_ok.choices[0].message.content = "summary via main model"
+
+        err_413 = Exception("413 TPM exhausted: rate limit exceeded")
+        err_413.status_code = 413
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="main-model",
+                summary_model_override=None,  # default — no aux model
+                quiet_mode=True,
+            )
+
+        # summary_model should be empty when no override is set
+        assert c.summary_model == ""
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[err_413, mock_ok],
+        ) as mock_call:
+            result = c._generate_summary(self._msgs())
+
+        # Should retry: first call fails, second succeeds on main model
+        assert mock_call.call_count == 2
+        # Second call should explicitly use the main model
+        assert mock_call.call_args_list[1].kwargs.get("model") == "main-model"
+        assert result is not None
+        assert "summary via main model" in result
+        # Aux-model failure recorded with "(default)" placeholder
+        assert c._last_aux_model_failure_model == "(default)"
+        assert c._last_aux_model_failure_error is not None
+        assert "413" in c._last_aux_model_failure_error
+
 
 class TestAuxModelFallbackSurfacedToCallers:
     """When summary_model fails but retry-on-main succeeds, compress() must


### PR DESCRIPTION
## Problem

When `summary_model_override` is not configured (the default, `None`), `self.summary_model` is set to an empty string (`""`) which is **falsy**. The fallback conditions in `_generate_summary()` both check `self.summary_model`:

```python
# Line 906 (model-not-found fast path)
if (
    _is_model_not_found
    and self.summary_model          # ← falsy when ""
    and self.summary_model != self.model
    ...
):

# Line 939 (unknown-error best-effort retry)
if (
    self.summary_model              # ← falsy when ""
    and self.summary_model != self.model
    ...
):
```

When `self.summary_model` is empty, both conditions short-circuit — **no fallback to the main model ever happens**. This means users with no explicit `summary_model_override` get zero compression once the default provider hits rate limits (413 TPM exhausted), because there is no retry on the main model.

## Fix

1. **Add `_is_rate_limited` check** — detects 413 status, "rate limit", "TPM", "tokens per minute" error strings
2. **Broaden fallback conditions** — allow fallback when `summary_model` is empty AND the error is rate-limit or model-not-found (not generic errors, to avoid pointless retries when the default provider IS the main model)
3. **Explicit model on retry** — when falling back from empty `summary_model`, set it to `self.model` so the retry explicitly uses the main model instead of the default provider that may differ
4. **Add regression test** — `test_empty_summary_model_413_falls_back_to_main` verifies the 413 → fallback → success flow

## Before vs After

| Scenario | Before | After |
|---|---|---|
| `summary_model_override=None`, provider returns 413 | ❌ No retry, returns None | ✅ Retries on main model |
| `summary_model_override=None`, provider returns 404 | ❌ No retry, returns None | ✅ Retries on main model |
| `summary_model_override=None`, generic error | ❌ No retry, returns None | ❌ No retry (correct — same provider) |
| `summary_model_override="other"`, any error | ✅ Retries on main | ✅ Retries on main (unchanged) |

## Tests

All 67 existing tests pass + 1 new regression test added.

Fixes #18588
