### PR TITLE
fix: use _message_thread_id_for_send in send_model_picker

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1568,7 +1568,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 text=text,
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=keyboard,
-                message_thread_id=int(thread_id) if thread_id else None,
+                message_thread_id=self._message_thread_id_for_send(thread_id),
                 **self._link_preview_kwargs(),
             )
 


### PR DESCRIPTION
## Problem

`send_model_picker` in the Telegram adapter uses raw `int(thread_id) if thread_id else None` for `message_thread_id`, bypassing the `_message_thread_id_for_send` helper. This helper maps the General topic (`thread_id="1"`) to `None`, which is required because the Telegram Bot API rejects `message_thread_id=1` with `Message thread not found` in forum groups.

As a result, `/model` in the General topic of a forum group fails to show the interactive inline keyboard picker, falling back to the plain text list.

## Fix

One-line change: replace the raw `int()` conversion with the existing `_message_thread_id_for_send()` helper, consistent with all other send methods in the adapter.

## Testing

Verified the issue in gateway logs:
```
send_model_picker failed: Message thread not found
```

All other send methods (`send_message`, `send_voice`, `send_image_file`, etc.) already use the helper correctly — `send_model_picker` was the only one still using raw conversion.