### PR TITLE
fix: remove ZWJ from invisible char blocklist to allow compound emoji in context files

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -47,7 +47,7 @@ _CONTEXT_THREAT_PATTERNS = [
 ]
 
 _CONTEXT_INVISIBLE_CHARS = {
-    '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
+    '\u200b', '\u200c', '\u2060', '\ufeff',
     '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
 }
 


### PR DESCRIPTION
The `_CONTEXT_INVISIBLE_CHARS` blocklist in `prompt_builder.py` includes `\u200d` (Zero Width Joiner), which is used in standard compound emoji sequences like 🤸‍♀️, 👨‍👩‍👧‍👦, 🏳️‍🌈, 👩‍💻, etc. When a SOUL.md or AGENTS.md file contains any of these emoji, the entire file is blocked as a potential prompt injection, which is a false positive.

**Why this is safe:** ZWJ has no steganographic capability — it only functions between specific emoji codepoints to signal glyph composition. Unlike ZWSP (`\u200b`) which can encode invisible binary data, ZWJ cannot hide text or alter how an LLM processes content.

**Fix:** Remove `\u200d` from the `_CONTEXT_INVISIBLE_CHARS` set. The remaining 9 characters (ZWSP, ZWNJ, Word Joiner, BOM, BiDi controls) all have genuine security justifications and are unchanged.

**Verification:**
- `py_compile` passes
- All 116 existing `test_prompt_builder` tests pass

Closes #18581
