### PR TITLE
Fix Telegram multi-bot dispatch edge cases

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -997,10 +997,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=False,  # PATCH (multi-bot anti-loop v5): keep pending updates for multi-bot relay
                     error_callback=_polling_error_callback,
                 )
-            
+
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
             # gateway command there automatically adds it to the Telegram menu.
@@ -2729,6 +2729,16 @@ class TelegramAdapter(BasePlatformAdapter):
         # (bug #12545). Entities also correctly handle @handles inside URLs, code
         # blocks, and quoted text, where a regex scan would over-match.
         for source_text, entities in _iter_sources():
+            if not source_text:
+                continue
+            # PATCH (multi-bot anti-loop v5): Telegram MessageEntity offsets are
+            # UTF-16 code units, but python-telegram-bot exposes them as-is.
+            # Slicing a Python str by these offsets misaligns as soon as the
+            # message contains any non-BMP character (e.g. a "💭" prefix added
+            # by show_reasoning) — the captured range drops its leading "@" and
+            # the bot-username comparison fails, silently breaking bot-to-bot
+            # @mentions. Encode to UTF-16-LE, slice by bytes, then decode.
+            utf16_bytes = source_text.encode("utf-16-le")
             for entity in entities:
                 entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
                 if entity_type == "mention" and expected:
@@ -2736,7 +2746,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    if source_text[offset:offset + length].strip().lower() == expected:
+                    slice_bytes = utf16_bytes[offset * 2 : (offset + length) * 2]
+                    captured = slice_bytes.decode("utf-16-le", errors="replace")
+                    if captured.strip().lower() == expected:
                         return True
                 elif entity_type == "text_mention":
                     user = getattr(entity, "user", None)
@@ -2762,6 +2774,45 @@ class TelegramAdapter(BasePlatformAdapter):
                         continue
                     if command_text[at_index:].strip().lower() == expected:
                         return True
+        return False
+
+    def _command_addresses_bot(self, message: Message) -> bool:
+        """True if any bot_command entity addresses this bot (e.g. `/new@my_bot`).
+
+        PATCH (multi-bot anti-loop v5): Telegram emits only a ``bot_command``
+        entity for ``/cmd@botname`` — no ``mention`` entity is generated for
+        the ``@botname`` suffix — so ``_message_mentions_bot`` never sees it
+        and ``require_mention=true`` groups silently drop ``/cmd@thisbot``
+        updates. We recognise them here instead, mirroring the behaviour the
+        entity-only refactor (upstream ``e330112``) accidentally removed.
+        """
+        if not self._bot:
+            return False
+        bot_username = (getattr(self._bot, "username", None) or "").lstrip("@").lower()
+        if not bot_username:
+            return False
+        suffix = f"@{bot_username}"
+
+        def _iter_sources():
+            yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
+            yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
+
+        for source_text, entities in _iter_sources():
+            if not source_text:
+                continue
+            utf16_bytes = source_text.encode("utf-16-le")
+            for entity in entities:
+                entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
+                if entity_type != "bot_command":
+                    continue
+                offset = int(getattr(entity, "offset", -1))
+                length = int(getattr(entity, "length", 0))
+                if offset < 0 or length <= 0:
+                    continue
+                slice_bytes = utf16_bytes[offset * 2 : (offset + length) * 2]
+                captured = slice_bytes.decode("utf-16-le", errors="replace").strip().lower()
+                if captured.endswith(suffix):
+                    return True
         return False
 
     def _message_matches_mention_patterns(self, message: Message) -> bool:
@@ -2813,8 +2864,17 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):
+            # PATCH (multi-bot anti-loop v5): bot-to-bot replies must explicitly
+            # @mention this bot, otherwise ignore. Prevents A→B→A→… reply chains.
+            sender_is_bot = bool(getattr(getattr(message, "from_user", None), "is_bot", False))
+            if sender_is_bot and not self._message_mentions_bot(message):
+                return False
             return True
         if self._message_mentions_bot(message):
+            return True
+        # PATCH (multi-bot anti-loop v5): /cmd@<this_bot> addresses us even when
+        # Telegram emits only a bot_command entity (no mention entity).
+        if is_command and self._command_addresses_bot(message):
             return True
         return self._message_matches_mention_patterns(message)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6430,6 +6430,11 @@ class GatewayRunner:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
 
