### PR TITLE
fix(gateway): quiet session search timeout logs

### DIFF
--- a/.devlogs/2026-05-02-gateway-timeout-log-timestamps.md
+++ b/.devlogs/2026-05-02-gateway-timeout-log-timestamps.md
@@ -1,0 +1,88 @@
+# Gateway timeout log cleanup and timestamped stderr
+
+**Date:** 2026-05-02
+**Author:** Hermes Agent
+**Branch:** fix/gateway-timeout-log-timestamps-20260502030014
+**PR:** https://github.com/NousResearch/hermes-agent/pull/18648
+
+## Goal
+
+Reduce noisy Hermes gateway log output from expected session_search provider timeouts, and add application timestamps to gateway stderr log lines so Docker logs are easier to correlate.
+
+## What Was Done
+
+- Added plan/spec: `.hermes/plans/2026-05-02-gateway-timeout-log-timestamps.md`.
+- Updated `tools/session_search_tool.py`:
+  - Added `_is_timeout_exception()` to structurally recognize built-in, asyncio, OpenAI, httpx, and httpcore timeout exception shapes without importing optional providers.
+  - Converted expected per-session summarization timeouts into concise warnings without traceback spam.
+  - Converted outer `_run_async` summarization bridge timeout logging into a concise warning without `exc_info=True` while preserving the existing JSON error response.
+- Updated `gateway/run.py`:
+  - Added `%(asctime)s` with `datefmt="%H:%M:%S"` to the gateway verbosity stderr handler, preserving `RedactingFormatter` and the existing level/name/message fields.
+- Updated tests:
+  - `tests/tools/test_session_search.py` now covers timeout logging, timeout classification, and outer bridge timeout logging.
+  - `tests/gateway/test_runner_startup_failures.py` now verifies gateway stderr verbosity logs include an HH:MM:SS timestamp.
+
+## Key Decisions
+
+- No ADR: this is an operational logging/triage refinement, not an architectural or API contract change.
+- For known provider/network timeouts inside `_summarize_session()`, return after a concise warning rather than retrying and eventually printing a large traceback. This intentionally reduces gateway stalls/log noise for expected timeout failures; unexpected exceptions still keep the existing retry and final traceback path.
+- Used a structural timeout classifier so Hermes does not need hard imports of every optional provider client just to classify expected timeout failures.
+- Kept timestamps in the application formatter rather than changing Docker logging configuration, because the user specifically wanted the timestamp next to gateway log lines and this works regardless of runtime logging driver.
+
+## Validation
+
+- `python -m pytest tests/tools/test_session_search.py::TestSummarizeSessionTimeouts::test_timeout_failure_logs_concise_warning_without_traceback tests/gateway/test_runner_startup_failures.py::test_start_gateway_stderr_verbosity_includes_timestamp -q` — RED observed before implementation; failed for missing concise timeout handling/timestamped gateway stderr. Log: `.hermes/test-output/2026-05-02-red-session-search-gateway-stderr.log`.
+- `python -m pytest tests/tools/test_session_search.py::TestSummarizeSessionTimeouts::test_outer_summarization_timeout_logs_concise_warning_without_traceback -q` — RED observed for outer bridge timeout traceback. Log: `.hermes/test-output/2026-05-02-red-outer-timeout.log`.
+- `python -m pytest tests/tools/test_session_search.py::TestSummarizeSessionTimeouts tests/gateway/test_runner_startup_failures.py::test_start_gateway_stderr_verbosity_includes_timestamp -q` — passed, 4 tests. Log: `.hermes/test-output/2026-05-02-green-timeout-expanded.log`.
+- `python -m pytest tests/tools/test_session_search.py tests/gateway/test_runner_startup_failures.py tests/test_hermes_logging.py -q` — passed, 99 tests. Log: `.hermes/test-output/2026-05-02-regression-targeted-suites-final.log`.
+- `python ${HERMES_HOME:-/work/.hermes-data/hermes-agent}/skills/software-development/requesting-code-review/scripts/static_scan_diff.py --unstaged` — passed, no findings.
+- `python -m py_compile tools/session_search_tool.py gateway/run.py tests/tools/test_session_search.py tests/gateway/test_runner_startup_failures.py` — passed.
+- `python -m ruff check gateway/run.py tools/session_search_tool.py tests/tools/test_session_search.py tests/gateway/test_runner_startup_failures.py` — failed on pre-existing broad lint issues in `gateway/run.py`/tests plus one pre-existing unused import; no new lint issue was introduced by the edited hunks.
+- Independent review via `delegate_task` — passed, no blocking security or logic issues; reviewer noted non-blocking suggestions around retry intent and additional real-provider classifier tests. Retry intent was documented in the plan/devlog.
+- `python -m pytest -q` — attempted broad full suite; did not complete cleanly in this environment. It reached ~90%, emitted many xdist `node down: Not properly terminated` failures, then stopped making progress and was killed to unblock PR prep. Partial log: `.hermes/test-output/2026-05-02-full-pytest.log`.
+- `HERMES_TDD_EVIDENCE="RED .hermes/test-output/2026-05-02-red-session-search-gateway-stderr.log; RED .hermes/test-output/2026-05-02-red-outer-timeout.log; GREEN .hermes/test-output/2026-05-02-green-timeout-expanded.log; REGRESSION .hermes/test-output/2026-05-02-regression-targeted-suites-final.log" /work/.hermes-data/scripts/code_work_guard.py --mode final` — passed.
+
+## What Skills and Tools Were Used
+
+- Skills: `hermes-agent`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `requesting-code-review`, `devlog`, `github-pr-workflow`.
+- Tools: worktree-based git workflow, pytest, static diff scan, py_compile, independent reviewer subagent.
+
+## Artifacts Updated
+
+- `.hermes/plans/2026-05-02-gateway-timeout-log-timestamps.md`
+- `.devlogs/2026-05-02-gateway-timeout-log-timestamps.md`
+- `.hermes/test-output/` validation logs
+
+## Related Repos
+
+- `/work/.hermes-data/hermes-agent-gateway-timeout-logs-20260502030014`
+
+## Issues & Blockers
+
+- `ruff check` on the selected files reports pre-existing lint violations in large legacy modules/tests; treated as non-blocking because targeted syntax, tests, static scan, and independent review passed.
+- No blocker remains before PR once final guard, commit, push, PR creation, and CI check are complete.
+
+## Key Learnings
+
+- The gateway verbosity stderr handler used a non-timestamped formatter even though file logs and verbose logging elsewhere already use timestamps.
+- `session_search` has two timeout surfaces: per-session provider/client timeouts inside `_summarize_session()` and an outer `_run_async` bridge timeout in `session_search()`.
+
+## Next Steps
+
+- Final code-work guard passed with RED/GREEN evidence paths.
+- Commit, push, open PR, then update this devlog with PR URL and CI/review status.
+
+## Prompting Notes
+
+- **Initial ask:** User pasted Hermes gateway timeout stack traces and asked to improve/fix them and add timestamps next to gateway log lines while following full dev process through PR.
+- **Clarifications needed:** None; scope was clear enough to proceed.
+- **Corrections made:** Independent review identified an outer timeout log path still using `exc_info=True`; added a RED regression and fixed it.
+- **Scope drift:** Small, directly related expansion to cover the outer `session_search()` bridge timeout path.
+
+## Session Quality
+
+- **Faithfulness:** Stayed on track — followed worktree/spec/TDD/review/devlog workflow and kept changes focused on logging/timeout behavior.
+- **Prompt patterns:** Strong operational evidence in the pasted log excerpt made the problem concrete; requested process requirements were explicit.
+
+---
+*Generated by Hermes Agent — devlog skill*

