### PR TITLE
feat(gateway): persona emoji + dynamic tool reactions for platform adapters

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -132,13 +132,65 @@ def get_skin_tool_prefix() -> str:
     return "┊"
 
 
+# Built-in tool → emoji map.  Used as layer 3 in get_tool_emoji() so that
+# dynamic reactions work out-of-the-box without requiring a skin or per-tool
+# registry emoji.  Grouped by toolset for readability.
+_BUILTIN_TOOL_EMOJIS: dict[str, str] = {
+    # file
+    "read_file": "📄",
+    "write_file": "📝",
+    "patch": "🩹",
+    "search_files": "🔎",
+    # terminal
+    "terminal": "💻",
+    "process": "⚙️",
+    "execute_code": "🐍",
+    # browser
+    "browser_navigate": "🌐",
+    "browser_click": "🖱️",
+    "browser_type": "⌨️",
+    "browser_snapshot": "📸",
+    "browser_scroll": "📜",
+    "browser_vision": "👁️",
+    "browser_back": "◀️",
+    "browser_press": "⌨️",
+    "browser_get_images": "🖼️",
+    "browser_console": "🌐",
+    # web / search
+    "web_search": "🔍",
+    "web_extract": "🌐",
+    # memory / session
+    "memory": "🧠",
+    "session_search": "🔍",
+    "hindsight_retain": "🧠",
+    "hindsight_recall": "🔍",
+    "hindsight_reflect": "💭",
+    # skills
+    "skill_view": "📖",
+    "skill_manage": "🛠️",
+    "skills_list": "📚",
+    # delegation / cron
+    "delegate_task": "👥",
+    "cronjob": "⏰",
+    # communication
+    "send_message": "💬",
+    "clarify": "❓",
+    # media
+    "text_to_speech": "🔊",
+    "vision_analyze": "👁️",
+    # todo
+    "todo": "✅",
+}
+
+
 def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
     """Get the display emoji for a tool.
 
     Resolution order:
     1. Active skin's ``tool_emojis`` overrides (if a skin is loaded)
     2. Tool registry's per-tool ``emoji`` field
-    3. *default* fallback
+    3. Built-in tool emoji map (covers core tools without requiring skin/registry)
+    4. *default* fallback
     """
     # 1. Skin override
     skin = _get_skin()
@@ -154,8 +206,8 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
             return emoji
     except Exception:
         pass
-    # 3. Hardcoded fallback
-    return default
+    # 3. Built-in map
+    return _BUILTIN_TOOL_EMOJIS.get(tool_name, default)
 
 
 # =========================================================================

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2010,6 +2010,15 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_tool_call_start(self, event: MessageEvent, tool_name: str) -> None:
+        """Hook called each time a tool call begins during processing.
+
+        Platform adapters can override this to show per-tool status indicators
+        (e.g. Discord swaps the active reaction emoji to reflect the current tool).
+        ``tool_name`` is the raw tool function name (e.g. ``read_file``,
+        ``web_search``, ``terminal``).
+        """
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -45,6 +45,7 @@ from gateway.config import Platform, PlatformConfig
 import re
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
+from gateway.platforms.reaction_mixin import DynamicReactionMixin
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -470,7 +471,7 @@ class VoiceReceiver:
                 pass
 
 
-class DiscordAdapter(BasePlatformAdapter):
+class DiscordAdapter(DynamicReactionMixin, BasePlatformAdapter):
     """
     Discord bot adapter.
 
@@ -529,22 +530,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
-        # Per-message active reaction tracking for persona/tool emoji swapping.
-        # Key: message.id (int), Value: currently active reaction emoji (str).
-        self._active_tool_reactions: Dict[int, str] = {}
-        # Timestamp of last reaction swap per message — hysteresis to avoid
-        # Discord rate limits (reaction endpoints: ~1 req/0.25s per channel).
-        # Default cooldown: 1 second between swaps per message.
-        self._last_reaction_swap: Dict[int, float] = {}
-        self._reaction_cooldown: float = float(
-            self.config.extra.get("reaction_cooldown",
-                                  1.0)
-        )
-        # Cache resolved config values at init to avoid disk reads on every
-        # tool call.  Persona emoji and dynamic-reactions flag are stable for
-        # the lifetime of the adapter.
-        self._cached_persona_emoji: str = self._resolve_persona_emoji()
-        self._cached_dynamic_reactions: bool = self._resolve_dynamic_reactions()
+        # Cache raw Discord message objects by session key so on_tool_call_start
+        # can resolve them from a SessionSource (which lacks raw_message).
+        # Populated in on_processing_start, cleaned up in on_processing_complete.
+        self._session_raw_messages: Dict[str, Any] = {}
+        # Initialize the platform-agnostic dynamic reaction mixin.
+        self._init_reaction_mixin()
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1062,101 +1053,54 @@ class DiscordAdapter(BasePlatformAdapter):
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no") \
             and self.config.extra.get("reactions", True)
 
-    def _resolve_dynamic_reactions(self) -> bool:
-        """Resolve dynamic reactions flag once at init.
+    def _session_key_from_source(self, source) -> str:
+        """Derive a stable session key from a SessionSource or MessageEvent."""
+        if hasattr(source, "source") and source.source is not None:
+            source = source.source  # MessageEvent → inner SessionSource
+        return f"{source.platform}:{source.chat_id}:{source.thread_id or ''}"
 
-        Resolution order:
-        1. ``discord.dynamic_reactions`` in config.yaml (platform override)
-        2. ``dynamic_reactions`` at top-level in config.yaml (global default)
-        3. True (built-in default)
-        """
-        if not self._reactions_enabled():
-            return False
-        extra = self.config.extra
-        if "dynamic_reactions" in extra:
-            return bool(extra["dynamic_reactions"])
-        from hermes_cli.config import load_config
-        return bool(load_config().get("dynamic_reactions", True))
+    # ── DynamicReactionMixin primitives ──────────────────────────────────
 
-    def _dynamic_reactions_enabled(self) -> bool:
-        """Check if per-tool reaction swapping is enabled (cached)."""
-        return self._cached_dynamic_reactions
+    async def _reaction_add(self, msg_ref: Any, emoji: str) -> bool:
+        """Add an emoji reaction to a Discord message."""
+        return await self._add_reaction(msg_ref, emoji)
 
-    def _resolve_persona_emoji(self) -> str:
-        """Resolve the agent's persona emoji once at init.
+    async def _reaction_remove(self, msg_ref: Any, emoji: str) -> bool:
+        """Remove the bot's own emoji reaction from a Discord message."""
+        return await self._remove_reaction(msg_ref, emoji)
 
-        Resolution order:
-        1. ``discord.persona_emoji`` in config.yaml (platform override)
-        2. ``persona_emoji`` at top-level in config.yaml (global default)
-        3. 👀 (built-in fallback so existing deployments are unaffected)
-        """
-        if emoji := self.config.extra.get("persona_emoji"):
-            return emoji
-        from hermes_cli.config import load_config
-        return load_config().get("persona_emoji") or "👀"
+    def _reaction_resolve_message(self, event: Any) -> Any:
+        """Extract the raw Discord message from the event or session cache."""
+        message = getattr(event, "raw_message", None)
+        if message and hasattr(message, "add_reaction"):
+            return message
+        # Fall back to session cache (when called with a SessionSource)
+        sk = self._session_key_from_source(event)
+        return self._session_raw_messages.get(sk)
 
-    def _persona_emoji(self) -> str:
-        """Return the agent's persona emoji (cached)."""
-        return self._cached_persona_emoji
+    def _reaction_msg_key(self, event: Any) -> Optional[int]:
+        """Return message.id as the tracking key."""
+        msg = self._reaction_resolve_message(event)
+        return getattr(msg, "id", None)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add the agent's persona emoji when processing begins."""
-        if not self._reactions_enabled():
-            return
+        """Add persona emoji and cache the raw message for tool-call lookups."""
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            emoji = self._persona_emoji()
-            await self._add_reaction(message, emoji)
-            self._active_tool_reactions[message.id] = emoji
+            sk = self._session_key_from_source(event)
+            self._session_raw_messages[sk] = message
+        await self._rxn_on_processing_start(event)
 
