### PR TITLE
fix(session-search): center excerpts on matched messages

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -384,6 +384,43 @@ class TestSessionSearch:
         assert result["sessions_searched"] == 1
         assert current_sid not in [r.get("session_id") for r in result.get("results", [])]
 
+    def test_truncates_around_fts_matched_message_content(self, monkeypatch):
+        """The summarizer window should use the message FTS matched, not the first text term."""
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        target = "TARGET_RESUME_REVIEW resume details near the end"
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "s1",
+                "content": target,
+                "source": "cli",
+                "session_started": 1709500000,
+                "model": "test",
+            },
+        ]
+        mock_db.get_session.return_value = {"parent_session_id": None}
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "resume appears early"},
+            {"role": "assistant", "content": "x" * (MAX_SESSION_CHARS + 5000)},
+            {"role": "user", "content": target},
+        ]
+
+        captured = {}
+
+        async def fake_summarize(text, _query, _meta):
+            captured["text"] = text
+            return "summary"
+
+        monkeypatch.setattr("tools.session_search_tool._summarize_session", fake_summarize)
+        monkeypatch.setattr("model_tools._run_async", lambda coro: asyncio.run(coro))
+
+        result = json.loads(session_search(query="resume", db=mock_db, limit=1))
+
+        assert result["success"] is True
+        assert target in captured["text"]
+
     def test_current_child_session_excludes_parent_lineage(self):
         """Compression/delegation parents should be excluded for the active child session."""
         from unittest.mock import MagicMock

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -109,7 +109,10 @@ def _format_conversation(messages: List[Dict[str, Any]]) -> str:
 
 
 def _truncate_around_matches(
-    full_text: str, query: str, max_chars: int = MAX_SESSION_CHARS
+    full_text: str,
+    query: str,
+    max_chars: int = MAX_SESSION_CHARS,
+    match_positions: Optional[List[int]] = None,
 ) -> str:
     """
     Truncate a conversation transcript to *max_chars*, choosing a window
@@ -129,14 +132,20 @@ def _truncate_around_matches(
 
     text_lower = full_text.lower()
     query_lower = query.lower().strip()
-    match_positions: list[int] = []
+    candidate_positions: list[int] = []
+
+    if match_positions:
+        candidate_positions.extend(
+            pos for pos in match_positions if isinstance(pos, int) and pos >= 0
+        )
 
     # --- 1. Full-phrase search ------------------------------------------------
-    phrase_pat = re.compile(re.escape(query_lower))
-    match_positions = [m.start() for m in phrase_pat.finditer(text_lower)]
+    if not candidate_positions:
+        phrase_pat = re.compile(re.escape(query_lower))
+        candidate_positions = [m.start() for m in phrase_pat.finditer(text_lower)]
 
     # --- 2. Proximity co-occurrence of all terms (within 200 chars) -----------
-    if not match_positions:
+    if not candidate_positions:
         terms = query_lower.split()
         if len(terms) > 1:
             # Collect every occurrence of each term
@@ -153,33 +162,33 @@ def _truncate_around_matches(
                     for t in terms
                     if t != rarest
                 ):
-                    match_positions.append(pos)
+                    candidate_positions.append(pos)
 
     # --- 3. Individual term positions (last resort) ---------------------------
-    if not match_positions:
+    if not candidate_positions:
         terms = query_lower.split()
         for t in terms:
             for m in re.finditer(re.escape(t), text_lower):
-                match_positions.append(m.start())
+                candidate_positions.append(m.start())
 
-    if not match_positions:
+    if not candidate_positions:
         # Nothing at all — take from the start
         truncated = full_text[:max_chars]
         suffix = "\n\n...[later conversation truncated]..." if max_chars < len(full_text) else ""
         return truncated + suffix
 
     # --- Pick window that covers the most match positions ---------------------
-    match_positions.sort()
+    candidate_positions.sort()
 
     best_start = 0
     best_count = 0
-    for candidate in match_positions:
+    for candidate in candidate_positions:
         ws = max(0, candidate - max_chars // 4)  # bias: 25% before, 75% after
         we = ws + max_chars
         if we > len(full_text):
             ws = max(0, len(full_text) - max_chars)
             we = len(full_text)
-        count = sum(1 for p in match_positions if ws <= p < we)
+        count = sum(1 for p in candidate_positions if ws <= p < we)
         if count > best_count:
             best_count = count
             best_start = ws
@@ -191,6 +200,22 @@ def _truncate_around_matches(
     prefix = "...[earlier conversation truncated]...\n\n" if start > 0 else ""
     suffix = "\n\n...[later conversation truncated]..." if end < len(full_text) else ""
     return prefix + truncated + suffix
+
+
+def _find_match_positions_from_contents(
+    conversation_text: str,
+    matched_contents: List[str],
+) -> List[int]:
+    """Map FTS matched message content back to formatted transcript offsets."""
+    text_lower = conversation_text.lower()
+    positions: List[int] = []
+    for content in matched_contents:
+        if not isinstance(content, str) or not content:
+            continue
+        pos = text_lower.find(content.lower())
+        if pos >= 0:
+            positions.append(pos)
+    return positions
 
 
 async def _summarize_session(
@@ -424,7 +449,11 @@ def session_search(
             if resolved_sid not in seen_sessions:
                 result = dict(result)
                 result["session_id"] = resolved_sid
+                result["_matched_contents"] = []
                 seen_sessions[resolved_sid] = result
+            content = result.get("content")
+            if isinstance(content, str) and content:
+                seen_sessions[resolved_sid]["_matched_contents"].append(content)
             if len(seen_sessions) >= limit:
                 break
 
@@ -437,7 +466,15 @@ def session_search(
                     continue
                 session_meta = db.get_session(session_id) or {}
                 conversation_text = _format_conversation(messages)
-                conversation_text = _truncate_around_matches(conversation_text, query)
+                match_positions = _find_match_positions_from_contents(
+                    conversation_text,
+                    match_info.get("_matched_contents", []),
+                )
+                conversation_text = _truncate_around_matches(
+                    conversation_text,
+                    query,
+                    match_positions=match_positions,
+                )
                 tasks.append((session_id, match_info, conversation_text, session_meta))
             except Exception as e:
                 logging.warning(


### PR DESCRIPTION
## Summary
- retain FTS matched message content while grouping session_search hits
- map matched messages back into the formatted transcript and prefer those offsets for truncation
- add a regression proving late matched content remains in the summarizer window

Fixes #4239

## Verification
- scripts/run_tests.sh tests/tools/test_session_search.py::TestSessionSearch::test_truncates_around_fts_matched_message_content
- scripts/run_tests.sh tests/tools/test_session_search.py
- git diff --check origin/main...HEAD