### PR TITLE
fix(slack): throttle repeated channel directory warnings

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -8,6 +8,7 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 
 import json
 import logging
+import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,8 @@ from utils import atomic_json_write
 logger = logging.getLogger(__name__)
 
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+_SLACK_DIRECTORY_WARNING_INTERVAL_SECONDS = 3600
+_slack_directory_warning_last: Dict[tuple[str, str], float] = {}
 
 
 def _normalize_channel_query(value: str) -> str:
@@ -51,6 +54,27 @@ def _session_entry_name(origin: Dict[str, Any]) -> str:
 
     topic_label = origin.get("chat_topic") or f"topic {thread_id}"
     return f"{base_name} / {topic_label}"
+
+
+def _warn_slack_directory(team_id: str, detail: str) -> None:
+    """Warn once per team/error per interval for recurring Slack refresh failures."""
+    key = (str(team_id), str(detail))
+    now = time.monotonic()
+    last = _slack_directory_warning_last.get(key)
+    if last is None or now - last >= _SLACK_DIRECTORY_WARNING_INTERVAL_SECONDS:
+        _slack_directory_warning_last[key] = now
+        logger.warning(
+            "Channel directory: failed to list Slack channels for team %s: %s",
+            team_id,
+            detail,
+        )
+    else:
+        logger.debug(
+            "Channel directory: suppressed repeated Slack channel list failure "
+            "for team %s: %s",
+            team_id,
+            detail,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -172,11 +196,8 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
                     cursor=cursor,
                 )
                 if not response.get("ok"):
-                    logger.warning(
-                        "Channel directory: users.conversations not ok for team %s: %s",
-                        team_id,
-                        response.get("error", "unknown"),
-                    )
+                    detail = f"users.conversations not ok: {response.get('error', 'unknown')}"
+                    _warn_slack_directory(team_id, detail)
                     break
                 for ch in response.get("channels", []):
                     cid = ch.get("id")
@@ -193,10 +214,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
                 if not cursor:
                     break
         except Exception as e:
-            logger.warning(
-                "Channel directory: failed to list Slack channels for team %s: %s",
-                team_id, e,
-            )
+            _warn_slack_directory(team_id, str(e))
             continue
 
     # Merge in DM/group entries discovered from session history.

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -15,6 +15,7 @@ from gateway.channel_directory import (
     load_directory,
     _build_from_sessions,
     _build_slack,
+    _slack_directory_warning_last,
     DIRECTORY_PATH,
 )
 
@@ -482,3 +483,29 @@ class TestBuildSlack:
             entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
 
         assert entries == []
+
+    def test_repeated_workspace_errors_are_warning_throttled(
+        self, tmp_path, caplog, monkeypatch
+    ):
+        client = _make_slack_client([
+            {"ok": False, "error": "missing_scope"},
+            {"ok": False, "error": "missing_scope"},
+        ])
+        _slack_directory_warning_last.clear()
+        monkeypatch.setattr("gateway.channel_directory.time.monotonic", lambda: 1000.0)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}), caplog.at_level("DEBUG"):
+            asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+            asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
+
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelname == "WARNING"
+        ]
+        assert len(warning_messages) == 1
+        assert "missing_scope" in warning_messages[0]
+        assert any(
+            "suppressed repeated Slack channel list failure" in record.getMessage()
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary
- Throttle repeated Slack channel-directory refresh warnings by team/error so recurring Slack API failures do not flood gateway logs.
- Keep the first warning visible and emit suppressed repeats at debug level.
- Add regression coverage for repeated workspace failures.

Fixes #18485
Signal Deck card: ops-ops-channel-directory-failed-to-list-slack-channels-for-team-the-request-to-the-slack-api-

## Tests
- scripts/run_tests.sh tests/gateway/test_channel_directory.py::TestBuildSlack::test_repeated_workspace_errors_are_warning_throttled tests/gateway/test_channel_directory.py::TestBuildSlack::test_per_workspace_error_does_not_block_others tests/gateway/test_channel_directory.py::TestBuildSlack::test_response_not_ok_breaks_pagination_for_that_workspace
- scripts/run_tests.sh tests/gateway/test_channel_directory.py
- git diff --check origin/main...HEAD