-    async def on_tool_call_start(self, event: MessageEvent, tool_name: str) -> None:
-        """Swap the active reaction to the tool-specific emoji.
-
-        Called by the gateway's progress_callback on every ``tool.started``
-        event. Removes the previous reaction (persona or prior tool) and
-        adds the emoji that represents the current tool, so the message
-        always shows exactly one reaction reflecting what the agent is doing.
-
-        A per-message cooldown (default 1s) prevents hitting Discord's
-        reaction rate limits (~1 req/0.25s per channel, but remove+add = 2
-        calls per swap).
-        """
-        if not self._dynamic_reactions_enabled():
-            return
-        message = event.raw_message
-        if not hasattr(message, "add_reaction"):
-            return
-
-        # Hysteresis: skip if last swap was too recent
-        now = time.monotonic()
-        last = self._last_reaction_swap.get(message.id, 0.0)
-        if now - last < self._reaction_cooldown:
-            return
-
-        from agent.display import get_tool_emoji
-        tool_emoji = get_tool_emoji(tool_name, default="⚙️")
-        current = self._active_tool_reactions.get(message.id)
-        if current and current != tool_emoji:
-            await self._remove_reaction(message, current)
-        if current != tool_emoji:
-            await self._add_reaction(message, tool_emoji)
-        self._active_tool_reactions[message.id] = tool_emoji
-        self._last_reaction_swap[message.id] = now
+    async def on_tool_call_start(self, event, tool_name: str) -> None:
+        """Swap the active reaction to the tool-specific emoji."""
+        await self._rxn_on_tool_call_start(event, tool_name)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Replace the active reaction with the persona emoji (success) or ❌ (failure)."""
-        if not self._reactions_enabled():
-            return
-        message = event.raw_message
-        if hasattr(message, "add_reaction"):
-            current = self._active_tool_reactions.pop(message.id, self._persona_emoji())
-            self._last_reaction_swap.pop(message.id, None)
-            await self._remove_reaction(message, current)
-            if outcome == ProcessingOutcome.SUCCESS:
-                await self._add_reaction(message, self._persona_emoji())
-            elif outcome == ProcessingOutcome.FAILURE:
-                await self._add_reaction(message, "❌")
-            # CANCELLED: remove active reaction, leave nothing
+        """Replace the active reaction with the persona emoji or ❌."""
+        # Clean up cached raw message for this session
+        sk = self._session_key_from_source(event)
+        self._session_raw_messages.pop(sk, None)
+        await self._rxn_on_processing_complete(event, outcome)
 
     async def send(
         self,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -529,6 +529,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # Per-message active reaction tracking for persona/tool emoji swapping.
+        # Key: message.id (int), Value: currently active reaction emoji (str).
+        self._active_tool_reactions: Dict[int, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1043,27 +1046,65 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
-        return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no")
+        return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no") \
+            and self.config.extra.get("reactions", True)
+
+    def _dynamic_reactions_enabled(self) -> bool:
+        """Check if per-tool reaction swapping is enabled."""
+        return self._reactions_enabled() and self.config.extra.get("dynamic_reactions", True)
+
+    def _persona_emoji(self) -> str:
+        """Return the agent's persona emoji from config.
+
+        Set ``discord.persona_emoji`` in config.yaml to give the agent a
+        unique identity emoji (e.g. 🔎 for Sherlock, ⚡ for Newton).
+        Falls back to 👀 so existing deployments are unaffected.
+        """
+        return self.config.extra.get("persona_emoji", "👀")
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction for normal Discord message events."""
+        """Add the agent's persona emoji when processing begins."""
         if not self._reactions_enabled():
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._add_reaction(message, "👀")
+            emoji = self._persona_emoji()
+            await self._add_reaction(message, emoji)
+            self._active_tool_reactions[message.id] = emoji
+    async def on_tool_call_start(self, event: MessageEvent, tool_name: str) -> None:
+        """Swap the active reaction to the tool-specific emoji.
+
+        Called by the gateway's progress_callback on every ``tool.started``
+        event. Removes the previous reaction (persona or prior tool) and
+        adds the emoji that represents the current tool, so the message
+        always shows exactly one reaction reflecting what the agent is doing.
+        """
+        if not self._dynamic_reactions_enabled():
+            return
+        message = event.raw_message
+        if not hasattr(message, "add_reaction"):
+            return
+        from agent.display import get_tool_emoji
+        tool_emoji = get_tool_emoji(tool_name, default="⚙️")
+        current = self._active_tool_reactions.get(message.id)
+        if current and current != tool_emoji:
+            await self._remove_reaction(message, current)
+        await self._add_reaction(message, tool_emoji)
+        self._active_tool_reactions[message.id] = tool_emoji
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction."""
+        """Replace the active reaction with the persona emoji (success) or ❌ (failure)."""
         if not self._reactions_enabled():
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._remove_reaction(message, "👀")
+            current = self._active_tool_reactions.pop(message.id, self._persona_emoji())
+            await self._remove_reaction(message, current)
             if outcome == ProcessingOutcome.SUCCESS:
-                await self._add_reaction(message, "✅")
+                await self._add_reaction(message, self._persona_emoji())
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
+            # CANCELLED: remove active reaction, leave nothing
 
     async def send(
         self,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1050,17 +1050,33 @@ class DiscordAdapter(BasePlatformAdapter):
             and self.config.extra.get("reactions", True)
 
     def _dynamic_reactions_enabled(self) -> bool:
-        """Check if per-tool reaction swapping is enabled."""
-        return self._reactions_enabled() and self.config.extra.get("dynamic_reactions", True)
+        """Check if per-tool reaction swapping is enabled.
+
+        Resolution order:
+        1. ``discord.dynamic_reactions`` in config.yaml (platform override)
+        2. ``dynamic_reactions`` at top-level in config.yaml (global default)
+        3. True (built-in default)
+        """
+        if not self._reactions_enabled():
+            return False
+        extra = self.config.extra
+        if "dynamic_reactions" in extra:
+            return bool(extra["dynamic_reactions"])
+        from hermes_cli.config import load_config
+        return bool(load_config().get("dynamic_reactions", True))
 
     def _persona_emoji(self) -> str:
-        """Return the agent's persona emoji from config.
+        """Return the agent's persona emoji.
 
-        Set ``discord.persona_emoji`` in config.yaml to give the agent a
-        unique identity emoji (e.g. 🔎 for Sherlock, ⚡ for Newton).
-        Falls back to 👀 so existing deployments are unaffected.
+        Resolution order:
+        1. ``discord.persona_emoji`` in config.yaml (platform override)
+        2. ``persona_emoji`` at top-level in config.yaml (global default)
+        3. 👀 (built-in fallback so existing deployments are unaffected)
         """
-        return self.config.extra.get("persona_emoji", "👀")
+        if emoji := self.config.extra.get("persona_emoji"):
+            return emoji
+        from hermes_cli.config import load_config
+        return load_config().get("persona_emoji") or "👀"
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add the agent's persona emoji when processing begins."""

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -532,6 +532,19 @@ class DiscordAdapter(BasePlatformAdapter):
         # Per-message active reaction tracking for persona/tool emoji swapping.
         # Key: message.id (int), Value: currently active reaction emoji (str).
         self._active_tool_reactions: Dict[int, str] = {}
+        # Timestamp of last reaction swap per message — hysteresis to avoid
+        # Discord rate limits (reaction endpoints: ~1 req/0.25s per channel).
+        # Default cooldown: 1 second between swaps per message.
+        self._last_reaction_swap: Dict[int, float] = {}
+        self._reaction_cooldown: float = float(
+            self.config.extra.get("reaction_cooldown",
+                                  1.0)
+        )
+        # Cache resolved config values at init to avoid disk reads on every
+        # tool call.  Persona emoji and dynamic-reactions flag are stable for
+        # the lifetime of the adapter.
+        self._cached_persona_emoji: str = self._resolve_persona_emoji()
+        self._cached_dynamic_reactions: bool = self._resolve_dynamic_reactions()
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1049,8 +1062,8 @@ class DiscordAdapter(BasePlatformAdapter):
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no") \
             and self.config.extra.get("reactions", True)
 
-    def _dynamic_reactions_enabled(self) -> bool:
-        """Check if per-tool reaction swapping is enabled.
+    def _resolve_dynamic_reactions(self) -> bool:
+        """Resolve dynamic reactions flag once at init.
 
         Resolution order:
         1. ``discord.dynamic_reactions`` in config.yaml (platform override)
@@ -1065,8 +1078,12 @@ class DiscordAdapter(BasePlatformAdapter):
         from hermes_cli.config import load_config
         return bool(load_config().get("dynamic_reactions", True))
 
-    def _persona_emoji(self) -> str:
-        """Return the agent's persona emoji.
+    def _dynamic_reactions_enabled(self) -> bool:
+        """Check if per-tool reaction swapping is enabled (cached)."""
+        return self._cached_dynamic_reactions
+
+    def _resolve_persona_emoji(self) -> str:
+        """Resolve the agent's persona emoji once at init.
 
         Resolution order:
         1. ``discord.persona_emoji`` in config.yaml (platform override)
@@ -1078,6 +1095,10 @@ class DiscordAdapter(BasePlatformAdapter):
         from hermes_cli.config import load_config
         return load_config().get("persona_emoji") or "👀"
 
+    def _persona_emoji(self) -> str:
+        """Return the agent's persona emoji (cached)."""
+        return self._cached_persona_emoji
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add the agent's persona emoji when processing begins."""
         if not self._reactions_enabled():
@@ -1087,6 +1108,7 @@ class DiscordAdapter(BasePlatformAdapter):
             emoji = self._persona_emoji()
             await self._add_reaction(message, emoji)
             self._active_tool_reactions[message.id] = emoji
+
     async def on_tool_call_start(self, event: MessageEvent, tool_name: str) -> None:
         """Swap the active reaction to the tool-specific emoji.
 
@@ -1094,19 +1116,32 @@ class DiscordAdapter(BasePlatformAdapter):
         event. Removes the previous reaction (persona or prior tool) and
         adds the emoji that represents the current tool, so the message
         always shows exactly one reaction reflecting what the agent is doing.
+
+        A per-message cooldown (default 1s) prevents hitting Discord's
+        reaction rate limits (~1 req/0.25s per channel, but remove+add = 2
+        calls per swap).
         """
         if not self._dynamic_reactions_enabled():
             return
         message = event.raw_message
         if not hasattr(message, "add_reaction"):
             return
+
+        # Hysteresis: skip if last swap was too recent
+        now = time.monotonic()
+        last = self._last_reaction_swap.get(message.id, 0.0)
+        if now - last < self._reaction_cooldown:
+            return
+
         from agent.display import get_tool_emoji
         tool_emoji = get_tool_emoji(tool_name, default="⚙️")
         current = self._active_tool_reactions.get(message.id)
         if current and current != tool_emoji:
             await self._remove_reaction(message, current)
-        await self._add_reaction(message, tool_emoji)
+        if current != tool_emoji:
+            await self._add_reaction(message, tool_emoji)
         self._active_tool_reactions[message.id] = tool_emoji
