### PR TITLE
fix: add trusted HQ escalation routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -844,6 +844,21 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(telegram_cfg, dict):
                 if "require_mention" in telegram_cfg and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
                     os.environ["TELEGRAM_REQUIRE_MENTION"] = str(telegram_cfg["require_mention"]).lower()
+                if "allow_bots" in telegram_cfg and not os.getenv("TELEGRAM_ALLOW_BOTS"):
+                    os.environ["TELEGRAM_ALLOW_BOTS"] = str(telegram_cfg["allow_bots"]).lower()
+                hq_aliases = telegram_cfg.get("hq_aliases")
+                if hq_aliases is not None and not os.getenv("TELEGRAM_HQ_ALIASES"):
+                    if isinstance(hq_aliases, list):
+                        hq_aliases = ",".join(str(v) for v in hq_aliases)
+                    os.environ["TELEGRAM_HQ_ALIASES"] = str(hq_aliases)
+                if "hq_bot_id" in telegram_cfg and not os.getenv("TELEGRAM_HQ_BOT_ID"):
+                    os.environ["TELEGRAM_HQ_BOT_ID"] = str(telegram_cfg["hq_bot_id"]).lower()
+                if "hq_assignment" in telegram_cfg and not os.getenv("TELEGRAM_HQ_ASSIGNMENT"):
+                    import json as _json
+                    os.environ["TELEGRAM_HQ_ASSIGNMENT"] = _json.dumps(telegram_cfg["hq_assignment"])
+                if "hq_escalation" in telegram_cfg and not os.getenv("TELEGRAM_HQ_ESCALATION"):
+                    import json as _json
+                    os.environ["TELEGRAM_HQ_ESCALATION"] = _json.dumps(telegram_cfg["hq_escalation"])
                 if "mention_patterns" in telegram_cfg and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
                     os.environ["TELEGRAM_MENTION_PATTERNS"] = json.dumps(telegram_cfg["mention_patterns"])
                 frc = telegram_cfg.get("free_response_chats")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -892,6 +892,7 @@ class MessageEvent:
     # ("Error while calling `get_updates` one more time to mark all fetched
     # updates" in gateway.log).
     platform_update_id: Optional[int] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
     
     # Media attachments
     # media_urls: local file paths (for vision tool access)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2658,6 +2658,325 @@ class TelegramAdapter(BasePlatformAdapter):
             except (TypeError, ValueError):
                 logger.warning("[%s] Ignoring invalid Telegram thread id: %r", self.name, value)
         return ignored
