### PR TITLE
fix: strip extra_content from tool_calls for strict APIs (Fireworks, Mistral)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -113,8 +113,9 @@ class ChatCompletionsTransport(ProviderTransport):
         """Messages are already in OpenAI format — sanitize Codex leaks only.
 
         Strips Codex Responses API fields (``codex_reasoning_items`` /
-        ``codex_message_items`` on the message, ``call_id``/``response_item_id``
-        on tool_calls) that strict chat-completions providers reject with 400/422.
+        ``codex_message_items`` on the message, ``call_id``/``response_item_id`` /
+        ``extra_content`` on tool_calls) that strict chat-completions providers
+        reject with 400/422.
         """
         needs_sanitize = False
         for msg in messages:
@@ -126,7 +127,8 @@ class ChatCompletionsTransport(ProviderTransport):
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
-                    if isinstance(tc, dict) and ("call_id" in tc or "response_item_id" in tc):
+                    if isinstance(tc, dict) and ("call_id" in tc or "response_item_id" in tc
+                                               or "extra_content" in tc):
                         needs_sanitize = True
                         break
                 if needs_sanitize:
@@ -147,6 +149,7 @@ class ChatCompletionsTransport(ProviderTransport):
                     if isinstance(tc, dict):
                         tc.pop("call_id", None)
                         tc.pop("response_item_id", None)
+                        tc.pop("extra_content", None)
         return sanitized
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8837,17 +8837,20 @@ class AIAgent:
         the internal message history — this method only modifies the outgoing
         API copy.
 
+        Also strips extra_content (e.g. Gemini thought_signature) which strict
+        providers like Fireworks reject with "Extra inputs are not permitted".
+
         Creates new tool_call dicts rather than mutating in-place, so the
         original messages list retains call_id/response_item_id for Codex
         Responses API compatibility (e.g. if the session falls back to a
         Codex provider later).
 
-        Fields stripped: call_id, response_item_id
+        Fields stripped: call_id, response_item_id, extra_content
         """
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
             return api_msg
-        _STRIP_KEYS = {"call_id", "response_item_id"}
+        _STRIP_KEYS = {"call_id", "response_item_id", "extra_content"}
         api_msg["tool_calls"] = [
             {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
             if isinstance(tc, dict) else tc

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,24 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_strips_extra_content_from_tool_calls(self, transport):
+        """Strict providers like Fireworks reject extra_content on tool_calls with 400.
+
+        Gemini 3 thinking models attach extra_content (thought_signature) to
+        tool_calls for replay.  The agent loop writes it into the assistant
+        message; this transport must strip it before sending to strict APIs.
+        """
+        msgs = [
+            {"role": "assistant", "content": "ok",
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "extra_content": {"google": {"thought_signature": "SIG_123"}},
+                             "function": {"name": "t", "arguments": "{}"}}]},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "extra_content" not in result[0]["tool_calls"][0]
+        # Original list untouched (deepcopy-on-demand)
+        assert "extra_content" in msgs[0]["tool_calls"][0]
+
 
 class TestChatCompletionsBuildKwargs:
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -191,6 +191,23 @@ class TestBuildApiKwargsOpenRouter:
         anthropic_agent.api_mode = "anthropic_messages"
         assert anthropic_agent._should_sanitize_tool_calls() is True
 
+    def test_sanitize_tool_calls_strips_extra_content(self, monkeypatch):
+        """Strict providers like Fireworks reject extra_content on tool_calls."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        api_msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "extra_content": {"google": {"thought_signature": "SIG_123"}},
+                 "function": {"name": "t", "arguments": "{}"}},
+            ],
+        }
+        result = agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert "extra_content" not in result["tool_calls"][0]
+        # Original message dict mutated in-place (by design)
+        assert "extra_content" not in api_msg["tool_calls"][0]
+
 
 class TestDeveloperRoleSwap:
     """GPT-5 and Codex models should get 'developer' instead of 'system' role."""


### PR DESCRIPTION
## Summary

Fixes HTTP 400 errors on strict OpenAI-compatible providers (Fireworks, Mistral) when tool_calls contain `extra_content` fields.

## Problem

Gemini 3 thinking models attach `extra_content` (thought_signature) to tool_calls for replay on subsequent API calls. When these messages are replayed to strict providers like Fireworks, they reject the request with:

```
HTTP 400: Extra inputs are not permitted, field: 'messages[N].tool_calls[M].extra_content'
```

This causes the first message of every new session to fail on Fireworks, forcing fallback to other providers (issue #17986).

## Changes

- **agent/transports/chat_completions.py**: Strip `extra_content` from tool_calls in `convert_messages()` alongside existing `call_id`/`response_item_id` stripping
- **run_agent.py**: Add `extra_content` to `_sanitize_tool_calls_for_strict_api()` `_STRIP_KEYS` set

## Testing

- Added test in `tests/agent/transports/test_chat_completions.py`
- Added test in `tests/run_agent/test_provider_parity.py`
- Both tests pass locally

## Related Issues

- Fixes #17986 (HTTP 400 on Fireworks custom endpoint — first turn only)
- Related: #893, #5183