### PR TITLE
fix(cron): report shared gateway runtime owner

### DIFF
--- a/.devlogs/2026-05-01-cron-container-health.md
+++ b/.devlogs/2026-05-01-cron-container-health.md
@@ -1,0 +1,85 @@
+# Cron container-aware gateway health
+
+**Date:** 2026-05-01
+**Author:** Hermes Agent
+**Branch:** cron-health-observability-20260501223311
+**PR:** Pending creation
+
+## Goal
+
+Make Hermes cron diagnostics accurate in container/shared-`HERMES_HOME` deployments where the Docker-supervised gateway owns the scheduler but its PID may not be visible from the inspecting CLI/container. Prevent operators from starting duplicate gateways because of a PID-namespace false negative.
+
+## What Was Done
+
+- Added plan/spec: `.hermes/plans/2026-05-01-cron-container-health.md`.
+- Added ADR: `docs/adr/2026-05-01-container-aware-cron-health.md`.
+- Updated `gateway/status.py` with `get_gateway_owner_status()` to report `local_pid_running`, `shared_lock_active`, or `not_running` from runtime lock/PID metadata.
+- Updated `gateway/status.py` so `get_running_pid()` preserves PID/lock metadata when a shared runtime lock is active but the PID is not locally visible.
+- Updated `hermes_cli/cron.py` so `hermes cron status` and `hermes cron list` use runtime-owner status instead of local PID-only detection.
+- Added cron/status regression tests in `tests/hermes_cli/test_cron.py`.
+- Added runtime-owner and metadata-preservation tests in `tests/hermes_cli/test_gateway_runtime_health.py`.
+- Updated `website/docs/guides/cron-troubleshooting.md` with container-aware cron/gateway diagnosis and duplicate-gateway warning.
+
+## Key Decisions
+
+- Runtime lock ownership is now the cross-namespace scheduler-owner signal for cron diagnostics.
+- `get_running_pid()` remains a local-PID helper for backward compatibility; broader cron diagnostics use the new owner-state helper.
+- ADR required because this changes the operational source of truth for cron/gateway liveness in containerized deployments.
+- No Docker Compose/service changes were made in this branch; this branch is limited to status logic, tests, docs, and ADR.
+
+## Validation
+
+- RED: `python -m pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py -q` — failed as expected before production changes because `gateway.status.get_gateway_owner_status` did not exist; output captured at `/work/.hermes-data/tdd-evidence/2026-05-01-cron-health-red.txt`.
+- GREEN targeted: `python -m pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py -q` — passed after implementation; earlier output captured at `/work/.hermes-data/tdd-evidence/2026-05-01-cron-health-green-targeted.txt`.
+- Final relevant regression: `python -m pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py tests/hermes_cli/test_gateway.py -q` — 34 passed; output captured at `/work/.hermes-data/tdd-evidence/2026-05-01-cron-health-green-regression-final2.txt`.
+- Compile check: `python -m py_compile gateway/status.py hermes_cli/cron.py` — passed.
+- Static scan: `python /work/.hermes-data/skills/software-development/requesting-code-review/scripts/static_scan_diff.py --unstaged` — `STATIC_SCAN_PASS True`.
+- Broader adjacent check: `python -m pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py -q` — 130 passed, 7 failed in gateway service/systemd-root environment cases; output captured at `/work/.hermes-data/tdd-evidence/2026-05-01-cron-health-regression.txt`. These failures were outside touched files and not resolved in this branch.
+- Independent review: delegate reviewer passed the diff with no security concerns or logic errors. Reviewer suggestions for metadata-preservation and branch coverage were addressed with additional tests.
+
+## What Skills and Tools Were Used
+
+- Skills: `hermes-agent`, `test-driven-development`, `requesting-code-review`, `devlog`.
+- Tools: git worktree, pytest, py_compile, static diff scanner, independent `delegate_task` reviewer.
+
+## Artifacts Updated
+
+- `.hermes/plans/2026-05-01-cron-container-health.md`
+- `docs/adr/2026-05-01-container-aware-cron-health.md`
+- `.devlogs/2026-05-01-cron-container-health.md`
+- `website/docs/guides/cron-troubleshooting.md`
+
+## Related Repos
+
+- `hermes-agent` worktree: `/work/.hermes-data/worktrees/hermes-agent-cron-health-20260501223311`
+
+## Issues & Blockers
+
+- Full gateway-service-adjacent regression includes existing environment-sensitive systemd/root failures in `tests/hermes_cli/test_gateway_service.py`; this branch did not change those paths. Follow-up: https://github.com/NousResearch/hermes-agent/issues/18630
+- CLI-level shared-lock coverage is useful but intentionally out of scope for this branch's minimal unit/doc/ADR change. Follow-up: https://github.com/NousResearch/hermes-agent/issues/18631
+
+## Key Learnings
+
+- Cron status in shared-volume/container deployments should not be derived solely from locally visible PIDs.
+- Active gateway runtime locks are a safer scheduler-owner signal than PID visibility across process namespaces, but they do not prove platform adapter health.
+- Tests should explicitly cover both operator UI behavior (`cron status`/`list`) and metadata preservation behavior (`get_running_pid`).
+
+## Next Steps
+
+- Follow up on gateway service test stabilization: https://github.com/NousResearch/hermes-agent/issues/18630.
+- Follow up on CLI-level shared-lock cron status coverage: https://github.com/NousResearch/hermes-agent/issues/18631.
+
+## Prompting Notes
+
+- **Initial ask:** Continue preserved task list after context compression and finish validation/review/devlog/final guard.
+- **Clarifications needed:** None.
+- **Corrections made:** Added direct metadata-preservation and branch coverage tests after independent review suggestions.
+- **Scope drift:** Kept scope to cron/gateway status logic, tests, docs, and ADR; did not modify deployment scripts.
+
+## Session Quality
+
+- **Faithfulness:** Stayed on track — completed the preserved validation/review and devlog path without committing.
+- **Prompt patterns:** The preserved task list and previous handoff gave clear success criteria; context compression required re-verifying files and evidence instead of relying on the handoff.
+
+---
+*Generated by Hermes Agent — devlog skill*

