### PR TITLE
fix(dashboard): defer unknown-route redirect while dashboard plugins load

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -81,22 +81,11 @@ function RootRedirect() {
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
-  if (!pluginsLoading) {
-    return <Navigate to="/sessions" replace />;
+  if (pluginsLoading) {
+    // Render nothing during the plugin-load window — a spinner here would just flash.
+    return null;
   }
-
-  return (
-    <div
-      className="flex min-h-[16rem] min-w-0 items-center justify-center"
-      aria-busy="true"
-      aria-live="polite"
-    >
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Spinner />
-        <span>Loading dashboard plugins…</span>
-      </div>
-    </div>
-  );
+  return <Navigate to="/sessions" replace />;
 }
 
 const CHAT_NAV_ITEM: NavItem = {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -80,6 +80,25 @@ function RootRedirect() {
   return <Navigate to="/sessions" replace />;
 }
 
+function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
+  if (!pluginsLoading) {
+    return <Navigate to="/sessions" replace />;
+  }
+
+  return (
+    <div
+      className="flex min-h-[16rem] min-w-0 items-center justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner />
+        <span>Loading dashboard plugins…</span>
+      </div>
+    </div>
+  );
+}
+
 const CHAT_NAV_ITEM: NavItem = {
   path: "/chat",
   labelKey: "chat",
@@ -582,7 +601,9 @@ export default function App() {
                   ))}
                   <Route
                     path="*"
-                    element={<Navigate to="/sessions" replace />}
+                    element={
+                      <UnknownRouteFallback pluginsLoading={pluginsLoading} />
+                    }
                   />
                 </Routes>
 


### PR DESCRIPTION
## Summary

Follow-up to #16906. That PR fixed the dashboard routing race for `/chat` by parking a placeholder `ChatRouteSink` route so the `*` catch-all wouldn't fire on it. The same race still hits arbitrary plugin tab paths (`/kanban`, `/achievements`, ...): on refresh or deep-link the `<Route path="*">` element fires before plugin manifests are fetched and rewrites the URL to `/sessions`. Plugin paths can't be hardcoded as placeholders the way `/chat` can — they come from `/api/dashboard/plugins` at runtime — so the fallback itself needs to defer.

## Reproduction (on my gateway, with the bundled `kanban` plugin)

| action | before | after |
|---|---|---|
| sidebar click → `/kanban` | renders kanban | renders kanban |
| refresh on `/kanban` | URL replaced with `/sessions`, kanban hidden | brief spinner, then `/kanban` renders |
| open `/kanban` in a new tab | URL replaced with `/sessions` | brief spinner, then `/kanban` renders |
| open genuinely unknown `/foobar` | redirect to `/sessions` | spinner ≤2 s, then `/sessions` |

## Approach

- Extract the `*` route element into `UnknownRouteFallback({ pluginsLoading })`.
- While `pluginsLoading` is true, render a small `Loading dashboard plugins…` spinner instead of an immediate `<Navigate to="/sessions" replace />`.
- When `pluginsLoading` clears, the `routes` memo has already rebuilt with the plugin manifests, so the matching plugin path claims the URL and the fallback no longer renders. For paths that are actually unknown, the redirect fires as before.
- Reuses the existing `pluginsLoading` state from `usePlugins`. The manifest-fetch failure (`catch`) and no-plugins-installed branches already flip it to `false` synchronously, so broken setups still fall through to the redirect immediately. The `usePlugins` 2 s safety timeout caps the worst case for genuinely unknown paths.

## Tests

No automated test added — `web/` does not currently have a component-test harness, and the change is one conditional element. Verified manually on my gateway:

- `tsc --noEmit` and `npm run build` clean.
- Refresh and new-tab deep-link on `/kanban` both land on `/kanban` after a short spinner.
- `/foobar-not-a-route` still redirects to `/sessions`.

## Closes

Closes #18660
