### PR TITLE
fix(session-db): warn when assistant messages leak transcript role headers

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1196,6 +1196,43 @@ class SessionDB:
                 return content
         return content
 
+    # ------------------------------------------------------------------
+    # Role-prefix leak detection
+    #
+    # Assistant output that begins with a bare transcript role marker
+    # (`user\n`, `assistant\n`, `system\n`, `tool\n`, `developer\n`) is
+    # almost always a sign of model degeneration or prompt-format confusion:
+    # the model is regurgitating the chat template's role headers back as
+    # content. When such output is stored as role=assistant and later
+    # rendered in a UI that displays content verbatim, it can visually
+    # impersonate a user turn and poison session context (see #18556:
+    # 95kB assistant message beginning with `user\n...` produced fake
+    # user-looking lines that confused session review).
+    #
+    # This is a narrow detector: only exact `role\n` (or `role\r\n`) at
+    # the very start of the content is flagged. `role:` is deliberately
+    # NOT matched — it produces too many false positives ("user: bob",
+    # "assistant: this script", etc.). Code and prose that happens to
+    # contain role words elsewhere is untouched.
+    #
+    # Behavior on detection: the message is still persisted as-is (so
+    # callers are not silently lossy), but a WARNING is emitted with
+    # session_id, the leaked role, and a content prefix so operators
+    # can audit the session.
+    # ------------------------------------------------------------------
+    _ROLE_PREFIX_LEAK_RE = re.compile(
+        r"^(user|assistant|system|tool|developer)\r?\n"
+    )
+
+    @classmethod
+    def _detect_role_prefix_leak(cls, role: str, content: Any) -> Optional[str]:
+        """Return the leaked role label if an assistant message begins with
+        a raw transcript role header, else None."""
+        if role != "assistant" or not isinstance(content, str) or not content:
+            return None
+        m = cls._ROLE_PREFIX_LEAK_RE.match(content)
+        return m.group(1) if m else None
+
     def append_message(
         self,
         session_id: str,
@@ -1218,6 +1255,25 @@ class SessionDB:
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
         """
+        # Audit: detect assistant messages that begin with a raw transcript
+        # role header (e.g. "user\n..."). These are almost always a symptom
+        # of model degeneration and can visually impersonate user input in
+        # UIs that render content verbatim. See #18556 for a concrete
+        # incident (95kB corrupted assistant message beginning with "user\n"
+        # that generated fake user-looking lines and a divider loop).
+        leaked_role = self._detect_role_prefix_leak(role, content)
+        if leaked_role:
+            preview = content[:200].replace("\n", " ")
+            logger.warning(
+                "role-prefix leak in session %s: assistant message begins "
+                "with raw %r header (may impersonate user turn in UIs). "
+                "len=%d, preview=%r. Stored as-is — audit session integrity.",
+                session_id,
+                leaked_role,
+                len(content),
+                preview,
+            )
+
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
             json.dumps(reasoning_details)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -519,6 +519,148 @@ class TestMessageStorage:
 
 
 # =========================================================================
+# Role-prefix leak detection (#18556)
+# =========================================================================
+
+class TestRolePrefixLeakDetection:
+    """append_message() must emit a WARNING when an assistant message begins
+    with a raw transcript role marker (`user\\n`, `assistant\\n`, etc.).
+    Such content can visually impersonate a user turn in UIs that render
+    message content verbatim, poisoning session review (#18556)."""
+
+    def test_leaked_user_prefix_logs_warning(self, db, caplog):
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content="user\nNew reviews are fine\n---\n---\n---",
+            )
+        assert any("role-prefix leak" in rec.message for rec in caplog.records), (
+            f"expected leak warning; got: {[r.message for r in caplog.records]}"
+        )
+        # Content is still persisted as-is (advisory, not lossy)
+        messages = db.get_messages("s1")
+        assert messages[0]["content"].startswith("user\n")
+
+    def test_leaked_assistant_prefix_logs_warning(self, db, caplog):
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content="assistant\nDoing the thing.",
+            )
+        assert any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_leaked_system_prefix_logs_warning(self, db, caplog):
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content="system\nYou are a helpful assistant.",
+            )
+        assert any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_leaked_prefix_with_crlf_logs_warning(self, db, caplog):
+        """Windows-style line endings in model output should still trip the detector."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content="user\r\nsome fake user content",
+            )
+        assert any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_role_colon_form_does_not_trigger(self, db, caplog):
+        """`user:` (colon form) is NOT a leak signal — too many false positives
+        (code `user_id:`, markdown `- user:`, etc.). Only bare `role\\n`
+        transcript leakage fires."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content="user: the field you asked about is named `id`.",
+            )
+        assert not any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_role_word_in_middle_does_not_trigger(self, db, caplog):
+        """The detector anchors at ^ — role words inside the message don't fire."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content="The user\nwants to reset the password.",
+            )
+        assert not any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_user_role_message_does_not_trigger_even_when_prefixed(self, db, caplog):
+        """Only assistant-role messages are subject to the leak check. User
+        messages naturally can start with any word."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="user",
+                content="user\nsome literal content",
+            )
+        assert not any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_tool_role_message_does_not_trigger(self, db, caplog):
+        """Tool outputs can contain arbitrary text — don't gate them."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="tool",
+                content="assistant\nsome tool output text",
+                tool_name="terminal",
+            )
+        assert not any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_empty_assistant_content_does_not_trigger(self, db, caplog):
+        """Empty content (None or '') should not crash the detector."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message("s1", role="assistant", content=None)
+            db.append_message("s1", role="assistant", content="")
+        assert not any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_multimodal_list_content_does_not_trigger(self, db, caplog):
+        """Multimodal content (list of parts) is not a plain string — don't
+        try to regex-match it. Text parts are handled by normal LLM flow,
+        not by a role-prefix check at the DB layer."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message(
+                "s1", role="assistant",
+                content=[{"type": "text", "text": "user\nhi"}],
+            )
+        assert not any("role-prefix leak" in rec.message for rec in caplog.records)
+
+    def test_detector_preview_is_truncated(self, db, caplog):
+        """The logged preview should be short (first 200 chars) — the full
+        95k-char corrupted message from #18556 must not flood the log."""
+        import logging
+        db.create_session(session_id="s1", source="cli")
+        huge = "user\n" + ("A" * 10_000)
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db.append_message("s1", role="assistant", content=huge)
+        leak_records = [r for r in caplog.records if "role-prefix leak" in r.message]
+        assert leak_records
+        # The formatted warning record should not contain the full 10k body
+        assert len(leak_records[0].getMessage()) < 1000, (
+            "warning message should be bounded by the 200-char preview"
+        )
+
+
+# =========================================================================
 # FTS5 search
 # =========================================================================
 


