### PR TITLE
fix: profile setup command and clipboard fallback for HTTP dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2437,7 +2437,7 @@ def _resolve_profile_dir(name: str) -> Path:
 def _profile_setup_command(name: str) -> str:
     """Return the shell command used to configure a profile in the CLI."""
     _resolve_profile_dir(name)
-    return "hermes setup" if name == "default" else f"{name} setup"
+    return "hermes setup" if name == "default" else f"hermes -p {name} setup"
 
 
 @app.get("/api/profiles")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -665,7 +665,7 @@ class TestNewEndpoints:
         resp = self.client.get("/api/profiles/coder/setup-command")
 
         assert resp.status_code == 200
-        assert resp.json()["command"] == "coder setup"
+        assert resp.json()["command"] == "hermes -p coder setup"
 
     def test_profile_setup_command_uses_hermes_for_default_profile(self):
         from hermes_constants import get_hermes_home

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -148,7 +148,20 @@ export default function ProfilesPage() {
       await navigator.clipboard.writeText(cmd);
       showToast(`${t.profiles.commandCopied}: ${cmd}`, "success");
     } catch {
-      showToast(`${t.profiles.copyFailed}: ${cmd}`, "error");
+      // Fallback for HTTP (non-secure) contexts where Clipboard API is blocked
+      try {
+        const ta = document.createElement("textarea");
+        ta.value = cmd;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+        showToast(`${t.profiles.commandCopied}: ${cmd}`, "success");
+      } catch {
+        showToast(`${t.profiles.copyFailed}: ${cmd}`, "error");
+      }
     }
   };
 


### PR DESCRIPTION
## What

Two bugs in the dashboard Profiles page (multi-agent configuration):

1. **Wrong CLI command for non-default profiles** — `_profile_setup_command()` returned bare `{name} setup` (e.g. `coder setup`) instead of `hermes -p {name} setup`. The generated command doesn't work unless a wrapper script happens to exist.

2. **Clipboard copy fails over HTTP** — `navigator.clipboard.writeText()` requires a secure context (HTTPS or localhost). The dashboard explicitly supports `--insecure` (HTTP) mode, but the clipboard code had no fallback, causing "复制失败" for every HTTP user.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/web_server.py` | `_profile_setup_command()`: return `hermes -p {name} setup` for non-default profiles |
| `web/src/pages/ProfilesPage.tsx` | Add `document.execCommand('copy')` textarea fallback when Clipboard API is unavailable |
| `tests/hermes_cli/test_web_server.py` | Update assertion to match new command format |

## Testing

- `test_profile_setup_command_uses_named_profile_wrapper` — updated and passing
- `test_profile_setup_command_uses_hermes_for_default_profile` — still passing (unchanged behavior)