### PR TITLE
fix(feishu): send fenced code blocks as native post blocks

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -159,6 +159,17 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_FEISHU_CODE_BLOCK_LANGUAGES = {
+    "PYTHON", "C", "CPP", "GO", "JAVA", "KOTLIN", "SWIFT", "PHP",
+    "RUBY", "RUST", "JAVASCRIPT", "TYPESCRIPT", "BASH", "SHELL",
+    "SQL", "JSON", "XML", "YAML", "HTML", "THRIFT",
+}
+_FEISHU_CODE_BLOCK_LANGUAGE_ALIASES = {
+    "PY": "PYTHON",
+    "JS": "JAVASCRIPT",
+    "TS": "TYPESCRIPT",
+    "SH": "SHELL",
+}
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -473,6 +484,16 @@ def _sanitize_fence_language(language: str) -> str:
     return language.strip().replace("\n", " ").replace("\r", " ")
 
 
+def _normalize_code_block_language(language: str) -> str:
+    """Return a Feishu-supported code_block language or an empty string."""
+    sanitized = _sanitize_fence_language(language)
+    if not sanitized:
+        return ""
+    token = sanitized.split()[0].strip().upper()
+    normalized = _FEISHU_CODE_BLOCK_LANGUAGE_ALIASES.get(token, token)
+    return normalized if normalized in _FEISHU_CODE_BLOCK_LANGUAGES else ""
+
+
 def _render_text_element(element: Dict[str, Any]) -> str:
     text = str(element.get("text", "") or "")
     style = element.get("style")
@@ -559,9 +580,10 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     """Build Feishu post rows while isolating fenced code blocks.
 
     Feishu's `md` renderer can swallow trailing content when a fenced code block
-    appears inside one large markdown element. Split the reply at real fence
-    lines so prose before/after the code block remains visible while code stays
-    in a dedicated row.
+    appears inside one large markdown element. Long fenced blocks in an `md` tag
+    can also render as a collapsed snippet that the Feishu client cannot expand.
+    Convert complete fenced blocks to Feishu's native `code_block` post tag and
+    keep prose before/after the block in dedicated markdown rows.
     """
     if not content:
         return [[{"tag": "md", "text": ""}]]
@@ -569,38 +591,68 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
         return [[{"tag": "md", "text": content}]]
 
     rows: List[List[Dict[str, str]]] = []
-    current: List[str] = []
+    prose_lines: List[str] = []
+    code_lines: List[str] = []
+    code_raw_lines: List[str] = []
+    code_language = ""
     in_code_block = False
 
-    def _flush_current() -> None:
-        nonlocal current
-        if not current:
+    def _flush_prose() -> None:
+        nonlocal prose_lines
+        if not prose_lines:
             return
-        segment = "\n".join(current)
+        segment = "\n".join(prose_lines)
         if segment.strip():
             rows.append([{"tag": "md", "text": segment}])
-        current = []
+        prose_lines = []
+
+    def _flush_code_block() -> None:
+        nonlocal code_lines, code_raw_lines, code_language
+        code_text = "\n".join(code_lines)
+        if code_text:
+            element: Dict[str, str] = {"tag": "code_block", "text": code_text}
+            language = _normalize_code_block_language(code_language)
+            if language:
+                element["language"] = language
+            rows.append([element])
+        else:
+            raw_segment = "\n".join(code_raw_lines)
+            if raw_segment.strip():
+                rows.append([{"tag": "md", "text": raw_segment}])
+        code_lines = []
+        code_raw_lines = []
+        code_language = ""
 
     for raw_line in content.splitlines():
         stripped_line = raw_line.strip()
-        is_fence = bool(
-            _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line)
-            if in_code_block
-            else _MARKDOWN_FENCE_OPEN_RE.match(stripped_line)
-        )
 
-        if is_fence:
-            if not in_code_block:
-                _flush_current()
-            current.append(raw_line)
-            in_code_block = not in_code_block
-            if not in_code_block:
-                _flush_current()
+        if in_code_block:
+            if _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line):
+                code_raw_lines.append(raw_line)
+                _flush_code_block()
+                in_code_block = False
+                continue
+            code_raw_lines.append(raw_line)
+            code_lines.append(raw_line)
             continue
 
