### PR TITLE
fix(install): implement dynamic browser bin discovery for agent-browser

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,12 @@ set -e
 HERMES_HOME="${HERMES_HOME:-/opt/data}"
 INSTALL_DIR="/opt/hermes"
 
+# --- Dynamic Browser Discovery for agent-browser ---
+# Find a viable browser binary in the Playwright cache to avoid "Chrome not found" 
+# issues in Docker. We look for any executable containing 'chrome' or 'chromium'.
+# See issue #15697
+[ -z "$AGENT_BROWSER_EXECUTABLE_PATH" ] && export AGENT_BROWSER_EXECUTABLE_PATH=$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f -executable | grep -Ei "chrome|chromium" | head -n 1)
+
 # --- Privilege dropping via gosu ---
 # When started as root (the default for Docker, or fakeroot in rootless Podman),
 # optionally remap the hermes user/group to match host-side ownership, fix volume


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Like this comment mentioned https://github.com/NousResearch/hermes-agent/issues/15697#issuecomment-4362644216. 
Providing a fix of preset `agent-browser` environment to ignore the missing of chrome binary folder discover logics.  
  
This PR is similar to #15908, but the fix of 15908 is no longer work anymore.  
The latest installation of Playwright with different naming.  


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #15697 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Dynamically detect any executable bin from `PLAYWRIGHT_BROWSERS_PATH` env.
- Add bin path into `AGENT_BROWSER_EXECUTABLE_PATH` env for `agent-browser` if not given.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Build the image
2. Open with docker run / docker compose 
3. Request model to access any js website.
4. See if navigate-* tools works normally.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS15.6.1, (Linode)Ubuntu24.04<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