+        self._last_reaction_swap[message.id] = now
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Replace the active reaction with the persona emoji (success) or ❌ (failure)."""
@@ -1115,6 +1150,7 @@ class DiscordAdapter(BasePlatformAdapter):
         message = event.raw_message
         if hasattr(message, "add_reaction"):
             current = self._active_tool_reactions.pop(message.id, self._persona_emoji())
+            self._last_reaction_swap.pop(message.id, None)
             await self._remove_reaction(message, current)
             if outcome == ProcessingOutcome.SUCCESS:
                 await self._add_reaction(message, self._persona_emoji())

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -93,6 +93,7 @@ except ImportError:
     TrustState = _TrustStateStub  # type: ignore[misc,assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.reaction_mixin import DynamicReactionMixin
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -288,7 +289,7 @@ class _CryptoStateStore:
         return list(self._joined_rooms)
 
 
-class MatrixAdapter(BasePlatformAdapter):
+class MatrixAdapter(DynamicReactionMixin, BasePlatformAdapter):
     """Gateway adapter for Matrix (any homeserver)."""
 
     # Threshold for detecting Matrix client-side message splits.
@@ -392,6 +393,8 @@ class MatrixAdapter(BasePlatformAdapter):
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
         }
+        # Initialize the platform-agnostic dynamic reaction mixin.
+        self._init_reaction_mixin()
 
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
@@ -1929,41 +1932,58 @@ class MatrixAdapter(BasePlatformAdapter):
         """Remove a reaction by redacting its event."""
         return await self.redact_message(room_id, reaction_event_id, reason)
 
-    async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add eyes reaction when the agent starts processing a message."""
-        if not self._reactions_enabled:
-            return
-        msg_id = event.message_id
-        room_id = event.source.chat_id
+    # ── DynamicReactionMixin primitives ──────────────────────────────────
+
+    # Matrix reactions are separate events.  Adding returns an event_id;
+    # removing means redacting that event.  We track event_ids per
+    # (msg_key, emoji) so _reaction_remove can find the right one.
+
+    def _reaction_resolve_message(self, event: Any) -> Any:
+        """Return (room_id, event_id) tuple for Matrix."""
+        msg_id = getattr(event, "message_id", None)
+        room_id = getattr(getattr(event, "source", None), "chat_id", None)
         if msg_id and room_id:
-            reaction_event_id = await self._send_reaction(room_id, msg_id, "\U0001f440")
-            if reaction_event_id:
-                self._pending_reactions[(room_id, msg_id)] = reaction_event_id
+            return (room_id, msg_id)
+        return None
+
+    def _reaction_msg_key(self, event: Any) -> Optional[tuple]:
+        """Return (room_id, msg_id) as the tracking key."""
+        return self._reaction_resolve_message(event)
+
+    async def _reaction_add(self, msg_ref: Any, emoji: str) -> bool:
+        """Send a reaction and track its event_id for later redaction."""
+        room_id, event_id = msg_ref
+        reaction_event_id = await self._send_reaction(room_id, event_id, emoji)
+        if reaction_event_id:
+            # Store so _reaction_remove can find it
+            self._pending_reactions[(room_id, event_id, emoji)] = reaction_event_id
+            return True
+        return False
+
+    async def _reaction_remove(self, msg_ref: Any, emoji: str) -> bool:
+        """Redact a previously sent reaction."""
+        room_id, event_id = msg_ref
+        key = (room_id, event_id, emoji)
+        reaction_event_id = self._pending_reactions.pop(key, None)
+        if reaction_event_id:
+            return await self._redact_reaction(room_id, reaction_event_id)
+        return False
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add persona emoji when processing begins."""
+        await self._rxn_on_processing_start(event)
+
+    async def on_tool_call_start(self, event, tool_name: str) -> None:
+        """Swap reaction to tool-specific emoji."""
+        await self._rxn_on_tool_call_start(event, tool_name)
 
     async def on_processing_complete(
         self,
         event: MessageEvent,
         outcome: ProcessingOutcome,
     ) -> None:
-        """Replace eyes with checkmark (success) or cross (failure)."""
-        if not self._reactions_enabled:
-            return
-        msg_id = event.message_id
-        room_id = event.source.chat_id
-        if not msg_id or not room_id:
-            return
-        if outcome == ProcessingOutcome.CANCELLED:
-            return
-        reaction_key = (room_id, msg_id)
-        if reaction_key in self._pending_reactions:
-            eyes_event_id = self._pending_reactions.pop(reaction_key)
-            if not await self._redact_reaction(room_id, eyes_event_id):
-                logger.debug("Matrix: failed to redact eyes reaction %s", eyes_event_id)
-        await self._send_reaction(
-            room_id,
-            msg_id,
-            "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c",
-        )
+        """Replace active reaction with final emoji."""
+        await self._rxn_on_processing_complete(event, outcome)
 
     async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""

--- a/gateway/platforms/reaction_mixin.py
+++ b/gateway/platforms/reaction_mixin.py
@@ -1,0 +1,274 @@
+"""Platform-agnostic dynamic tool reactions mixin.
+
+Provides the full lifecycle state machine for emoji reactions during message
+processing:
+
+    on_processing_start  → add persona emoji
+    on_tool_call_start   → swap to tool-specific emoji (with cooldown)
+    on_processing_complete → swap to final emoji (persona / ❌)
+
+Platforms opt in by:
+1. Inheriting ``DynamicReactionMixin`` (before ``BasePlatformAdapter`` in MRO)
+2. Implementing the three primitives:
+   - ``_reaction_add(msg_ref, emoji) -> bool``
+   - ``_reaction_remove(msg_ref, emoji) -> bool``
+   - ``_reaction_msg_key(event) -> Optional[Hashable]``
+
+For replace-all platforms (Telegram), override ``_reaction_replace_mode = True``
+and implement ``_reaction_set(msg_ref, emoji) -> bool`` instead of add/remove.
+
+The mixin resolves ``dynamic_reactions``, ``persona_emoji``, and
+``reaction_cooldown`` from config once at init.  Platforms that don't call
+``_init_reaction_mixin()`` get zero behavior — all hooks short-circuit.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Hashable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class DynamicReactionMixin:
+    """Shared dynamic tool-reaction logic for any messaging platform.
+
+    Call ``_init_reaction_mixin()`` at the end of your adapter's ``__init__``
+    to activate.  Without that call every hook is a no-op.
+    """
+
+    # Subclass overrides ──────────────────────────────────────────────────
+
+    # Set True for platforms where setting a reaction replaces all existing
+    # reactions (e.g. Telegram).  When True, the mixin calls
+    # ``_reaction_set`` instead of ``_reaction_add`` + ``_reaction_remove``.
+    _reaction_replace_mode: bool = False
+
+    # ── Primitives (subclass MUST implement) ─────────────────────────────
+
+    async def _reaction_add(self, msg_ref: Any, emoji: str) -> bool:
+        """Add *emoji* to the message identified by *msg_ref*.
+
+        *msg_ref* is whatever ``_reaction_resolve_message`` returns — a raw
+        Discord message object, a ``(chat_id, message_id)`` tuple, etc.
+        """
+        return False
+
+    async def _reaction_remove(self, msg_ref: Any, emoji: str) -> bool:
+        """Remove *emoji* from the message identified by *msg_ref*."""
+        return False
+
+    async def _reaction_set(self, msg_ref: Any, emoji: str) -> bool:
+        """Replace all reactions on the message with *emoji*.
+
+        Only used when ``_reaction_replace_mode`` is True.
+        """
+        return False
+
+    def _reaction_resolve_message(self, event: Any) -> Any:
+        """Extract a platform-native message reference from *event*.
+
+        Return ``None`` if the event doesn't carry enough info to react.
+        The returned object is passed verbatim to ``_reaction_add`` /
+        ``_reaction_remove`` / ``_reaction_set``.
+        """
+        return None
+
+    def _reaction_msg_key(self, event: Any) -> Optional[Hashable]:
+        """Return a hashable key that uniquely identifies the message.
+
+        Used for tracking active reactions and cooldown timestamps.
+        Return ``None`` to skip reaction handling for this event.
+        """
+        return None
+
+    def _reaction_translate_emoji(self, emoji: str) -> Optional[str]:
+        """Translate a Unicode emoji to the platform's native format.
+
+        Return ``None`` if the emoji is not supported on this platform
+        (the mixin will fall back to the default tool emoji ``⚙️``).
+
+        Default implementation returns the emoji unchanged (Unicode passthrough).
+        """
+        return emoji
+
+    # ── Init ─────────────────────────────────────────────────────────────
+
+    def _init_reaction_mixin(self) -> None:
+        """Initialize mixin state.  Call from adapter ``__init__``."""
+        # Per-message tracking: msg_key → currently displayed emoji
+        self._rxn_active: Dict[Hashable, str] = {}
+        # Per-message tracking: msg_key → resolved message reference
+        self._rxn_msg_refs: Dict[Hashable, Any] = {}
+        # Cooldown: msg_key → monotonic timestamp of last swap
+        self._rxn_last_swap: Dict[Hashable, float] = {}
+
+        # Resolve config once
+        self._rxn_persona_emoji: str = self._rxn_resolve_persona_emoji()
+        self._rxn_dynamic: bool = self._rxn_resolve_dynamic_reactions()
+        self._rxn_cooldown: float = self._rxn_resolve_cooldown()
+        self._rxn_initialized: bool = True
+
+    # ── Config resolution ────────────────────────────────────────────────
+
+    def _rxn_resolve_persona_emoji(self) -> str:
+        """Resolve persona emoji from platform config → global config → default."""
+        extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        if emoji := extra.get("persona_emoji"):
+            return emoji
+        try:
+            from hermes_cli.config import load_config
+            return load_config().get("persona_emoji") or "👀"
+        except Exception:
+            return "👀"
+
+    def _rxn_resolve_dynamic_reactions(self) -> bool:
+        """Resolve dynamic_reactions flag from platform → global → True."""
+        if not self._rxn_reactions_enabled():
+            return False
+        extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        if "dynamic_reactions" in extra:
+            return bool(extra["dynamic_reactions"])
+        try:
+            from hermes_cli.config import load_config
+            return bool(load_config().get("dynamic_reactions", True))
+        except Exception:
+            return True
+
+    def _rxn_resolve_cooldown(self) -> float:
+        """Resolve reaction_cooldown from platform config → default 1.0s."""
+        extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        return float(extra.get("reaction_cooldown", 1.0))
+
+    def _rxn_reactions_enabled(self) -> bool:
+        """Check if reactions are enabled at all.
+
+        Delegates to the adapter's own ``_reactions_enabled()`` if it exists
+        as a callable, or reads it as a bool attribute.  Otherwise returns True.
+        """
+        attr = getattr(self, "_reactions_enabled", None)
+        if callable(attr):
+            return attr()
+        if attr is not None:
+            return bool(attr)
+        return True
+
+    # ── Lifecycle hooks ──────────────────────────────────────────────────
+
+    async def _rxn_on_processing_start(self, event: Any) -> None:
+        """Add persona emoji when processing begins."""
+        if not getattr(self, "_rxn_initialized", False):
+            return
+        if not self._rxn_reactions_enabled():
+            return
+
+        msg_ref = self._reaction_resolve_message(event)
+        if msg_ref is None:
+            return
+        key = self._reaction_msg_key(event)
+        if key is None:
+            return
+
+        emoji = self._rxn_persona_emoji
+        translated = self._reaction_translate_emoji(emoji)
+        if translated is None:
+            translated = "👀"
+
+        if self._reaction_replace_mode:
+            await self._reaction_set(msg_ref, translated)
+        else:
+            await self._reaction_add(msg_ref, translated)
+
+        self._rxn_active[key] = translated
+        self._rxn_msg_refs[key] = msg_ref
+
+    async def _rxn_on_tool_call_start(self, event: Any, tool_name: str) -> None:
+        """Swap reaction to tool-specific emoji (with cooldown)."""
+        if not getattr(self, "_rxn_initialized", False):
+            return
+        if not self._rxn_dynamic:
+            return
+
+        key = self._reaction_msg_key(event)
+        if key is None:
+            return
+        msg_ref = self._rxn_msg_refs.get(key)
+        if msg_ref is None:
+            # Try resolving from event directly (fallback)
+            msg_ref = self._reaction_resolve_message(event)
+            if msg_ref is None:
+                return
+            self._rxn_msg_refs[key] = msg_ref
+
+        # Cooldown check
+        now = time.monotonic()
+        last = self._rxn_last_swap.get(key, 0.0)
+        if now - last < self._rxn_cooldown:
+            return
+
+        from agent.display import get_tool_emoji
+        raw_emoji = get_tool_emoji(tool_name, default="⚙️")
+        tool_emoji = self._reaction_translate_emoji(raw_emoji)
+        if tool_emoji is None:
+            tool_emoji = self._reaction_translate_emoji("⚙️") or "⚙️"
+
+        current = self._rxn_active.get(key)
+        if current == tool_emoji:
+            return  # Already showing this emoji
+
+        if self._reaction_replace_mode:
+            await self._reaction_set(msg_ref, tool_emoji)
+        else:
+            await self._reaction_add(msg_ref, tool_emoji)
+            if current and current != tool_emoji:
+                await self._reaction_remove(msg_ref, current)
+
+        self._rxn_active[key] = tool_emoji
+        self._rxn_last_swap[key] = now
+
+    async def _rxn_on_processing_complete(self, event: Any, outcome: Any) -> None:
+        """Replace active reaction with final emoji."""
+        if not getattr(self, "_rxn_initialized", False):
+            return
+        if not self._rxn_reactions_enabled():
+            return
+
+        key = self._reaction_msg_key(event)
+        if key is None:
+            return
+        msg_ref = self._rxn_msg_refs.pop(key, None)
+        if msg_ref is None:
+            msg_ref = self._reaction_resolve_message(event)
+        current = self._rxn_active.pop(key, None)
+        self._rxn_last_swap.pop(key, None)
+
+        if msg_ref is None:
+            return
+
+        # Import here to avoid circular imports at module level
+        from gateway.platforms.base import ProcessingOutcome
+
+        if outcome == ProcessingOutcome.CANCELLED:
+            # Just clean up, don't change the reaction
+            if current:
+                if not self._reaction_replace_mode:
+                    await self._reaction_remove(msg_ref, current)
+            return
+
+        if outcome == ProcessingOutcome.SUCCESS:
+            final = self._rxn_persona_emoji
+        else:
+            final = "❌"
+
+        translated = self._reaction_translate_emoji(final)
+        if translated is None:
+            translated = self._reaction_translate_emoji("❌") or "❌"
+
+        if self._reaction_replace_mode:
+            await self._reaction_set(msg_ref, translated)
+        else:
+            if translated != current:
+                await self._reaction_add(msg_ref, translated)
+            if current and current != translated:
+                await self._reaction_remove(msg_ref, current)