+            # PATCH (dispatch reply enforcement v6): auto-inject
+            # @<dispatcher> prefix when completing a bot-to-bot [派单]
+            # dispatch. Scoped to the final response only; tool-echo messages
+            # emitted during the agent run are intentionally NOT injected.
+            response = self._v6_maybe_inject_dispatcher(response, event, source)
             return response
             
         except Exception as e:
@@ -7838,6 +7843,57 @@ class GatewayRunner:
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
             logger.debug("goal continuation: enqueue failed: %s", exc)
+
+    def _v6_maybe_inject_dispatcher(
+        self,
+        response: str,
+        event: Optional["MessageEvent"],
+        source: "SessionSource",
+    ) -> str:
+        """PATCH (dispatch reply enforcement v6): keep bot-to-bot dispatch closed-loop."""
+        if not response or event is None:
+            return response
+        if getattr(source, "platform", None) != Platform.TELEGRAM:
+            return response
+
+        raw = getattr(event, "raw_message", None)
+        if raw is None:
+            return response
+        from_user = getattr(raw, "from_user", None)
+        if from_user is None or not getattr(from_user, "is_bot", False):
+            return response
+
+        dispatcher = (getattr(from_user, "username", None) or "").lstrip("@")
+        if not dispatcher:
+            return response
+
+        trigger_text = (
+            getattr(raw, "text", None) or getattr(raw, "caption", None) or ""
+        ).lstrip()
+        if not trigger_text.startswith("[派单]"):
+            return response
+
+        adapter = self.adapters.get(source.platform)
+        bot_username = ""
+        if adapter is not None:
+            bot_obj = getattr(adapter, "_bot", None)
+            if bot_obj is not None:
+                bot_username = (
+                    getattr(bot_obj, "username", None) or ""
+                ).lstrip("@").lower()
+        if dispatcher.lower() == bot_username:
+            return response
+
+        mention_re = re.compile(rf"@{re.escape(dispatcher)}(?!\w)", re.IGNORECASE)
+        if mention_re.search(response):
+            return response
+
+        logger.info(
+            "v6 dispatch-reply: injecting @%s prefix into final response (bot=%s)",
+            dispatcher,
+            bot_username or "?",
+        )
+        return f"@{dispatcher} {response}"
 
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""

