### PR TITLE
fix: pass target_model to resolve_runtime_provider in delegation

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2292,7 +2292,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider)
+        runtime = resolve_runtime_provider(
+            requested=configured_provider,
+            target_model=configured_model,
+        )
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
## Problem

When `delegation.provider` is set to a provider like `opencode-go`, `_resolve_delegation_credentials()` calls `resolve_runtime_provider()` without passing `target_model`:

```python
# Line 2295 (before fix)
runtime = resolve_runtime_provider(requested=configured_provider)
```

For providers like `opencode-go`, `resolve_runtime_provider()` behaves differently depending on whether `target_model` is provided:

| | Without `target_model` | With `target_model=deepseek-v4-flash` |
|---|---|---|
| `api_mode` | `anthropic_messages` | `chat_completions` |
| `base_url` | `https://opencode.ai/zen/go` (no `/v1`) | `https://opencode.ai/zen/go/v1` |

The subagent therefore hits an Anthropic-compatible endpoint that does not exist on the OpenCode Go surface, receiving **HTTP 404** on every API call.

## Fix

Pass `target_model=configured_model` to `resolve_runtime_provider()`:

```python
# Line 2295 (after fix)
runtime = resolve_runtime_provider(
    requested=configured_provider,
    target_model=configured_model,
)
```

This mirrors the logic used elsewhere (e.g. `model_switch.py`) and ensures the provider resolves the correct API surface for the chosen model.

## Impact

- Fixes HTTP 404 for all delegation calls using `opencode-go` provider
- Also fixes `opencode-zen` which uses the same `opencode_model_api_mode()` routing
- Zero-risk change: `target_model` defaults to `None` when not configured, preserving existing behavior

Fixes #18586