-        current.append(raw_line)
+        fence_match = _MARKDOWN_FENCE_OPEN_RE.match(stripped_line)
+        if fence_match:
+            _flush_prose()
+            in_code_block = True
+            code_language = fence_match.group(1)
+            code_raw_lines = [raw_line]
+            code_lines = []
+            continue
 
-    _flush_current()
+        prose_lines.append(raw_line)
+
+    if in_code_block:
+        raw_segment = "\n".join(code_raw_lines)
+        if raw_segment.strip():
+            rows.append([{"tag": "md", "text": raw_segment}])
+    else:
+        _flush_prose()
     return rows or [[{"tag": "md", "text": content}]]
 
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2504,13 +2504,32 @@ class TestAdapterBehavior(unittest.TestCase):
                         "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
                     }
                 ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
+                [{"tag": "code_block", "language": "JSON", "text": "{\"cron\": \"list\"}"}],
                 [{"tag": "md", "text": "后续说明仍应保留。"}],
             ],
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
+    def test_build_post_payload_uses_native_code_block_for_long_fence(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        code = "\n".join(f"line{i}: print({i})" for i in range(1, 41))
+        payload = json.loads(adapter._build_post_payload(f"```python\n{code}\n```"))
+
+        rows = payload["zh_cn"]["content"]
+        self.assertEqual(len(rows), 1)
+        element = rows[0][0]
+        self.assertEqual(element["tag"], "code_block")
+        self.assertEqual(element["language"], "PYTHON")
+        self.assertEqual(element["text"].splitlines()[0], "line1: print(1)")
+        self.assertEqual(element["text"].splitlines()[-1], "line40: print(40)")
+        self.assertEqual(len(element["text"].splitlines()), 40)
+        self.assertNotIn("```", element["text"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_keeps_fence_like_code_lines_inside_native_code_block(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2525,7 +2544,7 @@ class TestAdapterBehavior(unittest.TestCase):
             payload["zh_cn"]["content"],
             [
                 [{"tag": "md", "text": "before"}],
-                [{"tag": "md", "text": "```python\n```oops\n```"}],
+                [{"tag": "code_block", "language": "PYTHON", "text": "```oops"}],
                 [{"tag": "md", "text": "after"}],
             ],
         )
@@ -2546,7 +2565,7 @@ class TestAdapterBehavior(unittest.TestCase):
             payload["zh_cn"]["content"],
             [
                 [{"tag": "md", "text": "before"}],
-                [{"tag": "md", "text": "```python\nline with two spaces  \n```"}],
+                [{"tag": "code_block", "language": "PYTHON", "text": "line with two spaces  "}],
                 [{"tag": "md", "text": "after"}],
             ],
         )
@@ -2567,9 +2586,9 @@ class TestAdapterBehavior(unittest.TestCase):
             payload["zh_cn"]["content"],
             [
                 [{"tag": "md", "text": "before"}],
-                [{"tag": "md", "text": "```python\nprint(1)\n```"}],
+                [{"tag": "code_block", "language": "PYTHON", "text": "print(1)"}],
                 [{"tag": "md", "text": "middle"}],
-                [{"tag": "md", "text": "```json\n{}\n```"}],
+                [{"tag": "code_block", "language": "JSON", "text": "{}"}],
                 [{"tag": "md", "text": "after"}],
             ],
         )


### PR DESCRIPTION
## Summary
- Convert complete Markdown fenced code blocks in Feishu/Lark post messages to native `code_block` post elements.
- Preserve Markdown prose before/after fenced blocks as separate rows.
- Normalize common language aliases (`py`, `js`, `ts`, `sh`) to Feishu-supported language names.

## Why
Feishu's `md` post renderer can collapse long fenced code snippets into a preview that some clients cannot expand, so users only see the first few lines. Feishu's post schema has a native `code_block` tag for this content, which avoids relying on the Markdown renderer for fenced blocks.

Official Feishu/Lark IM post content docs list `code_block` as a supported rich-text node, with `language` and `text` fields under `zh_cn.content` rows.

Reference: https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json.md

## Test plan
- `python -m pytest tests/gateway/test_feishu.py -k 'markdown_post or code' -q -o 'addopts='`
- `python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='`
