### PR TITLE
Fix Kanban worker board DB handoff

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1,8 +1,9 @@
 """SQLite-backed Kanban board for multi-profile collaboration.
 
-The board lives at ``$HERMES_HOME/kanban.db`` (profile-agnostic on purpose:
-multiple profiles on the same machine all see the same board, which IS the
-coordination primitive).
+The board lives at ``$HERMES_HOME/kanban.db`` by default. The dispatcher passes
+the resolved path to workers via ``HERMES_KANBAN_DB`` so a spawned profile keeps
+using the same board database even when ``hermes -p <profile>`` activates a
+different ``HERMES_HOME``.
 
 Schema is intentionally small: tasks, task_links, task_comments,
 task_events.  The ``workspace_kind`` field decouples coordination from git
@@ -62,7 +63,15 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
+    """Return the Kanban DB path for the current process.
+
+    Workers spawned by the dispatcher may run under a profile-specific
+    ``HERMES_HOME``. In that case ``HERMES_KANBAN_DB`` pins tool calls back to
+    the dispatcher's board database.
+    """
+    override = os.environ.get("HERMES_KANBAN_DB")
+    if override:
+        return Path(override).expanduser()
     from hermes_constants import get_hermes_home
     return get_hermes_home() / "kanban.db"
 
@@ -2068,6 +2077,7 @@ def _default_spawn(task: Task, workspace: str) -> Optional[int]:
     env = dict(os.environ)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
+    env["HERMES_KANBAN_DB"] = str(kanban_db_path())
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2215,6 +2215,7 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     env = captured["env"]
     assert env.get("HERMES_KANBAN_TASK") == tid
     assert env.get("HERMES_PROFILE") == "some-profile"
+    assert env.get("HERMES_KANBAN_DB") == str(kb.kanban_db_path())
 
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -96,6 +97,38 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert d["task"]["status"] == "running"
     assert "worker_context" in d
     assert "runs" in d
+
+
+def test_worker_uses_dispatcher_kanban_db_override(monkeypatch, tmp_path):
+    """A profile-scoped worker must still update the dispatcher's board DB."""
+    dispatcher_home = tmp_path / "dispatcher-home"
+    worker_home = tmp_path / "worker-profile-home"
+    dispatcher_home.mkdir()
+    worker_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(dispatcher_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cross-profile task", assignee="seo")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+
+    dispatcher_db = kb.kanban_db_path()
+    monkeypatch.setenv("HERMES_HOME", str(worker_home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(dispatcher_db))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_show({})
+    d = json.loads(out)
+    assert d["task"]["id"] == tid
+    assert d["task"]["status"] == "running"
+    assert not (worker_home / "kanban.db").exists()
 
 
 def test_show_explicit_task_id(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -10,7 +10,8 @@ Why tools instead of just shelling out to ``hermes kanban``?
    / Modal / Singularity / SSH would run ``hermes kanban complete …``
    inside the container, where ``hermes`` isn't installed and the DB
    isn't mounted. Tools run in the agent's Python process, so they
-   always reach ``~/.hermes/kanban.db`` regardless of terminal backend.
+   always reach the dispatcher's Kanban DB regardless of terminal backend
+   or the worker profile's ``HERMES_HOME``.
 
 2. **No shell-quoting footguns.** Passing ``--metadata '{"x": [...]}'``
    through shlex+argparse is fragile. Structured tool args skip it.


### PR DESCRIPTION
## Summary
- pass the dispatcher's resolved Kanban DB path to spawned workers via `HERMES_KANBAN_DB`
- make `kanban_db_path()` honor that override so worker tool calls keep using the dispatcher board across profile-specific `HERMES_HOME` values
- add regressions for spawn env propagation and cross-profile `kanban_show` lookup

Fixes #18657

## Test plan
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_auto_loads_kanban_worker_skill tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_appends_per_task_skills tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_dedupes_kanban_worker_from_task_skills`
- `git diff --check origin/main...HEAD`