### PR TITLE
fix(auxiliary): keep Kimi coding v1 on OpenAI transport

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -855,8 +855,15 @@ def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     hostname = base_url_hostname(normalized)
     if hostname == "api.anthropic.com":
         return True
-    if hostname == "api.kimi.com" and "/coding" in normalized:
-        return True
+    if hostname == "api.kimi.com":
+        # Kimi exposes two different Coding Plan surfaces:
+        #   https://api.kimi.com/coding     → Anthropic Messages wire
+        #   https://api.kimi.com/coding/v1  → OpenAI chat.completions wire
+        # Only the bare /coding route should be wrapped. Treating /coding/v1
+        # as Anthropic sends requests to a non-existent messages endpoint and
+        # causes 404 resource_not_found_error for auxiliary tasks.
+        path = urlparse(normalized).path.rstrip("/")
+        return path == "/coding"
     return False
 
 

--- a/tests/agent/test_auxiliary_transport_autodetect.py
+++ b/tests/agent/test_auxiliary_transport_autodetect.py
@@ -34,8 +34,11 @@ def _clean_env(monkeypatch):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("url,expected,label", [
-    ("https://api.kimi.com/coding/v1", True, "Kimi Coding Plan /v1"),
-    ("https://api.kimi.com/coding", True, "Kimi Coding Plan no /v1"),
+    ("https://api.kimi.com/coding/v1", False, "Kimi Coding Plan OpenAI /v1"),
+    ("https://api.kimi.com/coding/v1/", False, "Kimi Coding Plan OpenAI /v1 trailing slash"),
+    ("https://api.kimi.com/coding/v1?client=hermes", False, "Kimi Coding Plan OpenAI /v1 query"),
+    ("https://api.kimi.com/coding", True, "Kimi Coding Plan bare Anthropic route"),
+    ("https://api.kimi.com/coding/", True, "Kimi Coding Plan bare Anthropic route trailing slash"),
     ("https://api.moonshot.ai/v1", False, "Moonshot legacy"),
     ("https://api.minimax.io/anthropic", True, "MiniMax /anthropic"),
     ("https://litellm.example.com/v1/anthropic", True, "/anthropic suffix"),
@@ -74,6 +77,19 @@ def test_maybe_wrap_anthropic_rewraps_kimi_coding_url():
             "https://api.kimi.com/coding", api_mode=None,
         )
     assert isinstance(result, AnthropicAuxiliaryClient)
+
+
+def test_maybe_wrap_anthropic_leaves_kimi_coding_v1_openai_wire():
+    """api.kimi.com/coding/v1 is OpenAI-compatible and must not be rewrapped."""
+    from agent.auxiliary_client import _maybe_wrap_anthropic, AnthropicAuxiliaryClient
+
+    plain_client = MagicMock(name="plain_openai")
+    result = _maybe_wrap_anthropic(
+        plain_client, "kimi-for-coding", "sk-kimi-test",
+        "https://api.kimi.com/coding/v1", api_mode=None,
+    )
+    assert result is plain_client
+    assert not isinstance(result, AnthropicAuxiliaryClient)
 
 
 def test_maybe_wrap_anthropic_rewraps_slash_anthropic_url():


### PR DESCRIPTION
## Summary

- Treat `https://api.kimi.com/coding/v1` as OpenAI-compatible chat.completions transport.
- Keep the bare `https://api.kimi.com/coding` endpoint on Anthropic Messages transport.
- Add regression coverage for both endpoint shapes.

## Why

Kimi Coding exposes two different API surfaces:

- `https://api.kimi.com/coding` speaks the Anthropic Messages / Claude Code style protocol.
- `https://api.kimi.com/coding/v1` speaks OpenAI-compatible chat.completions.

The previous detection matched any `api.kimi.com` URL containing `/coding`, which caused `/coding/v1` auxiliary clients to be wrapped as Anthropic and sent to the wrong transport.

## Test Plan

- `python -m pytest tests/agent/test_auxiliary_transport_autodetect.py -q -o 'addopts='`