--- a/gateway/platforms/reaction_mixin.py
+++ b/gateway/platforms/reaction_mixin.py
@@ -127,7 +127,7 @@ class DynamicReactionMixin:
             return "👀"
 
     def _rxn_resolve_dynamic_reactions(self) -> bool:
-        """Resolve dynamic_reactions flag from platform → global → True."""
+        """Resolve dynamic_reactions flag from platform → global → False."""
         if not self._rxn_reactions_enabled():
             return False
         extra = getattr(getattr(self, "config", None), "extra", {}) or {}
@@ -135,9 +135,9 @@ class DynamicReactionMixin:
             return bool(extra["dynamic_reactions"])
         try:
             from hermes_cli.config import load_config
-            return bool(load_config().get("dynamic_reactions", True))
+            return bool(load_config().get("dynamic_reactions", False))
         except Exception:
-            return True
+            return False
 
     def _rxn_resolve_cooldown(self) -> float:
         """Resolve reaction_cooldown from platform config → default 1.0s."""

--- a/gateway/platforms/reaction_mixin.py
+++ b/gateway/platforms/reaction_mixin.py
@@ -24,6 +24,7 @@ The mixin resolves ``dynamic_reactions``, ``persona_emoji``, and
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any, Dict, Hashable, Optional
@@ -103,6 +104,8 @@ class DynamicReactionMixin:
         self._rxn_msg_refs: Dict[Hashable, Any] = {}
         # Cooldown: msg_key → monotonic timestamp of last swap
         self._rxn_last_swap: Dict[Hashable, float] = {}
+        # Per-message lock to serialize reaction swaps (prevents stacking)
+        self._rxn_locks: Dict[Hashable, asyncio.Lock] = {}
 
         # Resolve config once
         self._rxn_persona_emoji: str = self._rxn_resolve_persona_emoji()
@@ -156,6 +159,12 @@ class DynamicReactionMixin:
 
     # ── Lifecycle hooks ──────────────────────────────────────────────────
 
+    def _rxn_lock(self, key: Hashable) -> asyncio.Lock:
+        """Get or create a per-message lock to serialize reaction swaps."""
+        if key not in self._rxn_locks:
+            self._rxn_locks[key] = asyncio.Lock()
+        return self._rxn_locks[key]
+
     async def _rxn_on_processing_start(self, event: Any) -> None:
         """Add persona emoji when processing begins."""
         if not getattr(self, "_rxn_initialized", False):
@@ -193,39 +202,43 @@ class DynamicReactionMixin:
         key = self._reaction_msg_key(event)
         if key is None:
             return
-        msg_ref = self._rxn_msg_refs.get(key)
-        if msg_ref is None:
-            # Try resolving from event directly (fallback)
-            msg_ref = self._reaction_resolve_message(event)
+
+        async with self._rxn_lock(key):
+            msg_ref = self._rxn_msg_refs.get(key)
             if msg_ref is None:
+                # Try resolving from event directly (fallback)
+                msg_ref = self._reaction_resolve_message(event)
+                if msg_ref is None:
+                    return
+                self._rxn_msg_refs[key] = msg_ref
+
+            # Cooldown check
+            now = time.monotonic()
+            last = self._rxn_last_swap.get(key, 0.0)
+            if now - last < self._rxn_cooldown:
                 return
-            self._rxn_msg_refs[key] = msg_ref
 
-        # Cooldown check
-        now = time.monotonic()
-        last = self._rxn_last_swap.get(key, 0.0)
-        if now - last < self._rxn_cooldown:
-            return
+            from agent.display import get_tool_emoji
+            raw_emoji = get_tool_emoji(tool_name, default="⚙️")
+            tool_emoji = self._reaction_translate_emoji(raw_emoji)
+            if tool_emoji is None:
+                tool_emoji = self._reaction_translate_emoji("⚙️") or "⚙️"
 
-        from agent.display import get_tool_emoji
-        raw_emoji = get_tool_emoji(tool_name, default="⚙️")
-        tool_emoji = self._reaction_translate_emoji(raw_emoji)
-        if tool_emoji is None:
-            tool_emoji = self._reaction_translate_emoji("⚙️") or "⚙️"
+            current = self._rxn_active.get(key)
+            if current == tool_emoji:
+                return  # Already showing this emoji
 
-        current = self._rxn_active.get(key)
-        if current == tool_emoji:
-            return  # Already showing this emoji
+            if self._reaction_replace_mode:
+                await self._reaction_set(msg_ref, tool_emoji)
+            else:
+                # Add new FIRST, then remove old — prevents zero-reaction
+                # reflow jitter on Discord (message shifts when reactions disappear)
+                await self._reaction_add(msg_ref, tool_emoji)
+                if current and current != tool_emoji:
+                    await self._reaction_remove(msg_ref, current)
 
-        if self._reaction_replace_mode:
-            await self._reaction_set(msg_ref, tool_emoji)
-        else:
-            await self._reaction_add(msg_ref, tool_emoji)
-            if current and current != tool_emoji:
-                await self._reaction_remove(msg_ref, current)
-
-        self._rxn_active[key] = tool_emoji
-        self._rxn_last_swap[key] = now
+            self._rxn_active[key] = tool_emoji
+            self._rxn_last_swap[key] = now
 
     async def _rxn_on_processing_complete(self, event: Any, outcome: Any) -> None:
         """Replace active reaction with final emoji."""
@@ -237,38 +250,45 @@ class DynamicReactionMixin:
         key = self._reaction_msg_key(event)
         if key is None:
             return
-        msg_ref = self._rxn_msg_refs.pop(key, None)
-        if msg_ref is None:
-            msg_ref = self._reaction_resolve_message(event)
-        current = self._rxn_active.pop(key, None)
-        self._rxn_last_swap.pop(key, None)
 
-        if msg_ref is None:
-            return
+        async with self._rxn_lock(key):
+            msg_ref = self._rxn_msg_refs.pop(key, None)
+            if msg_ref is None:
+                msg_ref = self._reaction_resolve_message(event)
+            current = self._rxn_active.pop(key, None)
+            self._rxn_last_swap.pop(key, None)
 
-        # Import here to avoid circular imports at module level
-        from gateway.platforms.base import ProcessingOutcome
+            if msg_ref is None:
+                self._rxn_locks.pop(key, None)
+                return
 
