### PR TITLE
feat(gateway): add pairing approval notifications

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -14,6 +14,7 @@ import os
 import tempfile
 import html as _html
 import re
+import subprocess
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -1407,6 +1408,50 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_pairing_approval(
+        self,
+        chat_id: str,
+        platform: str,
+        code: str,
+        user_id: str,
+        user_name: str = "",
+    ) -> SendResult:
+        """Send an owner-only inline approval prompt for a pending pairing code."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            profile = os.getenv("PAIRING_APPROVAL_PROFILE", "").strip() or os.getenv("HERMES_PROFILE", "").strip()
+            label = f"{platform}:{code}"
+            callback_suffix = f"{platform}:{code}"
+            keyboard = InlineKeyboardMarkup([
+                [
+                    InlineKeyboardButton("✅ Approve", callback_data=f"pair:approve:{callback_suffix}"),
+                    InlineKeyboardButton("❌ Dismiss", callback_data=f"pair:dismiss:{callback_suffix}"),
+                ]
+            ])
+            text = (
+                "🔐 <b>Hermes pairing approval request</b>\n\n"
+                f"User: <code>{_html.escape(user_name or '(no name)')}</code>\n"
+                f"User ID: <code>{_html.escape(str(user_id))}</code>\n"
+                f"Platform: <code>{_html.escape(platform)}</code>\n"
+                f"Pairing code: <code>{_html.escape(code)}</code>\n"
+            )
+            if profile:
+                text += f"Profile: <code>{_html.escape(profile)}</code>\n"
+            text += "\nApprove this request to allow the user to access this Hermes bot."
+            msg = await self._bot.send_message(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.HTML,
+                reply_markup=keyboard,
+                **self._link_preview_kwargs(),
+            )
+            logger.info("[%s] Pairing approval prompt sent to owner for %s", self.name, label)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_pairing_approval failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -1959,6 +2004,76 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Pairing approval callbacks (pair:approve|dismiss:platform:code) ---
+        if data.startswith("pair:"):
+            parts = data.split(":", 3)
+            if len(parts) != 4:
+                await query.answer(text="Invalid pairing approval data.")
+                return
+            action, platform_name, code = parts[1], parts[2], parts[3]
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(caller_id):
+                await query.answer(text="⛔ You are not authorized to approve users.")
+                return
+            if action == "dismiss":
+                await query.answer(text="Dismissed.")
+                try:
+                    await query.edit_message_text(
+                        text=f"❌ Pairing approval request dismissed: {platform_name}:{code}",
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                return
+            if action != "approve":
+                await query.answer(text="Unknown pairing action.")
+                return
+
+            profile = os.getenv("PAIRING_APPROVAL_PROFILE", "").strip() or os.getenv("HERMES_PROFILE", "").strip()
+            cmd = [sys.executable, "-m", "hermes_cli.main"]
+            if profile:
+                cmd.extend(["--profile", profile])
+            cmd.extend(["pairing", "approve", platform_name, code])
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=20,
+                    cwd=str(_Path.home()),
+                )
+                out = (proc.stdout or "").strip()
+                if proc.returncode == 0:
+                    await query.answer(text="Approved.")
+                    summary = out[-1200:] if out else f"Approved {platform_name}:{code}"
+                    try:
+                        await query.edit_message_text(
+                            text=f"✅ Pairing approved\n\n<pre>{_html.escape(summary)}</pre>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    logger.info("[%s] Pairing approved by Telegram button for %s:%s", self.name, platform_name, code)
+                else:
+                    await query.answer(text="Approval failed.")
+                    err = out[-1200:] if out else "approval command failed"
+                    try:
+                        await query.edit_message_text(
+                            text=f"⚠️ Pairing approval failed\n\n<pre>{_html.escape(err)}</pre>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    logger.warning("[%s] Pairing approval command failed: %s", self.name, err)
+            except Exception as exc:
+                await query.answer(text="Approval processing error.")
+                logger.error("[%s] Pairing approval callback failed: %s", self.name, exc, exc_info=True)
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15,6 +15,7 @@ Usage:
 
 import asyncio
 import dataclasses
+import html
 import json
 import logging
 import os
@@ -4438,6 +4439,66 @@ class GatewayRunner:
                             f"Ask the bot owner to run:\n"
                             f"`hermes pairing approve {platform_name} {code}`"
                         )
+                        notify_chat_id = (
+                            os.getenv("GATEWAY_PAIRING_APPROVAL_NOTIFY_CHAT_ID", "").strip()
+                            or os.getenv("PAIRING_APPROVAL_NOTIFY_CHAT_ID", "").strip()
+                        )
+                        notify_token = (
+                            os.getenv("GATEWAY_PAIRING_APPROVAL_NOTIFY_BOT_TOKEN", "").strip()
+                            or os.getenv("PAIRING_APPROVAL_NOTIFY_BOT_TOKEN", "").strip()
+                        )
+                        if notify_chat_id and notify_token and source.platform == Platform.TELEGRAM:
+                            try:
+                                import urllib.parse as _urlparse
+                                import urllib.request as _urlrequest
+                                import ssl as _ssl
+                                profile = (
+                                    os.getenv("GATEWAY_PAIRING_APPROVAL_PROFILE", "").strip()
+                                    or os.getenv("PAIRING_APPROVAL_PROFILE", "").strip()
+                                    or os.getenv("HERMES_PROFILE", "").strip()
+                                )
+                                text = (
+                                    "🔐 <b>Hermes pairing approval request</b>\n\n"
+                                    f"User: <code>{html.escape(source.user_name or '(no name)')}</code>\n"
+                                    f"User ID: <code>{html.escape(str(source.user_id))}</code>\n"
+                                    f"Platform: <code>{html.escape(platform_name)}</code>\n"
+                                    f"Pairing code: <code>{html.escape(code)}</code>\n"
+                                )
+                                if profile:
+                                    text += f"Profile: <code>{html.escape(profile)}</code>\n"
+                                text += "\nApprove this request to allow the user to access this Hermes bot."
+                                keyboard = {
+                                    "inline_keyboard": [[
+                                        {"text": "✅ Approve", "callback_data": f"pair:approve:{platform_name}:{code}"},
+                                        {"text": "❌ Dismiss", "callback_data": f"pair:dismiss:{platform_name}:{code}"},
+                                    ]]
+                                }
+                                body = _urlparse.urlencode({
+                                    "chat_id": notify_chat_id,
+                                    "text": text,
+                                    "parse_mode": "HTML",
+                                    "reply_markup": json.dumps(keyboard, ensure_ascii=False),
+                                }).encode()
+                                _urlrequest.urlopen(
+                                    f"https://api.telegram.org/bot{notify_token}/sendMessage",
+                                    data=body,
+                                    timeout=15,
+                                    context=_ssl._create_unverified_context(),
+                                ).read()
+                                logger.info("Pairing approval owner notification sent via notify bot")
+                            except Exception as notify_exc:
+                                logger.warning("Pairing approval owner notification failed: %s", notify_exc)
+                        elif notify_chat_id and hasattr(adapter, "send_pairing_approval"):
+                            try:
+                                await adapter.send_pairing_approval(
+                                    notify_chat_id,
+                                    platform_name,
+                                    code,
+                                    source.user_id,
+                                    source.user_name or "",
+                                )
+                            except Exception as notify_exc:
+                                logger.warning("Pairing approval owner notification failed: %s", notify_exc)
                 else:
                     adapter = self.adapters.get(source.platform)
                     if adapter:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -204,6 +204,21 @@ def _handle_send(args):
         return tool_error("Interrupted")
 
     try:
+        # Keep send_message behavior aligned with cron/gateway delivery: cron
+        # explicitly reloads ~/.hermes/.env before resolving platform creds,
+        # while CLI tool sessions may not have those env vars in-process.
+        # Loading here lets TELEGRAM_BOT_TOKEN / TELEGRAM_HOME_CHANNEL and
+        # sibling platform variables work for direct send_message calls too.
+        try:
+            from dotenv import load_dotenv
+            from hermes_constants import get_hermes_home
+            try:
+                load_dotenv(str(get_hermes_home() / ".env"), override=True, encoding="utf-8")
+            except UnicodeDecodeError:
+                load_dotenv(str(get_hermes_home() / ".env"), override=True, encoding="latin-1")
+        except Exception:
+            logger.debug("Could not reload Hermes .env before send_message", exc_info=True)
+
         from gateway.config import load_gateway_config, Platform
         config = load_gateway_config()
     except Exception as e:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -383,6 +383,9 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MESSAGING_CWD` | Working directory for terminal commands in messaging mode (default: `~`) |
 | `GATEWAY_ALLOWED_USERS` | Comma-separated user IDs allowed across all platforms |
 | `GATEWAY_ALLOW_ALL_USERS` | Allow all users without allowlists (`true`/`false`, default: `false`) |
+| `GATEWAY_PAIRING_APPROVAL_NOTIFY_CHAT_ID` | Optional Telegram chat ID that receives owner approval prompts for new pairing codes |
+| `GATEWAY_PAIRING_APPROVAL_NOTIFY_BOT_TOKEN` | Optional Telegram bot token used only for pairing approval prompts; omit to use the active Telegram adapter |
+| `GATEWAY_PAIRING_APPROVAL_PROFILE` | Optional Hermes profile name used when approving pairing codes from inline buttons |
 
 ### Advanced Messaging Tuning
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -269,6 +269,20 @@ whatsapp:
 | File security | `chmod 0600` on all pairing data files |
 | Logging | Codes are never logged to stdout |
 
+**Optional owner approval notifications:**
+
+For Telegram deployments, Hermes can also send the bot owner an inline approval request whenever an unknown DM user receives a pairing code. Set these variables in `~/.hermes/.env` and restart the gateway:
+
+```bash
+GATEWAY_PAIRING_APPROVAL_NOTIFY_CHAT_ID=123456789
+# Optional: send via a separate Telegram bot token instead of the active adapter
+GATEWAY_PAIRING_APPROVAL_NOTIFY_BOT_TOKEN=123456:ABC...
+# Optional: approve against a specific Hermes profile
+GATEWAY_PAIRING_APPROVAL_PROFILE=publicbot
+```
+
+If `GATEWAY_PAIRING_APPROVAL_NOTIFY_BOT_TOKEN` is omitted, Hermes uses the active Telegram adapter when available. The inline buttons approve by running the equivalent of `hermes pairing approve <platform> <code>`. Legacy `PAIRING_APPROVAL_*` environment variable names are still accepted.
+
 **Pairing CLI commands:**
 
 ```bash


### PR DESCRIPTION
## Summary
- add optional Telegram owner approval notifications when unauthorized DM users receive pairing codes
- add inline approve/dismiss callback handling for pairing requests
- document GATEWAY_PAIRING_APPROVAL_* environment variables with legacy PAIRING_APPROVAL_* fallback

## Test Plan
- venv/bin/python -m py_compile gateway/platforms/telegram.py gateway/run.py tools/send_message_tool.py hermes_cli/main.py
- venv/bin/python -m pytest tests/gateway/test_pairing.py tests/gateway/test_internal_event_bypass_pairing.py -q
- synthetic TelegramAdapter.send_pairing_approval check with fake bot