### PR TITLE
Surface custom LLM providers in dashboard

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -280,29 +280,45 @@ def _normalize_custom_pool_name(name: str) -> str:
 
 
 def _iter_custom_providers(config: Optional[dict] = None):
-    """Yield (normalized_name, entry_dict) for each valid custom_providers entry."""
+    """Yield (normalized_name, entry_dict) for every configured custom provider.
+
+    Older configs use ``custom_providers:`` while v12+ configs use the
+    ``providers:`` dict.  Include both forms so credential-pool lookups keep
+    working in mixed configs during migration.
+    """
     if config is None:
         config = _load_config_safe()
     if config is None:
         return
-    custom_providers = config.get("custom_providers")
-    if not isinstance(custom_providers, list):
-        # Fall back to the v12+ providers dict via the compatibility layer
-        try:
-            from hermes_cli.config import get_compatible_custom_providers
 
-            custom_providers = get_compatible_custom_providers(config)
-        except Exception:
+    seen: set[tuple[str, str]] = set()
+
+    def _yield_entries(entries):
+        if not entries:
             return
-    if not custom_providers:
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            base_url = str(entry.get("base_url") or "").strip().rstrip("/")
+            key = (_normalize_custom_pool_name(name), base_url)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield key[0], entry
+
+    custom_providers = config.get("custom_providers")
+    if isinstance(custom_providers, list):
+        yield from _yield_entries(custom_providers)
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        yield from _yield_entries(get_compatible_custom_providers(config))
+    except Exception:
         return
-    for entry in custom_providers:
-        if not isinstance(entry, dict):
-            continue
-        name = entry.get("name")
-        if not isinstance(name, str):
-            continue
-        yield _normalize_custom_pool_name(name), entry
 
 
 def get_custom_provider_pool_key(base_url: str) -> Optional[str]:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -49,7 +49,7 @@ _INTERNAL_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
-    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as informational background data\.\]\s*',
+    r'\[System note:[^\]]*recalled memory context[^\]]*\]\s*',
     re.IGNORECASE,
 )
 
