### PR TITLE
fix(stt): recover from CUBLAS_STATUS_NOT_SUPPORTED on Blackwell GPUs (pin ctranslate2, narrow float16 fallback)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,10 @@ voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime),
   # so keep it out of the base install for source-build packagers like Homebrew.
   "faster-whisper==1.2.1",
+  # Pinned explicitly (normally transitive via faster-whisper): ctranslate2
+  # < 4.6.3 selects int8 kernels on Blackwell GPUs (sm120) that fail with
+  # CUBLAS_STATUS_NOT_SUPPORTED (OpenNMT/CTranslate2#1865, fixed in 4.6.3/4.7.0).
+  "ctranslate2==4.8.1",
   "sounddevice==0.5.5",
   "numpy==2.4.3",
 ]

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -620,6 +620,87 @@ class TestTranscribeLocalExtended:
         assert result["success"] is False
         assert "CUDA out of memory" in result["error"]
 
+    def test_load_time_cublas_unsupported_retries_float16_on_cuda(self, tmp_path):
+        """cuBLAS_STATUS_NOT_SUPPORTED at load → retry explicit float16 on CUDA, not CPU."""
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        seg = MagicMock()
+        seg.text = "hi"
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 1.0
+
+        gpu_model = MagicMock()
+        gpu_model.transcribe.return_value = ([seg], info)
+
+        call_args = []
+
+        def fake_whisper(model_name, device, compute_type):
+            call_args.append((device, compute_type))
+            if device == "auto":
+                raise RuntimeError("cuBLAS failed with status CUBLAS_STATUS_NOT_SUPPORTED")
+            return gpu_model
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", side_effect=fake_whisper), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hi"
+        assert call_args == [("auto", "auto"), ("cuda", "float16")]
+
+    def test_runtime_cublas_unsupported_evicts_cache_and_retries_float16(self, tmp_path, caplog):
+        """Auto-picked int8 kernels unsupported (Blackwell + ctranslate2 < 4.6.3)
+        at transcribe() → evict cache, reload with explicit float16 on CUDA and
+        retry. The GPU works; only the auto-selected compute type doesn't — so
+        this must NOT take the CPU fallback."""
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        seg = MagicMock()
+        seg.text = "recovered"
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 1.0
+
+        # First model loads fine (auto → int8 kernels), but the first GEMM at
+        # transcribe() hits the unsupported cuBLAS path.
+        int8_model = MagicMock()
+        int8_model.transcribe.side_effect = RuntimeError(
+            "cuBLAS failed with status CUBLAS_STATUS_NOT_SUPPORTED"
+        )
+        # Second model (explicit float16 on CUDA) works.
+        float16_model = MagicMock()
+        float16_model.transcribe.return_value = ([seg], info)
+
+        models = [int8_model, float16_model]
+        call_args = []
+
+        def fake_whisper(model_name, device, compute_type):
+            call_args.append((device, compute_type))
+            return models.pop(0)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", side_effect=fake_whisper), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None), \
+             caplog.at_level("WARNING"):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == "recovered"
+        assert call_args == [("auto", "auto"), ("cuda", "float16")]
+        assert int8_model.transcribe.call_count == 1
+        assert float16_model.transcribe.call_count == 1
+        # Float16 is the degraded mode, not the destination — the log must
+        # point at the real fix (upgrading ctranslate2).
+        assert "ctranslate2" in caplog.text
+
 
 # ============================================================================
 # Model auto-correction

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -131,6 +131,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "stt.mistral": ("mistralai==2.4.8",),
     "stt.faster_whisper": (
         "faster-whisper==1.2.1",
+        # Pinned explicitly (normally transitive via faster-whisper):
+        # ctranslate2 < 4.6.3 selects int8 kernels on Blackwell GPUs (sm120)
+        # that fail with CUBLAS_STATUS_NOT_SUPPORTED (OpenNMT/CTranslate2#1865,
+        # fixed in 4.6.3/4.7.0).  Listing it here also upgrades stale venvs
+        # where an old ctranslate2 already satisfies the transitive dep.
+        "ctranslate2==4.8.1",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
     ),

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1086,6 +1086,36 @@ def _looks_like_cuda_lib_error(exc: BaseException) -> bool:
     return any(marker in msg for marker in _CUDA_LIB_ERROR_MARKERS)
 
 