--- a/tests/gateway/test_telegram_dispatch_reply_v6.py
+++ b/tests/gateway/test_telegram_dispatch_reply_v6.py
@@ -1,0 +1,170 @@
+"""Tests for v6 dispatch reply enforcement.
+
+Covers ``GatewayRunner._v6_maybe_inject_dispatcher`` — injects
+``@<dispatcher>`` into the agent's FINAL response when completing a
+bot-to-bot ``[派单]`` dispatch. Runs entirely at the runner level
+(response-return seam); tool-echo messages emitted during the agent
+run are intentionally outside this hook's reach.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+BOT_USERNAME = "hm_xiaoxiong_content_bot"        # this bot (染墨)
+DISPATCHER_USERNAME = "hm_xiaoxiong_main_bot"    # dispatcher (知微)
+STRANGER_BOT_USERNAME = "hm_xiaoxiong_dev_bot"   # a third teammate
+
+
+def _make_runner():
+    """Create a GatewayRunner stub with a mocked Telegram adapter."""
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter._bot = MagicMock()
+    adapter._bot.username = BOT_USERNAME
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner
+
+
+def _make_event(text: str = "", is_bot: bool = True, username: str = DISPATCHER_USERNAME):
+    """Build a minimal MessageEvent stand-in with a telegram.Message-ish raw."""
+    from_user = SimpleNamespace(is_bot=is_bot, username=username)
+    raw = SimpleNamespace(from_user=from_user, text=text, caption=None)
+    return SimpleNamespace(raw_message=raw)
+
+
+def _make_source(platform: Platform = Platform.TELEGRAM):
+    return SimpleNamespace(platform=platform)
+
+
+def test_inject_when_response_missing_at():
+    """The real-world bug: subagent forgot to @-back — v6 injects."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} 写 200 字 SEO 文案")
+    out = runner._v6_maybe_inject_dispatcher(
+        "找新词是内容创作的核心技能...", event, _make_source()
+    )
+    assert out.startswith(f"@{DISPATCHER_USERNAME} ")
+    assert "找新词是内容创作的核心技能..." in out
+
+
+def test_no_inject_when_response_has_at_at_start():
+    """Model already @-ed dispatcher at the start — leave alone."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} 写 X")
+    original = f"@{DISPATCHER_USERNAME} [完成] 交付：..."
+    assert runner._v6_maybe_inject_dispatcher(original, event, _make_source()) == original
+
+
+def test_no_inject_when_response_has_at_in_middle():
+    """Model @-ed dispatcher mid-text — still skip (whole-text scan)."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} 写 X")
+    original = f"[完成] @{DISPATCHER_USERNAME} 交付：..."
+    assert runner._v6_maybe_inject_dispatcher(original, event, _make_source()) == original
+
+
+def test_no_inject_when_response_has_at_case_insensitive():
+    """Case-insensitive mention match."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} 写 X")
+    original = f"@{DISPATCHER_USERNAME.upper()} [完成] hi"
+    assert runner._v6_maybe_inject_dispatcher(original, event, _make_source()) == original
+
+
+def test_inject_when_existing_at_is_prefix_match_only():
+    """``@dispatcher_assistant`` must NOT match whole-token ``@dispatcher``."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} do X")
+    original = f"@{DISPATCHER_USERNAME}_assistant did something"
+    out = runner._v6_maybe_inject_dispatcher(original, event, _make_source())
+    assert out.startswith(f"@{DISPATCHER_USERNAME} ")
+
+
+def test_no_inject_when_trigger_is_user():
+    """v6 must only fire on bot-to-bot dispatches."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} 写 X", is_bot=False, username="Kit668")
+    out = runner._v6_maybe_inject_dispatcher("写好了，在群里看看?", event, _make_source())
+    assert not out.startswith("@Kit668")
+    assert out == "写好了，在群里看看?"
+
+
+def test_no_inject_when_trigger_lacks_tag():
+    """Without [派单] tag, v6 is dormant — breaks the loop path."""
+    runner = _make_runner()
+    event = _make_event(f"@{BOT_USERNAME} 刚才那个 fix 还行")
+    out = runner._v6_maybe_inject_dispatcher("嗯，老板要的话可以推", event, _make_source())
+    assert "@" + DISPATCHER_USERNAME not in out
+
+
+def test_no_inject_on_self_dispatch():
+    """Never inject @self — defensive against pathological configurations."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} 自己派自己", username=BOT_USERNAME)
+    out = runner._v6_maybe_inject_dispatcher("跑一下", event, _make_source())
+    assert not out.startswith(f"@{BOT_USERNAME}")
+
+
+def test_inject_tolerates_leading_whitespace():
+    """Dispatcher accidentally wrote ``  [派单] @bot ...`` with leading spaces."""
+    runner = _make_runner()
+    event = _make_event(f"   [派单] @{BOT_USERNAME} 做一下")
+    out = runner._v6_maybe_inject_dispatcher("好了，这是交付内容", event, _make_source())
+    assert out.startswith(f"@{DISPATCHER_USERNAME} ")
+
+
+def test_tag_must_be_at_start_of_trigger_text():
+    """Only leading [派单] activates — [派单] in the middle is NOT a dispatch."""
+    runner = _make_runner()
+    event = _make_event("我们昨天讨论了[派单]的规则")
+    out = runner._v6_maybe_inject_dispatcher(
+        "收到，[派单] 规则我记住了", event, _make_source()
+    )
+    assert not out.startswith(f"@{DISPATCHER_USERNAME}")
+
+
+def test_no_inject_when_response_empty():
+    """Empty response passes through unchanged."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} do X")
+    assert runner._v6_maybe_inject_dispatcher("", event, _make_source()) == ""
+
+
+def test_no_inject_when_event_is_none():
+    """Missing event (synthetic triggers / CLI) — pass through."""
+    runner = _make_runner()
+    out = runner._v6_maybe_inject_dispatcher("hello", None, _make_source())
+    assert out == "hello"
+
+
+def test_no_inject_when_raw_message_is_none():
+    """Event without raw_message (e.g. internal synthetic events) — pass through."""
+    runner = _make_runner()
+    event = SimpleNamespace(raw_message=None)
+    out = runner._v6_maybe_inject_dispatcher("hello", event, _make_source())
+    assert out == "hello"
+
+
+def test_no_inject_on_non_telegram_platform():
+    """Discord/Slack etc. not handled yet; guard is Telegram-only."""
+    runner = _make_runner()
+    event = _make_event(f"[派单] @{BOT_USERNAME} do X")
+    source = SimpleNamespace(platform=Platform.DISCORD)
+    out = runner._v6_maybe_inject_dispatcher("hello world", event, source)
+    assert out == "hello world"
+
+
+def test_inject_uses_caption_when_text_missing():
+    """For media messages, trigger text lives in .caption — should still work."""
+    runner = _make_runner()
+    from_user = SimpleNamespace(is_bot=True, username=DISPATCHER_USERNAME)
+    raw = SimpleNamespace(from_user=from_user, text=None, caption=f"[派单] @{BOT_USERNAME} 做一下")
+    event = SimpleNamespace(raw_message=raw)
+    out = runner._v6_maybe_inject_dispatcher("好了", event, _make_source())
+    assert out.startswith(f"@{DISPATCHER_USERNAME} ")

--- a/tests/tools/test_send_message_dispatch_guard.py
+++ b/tests/tools/test_send_message_dispatch_guard.py
@@ -1,0 +1,154 @@
+"""Tests for the send_message dispatch guard (v7).
+
+Covers the ``_validate_dispatch_target`` helper that prevents group-triggered
+agent dispatches from being misrouted to a user's DM.
+"""
+
+import os
+
+import pytest
+
+from gateway.session_context import clear_session_vars, set_session_vars
+from tools.send_message_tool import _validate_dispatch_target
+
+
+GROUP_CHAT_ID = "-1003732657330"
+BOSS_USER_ID = "6590198078"
+OTHER_GROUP_CHAT_ID = "-1009999999999"
+STRANGER_USER_ID = "1234567890"
+
+
+@pytest.fixture
+def tg_group_session():
+    """Session context: triggered by the boss in the main group."""
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id=GROUP_CHAT_ID,
+        user_id=BOSS_USER_ID,
+    )
+    try:
+        yield
+    finally:
+        clear_session_vars(tokens)
+
+
+@pytest.fixture
+def tg_dm_session():
+    """Session context: triggered by the boss in a direct message."""
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id=BOSS_USER_ID,
+        user_id=BOSS_USER_ID,
+    )
+    try:
+        yield
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_group_trigger_dm_target_with_bot_mention_redirects(tg_group_session):
+    """The real-world bug: group trigger → DM target + @bot mention → redirect."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram",
+        BOSS_USER_ID,
+        '@hm_xiaoxiong_content_bot 写一段 200 字 SEO 文案',
+    )
+    assert new_chat == GROUP_CHAT_ID
+    assert warning is not None
+    assert "auto-redirected" in warning
+
+
+def test_group_trigger_dm_target_is_trigger_user_redirects_without_mention(tg_group_session):
+    """Even without a bot mention, DM to the triggering user is a classic mix-up."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", BOSS_USER_ID, "just a note to boss"
+    )
+    assert new_chat == GROUP_CHAT_ID
+    assert warning is not None
+
+
+def test_group_trigger_same_group_target_no_redirect(tg_group_session):
+    """Sending to the trigger group itself is always fine."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", GROUP_CHAT_ID, "@hm_xiaoxiong_content_bot 任务"
+    )
+    assert new_chat == GROUP_CHAT_ID
+    assert warning is None
+
+
+def test_group_trigger_different_group_target_no_redirect(tg_group_session):
+    """Dispatching to another group is legitimate cross-chat usage."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", OTHER_GROUP_CHAT_ID, "@hm_xiaoxiong_content_bot 任务"
+    )
+    assert new_chat == OTHER_GROUP_CHAT_ID
+    assert warning is None
+
+
+def test_group_trigger_stranger_dm_no_mention_no_redirect(tg_group_session):
+    """DM to someone who's not the trigger user, no @bot → legitimate, don't touch."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", STRANGER_USER_ID, "hello friend"
+    )
+    assert new_chat == STRANGER_USER_ID
+    assert warning is None
+
+
+def test_group_trigger_stranger_dm_with_bot_mention_redirects(tg_group_session):
+    """@bot mention alone signals dispatch intent — redirect even for stranger DM."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", STRANGER_USER_ID, "@hm_xiaoxiong_content_bot 写文案"
+    )
+    assert new_chat == GROUP_CHAT_ID
+    assert warning is not None
+
+
+def test_dm_trigger_any_target_no_redirect(tg_dm_session):
+    """When agent is triggered in a DM, don't second-guess its targets."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", BOSS_USER_ID, "@hm_xiaoxiong_content_bot do X"
+    )
+    assert new_chat == BOSS_USER_ID
+    assert warning is None
+
+
+def test_no_session_context_no_redirect():
+    """CLI/cron without gateway session vars → guard is a no-op."""
+    # Ensure no stale env vars leak in from the runner
+    for key in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_USER_ID",
+    ):
+        os.environ.pop(key, None)
+
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", BOSS_USER_ID, "@hm_xiaoxiong_content_bot do X"
+    )
+    assert new_chat == BOSS_USER_ID
+    assert warning is None
+
+
+def test_non_telegram_platform_no_redirect(tg_group_session):
+    """Guard is Telegram-only for now."""
+    new_chat, warning = _validate_dispatch_target(
+        "discord", BOSS_USER_ID, "@hm_xiaoxiong_content_bot do X"
+    )
+    assert new_chat == BOSS_USER_ID
+    assert warning is None
+
+
+def test_none_chat_id_returns_as_is(tg_group_session):
+    """Unresolved chat_id (None) passes through unchanged."""
+    new_chat, warning = _validate_dispatch_target("telegram", None, "any message")
+    assert new_chat is None
+    assert warning is None
+
+
+def test_non_numeric_chat_id_passes_through(tg_group_session):
+    """Non-numeric chat_id (e.g. channel name left unresolved) shouldn't crash."""
+    new_chat, warning = _validate_dispatch_target(
+        "telegram", "not-a-number", "@hm_xiaoxiong_content_bot"
+    )
+    assert new_chat == "not-a-number"
+    assert warning is None

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -330,21 +330,21 @@ class TestBackendSelection:
         """Only PARALLEL_API_KEY set → 'parallel'."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key", "TAVILY_API_KEYS": ""}):
             assert _get_backend() == "parallel"
 
     def test_fallback_exa_only_key(self):
         """Only EXA_API_KEY set → 'exa'."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