-        if outcome == ProcessingOutcome.CANCELLED:
-            # Just clean up, don't change the reaction
-            if current:
-                if not self._reaction_replace_mode:
+            # Import here to avoid circular imports at module level
+            from gateway.platforms.base import ProcessingOutcome
+
+            if outcome == ProcessingOutcome.CANCELLED:
+                # Just clean up, don't change the reaction
+                if current:
+                    if not self._reaction_replace_mode:
+                        await self._reaction_remove(msg_ref, current)
+                self._rxn_locks.pop(key, None)
+                return
+
+            if outcome == ProcessingOutcome.SUCCESS:
+                final = self._rxn_persona_emoji
+            else:
+                final = "❌"
+
+            translated = self._reaction_translate_emoji(final)
+            if translated is None:
+                translated = self._reaction_translate_emoji("❌") or "❌"
+
+            if self._reaction_replace_mode:
+                await self._reaction_set(msg_ref, translated)
+            else:
+                if translated != current:
+                    await self._reaction_add(msg_ref, translated)
+                if current and current != translated:
                     await self._reaction_remove(msg_ref, current)
-            return
 
-        if outcome == ProcessingOutcome.SUCCESS:
-            final = self._rxn_persona_emoji
-        else:
-            final = "❌"
-
-        translated = self._reaction_translate_emoji(final)
-        if translated is None:
-            translated = self._reaction_translate_emoji("❌") or "❌"
-
-        if self._reaction_replace_mode:
-            await self._reaction_set(msg_ref, translated)
-        else:
-            if translated != current:
-                await self._reaction_add(msg_ref, translated)
-            if current and current != translated:
-                await self._reaction_remove(msg_ref, current)
+        # Clean up lock outside the lock itself
+        self._rxn_locks.pop(key, None)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
+from gateway.platforms.reaction_mixin import DynamicReactionMixin
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -253,7 +254,7 @@ def _resolve_slack_proxy_url() -> Optional[str]:
     return proxy_url
 
 
