### PR TITLE
fix: use extract_content_or_reasoning() for title generation with reasoning models

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        title = extract_content_or_reasoning(response).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):


### PR DESCRIPTION
When `auxiliary.title_generation` uses a reasoning model (MiniMax-M2.7, DeepSeek-R1, Qwen-QwQ, etc.), the auto-generated session title is empty because the code reads `response.choices[0].message.content` directly — which is `None` when the model returns content via structured reasoning fields instead of `.content`.

**Fix:** Replace the direct `.message.content` access with the existing `extract_content_or_reasoning()` helper that already handles reasoning models correctly. This is the same pattern used in `session_search_tool.py`, `web_tools.py`, and `vision_tools.py`.

**Changes:**
- Add `extract_content_or_reasoning` to the import from `agent.auxiliary_client`
- Replace `response.choices[0].message.content` with `extract_content_or_reasoning(response)`

**Verification:**
- `py_compile` passes
- All 19 existing title generator tests pass

Closes #18529
