### PR TITLE
fix: send correct resolution param to xAI image generation API

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -63,10 +63,7 @@ _XAI_ASPECT_RATIOS = {
 }
 
 # xAI resolutions
-_XAI_RESOLUTIONS = {
-    "1k": "1024",
-    "2k": "2048",
-}
+_XAI_RESOLUTIONS = {"1k", "2k"}
 
 DEFAULT_RESOLUTION = "1k"
 
@@ -177,7 +174,7 @@ class XAIImageGenProvider(ImageGenProvider):
         aspect = resolve_aspect_ratio(aspect_ratio)
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()
-        xai_res = _XAI_RESOLUTIONS.get(resolution, "1024")
+        xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
 
         payload: Dict[str, Any] = {
             "model": API_MODEL,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -672,6 +672,8 @@ AUTHOR_MAP = {
     "web3blind@gmail.com": "web3blind",
     "ztzheng@163.com": "chengoak",  # PR #17467
     "24110240104@m.fudan.edu.cn": "YuShu",  # co-author only
+    # xAI image resolution fix (PR #18678)
+    "ayman.a.kamal@hotmail.com": "A-kamal",
 }
 
 


### PR DESCRIPTION
## Problem

The xAI image generation provider (`grok-imagine-image`) was **completely broken** — every request returned a **422 Unprocessable Entity** error. No images could be generated through this provider at all.

Two bugs caused this:

1. **Wrong resolution value format:** The `resolution` parameter was being sent as `"1024"` / `"2048"` (numeric strings), but xAI expects the literal values `"1k"` / `"2k"`. This caused every request to be rejected by the API.

2. **Dead dict mapping:** `_XAI_RESOLUTIONS` was a `dict` mapping `{"1k": "1024", "2k": "2048"}`, converting the correct config values into the wrong API values. No longer needed once the values are passed directly.

## Changes

- Changed `_XAI_RESOLUTIONS` from a `dict` to a `set {"1k", "2k"}` used only for validation
- Changed resolution passing to send the key (`"1k"` / `"2k"`) directly to the API instead of the mapped numeric value
- Added fallback to `DEFAULT_RESOLUTION` on invalid config values

## Test Plan

- [x] All 60 image generation plugin tests pass (including 18 xAI-specific tests)
- [x] Full repo CI-style suite: 18,764 passed, 112 failed (all pre-existing browser/gateway failures, unrelated)
- [x] Tested live against xAI API — image generation now succeeds, 422 error is resolved

Closes the 422 error that made xAI image generation unusable.