--- a/.hermes/plans/2026-05-02-gateway-timeout-log-timestamps.md
+++ b/.hermes/plans/2026-05-02-gateway-timeout-log-timestamps.md
@@ -1,0 +1,72 @@
+# Gateway timeout logs and timestamped console output
+
+Date: 2026-05-02
+Branch: fix/gateway-timeout-log-timestamps-20260502030014
+Worktree: /work/.hermes-data/hermes-agent-gateway-timeout-logs-20260502030014
+
+## Problem
+
+A gateway log excerpt showed noisy Python stack traces ending in `httpx.ReadTimeout` / `openai.APITimeoutError` during `session_search` summarization, followed by context compaction. The docker log prefix only showed `hermes-gateway |`, making it harder to correlate incidents without timestamps.
+
+## Facts from inspection
+
+- `tools/session_search_tool.py::_summarize_session` retries all generic exceptions three times and logs the final failure with `exc_info=True`, which emits a large stack trace for expected upstream timeout failures.
+- `session_search()` only catches `concurrent.futures.TimeoutError` around `_run_async(_summarize_all())`; per-call OpenAI/httpx timeout exceptions are handled inside `_summarize_session` as generic exceptions.
+- `gateway/run.py::start_gateway` attaches a stderr `StreamHandler` when verbosity is not `None`; its formatter is currently `'%(levelname)s %(name)s: %(message)s'`, so container stdout/stderr lines have no application timestamp unless Docker is configured separately.
+- `hermes_logging.py` already defines timestamped file-log formats and `setup_verbose_logging()` uses timestamped console formatting, but gateway stderr does not.
+
+## Scope
+
+Implement two low-risk behavior improvements:
+
+1. Treat session-search LLM timeout failures as expected, concise warnings rather than multi-line stack traces.
+2. Add a timestamp to gateway stderr log lines so docker compose logs contain time context next to the `hermes-gateway |` prefix.
+
+Out of scope:
+
+- Changing Docker Compose logging driver configuration.
+- Changing provider/client timeout durations globally.
+- Changing context compaction behavior.
+- Reworking the session_search LLM summarization pipeline.
+
+## No-ADR rationale
+
+No ADR is needed. This is an operational logging/triage refinement with no architecture, persistence, API, or product behavior contract change. The plan and tests are sufficient documentation.
+
+## Test strategy
+
+RED first:
+
+1. Add a unit test in `tests/tools/test_session_search.py` that patches `async_call_llm` to raise a timeout exception, calls `_summarize_session()`, and asserts:
+   - result is `None`
+   - warning is concise
+   - `exc_info` is not attached for expected timeout warnings
+2. Add a gateway startup test in `tests/gateway/test_runner_startup_failures.py` or logging test in `tests/test_hermes_logging.py` that exercises the gateway stderr handler and asserts the formatter output starts with an HH:MM:SS timestamp before the level/name/message.
+
+Expected RED cause:
+
+- Session-search timeout warning currently logs stack traces via `exc_info=True` after generic retry exhaustion.
+- Gateway stderr formatter currently emits `WARNING gateway.run: message` without a timestamp.
+
+GREEN implementation:
+
+- Add a narrow timeout classifier/helper in `tools/session_search_tool.py` that recognizes OpenAI/httpx/httpcore/asyncio timeout exception classes without requiring all optional imports to be present.
+- On expected per-session summarization timeout failures, log a concise warning and return `None` rather than retrying three times and printing a traceback. This intentionally trades retry recovery for lower gateway stalls and cleaner logs for known timeout failures; unexpected exceptions still use the existing retry/final traceback path.
+- On outer `_run_async` bridge timeouts, keep the existing JSON error response but log a concise warning without `exc_info=True`.
+- Update gateway stderr formatter in `gateway/run.py` to include `%(asctime)s` with a short date format (HH:MM:SS) while preserving redaction and existing level/name/message fields.
+
+Validation commands:
+
+- `python -m pytest tests/tools/test_session_search.py -q`
+- `python -m pytest tests/gateway/test_runner_startup_failures.py -q`
+- `python -m pytest tests/test_hermes_logging.py -q`
+- broader relevant regression if targeted tests are green: `python -m pytest tests/tools/test_session_search.py tests/gateway/test_runner_startup_failures.py tests/test_hermes_logging.py -q`
+- final code work guard with `HERMES_TDD_EVIDENCE` pointing to RED/GREEN output artifacts.
+
+## Acceptance criteria
+
+- Session search timeout handling no longer emits a full stack trace for expected timeout failures.
+- Session search still logs unexpected summarization failures with traceback for debugging.
+- Gateway stderr log lines include a timestamp before level/name/message.
+- Targeted tests pass.
+- Devlog is updated before PR.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13644,7 +13644,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)
-        _stderr_handler.setFormatter(RedactingFormatter('%(levelname)s %(name)s: %(message)s'))
+        _stderr_handler.setFormatter(RedactingFormatter('%(asctime)s %(levelname)s %(name)s: %(message)s', datefmt="%H:%M:%S"))
         logging.getLogger().addHandler(_stderr_handler)
         # Lower root logger level if needed so DEBUG records can reach the handler
         if _stderr_level < logging.getLogger().level:

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,3 +1,6 @@
+import logging
+import re
+
 import pytest
 from unittest.mock import AsyncMock
 
