### PR TITLE
fix(matrix): populate reply_to_text from seen messages

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -332,6 +332,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
         self._processed_events: deque = deque(maxlen=1000)
         self._processed_events_set: set = set()
+        self._message_text_cache: Dict[str, str] = {}
+        self._message_text_cache_order: deque = deque()
+        self._message_text_cache_limit = 1000
 
         # Buffer for undecrypted events pending key receipt.
         # Each entry: (room_id, event, timestamp)
@@ -405,6 +408,37 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events.append(event_id)
         self._processed_events_set.add(event_id)
         return False
+
+    def _cache_message_text(self, event_id: str, text: str) -> None:
+        """Cache recent Matrix text by event ID for reply context."""
+        event_id = str(event_id or "")
+        text = str(text or "").strip()
+        if not event_id or not text:
+            return
+        if event_id not in self._message_text_cache:
+            self._message_text_cache_order.append(event_id)
+        self._message_text_cache[event_id] = text
+
+        while len(self._message_text_cache_order) > self._message_text_cache_limit:
+            evicted = self._message_text_cache_order.popleft()
+            self._message_text_cache.pop(evicted, None)
+
+    @staticmethod
+    def _reply_to_event_id(relates_to: dict) -> Optional[str]:
+        in_reply_to = relates_to.get("m.in_reply_to", {})
+        if isinstance(in_reply_to, dict):
+            reply_to = in_reply_to.get("event_id")
+            if reply_to:
+                return str(reply_to)
+        return None
+
+    def _reply_to_text_for(self, reply_to: Optional[str]) -> Optional[str]:
+        if not reply_to:
+            return None
+        return (
+            self._message_text_cache.get(str(reply_to))
+            or "reply message text unavailable"
+        )
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -911,6 +945,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     timeout=45,
                 )
                 last_event_id = str(event_id)
+                self._cache_message_text(last_event_id, chunk)
                 logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
             except Exception as exc:
                 # On E2EE errors, retry after sharing keys.
@@ -926,6 +961,7 @@ class MatrixAdapter(BasePlatformAdapter):
                             timeout=45,
                         )
                         last_event_id = str(event_id)
+                        self._cache_message_text(last_event_id, chunk)
                         logger.info(
                             "Matrix: sent event %s to %s (after key share)",
                             last_event_id,
@@ -1628,10 +1664,7 @@ class MatrixAdapter(BasePlatformAdapter):
         body, is_dm, chat_type, thread_id, display_name, source = ctx
 
         # Reply-to detection.
-        reply_to = None
-        in_reply_to = relates_to.get("m.in_reply_to", {})
-        if in_reply_to:
-            reply_to = in_reply_to.get("event_id")
+        reply_to = self._reply_to_event_id(relates_to)
 
         # Strip reply fallback from body.
         if reply_to and body.startswith("> "):
@@ -1649,6 +1682,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 stripped.append(line)
             body = "\n".join(stripped) if stripped else body
 
+        reply_to_text = self._reply_to_text_for(reply_to)
+        self._cache_message_text(event_id, body)
+
         msg_type = MessageType.TEXT
         if body.startswith(("!", "/")):
             msg_type = MessageType.COMMAND
@@ -1660,6 +1696,7 @@ class MatrixAdapter(BasePlatformAdapter):
             raw_message=source_content,
             message_id=event_id,
             reply_to_message_id=reply_to,
+            reply_to_text=reply_to_text,
         )
 
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
@@ -1826,6 +1863,9 @@ class MatrixAdapter(BasePlatformAdapter):
         if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""
 
+        reply_to = self._reply_to_event_id(relates_to)
+        reply_to_text = self._reply_to_text_for(reply_to)
+
         allow_http_fallback = bool(http_url) and not is_encrypted_media
         media_urls = (
             [cached_path]
@@ -1840,6 +1880,8 @@ class MatrixAdapter(BasePlatformAdapter):
             source=source,
             raw_message=source_content,
             message_id=event_id,
+            reply_to_message_id=reply_to,
+            reply_to_text=reply_to_text,
             media_urls=media_urls,
             media_types=media_types,
         )

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -259,6 +259,58 @@ class TestOutboundMentions:
         assert content["msgtype"] == "m.notice"
         assert content["m.mentions"] == {"user_ids": ["@alice:example.org"]}
 
+    @pytest.mark.asyncio
+    async def test_send_caches_outgoing_text_by_event_id(self):
+        result = await self.adapter.send("!room1:example.org", "Bot reply")
+
+        assert result.success is True
+        assert self.adapter._message_text_cache["$evt1"] == "Bot reply"
+
+
+# ---------------------------------------------------------------------------
+# Reply context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reply_to_text_resolved_from_seen_message(monkeypatch):
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    parent = _make_event("parent text", event_id="$parent")
+
+    await adapter._on_room_message(parent)
+
+    reply = _make_event("reply body", event_id="$reply")
+    reply.content["m.relates_to"] = {
+        "m.in_reply_to": {"event_id": "$parent"},
+    }
+
+    await adapter._on_room_message(reply)
+
+    msg = adapter.handle_message.await_args_list[-1].args[0]
+    assert msg.reply_to_message_id == "$parent"
+    assert msg.reply_to_text == "parent text"
+
+
+@pytest.mark.asyncio
+async def test_reply_to_text_uses_fallback_for_unknown_parent(monkeypatch):
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    reply = _make_event("reply body", event_id="$reply")
+    reply.content["m.relates_to"] = {
+        "m.in_reply_to": {"event_id": "$missing"},
+    }
+
+    await adapter._on_room_message(reply)
+
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.reply_to_message_id == "$missing"
+    assert msg.reply_to_text == "reply message text unavailable"
+
 
 # ---------------------------------------------------------------------------
 # Require-mention gating in _on_room_message


### PR DESCRIPTION
## Summary
- cache recently seen Matrix text events by event id
- resolve reply_to_text for Matrix replies, with the issue-proposed fallback when the parent was not seen
- cache outgoing Matrix text after successful sends so later replies can use it as context

Fixes #18396

## Tests
- scripts/run_tests.sh tests/gateway/test_matrix_mention.py::test_reply_to_text_resolved_from_seen_message tests/gateway/test_matrix_mention.py::test_reply_to_text_uses_fallback_for_unknown_parent tests/gateway/test_matrix_mention.py::TestOutboundMentions::test_send_caches_outgoing_text_by_event_id
- scripts/run_tests.sh tests/gateway/test_matrix_mention.py
- git diff --check origin/main...HEAD