### PR TITLE
perf(analytics): skip full InsightsEngine on dashboard /api/analytics/usage (#18511)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -108,6 +108,18 @@ class InsightsEngine:
         self.db = db
         self._conn = db._conn
 
+    def get_skill_breakdown(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+        """Compute only the per-skill usage summary + ranked list.
+
+        This is a narrow public entry point for callers (e.g. the dashboard
+        analytics endpoint) that need just the `skills` section of the full
+        insights report. It avoids the full `generate()` pass, which also
+        scans sessions, models, platforms, tools, activity, and top sessions.
+        """
+        cutoff = time.time() - (days * 86400)
+        skill_usage = self._get_skill_usage(cutoff, source)
+        return self._compute_skill_breakdown(skill_usage)
+
     def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
         """
         Generate a complete insights report.
@@ -305,6 +317,9 @@ class InsightsEngine:
         # the literal substring "skill_view" or "skill_manage" cannot
         # contribute. This avoids parsing tens of thousands of unrelated
         # tool_calls JSON blobs in Python on dashboards / large session DBs.
+        # `instr()` is used (not LIKE) because LIKE treats `_` as a single-char
+        # wildcard, which would also match e.g. "skillXview" / "skill?manage"
+        # and weaken the prefilter's selectivity.
         if source:
             cursor = self._conn.execute(
                 """SELECT m.tool_calls, m.timestamp
@@ -312,8 +327,8 @@ class InsightsEngine:
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ? AND s.source = ?
                      AND m.role = 'assistant' AND m.tool_calls IS NOT NULL
-                     AND (m.tool_calls LIKE '%skill_view%'
-                          OR m.tool_calls LIKE '%skill_manage%')""",
+                     AND (instr(m.tool_calls, 'skill_view') > 0
+                          OR instr(m.tool_calls, 'skill_manage') > 0)""",
                 (cutoff, source),
             )
         else:
@@ -323,8 +338,8 @@ class InsightsEngine:
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ?
                      AND m.role = 'assistant' AND m.tool_calls IS NOT NULL
-                     AND (m.tool_calls LIKE '%skill_view%'
-                          OR m.tool_calls LIKE '%skill_manage%')""",
+                     AND (instr(m.tool_calls, 'skill_view') > 0
+                          OR instr(m.tool_calls, 'skill_manage') > 0)""",
                 (cutoff,),
             )
 

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -300,13 +300,20 @@ class InsightsEngine:
         """Extract per-skill usage from assistant tool calls."""
         skill_counts: Dict[str, Dict[str, Any]] = {}
 
+        # Pre-filter at SQL: only the two skill-related tool names ever count
+        # toward skill usage, so any row whose tool_calls JSON does not contain
+        # the literal substring "skill_view" or "skill_manage" cannot
+        # contribute. This avoids parsing tens of thousands of unrelated
+        # tool_calls JSON blobs in Python on dashboards / large session DBs.
         if source:
             cursor = self._conn.execute(
                 """SELECT m.tool_calls, m.timestamp
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ? AND s.source = ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL
+                     AND (m.tool_calls LIKE '%skill_view%'
+                          OR m.tool_calls LIKE '%skill_manage%')""",
                 (cutoff, source),
             )
         else:
@@ -315,7 +322,9 @@ class InsightsEngine:
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
+                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL
+                     AND (m.tool_calls LIKE '%skill_view%'
+                          OR m.tool_calls LIKE '%skill_manage%')""",
                 (cutoff,),
             )
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2747,10 +2747,8 @@ async def get_usage_analytics(days: int = 30):
         # here scanned/parsed every assistant tool_calls row twice (once for
         # _get_tool_usage, once for _get_skill_usage) and head-of-line blocked
         # the FastAPI event loop on multi-second DB+JSON work for unrelated
-        # endpoints. Compose the two skill-only helpers directly instead.
-        engine = InsightsEngine(db)
-        skill_usage = engine._get_skill_usage(cutoff)
-        skills = engine._compute_skill_breakdown(skill_usage)
+        # endpoints.
+        skills = InsightsEngine(db).get_skill_breakdown(days=days)
 
         return {
             "daily": daily,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2741,16 +2741,16 @@ async def get_usage_analytics(days: int = 30):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
-        insights_report = InsightsEngine(db).generate(days=days)
-        skills = insights_report.get("skills", {
-            "summary": {
-                "total_skill_loads": 0,
-                "total_skill_edits": 0,
-                "total_skill_actions": 0,
-                "distinct_skills_used": 0,
-            },
-            "top_skills": [],
-        })
+        # Compute only the skill breakdown — the dashboard endpoint discards
+        # every other section InsightsEngine.generate() builds (sessions,
+        # tools, models, platforms, activity, top_sessions). Calling generate()
+        # here scanned/parsed every assistant tool_calls row twice (once for
+        # _get_tool_usage, once for _get_skill_usage) and head-of-line blocked
+        # the FastAPI event loop on multi-second DB+JSON work for unrelated
+        # endpoints. Compose the two skill-only helpers directly instead.
+        engine = InsightsEngine(db)
+        skill_usage = engine._get_skill_usage(cutoff)
+        skills = engine._compute_skill_breakdown(skill_usage)
 
         return {
             "daily": daily,

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -382,6 +382,25 @@ class TestInsightsPopulated:
         skill_names = [s["skill"] for s in skills["top_skills"]]
         assert "systematic-debugging" not in skill_names
 
+    def test_get_skill_breakdown_public_method_matches_full_generate(self, populated_db):
+        """The public `get_skill_breakdown(days)` shortcut must return the same
+        `skills` payload that `generate(days)["skills"]` would, so callers
+        like the dashboard analytics endpoint can avoid the full pass without
+        reaching into private `_get_skill_usage` / `_compute_skill_breakdown`
+        helpers."""
+        engine = InsightsEngine(populated_db)
+        full = engine.generate(days=30)["skills"]
+        narrow = engine.get_skill_breakdown(days=30)
+        assert narrow == full
+
+    def test_get_skill_breakdown_respects_source_filter(self, populated_db):
+        """Source filter on the public shortcut must be honored, just like the
+        full report's source filter."""
+        engine = InsightsEngine(populated_db)
+        full = engine.generate(days=30, source="cli")["skills"]
+        narrow = engine.get_skill_breakdown(days=30, source="cli")
+        assert narrow == full
+
     def test_get_skill_usage_ignores_non_skill_tool_calls(self, db):
         """SQL prefilter on _get_skill_usage must not change semantics — rows
         whose tool_calls JSON contains the literal substring "skill_view" or

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -382,6 +382,56 @@ class TestInsightsPopulated:
         skill_names = [s["skill"] for s in skills["top_skills"]]
         assert "systematic-debugging" not in skill_names
 
+    def test_get_skill_usage_ignores_non_skill_tool_calls(self, db):
+        """SQL prefilter on _get_skill_usage must not change semantics — rows
+        whose tool_calls JSON contains the literal substring "skill_view" or
+        "skill_manage" only inside an argument value (not as the function
+        name) must still be excluded by the Python-side filter."""
+        now = time.time()
+        db.create_session(
+            session_id="prefilter-test", source="cli", model="anthropic/test",
+        )
+        # Real skill_view call — must count.
+        db.append_message(
+            "prefilter-test",
+            role="assistant",
+            content="loading",
+            tool_calls=[
+                {"function": {"name": "skill_view",
+                              "arguments": '{"name":"real-skill"}'}},
+            ],
+        )
+        # Non-skill tool whose arguments mention "skill_view" as a substring —
+        # the row will pass the SQL LIKE prefilter but must NOT be counted
+        # by the Python-side `name in {"skill_view","skill_manage"}` check.
+        db.append_message(
+            "prefilter-test",
+            role="assistant",
+            content="searching",
+            tool_calls=[
+                {"function": {"name": "search_files",
+                              "arguments": '{"pattern":"skill_view"}'}},
+            ],
+        )
+        # Non-skill tool with no skill substring at all — must be excluded by
+        # the SQL LIKE prefilter (perf-only, not a correctness assertion).
+        db.append_message(
+            "prefilter-test",
+            role="assistant",
+            content="reading",
+            tool_calls=[
+                {"function": {"name": "read_file",
+                              "arguments": '{"path":"/tmp/x"}'}},
+            ],
+        )
+
+        engine = InsightsEngine(db)
+        usage = engine._get_skill_usage(cutoff=now - 86400)
+        assert len(usage) == 1
+        assert usage[0]["skill"] == "real-skill"
+        assert usage[0]["view_count"] == 1
+        assert usage[0]["manage_count"] == 0
+
     def test_activity_patterns(self, populated_db):
         engine = InsightsEngine(populated_db)
         report = engine.generate(days=30)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -972,6 +972,35 @@ class TestNewEndpoints:
             "top_skills": [],
         }
 
+    def test_analytics_usage_skips_full_insights_generate(self):
+        """/api/analytics/usage must not invoke InsightsEngine.generate() —
+        that scans/parses every assistant tool_calls row twice (once for
+        _get_tool_usage, once for _get_skill_usage) and head-of-line blocks
+        the FastAPI event loop on multi-second work, even though the
+        endpoint discards every section but `skills`. See issue #18511."""
+        import agent.insights as insights_module
+
+        original_generate = insights_module.InsightsEngine.generate
+        calls = []
+
+        def _spy(self, *args, **kwargs):
+            calls.append((args, kwargs))
+            return original_generate(self, *args, **kwargs)
+
+        insights_module.InsightsEngine.generate = _spy
+        try:
+            resp = self.client.get("/api/analytics/usage?days=7")
+            assert resp.status_code == 200
+            assert "skills" in resp.json()
+        finally:
+            insights_module.InsightsEngine.generate = original_generate
+
+        assert calls == [], (
+            "get_usage_analytics() should not invoke "
+            "InsightsEngine.generate() — the dashboard endpoint only needs "
+            "the skill breakdown."
+        )
+
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB
 


