### PR TITLE
Fix TUI backspace across continued composer lines

### DIFF
--- a/ui-tui/src/__tests__/composerContinuationBackspace.test.ts
+++ b/ui-tui/src/__tests__/composerContinuationBackspace.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeBufferedInputLine } from '../app/useComposerState.js'
+
+describe('mergeBufferedInputLine', () => {
+  it('returns null when no continuation lines are buffered', () => {
+    expect(mergeBufferedInputLine([], 'next')).toBeNull()
+  })
+
+  it('deletes the continuation boundary before the active input', () => {
+    expect(mergeBufferedInputLine(['77'], '88')).toEqual({
+      input: {
+        cursor: 2,
+        value: '7788'
+      },
+      inputBuf: []
+    })
+  })
+
+  it('merges only the last buffered line into the active input', () => {
+    expect(mergeBufferedInputLine(['11', '22'], '33')).toEqual({
+      input: {
+        cursor: 2,
+        value: '2233'
+      },
+      inputBuf: ['11']
+    })
+  })
+
+  it('handles an empty buffered line as a deletable blank continuation', () => {
+    expect(mergeBufferedInputLine(['11', ''], '22')).toEqual({
+      input: {
+        cursor: 0,
+        value: '22'
+      },
+      inputBuf: ['11']
+    })
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -137,6 +137,7 @@ export interface ComposerActions {
   dequeue: () => string | undefined
   enqueue: (text: string) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
+  mergeContinuationBackspace: (current: string) => ComposerPasteResult | null
   openEditor: () => Promise<void>
   pushHistory: (text: string) => void
   removeQueue: (index: number) => void
@@ -313,6 +314,7 @@ export interface AppLayoutComposerProps {
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
   input: string
   inputBuf: string[]
+  mergeContinuationBackspace: (current: string) => ComposerPasteResult | null
   pagerPageSize: number
   queueEditIdx: null | number
   queuedDisplay: string[]

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { useStdin, withInkSuspended } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 
 import type { PasteEvent } from '../components/textInput.js'
 import { LARGE_PASTE } from '../config/limits.js'
@@ -98,6 +98,26 @@ export function looksLikeDroppedPath(text: string): boolean {
   return false
 }
 
+export function mergeBufferedInputLine(
+  inputBuf: string[],
+  current: string
+): null | { input: { cursor: number; value: string }; inputBuf: string[] } {
+  if (!inputBuf.length) {
+    return null
+  }
+
+  const nextInputBuf = inputBuf.slice(0, -1)
+  const tail = inputBuf[inputBuf.length - 1] ?? ''
+
+  return {
+    input: {
+      cursor: tail.length,
+      value: `${tail}${current}`
+    },
+    inputBuf: nextInputBuf
+  }
+}
+
 export function useComposerState({
   gw,
   onClipboardPaste,
@@ -105,8 +125,9 @@ export function useComposerState({
   submitRef
 }: UseComposerStateOptions): UseComposerStateResult {
   const [input, setInput] = useState('')
-  const [inputBuf, setInputBuf] = useState<string[]>([])
+  const [inputBuf, setInputBufState] = useState<string[]>([])
   const [pasteSnips, setPasteSnips] = useState<PasteSnippet[]>([])
+  const inputBufRef = useRef<string[]>([])
   const isBlocked = useStore($isBlocked)
   const { querier } = useStdin() as { querier: Parameters<typeof readOsc52Clipboard>[0] }
 
@@ -126,6 +147,13 @@ export function useComposerState({
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
   const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
 
+  const setInputBuf = useCallback((next: string[] | ((prev: string[]) => string[])) => {
+    const resolved = typeof next === 'function' ? next(inputBufRef.current) : next
+
+    inputBufRef.current = resolved
+    setInputBufState(resolved)
+  }, [])
+
   const clearIn = useCallback(() => {
     setInput('')
     setInputBuf([])
@@ -133,7 +161,22 @@ export function useComposerState({
     setQueueEdit(null)
     setHistoryIdx(null)
     historyDraftRef.current = ''
-  }, [historyDraftRef, setQueueEdit, setHistoryIdx])
+  }, [historyDraftRef, setInputBuf, setQueueEdit, setHistoryIdx])
+
+  const mergeContinuationBackspace = useCallback(
+    (current: string): null | { cursor: number; value: string } => {
+      const merged = mergeBufferedInputLine(inputBufRef.current, current)
+
+      if (!merged) {
+        return null
+      }
+
+      setInputBuf(merged.inputBuf)
+
+      return merged.input
+    },
+    [setInputBuf]
+  )
 
   const handleResolvedPaste = useCallback(
     async ({
@@ -294,7 +337,7 @@ export function useComposerState({
     } finally {
       rmSync(dir, { force: true, recursive: true })
     }
-  }, [input, inputBuf, submitRef])
+  }, [input, inputBuf, setInputBuf, submitRef])
 
   const actions = useMemo(
     () => ({
@@ -302,6 +345,7 @@ export function useComposerState({
       dequeue,
       enqueue,
       handleTextPaste,
+      mergeContinuationBackspace,
       openEditor,
       pushHistory,
       removeQueue: removeQ,
@@ -319,12 +363,14 @@ export function useComposerState({
       dequeue,
       enqueue,
       handleTextPaste,
+      mergeContinuationBackspace,
       openEditor,
       pushHistory,
       removeQ,
       replaceQ,
       setCompIdx,
       setHistoryIdx,
+      setInputBuf,
       setQueueEdit,
       syncQueue
     ]

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -768,6 +768,7 @@ export function useMainApp(gw: GatewayClient) {
       handleTextPaste: composerActions.handleTextPaste,
       input: composerState.input,
       inputBuf: composerState.inputBuf,
+      mergeContinuationBackspace: composerActions.mergeContinuationBackspace,
       pagerPageSize,
       queueEditIdx: composerState.queueEditIdx,
       queuedDisplay: composerState.queuedDisplay,

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -283,6 +283,7 @@ const ComposerPane = memo(function ComposerPane({
                 <TextInput
                   columns={inputColumns}
                   mouseApiRef={inputMouseRef}
+                  onBackspaceAtStart={composer.mergeContinuationBackspace}
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -235,6 +235,7 @@ export function TextInput({
   columns = 80,
   value,
   onChange,
+  onBackspaceAtStart,
   onPaste,
   onSubmit,
   mask,
@@ -267,9 +268,11 @@ export function TextInput({
   const redo = useRef<{ cursor: number; value: string }[]>([])
 
   const cbChange = useRef(onChange)
+  const cbBackspaceAtStart = useRef(onBackspaceAtStart)
   const cbSubmit = useRef(onSubmit)
   const cbPaste = useRef(onPaste)
   cbChange.current = onChange
+  cbBackspaceAtStart.current = onBackspaceAtStart
   cbSubmit.current = onSubmit
   cbPaste.current = onPaste
 
@@ -837,6 +840,14 @@ export function TextInput({
       } else if (range && (k.backspace || delFwd)) {
         v = v.slice(0, range.start) + v.slice(range.end)
         c = range.start
+      } else if (k.backspace && c === 0) {
+        const merged = cbBackspaceAtStart.current?.(v)
+
+        if (merged) {
+          commit(merged.value, merged.cursor)
+        }
+
+        return
       } else if (k.backspace && c > 0) {
         if (wordMod) {
           const t = wordLeft(v, c)
@@ -1034,6 +1045,7 @@ interface TextInputProps {
   focus?: boolean
   mask?: string
   mouseApiRef?: MutableRefObject<null | TextInputMouseApi>
+  onBackspaceAtStart?: (current: string) => { cursor: number; value: string } | null
   onChange: (v: string) => void
   onPaste?: (
     e: PasteEvent


### PR DESCRIPTION
## Summary
- allow the TUI text input to delegate Backspace at cursor start to the composer
- merge the previous backslash-continued composer line into the active input so Backspace deletes the continuation boundary
- add regression coverage for continuation-line merging

Fixes #18394

## Tests
- npm test -- composerContinuationBackspace textInputLineNav
- npm run type-check
- git diff --check origin/main...HEAD