--- a/.devlogs/2026-05-01-cron-container-health.md
+++ b/.devlogs/2026-05-01-cron-container-health.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-01
 **Author:** Hermes Agent
 **Branch:** cron-health-observability-20260501223311
-**PR:** Pending creation
+**PR:** https://github.com/NousResearch/hermes-agent/pull/18634
 
 ## Goal
 

--- a/.hermes/plans/2026-05-01-cron-container-health.md
+++ b/.hermes/plans/2026-05-01-cron-container-health.md
@@ -1,0 +1,79 @@
+# Cron container-aware health and gateway ownership
+
+Created: 2026-05-01
+Branch: cron-health-observability-20260501223311
+Worktree: /work/.hermes-data/worktrees/hermes-agent-cron-health-20260501223311
+
+## Problem
+
+`hermes cron status` and `hermes cron list` currently decide whether cron will fire by looking for locally visible gateway PIDs via `hermes_cli.gateway.find_gateway_pids()`. That is misleading in containerized deployments where the scheduler/gateway runs in another container but shares the same `HERMES_HOME` volume. In that case the gateway's process namespace may be invisible, while the shared runtime lock and status files are still authoritative enough to show that one gateway owner exists.
+
+The current gateway status helper also risks treating a lock-held PID file as stale when the PID cannot be verified from the current namespace. That is unsafe for shared-volume/container deployments.
+
+## Goals
+
+1. Make cron status/list distinguish:
+   - local gateway PID visible;
+   - shared gateway runtime lock active but PID not locally visible;
+   - no gateway owner detected.
+2. Avoid deleting gateway PID/lock metadata when a runtime lock is actively held but the PID is not visible from this namespace.
+3. Document the one-supervised-gateway-owner model for container/shared-HERMES_HOME cron deployments.
+4. Preserve existing non-container behavior.
+
+## Non-goals
+
+- Add a new scheduler process or cron-only mode.
+- Change cron job execution semantics.
+- Change Docker Compose or deployment scripts in this PR.
+- Make cross-host/network-filesystem locks a supported guarantee.
+
+## Proposed implementation
+
+### Production changes
+
+1. `gateway/status.py`
+   - Add a small public helper that reports gateway runtime owner state from the shared runtime lock/PID metadata without requiring local PID visibility.
+   - Keep `get_running_pid()` backwards compatible for callers that need a local PID.
+   - Change stale cleanup behavior so an active runtime lock with unverifiable PID does not delete PID/lock files.
+
+2. `hermes_cli/cron.py`
+   - Replace direct `find_gateway_pids()` cron health checks with a cron-local formatter that uses the gateway runtime helper.
+   - Output should be explicit:
+     - local PID visible: green, jobs fire automatically;
+     - shared runtime lock active: green/notice, jobs likely fire from another namespace/container;
+     - no owner: red/yellow, jobs will not fire automatically.
+
+3. Docs
+   - Update `website/docs/guides/cron-troubleshooting.md` with container/shared-volume diagnosis.
+   - Add ADR `docs/adr/2026-05-01-container-aware-cron-health.md` documenting runtime lock as the cross-namespace scheduler-owner signal.
+
+### Tests
+
+1. Add/extend `tests/hermes_cli/test_cron.py`
+   - RED: with no locally visible PID but an active gateway runtime lock, `cron status` should not say jobs will NOT fire.
+   - RED: `cron list` should not warn that gateway is not running when a shared runtime lock is active.
+
+2. Add/extend gateway runtime status tests
+   - RED: when runtime lock is active but PID is not visible from current namespace, status detection reports `shared_lock_active` or equivalent and does not delete metadata.
+
+## Acceptance criteria
+
+- `pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py` passes.
+- Targeted tests show RED before production changes and GREEN after.
+- `python -m py_compile gateway/status.py hermes_cli/cron.py` passes.
+- Docs and ADR are present in the same branch.
+- Repo-local devlog captures goal, files, decisions, RED/GREEN evidence, and learning triage.
+- Final guard passes with `HERMES_TDD_EVIDENCE` populated.
+
+## ADR rationale
+
+ADR required. This changes the operational source of truth for cron/gateway liveness in containerized deployments and should be durable architecture knowledge, not just inline comments.
+
+## Risks and mitigations
+
+- Risk: Runtime lock held by a wedged process could make status optimistic.
+  - Mitigation: message says shared runtime owner detected, not that every platform is healthy; recent runtime health lines still surface fatal platform states.
+- Risk: Network filesystems may not preserve lock semantics.
+  - Mitigation: docs explicitly scope this to verified local shared volumes/bind mounts.
+- Risk: Existing callers expect PID-based detection.
+  - Mitigation: keep `get_running_pid()` semantics and add separate owner-state helper for status/UI use.

