### PR TITLE
Feature/optional persona emoji reactions and dynamic reactions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2463,6 +2463,15 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_tool_call_start(self, event: MessageEvent, tool_name: str) -> None:
+        """Hook called each time a tool call begins during processing.
+
+        Platform adapters can override this to show per-tool status indicators
+        (e.g. Discord swaps the active reaction emoji to reflect the current tool).
+        ``tool_name`` is the raw tool function name (e.g. ``read_file``,
+        ``web_search``, ``terminal``).
+        """
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -594,6 +594,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
+        # Per-message active reaction tracking for persona/tool emoji swapping.
+        # Key: message.id (int), Value: currently active reaction emoji (str).
+        self._active_tool_reactions: Dict[int, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1346,27 +1349,69 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
-        return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
+        return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"} \
+            and self.config.extra.get("reactions", True)
+
+    def _dynamic_reactions_enabled(self) -> bool:
+        """Check if per-tool reaction swapping is enabled."""
+        return self._reactions_enabled() and self.config.extra.get("dynamic_reactions", True)
+
+    def _persona_emoji(self) -> str:
+        """Return the agent's persona emoji from config.
+
+        Set ``discord.persona_emoji`` in config.yaml to give the agent a
+        unique identity emoji (e.g. 🔎 for Sherlock, ⚡ for Newton).
+        Falls back to 👀 so existing deployments are unaffected.
+        """
+        return self.config.extra.get("persona_emoji", "👀")
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction for normal Discord message events."""
+        """Add the agent's persona emoji when processing begins."""
         if not self._reactions_enabled():
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._add_reaction(message, "👀")
+            emoji = self._persona_emoji()
+            await self._add_reaction(message, emoji)
+            self._active_tool_reactions[message.id] = emoji
+    async def on_tool_call_start(self, event: MessageEvent, tool_name: str) -> None:
+        """Swap the active reaction to the tool-specific emoji.
+
+        Called by the gateway's progress_callback on every ``tool.started``
+        event. Removes the previous reaction (persona or prior tool) and
+        adds the emoji that represents the current tool, so the message
+        always shows exactly one reaction reflecting what the agent is doing.
+        """
+        if not self._dynamic_reactions_enabled():
+            return
+        message = event.raw_message
+        if not hasattr(message, "add_reaction"):
+            return
+        from agent.display import get_tool_emoji
+        tool_emoji = get_tool_emoji(tool_name, default="⚙️")
+        current = self._active_tool_reactions.get(message.id)
+        if current and current != tool_emoji:
+            await self._remove_reaction(message, current)
+        await self._add_reaction(message, tool_emoji)
+        self._active_tool_reactions[message.id] = tool_emoji
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction."""
+        """Replace the active reaction with ✅ (success) or ❌ (failure).
+
+        Persona emoji identifies the agent during work; the terminal
+        reaction is a status indicator independent of identity.
+        """
         if not self._reactions_enabled():
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._remove_reaction(message, "👀")
+            current = self._active_tool_reactions.pop(message.id, self._persona_emoji())
+            await self._remove_reaction(message, current)
             if outcome == ProcessingOutcome.SUCCESS:
                 await self._add_reaction(message, "✅")
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
+            # CANCELLED: remove active reaction, leave nothing
 
     async def send(
         self,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1353,17 +1353,33 @@ class DiscordAdapter(BasePlatformAdapter):
             and self.config.extra.get("reactions", True)
 
     def _dynamic_reactions_enabled(self) -> bool:
-        """Check if per-tool reaction swapping is enabled."""
-        return self._reactions_enabled() and self.config.extra.get("dynamic_reactions", True)
+        """Check if per-tool reaction swapping is enabled.
+
+        Resolution order:
+        1. ``discord.dynamic_reactions`` in config.yaml (platform override)
+        2. ``dynamic_reactions`` at top-level in config.yaml (global default)
+        3. True (built-in default)
+        """
+        if not self._reactions_enabled():
+            return False
+        extra = self.config.extra
+        if "dynamic_reactions" in extra:
+            return bool(extra["dynamic_reactions"])
+        from hermes_cli.config import load_config
+        return bool(load_config().get("dynamic_reactions", True))
 
     def _persona_emoji(self) -> str:
-        """Return the agent's persona emoji from config.
+        """Return the agent's persona emoji.
 
-        Set ``discord.persona_emoji`` in config.yaml to give the agent a
-        unique identity emoji (e.g. 🔎 for Sherlock, ⚡ for Newton).
-        Falls back to 👀 so existing deployments are unaffected.
+        Resolution order:
+        1. ``discord.persona_emoji`` in config.yaml (platform override)
+        2. ``persona_emoji`` at top-level in config.yaml (global default)
+        3. 👀 (built-in fallback so existing deployments are unaffected)
         """
-        return self.config.extra.get("persona_emoji", "👀")
+        if emoji := self.config.extra.get("persona_emoji"):
+            return emoji
+        from hermes_cli.config import load_config
+        return load_config().get("persona_emoji") or "👀"
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add the agent's persona emoji when processing begins."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15533,6 +15533,19 @@ class GatewayRunner:
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            # Fire on_tool_call_start hook before the progress_queue guard so
+            # reaction swapping works even when tool progress messages are off.
+            if event_type == "tool.started" and tool_name and _status_adapter and _loop_for_step and _run_still_current():
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter._run_processing_hook(
+                            "on_tool_call_start", source, tool_name
+                        ),
+                        _loop_for_step,
+                    )
+                except Exception:
+                    pass
+
             if not progress_queue or not _run_still_current():
                 return
 
