### PR TITLE
fix(skills): bound fallback supporting file scan

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -6,6 +6,7 @@ can invoke skills via /skill-name commands.
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -23,6 +24,44 @@ _skill_commands: Dict[str, Dict[str, Any]] = {}
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_SUPPORTING_FILE_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        ".venv",
+        "venv",
+        ".tox",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+    }
+)
+_MAX_SUPPORTING_FILES = 200
+
+
+def _iter_fallback_supporting_files(skill_dir: Path, subdir: str):
+    """Yield bounded fallback supporting files without traversing dependency caches."""
+    subdir_path = skill_dir / subdir
+    if not subdir_path.exists():
+        return
+
+    for root, dirs, files in os.walk(subdir_path):
+        dirs[:] = sorted(d for d in dirs if d not in _SUPPORTING_FILE_SKIP_DIRS)
+        root_path = Path(root)
+        for filename in sorted(files):
+            f = root_path / filename
+            if f.is_symlink() or not f.is_file():
+                continue
+            try:
+                if f.stat().st_size == 0:
+                    continue
+            except OSError:
+                continue
+            yield str(f.relative_to(skill_dir))
+
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
@@ -171,19 +210,25 @@ def _build_skill_message(
         )
 
     supporting = []
+    supporting_truncated = False
     linked_files = loaded_skill.get("linked_files") or {}
     for entries in linked_files.values():
         if isinstance(entries, list):
-            supporting.extend(entries)
+            for entry in entries:
+                if len(supporting) >= _MAX_SUPPORTING_FILES:
+                    supporting_truncated = True
+                    break
+                supporting.append(entry)
 
     if not supporting and skill_dir:
         for subdir in ("references", "templates", "scripts", "assets"):
-            subdir_path = skill_dir / subdir
-            if subdir_path.exists():
-                for f in sorted(subdir_path.rglob("*")):
-                    if f.is_file() and not f.is_symlink():
-                        rel = str(f.relative_to(skill_dir))
-                        supporting.append(rel)
+            for rel in _iter_fallback_supporting_files(skill_dir, subdir):
+                if len(supporting) >= _MAX_SUPPORTING_FILES:
+                    supporting_truncated = True
+                    break
+                supporting.append(rel)
+            if supporting_truncated:
+                break
 
     if supporting and skill_dir:
         try:
@@ -195,6 +240,8 @@ def _build_skill_message(
         parts.append("[This skill has supporting files:]")
         for sf in supporting:
             parts.append(f"- {sf}  ->  {skill_dir / sf}")
+        if supporting_truncated:
+            parts.append(f"- ... (truncated at {_MAX_SUPPORTING_FILES} supporting files)")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -428,6 +428,32 @@ class TestSkillDirectoryHeader:
         assert str(skill_dir / "scripts" / "run.js") in msg
         assert f"node {skill_dir}/scripts/foo.js" in msg
 
+    def test_fallback_supporting_file_scan_skips_dependency_dirs_and_caps(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "bounded-scan")
+            scripts_dir = skill_dir / "scripts"
+            allowed_dir = scripts_dir / "misc"
+            dependency_dir = scripts_dir / "node_modules" / "fake-dep" / "lib"
+            allowed_dir.mkdir(parents=True)
+            dependency_dir.mkdir(parents=True)
+            (scripts_dir / "empty.txt").write_text("")
+            for i in range(205):
+                (allowed_dir / f"file_{i:03}.txt").write_text("ok")
+            for i in range(5):
+                (dependency_dir / f"module_{i:03}.js").write_text("skip")
+
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/bounded-scan")
+
+        assert msg is not None
+        supporting_lines = [
+            line for line in msg.splitlines() if line.startswith("- scripts/misc/file_")
+        ]
+        assert len(supporting_lines) == 200
+        assert "scripts/empty.txt" not in msg
+        assert "node_modules" not in msg
+        assert "truncated at 200 supporting files" in msg
+
 
 class TestTemplateVarSubstitution:
     """``${HERMES_SKILL_DIR}`` and ``${HERMES_SESSION_ID}`` in SKILL.md body


### PR DESCRIPTION
Fixes #18675.

## Summary
- replace the unbounded fallback `rglob("*")` supporting-file scan with a deterministic scanner that prunes dependency/cache directories before descent
- cap supporting-file hints at 200 entries and emit a truncation note outside the file-path list
- skip empty files in the fallback scan
- add regression coverage for nested `node_modules`, empty files, and the 200-file cap

## Verification
- `scripts/run_tests.sh tests/agent/test_skill_commands.py::TestSkillDirectoryHeader::test_fallback_supporting_file_scan_skips_dependency_dirs_and_caps`
- `scripts/run_tests.sh tests/agent/test_skill_commands.py`
- `git diff --check origin/main...HEAD`