--- a/docs/adr/2026-05-01-container-aware-cron-health.md
+++ b/docs/adr/2026-05-01-container-aware-cron-health.md
@@ -1,0 +1,46 @@
+# ADR: Container-aware cron gateway health
+
+Date: 2026-05-01
+Status: Accepted
+
+## Context
+
+Hermes cron jobs are executed by the gateway scheduler. Historically `hermes cron status` and `hermes cron list` inferred automatic execution from locally visible gateway PIDs. That works for a foreground gateway or a systemd/launchd service in the same process namespace.
+
+It is misleading for containerized deployments where one supervised gateway container owns the scheduler and another CLI/container shares the same `HERMES_HOME` volume. In that topology the gateway PID may not be visible from the inspecting process namespace, but the shared gateway runtime lock can still prove that a gateway owner exists for that `HERMES_HOME`.
+
+A PID-only check can therefore produce a false negative: "Gateway is not running — cron jobs will NOT fire" while the Docker-supervised gateway is actually ticking jobs. Worse, stale-PID cleanup must not remove metadata when the runtime lock is actively held by another namespace.
+
+## Decision
+
+Hermes cron diagnostics will treat the gateway runtime lock as the scheduler-owner signal for shared `HERMES_HOME` deployments.
+
+`gateway.status.get_gateway_owner_status()` reports three states:
+
+- `local_pid_running`: the gateway PID is visible and verified in the current namespace.
+- `shared_lock_active`: a gateway runtime lock is held, but the PID is not locally visible or not inspectable; this is expected for shared-volume container/service-scope deployments.
+- `not_running`: no active gateway runtime lock was found.
+
+`get_running_pid()` remains PID-oriented for callers that need a local PID, but it no longer deletes PID/lock metadata merely because the PID is not visible while the runtime lock is active.
+
+`hermes cron status` and `hermes cron list` use `get_gateway_owner_status()` so operators see container-aware status instead of a PID-namespace false negative.
+
+## Consequences
+
+Positive:
+
+- Cron status is accurate for Docker/shared-volume deployments.
+- Operators are less likely to start a second gateway and create platform polling conflicts.
+- Gateway metadata is preserved when another namespace owns the runtime lock.
+
+Tradeoffs:
+
+- A held lock can only prove an owner holds the scheduler lock; it does not prove every platform adapter is healthy.
+- Lock semantics are only reliable on filesystems that preserve advisory locks across the relevant processes/containers.
+
+## Operational guidance
+
+- Run exactly one supervised gateway owner per shared `HERMES_HOME`.
+- In container deployments, prefer the Docker/Compose/systemd owner instead of launching ad hoc foreground gateways for cron ticks.
+- If `hermes cron status` reports a shared runtime lock, inspect gateway logs and runtime health before replacing the gateway.
+- Do not rely on this guarantee over unverified network filesystems.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -743,15 +743,91 @@ def clear_takeover_marker() -> None:
         pass
 
 
