### PR TITLE
fix(web-ui): force NODE_ENV=development during npm install/build

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5266,6 +5266,7 @@ def _run_npm_install_deterministic(
     *,
     extra_args: tuple[str, ...] = (),
     capture_output: bool = True,
+    env: dict | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
@@ -5277,27 +5278,18 @@ def _run_npm_install_deterministic(
     lockfile — repeatedly.
     """
     lockfile = cwd / "package-lock.json"
+    run_kwargs = {"cwd": cwd, "capture_output": capture_output, "text": True, "check": False}
+    if env is not None:
+        run_kwargs["env"] = env
     if lockfile.exists():
         ci_cmd = [npm, "ci", *extra_args]
-        ci_result = subprocess.run(
-            ci_cmd,
-            cwd=cwd,
-            capture_output=capture_output,
-            text=True,
-            check=False,
-        )
+        ci_result = subprocess.run(ci_cmd, **run_kwargs)
         if ci_result.returncode == 0:
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
     install_cmd = [npm, "install", *extra_args]
-    return subprocess.run(
-        install_cmd,
-        cwd=cwd,
-        capture_output=capture_output,
-        text=True,
-        check=False,
-    )
+    return subprocess.run(install_cmd, **run_kwargs)
 
 
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
@@ -5323,7 +5315,8 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",))
+    build_env = {**os.environ, "NODE_ENV": "development"}
+    r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",), env=build_env)
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
@@ -5332,7 +5325,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False
-    r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
+    r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True, env=build_env)
     if r2.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI build failed"


### PR DESCRIPTION
## Problem
When the user's shell has  set, 
> hermes-agent@1.0.0 postinstall
> echo '✅ Browser tools ready. Run: python run_agent.py --help'

✅ Browser tools ready. Run: python run_agent.py --help

added 204 packages, and audited 205 packages in 11s

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities silently skips . This causes the subsequent  to fail with  because  is listed under  in .

## Changes
-  now accepts an optional HERMES_GATEWAY_SESSION=1
HERMES_TUI_ACTIVE_SESSION_FILE=/var/folders/05/1pwjb5lj7v78vs92q06ch61m0000gn/T/hermes-tui-active-session-_4z9e2z4.json
TERMINAL_PERSISTENT_SHELL=True
TERMINAL_CONTAINER_CPU=1
TERM_PROGRAM=Apple_Terminal
BROWSER_INACTIVITY_TIMEOUT=120
X_ACCESS_TOKEN_SECRET=herems
TERM=xterm-256color
SHELL=/bin/zsh
HERMES_PYTHON=/Users/drewolson/.hermes/hermes-agent/venv/bin/python3
HERMES_MAX_ITERATIONS=90
TERMINAL_LIFETIME_SECONDS=300
TMPDIR=/var/folders/05/1pwjb5lj7v78vs92q06ch61m0000gn/T/
HOMEBREW_REPOSITORY=/opt/homebrew
TERM_PROGRAM_VERSION=466
TERMINAL_DOCKER_VOLUMES=[]
HERMES_QUIET=1
NODE_OPTIONS=--max-old-space-size=8192 --expose-gc
FPATH=/opt/homebrew/share/zsh/site-functions:/usr/local/share/zsh/site-functions:/usr/share/zsh/site-functions:/usr/share/zsh/5.9/functions
OLDPWD=/Users/drewolson/.hermes/hermes-agent
TERMINAL_ENV=local
VISION_TOOLS_DEBUG=false
MOA_TOOLS_DEBUG=false
TERM_SESSION_ID=887D8927-F1A8-4ACA-A21A-9D4A9CE6DE9C
TERMINAL_CONTAINER_PERSISTENT=True
USER=drewolson
WEB_TOOLS_DEBUG=false
HERMES_PYTHON_SRC_ROOT=/Users/drewolson/.hermes/hermes-agent
X_ACCESS_TOKEN=stop
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.P0lYXVupxS/Listeners
IMAGE_TOOLS_DEBUG=false
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
TERMINAL_SINGULARITY_IMAGE=docker://nikolaik/python-nodejs:python3.11-nodejs20
PATH=/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/drewolson/.local/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/sbin
HERMES_REDACT_SECRETS=true
BROWSERBASE_ADVANCED_STEALTH=false
__CFBundleIdentifier=com.apple.Terminal
TERMINAL_DAYTONA_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
HERMES_CWD=/Users/drewolson
PWD=/Users/drewolson/.hermes/hermes-agent
TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=False
LANG=en_US.UTF-8
HERMES_INTERACTIVE=1
XPC_FLAGS=0x0
NODE_ENV=production
TERMINAL_TIMEOUT=60
TERMINAL_MODAL_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
TERMINAL_DOCKER_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
TERMINAL_CONTAINER_MEMORY=5120
TERMINAL_CWD=/Users/drewolson
XPC_SERVICE_NAME=0
HOME=/Users/drewolson
SHLVL=3
HOMEBREW_PREFIX=/opt/homebrew
PYTHONPATH=/Users/drewolson/.hermes/hermes-agent
LOGNAME=drewolson
BROWSERBASE_PROXIES=true
TERMINAL_DOCKER_FORWARD_ENV=[]
BROWSER_SESSION_TIMEOUT=300
HOMEBREW_CELLAR=/opt/homebrew/Cellar
INFOPATH=/opt/homebrew/share/info:
OSLogRateLimit=64
TERMINAL_CONTAINER_DISK=51200
HERMES_EXEC_ASK=1
X_BEARER_TOKEN=skip
COLORTERM=truecolor
_=/usr/bin/env parameter and passes it through to 
-  creates a  with  and passes it to both the npm install and npm run build steps

## Testing
- Verified on a system with  in the shell environment
- Web UI now builds successfully: 2060 modules transformed, 1.6MB JS bundle

Closes: users who see  during ⚕ Updating Hermes Agent...

→ Fetching updates...
  ⚠ Currently on branch 'fix/node-env-web-ui-build' — switching to main for update...
✓ Already up to date! when running in production-oriented shell environments.