+# A separate failure family from the missing-lib markers above: the CUDA
+# runtime is present and working, but the compute type ctranslate2
+# auto-selected has no supported kernel on this GPU.  Seen on RTX 50-series
+# (Blackwell / sm120) with ctranslate2 < 4.6.3, where "auto" resolves to an
+# int8_* type and the int8 GEMM fails at first use (OpenNMT/CTranslate2#1865;
+# fixed upstream in 4.6.3/4.7.0).  Explicit float16 works on the same GPU,
+# so this must NOT take the CPU fallback.
+_CUBLAS_UNSUPPORTED_MARKER = "CUBLAS_STATUS_NOT_SUPPORTED"
+
+
+def _looks_like_cublas_unsupported(exc: BaseException) -> bool:
+    """Heuristic: did the auto-selected compute type hit an unsupported cuBLAS kernel?
+
+    ctranslate2 raises plain RuntimeError with the literal status enum name,
+    e.g. ``cuBLAS failed with status CUBLAS_STATUS_NOT_SUPPORTED``.
+    """
+    return _CUBLAS_UNSUPPORTED_MARKER in str(exc)
+
+
+def _warn_cublas_unsupported(exc: BaseException) -> None:
+    logger.warning(
+        "faster-whisper hit an unsupported cuBLAS kernel (%s) — the compute "
+        "type auto-selected by ctranslate2 isn't supported on this GPU "
+        "(int8 on Blackwell-class GPUs with ctranslate2 < 4.6.3). Retrying "
+        "with explicit float16 on CUDA. Upgrade ctranslate2 "
+        "(pip install -U ctranslate2) to restore int8 performance.",
+        exc,
+    )
+
+
 def _load_local_whisper_model(model_name: str):
     """Load faster-whisper with graceful CUDA → CPU fallback.
 
@@ -1096,13 +1126,19 @@ def _load_local_whisper_model(model_name: str):
     On those hosts the load itself sometimes succeeds and the dlopen failure
     only surfaces at first ``transcribe()`` call.
 
-    We try ``auto`` first (fast CUDA path when it works), and on any CUDA
-    library load failure fall back to CPU + int8.
+    We try ``auto`` first (fast CUDA path when it works).  If the
+    auto-selected compute type has no supported kernel on this GPU
+    (``CUBLAS_STATUS_NOT_SUPPORTED``), we retry with explicit float16 on CUDA
+    — the GPU itself works.  On a CUDA library load failure we fall back to
+    CPU + int8.
     """
     from faster_whisper import WhisperModel
     try:
         return WhisperModel(model_name, device="auto", compute_type="auto")
     except Exception as exc:
