### PR TITLE
Fix embedded chat session resume switching

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -298,7 +298,7 @@ function buildRoutes(
 
 export default function App() {
   const { t } = useI18n();
-  const { pathname } = useLocation();
+  const { pathname, search: locationSearch } = useLocation();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -306,6 +306,18 @@ export default function App() {
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
+  const [chatInstanceKey, setChatInstanceKey] = useState(() => {
+    if (!isChatRoute) return "chat";
+    const resume = new URLSearchParams(locationSearch).get("resume");
+    return resume ? `resume:${resume}` : "chat";
+  });
+
+  useEffect(() => {
+    if (!isChatRoute) return;
+    const resume = new URLSearchParams(locationSearch).get("resume");
+    if (!resume) return;
+    setChatInstanceKey(`resume:${resume}`);
+  }, [isChatRoute, locationSearch]);
   const embeddedChat = isDashboardEmbeddedChatEnabled();
 
   // A plugin can replace the built-in /chat page via `tab.override: "/chat"`
@@ -610,7 +622,7 @@ export default function App() {
                       )}
                       aria-hidden={!isChatRoute}
                     >
-                      <ChatPage isActive={isChatRoute} />
+                      <ChatPage key={chatInstanceKey} isActive={isChatRoute} />
                     </div>
                   ))}
               </div>


### PR DESCRIPTION
## Summary

Fix embedded dashboard chat staying attached to the previous resumed session when navigating from Sessions to `/chat?resume=<different-session>`.

## Root cause

The embedded Chat page is rendered as a persistent host outside the normal route tree so the PTY/WebSocket/xterm session can survive tab navigation. `ChatPage` captures the initial `resume` query parameter on mount, so navigating to another `/chat?resume=...` URL does not recreate the PTY and the old session remains active.

## Fix

Track the active resume target in `App.tsx` and key the persistent `ChatPage` by the resumed session id when a `resume` query parameter is present. This preserves persistent-chat behavior across normal tab navigation while forcing a remount when switching to a different resumed session.

## Validation

- `npm run build`
- Manual test:
  1. Open Sessions.
  2. Continue session A in Chat.
  3. Return to Sessions.
  4. Continue session B.
  5. Chat remounts into session B instead of staying on session A.