@@ -182,8 +182,10 @@ def build_memory_context_block(raw_context: str) -> str:
         logger.warning("memory provider returned pre-wrapped context; stripped")
     return (
         "<memory-context>\n"
-        "[System note: The following is recalled memory context, "
-        "NOT new user input. Treat as informational background data.]\n\n"
+        "[System note: The following is recalled memory context for the assistant only. "
+        "It is NOT new user input, NOT something the user pasted, and NOT conversational evidence. "
+        "Use it silently as background. Do not mention this block, its tag, source, or provenance "
+        "unless the user explicitly asks to debug memory internals.]\n\n"
         f"{clean}\n"
         "</memory-context>"
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -921,11 +921,26 @@ def get_model_info():
         # Effective is what the agent actually uses
         effective_ctx = config_ctx_int if config_ctx_int > 0 else auto_ctx
 
-        # Try to get model capabilities from models.dev
+        # Try to get model capabilities from models.dev. This is optional UI
+        # decoration, so keep the dashboard responsive if DNS/network fetches
+        # stall while models.dev cache is cold.
         caps = {}
         try:
+            import threading
             from agent.models_dev import get_model_capabilities
-            mc = get_model_capabilities(provider=provider, model=model_name)
+
+            holder: dict = {}
+
+            def _load_caps() -> None:
+                try:
+                    holder["value"] = get_model_capabilities(provider=provider, model=model_name)
+                except Exception:
+                    holder["value"] = None
+
+            thread = threading.Thread(target=_load_caps, daemon=True)
+            thread.start()
+            thread.join(0.5)
+            mc = holder.get("value")
             if mc is not None:
                 caps = {
                     "supports_tools": mc.supports_tools,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -187,8 +187,11 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_lc in _LOOPBACK_HOST_VALUES:
         return host_only in _LOOPBACK_HOST_VALUES
 
-    # Explicit non-loopback bind: require exact host match
-    return host_only == bound_lc
+    # Explicit non-loopback bind: require exact host match.
+    # Browsers and DNS tooling may preserve a trailing root dot for FQDNs
+    # (e.g. momo-hermes.tailnet.ts.net.). Treat that as the same host
+    # rather than rejecting the dashboard URL with a confusing 400.
+    return host_only.rstrip(".") == bound_lc.rstrip(".")
 
 
 @app.middleware("http")
@@ -458,6 +461,18 @@ class ModelAssignment(BaseModel):
     provider: str
     model: str
     task: str = ""
+
+
+class CustomProviderCreate(BaseModel):
+    """Payload for POST /api/providers/custom — add/update a config provider."""
+    provider_id: str
+    name: str = ""
+    base_url: str
+    default_model: str = ""
+    api_key: str = ""
+    key_env: str = ""
+    transport: str = "openai_chat"
+    discover_models: bool = True
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
@@ -955,6 +970,201 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
     "title_generation",
     "curator",
 )
+
+
+
+# ---------------------------------------------------------------------------
+# Custom provider management — v12+ providers: config plus auth-pool secrets.
+# ---------------------------------------------------------------------------
+
+
+def _provider_config_to_model_list(provider_cfg: Dict[str, Any]) -> List[str]:
+    """Extract displayable model ids from a providers: entry without secrets."""
+    models: List[str] = []
+    default_model = str(
+        provider_cfg.get("default_model", "") or provider_cfg.get("model", "") or ""
+    ).strip()
+    if default_model:
+        models.append(default_model)
+    cfg_models = provider_cfg.get("models", [])
+    if isinstance(cfg_models, dict):
+        for model_id in cfg_models:
+            model_id = str(model_id or "").strip()
+            if model_id and model_id not in models:
+                models.append(model_id)
+    elif isinstance(cfg_models, list):
+        for model_id in cfg_models:
+            if isinstance(model_id, dict):
+                model_id = str(model_id.get("id", "") or model_id.get("name", "") or "").strip()
+            else:
+                model_id = str(model_id or "").strip()
+            if model_id and model_id not in models:
+                models.append(model_id)
+    return models
+
+
+def _custom_provider_pool_status(base_url: str) -> Dict[str, Any]:
+    """Return safe credential-pool status for a custom provider endpoint."""
+    try:
+        from agent.credential_pool import get_custom_provider_pool_key, load_pool
+
+        pool_key = get_custom_provider_pool_key(base_url)
+        if not pool_key:
+            return {"logged_in": False, "pool_key": None, "credentials": 0}
+        pool = load_pool(pool_key)
+        entries = pool.entries()
+        return {
+            "logged_in": bool(entries),
+            "pool_key": pool_key,
+            "credentials": len(entries),
+            "labels": [str(getattr(entry, "label", "") or "") for entry in entries],
+        }
+    except Exception:
+        return {"logged_in": False, "pool_key": None, "credentials": 0}
+
+
+@app.get("/api/providers/custom")
+def list_custom_providers():
+    """Return v12+ config-based custom providers without exposing secrets."""
+    try:
+        cfg = load_config()
+        providers_cfg = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+        model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
+        current_provider = str(model_cfg.get("provider", "") or "")
+        rows = []
+        for provider_id, provider_cfg in sorted(providers_cfg.items()):
+            if not isinstance(provider_cfg, dict):
+                continue
+            base_url = str(
+                provider_cfg.get("base_url", "")
+                or provider_cfg.get("api", "")
+                or provider_cfg.get("url", "")
+                or ""
+            ).strip()
+            auth = _custom_provider_pool_status(base_url)
+            key_env = str(provider_cfg.get("key_env", "") or "").strip()
+            inline_api_key = str(provider_cfg.get("api_key", "") or "").strip()
+            env_has_key = bool(os.environ.get(key_env, "").strip()) if key_env else False
+            auth["logged_in"] = bool(auth.get("logged_in") or env_has_key or inline_api_key)
+            rows.append({
+                "slug": str(provider_id),
+                "name": str(provider_cfg.get("name", "") or provider_id),
+                "base_url": base_url,
+                "api_url": base_url,
+                "transport": str(provider_cfg.get("transport", "") or provider_cfg.get("api_mode", "") or "openai_chat"),
+                "key_env": key_env,
+                "discover_models": provider_cfg.get("discover_models", True),
+                "default_model": str(provider_cfg.get("default_model", "") or provider_cfg.get("model", "") or ""),
+                "models": _provider_config_to_model_list(provider_cfg),
+                "source": "user-config",
+                "is_user_defined": True,
+                "is_current": str(provider_id) == current_provider,
+                "auth": auth,
+            })
+        return {"providers": rows}
+    except Exception:
+        _log.exception("GET /api/providers/custom failed")
+        raise HTTPException(status_code=500, detail="Failed to list custom providers")
+
+
+@app.post("/api/providers/custom")
+def create_custom_provider(body: CustomProviderCreate):
+    """Add or update a v12+ providers: entry.
+
+    API keys are never written to config.yaml. When provided, they are stored in
+    the Hermes credential pool for the matching custom endpoint.
+    """
+    import re
+    import uuid
+
+    provider_id = (body.provider_id or "").strip()
+    if not provider_id:
+        raise HTTPException(status_code=400, detail="provider_id is required")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,95}", provider_id):
+        raise HTTPException(status_code=400, detail="provider_id may contain letters, numbers, dot, underscore, colon, or dash")
+
+    base_url = (body.base_url or "").strip().rstrip("/")
+    if not base_url.startswith(("http://", "https://")):
+        raise HTTPException(status_code=400, detail="base_url must start with http:// or https://")
+
+    transport = (body.transport or "openai_chat").strip()
+    allowed_transports = {"openai_chat", "chat_completions", "anthropic_messages", "codex_responses", "responses"}
+    if transport not in allowed_transports:
+        raise HTTPException(status_code=400, detail="unsupported transport")
+
+    try:
+        cfg = load_config()
+        providers_cfg = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+        entry = dict(providers_cfg.get(provider_id) or {})
+        entry["name"] = (body.name or provider_id).strip()
+        entry["base_url"] = base_url
+        entry["transport"] = transport
+        entry["discover_models"] = bool(body.discover_models)
+        if body.default_model.strip():
+            entry["default_model"] = body.default_model.strip()
+            models = entry.get("models") if isinstance(entry.get("models"), list) else []
+            if body.default_model.strip() not in models:
+                models = [body.default_model.strip(), *models]
+            entry["models"] = models
+        if body.key_env.strip():
+            entry["key_env"] = body.key_env.strip()
+        else:
+            entry.pop("key_env", None)
+        # Never persist plaintext secrets from the dashboard.
+        entry.pop("api_key", None)
+
+        providers_cfg[provider_id] = entry
+        cfg["providers"] = providers_cfg
+        save_config(cfg)
+
+        stored_credential = False
+        if body.api_key.strip():
+            from agent.credential_pool import (
+                AUTH_TYPE_API_KEY,
+                SOURCE_MANUAL,
+                PooledCredential,
+                get_custom_provider_pool_key,
+                load_pool,
+            )
+
+            pool_key = get_custom_provider_pool_key(base_url)
+            if not pool_key:
+                # get_custom_provider_pool_key depends on freshly saved config;
+                # this fallback keeps the secret usable even if compatibility
+                # lookup cannot see the new providers: entry for some reason.
+                pool_key = "custom:" + provider_id.lower().replace(" ", "-")
+            pool = load_pool(pool_key)
+            pool.add_entry(PooledCredential.from_dict(pool_key, {
+                "id": uuid.uuid4().hex[:6],
+                "label": entry["name"],
+                "auth_type": AUTH_TYPE_API_KEY,
+                "source": SOURCE_MANUAL,
+                "access_token": body.api_key.strip(),
+                "base_url": base_url,
+            }))
+            stored_credential = True
+
+        return {
+            "ok": True,
+            "provider": provider_id,
+            "stored_credential": stored_credential,
+            "entry": {
+                "slug": provider_id,
+                "name": entry.get("name", provider_id),
+                "base_url": base_url,
+                "api_url": base_url,
+                "transport": transport,
+                "default_model": entry.get("default_model", ""),
+                "models": _provider_config_to_model_list(entry),
+                "source": "user-config",
+                "is_user_defined": True,
+            },
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/providers/custom failed")
+        raise HTTPException(status_code=500, detail="Failed to save custom provider")
 
 
 @app.get("/api/model/options")

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -376,6 +376,7 @@
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.72rem;
   color: var(--color-foreground);
+  text-shadow: none;
 }
 
 .hermes-kanban-comment {
@@ -636,6 +637,8 @@
   padding: 0.05rem 0.3rem;
   background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
   border-radius: 3px;
+  color: var(--color-foreground);
+  text-shadow: none;
 }
 .hermes-kanban-md-code {
   margin: 0.35rem 0;
@@ -644,12 +647,15 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 0.25rem);
   overflow-x: auto;