### PR DESCRIPTION
## Summary

`/api/analytics/usage` only uses the **skill breakdown** out of its `InsightsEngine` call, but was invoking the full `.generate()` report — which scans and JSON-parses every assistant `tool_calls` row twice (`_get_tool_usage` + `_get_skill_usage`) and builds overview / models / platforms / tools / activity / top_sessions sections that the endpoint immediately discards. On the reporter's local DB (~130k messages, ~47k assistant tool_calls) the route took 6–16s and head-of-line blocked unrelated FastAPI requests (`/api/status`, `/api/dashboard/plugins`) that share the event loop.

## The bug

In `hermes_cli/web_server.py:get_usage_analytics()`:

```python
insights_report = InsightsEngine(db).generate(days=days)
skills = insights_report.get("skills", { ... default ... })
```

`generate()` does:

1. Fetches all sessions in the window, computes overview / models / platforms / activity / top_sessions — all unused here.
2. Calls `_get_tool_usage(cutoff)`: scans every assistant `tool_calls` row in the window, JSON-parses each — unused here.
3. Calls `_get_skill_usage(cutoff)`: scans every assistant `tool_calls` row again, JSON-parses each, filters to `skill_view`/`skill_manage`.

For the reporter's DB the issue lists the skill query alone as multi-second; #2 doubles that, and the route is `async` but the work is synchronous, so the event loop blocks for everything else.

## The fix

Two narrow changes:

1. **`agent/insights._get_skill_usage`**: pre-filter at SQL with `tool_calls LIKE '%skill_view%' OR LIKE '%skill_manage%'`. Only those two tool names ever count toward skill usage, so any row whose `tool_calls` JSON does not contain either literal substring cannot contribute. The existing Python-side `name in {"skill_view","skill_manage"}` check keeps semantics identical for any false-positive rows that still pass the LIKE prefilter (e.g. a `search_files` call whose `arguments` JSON value happens to mention `"skill_view"` as text). On the reporter's DB this cuts JSON-parsed rows by ~99%.
2. **`hermes_cli/web_server.get_usage_analytics`**: replace `InsightsEngine(db).generate(days=days)` with a direct `engine._get_skill_usage(cutoff)` + `engine._compute_skill_breakdown(skill_usage)` composition. This eliminates the duplicate `_get_tool_usage` scan and every unused breakdown section.

Net: the route's dominant cost becomes a single SQL scan filtered by the LIKE clause + JSON parse over only the few rows that actually contain skill calls.

## Test plan

- [x] **Focused regression test**: `tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_analytics_usage_skips_full_insights_generate` spies on `InsightsEngine.generate` and asserts the dashboard endpoint never invokes it. Fails on `origin/main` with `Left contains one more item: ((), {'days': 7})` and passes on this branch.
- [x] **Correctness regression test**: `tests/agent/test_insights.py::test_get_skill_usage_ignores_non_skill_tool_calls` guards the SQL prefilter — a row containing the literal substring `skill_view` only inside a non-skill tool's argument value must still not be counted; a row with no skill substring must be skipped.
- [x] **Adjacent suite**:
  - `uv run --with pytest --with pytest-xdist python3 -m pytest tests/agent/test_insights.py -v` → **57/57 pass**
  - `uv run --with pytest --with pytest-xdist --with fastapi --with starlette --with httpx python3 -m pytest tests/hermes_cli/test_web_server.py -q` → **135/138 pass**; the 3 failures are all in `TestPtyWebSocket` (`KeyError: 'bytes'` from starlette test-client websocket handling), reproduce on clean `origin/main`, and are unrelated to this change.
- [x] **Regression guard**: stashed `hermes_cli/web_server.py` only, re-ran the spy test → fails as designed; `git stash pop` → passes again.

## Behavior preserved

- Endpoint response shape is unchanged: `{ daily, by_model, totals, period_days, skills: { summary, top_skills } }`.
- `_get_skill_usage` returns identical rows for every input — the LIKE prefilter is a strict superset of the rows the existing Python-side filter would keep, and the Python check still runs unchanged.
- All other `InsightsEngine.generate()` callers (`cli.py`, `hermes_cli/main.py`, `gateway/run.py`) are unaffected.

## Related

- Fixes #18511.