-class SlackAdapter(BasePlatformAdapter):
+class SlackAdapter(DynamicReactionMixin, BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
 
@@ -310,6 +311,8 @@ class SlackAdapter(BasePlatformAdapter):
         # Track active assistant thread status indicators so stop_typing can
         # clear them (chat_id → thread_ts).
         self._active_status_threads: Dict[str, str] = {}
+        # Initialize the platform-agnostic dynamic reaction mixin.
+        self._init_reaction_mixin()
 
     def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
@@ -1040,7 +1043,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Reactions -----
 
-    async def _add_reaction(
+    async def _add_slack_reaction(
         self, channel: str, timestamp: str, emoji: str
     ) -> bool:
         """Add an emoji reaction to a message. Returns True on success."""
@@ -1056,7 +1059,7 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] reactions.add failed (%s): %s", emoji, e)
             return False
 
-    async def _remove_reaction(
+    async def _remove_slack_reaction(
         self, channel: str, timestamp: str, emoji: str
     ) -> bool:
         """Remove an emoji reaction from a message. Returns True on success."""
@@ -1075,33 +1078,87 @@ class SlackAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("SLACK_REACTIONS", "true").lower() not in ("false", "0", "no")
 
-    async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
-        if not self._reactions_enabled():
-            return
+    # ── DynamicReactionMixin primitives ──────────────────────────────────
+
+    # Slack uses shortcode emoji names (e.g. "eyes" not "👀").
+    _UNICODE_TO_SLACK: Dict[str, str] = {
+        "👀": "eyes",
+        "✅": "white_check_mark",
+        "❌": "x",
+        "⚙️": "gear",
+        "📄": "page_facing_up",
+        "📝": "memo",
+        "🩹": "adhesive_bandage",
+        "🔎": "mag_right",
+        "💻": "computer",
+        "🐍": "snake",
+        "🌐": "globe_with_meridians",
+        "🖱️": "computer_mouse",
+        "⌨️": "keyboard",
+        "📸": "camera_with_flash",
+        "📜": "scroll",
+        "👁️": "eye",
+        "◀️": "arrow_backward",
+        "🖼️": "frame_with_picture",
+        "🔍": "mag",
+        "💬": "speech_balloon",
+        "📊": "bar_chart",
+        "🧠": "brain",
+        "📁": "file_folder",
+        "🔧": "wrench",
+        "⏰": "alarm_clock",
+        "📋": "clipboard",
+        "🎵": "musical_note",
+        "🗣️": "speaking_head_in_silhouette",
+        "🖼": "frame_with_picture",
+    }
+
+    async def _reaction_add(self, msg_ref: Any, emoji: str) -> bool:
+        """Add an emoji reaction to a Slack message."""
+        channel, ts = msg_ref
+        return await self._add_slack_reaction(channel, ts, emoji)
+
+    async def _reaction_remove(self, msg_ref: Any, emoji: str) -> bool:
+        """Remove an emoji reaction from a Slack message."""
+        channel, ts = msg_ref
+        return await self._remove_slack_reaction(channel, ts, emoji)
+
+    def _reaction_resolve_message(self, event: Any) -> Any:
+        """Return (channel_id, ts) tuple for Slack."""
         ts = getattr(event, "message_id", None)
         if not ts or ts not in self._reacting_message_ids:
-            return
-        channel_id = getattr(event.source, "chat_id", None)
+            return None
+        channel_id = getattr(getattr(event, "source", None), "chat_id", None)
         if channel_id:
-            await self._add_reaction(channel_id, ts, "eyes")
+            return (channel_id, ts)
+        return None
+
+    def _reaction_msg_key(self, event: Any) -> Optional[str]:
+        """Return message timestamp as the tracking key."""
+        ts = getattr(event, "message_id", None)
+        if ts and ts in self._reacting_message_ids:
+            return ts
+        return None
+
+    def _reaction_translate_emoji(self, emoji: str) -> Optional[str]:
+        """Translate Unicode emoji to Slack shortcode."""
+        return self._UNICODE_TO_SLACK.get(emoji, "gear")
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add persona emoji when processing begins."""
+        await self._rxn_on_processing_start(event)
+
+    async def on_tool_call_start(self, event, tool_name: str) -> None:
+        """Swap reaction to tool-specific emoji."""
+        await self._rxn_on_tool_call_start(event, tool_name)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction."""
-        if not self._reactions_enabled():
-            return
+        """Replace active reaction with final emoji."""
+        # Call mixin first (it needs _reacting_message_ids to resolve the message).
+        await self._rxn_on_processing_complete(event, outcome)
         ts = getattr(event, "message_id", None)
-        if not ts or ts not in self._reacting_message_ids:
-            return
-        self._reacting_message_ids.discard(ts)
-        channel_id = getattr(event.source, "chat_id", None)
-        if not channel_id:
-            return
-        await self._remove_reaction(channel_id, ts, "eyes")
-        if outcome == ProcessingOutcome.SUCCESS:
-            await self._add_reaction(channel_id, ts, "white_check_mark")
-        elif outcome == ProcessingOutcome.FAILURE:
-            await self._add_reaction(channel_id, ts, "x")
+        if ts:
+            self._reacting_message_ids.discard(ts)
 
     # ----- User identity resolution -----
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -63,6 +63,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.reaction_mixin import DynamicReactionMixin
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -234,7 +235,7 @@ def _wrap_markdown_tables(text: str) -> str:
     return '\n'.join(out)
 
 
-class TelegramAdapter(BasePlatformAdapter):
+class TelegramAdapter(DynamicReactionMixin, BasePlatformAdapter):
     """
     Telegram bot adapter.
 
@@ -289,6 +290,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
+        # Telegram uses replace-all reactions (set_message_reaction replaces
+        # all existing reactions in one call).
+        self._reaction_replace_mode = True
+        self._init_reaction_mixin()
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -3436,28 +3441,61 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[%s] set_message_reaction failed (%s): %s", self.name, emoji, e)
             return False
 
-    async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
-        if not self._reactions_enabled():
-            return
-        chat_id = getattr(event.source, "chat_id", None)
+    # ── DynamicReactionMixin primitives ──────────────────────────────────
+
+    # Telegram's set_message_reaction replaces all reactions in one call,
+    # so we use _reaction_set (replace mode) instead of add/remove.
+
+    _TELEGRAM_ALLOWED_EMOJIS = frozenset({
+        "👍", "👎", "❤️", "🔥", "🥰", "👏", "😁", "🤔", "🤯", "😱",
+        "🤬", "😢", "🎉", "🤩", "🤮", "💩", "🙏", "👌", "🕊", "🤡",
+        "🥱", "🥴", "😍", "🐳", "❤️\u200d🔥", "🌚", "🌭", "💯", "🤣",
+        "⚡", "🍌", "🏆", "💔", "🤨", "😐", "🍓", "🍾", "💋", "🖕",
+        "😈", "😴", "😭", "🤓", "👻", "👨\u200d💻", "👀", "🎃", "🙈",
+        "😇", "😨", "🤝", "✍️", "🤗", "🫡", "🎅", "🎄", "☃️", "💅",
+        "🤪", "🗿", "🆒", "💘", "🙉", "🦄", "😘", "💊", "🙊", "😎",
+        "👾", "🤷\u200d♂️", "🤷", "🤷\u200d♀️", "😡",
+    })
+
+    async def _reaction_set(self, msg_ref: Any, emoji: str) -> bool:
+        """Replace all reactions on the message with *emoji*."""
+        chat_id, message_id = msg_ref
+        return await self._set_reaction(chat_id, message_id, emoji)
+
+    def _reaction_resolve_message(self, event: Any) -> Any:
+        """Return (chat_id, message_id) tuple for Telegram."""
+        chat_id = getattr(getattr(event, "source", None), "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            return (str(chat_id), str(message_id))
+        return None
+
+    def _reaction_msg_key(self, event: Any) -> Optional[tuple]:
+        """Return (chat_id, message_id) as the tracking key."""
+        return self._reaction_resolve_message(event)
+
+    def _reaction_translate_emoji(self, emoji: str) -> Optional[str]:
+        """Map emoji to Telegram's allowed reaction set.
+
+        Telegram only supports a fixed set of reaction emojis.  Tool emojis
+        that aren't in the set get mapped to 👨‍💻 (technologist).
+        """
+        if emoji in self._TELEGRAM_ALLOWED_EMOJIS:
+            return emoji
+        # Common fallbacks
+        if emoji == "❌":
+            return "👎"
+        # Generic tool activity → technologist
+        return "👨\u200d💻"
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add persona emoji when processing begins."""
+        await self._rxn_on_processing_start(event)
+
+    async def on_tool_call_start(self, event, tool_name: str) -> None:
+        """Swap reaction to tool-specific emoji."""
+        await self._rxn_on_tool_call_start(event, tool_name)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction.
-
-        Unlike Discord (additive reactions), Telegram's set_message_reaction
-        replaces all existing reactions in one call — no remove step needed.
-        """
-        if not self._reactions_enabled():
-            return
-        chat_id = getattr(event.source, "chat_id", None)
-        message_id = getattr(event, "message_id", None)
-        if chat_id and message_id and outcome != ProcessingOutcome.CANCELLED:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-            )
+        """Replace active reaction with final emoji."""
+        await self._rxn_on_processing_complete(event, outcome)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10706,6 +10706,19 @@ class GatewayRunner:
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            # Fire on_tool_call_start hook before the progress_queue guard so
+            # reaction swapping works even when tool progress messages are off.
+            if event_type == "tool.started" and tool_name and _status_adapter and _loop_for_step and _run_still_current():
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter._run_processing_hook(
+                            "on_tool_call_start", source, tool_name
+                        ),
+                        _loop_for_step,
+                    )
+                except Exception:
+                    pass
+
             if not progress_queue or not _run_still_current():
                 return
 
@@ -10760,7 +10773,7 @@ class GatewayRunner:
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
-            
+
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
@@ -11297,7 +11310,7 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            agent.tool_progress_callback = progress_callback  # always register — hook fires before progress_queue guard
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -996,7 +996,9 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
-        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "reactions": True,             # Add emoji reactions to messages during processing
+        "persona_emoji": "",           # Agent identity emoji shown on ack + completion (e.g. 🔎). Empty = 👀
+        "dynamic_reactions": True,     # Swap reaction per tool call to show current activity
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # discord / discord_admin tools: restrict which actions the agent may call.
         # Default (empty) = all actions allowed (subject to bot privileged intents).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -990,6 +990,18 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Agent identity emoji shown on message acknowledgment and completion.
+    # Platforms that support reactions (Discord, Signal, etc.) display this emoji
+    # while the agent is processing. Empty string falls back to 👀.
+    # Can be overridden per-platform under discord.persona_emoji, etc.
+    "persona_emoji": "",
+
+    # Swap the active reaction emoji to reflect the current tool call.
+    # Provides per-tool visibility (📖 read_file, 💻 terminal, 🌐 browser, etc.)
+    # without cluttering the chat with text messages.
+    # Can be overridden per-platform under discord.dynamic_reactions, etc.
+    "dynamic_reactions": True,
+
     # Discord platform settings (gateway mode)
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels
@@ -997,8 +1009,8 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add emoji reactions to messages during processing
-        "persona_emoji": "",           # Agent identity emoji shown on ack + completion (e.g. 🔎). Empty = 👀
-        "dynamic_reactions": True,     # Swap reaction per tool call to show current activity
+        # persona_emoji: ""            # Per-platform override (inherits global persona_emoji if unset)
+        # dynamic_reactions: true      # Per-platform override (inherits global dynamic_reactions if unset)
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # discord / discord_admin tools: restrict which actions the agent may call.
         # Default (empty) = all actions allowed (subject to bot privileged intents).

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -57,7 +57,7 @@ class FakeTree:
 
 @pytest.fixture
 def adapter():
-    config = PlatformConfig(enabled=True, token="***")
+    config = PlatformConfig(enabled=True, token="***", extra={"persona_emoji": "👀"})
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
         tree=FakeTree(),
@@ -89,6 +89,7 @@ async def test_process_message_background_adds_and_swaps_reactions(adapter):
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
+        id=1001,
     )
 
     async def handler(_event):
@@ -105,9 +106,11 @@ async def test_process_message_background_adds_and_swaps_reactions(adapter):
     event = _make_event("1", raw_message)
     await adapter._process_message_background(event, build_session_key(event.source))
 
+    # Mixin adds persona emoji on start; on success the final emoji is the
+    # same persona emoji, so no remove+re-add is needed (optimized away).
     assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
-    assert raw_message.remove_reaction.await_args_list[0].args == ("👀", adapter._client.user)
-    assert raw_message.add_reaction.await_args_list[1].args == ("✅",)
+    assert raw_message.add_reaction.await_count == 1
+    raw_message.remove_reaction.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -151,6 +154,7 @@ async def test_reaction_helper_failures_do_not_break_message_flow(adapter):
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(side_effect=[RuntimeError("no perms"), RuntimeError("no perms")]),
         remove_reaction=AsyncMock(side_effect=RuntimeError("no perms")),
+        id=1003,
     )
 
     async def handler(_event):
@@ -178,6 +182,7 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
+        id=1004,
     )
 
     async def handler(_event):
@@ -208,6 +213,7 @@ async def test_reactions_disabled_via_env_zero(adapter, monkeypatch):
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
+        id=1005,
     )
 
     event = _make_event("5", raw_message)
@@ -226,6 +232,7 @@ async def test_reactions_enabled_by_default(adapter, monkeypatch):
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
+        id=1006,
     )
 
     event = _make_event("6", raw_message)
@@ -239,9 +246,14 @@ async def test_on_processing_complete_cancelled_removes_eyes_without_terminal_re
     raw_message = SimpleNamespace(
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
+        id=1007,
     )
 
     event = _make_event("7", raw_message)
+    # Must start processing first so the mixin tracks the reaction state.
+    await adapter.on_processing_start(event)
+    raw_message.add_reaction.reset_mock()
+    raw_message.remove_reaction.reset_mock()
     await adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
 
     raw_message.remove_reaction.assert_awaited_once_with("👀", adapter._client.user)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -351,6 +351,7 @@ def _make_adapter():
         extra={
             "homeserver": "https://matrix.example.org",
             "user_id": "@bot:example.org",
+            "persona_emoji": "👀",
         },
     )
     adapter = MatrixAdapter(config)
@@ -1713,8 +1714,8 @@ class TestMatrixReactions:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_on_processing_start_sends_eyes(self):
-        """on_processing_start should send eyes reaction."""
+    async def test_on_processing_start_sends_persona_emoji(self):
+        """on_processing_start should send the configured persona emoji."""
         from gateway.platforms.base import MessageEvent, MessageType
 
         self.adapter._reactions_enabled = True
@@ -1730,17 +1731,19 @@ class TestMatrixReactions:
             message_id="$msg1",
         )
         await self.adapter.on_processing_start(event)
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\U0001f440")
-        assert self.adapter._pending_reactions == {("!room:ex", "$msg1"): "$reaction_event_123"}
+        persona = self.adapter._rxn_persona_emoji
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", persona)
+        # Mixin tracks reactions with (room_id, msg_id, emoji) key
+        assert ("!room:ex", "$msg1", persona) in self.adapter._pending_reactions
 
     @pytest.mark.asyncio
-    async def test_on_processing_complete_sends_check(self):
+    async def test_on_processing_complete_success_keeps_persona(self):
+        """Success restores persona emoji — no swap needed if already showing it."""
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 
         self.adapter._reactions_enabled = True
-        self.adapter._pending_reactions = {("!room:ex", "$msg1"): "$eyes_reaction_123"}
+        self.adapter._send_reaction = AsyncMock(return_value="$eyes_reaction_123")
         self.adapter._redact_reaction = AsyncMock(return_value=True)
-        self.adapter._send_reaction = AsyncMock(return_value="$check_reaction_456")
 
         source = MagicMock()
         source.chat_id = "!room:ex"
@@ -1751,18 +1754,22 @@ class TestMatrixReactions:
             raw_message={},
             message_id="$msg1",
         )
+        await self.adapter.on_processing_start(event)
+        self.adapter._send_reaction.reset_mock()
+        self.adapter._redact_reaction.reset_mock()
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
-        self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u2705")
+        # Persona emoji on start == persona emoji on success → optimized away
+        self.adapter._redact_reaction.assert_not_called()
+        self.adapter._send_reaction.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_on_processing_complete_sends_cross_on_failure(self):
+    async def test_on_processing_complete_failure_shows_cross(self):
+        """Failure should redact persona emoji and show ❌."""
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 
         self.adapter._reactions_enabled = True
-        self.adapter._pending_reactions = {("!room:ex", "$msg1"): "$eyes_reaction_123"}
+        self.adapter._send_reaction = AsyncMock(return_value="$eyes_reaction_123")
         self.adapter._redact_reaction = AsyncMock(return_value=True)
-        self.adapter._send_reaction = AsyncMock(return_value="$cross_reaction_456")
 
         source = MagicMock()
         source.chat_id = "!room:ex"
@@ -1773,16 +1780,21 @@ class TestMatrixReactions:
             raw_message={},
             message_id="$msg1",
         )
+        await self.adapter.on_processing_start(event)
+        self.adapter._send_reaction.reset_mock()
+        self.adapter._redact_reaction.reset_mock()
+        self.adapter._send_reaction.return_value = "$cross_reaction_456"
         await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
         self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
         self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u274c")
 
     @pytest.mark.asyncio
-    async def test_on_processing_complete_cancelled_sends_no_terminal_reaction(self):
+    async def test_on_processing_complete_cancelled_cleans_up(self):
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 
         self.adapter._reactions_enabled = True
-        self.adapter._send_reaction = AsyncMock(return_value=True)
+        self.adapter._send_reaction = AsyncMock(return_value="$eyes_reaction_123")
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
 
         source = MagicMock()
         source.chat_id = "!room:ex"
@@ -1793,12 +1805,17 @@ class TestMatrixReactions:
             raw_message={},
             message_id="$msg1",
         )
+        await self.adapter.on_processing_start(event)
+        self.adapter._send_reaction.reset_mock()
+        self.adapter._redact_reaction.reset_mock()
         await self.adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+        # Cancelled: redact the active reaction, don't add a new one
+        self.adapter._redact_reaction.assert_called_once()
         self.adapter._send_reaction.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_on_processing_complete_no_pending_reaction(self):
-        """on_processing_complete should skip redaction if no eyes reaction was tracked."""
+    async def test_on_processing_complete_no_prior_start(self):
+        """on_processing_complete without prior start sends persona emoji."""
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 
         self.adapter._reactions_enabled = True
@@ -1817,13 +1834,16 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         self.adapter._redact_reaction.assert_not_called()
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u2705")
+        persona = self.adapter._rxn_persona_emoji
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", persona)
 
     @pytest.mark.asyncio
     async def test_reactions_disabled(self):
         from gateway.platforms.base import MessageEvent, MessageType
 
         self.adapter._reactions_enabled = False
+        # Re-init mixin so it picks up the disabled flag
+        self.adapter._init_reaction_mixin()
         self.adapter._send_reaction = AsyncMock()
 
         source = MagicMock()
@@ -1837,8 +1857,6 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_start(event)
         self.adapter._send_reaction.assert_not_called()
-
-
 # ---------------------------------------------------------------------------
 # Read receipts
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_reaction_mixin.py
+++ b/tests/gateway/test_reaction_mixin.py
@@ -1,0 +1,414 @@
+"""Tests for the platform-agnostic DynamicReactionMixin.
+
+Tests the configurable behavior: persona emoji, dynamic reactions toggle,
+cooldown, and the full lifecycle state machine — independent of any platform.
+"""
+
+import time
+from types import SimpleNamespace
+from typing import Any, Dict, Hashable, Optional
+from unittest.mock import AsyncMock, patch as mock_patch
+
+import pytest
+
+from gateway.platforms.base import ProcessingOutcome
+from gateway.platforms.reaction_mixin import DynamicReactionMixin
+
+
+# ── Fake adapter that implements the mixin primitives ────────────────────
+
+class FakeAdapter(DynamicReactionMixin):
+    """Minimal adapter that wires the mixin to in-memory tracking."""
+
+    def __init__(self, extra: Optional[Dict] = None, replace_mode: bool = False):
+        self.config = SimpleNamespace(extra=extra or {})
+        self._reaction_replace_mode = replace_mode
+        self._reactions_on = True
+
+        # Track all calls for assertions
+        self.added: list = []
+        self.removed: list = []
+        self.replaced: list = []
+
+        self._init_reaction_mixin()
+
+    def _reactions_enabled(self) -> bool:
+        return self._reactions_on
+
+    async def _reaction_add(self, msg_ref: Any, emoji: str) -> bool:
+        self.added.append((msg_ref, emoji))
+        return True
+
+    async def _reaction_remove(self, msg_ref: Any, emoji: str) -> bool:
+        self.removed.append((msg_ref, emoji))
+        return True
+
+    async def _reaction_set(self, msg_ref: Any, emoji: str) -> bool:
+        self.replaced.append((msg_ref, emoji))
+        return True
+
+    def _reaction_resolve_message(self, event: Any) -> Any:
+        return getattr(event, "msg_ref", None)
+
+    def _reaction_msg_key(self, event: Any) -> Optional[Hashable]:
+        return getattr(event, "msg_key", None)
+
+
+def _make_event(msg_ref="msg1", msg_key="key1"):
+    return SimpleNamespace(msg_ref=msg_ref, msg_key=msg_key)
+
+
+# ── Config resolution ────────────────────────────────────────────────────
+
+
+class TestPersonaEmojiResolution:
+    """Persona emoji should be configurable at platform and global level."""
+
+    def test_default_persona_emoji(self):
+        """Without any config, persona emoji defaults to 👀."""
+        with mock_patch("hermes_cli.config.load_config", return_value={}):
+            adapter = FakeAdapter()
+        assert adapter._rxn_persona_emoji == "👀"
+
+    def test_platform_config_overrides_default(self):
+        """Platform-level persona_emoji takes priority."""
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        assert adapter._rxn_persona_emoji == "🤖"
+
+    def test_global_config_used_when_no_platform_override(self):
+        """Global config.yaml persona_emoji is used when platform doesn't set one."""
+        with mock_patch("hermes_cli.config.load_config", return_value={"persona_emoji": "🦊"}):
+            adapter = FakeAdapter()
+        assert adapter._rxn_persona_emoji == "🦊"
+
+    def test_platform_overrides_global(self):
+        """Platform-level wins over global config."""
+        with mock_patch("hermes_cli.config.load_config", return_value={"persona_emoji": "🦊"}):
+            adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        assert adapter._rxn_persona_emoji == "🤖"
+
+
+class TestDynamicReactionsResolution:
+    """dynamic_reactions flag should be configurable."""
+
+    def test_enabled_by_default(self):
+        """Dynamic reactions are on by default."""
+        with mock_patch("hermes_cli.config.load_config", return_value={}):
+            adapter = FakeAdapter()
+        assert adapter._rxn_dynamic is True
+
+    def test_disabled_via_platform_config(self):
+        """Platform-level dynamic_reactions=false disables tool swapping."""
+        adapter = FakeAdapter(extra={"dynamic_reactions": False})
+        assert adapter._rxn_dynamic is False
+
+    def test_disabled_via_global_config(self):
+        """Global dynamic_reactions=false disables tool swapping."""
+        with mock_patch("hermes_cli.config.load_config", return_value={"dynamic_reactions": False}):
+            adapter = FakeAdapter()
+        assert adapter._rxn_dynamic is False
+
+    def test_disabled_when_reactions_off(self):
+        """Dynamic reactions are off when base reactions are disabled."""
+        adapter = FakeAdapter()
+        adapter._reactions_on = False
+        adapter._init_reaction_mixin()
+        assert adapter._rxn_dynamic is False
+
+
+class TestCooldownResolution:
+    """reaction_cooldown should be configurable."""
+
+    def test_default_cooldown(self):
+        adapter = FakeAdapter()
+        assert adapter._rxn_cooldown == 1.0
+
+    def test_custom_cooldown(self):
+        adapter = FakeAdapter(extra={"reaction_cooldown": 2.5})
+        assert adapter._rxn_cooldown == 2.5
+
+
+# ── Lifecycle: add-remove mode (Discord, Slack, Matrix) ──────────────────
+
+
+class TestAddRemoveLifecycle:
+    """Full lifecycle with add/remove reactions (Discord-style)."""
+
+    @pytest.mark.asyncio
+    async def test_processing_start_adds_persona_emoji(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+
+        assert adapter.added == [("msg1", "🤖")]
+        assert adapter._rxn_active["key1"] == "🤖"
+
+    @pytest.mark.asyncio
+    async def test_processing_start_skipped_when_disabled(self):
+        adapter = FakeAdapter()
+        adapter._reactions_on = False
+        adapter._init_reaction_mixin()
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+
+        assert adapter.added == []
+
+    @pytest.mark.asyncio
+    async def test_tool_call_swaps_emoji(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        adapter._rxn_cooldown = 0  # disable cooldown for test
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+
+        # Should add tool emoji and remove persona
+        assert len(adapter.added) == 1
+        assert adapter.added[0][0] == "msg1"
+        assert len(adapter.removed) == 1
+        assert adapter.removed[0] == ("msg1", "🤖")
+
+    @pytest.mark.asyncio
+    async def test_tool_call_skipped_when_dynamic_disabled(self):
+        adapter = FakeAdapter(extra={"dynamic_reactions": False})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+
+        assert adapter.added == []
+        assert adapter.removed == []
+
+    @pytest.mark.asyncio
+    async def test_cooldown_prevents_rapid_swaps(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖", "reaction_cooldown": 10.0})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+
+        # First tool call should work
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+        assert len(adapter.added) == 1
+
+        # Second tool call within cooldown should be skipped
+        adapter.added.clear()
+        await adapter._rxn_on_tool_call_start(event, "read_file")
+        assert adapter.added == []
+
+    @pytest.mark.asyncio
+    async def test_success_restores_persona_emoji(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        adapter._rxn_cooldown = 0
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+        adapter.added.clear()
+        adapter.removed.clear()
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        # Should swap tool emoji → persona emoji
+        assert any(emoji == "🤖" for _, emoji in adapter.added)
+        assert len(adapter.removed) >= 1
+
+    @pytest.mark.asyncio
+    async def test_success_no_swap_when_already_persona(self):
+        """When no tool calls happened, success shouldn't remove+re-add."""
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        # Persona → persona: no swap needed
+        assert adapter.added == []
+        assert adapter.removed == []
+
+    @pytest.mark.asyncio
+    async def test_failure_shows_error_emoji(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+        adapter.removed.clear()
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+        assert any(emoji == "❌" for _, emoji in adapter.added)
+        assert any(emoji == "🤖" for _, emoji in adapter.removed)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_removes_reaction(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+        adapter.removed.clear()
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.CANCELLED)
+
+        assert ("msg1", "🤖") in adapter.removed
+        assert adapter.added == []
+
+    @pytest.mark.asyncio
+    async def test_cleanup_after_complete(self):
+        """Tracking dicts should be cleaned up after processing completes."""
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        assert "key1" in adapter._rxn_active
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        assert "key1" not in adapter._rxn_active
+        assert "key1" not in adapter._rxn_msg_refs
+        assert "key1" not in adapter._rxn_last_swap
+
+
+# ── Lifecycle: replace mode (Telegram) ───────────────────────────────────
+
+
+class TestReplaceLifecycle:
+    """Full lifecycle with replace-all reactions (Telegram-style)."""
+
+    @pytest.mark.asyncio
+    async def test_processing_start_sets_persona(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🦊"}, replace_mode=True)
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+
+        assert adapter.replaced == [("msg1", "🦊")]
+        assert adapter.added == []
+
+    @pytest.mark.asyncio
+    async def test_tool_call_replaces_emoji(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🦊"}, replace_mode=True)
+        adapter._rxn_cooldown = 0
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.replaced.clear()
+
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+
+        # Replace mode: single set call, no add+remove
+        assert len(adapter.replaced) == 1
+        assert adapter.added == []
+        assert adapter.removed == []
+
+    @pytest.mark.asyncio
+    async def test_success_replaces_with_persona(self):
+        adapter = FakeAdapter(extra={"persona_emoji": "🦊"}, replace_mode=True)
+        adapter._rxn_cooldown = 0
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+        adapter.replaced.clear()
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        assert any(emoji == "🦊" for _, emoji in adapter.replaced)
+
+
+# ── Emoji translation ────────────────────────────────────────────────────
+
+
+class TestEmojiTranslation:
+    """Platforms can override _reaction_translate_emoji for format conversion."""
+
+    @pytest.mark.asyncio
+    async def test_custom_translation(self):
+        """Subclass emoji translation is applied to all reactions."""
+
+        class SlackLikeAdapter(FakeAdapter):
+            def _reaction_translate_emoji(self, emoji: str) -> Optional[str]:
+                return {"👀": "eyes", "❌": "x"}.get(emoji, "gear")
+
+        adapter = SlackLikeAdapter(extra={"persona_emoji": "👀"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+
+        assert adapter.added == [("msg1", "eyes")]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_emoji_falls_back(self):
+        """When translation returns None, fallback emoji is used."""
+
+        class LimitedAdapter(FakeAdapter):
+            def _reaction_translate_emoji(self, emoji: str) -> Optional[str]:
+                if emoji == "👀":
+                    return "👀"
+                return None  # unsupported
+
+        adapter = LimitedAdapter(extra={"persona_emoji": "👀"})
+        adapter._rxn_cooldown = 0
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        adapter.added.clear()
+
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+
+        # Tool emoji unsupported → falls back to ⚙️ → also None → "⚙️"
+        # The mixin tries translate(raw) then translate("⚙️") then "⚙️"
+        assert len(adapter.added) == 1
+
+
+# ── Edge cases ───────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+
+    @pytest.mark.asyncio
+    async def test_no_msg_ref_is_noop(self):
+        """Events that don't resolve to a message are silently skipped."""
+        adapter = FakeAdapter()
+        event = SimpleNamespace(msg_ref=None, msg_key=None)
+
+        await adapter._rxn_on_processing_start(event)
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        assert adapter.added == []
+        assert adapter.removed == []
+
+    @pytest.mark.asyncio
+    async def test_complete_without_start_is_safe(self):
+        """on_processing_complete without prior start doesn't crash."""
+        adapter = FakeAdapter(extra={"persona_emoji": "🤖"})
+        event = _make_event()
+
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        # Should add persona emoji even without prior tracking
+        assert any(emoji == "🤖" for _, emoji in adapter.added)
+
+    @pytest.mark.asyncio
+    async def test_mixin_not_initialized_is_noop(self):
+        """If _init_reaction_mixin was never called, all hooks are no-ops."""
+        adapter = FakeAdapter.__new__(FakeAdapter)
+        adapter.added = []
+        adapter.removed = []
+        event = _make_event()
+
+        await adapter._rxn_on_processing_start(event)
+        await adapter._rxn_on_tool_call_start(event, "terminal")
+        await adapter._rxn_on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        assert adapter.added == []
+        assert adapter.removed == []

--- a/tests/gateway/test_reaction_mixin.py
+++ b/tests/gateway/test_reaction_mixin.py
@@ -91,11 +91,11 @@ class TestPersonaEmojiResolution:
 class TestDynamicReactionsResolution:
     """dynamic_reactions flag should be configurable."""
 
-    def test_enabled_by_default(self):
-        """Dynamic reactions are on by default."""
+    def test_disabled_by_default(self):
+        """Dynamic reactions are off by default."""
         with mock_patch("hermes_cli.config.load_config", return_value={}):
             adapter = FakeAdapter()
-        assert adapter._rxn_dynamic is True
+        assert adapter._rxn_dynamic is False
 
     def test_disabled_via_platform_config(self):
         """Platform-level dynamic_reactions=false disables tool swapping."""

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1484,7 +1484,7 @@ class TestReactions:
     @pytest.mark.asyncio
     async def test_add_reaction_calls_api(self, adapter):
         adapter._app.client.reactions_add = AsyncMock()
-        result = await adapter._add_reaction("C123", "ts1", "eyes")
+        result = await adapter._add_slack_reaction("C123", "ts1", "eyes")
         assert result is True
         adapter._app.client.reactions_add.assert_called_once_with(
             channel="C123", timestamp="ts1", name="eyes"
@@ -1493,13 +1493,13 @@ class TestReactions:
     @pytest.mark.asyncio
     async def test_add_reaction_handles_error(self, adapter):
         adapter._app.client.reactions_add = AsyncMock(side_effect=Exception("already_reacted"))
-        result = await adapter._add_reaction("C123", "ts1", "eyes")
+        result = await adapter._add_slack_reaction("C123", "ts1", "eyes")
         assert result is False
 
     @pytest.mark.asyncio
     async def test_remove_reaction_calls_api(self, adapter):
         adapter._app.client.reactions_remove = AsyncMock()
-        result = await adapter._remove_reaction("C123", "ts1", "eyes")
+        result = await adapter._remove_slack_reaction("C123", "ts1", "eyes")
         assert result is True
 
     @pytest.mark.asyncio
@@ -1550,10 +1550,10 @@ class TestReactions:
 
         add_calls = adapter._app.client.reactions_add.call_args_list
         remove_calls = adapter._app.client.reactions_remove.call_args_list
-        assert len(add_calls) == 2
-        assert add_calls[1].kwargs["name"] == "white_check_mark"
-        assert len(remove_calls) == 1
-        assert remove_calls[0].kwargs["name"] == "eyes"
+        # Mixin optimizes: persona emoji on start == persona emoji on success,
+        # so no remove+re-add is needed.
+        assert len(add_calls) == 1
+        assert len(remove_calls) == 0
 
         # Message ID should be cleaned up
         assert "1234567890.000001" not in adapter._reacting_message_ids
@@ -1579,6 +1579,12 @@ class TestReactions:
             source=source,
             message_id="1234567890.000002",
         )
+        # Must start processing first so the mixin tracks the reaction state.
+        await adapter.on_processing_start(msg_event)
+        adapter._app.client.reactions_add.reset_mock()
+        adapter._app.client.reactions_remove.reset_mock()
+        # Re-add so on_processing_complete can find it
+        adapter._reacting_message_ids.add("1234567890.000002")
         await adapter.on_processing_complete(msg_event, ProcessingOutcome.FAILURE)
 
         add_calls = adapter._app.client.reactions_add.call_args_list

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -15,9 +15,17 @@ def _make_adapter(**extra_env):
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
-    adapter.config = PlatformConfig(enabled=True, token="fake-token")
+    # Use persona_emoji=👀 so tests are deterministic and don't depend on
+    # the host's config.yaml.
+    adapter.config = PlatformConfig(
+        enabled=True, token="fake-token",
+        extra={"persona_emoji": "👀"},
+    )
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()
+    # Initialize the dynamic reaction mixin (normally done in __init__).
+    adapter._reaction_replace_mode = True
+    adapter._init_reaction_mixin()
     return adapter
 
 
@@ -175,23 +183,24 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_success(monkeypatch):
-    """Successful processing should set thumbs-up reaction."""
+    """Successful processing should set persona emoji reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
 
     await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
 
+    # Mixin uses persona emoji (👀) for success
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44d",
+        reaction="👀",
     )
 
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_failure(monkeypatch):
-    """Failed processing should set thumbs-down reaction."""
+    """Failed processing should set thumbs-down reaction (❌ mapped to 👎 on Telegram)."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -201,7 +210,7 @@ async def test_on_processing_complete_failure(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44e",
+        reaction="👎",
     )
 
 


### PR DESCRIPTION
What and why

Optionally replace the hardcoded 👀->✅ reaction cycle with configurable persona emojis and live tool-specific emoji swaps. Each agent gets its own dedicated emoji. When dynamic_reactions is on, the reaction reflects the active tool during processing: 📄 for file reads, 💻 for terminal, 🔍 for search (with configurable hysterisis).

Useful if you disable the tool output in chat but still want to know your agent is actively working


https://github.com/user-attachments/assets/28455237-f47b-4e2c-bdd1-52431543074f



The state machine lives in a new mixin (reaction_mixin.py). Discord, Telegram, Slack, and Matrix all use it. Each adapter implements a few primitives, and the mixin handles lifecycle, cooldown, locking, and config.

Files changed

gateway/platforms/reaction_mixin.py (new): lifecycle state machine, per-message locks, cooldown, config resolution
agent/display.py  built-in tool emoji map for get_tool_emoji()
gateway/platforms/discord.py: mixin integration, add/remove primitives, raw message caching
gateway/platforms/telegram.py: mixin in replace mode (_reaction_set)
gateway/platforms/slack.py: mixin with emoji translation (Unicode → Slack shortcodes)
gateway/platforms/matrix.py: mixin with reaction event ID tracking for redaction
gateway/platforms/base.py: adds on_tool_call_start hook
gateway/run.py: wires on_tool_call_start into the pipeline
tests/gateway/test_reaction_mixin.py (new): config, lifecycle, replace-mode, translation, cooldown, edge cases
Updated tests for Discord, Telegram, Slack, Matrix

Config (all optional)

persona_emoji: "🤖"        # default: 👀
dynamic_reactions: true     # default: false
reaction_cooldown: 1.0      # seconds, default: 1.0 (hysterisis)

Set globally or per-platform (platform wins).

Adding to a new platform

Inherit DynamicReactionMixin before BasePlatformAdapter, call _init_reaction_mixin() in __init__ (1/2)
Implement primitives: _reaction_add/_reaction_remove (or _reaction_set with _reaction_replace_mode = True), plus _reaction_resolve_message and _reaction_msg_key
Wire hooks: on_processing_start → _rxn_on_processing_start, on_tool_call_start → _rxn_on_tool_call_start, on_processing_complete → _rxn_on_processing_complete
Optional: override _reaction_translate_emoji() for platforms that use named reactions

How to test

pytest tests/gateway/test_reaction_mixin.py tests/gateway/test_discord_reactions.py tests/gateway/test_telegram_reactions.py tests/gateway/test_slack.py tests/gateway/test_matrix.py -v

Manual: set persona_emoji + dynamic_reactions: true, send a message that triggers multiple tools, watch the reaction swap mid-turn.

Tested on: Discord (live DMs, multi-tool turns)