+             patch.dict(os.environ, {"EXA_API_KEY": "exa-test", "TAVILY_API_KEYS": ""}):
             assert _get_backend() == "exa"
 
     def test_fallback_parallel_takes_priority_over_exa(self):
         """Exa should only win the fallback path when it is the only configured backend."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"EXA_API_KEY": "exa-test", "PARALLEL_API_KEY": "par-test"}):
+             patch.dict(os.environ, {"EXA_API_KEY": "exa-test", "PARALLEL_API_KEY": "par-test", "TAVILY_API_KEYS": ""}):
             assert _get_backend() == "parallel"
 
     def test_fallback_tavily_only_key(self):
@@ -358,14 +358,14 @@ class TestBackendSelection:
         """Tavily + Firecrawl keys, no config → 'firecrawl' (backward compat)."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "FIRECRAWL_API_KEY": "fc-test"}):
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "TAVILY_API_KEYS": "", "FIRECRAWL_API_KEY": "fc-test"}):
             assert _get_backend() == "firecrawl"
 
     def test_fallback_tavily_with_parallel_prefers_parallel(self):
         """Tavily + Parallel keys, no config → 'parallel' (Parallel takes priority over Tavily)."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "PARALLEL_API_KEY": "par-test"}):
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "TAVILY_API_KEYS": "", "PARALLEL_API_KEY": "par-test"}):
             # Parallel + no Firecrawl → parallel
             assert _get_backend() == "parallel"
 
@@ -373,27 +373,28 @@ class TestBackendSelection:
         """Both keys set, no config → 'firecrawl' (backward compat)."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key", "FIRECRAWL_API_KEY": "fc-test"}):