+    def _telegram_hq_aliases(self) -> list[str]:
+        raw = self.config.extra.get("hq_aliases")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_HQ_ALIASES", "")
+        if isinstance(raw, list):
+            return [str(part).strip().lower() for part in raw if str(part).strip()]
+        return [part.strip().lower() for part in str(raw).split(",") if part.strip()]
+
+    def _telegram_hq_bot_id(self) -> str:
+        configured = self.config.extra.get("hq_bot_id")
+        if configured is None:
+            configured = os.getenv("TELEGRAM_HQ_BOT_ID", "")
+        return str(configured).strip().lower()
+
+    @staticmethod
+    def _coerce_string_set(raw: Any, *, lower: bool = False, strip_at: bool = False) -> set[str]:
+        if raw is None:
+            return set()
+        if isinstance(raw, str):
+            values = [part.strip() for part in raw.split(",") if part.strip()]
+        elif isinstance(raw, (list, tuple, set)):
+            values = [str(part).strip() for part in raw if str(part).strip()]
+        else:
+            values = [str(raw).strip()] if str(raw).strip() else []
+        result: set[str] = set()
+        for value in values:
+            if strip_at:
+                value = value.lstrip("@")
+            if lower:
+                value = value.lower()
+            if value:
+                result.add(value)
+        return result
+
+    def _telegram_hq_assignment_config(self) -> dict:
+        raw = self.config.extra.get("hq_assignment")
+        if raw is None:
+            raw_env = os.getenv("TELEGRAM_HQ_ASSIGNMENT", "").strip()
+            if raw_env:
+                try:
+                    raw = json.loads(raw_env)
+                except Exception:
+                    logger.warning("[%s] Invalid TELEGRAM_HQ_ASSIGNMENT JSON; ignoring", self.name)
+                    raw = None
+        return raw if isinstance(raw, dict) else {}
+
+    def _hq_assignment_enabled(self) -> bool:
+        value = self._telegram_hq_assignment_config().get("enabled", False)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _hq_assignment_allowed_chat_ids(self) -> set[str]:
+        raw = self._telegram_hq_assignment_config().get("allowed_chat_ids")
+        return self._coerce_string_set(raw)
+
+    def _hq_assignment_trusted_sender_ids(self) -> set[str]:
+        raw = self._telegram_hq_assignment_config().get("trusted_sender_user_ids")
+        return self._coerce_string_set(raw)
+
+    def _hq_assignment_trusted_sender_usernames(self) -> set[str]:
+        raw = self._telegram_hq_assignment_config().get("trusted_sender_usernames")
+        return self._coerce_string_set(raw, lower=True, strip_at=True)
+
+    def _hq_assignment_turn_limits(self) -> tuple[int, int]:
+        cfg = self._telegram_hq_assignment_config()
+        try:
+            default_turns = int(cfg.get("max_turns_default", 1) or 1)
+        except (TypeError, ValueError):
+            default_turns = 1
+        try:
+            max_turns = int(cfg.get("max_turns_max", 3) or 3)
+        except (TypeError, ValueError):
+            max_turns = 3
+        default_turns = max(1, default_turns)
+        max_turns = max(1, max_turns)
+        return min(default_turns, max_turns), max_turns
+
+    def _telegram_hq_escalation_config(self) -> dict:
+        raw = self.config.extra.get("hq_escalation")
+        if raw is None:
+            raw_env = os.getenv("TELEGRAM_HQ_ESCALATION", "").strip()
+            if raw_env:
+                try:
+                    raw = json.loads(raw_env)
+                except Exception:
+                    logger.warning("[%s] Invalid TELEGRAM_HQ_ESCALATION JSON; ignoring", self.name)
+                    raw = None
+        return raw if isinstance(raw, dict) else {}
+
+    def _hq_escalation_enabled(self) -> bool:
+        value = self._telegram_hq_escalation_config().get("enabled", False)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _hq_escalation_allowed_chat_ids(self) -> set[str]:
+        raw = self._telegram_hq_escalation_config().get("allowed_chat_ids")
+        return self._coerce_string_set(raw)
+
+    def _hq_escalation_trusted_worker_ids(self) -> set[str]:
+        raw = self._telegram_hq_escalation_config().get("trusted_worker_user_ids")
+        return self._coerce_string_set(raw)
+
+    def _hq_escalation_trusted_worker_usernames(self) -> set[str]:
+        raw = self._telegram_hq_escalation_config().get("trusted_worker_usernames")
+        return self._coerce_string_set(raw, lower=True, strip_at=True)
+
+    def _hq_escalation_accepted_types(self) -> set[str]:
+        raw = self._telegram_hq_escalation_config().get("accepted_types", ["HQ_ESCALATE", "HQ_RESULT"])
+        return {value.upper() for value in self._coerce_string_set(raw) if value.upper() in {"HQ_ESCALATE", "HQ_RESULT"}}
+
+    def _hq_escalation_statuses(self) -> set[str]:
+        raw = self._telegram_hq_escalation_config().get("statuses", ["done", "blocked", "failed", "needs_human"])
+        return self._coerce_string_set(raw, lower=True)
+
+    def _hq_escalation_turn_limits(self) -> tuple[int, int]:
+        cfg = self._telegram_hq_escalation_config()
+        try:
+            default_turns = int(cfg.get("max_turns_default", 1) or 1)
+        except (TypeError, ValueError):
+            default_turns = 1
+        try:
+            max_turns = int(cfg.get("max_turns_max", 3) or 3)
+        except (TypeError, ValueError):
+            max_turns = 3
+        default_turns = max(1, default_turns)
+        max_turns = max(1, max_turns)
+        return min(default_turns, max_turns), max_turns
+
+    def _parse_hq_assignment(self, message: Message) -> Optional[dict]:
+        bot_id = self._telegram_hq_bot_id()
+        if not bot_id:
+            return None
+        text = (getattr(message, "text", None) or getattr(message, "caption", None) or "").strip()
+        match = re.match(r"^\[HQ_ASSIGN\s+([^\]]+)\]\s*(.*)$", text, re.IGNORECASE | re.DOTALL)
+        if not match:
+            return None
+        fields = {
+            key.lower(): value.strip().strip("'\"").lower()
+            for key, value in re.findall(r"(\w+)=([^\s\]]+)", match.group(1))
+        }
+        target = fields.get("target", "").strip().lower()
+        if target != bot_id:
+            return None
+        body = (match.group(2) or "").strip()
+        if not body:
+            return None
+        default_turns, max_turns_cap = self._hq_assignment_turn_limits()
+        try:
+            max_turns = int(fields.get("max_turns", default_turns) or default_turns)
+        except (TypeError, ValueError):
+            max_turns = default_turns
+        max_turns = max(1, min(max_turns, max_turns_cap))
+        return {
+            "target": target,
+            "body": body,
+            "max_turns": max_turns,
+            "trace_id": fields.get("trace_id"),
+            "fields": fields,
+        }
+
+    def _sender_is_trusted_hq_assignment_bot(self, message: Message) -> bool:
+        sender = getattr(message, "from_user", None)
+        if not sender:
+            return False
+        sender_id = str(getattr(sender, "id", "") or "")
+        sender_username = str(getattr(sender, "username", "") or "").lstrip("@").lower()
+        return (
+            sender_id in self._hq_assignment_trusted_sender_ids()
+            or sender_username in self._hq_assignment_trusted_sender_usernames()
+        )
+
+    def _parse_hq_escalation(self, message: Message) -> Optional[dict]:
+        bot_id = self._telegram_hq_bot_id()
+        if bot_id != "architect":
+            return None
+        accepted_types = self._hq_escalation_accepted_types()
+        if not accepted_types:
+            return None
+        text = (getattr(message, "text", None) or getattr(message, "caption", None) or "").strip()
+        match = re.match(r"^\[(HQ_ESCALATE|HQ_RESULT)\s+([^\]]+)\]\s*(.*)$", text, re.IGNORECASE | re.DOTALL)
+        if not match:
+            return None
+        envelope_type = match.group(1).upper()
+        if envelope_type not in accepted_types:
+            return None
+        fields = {
+            key.lower(): value.strip().strip("'\"")
+            for key, value in re.findall(r"(\w+)=([^\s\]]+)", match.group(2))
+        }
+        target = fields.get("target", "").strip().lower()
+        if target != bot_id:
+            return None
+        from_bot = fields.get("from", "").strip().lower()
+        if not from_bot:
+            return None
+        body = (match.group(3) or "").strip()
+        if not body:
+            return None
+        ticket = fields.get("ticket", "").strip()
+        status = fields.get("status", "").strip().lower()
+        if envelope_type == "HQ_RESULT":
+            if not ticket:
+                return None
+            if status not in self._hq_escalation_statuses():
+                return None
+        default_turns, max_turns_cap = self._hq_escalation_turn_limits()
+        try:
+            max_turns = int(fields.get("max_turns", default_turns) or default_turns)
+        except (TypeError, ValueError):
+            max_turns = default_turns
+        max_turns = max(1, min(max_turns, max_turns_cap))
+        return {
+            "type": envelope_type,
+            "target": target,
+            "from": from_bot,
+            "ticket": ticket,
+            "status": status,
+            "severity": fields.get("severity", "").strip().lower(),
+            "body": body,
+            "max_turns": max_turns,
+            "trace_id": fields.get("trace_id"),
+            "fields": fields,
+        }
+
+    def _sender_is_trusted_hq_escalation_worker(self, message: Message) -> bool:
+        sender = getattr(message, "from_user", None)
+        if not sender:
+            return False
+        sender_id = str(getattr(sender, "id", "") or "")
+        sender_username = str(getattr(sender, "username", "") or "").lstrip("@").lower()
+        return (
+            sender_id in self._hq_escalation_trusted_worker_ids()
+            or sender_username in self._hq_escalation_trusted_worker_usernames()
+        )
+
+    def _message_is_trusted_hq_escalation_for_architect(self, message: Message) -> bool:
+        if not self._sender_is_bot(message):
+            return False
+        if self._is_own_bot_message(message):
+            return False
+        if not self._hq_escalation_enabled():
+            return False
+        allowed_chats = self._hq_escalation_allowed_chat_ids()
+        chat_id = str(getattr(getattr(message, "chat", None), "id", "") or "")
+        if allowed_chats and chat_id not in allowed_chats:
+            return False
+        if not self._sender_is_trusted_hq_escalation_worker(message):
+            return False
+        return self._parse_hq_escalation(message) is not None
+
+    def _message_is_trusted_hq_assignment_for_this_bot(self, message: Message) -> bool:
+        if not self._sender_is_bot(message):
+            return False
+        if self._is_own_bot_message(message):
+            return False
+        if not self._hq_assignment_enabled():
+            return False
+        allowed_chats = self._hq_assignment_allowed_chat_ids()
+        chat_id = str(getattr(getattr(message, "chat", None), "id", "") or "")
+        if allowed_chats and chat_id not in allowed_chats:
+            return False
+        if not self._sender_is_trusted_hq_assignment_bot(message):
+            return False
+        return self._parse_hq_assignment(message) is not None
+
+    def _apply_hq_assignment_to_event(self, message: Message, event: MessageEvent) -> MessageEvent:
+        assignment = self._parse_hq_assignment(message)
+        if not assignment:
+            return event
+        cfg = self._telegram_hq_assignment_config()
+        if cfg.get("strip_header", True):
+            event.text = assignment["body"]
+        if not getattr(event, "metadata", None):
+            event.metadata = {}
+        sender = getattr(message, "from_user", None)
+        event.metadata["hq_assignment"] = {
+            "target": assignment["target"],
+            "max_turns": assignment["max_turns"],
+            "trace_id": assignment.get("trace_id"),
+            "sender_user_id": str(getattr(sender, "id", "") or "") if sender else "",
+            "sender_username": str(getattr(sender, "username", "") or "") if sender else "",
+        }
+        return event
+
+    def _apply_hq_escalation_to_event(self, message: Message, event: MessageEvent) -> MessageEvent:
+        escalation = self._parse_hq_escalation(message)
+        if not escalation:
+            return event
+        cfg = self._telegram_hq_escalation_config()
+        if cfg.get("strip_header", True):
+            event.text = escalation["body"]
+        if not getattr(event, "metadata", None):
+            event.metadata = {}
+        sender = getattr(message, "from_user", None)
+        event.metadata["hq_escalation"] = {
+            "type": escalation["type"],
+            "target": escalation["target"],
+            "from": escalation["from"],
+            "ticket": escalation["ticket"],
+            "status": escalation["status"],
+            "severity": escalation["severity"],
+            "max_turns": escalation["max_turns"],
+            "trace_id": escalation.get("trace_id"),
+            "sender_user_id": str(getattr(sender, "id", "") or "") if sender else "",
+            "sender_username": str(getattr(sender, "username", "") or "") if sender else "",
+        }
+        return event
+
+    def _telegram_allow_bots(self) -> str:
+        configured = self.config.extra.get("allow_bots")
+        if configured is None:
+            configured = os.getenv("TELEGRAM_ALLOW_BOTS", "none")
+        value = str(configured).lower().strip()
+        if value not in {"none", "mentions", "all"}:
+            logger.warning("[%s] Invalid Telegram allow_bots value %r; using 'none'", self.name, configured)
+            return "none"
+        return value
 
     def _compile_mention_patterns(self) -> List[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
@@ -2709,6 +3028,31 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         reply_user = getattr(message.reply_to_message, "from_user", None)
         return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
+
+    def _sender_is_bot(self, message: Message) -> bool:
+        return bool(getattr(getattr(message, "from_user", None), "is_bot", False))
+
+    def _is_own_bot_message(self, message: Message) -> bool:
+        if not self._bot:
+            return False
+        sender = getattr(message, "from_user", None)
+        return bool(sender and getattr(sender, "id", None) == getattr(self._bot, "id", None))
+
+    def _bot_sender_allowed(self, message: Message) -> bool:
+        if not self._sender_is_bot(message):
+            return True
+        if self._is_own_bot_message(message):
+            return False
+        if self._message_is_trusted_hq_assignment_for_this_bot(message):
+            return True
+        if self._message_is_trusted_hq_escalation_for_architect(message):
+            return True
+        allow_bots = self._telegram_allow_bots()
+        if allow_bots == "all":
+            return True
+        if allow_bots == "mentions":
+            return self._message_mentions_bot(message)
+        return False
 
     def _message_mentions_bot(self, message: Message) -> bool:
         if not self._bot:
@@ -2775,6 +3119,28 @@ class TelegramAdapter(BasePlatformAdapter):
                     return True
         return False
 
+    def _message_matches_hq_aliases(self, message: Message) -> bool:
+        aliases = self._telegram_hq_aliases()
+        if not aliases:
+            return False
+        separators = {" ", "\t", "\n", ":", "：", ",", "，", "、", "-", "—"}
+        for candidate in (getattr(message, "text", None), getattr(message, "caption", None)):
+            text = (candidate or "").strip().lower()
+            if not text:
+                continue
+            for alias in aliases:
+                if text == alias:
+                    return True
+                if text.startswith(alias) and len(text) > len(alias) and text[len(alias)] in separators:
+                    return True
+        return False
+
+    def _message_is_hq_assignment_for_this_bot(self, message: Message) -> bool:
+        return self._parse_hq_assignment(message) is not None
+
+    def _message_is_hq_escalation_for_architect(self, message: Message) -> bool:
+        return self._message_is_trusted_hq_escalation_for_architect(message)
+
     def _clean_bot_trigger_text(self, text: Optional[str]) -> Optional[str]:
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
@@ -2790,6 +3156,9 @@ class TelegramAdapter(BasePlatformAdapter):
         - ``require_mention`` is disabled
         - the message replies to the bot
         - the bot is @mentioned
+        - the text/caption matches a configured HQ alias
+        - the text/caption is an HQ assignment for this bot
+        - the text/caption is a trusted HQ escalation/result for architect
         - the text/caption matches a configured regex wake-word pattern
 
         When ``require_mention`` is enabled, slash commands are not given
@@ -2799,6 +3168,9 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
+        if not self._bot_sender_allowed(message):
+            logger.info("[%s] Ignoring Telegram bot-originated message", self.name)
+            return False
         if not self._is_group_chat(message):
             return True
         thread_id = getattr(message, "message_thread_id", None)
@@ -2815,6 +3187,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if self._is_reply_to_bot(message):
             return True
         if self._message_mentions_bot(message):
+            return True
+        if self._message_matches_hq_aliases(message):
+            return True
+        if self._message_is_hq_assignment_for_this_bot(message):
+            return True
+        if self._message_is_hq_escalation_for_architect(message):
             return True
         return self._message_matches_mention_patterns(message)
 
@@ -3464,6 +3842,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_name=user.full_name if user else (chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None),
             thread_id=thread_id_str,
             chat_topic=chat_topic,
+            is_bot=self._sender_is_bot(message),
         )
         
         # Extract reply context if this message is a reply
