### PR TITLE
fix(tui): drop corrupted SGR mouse fragments that escape existing recovery

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -421,6 +421,7 @@ AUTHOR_MAP = {
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
     "kagura.chen28@gmail.com": "kagura-agent",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
     "skmishra1991@gmail.com": "bugkill3r",

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -133,4 +133,22 @@ describe('fragmented SGR mouse recovery', () => {
 
     expect(key).toMatchObject({ kind: 'key', sequence: '1234;56;78M9;10;11M' })
   })
+
+  it('silently drops concatenated fragments without prefix', () => {
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, '5;34M34M35;16;35M')
+
+    expect(events).toEqual([])
+  })
+
+  it('silently drops pure corrupted fragment text', () => {
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, '37M37M6;29;37M5;32;37M')
+
+    expect(events).toEqual([])
+  })
+
+  it('does not drop mixed text containing fragment-like patterns', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, 'hello 5;34M world')
+
+    expect(key).toMatchObject({ kind: 'key', sequence: 'hello 5;34M world' })
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -64,6 +64,7 @@ const XTVERSION_RE = /^\x1bP>\|(.*?)(?:\x07|\x1b\\)$/s
 // eslint-disable-next-line no-control-regex
 const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/
 const SGR_MOUSE_FRAGMENT_RE = /(?<!\d)(?:\[<|<)?(?:[0-9]|[1-9][0-9]|1\d{2}|2[0-4]\d|25[0-5]);\d+;\d+[Mm]/g
+const CORRUPTED_SGR_FRAGMENT_RE = /^(?!.*\d{4})[0-9;Mm]+$/
 
 function createPasteKey(content: string): ParsedKey {
   return {
@@ -643,6 +644,10 @@ function parseSgrMouseFragment(fragment: string): ParsedInput {
 }
 
 function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
+  if (CORRUPTED_SGR_FRAGMENT_RE.test(text) && /\d[Mm]\d/.test(text)) {
+    return []
+  }
+
   SGR_MOUSE_FRAGMENT_RE.lastIndex = 0
 
   const matches = [...text.matchAll(SGR_MOUSE_FRAGMENT_RE)]


### PR DESCRIPTION
## Problem

Fixes #18658.

Under heavy render load in tmux with mouse tracking enabled, SGR mouse escape sequences leak into the chat composer as visible garbage text (e.g. `5;34M;34M35;16;35M...`).

The existing recovery in `parseTextWithSgrMouseFragments()` (commits 71b685aee, ded011c5a) handles fragments with explicit `[<` or `<` prefixes and multi-fragment bursts, but fails when:
1. Extreme concatenation produces adjacent fragments without separators
2. Multiple `M` terminators appear in a row from corrupted/overlapping writes

## Solution

Add an early-exit check in `parseTextWithSgrMouseFragments()`: if the entire text consists exclusively of SGR-mouse-fragment characters (`[0-9;Mm]`) AND contains the event-boundary signature (`\d[Mm]\d` — one event ending, another starting), silently discard it by returning an empty array.

This is safe because real user-typed text will never consist entirely of digits, semicolons, and M/m characters while also containing the boundary pattern. The negative lookahead `(?!.*\d{4})` ensures strings with 4+ digit runs (which can't be valid mouse coords 0-255) pass through normally.

## Changes

- `parse-keypress.ts`: Add `CORRUPTED_SGR_FRAGMENT_RE` constant and early-exit guard in `parseTextWithSgrMouseFragments()`
- `parse-keypress.test.ts`: 3 new test cases covering concatenated fragments, corrupted fragments, and mixed-text preservation

## Testing

All 19 tests in `parse-keypress.test.ts` pass via `vitest run`.