### PR TITLE
fix: allow WebSocket connections from non-loopback IPs in --insecure mode

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2882,6 +2882,25 @@ _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 # loopback so tests don't need to rewrite request scope.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
+
+def _is_public_bind() -> bool:
+    """True when bound to all-interfaces (operator used --insecure)."""
+    return getattr(app.state, "bound_host", "") in ("0.0.0.0", "::")
+
+
+def _ws_client_is_allowed(ws: "WebSocket") -> bool:
+    """Check if the WebSocket client IP is acceptable.
+
+    Allows loopback always; allows any IP when bound to all-interfaces
+    (--insecure mode, guarded by session token auth).
+    """
+    if _is_public_bind():
+        return True
+    client_host = ws.client.host if ws.client else ""
+    if not client_host:
+        return True
+    return client_host in _LOOPBACK_HOSTS
+
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
 # the chat tab generates on mount; entries auto-evict when the last subscriber
@@ -2972,8 +2991,7 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=4401)
         return
 
-    client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if not _ws_client_is_allowed(ws):
         await ws.close(code=4403)
         return
 
@@ -3080,8 +3098,7 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4401)
         return
 
-    client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if not _ws_client_is_allowed(ws):
         await ws.close(code=4403)
         return
 
@@ -3113,8 +3130,7 @@ async def pub_ws(ws: WebSocket) -> None:
         await ws.close(code=4401)
         return
 
-    client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if not _ws_client_is_allowed(ws):
         await ws.close(code=4403)
         return
 
@@ -3143,8 +3159,7 @@ async def events_ws(ws: WebSocket) -> None:
         await ws.close(code=4401)
         return
 
-    client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if not _ws_client_is_allowed(ws):
         await ws.close(code=4403)
         return
 


### PR DESCRIPTION
## Problem

When running `hermes dashboard --host 0.0.0.0 --insecure` behind a reverse proxy (e.g. Tailscale Serve), the dashboard page loads but WebSocket connections to `/api/pty`, `/api/ws`, `/api/pub`, and `/api/events` are rejected with close code 4403. This causes the **"events feed disconnected"** error in the UI — tool calls don't appear in the sidebar.

The `--insecure` flag bypasses the Host header middleware but the WebSocket endpoints have an independent hardcoded loopback-only check on the client IP that doesn't respect the bind mode.

## Fix

- Extract the repeated 4-line loopback check into `_ws_client_is_allowed(ws)` helper (DRY)
- When bound to `0.0.0.0`/`::` (public bind / `--insecure`), skip the client IP restriction
- Session token HMAC auth is still enforced on every WS endpoint regardless of bind mode

## Testing

- `tests/hermes_cli/test_web_server_host_header.py` — 8/8 pass
- `tests/hermes_cli/` WS/PTY tests — 306 passed, 1 skipped