### PR TITLE
fix(session-search): ignore FTS operators when centering excerpts

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -183,6 +183,21 @@ class TestTruncateAroundMatches:
         result = _truncate_around_matches(text, "alpha beta")
         assert result.lower().count("alpha beta") == 2
 
+    def test_fts5_boolean_operators_are_not_match_terms(self):
+        early_boolean_noise = "or " * 200
+        filler = "x" * 1200
+        target = "Luka asked to resume the Injoy integration discussion."
+        text = early_boolean_noise + filler + target + filler
+
+        result = _truncate_around_matches(
+            text,
+            "Luka OR resume OR Injoy",
+            max_chars=220,
+        )
+
+        assert "Luka" in result
+        assert "Injoy" in result
+
 
 class TestSessionSearchConcurrency:
     def test_defaults_to_three(self):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -25,6 +25,7 @@ from typing import Dict, Any, List, Optional, Union
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 MAX_SESSION_CHARS = 100_000
 MAX_SUMMARY_TOKENS = 10000
+_FTS5_QUERY_OPERATORS = {"and", "or", "not", "near"}
 
 
 def _get_session_search_max_concurrency(default: int = 3) -> int:
@@ -108,6 +109,15 @@ def _format_conversation(messages: List[Dict[str, Any]]) -> str:
     return "\n\n".join(parts)
 
 
+def _query_match_terms(query: str) -> list[str]:
+    """Return query terms useful for transcript window placement."""
+    terms = []
+    for raw_term in re.findall(r"[\w.-]+", query.lower()):
+        if raw_term not in _FTS5_QUERY_OPERATORS:
+            terms.append(raw_term)
+    return terms
+
+
 def _truncate_around_matches(
     full_text: str, query: str, max_chars: int = MAX_SESSION_CHARS
 ) -> str:
@@ -137,7 +147,7 @@ def _truncate_around_matches(
 
     # --- 2. Proximity co-occurrence of all terms (within 200 chars) -----------
     if not match_positions:
-        terms = query_lower.split()
+        terms = _query_match_terms(query_lower)
         if len(terms) > 1:
             # Collect every occurrence of each term
             term_positions: dict[str, list[int]] = {}
@@ -157,7 +167,7 @@ def _truncate_around_matches(
 
     # --- 3. Individual term positions (last resort) ---------------------------
     if not match_positions:
-        terms = query_lower.split()
+        terms = _query_match_terms(query_lower)
         for t in terms:
             for m in re.finditer(re.escape(t), text_lower):
                 match_positions.append(m.start())


### PR DESCRIPTION
## Summary
- exclude FTS5 boolean operators from transcript excerpt match terms
- keep phrase matching intact while avoiding early OR/AND/NOT noise in long transcripts
- add a regression covering OR-heavy queries that should center on real terms

Fixes #4238

## Verification
- scripts/run_tests.sh tests/tools/test_session_search.py::TestTruncateAroundMatches::test_fts5_boolean_operators_are_not_match_terms
- scripts/run_tests.sh tests/tools/test_session_search.py
- git diff --check origin/main...HEAD