### PR TITLE
fix(docker): expose hermes entrypoint on PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,6 @@ RUN uv venv && \
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/opt/hermes/docker/entrypoint.sh" ]

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -121,6 +121,24 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
     )
 
 
+def test_dockerfile_runtime_path_exposes_hermes_entrypoint(dockerfile_text):
+    """docker exec should find the installed hermes console script on PATH."""
+    path_envs = [
+        instruction
+        for instruction in _dockerfile_instructions(dockerfile_text)
+        if instruction.startswith("ENV PATH=")
+    ]
+
+    assert path_envs, "Dockerfile must set a runtime PATH"
+    final_path_env = path_envs[-1]
+
+    assert "/opt/hermes/.venv/bin" in final_path_env
+    assert "/opt/data/.local/bin" in final_path_env
+    assert final_path_env.index("/opt/hermes/.venv/bin") < final_path_env.index(
+        "/opt/data/.local/bin"
+    )
+
+
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
     assert any(
         "ui-tui" in step


### PR DESCRIPTION
## Summary
- add /opt/hermes/.venv/bin to the Docker image runtime PATH
- keep /opt/data/.local/bin on PATH for user-installed tools
- add a Dockerfile contract test for docker exec finding the hermes console script

Fixes #18673.

## Verification
- scripts/run_tests.sh tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_runtime_path_exposes_hermes_entrypoint
- git diff --check origin/main...HEAD