### PR TITLE
ci: add Codex PR review workflow

### DIFF
--- a/.github/workflows/codex-auto-review.yml
+++ b/.github/workflows/codex-auto-review.yml
@@ -1,0 +1,94 @@
+name: Codex Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: codex-auto-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex:
+    name: Codex PR review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      HAS_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - name: Skip when OPENAI_API_KEY is not configured
+        if: env.HAS_OPENAI_API_KEY != 'true'
+        run: |
+          echo "OPENAI_API_KEY is not configured; skipping Codex review."
+
+      - name: Check out pull request merge commit
+        if: env.HAS_OPENAI_API_KEY == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Fetch pull request refs
+        if: env.HAS_OPENAI_API_KEY == 'true'
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$PR_BASE_REF" "+refs/pull/$PR_NUMBER/head"
+
+      - name: Run Codex review
+        if: env.HAS_OPENAI_API_KEY == 'true'
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: read-only
+          prompt: |
+            This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
+
+            Review ONLY the changes introduced by this PR. Start by inspecting:
+              git diff --stat ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+              git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+            Pull request title and body:
+            ----
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+            ----
+
+            Focus on correctness, security, performance, test coverage, and maintainability.
+            Keep the review high signal. Avoid nitpicks and style-only comments unless they indicate a real bug or repository convention violation.
+
+            Return a GitHub-flavored Markdown review comment with:
+            - a short verdict
+            - blocking issues, if any
+            - non-blocking suggestions, if any
+            - what looks good
+
+  post_feedback:
+    name: Post Codex feedback
+    runs-on: ubuntu-latest
+    needs: codex
+    if: needs.codex.outputs.final_message != ''
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Comment on pull request
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: process.env.CODEX_FINAL_MESSAGE,
+            });


### PR DESCRIPTION
## Summary
- Add a Codex-powered automatic PR review workflow
- Trigger on opened, synchronized, reopened, and ready-for-review PRs
- Skip draft PRs and skip cleanly when `OPENAI_API_KEY` is not configured
- Run Codex in a read-only sandbox and post its feedback as a PR comment

## Setup needed after merge
A repository admin needs to add the `OPENAI_API_KEY` Actions secret. I found a local OpenAI API key on the setup machine, but the current GitHub token only has pull access to this repository, so it cannot write repository secrets.

## Test plan
- Parsed workflow YAML locally with Ruby's YAML parser
