### PR TITLE
fix(session-search): return raw fallback content

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -13,6 +13,7 @@ from tools.session_search_tool import (
     _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
     MAX_SESSION_CHARS,
+    MAX_RAW_FALLBACK_CHARS,
     SESSION_SEARCH_SCHEMA,
 )
 
@@ -498,3 +499,44 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+    def test_summarization_failure_returns_bounded_raw_content(self):
+        """When the summarizer is unavailable, return raw transcript content, not a 500-char preview."""
+        from unittest.mock import AsyncMock, MagicMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        marker_after_preview = "MARKER_AFTER_500_CHARS"
+        raw_message = (
+            "needle "
+            + ("a" * 1000)
+            + marker_after_preview
+            + ("b" * (MAX_RAW_FALLBACK_CHARS + 1000))
+        )
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "raw_sid",
+                "content": "needle",
+                "source": "cli",
+                "session_started": 1709500000,
+                "model": "test",
+            },
+        ]
+        mock_db.get_session.return_value = {"parent_session_id": None}
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": raw_message},
+        ]
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="needle", db=mock_db, limit=1))
+
+        entry = result["results"][0]
+        assert result["success"] is True
+        assert entry["content_type"] == "raw"
+        assert marker_after_preview in entry["summary"]
+        assert "[raw conversation truncated]" in entry["summary"]
+        assert len(entry["summary"]) <= MAX_RAW_FALLBACK_CHARS + 100

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -24,6 +24,7 @@ from typing import Dict, Any, List, Optional, Union
 
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 MAX_SESSION_CHARS = 100_000
+MAX_RAW_FALLBACK_CHARS = 50_000
 MAX_SUMMARY_TOKENS = 10000
 
 
@@ -191,6 +192,15 @@ def _truncate_around_matches(
     prefix = "...[earlier conversation truncated]...\n\n" if start > 0 else ""
     suffix = "\n\n...[later conversation truncated]..." if end < len(full_text) else ""
     return prefix + truncated + suffix
+
+
+def _format_raw_fallback(conversation_text: str) -> str:
+    """Return bounded raw transcript content when summarization is unavailable."""
+    if not conversation_text:
+        return "No raw conversation content available."
+    if len(conversation_text) <= MAX_RAW_FALLBACK_CHARS:
+        return conversation_text
+    return conversation_text[:MAX_RAW_FALLBACK_CHARS] + "\n...[raw conversation truncated]..."
 
 
 async def _summarize_session(
@@ -499,12 +509,17 @@ def session_search(
             }
 
             if result:
+                entry["content_type"] = "summary"
                 entry["summary"] = result
             else:
-                # Fallback: raw preview so matched sessions aren't silently
-                # dropped when the summarizer is unavailable (fixes #3409).
-                preview = (conversation_text[:500] + "\n…[truncated]") if conversation_text else "No preview available."
-                entry["summary"] = f"[Raw preview — summarization unavailable]\n{preview}"
+                # Fallback: raw transcript content so matched sessions aren't
+                # silently reduced to a short preview when the summarizer is
+                # unavailable (fixes #3409 and #18593).
+                entry["content_type"] = "raw"
+                entry["summary"] = (
+                    "[Raw conversation - summarization unavailable]\n"
+                    f"{_format_raw_fallback(conversation_text)}"
+                )
 
             summaries.append(entry)
 


### PR DESCRIPTION
Fixes #18593.

## Summary
- return bounded raw transcript content when session_search summarization is unavailable
- mark fallback responses with `content_type: raw` and normal summaries with `content_type: summary`
- add a regression test that proves content beyond the old 500-character preview is preserved up to the raw fallback cap

## Verification
- `scripts/run_tests.sh tests/tools/test_session_search.py::TestSessionSearch::test_summarization_failure_returns_bounded_raw_content`
- `scripts/run_tests.sh tests/tools/test_session_search.py`
- `git diff --check origin/main...HEAD`