### PR TITLE
fix(auth): re-resolve Kimi pool base URLs

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -931,6 +931,43 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
+def _normalize_loaded_credential_pool_entries(
+    provider_id: str,
+    entries: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Normalize provider-specific fields that may become stale on disk."""
+    if provider_id not in ("kimi-coding", "kimi-coding-cn"):
+        return list(entries)
+
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    if not pconfig:
+        return list(entries)
+
+    env_url = ""
+    if pconfig.base_url_env_var:
+        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+
+    normalized: List[Dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            normalized.append(entry)
+            continue
+        item = dict(entry)
+        api_key = str(
+            item.get("access_token")
+            or item.get("runtime_api_key")
+            or item.get("api_key")
+            or ""
+        ).strip()
+        item["base_url"] = _resolve_kimi_base_url(
+            api_key,
+            pconfig.inference_base_url,
+            env_url,
+        ).rstrip("/")
+        normalized.append(item)
+    return normalized
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice."""
     auth_store = _load_auth_store()
@@ -938,9 +975,17 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     if not isinstance(pool, dict):
         pool = {}
     if provider_id is None:
-        return dict(pool)
+        normalized_pool = {}
+        for pid, entries in pool.items():
+            if isinstance(entries, list):
+                normalized_pool[pid] = _normalize_loaded_credential_pool_entries(pid, entries)
+            else:
+                normalized_pool[pid] = entries
+        return normalized_pool
     provider_entries = pool.get(provider_id)
-    return list(provider_entries) if isinstance(provider_entries, list) else []
+    if not isinstance(provider_entries, list):
+        return []
+    return _normalize_loaded_credential_pool_entries(provider_id, provider_entries)
 
 
 def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Path:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -9,6 +9,7 @@ from hermes_cli.auth import (
     ProviderConfig,
     resolve_provider,
     get_api_key_provider_status,
+    read_credential_pool,
     resolve_api_key_provider_credentials,
     get_external_process_provider_status,
     resolve_external_process_provider_credentials,
@@ -977,6 +978,45 @@ class TestKimiCodeCredentialAutoDetect:
         monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)
         creds = resolve_api_key_provider_credentials("zai")
         assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+class TestKimiCodeCredentialPoolAutoDetect:
+    """Test that persisted Kimi pool entries are normalized when loaded."""
+
+    def test_sk_kimi_pool_entry_gets_kimi_code_url(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {
+            "credential_pool": {
+                "kimi-coding": [{
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": "sk-kimi-secret-key",
+                    "base_url": MOONSHOT_DEFAULT_URL,
+                    "label": "old Kimi key",
+                }],
+            },
+        })
+
+        entries = read_credential_pool("kimi-coding")
+
+        assert entries[0]["base_url"] == KIMI_CODE_BASE_URL
+
+    def test_kimi_pool_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("KIMI_BASE_URL", "https://override.example/v1")
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {
+            "credential_pool": {
+                "kimi-coding": [{
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": "sk-kimi-secret-key",
+                    "base_url": MOONSHOT_DEFAULT_URL,
+                    "label": "old Kimi key",
+                }],
+            },
+        })
+
+        entries = read_credential_pool("kimi-coding")
+
+        assert entries[0]["base_url"] == "https://override.example/v1"
 
 
 class TestZaiEndpointAutoDetect:


### PR DESCRIPTION
## Summary
- normalize loaded kimi-coding credential-pool entries with the current API key prefix rules
- keep explicit KIMI_BASE_URL overrides authoritative
- add regression coverage for stale Moonshot base_url values on sk-kimi keys

Fixes #5908

## Verification
- scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py::TestKimiCodeCredentialPoolAutoDetect tests/hermes_cli/test_api_key_providers.py::TestKimiCodeCredentialAutoDetect
- scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py
- git diff --check origin/main...HEAD