### PR TITLE
fix(auxiliary): forward explicit_api_key to _try_openrouter for credential pool fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1149,7 +1149,18 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 
-def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+    # If an explicit key was passed (e.g. from a credential pool via
+    # resolve_provider_client), use it directly — bypass pool/env lookup.
+    if explicit_api_key:
+        base_url = OPENROUTER_BASE_URL
+        pool_present, entry = _select_pool_entry("openrouter")
+        if pool_present and entry is not None:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+        logger.debug("Auxiliary client: OpenRouter via explicit key")
+        return OpenAI(api_key=explicit_api_key, base_url=base_url,
+                       default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = _pool_runtime_api_key(entry)
@@ -2055,7 +2066,7 @@ def resolve_provider_client(
 
     # ── OpenRouter ───────────────────────────────────────────────────
     if provider == "openrouter":
-        client, default = _try_openrouter()
+        client, default = _try_openrouter(explicit_api_key=explicit_api_key)
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -495,6 +495,23 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+    def test_explicit_api_key_used_for_openrouter(self, monkeypatch):
+        """resolve_provider_client must forward explicit_api_key to _try_openrouter.
+
+        Regression test for #18338: when a credential pool supplies a runtime
+        API key for OpenRouter, resolve_provider_client should pass it through
+        so the fallback uses the pool key instead of ignoring it.
+        """
+        # No pool entry, no env var — _try_openrouter would normally return (None, None)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            client, model = resolve_provider_client(
+                "openrouter", explicit_api_key="my-pool-runtime-key"
+            )
+        # explicit_api_key should be used, so client must not be None
+        assert client is not None
+        assert model is not None
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 


### PR DESCRIPTION
## Summary

`resolve_provider_client()` receives `explicit_api_key` from the credential pool and correctly propagates it to most downstream provider calls. However, when routing to OpenRouter, it calls `_try_openrouter()` without passing `explicit_api_key`, silently ignoring it.

This causes auth failures when the auxiliary client falls back to OpenRouter using a runtime API key from the credential pool — the key is available but never reaches the OpenRouter client constructor.

## Root Cause

In `agent/auxiliary_client.py`, the OpenRouter branch of `resolve_provider_client()` (line ~2058):

```python
if provider == "openrouter":
    client, default = _try_openrouter()  # explicit_api_key not passed
```

`_try_openrouter()` only checked the credential pool and `OPENROUTER_API_KEY` env var — it never accepted an explicit key parameter.

## Fix

1. Added `explicit_api_key` parameter to `_try_openrouter()`. When provided, it's used directly (bypassing pool/env lookup).
2. `resolve_provider_client()` now passes `explicit_api_key` to `_try_openrouter()`.

## Test Plan

- [x] New regression test `test_explicit_api_key_used_for_openrouter` — RED on main, GREEN with fix
- [x] All existing `test_auxiliary_client.py` tests pass (107 passed, 5 pre-existing failures unrelated to this change)
- [x] No new test regressions in `tests/agent/` (2290 passed vs 2289 on main — +1 is the new test)

Closes #18338