@@ -15590,7 +15603,7 @@ class GatewayRunner:
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
-            
+
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
@@ -16319,7 +16332,7 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            agent.tool_progress_callback = progress_callback  # always register — hook fires before progress_queue guard
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1337,6 +1337,18 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Agent identity emoji shown on message acknowledgment and completion.
+    # Platforms that support reactions (Discord, Signal, etc.) display this emoji
+    # while the agent is processing. Empty string falls back to 👀.
+    # Can be overridden per-platform under discord.persona_emoji, etc.
+    "persona_emoji": "",
+
+    # Swap the active reaction emoji to reflect the current tool call.
+    # Provides per-tool visibility (📖 read_file, 💻 terminal, 🌐 browser, etc.)
+    # without cluttering the chat with text messages.
+    # Can be overridden per-platform under discord.dynamic_reactions, etc.
+    "dynamic_reactions": True,
+
     # Slack platform settings (gateway mode)
     "slack": {
         "require_mention": True,       # Require @mention to respond in channels
@@ -1355,8 +1367,8 @@ DEFAULT_CONFIG = {
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "reactions": True,             # Add emoji reactions to messages during processing
-        "persona_emoji": "",           # Agent identity emoji shown on ack + completion (e.g. 🔎). Empty = 👀
-        "dynamic_reactions": True,     # Swap reaction per tool call to show current activity
+        # persona_emoji: ""            # Per-platform override (inherits global persona_emoji if unset)
+        # dynamic_reactions: true      # Per-platform override (inherits global dynamic_reactions if unset)
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1354,7 +1354,9 @@ DEFAULT_CONFIG = {
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
-        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "reactions": True,             # Add emoji reactions to messages during processing
+        "persona_emoji": "",           # Agent identity emoji shown on ack + completion (e.g. 🔎). Empty = 👀
+        "dynamic_reactions": True,     # Swap reaction per tool call to show current activity
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -87,6 +87,7 @@ def _make_event(message_id: str, raw_message) -> MessageEvent:
 @pytest.mark.asyncio
 async def test_process_message_background_adds_and_swaps_reactions(adapter):
     raw_message = SimpleNamespace(
+        id=1,
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
     )
@@ -149,6 +150,7 @@ async def test_interaction_backed_events_do_not_attempt_reactions(adapter):
 @pytest.mark.asyncio
 async def test_reaction_helper_failures_do_not_break_message_flow(adapter):
     raw_message = SimpleNamespace(
+        id=3,
         add_reaction=AsyncMock(side_effect=[RuntimeError("no perms"), RuntimeError("no perms")]),
         remove_reaction=AsyncMock(side_effect=RuntimeError("no perms")),
     )
@@ -224,6 +226,7 @@ async def test_reactions_enabled_by_default(adapter, monkeypatch):
     monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
 
     raw_message = SimpleNamespace(
+        id=6,
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
     )
@@ -237,6 +240,7 @@ async def test_reactions_enabled_by_default(adapter, monkeypatch):
 @pytest.mark.asyncio
 async def test_on_processing_complete_cancelled_removes_eyes_without_terminal_reaction(adapter):
     raw_message = SimpleNamespace(
+        id=7,
         add_reaction=AsyncMock(),
         remove_reaction=AsyncMock(),
     )


### PR DESCRIPTION
What and why

Optionally replace the hardcoded 👀->✅ reaction cycle with configurable persona emojis and live tool-specific emoji swaps. Each agent gets its own dedicated emoji. When dynamic_reactions is on, the reaction reflects the active tool during processing: 📄 for file reads, 💻 for terminal, 🔍 for search (with configurable hysterisis).

Useful if you disable the tool output in chat but still want to know your agent is actively working on a long turn

https://github.com/user-attachments/assets/6ed4c3bf-b0b4-47d2-8305-5ea209120146


The state machine lives in a new mixin (reaction_mixin.py). Discord, Telegram, Slack, and Matrix all use it. Each adapter implements a few primitives, and the mixin handles lifecycle, cooldown, locking, and config.

Files changed

gateway/platforms/reaction_mixin.py (new): lifecycle state machine, per-message locks, cooldown, config resolution
agent/display.py built-in tool emoji map for get_tool_emoji()
gateway/platforms/discord.py: mixin integration, add/remove primitives, raw message caching
gateway/platforms/telegram.py: mixin in replace mode (_reaction_set)
gateway/platforms/slack.py: mixin with emoji translation (Unicode -> Slack shortcodes)
gateway/platforms/matrix.py: mixin with reaction event ID tracking for redaction
gateway/platforms/base.py: adds on_tool_call_start hook
gateway/run.py: wires on_tool_call_start into the pipeline
tests/gateway/test_reaction_mixin.py (new): config, lifecycle, replace-mode, translation, cooldown, edge cases
Updated tests for Discord, Telegram, Slack, Matrix

Config (all optional)

persona_emoji: "🤖" # default: 👀
dynamic_reactions: true # default: false
reaction_cooldown: 1.0 # seconds, default: 1.0 (hysterisis)

Set globally or per-platform (platform wins).

Adding to a new platform

Inherit DynamicReactionMixin before BasePlatformAdapter, call _init_reaction_mixin() in init (1/2)
Implement primitives: _reaction_add/_reaction_remove (or _reaction_set with _reaction_replace_mode = True), plus _reaction_resolve_message and _reaction_msg_key
Wire hooks: on_processing_start -> _rxn_on_processing_start, on_tool_call_start -> _rxn_on_tool_call_start, on_processing_complete -> _rxn_on_processing_complete
Optional: override _reaction_translate_emoji() for platforms that use named reactions

How to test

pytest tests/gateway/test_reaction_mixin.py tests/gateway/test_discord_reactions.py tests/gateway/test_telegram_reactions.py tests/gateway/test_slack.py tests/gateway/test_matrix.py -v

Manual: set persona_emoji + dynamic_reactions: true, send a message that triggers multiple tools, watch the reaction swap mid-turn.

Tested on: Discord (live DMs, multi-tool turns)