### PR TITLE
fix(gateway): load $HERMES_HOME/.env from systemd unit so plugins see env vars

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1664,6 +1664,7 @@ User={username}
 Group={group_name}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
+EnvironmentFile=-{hermes_home}/.env
 Environment="HOME={home_dir}"
 Environment="USER={username}"
 Environment="LOGNAME={username}"
@@ -1699,6 +1700,7 @@ StartLimitBurst=5
 Type=simple
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
+EnvironmentFile=-{hermes_home}/.env
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -140,6 +140,41 @@ class TestGeneratedSystemdUnits:
         assert "TimeoutStopSec=90" in unit
         assert "WantedBy=multi-user.target" in unit
 
+    def test_user_unit_loads_hermes_env_file(self):
+        # The gateway runs under systemd with a clean environment, so it must
+        # explicitly load ~/.hermes/.env to pick up API keys (HINDSIGHT_API_URL,
+        # OPENAI_API_KEY, TELEGRAM_BOT_TOKEN, ...). Without this, plugins that
+        # require env vars silently skip registration (see PR #2768 / #2765),
+        # tools fail auth at runtime, and the gateway falls back to a minimal
+        # toolset. The leading "-" makes the directive optional so a missing
+        # file does not fail unit start.
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "EnvironmentFile=-" in unit
+        assert "/.env" in unit
+        # Must reference the same HERMES_HOME used elsewhere in the unit so
+        # profile-aware paths (e.g. ~/.hermes-dev/.env) resolve correctly.
+        for line in unit.splitlines():
+            if line.startswith("EnvironmentFile=-"):
+                env_file_path = line.split("=-", 1)[1]
+                assert env_file_path.endswith("/.env")
+                break
+        else:
+            raise AssertionError("EnvironmentFile=- directive not found")
+
+    def test_system_unit_loads_hermes_env_file(self):
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert "EnvironmentFile=-" in unit
+        assert "/.env" in unit
+        for line in unit.splitlines():
+            if line.startswith("EnvironmentFile=-"):
+                env_file_path = line.split("=-", 1)[1]
+                assert env_file_path.endswith("/.env")
+                break
+        else:
+            raise AssertionError("EnvironmentFile=- directive not found")
+
 
 class TestGatewayStopCleanup:
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Both generated `hermes-gateway.service` unit templates (system-wide and `--user`) are missing an `EnvironmentFile=` directive, so `~/.hermes/.env` is never loaded when the gateway runs under systemd. The shell-exported env vars that work in interactive `hermes` sessions never reach the systemd cgroup.

**User-visible symptom:** plugins that declare `requires_env` (Hindsight, OpenAI-backed tools, internal HTTP plugins, etc.) silently skip registration and the gateway boots into a degraded toolset, while the same Hermes install run interactively exposes the full toolset.

This is the root cause of #2765. PR #2768 added warnings that surface the symptom but does not fix the underlying unit template.

## Repro

On a Linux host with `systemd --user`:

```bash
hermes gateway install --user
hermes gateway start
GW_PID=$(systemctl --user show hermes-gateway -p MainPID --value)
sudo cat /proc/$GW_PID/environ | tr '\0' '\n' \
  | grep -cE '^(HINDSIGHT|OPENAI|TELEGRAM_BOT|DISCORD_BOT)'
# → 0   (no app env vars present in the gateway process)
```

Even though `~/.hermes/.env` contains valid keys, the gateway process never sees them.

## Fix

Add an `EnvironmentFile=-{hermes_home}/.env` line under `[Service]` in both templates (rendered by `generate_systemd_unit()` in `hermes_cli/gateway.py`):

* The directive is placed **before** the existing `Environment=` lines so unit-defined values still take precedence on conflict.
* The leading `-` makes the directive optional — a missing `.env` file does not fail unit start.
* The path uses the same `{hermes_home}` interpolation already used for `Environment="HERMES_HOME=..."`, so profile-aware paths (e.g. `~/.hermes-dev/.env`) resolve correctly without further changes.

After this change, the same repro yields a non-zero count corresponding to the keys present in `~/.hermes/.env`. Plugins that previously skipped registration now register their tools, and the gateway exposes the full toolset to messaging platforms (Telegram, Discord, etc.).

## Tests

Two new cases in `tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits`:

| Test | Asserts |
| --- | --- |
| `test_user_unit_loads_hermes_env_file` | User unit (`default.target`) renders `EnvironmentFile=-…/.env` |
| `test_system_unit_loads_hermes_env_file` | System unit (`multi-user.target`) renders `EnvironmentFile=-…/.env` |

Result locally: `5 passed` for the full `TestGeneratedSystemdUnits` class (3 existing + 2 new).

## Backwards compatibility

* The `-` prefix means hosts without `~/.hermes/.env` are unaffected (no new failure mode).
* Unit-staleness checks (`_normalize_service_definition`) compare normalized text, so existing installs will be flagged as outdated and refreshed by the next `hermes gateway start`/`restart`/`install` — same path already used for any other unit-template change.
* No behavior change for non-systemd transports (launchd plist, Windows, foreground `hermes gateway run`).

## Related

* Closes #2765 (root cause).
* Complements #2768, which added warnings making this exact failure mode discoverable in logs.