+  color: var(--color-foreground);
+  text-shadow: none;
 }
 .hermes-kanban-md-code code {
   background: transparent;
   padding: 0;
   font-size: 0.75rem;
   white-space: pre;
+  color: inherit;
 }
 .hermes-kanban-md strong { font-weight: 600; }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -606,8 +606,11 @@
 /* ---- Markdown rendering -------------------------------------------- */
 
 .hermes-kanban-md {
+  font-family: var(--theme-font-sans, var(--font-sans, system-ui, sans-serif));
   font-size: 0.8rem;
   line-height: 1.55;
+  letter-spacing: normal;
+  text-transform: none;
   color: var(--color-foreground);
 }
 .hermes-kanban-md p  { margin: 0.25rem 0; }

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -413,6 +413,8 @@
 }
 .hermes-kanban-event-payload {
   color: var(--color-muted-foreground);
+  background: transparent;
+  text-shadow: none;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -606,7 +608,7 @@
 /* ---- Markdown rendering -------------------------------------------- */
 
 .hermes-kanban-md {
-  font-family: var(--theme-font-sans, var(--font-sans, system-ui, sans-serif));
+  font-family: inherit;
   font-size: 0.8rem;
   line-height: 1.55;
   letter-spacing: normal;
@@ -763,6 +765,8 @@
   font-size: 0.65rem;
   padding: 0.15rem 0 0;
   color: var(--color-muted-foreground);
+  background: transparent;
+  text-shadow: none;
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, ui-monospace, monospace);

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -513,13 +513,21 @@ class HonchoMemoryProvider(MemoryProvider):
                 )
             return ""
 
