### PR TITLE
fix(session-search): strip FTS5 operators from truncation query terms

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -9,6 +9,7 @@ from tools.session_search_tool import (
     _format_timestamp,
     _format_conversation,
     _truncate_around_matches,
+    _strip_fts5_operators,
     _get_session_search_max_concurrency,
     _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
@@ -182,6 +183,88 @@ class TestTruncateAroundMatches:
         text = pre + match1 + gap + match2 + post
         result = _truncate_around_matches(text, "alpha beta")
         assert result.lower().count("alpha beta") == 2
+
+
+class TestStripFts5Operators:
+    """Tests for _strip_fts5_operators (#4238)."""
+
+    def test_plain_query_unchanged(self):
+        assert _strip_fts5_operators("docker postgres") == "docker postgres"
+
+    def test_strips_AND(self):
+        assert _strip_fts5_operators("docker AND postgres") == "docker postgres"
+
+    def test_strips_OR(self):
+        assert _strip_fts5_operators("docker OR postgres") == "docker postgres"
+
+    def test_strips_NOT(self):
+        assert _strip_fts5_operators("docker NOT test") == "docker test"
+
+    def test_strips_case_insensitive_operators(self):
+        assert _strip_fts5_operators("docker and postgres") == "docker postgres"
+        assert _strip_fts5_operators("docker Or postgres") == "docker postgres"
+
+    def test_strips_multiple_operators(self):
+        assert _strip_fts5_operators("a AND b OR c NOT d") == "a b c d"
+
+    def test_preserves_quoted_content(self):
+        assert _strip_fts5_operators('"exact phrase" AND other') == "exact phrase other"
+
+    def test_strips_NEAR(self):
+        assert _strip_fts5_operators("NEAR(docker postgres, 5)") == ""
+
+    def test_strips_column_filter(self):
+        assert _strip_fts5_operators("role:user docker") == "docker"
+
+    def test_strips_column_filter_with_content(self):
+        assert _strip_fts5_operators("body:important term") == "term"
+
+    def test_strips_special_chars(self):
+        assert _strip_fts5_operators("docker+ postgres* test^") == "docker postgres test"
+
+    def test_empty_after_stripping(self):
+        assert _strip_fts5_operators("AND OR NOT") == ""
+
+    def test_preserves_operational_in_words(self):
+        """'AND' inside a word like 'android' should not be stripped."""
+        # Note: word boundary \b means 'android' won't match \bAND\b
+        assert _strip_fts5_operators("android development") == "android development"
+
+
+class TestTruncateAroundMatchesFts5:
+    """Tests that _truncate_around_matches handles FTS5 queries correctly (#4238/#4239)."""
+
+    def test_boolean_operators_not_treated_as_terms(self):
+        """AND/OR/NOT should not generate match positions in text."""
+        padding = "x" * (MAX_SESSION_CHARS + 5000)
+        text = padding + " docker and postgres " + padding
+        # With the old code, "and" would match the literal "and" in text.
+        # With the fix, only "docker" and "postgres" are content terms.
+        result = _truncate_around_matches(text, "docker AND postgres")
+        assert "docker" in result.lower()
+        assert "postgres" in result.lower()
+
+    def test_query_with_not_operator(self):
+        """NOT should be stripped, remaining terms used for matching."""
+        padding = "x" * (MAX_SESSION_CHARS + 5000)
+        text = padding + " docker container running " + padding
+        result = _truncate_around_matches(text, "docker NOT postgres")
+        assert "docker" in result.lower()
+
+    def test_quoted_phrase_in_fts5_query(self):
+        """Quoted phrases should have their content preserved for matching."""
+        padding = "x" * (MAX_SESSION_CHARS + 5000)
+        text = padding + " exact phrase here " + padding
+        result = _truncate_around_matches(text, '"exact phrase" AND other')
+        assert "exact phrase" in result.lower()
+
+    def test_pure_operators_fallback(self):
+        """If query is only operators, fall back to raw query."""
+        padding = "x" * (MAX_SESSION_CHARS + 5000)
+        text = padding + " AND OR NOT " + padding
+        # Should not crash — falls back to raw query
+        result = _truncate_around_matches(text, "AND OR NOT")
+        assert len(result) <= MAX_SESSION_CHARS + 100
 
 
 class TestSessionSearchConcurrency:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -108,6 +108,37 @@ def _format_conversation(messages: List[Dict[str, Any]]) -> str:
     return "\n\n".join(parts)
 
 
+def _strip_fts5_operators(query: str) -> str:
+    """Extract plain content terms from an FTS5 query string.
+
+    Strips boolean operators (``AND``, ``OR``, ``NOT``), ``NEAR(...)``
+    clauses, column filters (``column:term``), prefix operators (``*``),
+    and FTS5 special characters (``+``, ``{}``, ``()``, ``^``, ``~``).
+    Preserves quoted-phrase content (without the quotes).
+
+    Returns an empty string if *query* contained only operators / syntax.
+    """
+    result = query
+
+    # Remove quoted phrases but keep their content
+    result = re.sub(r'"([^"]*)"', r'\1', result)
+
+    # Remove NEAR(...) clauses entirely
+    result = re.sub(r'NEAR\s*\([^)]*\)', '', result, flags=re.IGNORECASE)
+
+    # Remove column filters (e.g. role:user, body:term)
+    result = re.sub(r'\w+:\w+', '', result)
+
+    # Remove FTS5 special characters
+    result = re.sub(r'[+{}()^~*]', ' ', result)
+
+    # Remove boolean operators (standalone words)
+    result = re.sub(r'\b(?:AND|OR|NOT)\b', '', result, flags=re.IGNORECASE)
+
+    # Collapse whitespace
+    return ' '.join(result.split()).strip()
+
+
 def _truncate_around_matches(
     full_text: str, query: str, max_chars: int = MAX_SESSION_CHARS
 ) -> str:
@@ -123,21 +154,31 @@ def _truncate_around_matches(
 
     Once candidate positions are collected the function picks the window
     start that covers the most of them.
+
+    FTS5 boolean operators (AND, OR, NOT) and other query syntax are
+    stripped before matching so they are not treated as search terms
+    (fixes #4238 / #4239).
     """
     if len(full_text) <= max_chars:
         return full_text
 
     text_lower = full_text.lower()
     query_lower = query.lower().strip()
+
+    # Strip FTS5 operators so boolean keywords aren't treated as search terms.
+    clean_query = _strip_fts5_operators(query_lower)
+    if not clean_query:
+        clean_query = query_lower  # fallback if stripping removed everything
+
     match_positions: list[int] = []
 
     # --- 1. Full-phrase search ------------------------------------------------
-    phrase_pat = re.compile(re.escape(query_lower))
+    phrase_pat = re.compile(re.escape(clean_query))
     match_positions = [m.start() for m in phrase_pat.finditer(text_lower)]
 
     # --- 2. Proximity co-occurrence of all terms (within 200 chars) -----------
     if not match_positions:
-        terms = query_lower.split()
+        terms = clean_query.split()
         if len(terms) > 1:
             # Collect every occurrence of each term
             term_positions: dict[str, list[int]] = {}
@@ -157,7 +198,7 @@ def _truncate_around_matches(
 
     # --- 3. Individual term positions (last resort) ---------------------------
     if not match_positions:
-        terms = query_lower.split()
+        terms = clean_query.split()
         for t in terms:
             for m in re.finditer(re.escape(t), text_lower):
                 match_positions.append(m.start())


### PR DESCRIPTION
## What does this PR do?

`_truncate_around_matches()` treats FTS5 boolean operators (`AND`, `OR`, `NOT`) as content terms when splitting the query. Since common English words like "and" appear in virtually every conversation, this produces false match positions and mis-centered truncation windows.

Similarly, FTS5 syntax like `NEAR(...)`, column filters (`role:user`), and special characters (`+`, `*`, `^`) pollute the search terms.

## Related Issue

Fixes #4238

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A