### PR DESCRIPTION
Addresses the observability gap in #18556.

## Symptom

Reporter's corrupted session had `messages.id = 9093` saved with `role = assistant` but content starting with `user\nNew reviews are fine...` followed by fake "user" lines (login / Tailscale / passwords) and a 95,426-char repeated-divider loop. The DB role was correct, but any UI rendering content verbatim would show it as if the user had typed those lines.

The corruption originated on the model side (likely Gemini degeneration under a 100k-input / 645k-cache-read / 32-tool-call session), but Hermes silently accepted and persisted the output with no audit signal.

## Fix

`SessionDB.append_message()` is the single chokepoint all message persistence goes through. At that layer, add a narrow detector that flags assistant messages whose content starts with a bare transcript role marker (`user\n`, `assistant\n`, `system\n`, `tool\n`, `developer\n`).

When detected:
- Message is still persisted as-is (not lossy — callers aren't silently rewritten)
- `WARNING` emitted with session_id, leaked role, content length, and a 200-char preview — audit-grade detail, bounded so 95k-char corrupted blobs can't flood logs

This is one of the 5 guardrails @QuantumQuill77-glitch proposed — specifically a subset of (1) *"Detect assistant messages that begin with raw role labels"*. Starting with the observability layer before DB schema or streaming changes — if operators see this warning, they'll investigate and we'll learn whether false-positives are real before escalating to quarantine/strip.

## Design choices

| Choice | Rationale |
|---|---|
| Detect at `append_message`, not in agent code | Single chokepoint. 7 callers (`run_agent.py`, `cli.py`, `acp_adapter`, `tui_gateway`, `gateway/{run,session,mirror}.py`) all covered. |
| Warn not quarantine | Schema change for quarantine column is separate concern; a warning gets observability today. |
| `role\n` only, not `role:` | `user:` / `user_id:` / markdown `- user:` are common benign content. Only the transcript-exact form fires. |
| Skip user/tool/system roles | They can legitimately start with any text. Only assistant-role output is fraud-prone in UIs. |
| Skip list-form multimodal content | Not a plain string; regex doesn't apply. |
| Truncated 200-char preview | 95k char blobs shouldn't flood the log, but operators still need a forensic fingerprint. |

## Tests

11 new tests in `TestRolePrefixLeakDetection`:

- Each of the 4 role variants (`user`, `assistant`, `system`, `tool`) triggers the warning
- CRLF (`\r\n`) line ending also triggers
- `role:` colon form does **not** trigger (false-positive guard)
- Role words in middle of content do **not** trigger (anchor guard)
- User / tool / system role messages are not checked
- Empty/None content doesn't crash
- Multimodal list content doesn't crash
- Log preview is bounded (full 10k body is not in the emitted message)

**Full file: 216/216 pass.**

## Not in scope

- DB-level quarantine (schema change)
- Streaming-level cutoff for repeated-divider loops (different layer; risk of false positives on legit code / box-drawing)
- UI display changes in `web/` (separate PR; role display should use metadata anyway)

Happy to follow up with any of these if the maintainer prefers a stacked approach.

## Files

- `hermes_state.py`: +41
- `tests/test_hermes_state.py`: +138