+        silent_context_rule = (
+            " Memory context is model-facing background, not user-authored message text. "
+            "Use injected memory silently. Never say the user pasted, provided, sent, or showed "
+            "memory context. Do not mention <memory-context>, hidden blocks, recalled context, "
+            "injected context, memory provenance, or memory source unless the user explicitly asks "
+            "to debug memory/Honcho internals."
+        )
+
         # ----- B1: adapt text based on recall_mode -----
         if self._recall_mode == "context":
             header = (
                 "# Honcho Memory\n"
                 "Active (context-injection mode). Relevant user context is automatically "
                 "injected before each turn. No memory tools are available — context is "
-                "managed automatically."
+                "managed automatically." + silent_context_rule
             )
         elif self._recall_mode == "tools":
             header = (
@@ -539,7 +547,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 "honcho_search for raw excerpts, honcho_context for raw peer context, "
                 "honcho_reasoning for synthesized answers (pass reasoning_level "
                 "minimal/low/medium/high/max — you pick the depth per call), "
-                "honcho_conclude to save facts about the user."
+                "honcho_conclude to save facts about the user." + silent_context_rule
             )
 
         return header

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -629,6 +629,17 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
     assert data["render_markdown"] is False
 
 
+def test_markdown_code_uses_theme_foreground_for_contrast():
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert ".hermes-kanban-md code" in css
+    assert "color: var(--color-foreground);" in css
+    assert ".hermes-kanban-md-code code" in css
+    assert "color: inherit;" in css
+    assert "text-shadow: none;" in css
+
+
 # ---------------------------------------------------------------------------
 # Runs surfacing (vulcan-artivus RFC feedback)
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -645,12 +645,25 @@ def test_markdown_prose_preserves_source_casing_and_normal_font():
     css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
 
     assert ".hermes-kanban-md {" in css