@@ -163,6 +166,53 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
     ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=1)
 
     assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stderr_verbosity_includes_timestamp(
+    monkeypatch, tmp_path, capsys
+):
+    """Gateway stderr logs need app timestamps for docker log triage."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _CleanExitRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = True
+            self.exit_reason = None
+            self.adapters = {}
+
+        async def start(self):
+            return True
+
+        async def stop(self):
+            return None
+
+    pre_existing_handlers = list(logging.getLogger().handlers)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _CleanExitRunner)
+
+    from gateway.run import start_gateway
+
+    try:
+        ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=1)
+        assert ok is True
+
+        logging.getLogger("gateway.run").warning("timestamp smoke")
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        stderr = capsys.readouterr().err
+    finally:
+        root = logging.getLogger()
+        for handler in list(root.handlers):
+            if handler not in pre_existing_handlers:
+                root.removeHandler(handler)
+                handler.close()
+
+    assert re.search(r"\d{2}:\d{2}:\d{2} WARNING gateway\.run: timestamp smoke", stderr)
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -10,6 +10,7 @@ from tools.session_search_tool import (
     _format_conversation,
     _truncate_around_matches,
     _get_session_search_max_concurrency,
+    _is_timeout_exception,
     _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
     MAX_SESSION_CHARS,
@@ -113,6 +114,99 @@ class TestFormatConversation:
     def test_empty_messages(self):
         result = _format_conversation([])
         assert result == ""
+
+
+class TestSummarizeSessionTimeouts:
+    @pytest.mark.asyncio
+    async def test_timeout_failure_logs_concise_warning_without_traceback(
+        self, caplog, monkeypatch
+    ):
+        """Expected provider read timeouts should not flood gateway logs."""
+        from unittest.mock import AsyncMock
+
+        from tools import session_search_tool
+
+        monkeypatch.setattr(
+            session_search_tool,
+            "async_call_llm",
+            AsyncMock(side_effect=TimeoutError("Request timed out.")),
+        )
+        monkeypatch.setattr(
+            session_search_tool.asyncio,
+            "sleep",
+            AsyncMock(),
+        )
+
+        with caplog.at_level("WARNING"):
+            result = await session_search_tool._summarize_session(
+                "[USER]: find my old logs",
+                "old logs",
+                {"source": "cli", "started_at": 1700000000},
+            )
+
+        assert result is None
+        timeout_records = [
+            record
+            for record in caplog.records
+            if "timed out" in record.getMessage().lower()
+        ]
+        assert timeout_records
+        assert all(record.exc_info is None for record in timeout_records)
+
+    def test_timeout_classifier_recognizes_provider_timeout_shapes(self):
+        timeout_cases = [
+            TimeoutError("built-in timeout"),
+            type("APITimeoutError", (Exception,), {"__module__": "openai"})(),
+            type("ReadTimeout", (Exception,), {"__module__": "httpx"})(),
+            type("ConnectTimeout", (Exception,), {"__module__": "httpcore"})(),
+        ]
+
+        for exc in timeout_cases:
+            assert _is_timeout_exception(exc)
+
+        assert not _is_timeout_exception(ValueError("not a timeout"))
+
+    def test_outer_summarization_timeout_logs_concise_warning_without_traceback(
+        self, caplog, monkeypatch
+    ):
+        import concurrent.futures
+        from unittest.mock import MagicMock
+
+        import model_tools
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "older_sid",
+                "content": "match",
+                "source": "cli",
+                "session_started": 1700000000,
+                "model": "test",
+            }
+        ]
+        mock_db.get_session.return_value = {"parent_session_id": None}
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "find the timeout"},
+        ]
+
+        def raise_timeout(coro):
+            coro.close()
+            raise concurrent.futures.TimeoutError()
+
+        monkeypatch.setattr(model_tools, "_run_async", raise_timeout)
+
+        with caplog.at_level("WARNING"):
+            result = json.loads(session_search(query="timeout", db=mock_db))
+
+        assert result["success"] is False
+        timeout_records = [
+            record
+            for record in caplog.records
+            if "timed out" in record.getMessage().lower()
+        ]
+        assert timeout_records
+        assert all(record.exc_info is None for record in timeout_records)
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -48,6 +48,35 @@ def _get_session_search_max_concurrency(default: int = 3) -> int:
     return max(1, min(value, 5))
 
 
+def _is_timeout_exception(exc: BaseException) -> bool:
+    """Return True for expected provider/network timeout exceptions.
+
+    Keep this structural instead of importing every optional provider/client
+    exception type. Gateway installs can vary, but OpenAI/httpx/httpcore
+    timeout failures all carry timeout-oriented class names and modules.
+    """
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return True
+
+    timeout_class_names = {
+        "APITimeoutError",
+        "ConnectTimeout",
+        "PoolTimeout",
+        "ReadTimeout",
+        "TimeoutException",
+        "WriteTimeout",
+    }
+    if {cls.__name__ for cls in type(exc).__mro__} & timeout_class_names:
+        return True
+
+    module = type(exc).__module__
+    name = type(exc).__name__
+    return (
+        module.startswith(("openai", "httpx", "httpcore"))
+        and "Timeout" in name
+    )
+
+
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
 
@@ -245,6 +274,9 @@ async def _summarize_session(
             logging.warning("No auxiliary model available for session summarization")
             return None
         except Exception as e:
+            if _is_timeout_exception(e):
+                logging.warning("Session summarization timed out: %s", e)
+                return None
             if attempt < max_retries - 1:
                 await asyncio.sleep(1 * (attempt + 1))
             else:
@@ -473,10 +505,7 @@ def session_search(
             from model_tools import _run_async
             results = _run_async(_summarize_all())
         except concurrent.futures.TimeoutError:
-            logging.warning(
-                "Session summarization timed out after 60 seconds",
-                exc_info=True,
-            )
+            logging.warning("Session summarization timed out")
             return json.dumps({
                 "success": False,
                 "error": "Session summarization timed out. Try a more specific query or reduce the limit.",


### PR DESCRIPTION
## Summary
- Handle expected session_search provider/client timeout exceptions as concise warnings instead of emitting full gateway stack traces.
- Add HH:MM:SS timestamps to gateway verbosity stderr logs while preserving redaction and level/name/message fields.
- Add regression coverage for inner timeout handling, outer bridge timeout logging, timeout classifier shapes, and gateway stderr timestamp formatting.

## Process artifacts
- Plan/spec: `.hermes/plans/2026-05-02-gateway-timeout-log-timestamps.md`
- Devlog: `.devlogs/2026-05-02-gateway-timeout-log-timestamps.md`
- No ADR rationale: included in the plan/devlog; this is an operational logging refinement.

## Test plan
- [x] RED: `python -m pytest tests/tools/test_session_search.py::TestSummarizeSessionTimeouts::test_timeout_failure_logs_concise_warning_without_traceback tests/gateway/test_runner_startup_failures.py::test_start_gateway_stderr_verbosity_includes_timestamp -q`
- [x] RED: `python -m pytest tests/tools/test_session_search.py::TestSummarizeSessionTimeouts::test_outer_summarization_timeout_logs_concise_warning_without_traceback -q`
- [x] GREEN: `python -m pytest tests/tools/test_session_search.py::TestSummarizeSessionTimeouts tests/gateway/test_runner_startup_failures.py::test_start_gateway_stderr_verbosity_includes_timestamp -q`
- [x] Regression: `python -m pytest tests/tools/test_session_search.py tests/gateway/test_runner_startup_failures.py tests/test_hermes_logging.py -q` — 99 passed
- [x] Static scan: `static_scan_diff.py --unstaged` — pass
- [x] Syntax: `python -m py_compile tools/session_search_tool.py gateway/run.py tests/tools/test_session_search.py tests/gateway/test_runner_startup_failures.py`
- [x] Final guard: `code_work_guard.py --mode final` with RED/GREEN evidence — pass
- [x] Independent reviewer subagent — pass, no blocking findings

## Notes
- Full `python -m pytest -q` was attempted but did not complete cleanly in this Hermes sandbox: it reached about 90%, emitted many xdist `node down: Not properly terminated` failures, then stopped making progress and was killed. Targeted regression suites for the changed areas pass.
- `ruff check` on the selected files reports pre-existing broad lint issues in `gateway/run.py`/tests; no new lint issue was introduced by the edited hunks.