+def get_gateway_owner_status(pid_path: Optional[Path] = None) -> dict[str, Any]:
+    """Return runtime-owner status for the gateway scheduler.
+
+    ``get_running_pid()`` answers the narrower question "can this namespace see
+    a local gateway PID?". Cron diagnostics need a broader answer: a gateway in
+    another container/process namespace can still be the valid scheduler owner
+    when it holds the shared HERMES_HOME runtime lock. In that case the PID may
+    not be visible to ``os.kill(pid, 0)``, but the active lock means the metadata
+    must not be cleaned up as stale.
+    """
+    resolved_pid_path = pid_path or _get_pid_path()
+    resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
+    lock_active = is_gateway_runtime_lock_active(resolved_lock_path)
+    if not lock_active:
+        return {
+            "state": "not_running",
+            "pid": None,
+            "message": "No active gateway runtime lock found",
+        }
+
+    records = (
+        _read_pid_record(resolved_pid_path),
+        _read_gateway_lock_record(resolved_lock_path),
+    )
+    best_pid: Optional[int] = None
+    gateway_like_record = False
+
+    for record in records:
+        pid = _pid_from_record(record)
+        if pid is None:
+            continue
+        best_pid = pid if best_pid is None else best_pid
+        gateway_like_record = gateway_like_record or _record_looks_like_gateway(record)
+
+        try:
+            os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            if _record_looks_like_gateway(record):
+                return {
+                    "state": "shared_lock_active",
+                    "pid": pid,
+                    "message": "Gateway runtime lock is active but the PID is not inspectable from this user/service scope",
+                }
+            continue
+        except OSError:
+            continue
+
+        recorded_start = record.get("start_time")
+        current_start = _get_process_start_time(pid)
+        if recorded_start is not None and current_start is not None and current_start != recorded_start:
+            continue
+
+        if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
+            return {
+                "state": "local_pid_running",
+                "pid": pid,
+                "message": "Gateway PID is running in this namespace",
+            }
+
+    if gateway_like_record or best_pid is not None:
+        return {
+            "state": "shared_lock_active",
+            "pid": best_pid,
+            "message": "Gateway runtime lock is active in another namespace/container",
+        }
+
+    return {
+        "state": "shared_lock_active",
+        "pid": None,
+        "message": "Gateway runtime lock is active but owner metadata is unavailable",
+    }
+
+
 def get_running_pid(
     pid_path: Optional[Path] = None,
     *,
     cleanup_stale: bool = True,
 ) -> Optional[int]:
-    """Return the PID of a running gateway instance, or ``None``.
+    """Return the PID of a locally visible running gateway instance, or ``None``.
 
