### PR TITLE
fix(insights): include cache tokens in input totals

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -414,7 +414,8 @@ class InsightsEngine:
         total_output = sum(s.get("output_tokens") or 0 for s in sessions)
         total_cache_read = sum(s.get("cache_read_tokens") or 0 for s in sessions)
         total_cache_write = sum(s.get("cache_write_tokens") or 0 for s in sessions)
-        total_tokens = total_input + total_output + total_cache_read + total_cache_write
+        total_input_with_cache = total_input + total_cache_read + total_cache_write
+        total_tokens = total_input_with_cache + total_output
         total_tool_calls = sum(s.get("tool_call_count") or 0 for s in sessions)
         total_messages = sum(s.get("message_count") or 0 for s in sessions)
 
@@ -464,6 +465,7 @@ class InsightsEngine:
             "total_output_tokens": total_output,
             "total_cache_read_tokens": total_cache_read,
             "total_cache_write_tokens": total_cache_write,
+            "total_input_with_cache_tokens": total_input_with_cache,
             "total_tokens": total_tokens,
             "estimated_cost": total_cost,
             "actual_cost": actual_cost,
@@ -761,7 +763,13 @@ class InsightsEngine:
         lines.append("  " + "─" * 56)
         lines.append(f"  Sessions:          {o['total_sessions']:<12}  Messages:        {o['total_messages']:,}")
         lines.append(f"  Tool calls:        {o['total_tool_calls']:<12,}  User messages:   {o['user_messages']:,}")
-        lines.append(f"  Input tokens:      {o['total_input_tokens']:<12,}  Output tokens:   {o['total_output_tokens']:,}")
+        input_with_cache = o.get("total_input_with_cache_tokens", o.get("total_input_tokens", 0))
+        lines.append(f"  Input tokens:      {input_with_cache:<12,}  Output tokens:   {o['total_output_tokens']:,}")
+        if o.get("total_cache_read_tokens") or o.get("total_cache_write_tokens"):
+            lines.append(
+                f"  Prompt tokens:     {o['total_input_tokens']:<12,}  Cache input:     "
+                f"{(o.get('total_cache_read_tokens') or 0) + (o.get('total_cache_write_tokens') or 0):,}"
+            )
         lines.append(f"  Total tokens:      {o['total_tokens']:,}")
         if o["total_hours"] > 0:
             lines.append(f"  Active time:       ~{_format_duration(o['total_hours'] * 3600):<11}  Avg session:     ~{_format_duration(o['avg_session_duration'])}")
@@ -877,7 +885,11 @@ class InsightsEngine:
 
         # Overview
         lines.append(f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}")
-        lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})")
+        input_with_cache = o.get("total_input_with_cache_tokens", o.get("total_input_tokens", 0))
+        lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {input_with_cache:,} / out: {o['total_output_tokens']:,})")
+        if o.get("total_cache_read_tokens") or o.get("total_cache_write_tokens"):
+            cache_input = (o.get("total_cache_read_tokens") or 0) + (o.get("total_cache_write_tokens") or 0)
+            lines.append(f"_Input includes {cache_input:,} cache tokens; prompt-only input: {o['total_input_tokens']:,}._")
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{_format_duration(o['total_hours'] * 3600)} | **Avg session:** ~{_format_duration(o['avg_session_duration'])}")
         lines.append("")

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -39,7 +39,13 @@ def populated_db(db):
     db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 's1'", (now - 2 * day,))
     db.end_session("s1", end_reason="user_exit")
     db._conn.execute("UPDATE sessions SET ended_at = ? WHERE id = 's1'", (now - 2 * day + 3600,))
-    db.update_token_counts("s1", input_tokens=50000, output_tokens=15000)
+    db.update_token_counts(
+        "s1",
+        input_tokens=50000,
+        output_tokens=15000,
+        cache_read_tokens=1_000_000,
+        cache_write_tokens=200_000,
+    )
     db.append_message("s1", role="user", content="Hello, help me fix a bug")
     db.append_message("s1", role="assistant", content="Sure, let me look into that.")
     db.append_message("s1", role="assistant", content="Let me search the files.",
@@ -287,9 +293,13 @@ class TestInsightsPopulated:
 
         expected_input = 50000 + 20000 + 100000 + 10000
         expected_output = 15000 + 8000 + 40000 + 5000
+        expected_cache_input = 1_000_000 + 200_000
         assert overview["total_input_tokens"] == expected_input
         assert overview["total_output_tokens"] == expected_output
-        assert overview["total_tokens"] == expected_input + expected_output
+        assert overview["total_cache_read_tokens"] == 1_000_000
+        assert overview["total_cache_write_tokens"] == 200_000
+        assert overview["total_input_with_cache_tokens"] == expected_input + expected_cache_input
+        assert overview["total_tokens"] == expected_input + expected_output + expected_cache_input
 
     def test_overview_cost_positive(self, populated_db):
         engine = InsightsEngine(populated_db)
@@ -462,7 +472,9 @@ class TestTerminalFormatting:
 
         assert "Input tokens" in text
         assert "Output tokens" in text
-        # Cost and cache metrics are intentionally hidden (pricing was unreliable).
+        assert "Prompt tokens" in text
+        assert "Cache input" in text
+        # Cost metrics are intentionally hidden (pricing was unreliable).
         assert "Est. cost" not in text
         assert "Cache read" not in text
         assert "Cache write" not in text
@@ -515,14 +527,16 @@ class TestGatewayFormatting:
 
         assert "**" in text  # Markdown bold
 
-    def test_gateway_format_hides_cost(self, populated_db):
-        """Gateway format omits dollar figures and internal cache details."""
+    def test_gateway_format_summarizes_cache_input(self, populated_db):
+        """Gateway format includes cache tokens in input while keeping read/write internals hidden."""
         engine = InsightsEngine(populated_db)
         report = engine.generate(days=30)
         text = engine.format_gateway(report)
 
-        assert "$" not in text
-        assert "cache" not in text.lower()
+        assert "in: 1,380,000 / out: 68,000" in text
+        assert "Input includes 1,200,000 cache tokens" in text
+        assert "cache_read" not in text
+        assert "cache_write" not in text
 
     def test_gateway_format_shows_models(self, populated_db):
         engine = InsightsEngine(populated_db)


### PR DESCRIPTION
Closes #18615

## Summary
- Treat prompt cache read/write tokens as input tokens in `/insights` overview totals.
- Keep prompt-only input visible separately when cache input is present.
- Add regression coverage for cache-heavy sessions in terminal and gateway insights output.

## Tests
- `python3 -m pytest tests/agent/test_insights.py -q`