-    assert "font-family: var(--theme-font-sans" in css
+    assert "font-family: inherit;" in css
     assert "letter-spacing: normal;" in css
     assert "text-transform: none;" in css
     assert "font-family: var(--theme-font-mono" not in css
     assert ".hermes-kanban-md code" in css
     assert "font-family: var(--font-mono, ui-monospace, monospace);" in css
+
+
+def test_drawer_json_code_chips_do_not_inherit_global_highlight_background():
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    event_payload = css[css.index(".hermes-kanban-event-payload {"):css.index(".hermes-kanban-drawer-comment-row {")]
+    assert "background: transparent;" in event_payload
+    assert "text-shadow: none;" in event_payload
+
+    run_meta = css[css.index(".hermes-kanban-run-meta {"):]
+    assert "background: transparent;" in run_meta
+    assert "text-shadow: none;" in run_meta
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -640,6 +640,19 @@ def test_markdown_code_uses_theme_foreground_for_contrast():
     assert "text-shadow: none;" in css
 
 
+def test_markdown_prose_preserves_source_casing_and_normal_font():
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert ".hermes-kanban-md {" in css
+    assert "font-family: var(--theme-font-sans" in css
+    assert "letter-spacing: normal;" in css
+    assert "text-transform: none;" in css
+    assert "font-family: var(--theme-font-mono" not in css
+    assert ".hermes-kanban-md code" in css
+    assert "font-family: var(--font-mono, ui-monospace, monospace);" in css
+
+
 # ---------------------------------------------------------------------------
 # Runs surfacing (vulcan-artivus RFC feedback)
 # ---------------------------------------------------------------------------

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -500,6 +499,31 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1676,7 +1700,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1687,7 +1710,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1698,7 +1720,6 @@
       "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -1728,7 +1749,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2046,7 +2066,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2449,7 +2468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3185,7 +3203,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3317,7 +3334,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4226,7 +4242,6 @@
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
       "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "type-fest": "^4.18.2"
@@ -5663,7 +5678,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5773,7 +5787,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6598,7 +6611,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6725,7 +6737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6835,7 +6846,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7251,7 +7261,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -91,6 +91,14 @@ export const api = {
       body: JSON.stringify({ yaml_text }),
     }),
   getEnvVars: () => fetchJSON<Record<string, EnvVarInfo>>("/api/env"),