@@ -3482,7 +3861,7 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
-        return MessageEvent(
+        event = MessageEvent(
             text=message.text or "",
             message_type=msg_type,
             source=source,
@@ -3495,6 +3874,8 @@ class TelegramAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             timestamp=message.date,
         )
+        event = self._apply_hq_assignment_to_event(message, event)
+        return self._apply_hq_escalation_to_event(message, event)
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1404,6 +1404,26 @@ class GatewayRunner:
 
         return model, runtime_kwargs
 
+    @staticmethod
+    def _effective_max_iterations_for_event(event: Optional[MessageEvent], default_max_iterations: int) -> int:
+        """Clamp per-message HQ assignment turn budget to the normal gateway cap."""
+        try:
+            default_value = int(default_max_iterations)
+        except (TypeError, ValueError):
+            default_value = 90
+        default_value = max(1, default_value)
+        metadata = getattr(event, "metadata", {}) if event else {}
+        control = metadata.get("hq_assignment") if isinstance(metadata, dict) else None
+        if not isinstance(control, dict) and isinstance(metadata, dict):
+            control = metadata.get("hq_escalation")
+        if not isinstance(control, dict):
+            return default_value
+        try:
+            requested = int(control.get("max_turns", default_value))
+        except (TypeError, ValueError):
+            return default_value
+        return max(1, min(requested, default_value))
+
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
 
@@ -4406,6 +4426,14 @@ class GatewayRunner:
                 if _action == "allow":
                     break
 
+        event_metadata = getattr(event, "metadata", None)
+        is_trusted_hq_control_event = False
+        if isinstance(event_metadata, dict):
+            is_trusted_hq_control_event = any(
+                isinstance(event_metadata.get(key), dict)
+                for key in ("hq_assignment", "hq_escalation")
+            )
+
         if is_internal:
             pass
         elif source.user_id is None:
@@ -4415,7 +4443,7 @@ class GatewayRunner:
             # flow with a None user_id.
             logger.debug("Ignoring message with no user_id from %s", source.platform.value)
             return None
-        elif not self._is_user_authorized(source):
+        elif not is_trusted_hq_control_event and not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
@@ -6064,6 +6092,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                event_metadata=event.metadata,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -11608,6 +11637,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        event_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -12090,7 +12120,10 @@ class GatewayRunner:
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
             # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = self._effective_max_iterations_for_event(
+                MessageEvent(text=message, metadata=event_metadata or {}),
+                int(os.getenv("HERMES_MAX_ITERATIONS", "90")),
+            )
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
@@ -12320,6 +12353,7 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            agent.max_iterations = max_iterations
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -87,7 +87,7 @@ class SessionSource:
     chat_topic: Optional[str] = None  # Channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # Platform-specific stable alt ID (Signal UUID, Feishu union_id)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
