### PR TITLE
Fix #18140: resolve stale Qwen model names via OpenCode prefix matching

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.request
 import urllib.error
 import time
@@ -2721,6 +2722,26 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     return "chat_completions"
 
 
+def _prefix_family_match(
+    requested_model: str,
+    live_models: list[str],
+) -> Optional[str]:
+    """Match stale family slugs against the provider's live model list."""
+    family_match = re.match(r"^(qwen\d*)", str(requested_model or "").strip().lower())
+    if not family_match:
+        return None
+
+    family = family_match.group(1)
+    if len(family) < 4:
+        return None
+
+    for model in live_models or []:
+        candidate = str(model or "").strip()
+        if candidate.lower().startswith(family):
+            return candidate
+    return None
+
+
 def github_model_reasoning_efforts(
     model_id: Optional[str],
     *,
@@ -3356,6 +3377,17 @@ def validate_requested_model(
                     "recognized": True,
                     "corrected_model": auto[0],
                     "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                }
+
+            # Auto-correct if the model is a family slug
+            family_match = _prefix_family_match(requested_for_lookup, api_models)
+            if family_match:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": family_match,
+                    "message": f"Auto-corrected `{requested}` → `{family_match}`",
                 }
 
             suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -405,6 +405,18 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-zen", "gemini-3-flash") == "chat_completions"
         assert opencode_model_api_mode("opencode-zen", "minimax-m2.5") == "chat_completions"
 
+    def test_qwen_family_prefix_auto_corrects_from_live_models(self):
+        result = _validate(
+            "qwen3-coder",
+            provider="opencode-zen",
+            api_models=["qwen3.6-plus", "qwen3.5-plus", "gpt-5.3-codex"],
+        )
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["corrected_model"] == "qwen3.6-plus"
+
     def test_opencode_go_api_modes_match_docs(self):
         assert opencode_model_api_mode("opencode-go", "glm-5.1") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "opencode-go/glm-5.1") == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

Fixes model resolution for stale Qwen model names when using OpenCode providers.

Previously, configurations like `qwen3-coder` could not be resolved even though compatible models (e.g. `qwen3.6-plus`) existed in the provider’s live `/models` list.

This PR introduces a prefix-based family matcher that:
- extracts a Qwen family prefix (e.g. `qwen3`)
- matches it against the provider’s live model list
- selects the first matching candidate

This approach preserves existing strict matching behavior while adding a safe fallback for versioned model families, without lowering the global fuzzy matching threshold.

---

## Related Issue

Fixes #18140

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

---

## Changes Made

- Added `_prefix_family_match` helper in `hermes_cli/models.py`
- Implemented Qwen-family prefix detection using regex: ^(qwen\d*)
- Integrated fallback into `validate_requested_model` after fuzzy match fails
- Ensured fallback only applies when a valid family prefix is detected
- Added test: `test_qwen_family_prefix_auto_corrects_from_live_models` in `tests/hermes_cli/test_model_validation.py`

---

## How to Test

1. Configure Hermes with:
   model.default = qwen3-coder  
   model.provider = opencode-zen  

2. Ensure provider `/models` returns models like:
   qwen3.6-plus  
   qwen3.5-plus  

3. Run:
   hermes chat  

4. Verify:
   - Model resolves to a valid Qwen model (e.g. qwen3.6-plus)
   - No fallback to unrelated providers/models

---

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only related changes
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated cli-config.yaml.example — or N/A
- [x] I've updated CONTRIBUTING.md — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions — or N/A

---

## Screenshots / Logs

Example output after fix:

✓ Model switched: qwen3.6-plus  
Provider: OpenCode Zen  
Context: 1,000,000 tokens  
Max output: 65,536 tokens  
Cost: $0.50/M in, $3.00/M out, cache read $0.05/M  
Capabilities: reasoning, tools, vision  
⚠ Auto-corrected qwen3-coder → qwen3.6-plus  

This demonstrates that a stale model name is now correctly resolved to a valid live model.
