### PR TITLE
fix(delegation): respect delegation.model config for subagents (fixes #12440)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -943,7 +943,7 @@ def _build_child_agent(
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
     # Resolve the child's effective model early so it can ride on every event.
-    effective_model_for_cb = model or getattr(parent_agent, "model", None)
+    effective_model_for_cb = model or delegation_cfg.get("model") or getattr(parent_agent, "model", None)
 
     # Build progress callback to relay tool calls to parent display.
     # Identity kwargs thread the subagent_id through every emitted event so the
@@ -979,7 +979,7 @@ def _build_child_agent(
         child_thinking_cb = _child_thinking
 
     # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
+    effective_model = model or delegation_cfg.get("model") or parent_agent.model
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
     effective_base_url = override_base_url or parent_agent.base_url
     effective_api_key = override_api_key or parent_api_key


### PR DESCRIPTION
## Summary
Fixes #12440 - Subagents were ignoring the `delegation.model` config setting and always inheriting the parent agent's model.

## Changes
- Added `delegation_cfg.get("model")` to the model resolution chain at lines 946 and 982 in `tools/delegate_tool.py`
- Now respects the precedence: explicit model param > `delegation.model` config > parent agent model

## Testing
Manually verified that subagents now use the model specified in `delegation.model` in config.yaml instead of always inheriting the parent model.

## Related
- GitHub Issue: #12440