-    is_bot: bool = False  # True when the message author is a bot/webhook (Discord)
+    is_bot: bool = False  # True when the message author is a bot/webhook
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
@@ -123,6 +123,7 @@ class SessionSource:
             "user_name": self.user_name,
             "thread_id": self.thread_id,
             "chat_topic": self.chat_topic,
+            "is_bot": self.is_bot,
         }
         if self.user_id_alt:
             d["user_id_alt"] = self.user_id_alt
@@ -149,6 +150,7 @@ class SessionSource:
             chat_topic=data.get("chat_topic"),
             user_id_alt=data.get("user_id_alt"),
             chat_id_alt=data.get("chat_id_alt"),
+            is_bot=bool(data.get("is_bot", False)),
             guild_id=data.get("guild_id"),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -30,6 +30,7 @@ class TestSessionSourceRoundtrip:
             user_id="99",
             user_name="alice",
             thread_id="t1",
+            is_bot=True,
         )
         d = source.to_dict()
         restored = SessionSource.from_dict(d)
@@ -41,6 +42,7 @@ class TestSessionSourceRoundtrip:
         assert restored.user_id == "99"
         assert restored.user_name == "alice"
         assert restored.thread_id == "t1"
+        assert restored.is_bot is True
 
     def test_full_roundtrip_with_chat_topic(self):
         """chat_topic should survive to_dict/from_dict roundtrip."""

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1,8 +1,10 @@
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
-from gateway.config import Platform, PlatformConfig, load_gateway_config
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(
@@ -12,6 +14,11 @@ def _make_adapter(
     ignored_threads=None,
     allow_from=None,
     group_allow_from=None,
+    allow_bots=None,
+    hq_aliases=None,
+    hq_bot_id=None,
+    hq_assignment=None,
+    hq_escalation=None,
 ):
     from gateway.platforms.telegram import TelegramAdapter
 
@@ -28,6 +35,14 @@ def _make_adapter(
         extra["allow_from"] = allow_from
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if allow_bots is not None:
+        extra["allow_bots"] = allow_bots
+    if hq_aliases is not None:
+        extra["hq_aliases"] = hq_aliases
+    if hq_bot_id is not None:
+        extra["hq_bot_id"] = hq_bot_id
+    extra["hq_assignment"] = hq_assignment or {}
+    extra["hq_escalation"] = hq_escalation or {}
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -46,6 +61,8 @@ def _group_message(
     *,
     chat_id=-100,
     from_user_id=111,
+    from_user_username=None,
+    from_user_is_bot=False,
     thread_id=None,
     reply_to_bot=False,
     entities=None,
@@ -62,7 +79,7 @@ def _group_message(
         caption_entities=caption_entities or [],
         message_thread_id=thread_id,
         chat=SimpleNamespace(id=chat_id, type="group"),
-        from_user=SimpleNamespace(id=from_user_id),
+        from_user=SimpleNamespace(id=from_user_id, username=from_user_username, is_bot=from_user_is_bot),
         reply_to_message=reply_to_message,
     )
 
@@ -279,3 +296,558 @@ def test_config_bridges_telegram_ignored_threads(monkeypatch, tmp_path):
 
     assert config is not None
     assert __import__("os").environ["TELEGRAM_IGNORED_THREADS"] == "31,42"
+
+def _trusted_assignment_config(**overrides):
+    config = {
+        "enabled": True,
+        "allowed_chat_ids": ["-5166431570"],
+        "trusted_sender_usernames": ["Awoo999_bot"],
+        "max_turns_default": 1,
+        "max_turns_max": 3,
+        "strip_header": True,
+    }
+    config.update(overrides)
+    return config
+
+def test_bot_senders_are_ignored_by_default():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message(
+            "hi @hermes_bot",
+            entities=[_mention_entity("hi @hermes_bot")],
+            from_user_id=222,
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_bot_senders_can_be_opted_in_for_mentions():
+    adapter = _make_adapter(require_mention=True, allow_bots="mentions")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "hi @hermes_bot",
+            entities=[_mention_entity("hi @hermes_bot")],
+            from_user_id=222,
+            from_user_is_bot=True,
+        )
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("hello everyone", from_user_id=222, from_user_is_bot=True)
+    ) is False
+
+def test_own_bot_sender_is_never_processed():
+    adapter = _make_adapter(require_mention=True, allow_bots="all")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "hi @hermes_bot",
+            entities=[_mention_entity("hi @hermes_bot")],
+            from_user_id=999,
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_hq_aliases_trigger_this_bot_when_require_mention_enabled():
+    adapter = _make_adapter(require_mention=True, hq_aliases=["小礫", "rubble"])
+
+    assert adapter._should_process_message(_group_message("小礫 盤查 gateway")) is True
+    assert adapter._should_process_message(_group_message("rubble 盤查 gateway")) is True
+    assert adapter._should_process_message(_group_message("小礫：盤查 gateway")) is True
+
+def test_other_bot_alias_does_not_trigger_this_bot():
+    adapter = _make_adapter(require_mention=True, hq_aliases=["小礫", "rubble"])
+
+    assert adapter._should_process_message(_group_message("阿奇 盤查 gateway")) is False
+    assert adapter._should_process_message(_group_message("rubblefish 盤查 gateway")) is False
+
+def test_hq_assignment_for_this_bot_is_processed():
+    adapter = _make_adapter(require_mention=True, hq_bot_id="rubble")
+
+    assert adapter._should_process_message(
+        _group_message("[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway")
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("[HQ_ASSIGN target=RUBBLE max_turns=1]\n盤查 gateway")
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("[HQ_ASSIGN target=chase max_turns=1]\n盤查 gateway")
+    ) is False
+
+def test_hq_assignment_from_bot_still_hits_loop_guard():
+    adapter = _make_adapter(require_mention=True, hq_bot_id="rubble")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway",
+            from_user_id=222,
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_trusted_architect_bot_assignment_is_processed_when_enabled():
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway",
+            chat_id=-5166431570,
+            from_user_id=999001,
+            from_user_username="Awoo999_bot",
+            from_user_is_bot=True,
+        )
+    ) is True
+
+def test_bot_assignment_still_ignored_when_hq_assignment_disabled():
+    adapter = _make_adapter(require_mention=True, hq_bot_id="rubble")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway",
+            chat_id=-5166431570,
+            from_user_id=999001,
+            from_user_username="Awoo999_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_untrusted_bot_assignment_is_ignored():
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway",
+            chat_id=-5166431570,
+            from_user_id=123,
+            from_user_username="RandomBot",
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_trusted_bot_assignment_in_wrong_chat_is_ignored():
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway",
+            chat_id=-111,
+            from_user_id=999001,
+            from_user_username="Awoo999_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_trusted_bot_assignment_for_other_target_is_ignored():
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=zuma max_turns=1]\n做圖",
+            chat_id=-5166431570,
+            from_user_id=999001,
+            from_user_username="Awoo999_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_own_bot_assignment_is_never_processed_even_if_trusted():
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(trusted_sender_usernames=["hermes_bot"]),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ASSIGN target=rubble max_turns=1]\n盤查 gateway",
+            chat_id=-5166431570,
+            from_user_id=999,
+            from_user_username="hermes_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_hq_assignment_header_is_stripped_and_metadata_attached():
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(),
+    )
+    msg = _group_message(
+        "[HQ_ASSIGN target=rubble max_turns=2 trace_id=smoke-001]\n盤查 gateway",
+        chat_id=-5166431570,
+        from_user_id=999001,
+        from_user_username="Awoo999_bot",
+        from_user_is_bot=True,
+    )
+    event = MessageEvent(text=msg.text, message_type=MessageType.TEXT)
+
+    updated = adapter._apply_hq_assignment_to_event(msg, event)
+
+    assert updated.text == "盤查 gateway"
+    assert updated.metadata["hq_assignment"]["target"] == "rubble"
+    assert updated.metadata["hq_assignment"]["max_turns"] == 2
+    assert updated.metadata["hq_assignment"]["trace_id"] == "smoke-001"
+
+def test_hq_assignment_max_turns_is_clamped_to_config_cap():
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="rubble",
+        hq_assignment=_trusted_assignment_config(max_turns_max=3),
+    )
+    msg = _group_message(
+        "[HQ_ASSIGN target=rubble max_turns=99]\n盤查 gateway",
+        chat_id=-5166431570,
+        from_user_id=999001,
+        from_user_username="Awoo999_bot",
+        from_user_is_bot=True,
+    )
+
+    assignment = adapter._parse_hq_assignment(msg)
+
+    assert assignment["max_turns"] == 3
+
+def test_gateway_runner_uses_assignment_max_turns_when_lower_than_default():
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    event = MessageEvent(text="task", metadata={"hq_assignment": {"max_turns": 1}})
+
+    assert runner._effective_max_iterations_for_event(event, 90) == 1
+
+def test_gateway_runner_does_not_raise_iterations_above_default():
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    event = MessageEvent(text="task", metadata={"hq_assignment": {"max_turns": 999}})
+
+    assert runner._effective_max_iterations_for_event(event, 90) == 90
+
+def _architect_escalation_config(**overrides):
+    config = {
+        "enabled": True,
+        "allowed_chat_ids": ["-5166431570"],
+        "trusted_worker_usernames": ["Awoo008_bot", "Awoo001_bot"],
+        "accepted_types": ["HQ_ESCALATE", "HQ_RESULT"],
+        "statuses": ["done", "blocked", "failed", "needs_human"],
+        "max_turns_default": 1,
+        "max_turns_max": 3,
+        "strip_header": True,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_trusted_worker_escalation_to_architect_is_processed_when_enabled():
+    adapter = _make_adapter(
+        require_mention=True,
+        allow_bots="none",
+        hq_bot_id="architect",
+        hq_escalation=_architect_escalation_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ESCALATE target=architect from=rubble ticket=T20260502-rubble-smoke severity=urgent max_turns=2]\n卡點內容",
+            chat_id=-5166431570,
+            from_user_id=999008,
+            from_user_username="Awoo008_bot",
+            from_user_is_bot=True,
+        )
+    ) is True
+
+def test_hq_escalation_rejects_wrong_chat_untrusted_sender_wrong_target_and_human_bypass():
+    adapter = _make_adapter(
+        require_mention=True,
+        allow_bots="none",
+        hq_bot_id="architect",
+        hq_escalation=_architect_escalation_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ESCALATE target=architect from=rubble ticket=T20260502-rubble-smoke]\n卡點內容",
+            chat_id=-1,
+            from_user_username="Awoo008_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ESCALATE target=architect from=rubble ticket=T20260502-rubble-smoke]\n卡點內容",
+            chat_id=-5166431570,
+            from_user_username="untrusted_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ESCALATE target=rubble from=rubble ticket=T20260502-rubble-smoke]\n卡點內容",
+            chat_id=-5166431570,
+            from_user_username="Awoo008_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_ESCALATE target=architect from=rubble ticket=T20260502-rubble-smoke]\n卡點內容",
+            chat_id=-5166431570,
+            from_user_username="human_user",
+            from_user_is_bot=False,
+        )
+    ) is False
+
+def test_trusted_worker_result_to_architect_requires_from_ticket_and_allowed_status():
+    adapter = _make_adapter(
+        require_mention=True,
+        allow_bots="none",
+        hq_bot_id="architect",
+        hq_escalation=_architect_escalation_config(),
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_RESULT target=architect from=factory ticket=T20260502-rubble-smoke status=done max_turns=2]\n已查完",
+            chat_id=-5166431570,
+            from_user_username="Awoo001_bot",
+            from_user_is_bot=True,
+        )
+    ) is True
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_RESULT target=architect ticket=T20260502-rubble-smoke status=done]\nmissing from",
+            chat_id=-5166431570,
+            from_user_username="Awoo001_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_RESULT target=architect from=factory status=done]\nmissing ticket",
+            chat_id=-5166431570,
+            from_user_username="Awoo001_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+    assert adapter._should_process_message(
+        _group_message(
+            "[HQ_RESULT target=architect from=factory ticket=T20260502-rubble-smoke status=lol]\nbad status",
+            chat_id=-5166431570,
+            from_user_username="Awoo001_bot",
+            from_user_is_bot=True,
+        )
+    ) is False
+
+def test_hq_escalation_event_strips_header_and_attaches_metadata():
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    adapter = _make_adapter(
+        require_mention=True,
+        hq_bot_id="architect",
+        hq_escalation=_architect_escalation_config(),
+    )
+    msg = _group_message(
+        "[HQ_ESCALATE target=architect from=rubble ticket=T20260502-rubble-smoke severity=urgent max_turns=9 trace_id=t3]\n卡點內容",
+        chat_id=-5166431570,
+        from_user_username="Awoo008_bot",
+        from_user_is_bot=True,
+    )
+    event = MessageEvent(text=msg.text, message_type=MessageType.TEXT)
+
+    updated = adapter._apply_hq_escalation_to_event(msg, event)
+
+    assert updated.text == "卡點內容"
+    assert updated.metadata["hq_escalation"]["type"] == "HQ_ESCALATE"
+    assert updated.metadata["hq_escalation"]["target"] == "architect"
+    assert updated.metadata["hq_escalation"]["from"] == "rubble"
+    assert updated.metadata["hq_escalation"]["ticket"] == "T20260502-rubble-smoke"
+    assert updated.metadata["hq_escalation"]["severity"] == "urgent"
+    assert updated.metadata["hq_escalation"]["max_turns"] == 3
+    assert updated.metadata["hq_escalation"]["trace_id"] == "t3"
+
+def test_gateway_runner_clamps_hq_escalation_max_turns():
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    assert runner._effective_max_iterations_for_event(
+        MessageEvent(text="task", metadata={"hq_escalation": {"max_turns": 2}}),
+        90,
+    ) == 2
+    assert runner._effective_max_iterations_for_event(
+        MessageEvent(text="task", metadata={"hq_escalation": {"max_turns": 999}}),
+        90,
+    ) == 90
+
+
+@pytest.mark.asyncio
+async def test_hq_escalation_metadata_bypasses_human_user_allowlist(monkeypatch):
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "1926710271")
+    monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_CHATS", raising=False)
+    monkeypatch.delenv("TELEGRAM_ALLOW_ALL_USERS", raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)})
+    runner.adapters = {Platform.TELEGRAM: SimpleNamespace(send=AsyncMock())}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._update_prompt_pending = {}
+
+    async def _capture(event, source, _quick_key, _run_generation=None):
+        return f"processed:{event.metadata['hq_escalation']['ticket']}"
+
+    runner._handle_message_with_agent = _capture
+
+    event = MessageEvent(
+        text="smoke",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-5166431570",
+            chat_name="HQ",
+            chat_type="group",
+            user_id="8761586079",
+            user_name="小礫",
+            is_bot=True,
+        ),
+        metadata={"hq_escalation": {"ticket": "T20260502-rubble-smoke"}},
+    )
+
+    assert await runner._handle_message(event) == "processed:T20260502-rubble-smoke"
+
+def test_config_bridges_telegram_allow_bots(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  allow_bots: mentions\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert __import__("os").environ["TELEGRAM_ALLOW_BOTS"] == "mentions"
+
+def test_config_bridges_telegram_hq_aliases(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  hq_aliases:\n"
+        "    - 小礫\n"
+        "    - rubble\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_HQ_ALIASES", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert __import__("os").environ["TELEGRAM_HQ_ALIASES"] == "小礫,rubble"
+
+def test_config_bridges_telegram_hq_bot_id(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  hq_bot_id: Rubble\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_HQ_BOT_ID", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert __import__("os").environ["TELEGRAM_HQ_BOT_ID"] == "rubble"
+
+def test_config_bridges_telegram_hq_escalation(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  hq_escalation:\n"
+        "    enabled: true\n"
+        "    allowed_chat_ids:\n"
+        "      - \"-5166431570\"\n"
+        "    trusted_worker_usernames:\n"
+        "      - Awoo008_bot\n"
+        "    accepted_types:\n"
+        "      - HQ_ESCALATE\n"
+        "      - HQ_RESULT\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_HQ_ESCALATION", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    payload = json.loads(__import__("os").environ["TELEGRAM_HQ_ESCALATION"])
+    assert payload["enabled"] is True
+    assert payload["allowed_chat_ids"] == ["-5166431570"]
+    assert payload["trusted_worker_usernames"] == ["Awoo008_bot"]
+    assert payload["accepted_types"] == ["HQ_ESCALATE", "HQ_RESULT"]
+
+def test_config_bridges_telegram_hq_assignment(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  hq_assignment:\n"
+        "    enabled: true\n"
+        "    allowed_chat_ids:\n"
+        "      - \"-5166431570\"\n"
+        "    trusted_sender_usernames:\n"
+        "      - Awoo999_bot\n"
+        "    max_turns_default: 1\n"
+        "    max_turns_max: 3\n"
+        "    strip_header: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_HQ_ASSIGNMENT", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    bridged = json.loads(__import__("os").environ["TELEGRAM_HQ_ASSIGNMENT"])
+    assert bridged["enabled"] is True
+    assert bridged["allowed_chat_ids"] == ["-5166431570"]
+    assert bridged["trusted_sender_usernames"] == ["Awoo999_bot"]
+    assert bridged["max_turns_max"] == 3


### PR DESCRIPTION
## Summary
- add trusted Telegram HQ assignment/escalation parsing and metadata propagation
- allow trusted HQ control envelopes to bypass human pairing/allowlist checks without enabling general bot loops
- clamp per-envelope max_turns to the gateway iteration cap and add config/env bridging tests

## Tests
- `env -u TELEGRAM_REQUIRE_MENTION -u TELEGRAM_ALLOW_BOTS -u TELEGRAM_HQ_BOT_ID -u TELEGRAM_HQ_ASSIGNMENT -u TELEGRAM_HQ_ESCALATION -u TELEGRAM_ALLOWED_USERS -u TELEGRAM_GROUP_ALLOWED_USERS -u TELEGRAM_GROUP_ALLOWED_CHATS -u TELEGRAM_IGNORED_THREADS python -m pytest tests/gateway/test_telegram_group_gating.py tests/gateway/test_session.py tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_internal_event_bypass_pairing.py`
- Result: `151 passed in 2.34s`
