### PR TITLE
fix(goals): require filesystem verification evidence

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -47,12 +47,28 @@ DEFAULT_MAX_TURNS = 20
 DEFAULT_JUDGE_TIMEOUT = 30.0
 # Cap how much of the last response + recent messages we send to the judge.
 _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
+_FILESYSTEM_GOAL_RE = re.compile(
+    r"(/[\w./~:-]+|"
+    r"\b[\w.-]+\.(?:md|txt|py|json|ya?ml|toml|js|ts|tsx|jsx|html|css|csv)\b|"
+    r"\b(?:file|directory|folder|path)\b)",
+    re.IGNORECASE,
+)
+_FILESYSTEM_ACTION_RE = re.compile(
+    r"\b(?:create|write|save|modify|update|edit|append|delete|remove|rename)\b",
+    re.IGNORECASE,
+)
+_FILESYSTEM_VERIFICATION_RE = re.compile(
+    r"\b(?:read_file|list_files|ls|find|cat|stat|exists|verified|confirmed)\b",
+    re.IGNORECASE,
+)
 
 
 CONTINUATION_PROMPT_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
     "Goal: {goal}\n\n"
     "Continue working toward this goal. Take the next concrete step. "
+    "If the goal involves creating or modifying files, verify the change "
+    "with a read/list command and include that evidence before claiming completion. "
     "If you believe the goal is complete, state so explicitly and stop. "
     "If you are blocked and need input from the user, say so clearly and stop."
 )
@@ -68,6 +84,10 @@ JUDGE_SYSTEM_PROMPT = (
     "- The response clearly shows the final deliverable was produced, OR\n"
     "- The response explains the goal is unachievable / blocked / needs "
     "user input (treat this as DONE with reason describing the block).\n\n"
+    "For goals that ask the agent to create, save, or modify files, a bare "
+    "claim of success is not enough. Mark DONE only when the response includes "
+    "verification evidence such as read_file/list_files output, ls/find/stat "
+    "results, or an equivalent explicit filesystem check.\n\n"
     "Otherwise the goal is NOT done — CONTINUE.\n\n"
     "Reply ONLY with a single JSON object on one line:\n"
     '{\"done\": <true|false>, \"reason\": \"<one-sentence rationale>\"}'
@@ -265,6 +285,17 @@ def _parse_judge_response(raw: str) -> Tuple[bool, str]:
     return done, reason
 
 
+def _goal_needs_filesystem_verification(goal: str) -> bool:
+    return bool(
+        _FILESYSTEM_ACTION_RE.search(goal or "")
+        and _FILESYSTEM_GOAL_RE.search(goal or "")
+    )
+
+
+def _response_has_filesystem_verification(response: str) -> bool:
+    return bool(_FILESYSTEM_VERIFICATION_RE.search(response or ""))
+
+
 def judge_goal(
     goal: str,
     last_response: str,
@@ -285,6 +316,13 @@ def judge_goal(
     if not last_response.strip():
         # No substantive reply this turn — almost certainly not done yet.
         return "continue", "empty response (nothing to evaluate)"
+    if _goal_needs_filesystem_verification(
+        goal
+    ) and not _response_has_filesystem_verification(last_response):
+        return (
+            "continue",
+            "filesystem goal needs read/list verification evidence before completion",
+        )
 
     try:
         from agent.auxiliary_client import get_text_auxiliary_client

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -175,6 +175,43 @@ class TestJudgeGoal:
         assert verdict == "continue"
         assert reason == "not yet"
 
+    def test_filesystem_goal_without_verification_continues_before_judge(self):
+        from hermes_cli import goals
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client") as get_client:
+            verdict, reason = goals.judge_goal(
+                "Create /home/ubuntu/ml-resumo.md with a study summary",
+                "Done, I created /home/ubuntu/ml-resumo.md successfully.",
+            )
+
+        assert verdict == "continue"
+        assert "verification" in reason
+        get_client.assert_not_called()
+
+    def test_filesystem_goal_with_verification_uses_judge(self):
+        from hermes_cli import goals
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"done": true, "reason": "verified"}')
+                )
+            ]
+        )
+        with patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(fake_client, "judge-model"),
+        ) as get_client:
+            verdict, reason = goals.judge_goal(
+                "Create /home/ubuntu/ml-resumo.md with a study summary",
+                "Done. Verified with `read_file /home/ubuntu/ml-resumo.md`: content present.",
+            )
+
+        assert verdict == "done"
+        assert reason == "verified"
+        get_client.assert_called_once()
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence
@@ -333,6 +370,7 @@ class TestGoalManager:
         prompt = mgr.next_continuation_prompt()
         assert prompt is not None
         assert "port goal command to hermes" in prompt
+        assert "verify the change" in prompt
         assert prompt.strip()  # non-empty
 
 


### PR DESCRIPTION
Fixes #18421.

## Summary
- teach goal continuations to verify file creation/modification before claiming completion
- make the goal judge prompt reject bare success claims for filesystem goals
- add a deterministic pre-judge guard so filesystem goals continue when the response lacks read/list-style evidence
- cover both the missing-evidence path and verified path in goal tests

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_goals.py::TestJudgeGoal::test_filesystem_goal_without_verification_continues_before_judge tests/hermes_cli/test_goals.py::TestJudgeGoal::test_filesystem_goal_with_verification_uses_judge tests/hermes_cli/test_goals.py::TestGoalManager::test_continuation_prompt_shape`
- `scripts/run_tests.sh tests/hermes_cli/test_goals.py`
- `git diff --check origin/main...HEAD`