+  getCustomProviders: () =>
+    fetchJSON<CustomProvidersResponse>("/api/providers/custom"),
+  createCustomProvider: (body: CustomProviderCreateRequest) =>
+    fetchJSON<CustomProviderCreateResponse>("/api/providers/custom", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
   setEnvVar: (key: string, value: string) =>
     fetchJSON<{ ok: boolean }>("/api/env", {
       method: "PUT",
@@ -393,6 +401,52 @@ export interface EnvVarInfo {
   advanced: boolean;
 }
 
+
+export interface CustomProviderAuthStatus {
+  logged_in: boolean;
+  pool_key?: string | null;
+  credentials?: number;
+  labels?: string[];
+}
+
+export interface CustomProviderInfo {
+  slug: string;
+  name: string;
+  base_url: string;
+  api_url?: string;
+  transport: string;
+  key_env?: string;
+  discover_models?: boolean;
+  default_model?: string;
+  models?: string[];
+  source?: string;
+  is_user_defined?: boolean;
+  is_current?: boolean;
+  auth?: CustomProviderAuthStatus;
+}
+
+export interface CustomProvidersResponse {
+  providers: CustomProviderInfo[];
+}
+
+export interface CustomProviderCreateRequest {
+  provider_id: string;
+  name?: string;
+  base_url: string;
+  default_model?: string;
+  api_key?: string;
+  key_env?: string;
+  transport?: string;
+  discover_models?: boolean;
+}
+
+export interface CustomProviderCreateResponse {
+  ok: boolean;
+  provider: string;
+  stored_credential: boolean;
+  entry: CustomProviderInfo;
+}
+
 export interface SessionMessage {
   role: "user" | "assistant" | "system" | "tool";
   content: string | null;
@@ -593,6 +647,7 @@ export interface ModelOptionProvider {
   is_user_defined?: boolean;
   source?: string;
   warning?: string;
+  api_url?: string;
 }
 
 export interface ModelOptionsResponse {

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -5,6 +5,7 @@ import {
   ExternalLink,
   KeyRound,
   MessageSquare,
+  Plus,
   Pencil,
   Save,
   Settings,
@@ -15,7 +16,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { EnvVarInfo } from "@/lib/api";
+import type { CustomProviderInfo, EnvVarInfo } from "@/lib/api";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { Toast } from "@/components/Toast";
 import { useConfirmDelete } from "@/hooks/useConfirmDelete";
@@ -481,25 +482,139 @@ function ProviderGroupCard({
   );
 }
 
+
+/* ------------------------------------------------------------------ */
+/*  CustomProviderCard — config-backed providers                       */
+/* ------------------------------------------------------------------ */
+
+function CustomProviderCard({ provider }: { provider: CustomProviderInfo }) {
+  const [expanded, setExpanded] = useState(false);
+  const models = provider.models ?? [];
+  const loggedIn = !!provider.auth?.logged_in;
+  const credentialCount = provider.auth?.credentials ?? 0;
+
+  return (
+    <div className="border border-border bg-primary/5">
+      <ListItem
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="justify-between gap-3 px-4 py-3 hover:bg-primary/10"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-semibold text-sm tracking-wide truncate">
+                {provider.name || provider.slug}
+              </span>
+              <Badge tone="secondary" className="text-[0.6rem]">
+                custom
+              </Badge>
+              {provider.is_current && (
+                <Badge tone="success" className="text-[0.6rem]">
+                  current
+                </Badge>
+              )}
+              {loggedIn && (
+                <Badge tone="success" className="text-[0.6rem]">
+                  authenticated{credentialCount > 1 ? ` ×${credentialCount}` : ""}
+                </Badge>
+              )}
+            </div>
+            <div className="font-mono-ui text-[0.65rem] text-muted-foreground truncate">
+              {provider.slug}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-[0.65rem] text-muted-foreground/60">
+            {models.length} model{models.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </ListItem>
+
+      {expanded && (
+        <div className="border-t border-border px-4 py-3 grid gap-3">
+          <div className="grid gap-1">
+            <span className="text-[0.65rem] uppercase tracking-wide text-muted-foreground/70">
+              Endpoint
+            </span>
+            <code className="font-mono-ui text-xs break-all bg-muted/30 border border-border px-2 py-1">
+              {provider.base_url || provider.api_url || "---"}
+            </code>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
+            <div className="border border-border px-2 py-1.5">
+              <div className="text-[0.65rem] text-muted-foreground/70 uppercase tracking-wide">Transport</div>
+              <div className="font-mono-ui">{provider.transport || "openai_chat"}</div>
+            </div>
+            <div className="border border-border px-2 py-1.5">
+              <div className="text-[0.65rem] text-muted-foreground/70 uppercase tracking-wide">Auth</div>
+              <div>{loggedIn ? "Credential pool" : provider.key_env ? provider.key_env : "Not connected"}</div>
+            </div>
+            <div className="border border-border px-2 py-1.5">
+              <div className="text-[0.65rem] text-muted-foreground/70 uppercase tracking-wide">Models</div>
+              <div>{models.length || 0}</div>
+            </div>
+          </div>
+          {models.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {models.map((model) => (
+                <Badge key={model} tone="outline" className="text-[0.6rem] py-0 px-1.5">
+                  {model}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main page                                                          */
 /* ------------------------------------------------------------------ */
 
 export default function EnvPage() {
   const [vars, setVars] = useState<Record<string, EnvVarInfo> | null>(null);
+  const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [revealed, setRevealed] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(true); // Show all providers by default
+  const [showAddProvider, setShowAddProvider] = useState(false);
+  const [addingProvider, setAddingProvider] = useState(false);
+  const [providerForm, setProviderForm] = useState({
+    provider_id: "",
+    name: "",
+    base_url: "",
+    default_model: "",
+    api_key: "",
+    key_env: "",
+    transport: "openai_chat",
+  });
   const { toast, showToast } = useToast();
   const { t } = useI18n();
+
+  const refreshCustomProviders = useCallback(() => {
+    api
+      .getCustomProviders()
+      .then((resp) => setCustomProviders(resp.providers ?? []))
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     api
       .getEnvVars()
       .then(setVars)
       .catch(() => {});
-  }, []);
+    refreshCustomProviders();
+  }, [refreshCustomProviders]);
 
   const handleSave = async (key: string) => {
     const value = edits[key];
@@ -598,6 +713,42 @@ export default function EnvPage() {
     });
   };
 
+  const handleAddProvider = async () => {
+    if (!providerForm.provider_id.trim() || !providerForm.base_url.trim()) {
+      showToast("Provider id and base URL are required", "error");
+      return;
+    }
+    setAddingProvider(true);
+    try {
+      await api.createCustomProvider({
+        provider_id: providerForm.provider_id.trim(),
+        name: providerForm.name.trim() || providerForm.provider_id.trim(),
+        base_url: providerForm.base_url.trim(),
+        default_model: providerForm.default_model.trim(),
+        api_key: providerForm.api_key.trim(),
+        key_env: providerForm.key_env.trim(),
+        transport: providerForm.transport.trim() || "openai_chat",
+        discover_models: true,
+      });
+      showToast(`${providerForm.provider_id.trim()} added`, "success");
+      setProviderForm({
+        provider_id: "",
+        name: "",
+        base_url: "",
+        default_model: "",
+        api_key: "",
+        key_env: "",
+        transport: "openai_chat",
+      });
+      setShowAddProvider(false);
+      refreshCustomProviders();
+    } catch (e) {
+      showToast(`Failed to add provider: ${e}`, "error");
+    } finally {
+      setAddingProvider(false);
+    }
+  };
+
   /* ---- Build provider groups ---- */
   const { providerGroups, nonProviderGrouped } = useMemo(() => {
     if (!vars) return { providerGroups: [], nonProviderGrouped: [] };
@@ -658,8 +809,10 @@ export default function EnvPage() {
     );
   }
 
-  const totalProviders = providerGroups.length;
-  const configuredProviders = providerGroups.filter((g) => g.hasAnySet).length;
+  const totalProviders = providerGroups.length + customProviders.length;
+  const configuredProviders =
+    providerGroups.filter((g) => g.hasAnySet).length +
+    customProviders.filter((p) => p.auth?.logged_in || (p.models?.length ?? 0) > 0 || p.key_env).length;
 
   const pendingClearKey = keyClear.pendingId;
   const pendingKeyDescription =
@@ -708,18 +861,110 @@ export default function EnvPage() {
 
       <Card>
         <CardHeader className="border-b border-border bg-card">
-          <div className="flex items-center gap-2">
-            <Zap className="h-5 w-5 text-muted-foreground" />
-            <CardTitle className="text-base">{t.env.llmProviders}</CardTitle>
+          <div className="flex items-start justify-between gap-3">
+            <div className="grid gap-1">
+              <div className="flex items-center gap-2">
+                <Zap className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">{t.env.llmProviders}</CardTitle>
+              </div>
+              <CardDescription>
+                {t.env.providersConfigured
+                  .replace("{configured}", String(configuredProviders))
+                  .replace("{total}", String(totalProviders))}
+              </CardDescription>
+            </div>
+            <Button
+              size="sm"
+              outlined
+              prefix={<Plus />}
+              onClick={() => setShowAddProvider((v) => !v)}
+            >
+              Add Provider
+            </Button>
           </div>
-          <CardDescription>
-            {t.env.providersConfigured
-              .replace("{configured}", String(configuredProviders))
-              .replace("{total}", String(totalProviders))}
-          </CardDescription>
         </CardHeader>
 
         <CardContent className="grid gap-0 p-0">
+          {showAddProvider && (
+            <div className="border-b border-border bg-muted/20 p-4 grid gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="grid gap-1.5">
+                  <Label className="text-[0.7rem]">Provider ID</Label>
+                  <Input
+                    value={providerForm.provider_id}
+                    onChange={(e) => setProviderForm((p) => ({ ...p, provider_id: e.target.value }))}
+                    placeholder="example.provider"
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label className="text-[0.7rem]">Display name</Label>
+                  <Input
+                    value={providerForm.name}
+                    onChange={(e) => setProviderForm((p) => ({ ...p, name: e.target.value }))}
+                    placeholder="Example Provider"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-1.5">
+                <Label className="text-[0.7rem]">Base URL</Label>
+                <Input
+                  value={providerForm.base_url}
+                  onChange={(e) => setProviderForm((p) => ({ ...p, base_url: e.target.value }))}
+                  placeholder="https://api.example.com/v1"
+                />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="grid gap-1.5">
+                  <Label className="text-[0.7rem]">Default model</Label>
+                  <Input
+                    value={providerForm.default_model}
+                    onChange={(e) => setProviderForm((p) => ({ ...p, default_model: e.target.value }))}
+                    placeholder="model-id"
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label className="text-[0.7rem]">Transport</Label>
+                  <Input
+                    value={providerForm.transport}
+                    onChange={(e) => setProviderForm((p) => ({ ...p, transport: e.target.value }))}
+                    placeholder="openai_chat"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="grid gap-1.5">
+                  <Label className="text-[0.7rem]">API key</Label>
+                  <Input
+                    type="password"
+                    value={providerForm.api_key}
+                    onChange={(e) => setProviderForm((p) => ({ ...p, api_key: e.target.value }))}
+                    placeholder="stored in Hermes auth, not config.yaml"
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label className="text-[0.7rem]">Key env var</Label>
+                  <Input
+                    value={providerForm.key_env}
+                    onChange={(e) => setProviderForm((p) => ({ ...p, key_env: e.target.value }))}
+                    placeholder="OPTIONAL_API_KEY"
+                  />
+                </div>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button size="sm" outlined onClick={() => setShowAddProvider(false)} disabled={addingProvider}>
+                  {t.common.cancel}
+                </Button>
+                <Button size="sm" prefix={<Save />} onClick={handleAddProvider} disabled={addingProvider}>
+                  {addingProvider ? "..." : "Save Provider"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {customProviders.map((provider) => (
+            <CustomProviderCard key={provider.slug} provider={provider} />
+          ))}
+
           {providerGroups.map((group) => (
             <ProviderGroupCard
               key={group.name}


### PR DESCRIPTION
## Summary
- surface config-backed custom providers in the dashboard LLM Providers card
- add an Add Provider form that writes providers: config and stores pasted API keys in the Hermes credential pool, not config.yaml
- add protected custom-provider API endpoints and keep credential-pool lookup working for mixed custom_providers/providers configs
- tolerate trailing-root-dot FQDN Host headers for dashboard hostname binds

## Verification
- venv/bin/python -m py_compile hermes_cli/web_server.py agent/credential_pool.py
- cd web && npm run build
- live dashboard curl verified /api/providers/custom returns synthetic.new authenticated with 7 models
- attempted full suite with venv/bin/python -m pytest tests/ -v; it timed out after 600s around 66% and exposed an unrelated-looking existing failure in tests/run_agent/test_anthropic_error_handling.py::test_529_overloaded_is_retried_and_recovers, which also fails when isolated with a 30s test timeout

## Platforms tested
- Linux momo-hermes-2404, Ubuntu kernel 6.8.0-110-generic x86_64
- Python 3.11.15
- Node v22.22.2 / npm 10.9.7
- Hermes Agent v0.12.0

## Notes
- Browser visual QA via the browser tool could not run in my hermes container but I verified it from my mac :)