+             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key", "FIRECRAWL_API_KEY": "fc-test", "TAVILY_API_KEYS": ""}):
             assert _get_backend() == "firecrawl"
 
     def test_fallback_firecrawl_only_key(self):
         """Only FIRECRAWL_API_KEY set → 'firecrawl'."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "TAVILY_API_KEYS": ""}):
             assert _get_backend() == "firecrawl"
 
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"TAVILY_API_KEYS": ""}):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
         """web.backend=invalid → ignored, uses key-based fallback."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={"backend": "nonexistent"}), \
-             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
+             patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key", "TAVILY_API_KEYS": ""}):
             assert _get_backend() == "parallel"
 
 
@@ -581,8 +582,9 @@ class TestCheckWebApiKey:
             assert check_web_api_key() is True
 
     def test_no_keys_returns_false(self):
-        from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        with patch.dict(os.environ, {"TAVILY_API_KEYS": ""}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -20,9 +20,10 @@ class TestTavilyRequest:
     """Test suite for the _tavily_request helper."""
 
     def test_raises_without_api_key(self):
-        """No TAVILY_API_KEY → ValueError with guidance."""
+        """No TAVILY_API_KEY/TAVILY_API_KEYS → ValueError with guidance."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("TAVILY_API_KEY", None)
+            os.environ.pop("TAVILY_API_KEYS", None)
             from tools.web_tools import _tavily_request
             with pytest.raises(ValueError, match="TAVILY_API_KEY"):
                 _tavily_request("search", {"query": "test"})
@@ -33,7 +34,7 @@ class TestTavilyRequest:
         mock_response.json.return_value = {"results": []}
         mock_response.raise_for_status = MagicMock()
 
-        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}):
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key", "TAVILY_API_KEYS": ""}):
             with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
                 from tools.web_tools import _tavily_request
                 result = _tavily_request("search", {"query": "hello"})
@@ -45,6 +46,21 @@ class TestTavilyRequest:
                 assert payload["query"] == "hello"
                 assert "api.tavily.com/search" in call_kwargs.args[0]
 
+    def test_round_robins_tavily_api_keys(self):
+        """TAVILY_API_KEYS supports round-robin key rotation."""
+        from tools import web_tools
+
+        web_tools._tavily_key_index = 0
+        with patch.dict(os.environ, {"TAVILY_API_KEYS": "k1,k2 k3", "TAVILY_API_KEY": "k2"}):
+            assert [web_tools._get_tavily_api_key() for _ in range(6)] == [
+                "k1",
+                "k2",
+                "k3",
+                "k1",
+                "k2",
+                "k3",
+            ]
+
     def test_raises_on_http_error(self):
         """Non-2xx responses propagate as httpx.HTTPStatusError."""
         import httpx as _httpx
@@ -53,7 +69,7 @@ class TestTavilyRequest:
             "401 Unauthorized", request=MagicMock(), response=mock_response
         )
 
-        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-bad-key"}):
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-bad-key", "TAVILY_API_KEYS": ""}):
             with patch("tools.web_tools.httpx.post", return_value=mock_response):
                 from tools.web_tools import _tavily_request
                 with pytest.raises(_httpx.HTTPStatusError):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -120,7 +120,16 @@ SEND_MESSAGE_SCHEMA = {
         "(not just a bare platform name), call send_message(action='list') FIRST to see "
         "available targets, then send to the correct one.\n"
         "If the user just says a platform name like 'send to telegram', send directly "
-        "to the home channel without listing first."
+        "to the home channel without listing first.\n\n"
+        "GROUP-CHAT DISPATCH RULE (Telegram multi-bot setups): When you are triggered "
+        "by a GROUP chat (Telegram chat_id is negative, e.g. -1003732657330), any "
+        "send_message that dispatches work to a teammate bot (message contains "
+        "@teammate_bot) MUST target the SAME group chat_id — never a user's "
+        "private chat_id. A user's DM does NOT relay @mentions to other bots, so "
+        "a teammate will never see a dispatch sent to the user's DM. If you mistakenly "
+        "target a user DM for a group dispatch, the gateway auto-redirects the "
+        "message to the triggering group and adds a 'warning' to the tool result — "
+        "read the warning and use the correct group chat_id for subsequent dispatches."
     ),
     "parameters": {
         "type": "object",
@@ -262,6 +271,12 @@ def _handle_send(args):
                 f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
             })
 
+    # PATCH (send_message dispatch guard v7): prevent group-triggered dispatches
+    # from being misrouted to a user's DM. See _validate_dispatch_target().
+    chat_id, redirect_warning = _validate_dispatch_target(
+        platform_name, chat_id, cleaned_message
+    )
+
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:
         return json.dumps(duplicate_skip)
@@ -280,6 +295,10 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+        if redirect_warning and isinstance(result, dict) and result.get("success"):
+            warnings_list = list(result.get("warnings", []))
+            warnings_list.append(redirect_warning)
+            result["warnings"] = warnings_list
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:
@@ -382,6 +401,73 @@ def _get_cron_auto_delivery_target():
         "chat_id": chat_id,
         "thread_id": thread_id,
     }
+
+
+# PATCH (send_message dispatch guard v7) ----------------------------------
+# In multi-bot Telegram group setups, the LLM sometimes misroutes a dispatch
+# (e.g. "@teammate_bot do X") by calling send_message(target="telegram:<user_id>")
+# instead of send_message(target="telegram:<group_id>"). DMs don't relay
+# @mentions to other bots, so the teammate never sees the task. Detect this
+# pattern (group trigger + DM target + message mentions another bot, or
+# target equals the triggering user's DM) and auto-redirect to the triggering
+# group. Surgical guard — does not restrict legitimate cross-chat send_message.
+_BOT_MENTION_RE = re.compile(r"@[A-Za-z0-9_]+_bot\b")
+
+
+def _validate_dispatch_target(platform_name: str, chat_id, message: str):
+    """Return (possibly rewritten chat_id, warning_message_or_None).
+
+    Only acts on Telegram. Leaves chat_id untouched for CLI/cron (no session
+    env), DM-triggered sessions, matching chat, group target, or no-teammate
+    message. See module docstring for rationale.
+    """
+    if platform_name != "telegram" or chat_id is None:
+        return chat_id, None
+
+    from gateway.session_context import get_session_env
+
+    trigger_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    trigger_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    if trigger_platform != "telegram" or not trigger_chat_id:
+        return chat_id, None
+
+    try:
+        trigger_chat_int = int(trigger_chat_id)
+        target_chat_int = int(chat_id)
+    except (TypeError, ValueError):
+        return chat_id, None
+
+    if trigger_chat_int >= 0:
+        return chat_id, None  # trigger itself is a DM — nothing to guard
+    if target_chat_int < 0:
+        return chat_id, None  # target is already a group/channel
+    if target_chat_int == trigger_chat_int:
+        return chat_id, None  # same chat (shouldn't be reachable, but safe)
+
+    # Signal 1: message @-mentions a bot → almost always a dispatch intent.
+    has_bot_mention = bool(_BOT_MENTION_RE.search(message or ""))
+
+    # Signal 2: target equals the triggering user's id → classic
+    # user_id-vs-chat_id mix-up even when no bot @-mention is present.
+    trigger_user_id = get_session_env("HERMES_SESSION_USER_ID", "")
+    hits_trigger_user_dm = (
+        bool(trigger_user_id) and str(chat_id) == str(trigger_user_id)
+    )
+
+    if not (has_bot_mention or hits_trigger_user_dm):
+        return chat_id, None  # could be legitimate cross-chat DM
+
+    logger.warning(
+        "send_message dispatch guard: redirecting DM target %s -> group %s "
+        "(bot_mention=%s, hits_trigger_user=%s)",
+        chat_id, trigger_chat_id, has_bot_mention, hits_trigger_user_dm,
+    )
+    return str(trigger_chat_id), (
+        f"Dispatch was auto-redirected from user DM (chat_id={chat_id}) to the "
+        f"triggering group (chat_id={trigger_chat_id}). For teammate dispatches, "
+        "always target the group chat_id — user DMs do not relay @mentions to "
+        "other bots."
+    )
 
 
 def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id: str | None):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -45,6 +45,7 @@ import logging
 import os
 import re
 import asyncio
+import threading
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx
 # NOTE: `from firecrawl import Firecrawl` is deliberately NOT at module top —
@@ -135,7 +136,7 @@ def _get_backend() -> str:
     backend_candidates = (
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
-        ("tavily", _has_env("TAVILY_API_KEY")),
+        ("tavily", _has_env("TAVILY_API_KEY") or _has_env("TAVILY_API_KEYS")),
         ("exa", _has_env("EXA_API_KEY")),
     )
     for backend, available in backend_candidates:
@@ -154,7 +155,7 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "firecrawl":
         return check_firecrawl_api_key()
     if backend == "tavily":
-        return _has_env("TAVILY_API_KEY")
+        return _has_env("TAVILY_API_KEY") or _has_env("TAVILY_API_KEYS")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -225,6 +226,7 @@ def _web_requires_env() -> list[str]:
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
+        "TAVILY_API_KEYS",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
     ]
@@ -322,21 +324,42 @@ def _get_async_parallel_client():
 # ─── Tavily Client ───────────────────────────────────────────────────────────
 
 _TAVILY_BASE_URL = os.getenv("TAVILY_BASE_URL", "https://api.tavily.com")
+_tavily_key_lock = threading.Lock()
+_tavily_key_index = 0
+
+
+def _get_tavily_api_key() -> str:
+    """Return the next Tavily API key from single-key or multi-key config."""
+    global _tavily_key_index
+
+    raw_values = [
+        os.getenv("TAVILY_API_KEYS", ""),
+        os.getenv("TAVILY_API_KEY", ""),
+    ]
+    keys: List[str] = []
+    seen = set()
+    for raw in raw_values:
+        for key in re.split(r"[,;\s]+", raw or ""):
+            key = key.strip()
+            if key and key not in seen:
+                keys.append(key)
+                seen.add(key)
+
+    if not keys:
+        raise ValueError(
+            "TAVILY_API_KEY or TAVILY_API_KEYS environment variable not set. "
+            "Get your API key at https://app.tavily.com/home"
+        )
+
+    with _tavily_key_lock:
+        key = keys[_tavily_key_index % len(keys)]
+        _tavily_key_index += 1
+        return key
 
 
 def _tavily_request(endpoint: str, payload: dict) -> dict:
-    """Send a POST request to the Tavily API.
-
-    Auth is provided via ``api_key`` in the JSON body (no header-based auth).
-    Raises ``ValueError`` if ``TAVILY_API_KEY`` is not set.
-    """
-    api_key = os.getenv("TAVILY_API_KEY")
-    if not api_key:
-        raise ValueError(
-            "TAVILY_API_KEY environment variable not set. "
-            "Get your API key at https://app.tavily.com/home"
-        )
-    payload["api_key"] = api_key
+    """Send a POST request to the Tavily API."""
+    payload["api_key"] = _get_tavily_api_key()
     url = f"{_TAVILY_BASE_URL}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
     response = httpx.post(url, json=payload, timeout=60)


### PR DESCRIPTION
## Summary

This PR proposes fixes for several edge cases we hit while running multiple Hermes Telegram bots in the same group:

- preserve pending Telegram updates during gateway startup for multi-bot relay setups
- make bot mention detection UTF-16 aware, including `/cmd@botname` Telegram `bot_command` entities
- prevent bot-to-bot reply loops unless the replying bot explicitly mentions this bot
- add a final-response guard for bot-to-bot dispatch messages tagged with `[派单]`, so the worker replies back to the dispatching bot when the model forgets the mention
- prevent `send_message` from accidentally routing group dispatches to a user's DM when the message contains a teammate bot mention
- support `TAVILY_API_KEYS` for round-robin Tavily key rotation while keeping `TAVILY_API_KEY` compatibility

## Context / maintainer request

These changes are based on production issues observed in a Telegram multi-bot deployment. Some parts are intentionally conservative and may be too deployment-specific, especially the `[派单]` dispatch marker. I am opening this PR to share the failing scenarios and tests, and would appreciate maintainer guidance on the preferred upstream shape if you want a more generic dispatch marker/configuration mechanism.

## Tests

```bash
venv/bin/python -m pytest -q -n 0 \
  tests/gateway/test_telegram_mention_boundaries.py \
  tests/gateway/test_telegram_dispatch_reply_v6.py \
  tests/tools/test_send_message_dispatch_guard.py \
  tests/tools/test_web_tools_tavily.py \
  tests/tools/test_web_tools_config.py
```

Result: `110 passed, 3 warnings`.
