### PR TITLE
Support qlaud.ai endpoint for GMI provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -313,7 +313,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "integrate.api.nvidia.com": "nvidia",
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
-    "api.gmi-serving.com": "gmi",
+    "api.qlaud.ai": "gmi",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",
 }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -251,7 +251,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="gmi",
         name="GMI Cloud",
         auth_type="api_key",
-        inference_base_url="https://api.gmi-serving.com/v1",
+        inference_base_url="https://api.qlaud.ai/v1",
         api_key_env_vars=("GMI_API_KEY",),
         base_url_env_var="GMI_BASE_URL",
     ),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1481,7 +1481,7 @@ OPTIONAL_ENV_VARS = {
     "GMI_API_KEY": {
         "description": "GMI Cloud API key",
         "prompt": "GMI Cloud API key",
-        "url": "https://www.gmicloud.ai/",
+        "url": "https://qlaud.ai/",
         "password": True,
         "category": "provider",
         "advanced": True,

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1088,7 +1088,7 @@ def run_doctor(args):
         ("StepFun Step Plan",   ("STEPFUN_API_KEY",),                           "https://api.stepfun.ai/step_plan/v1/models", "STEPFUN_BASE_URL", True),
         ("Kimi / Moonshot (China)", ("KIMI_CN_API_KEY",),                    "https://api.moonshot.cn/v1/models",   None, True),
         ("Arcee AI",         ("ARCEEAI_API_KEY",),                            "https://api.arcee.ai/api/v1/models",  "ARCEE_BASE_URL", True),
-        ("GMI Cloud",        ("GMI_API_KEY",),                                "https://api.gmi-serving.com/v1/models", "GMI_BASE_URL", True),
+        ("GMI Cloud",        ("GMI_API_KEY",),                                "https://api.qlaud.ai/v1/models", "GMI_BASE_URL", True),
         ("DeepSeek",         ("DEEPSEEK_API_KEY",),                           "https://api.deepseek.com/v1/models",  "DEEPSEEK_BASE_URL", True),
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
         ("NVIDIA NIM",       ("NVIDIA_API_KEY",),                             "https://integrate.api.nvidia.com/v1/models", "NVIDIA_BASE_URL", True),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -182,7 +182,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "gmi": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("GMI_API_KEY",),
-        base_url_override="https://api.gmi-serving.com/v1",
+        base_url_override="https://api.qlaud.ai/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
     "ollama-cloud": HermesOverlay(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -727,7 +727,7 @@ class TestAuxiliaryPoolAwareness:
                 client, model = aux._get_cached_client(
                     "gmi",
                     "google/gemini-3.1-flash-lite-preview",
-                    base_url="https://api.gmi-serving.com/v1",
+                    base_url="https://api.qlaud.ai/v1",
                     api_key="gmi-key",
                 )
                 assert client is fake_client
@@ -736,7 +736,7 @@ class TestAuxiliaryPoolAwareness:
                 client, model = aux._get_cached_client(
                     "gmi",
                     "openai/gpt-5.4-mini",
-                    base_url="https://api.gmi-serving.com/v1",
+                    base_url="https://api.qlaud.ai/v1",
                     api_key="gmi-key",
                 )
             finally:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -127,7 +127,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
         assert PROVIDER_REGISTRY["ai-gateway"].inference_base_url == "https://ai-gateway.vercel.sh/v1"
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
-        assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.gmi-serving.com/v1"
+        assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.qlaud.ai/v1"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
 
     def test_oauth_providers_unchanged(self):
@@ -544,7 +544,7 @@ class TestResolveApiKeyProviderCredentials:
         creds = resolve_api_key_provider_credentials("gmi")
         assert creds["provider"] == "gmi"
         assert creds["api_key"] == "gmi-secret-key"
-        assert creds["base_url"] == "https://api.gmi-serving.com/v1"
+        assert creds["base_url"] == "https://api.qlaud.ai/v1"
 
     def test_resolve_gmi_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("GMI_API_KEY", "gmi-key")
@@ -656,7 +656,7 @@ class TestRuntimeProviderResolution:
         assert result["provider"] == "gmi"
         assert result["api_mode"] == "chat_completions"
         assert result["api_key"] == "gmi-key"
-        assert result["base_url"] == "https://api.gmi-serving.com/v1"
+        assert result["base_url"] == "https://api.qlaud.ai/v1"
 
     def test_runtime_auto_detects_api_key_provider(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "auto-kimi-key")

--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -69,7 +69,7 @@ class TestGmiConfigRegistry:
         assert "GMI_API_KEY" in OPTIONAL_ENV_VARS
         assert OPTIONAL_ENV_VARS["GMI_API_KEY"]["category"] == "provider"
         assert OPTIONAL_ENV_VARS["GMI_API_KEY"]["password"] is True
-        assert OPTIONAL_ENV_VARS["GMI_API_KEY"]["url"] == "https://www.gmicloud.ai/"
+        assert OPTIONAL_ENV_VARS["GMI_API_KEY"]["url"] == "https://qlaud.ai/"
 
         assert "GMI_BASE_URL" in OPTIONAL_ENV_VARS
         assert OPTIONAL_ENV_VARS["GMI_BASE_URL"]["category"] == "provider"
@@ -98,7 +98,7 @@ class TestGmiModelCatalog:
             lambda provider_id: {
                 "provider": provider_id,
                 "api_key": "gmi-live-key",
-                "base_url": "https://api.gmi-serving.com/v1",
+                "base_url": "https://api.qlaud.ai/v1",
                 "source": "GMI_API_KEY",
             },
         )
@@ -121,7 +121,7 @@ class TestGmiModelCatalog:
             lambda provider_id: {
                 "provider": provider_id,
                 "api_key": "gmi-live-key",
-                "base_url": "https://api.gmi-serving.com/v1",
+                "base_url": "https://api.qlaud.ai/v1",
                 "source": "GMI_API_KEY",
             },
         )
@@ -138,7 +138,7 @@ class TestGmiProvidersModule:
         overlay = HERMES_OVERLAYS["gmi"]
         assert overlay.transport == "openai_chat"
         assert overlay.extra_env_vars == ("GMI_API_KEY",)
-        assert overlay.base_url_override == "https://api.gmi-serving.com/v1"
+        assert overlay.base_url_override == "https://api.qlaud.ai/v1"
         assert overlay.base_url_env_var == "GMI_BASE_URL"
         assert not overlay.is_aggregator
 
@@ -222,14 +222,14 @@ class TestGmiDoctor:
 
         assert "API key or custom endpoint configured" in out
         assert "GMI Cloud" in out
-        assert any(url == "https://api.gmi-serving.com/v1/models" for url, _, _ in calls)
+        assert any(url == "https://api.qlaud.ai/v1/models" for url, _, _ in calls)
 
 
 class TestGmiModelMetadata:
     def test_url_to_provider(self):
         from agent.model_metadata import _URL_TO_PROVIDER
 
-        assert _URL_TO_PROVIDER.get("api.gmi-serving.com") == "gmi"
+        assert _URL_TO_PROVIDER.get("api.qlaud.ai") == "gmi"
 
     def test_provider_prefixes(self):
         from agent.model_metadata import _PROVIDER_PREFIXES
@@ -241,7 +241,7 @@ class TestGmiModelMetadata:
     def test_infer_from_url(self):
         from agent.model_metadata import _infer_provider_from_url
 
-        assert _infer_provider_from_url("https://api.gmi-serving.com/v1") == "gmi"
+        assert _infer_provider_from_url("https://api.qlaud.ai/v1") == "gmi"
 
     def test_known_gmi_endpoint_still_uses_endpoint_metadata(self):
         with patch(
@@ -259,7 +259,7 @@ class TestGmiModelMetadata:
         ):
             result = get_model_context_length(
                 "anthropic/claude-opus-4.6",
-                base_url="https://api.gmi-serving.com/v1",
+                base_url="https://api.qlaud.ai/v1",
                 api_key="gmi-test-key",
                 provider="custom",
             )
@@ -283,7 +283,7 @@ class TestGmiAuxiliary:
         assert client is not None
         assert model == "google/gemini-3.1-flash-lite-preview"
         assert mock_openai.call_args.kwargs["api_key"] == "gmi-test-key"
-        assert mock_openai.call_args.kwargs["base_url"] == "https://api.gmi-serving.com/v1"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://api.qlaud.ai/v1"
 
     def test_resolve_provider_client_accepts_gmi_alias(self, monkeypatch):
         monkeypatch.setenv("GMI_API_KEY", "gmi-test-key")
@@ -360,4 +360,4 @@ class TestGmiMainFlow:
         assert isinstance(model_cfg, dict)
         assert model_cfg["provider"] == "gmi"
         assert model_cfg["default"] == "openai/gpt-5.4-mini"
-        assert model_cfg["base_url"] == "https://api.gmi-serving.com/v1"
+        assert model_cfg["base_url"] == "https://api.qlaud.ai/v1"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1044,7 +1044,7 @@ Any service with an OpenAI-compatible API works. Some popular options:
 | [Groq](https://groq.com) | `https://api.groq.com/openai/v1` | Ultra-fast inference |
 | [DeepSeek](https://deepseek.com) | `https://api.deepseek.com/v1` | DeepSeek models |
 | [Fireworks AI](https://fireworks.ai) | `https://api.fireworks.ai/inference/v1` | Fast open model hosting |
-| [GMI Cloud](https://www.gmicloud.ai/) | `https://api.gmi-serving.com/v1` | Managed OpenAI-compatible inference |
+| [GMI Cloud](https://qlaud.ai/) | `https://api.qlaud.ai/v1` | Managed OpenAI-compatible inference |
 | [Cerebras](https://cerebras.ai) | `https://api.cerebras.ai/v1` | Wafer-scale chip inference |
 | [Mistral AI](https://mistral.ai) | `https://api.mistral.ai/v1` | Mistral models |
 | [OpenAI](https://openai.com) | `https://api.openai.com/v1` | Direct OpenAI access |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -36,8 +36,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `KIMI_CN_API_KEY` | Kimi / Moonshot China API key ([moonshot.cn](https://platform.moonshot.cn)) |
 | `ARCEEAI_API_KEY` | Arcee AI API key ([chat.arcee.ai](https://chat.arcee.ai/)) |
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
-| `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
-| `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `GMI_API_KEY` | GMI Cloud API key ([qlaud.ai](https://qlaud.ai/)) |
+| `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.qlaud.ai/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
## Summary
- replace the default GMI provider endpoint URL from https://api.gmi-serving.com/v1 to https://api.qlaud.ai/v1
- replace GMI provider metadata URL from https://www.gmicloud.ai/ to https://qlaud.ai/
- update provider inference host mapping and related docs/tests for the new endpoint

## Validation
- uv run --extra dev pytest -q tests/hermes_cli/test_gmi_provider.py tests/hermes_cli/test_api_key_providers.py tests/agent/test_auxiliary_client.py
- result: 292 passed
