### PR TITLE
fix(feishu): use root_id as fallback for reply_to_message_id (#18566)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2760,6 +2760,7 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
+            or getattr(message, "root_id", None)
             or None
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1858,6 +1858,46 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
 
+    def test_process_inbound_message_uses_root_id_as_reply_fallback(self):
+        """When parent_id and upper_message_id are absent but root_id is present,
+        reply_to_message_id should resolve to root_id (#18566)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="根消息内容")
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            parent_id=None,
+            upper_message_id=None,
+            root_id="om_root",
+            message_type="text",
+            content='{"text":"reply"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                chat_type="p2p",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.reply_to_message_id, "om_root")
+        self.assertEqual(event.reply_to_text, "根消息内容")
+
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig


### PR DESCRIPTION
## What broke
Feishu/Lark inbound reply events can carry reply-tree context in `root_id`. Hermes currently resolves `MessageEvent.reply_to_message_id` from `parent_id` or `upper_message_id` only. If the event payload has `root_id` but no `parent_id`, the gateway never injects the `[Replying to: ...]` context for the agent.

## Root cause
In `gateway/platforms/feishu.py`, the reply-to resolution chain only checks two fields:
```python
reply_to_message_id = (
    getattr(message, "parent_id", None)
    or getattr(message, "upper_message_id", None)
    or None
)
```
When Feishu sends a reply event where only `root_id` is populated (no `parent_id` or `upper_message_id`), `reply_to_message_id` remains `None` and `_fetch_message_text()` is never called.

## Why this fix is minimal
Single-line addition: add `root_id` as a third fallback in the existing resolution chain. No changes to `_fetch_message_text()`, no changes to outbound routing, no API surface changes.

## What I tested
Added `test_process_inbound_message_uses_root_id_as_reply_fallback` in `tests/gateway/test_feishu.py`:
- Verifies that when `parent_id` and `upper_message_id` are absent but `root_id` is present, `reply_to_message_id` resolves to `root_id` and `reply_to_text` is fetched correctly.

Existing test `test_process_inbound_message_fetches_reply_to_text` (parent_id path) remains unchanged.

## What I intentionally did not change
- Feishu outbound routing or topic routing (#6969 / #17875)
- `_fetch_message_text()` implementation
- Any other platform adapters