+        if _looks_like_cublas_unsupported(exc):
+            _warn_cublas_unsupported(exc)
+            return WhisperModel(model_name, device="cuda", compute_type="float16")
         if not _looks_like_cuda_lib_error(exc):
             raise
         logger.warning(
@@ -1142,22 +1178,31 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
             transcript = " ".join(segment.text.strip() for segment in segments)
         except Exception as exc:
-            # CUDA runtime libs sometimes only fail at dlopen-on-first-use,
+            # Two recoverable failure families surface only at first use,
             # AFTER the model loaded successfully.  Evict the broken cached
-            # model, reload on CPU, retry once.  Without this the module-
-            # global `_local_model` is poisoned and every subsequent voice
-            # message on this process fails identically until restart.
-            if not _looks_like_cuda_lib_error(exc):
+            # model, reload with a working config, retry once.  Without this
+            # the module-global `_local_model` is poisoned and every
+            # subsequent voice message on this process fails identically
+            # until restart.
+            #   - Unsupported auto-selected compute type (Blackwell + old
+            #     ctranslate2): the GPU works — reload with explicit float16.
+            #   - CUDA runtime libs failing dlopen-on-first-use: reload on CPU.
+            if _looks_like_cublas_unsupported(exc):
+                _warn_cublas_unsupported(exc)
+                retry_device, retry_compute = "cuda", "float16"
+            elif _looks_like_cuda_lib_error(exc):
+                logger.warning(
+                    "faster-whisper CUDA runtime failed mid-transcribe (%s) — "
+                    "evicting cached model and retrying on CPU (int8).",
+                    exc,
+                )
+                retry_device, retry_compute = "cpu", "int8"
+            else:
                 raise
-            logger.warning(
-                "faster-whisper CUDA runtime failed mid-transcribe (%s) — "
-                "evicting cached model and retrying on CPU (int8).",
-                exc,
-            )
             _local_model = None
             _local_model_name = None
             from faster_whisper import WhisperModel
-            _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
+            _local_model = WhisperModel(model_name, device=retry_device, compute_type=retry_compute)
             _local_model_name = model_name
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
             transcript = " ".join(segment.text.strip() for segment in segments)

--- a/uv.lock
+++ b/uv.lock
@@ -766,7 +766,7 @@ wheels = [
 
 [[package]]
 name = "ctranslate2"
-version = "4.7.1"
+version = "4.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -774,21 +774,21 @@ dependencies = [
     { name = "setuptools" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/25/41920ccee68e91cb6fa0fc9e8078ab2b7839f2c668f750dc123144cb7c6e/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f74200bab9996b14a57cf6f7cb27d0921ceedc4acc1e905598e3e85b4d75b1ec", size = 1256943, upload-time = "2026-02-04T06:11:17.781Z" },
-    { url = "https://files.pythonhosted.org/packages/79/22/bc81fcc9f10ba4da3ffd1a9adec15cfb73cb700b3bbe69c6c8b55d333316/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:59b427eb3ac999a746315b03a63942fddd351f511db82ba1a66880d4dea98e25", size = 11916445, upload-time = "2026-02-04T06:11:19.938Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/a7/494a66bb02c7926331cadfff51d5ce81f5abfb1e8d05d7f2459082f31b48/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95f0c1051c180669d2a83a44b44b518b2d1683de125f623bbc81ad5dd6f6141c", size = 16696997, upload-time = "2026-02-04T06:11:22.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/4e/b48f79fd36e5d3c7e12db383aa49814c340921a618ef7364bd0ced670644/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed92d9ab0ac6bc7005942be83d68714c80adb0897ab17f98157294ee0374347", size = 38836379, upload-time = "2026-02-04T06:11:26.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/23/8c01ac52e1f26fc4dbe985a35222ae7cd365bbf7ee5db5fd5545d8926f91/ctranslate2-4.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:67d9ad9b69933fbfeee7dcec899b2cd9341d5dca4fdfb53e8ba8c109dc332ee1", size = 18843315, upload-time = "2026-02-04T06:11:29.441Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/0f/581de94b64c5f2327a736270bc7e7a5f8fe5cf1ed56a2203b52de4d8986a/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c0cbd46a23b8dc37ccdbd9b447cb5f7fadc361c90e9df17d82ca84b1f019986", size = 1257089, upload-time = "2026-02-04T06:11:32.442Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e9/d55b0e436362f9fe26bd98fefd2dd5d81926121f1d7f799c805e6035bb26/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5b141ddad1da5f84cf3c2a569a56227a37de649a555d376cbd9b80e8f0373dd8", size = 11918502, upload-time = "2026-02-04T06:11:33.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/ce/9f29f0b0bb4280c2ebafb3ddb6cdff8ef1c2e185ee020c0ec0ecba7dc934/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d00a62544db4a3caaa58a3c50d39b25613c042b430053ae32384d94eb1d40990", size = 16859601, upload-time = "2026-02-04T06:11:36.227Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/86/428d270fd72117d19fb48ed3211aa8a3c8bd7577373252962cb634e0fd01/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:722b93a89647974cbd182b4c7f87fefc7794fff7fc9cbd0303b6447905cc157e", size = 38995338, upload-time = "2026-02-04T06:11:42.789Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/f4/d23dbfb9c62cb642c114a30f05d753ba61d6ffbfd8a3a4012fe85a073bcb/ctranslate2-4.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d0f734dc3757118094663bdaaf713f5090c55c1927fb330a76bb8b84173940e8", size = 18844949, upload-time = "2026-02-04T06:11:45.436Z" },
-    { url = "https://files.pythonhosted.org/packages/34/6d/eb49ba05db286b4ea9d5d3fcf5f5cd0a9a5e218d46349618d5041001e303/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6b2abf2929756e3ec6246057b56df379995661560a2d776af05f9d97f63afcf5", size = 1256960, upload-time = "2026-02-04T06:11:47.487Z" },
-    { url = "https://files.pythonhosted.org/packages/45/5a/b9cce7b00d89fc6fdeaf27587aa52d0597b465058563e93ff50910553bdd/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:857ef3959d6b1c40dc227c715a36db33db2d097164996d6c75b6db8e30828f52", size = 11918645, upload-time = "2026-02-04T06:11:49.599Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/03/c0db0a5276599fb44ceafa2f2cb1afd5628808ec406fe036060a39693680/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:393a9e7e989034660526a2c0e8bb65d1924f43d9a5c77d336494a353d16ba2a4", size = 16860452, upload-time = "2026-02-04T06:11:52.276Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/03/4e3728ce29d192ee75ed9a2d8589bf4f19edafe5bed3845187de51b179a3/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a3d0682f2b9082e31c73d75b45f16cde77355ab76d7e8356a24c3cb2480a6d3", size = 38995174, upload-time = "2026-02-04T06:11:55.477Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/15/6e8e87c6a201d69803a79ac2e29623ce7c2cc9cd1df9db99810cca714373/ctranslate2-4.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:baa6d2b10f57933d8c11791e8522659217918722d07bbef2389a443801125fe7", size = 18844953, upload-time = "2026-02-04T06:11:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c4/0e450796f90e54f3325697fc67db4f4ecd397aef96d7b3924e26fb8bd04b/ctranslate2-4.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c2db633a06e3b34bbfb72fd26eee58053d9df1f9c1610ac4df3a6a1e25af7d7", size = 1270559, upload-time = "2026-07-03T12:39:01.154Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/54/7b6db16470d0788fb8ab43a99e3e18ba9d41a9b50b7fef7dec353eafbe20/ctranslate2-4.8.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:079976cbce3a68de04bf9948d08c96beb86df44e5cd2974e4187bc9c9bb388f3", size = 11928069, upload-time = "2026-07-03T12:39:02.6Z" },
+    { url = "https://files.pythonhosted.org/packages/37/66/8fee1366631d224bf26b34db9063a0c88ce358d58331c2393689b0ea27ff/ctranslate2-4.8.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74bae0a8dc9f98c5a6100bf1c17a91782b384ea53b83e2606030ebf9f25318fe", size = 16707971, upload-time = "2026-07-03T12:39:05.09Z" },
+    { url = "https://files.pythonhosted.org/packages/30/84/f610e90bb419707632b9b668476b9fd4cdb090c9b53c119ce017699b58ca/ctranslate2-4.8.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0a584c17f21779eb9035bcbc1ec280998f90b36725b70a5ff911f33e343199a", size = 39351971, upload-time = "2026-07-03T12:39:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6c/7230ecbdd23ab867715e1b6ffe99211c39c11cae8ec2d6c3ec9208c38ee2/ctranslate2-4.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:82982f07a7d615d2248d17d6ec4c43cd50e534b094aa27cda62125a5e3a6e3fc", size = 19219248, upload-time = "2026-07-03T12:39:11.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/09/9a50eeab00db68aeac08f6ab7f98b5c36abd26b89cbd707ea39e70656500/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9de0dddd91ae68da0a7323441e90708d14b31d31cd443004dda0e1198b5bf11e", size = 1270522, upload-time = "2026-07-03T12:39:13.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/6c41c4d3ae539ec76b1943c362184677befd7c1d5290d2ec361182cdb1e0/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:82e0e6eb7d4301fd79a714495c8faf34242e09542cef04c9e9794c3fe90014a1", size = 11930367, upload-time = "2026-07-03T12:39:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/03428106134a0a58922461074f8942f92c5ed0bb3a8d018677ad64a9c476/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ca144b93035b9f53e6d67b7cdf5802c3fffca9aa0247940eecbd4592c68ce2f", size = 16882768, upload-time = "2026-07-03T12:39:17.425Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c9/976a565398a03fb2973cbe5edd5ca03c4332d86b634799e0ee562420d3bc/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dacc408f716ebc73b3b3c6ddd937700e776c4c68b6d9c81862990150ff0f6af6", size = 39529060, upload-time = "2026-07-03T12:39:20.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/82/0a5f7f2b03b4e10aacb3146715724e1b96bb993cc7d199be28c9825aa120/ctranslate2-4.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251", size = 19220789, upload-time = "2026-07-03T12:39:23.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a7/3101c3a0785253a8ef386f39744ad19c28c75b7f227e7c232aee7a5c416a/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba628835e6ad4ad399261ab6cb51bf152de563e6b122a9e8eb0c61e69f925931", size = 1270478, upload-time = "2026-07-03T12:39:25.401Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b9/e50c7558e96a054d6b1e6a6c5e729dda4a4f05584e065f2902aa5f1bc4c8/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:85ef15ce0b2172ec471975b8a30d5c5bc71e7cffcd163ad6c07ea32f1943d940", size = 11930241, upload-time = "2026-07-03T12:39:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2f/ea7a19c6d7e949b731fb034664633184bbfc7882846d107f4d790693fb76/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0030670278a73cae09dff9bca72cdd248af61f9367257f18db9b3b94fbb3a50d", size = 16883512, upload-time = "2026-07-03T12:39:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4a/21f325a9d0925d8ad24b04249adf29bf9909442967603634f7f6d4acbb79/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4242a7f8e285f922525f4cffd5b1fb43cbacc61d0611cf54832e9c447d030840", size = 39529085, upload-time = "2026-07-03T12:39:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e7/37da1a7500b57496a5269318c4f57962ea0c26dcac06b85222d7831acf00/ctranslate2-4.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:d52499f05a60a791aeadee28d609efa130142f376d1ea76b2b1c593bb01f8827", size = 19220784, upload-time = "2026-07-03T12:39:35.74Z" },
 ]
 
 [[package]]
@@ -1713,6 +1713,7 @@ vertex = [
     { name = "google-auth" },
 ]
 voice = [
+    { name = "ctranslate2" },
     { name = "faster-whisper" },
     { name = "numpy" },
     { name = "sounddevice" },
@@ -1751,6 +1752,7 @@ requires-dist = [
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==46.0.7" },
+    { name = "ctranslate2", marker = "extra == 'voice'", specifier = "==4.8.1" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },


### PR DESCRIPTION
## Problem

On RTX 5090 (Blackwell / sm120), local STT fails with `RuntimeError: cuBLAS failed with status CUBLAS_STATUS_NOT_SUPPORTED` at the first `transcribe()` call (the constructor loads fine; cuBLAS only runs at the first GEMM).

Root cause: ctranslate2 < 4.6.3 auto-selects an int8 compute type on sm120 whose cuBLAS GEMM path isn't supported (OpenNMT/CTranslate2#1865). Fixed upstream in ctranslate2 4.6.3 ("Disable INT8 for sm120") and properly in 4.7.0 ("multiple of 16 padding for INT8 Tensor Cores"). Explicit `compute_type="float16"` works on the same GPU (verified on my RTX 5090, CUDA 12.x, faster-whisper 1.2.1).

The committed `uv.lock` already resolves ctranslate2 4.7.1, so locked installs (`uv sync`) never hit this. The affected population is pip installs and stale venvs, where faster-whisper's loose `ctranslate2>=4.0,<5` requirement lets an old, already-installed ctranslate2 satisfy the dependency forever.

## Fix (two parts)

1. **Root cause — pin the fixed library.** Add `ctranslate2==4.8.1` to the `voice` extra and the `stt.faster_whisper` lazy-install spec (kept in sync per the packaging-metadata tests). Listing it explicitly makes lazy installs upgrade stale venvs instead of accepting whatever old version is present.
2. **Defense-in-depth — narrow runtime fallback** for envs hermes doesn't manage: on `CUBLAS_STATUS_NOT_SUPPORTED` at load or first transcribe, evict the cached model, retry once with explicit `cuda` + `float16`, and log an upgrade hint. This is deliberately a separate marker family from `_CUDA_LIB_ERROR_MARKERS`: it must NOT route to the CPU fallback, because the GPU works — only the auto-picked compute type doesn't. The matched string is the literal status enum from ctranslate2's `CUBLAS_CHECK` macro, stable across versions.

## Changes vs. the previous revision (addressing the automated review)

Both review problems confirmed and addressed — and float16-first turned out to be wrong on its own terms: `auto` resolves to int8 on most CUDA hosts (~half the weight memory of float16), so trying float16 first would newly OOM small-VRAM cards that work fine today.

- `auto`-first behavior is preserved exactly; the three existing CUDA fallback tests pass **unchanged**.
- CUDA OOM still surfaces immediately after a single load attempt (existing test unchanged); the new fallback fires only on the exact cuBLAS status string and is inert on healthy hosts.
- Two new tests pin both new paths: the call sequence `[("auto","auto"), ("cuda","float16")]`, the cache eviction (broken model called exactly once), and the upgrade-hint log.

## Evidence

- `pytest tests/tools/test_transcription_tools.py -q` → 109 passed (107 pre-existing, none modified, + 2 new)
- `pytest tests/tools/test_lazy_deps.py tests/test_packaging_metadata.py -q` → all passed (pyproject/lazy_deps pin-sync checks included)
- `uv lock --check` clean; `ruff check` clean on changed files