-    Checks the PID file and verifies the process is actually alive.
-    Cleans up stale PID files automatically.
+    Checks the PID file and verifies the process is actually alive. Cleans up
+    stale PID files only when the gateway runtime lock is not held; an active
+    lock may belong to a gateway in another process namespace/container.
     """
     resolved_pid_path = pid_path or _get_pid_path()
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
@@ -792,7 +868,6 @@ def get_running_pid(
         if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
             return pid
 
-    _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
     return None
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -38,6 +38,47 @@ def _cron_api(**kwargs):
     return json.loads(cronjob_tool(**kwargs))
 
 
+def _gateway_owner_status() -> dict:
+    from gateway import status as gateway_status
+
+    return gateway_status.get_gateway_owner_status()
+
+
+def _print_cron_gateway_notice(owner_status: dict, *, list_mode: bool = False) -> None:
+    state = owner_status.get("state")
+    pid = owner_status.get("pid")
+    message = owner_status.get("message") or "Gateway status unknown"
+
+    if state == "local_pid_running":
+        if list_mode:
+            return
+        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+        if pid is not None:
+            print(f"  PID: {pid}")
+        return
+
+    if state == "shared_lock_active":
+        print(color("✓ Gateway runtime lock is active — cron jobs will fire automatically", Colors.GREEN))
+        print(f"  {message}")
+        if pid is not None:
+            print(f"  Owner PID from shared metadata: {pid}")
+        return
+
+    if list_mode:
+        print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
+        print(color("     Start it with: hermes gateway install", Colors.DIM))
+        print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
+        print()
+        return
+
+    print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
+    print()
+    print("  To enable automatic execution:")
+    print("    hermes gateway install    # Install as a user service")
+    print("    sudo hermes gateway install --system  # Linux servers: boot-time system service")
+    print("    hermes gateway            # Or run in foreground")
+
+
 def cron_list(show_all: bool = False):
     """List all scheduled jobs."""
     from cron.jobs import list_jobs
@@ -113,12 +154,7 @@ def cron_list(show_all: bool = False):
 
         print()
 
-    from hermes_cli.gateway import find_gateway_pids
-    if not find_gateway_pids():
-        print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
-        print(color("     Start it with: hermes gateway install", Colors.DIM))
-        print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
-        print()
+    _print_cron_gateway_notice(_gateway_owner_status(), list_mode=True)
 
 
 def cron_tick():
@@ -130,21 +166,9 @@ def cron_tick():
 def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
-    from hermes_cli.gateway import find_gateway_pids
 
     print()
-
-    pids = find_gateway_pids()
-    if pids:
-        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
-        print(f"  PID: {', '.join(map(str, pids))}")
-    else:
-        print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
-        print()
-        print("  To enable automatic execution:")
-        print("    hermes gateway install    # Install as a user service")
-        print("    sudo hermes gateway install --system  # Linux servers: boot-time system service")
-        print("    hermes gateway            # Or run in foreground")
+    _print_cron_gateway_notice(_gateway_owner_status())
 
     print()
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -105,3 +105,38 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+    def test_status_treats_shared_runtime_lock_as_gateway_owner(self, tmp_cron_dir, monkeypatch, capsys):
+        create_job(prompt="Check server status", schedule="every 1h")
+        monkeypatch.setattr(
+            "gateway.status.get_gateway_owner_status",
+            lambda: {
+                "state": "shared_lock_active",
+                "pid": 17,
+                "message": "Gateway runtime lock is active in another namespace/container",
+            },
+        )
+
+        cron_command(Namespace(cron_command="status"))
+
+        out = capsys.readouterr().out
+        assert "cron jobs will fire automatically" in out
+        assert "another namespace/container" in out
+        assert "cron jobs will NOT fire" not in out
+
+    def test_list_does_not_warn_when_shared_runtime_lock_is_active(self, tmp_cron_dir, monkeypatch, capsys):
+        create_job(prompt="Check server status", schedule="every 1h")
+        monkeypatch.setattr(
+            "gateway.status.get_gateway_owner_status",
+            lambda: {
+                "state": "shared_lock_active",
+                "pid": 17,
+                "message": "Gateway runtime lock is active in another namespace/container",
+            },
+        )
+
+        cron_command(Namespace(cron_command="list", all=False))
+
+        out = capsys.readouterr().out
+        assert "another namespace/container" in out
+        assert "Gateway is not running" not in out

--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -20,3 +20,106 @@ def test_runtime_health_lines_include_fatal_platform_and_startup_reason(monkeypa
 
     assert "⚠ telegram: another poller is active" in lines
     assert "⚠ Last startup issue: telegram conflict" in lines
+
+
+def test_gateway_owner_status_reports_shared_lock_without_local_pid(monkeypatch, tmp_path):
+    from gateway import status
+
+    pid_path = tmp_path / "gateway.pid"
+    lock_path = tmp_path / "gateway.lock"
+    pid_path.write_text('{"pid": 424242, "kind": "hermes-gateway", "argv": ["hermes", "gateway"], "start_time": 1}')
+    lock_path.write_text('{"pid": 424242, "kind": "hermes-gateway", "argv": ["hermes", "gateway"], "start_time": 1}')
+
+    monkeypatch.setattr(status, "_get_pid_path", lambda: pid_path)
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda pid_path_arg=None: lock_path)
+    monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path_arg=None: True)
+    monkeypatch.setattr(status.os, "kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+
+    owner_status = status.get_gateway_owner_status()
+
+    assert owner_status["state"] == "shared_lock_active"
+    assert owner_status["pid"] == 424242
+    assert "another namespace/container" in owner_status["message"]
+    assert pid_path.exists()
+    assert lock_path.exists()
+
+
+def test_gateway_owner_status_reports_local_pid_when_visible(monkeypatch, tmp_path):
+    from gateway import status
+
+    pid_path = tmp_path / "gateway.pid"
+    lock_path = tmp_path / "gateway.lock"
+    record = '{"pid": 123, "kind": "hermes-gateway", "argv": ["hermes", "gateway"], "start_time": 77}'
+    pid_path.write_text(record)
+    lock_path.write_text(record)
+
+    monkeypatch.setattr(status, "_get_pid_path", lambda: pid_path)
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda pid_path_arg=None: lock_path)
+    monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path_arg=None: True)
+    monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 77)
+    monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+    owner_status = status.get_gateway_owner_status()
+
+    assert owner_status["state"] == "local_pid_running"
+    assert owner_status["pid"] == 123
+
+
+def test_gateway_owner_status_reports_not_running_without_runtime_lock(monkeypatch, tmp_path):
+    from gateway import status
+
+    pid_path = tmp_path / "gateway.pid"
+    lock_path = tmp_path / "gateway.lock"
+
+    monkeypatch.setattr(status, "_get_pid_path", lambda: pid_path)
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda pid_path_arg=None: lock_path)
+    monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path_arg=None: False)
+
+    owner_status = status.get_gateway_owner_status()
+
+    assert owner_status["state"] == "not_running"
+    assert owner_status["pid"] is None
+
+
+def test_gateway_owner_status_reports_shared_lock_when_pid_not_inspectable(monkeypatch, tmp_path):
+    from gateway import status
+
+    pid_path = tmp_path / "gateway.pid"
+    lock_path = tmp_path / "gateway.lock"
+    record = '{"pid": 123, "kind": "hermes-gateway", "argv": ["hermes", "gateway"], "start_time": 77}'
+    pid_path.write_text(record)
+    lock_path.write_text(record)
+
+    monkeypatch.setattr(status, "_get_pid_path", lambda: pid_path)
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda pid_path_arg=None: lock_path)
+    monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path_arg=None: True)
+    monkeypatch.setattr(status.os, "kill", lambda pid, sig: (_ for _ in ()).throw(PermissionError()))
+
+    owner_status = status.get_gateway_owner_status()
+
+    assert owner_status["state"] == "shared_lock_active"
+    assert owner_status["pid"] == 123
+    assert "not inspectable" in owner_status["message"]
+
+
+def test_get_running_pid_preserves_metadata_when_shared_lock_is_active(monkeypatch, tmp_path):
+    from gateway import status
+
+    pid_path = tmp_path / "gateway.pid"
+    lock_path = tmp_path / "gateway.lock"
+    record = '{"pid": 424242, "kind": "hermes-gateway", "argv": ["hermes", "gateway"], "start_time": 1}'
+    pid_path.write_text(record)
+    lock_path.write_text(record)
+
+    cleanup_calls = []
+    monkeypatch.setattr(status, "_get_pid_path", lambda: pid_path)
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda pid_path_arg=None: lock_path)
+    monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path_arg=None: True)
+    monkeypatch.setattr(status.os, "kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+    monkeypatch.setattr(status, "_cleanup_invalid_pid_path", lambda *args, **kwargs: cleanup_calls.append((args, kwargs)))
+
+    assert status.get_running_pid() is None
+    assert cleanup_calls == []
+    assert pid_path.exists()
+    assert lock_path.exists()

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -40,6 +40,29 @@ Cron jobs are fired by the gateway's background ticker thread, which ticks every
 
 If you're expecting jobs to fire automatically, you need a running gateway (`hermes gateway` or `hermes serve`). For one-off debugging, you can manually trigger a tick with `hermes cron tick`.
 
+Run:
+
+```bash
+hermes cron status
+```
+
+`hermes cron status` checks the shared gateway runtime lock, not just locally visible PIDs. This matters in Docker or service-scope deployments where the gateway runs in another process namespace but shares the same `HERMES_HOME` volume. In that case a status like "Gateway runtime lock is active" means a scheduler owner exists even if the owner PID is not inspectable from the current shell/container.
+
+Do **not** start a second foreground gateway just because you cannot see the gateway PID locally. Multiple gateways can conflict with polling platforms such as Telegram. First inspect the supervised gateway owner and logs:
+
+```bash
+hermes cron status
+hermes gateway status --full
+hermes logs gateway -n 100
+```
+
+For container deployments, inspect the container supervisor as well:
+
+```bash
+docker ps --filter name=hermes-gateway
+docker logs hermes-gateway --tail 100
+```
+
 ### Check 4: Check the system clock and timezone
 
 Jobs use the local timezone. If your machine's clock is wrong or in a different timezone than expected, jobs will fire at the wrong times. Verify:


### PR DESCRIPTION
## Summary

- Adds container-aware gateway owner detection via `gateway.status.get_gateway_owner_status()`.
- Updates `hermes cron status` / `hermes cron list` so an active shared runtime lock is treated as a scheduler owner even when the gateway PID is not visible from the current namespace/container.
- Preserves gateway PID/lock metadata when a shared runtime lock is active but local PID inspection fails.
- Adds regression tests, troubleshooting docs, an ADR, implementation plan, and devlog.

## Test plan

- [x] RED: `python -m pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py -q` failed before production changes because `get_gateway_owner_status` did not exist. Evidence: `/work/.hermes-data/tdd-evidence/2026-05-01-cron-health-red.txt`
- [x] GREEN/relevant regression: `python -m pytest tests/hermes_cli/test_cron.py tests/hermes_cli/test_gateway_runtime_health.py tests/hermes_cli/test_gateway.py -q` — 34 passed. Evidence: `/work/.hermes-data/tdd-evidence/2026-05-01-cron-health-green-regression-final2.txt`
- [x] `python -m py_compile gateway/status.py hermes_cli/cron.py`
- [x] `python /work/.hermes-data/skills/software-development/requesting-code-review/scripts/static_scan_diff.py --unstaged` — `STATIC_SCAN_PASS True`
- [x] Final guard passed with `HERMES_TDD_EVIDENCE` populated.

## Review

- Independent delegate review passed with no security concerns or logic errors.
- Reviewer suggestions for metadata preservation and branch coverage were addressed with additional tests.

## Follow-ups filed

- https://github.com/NousResearch/hermes-agent/issues/18630 — stabilize gateway service tests in container/root environments.
- https://github.com/NousResearch/hermes-agent/issues/18631 — add CLI-level regression coverage for shared-lock cron status.

## Notes

A broader adjacent regression including `tests/hermes_cli/test_gateway_service.py` had 130 passing tests and 7 failures in environment-sensitive systemd/root paths outside this branch's touched code. Those failures are tracked in #18630.
