### PR TITLE
feat(web): add Scrapling fallback for extract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "exa-py>=2.9.0,<3",
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",
+  "scrapling[fetchers]>=0.4.7,<0.5",
   "fal-client>=0.13.1,<1",
   # Cron scheduler (built-in feature — scheduled cron/interval jobs use croniter).
   "croniter>=6.0.0,<7",

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -625,3 +625,125 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+class TestWebExtractScraplingFallback:
+    @pytest.mark.asyncio
+    async def test_firecrawl_error_falls_back_to_scrapling(self):
+        import tools.web_tools
+
+        firecrawl_client = MagicMock()
+        firecrawl_client.scrape.side_effect = RuntimeError("firecrawl boom")
+        scrapling_result = {
+            "url": "https://example.com",
+            "title": "Example title",
+            "content": "Scrapling content",
+            "raw_content": "Scrapling content",
+            "metadata": {"extractor": "scrapling"},
+        }
+
+        with patch("tools.web_tools._get_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_firecrawl_client", return_value=firecrawl_client), \
+             patch("tools.web_tools._scrapling_extract_url", new=AsyncMock(return_value=scrapling_result)) as mock_scrapling, \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.web_tools.check_auxiliary_model", return_value=False), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(await tools.web_tools.web_extract_tool(["https://example.com"], use_llm_processing=False))
+
+        assert result["results"] == [{
+            "url": "https://example.com",
+            "title": "Example title",
+            "content": "Scrapling content",
+            "error": None,
+        }]
+        mock_scrapling.assert_awaited_once_with("https://example.com", None)
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_content_skips_scrapling_fallback(self):
+        import tools.web_tools
+
+        firecrawl_client = MagicMock()
+        firecrawl_client.scrape.return_value = {
+            "markdown": "Firecrawl content",
+            "metadata": {"title": "Firecrawl title", "sourceURL": "https://example.com"},
+        }
+
+        with patch("tools.web_tools._get_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_firecrawl_client", return_value=firecrawl_client), \
+             patch("tools.web_tools._scrapling_extract_url", new=AsyncMock()) as mock_scrapling, \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.web_tools.check_auxiliary_model", return_value=False), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(await tools.web_tools.web_extract_tool(["https://example.com"], use_llm_processing=False))
+
+        assert result["results"] == [{
+            "url": "https://example.com",
+            "title": "Firecrawl title",
+            "content": "Firecrawl content",
+            "error": None,
+        }]
+        mock_scrapling.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_empty_content_falls_back_to_scrapling(self):
+        import tools.web_tools
+
+        firecrawl_client = MagicMock()
+        firecrawl_client.scrape.return_value = {
+            "markdown": "",
+            "html": "",
+            "metadata": {"title": "Firecrawl title", "sourceURL": "https://example.com/final"},
+        }
+        scrapling_result = {
+            "url": "https://example.com/final",
+            "title": "Fallback title",
+            "content": "Fallback content",
+            "raw_content": "Fallback content",
+            "metadata": {"extractor": "scrapling"},
+        }
+
+        with patch("tools.web_tools._get_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_firecrawl_client", return_value=firecrawl_client), \
+             patch("tools.web_tools._scrapling_extract_url", new=AsyncMock(return_value=scrapling_result)) as mock_scrapling, \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.web_tools.check_auxiliary_model", return_value=False), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(await tools.web_tools.web_extract_tool(["https://example.com"], use_llm_processing=False))
+
+        assert result["results"] == [{
+            "url": "https://example.com/final",
+            "title": "Fallback title",
+            "content": "Fallback content",
+            "error": None,
+        }]
+        mock_scrapling.assert_awaited_once_with("https://example.com/final", None)
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_error_surfaces_when_scrapling_fallback_also_fails(self):
+        import tools.web_tools
+
+        firecrawl_client = MagicMock()
+        firecrawl_client.scrape.side_effect = RuntimeError("firecrawl boom")
+
+        with patch("tools.web_tools._get_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._get_firecrawl_client", return_value=firecrawl_client), \
+             patch("tools.web_tools._scrapling_extract_url", new=AsyncMock(side_effect=RuntimeError("scrapling boom"))), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.web_tools.check_auxiliary_model", return_value=False), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(await tools.web_tools.web_extract_tool(["https://example.com"], use_llm_processing=False))
+
+        assert result["results"] == [{
+            "url": "https://example.com",
+            "title": "",
+            "content": "",
+            "error": "firecrawl boom",
+        }]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -240,6 +240,63 @@ def _web_requires_env() -> list[str]:
     return requires
 
 
+def _scrapling_extract_sync(url: str, format: Optional[str] = None) -> Dict[str, Any]:
+    """Fetch and normalize page content with Scrapling.
+
+    Uses the lightweight HTTP fetcher first for stability; the goal is to provide
+    a best-effort fallback when the primary extraction backend fails.
+    """
+    from scrapling.fetchers import Fetcher
+
+    page = Fetcher.fetch(url, follow_redirects=True, timeout=45)
+    final_url = getattr(page, "url", url) or url
+    title = ""
+    try:
+        title = str(page.xpath("//title/text()").get() or "")
+    except Exception:
+        title = ""
+
+    raw_html = ""
+    try:
+        raw_html = page.body.decode(getattr(page, "encoding", "utf-8"), errors="ignore")
+    except Exception:
+        raw_html = ""
+
+    if format == "html":
+        content = raw_html
+    else:
+        try:
+            content = str(page.get_all_text(separator="\n", strip=True))
+        except Exception:
+            content = ""
+        if not content:
+            content = raw_html
+
+    if not content.strip():
+        raise ValueError("Scrapling returned no extractable content")
+
+    return {
+        "url": final_url,
+        "title": title,
+        "content": content,
+        "raw_content": raw_html or content,
+        "metadata": {"extractor": "scrapling", "sourceURL": final_url},
+    }
+
+
+async def _scrapling_extract_url(url: str, format: Optional[str] = None) -> Dict[str, Any]:
+    """Async wrapper around Scrapling extraction with timeout and policy re-check."""
+    result = await asyncio.wait_for(
+        asyncio.to_thread(_scrapling_extract_sync, url, format),
+        timeout=90,
+    )
+    final_url = result.get("url", url)
+    final_blocked = check_website_access(final_url)
+    if final_blocked:
+        raise ValueError(final_blocked["message"])
+    return result
+
+
 def _get_firecrawl_client():
     """Get or create Firecrawl client.
 
@@ -1332,6 +1389,8 @@ async def web_extract_tool(
 
                     try:
                         logger.info("Scraping: %s", url)
+                        scrape_error: Optional[str] = None
+
                         # Run synchronous Firecrawl scrape in a thread with a
                         # 60s timeout so a hung fetch doesn't block the session.
                         try:
@@ -1344,11 +1403,31 @@ async def web_extract_tool(
                                 timeout=60,
                             )
                         except asyncio.TimeoutError:
-                            logger.warning("Firecrawl scrape timed out for %s", url)
-                            results.append({
-                                "url": url, "title": "", "content": "",
-                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
-                            })
+                            scrape_error = "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead."
+                            scrape_result = None
+                        except Exception as firecrawl_err:
+                            scrape_error = str(firecrawl_err)
+                            scrape_result = None
+
+                        scrapling_result: Optional[Dict[str, Any]] = None
+                        if scrape_result is None:
+                            logger.info("Firecrawl unavailable for %s, trying Scrapling fallback", url)
+                            try:
+                                scrapling_result = await _scrapling_extract_url(url, format)
+                            except Exception as scrapling_err:
+                                logger.debug("Scrapling fallback failed for %s: %s", url, scrapling_err)
+                                results.append({
+                                    "url": url,
+                                    "title": "",
+                                    "content": "",
+                                    "raw_content": "",
+                                    "error": scrape_error or str(scrapling_err),
+                                })
+                                continue
+
+                        if scrapling_result is not None:
+                            results.append(scrapling_result)
+                            debug_call_data["processing_applied"].append("scrapling_fallback")
                             continue
 
                         scrape_payload = _extract_scrape_payload(scrape_result)
@@ -1383,6 +1462,17 @@ async def web_extract_tool(
 
                         # Choose content based on requested format
                         chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
+
+                        if not (chosen_content or "").strip():
+                            logger.info("Firecrawl returned no content for %s, trying Scrapling fallback", url)
+                            try:
+                                scrapling_result = await _scrapling_extract_url(final_url, format)
+                            except Exception as scrapling_err:
+                                logger.debug("Scrapling empty-content fallback failed for %s: %s", final_url, scrapling_err)
+                            else:
+                                results.append(scrapling_result)
+                                debug_call_data["processing_applied"].append("scrapling_fallback")
+                                continue
 
                         results.append({
                             "url": final_url,


### PR DESCRIPTION
## Summary
- add a Scrapling-based fallback path for `web_extract` when Firecrawl times out, errors, or returns empty content
- keep `web_search` unchanged and keep Firecrawl as the primary extract path for stable behavior
- add focused regression tests for error-path and empty-content fallback behavior
- add the Scrapling fetcher dependency to the core tool stack

## Test Plan
- `pytest tests/tools/test_web_tools_config.py -k scrapling -q`
- `pytest tests/tools/test_web_tools_config.py tests/tools/test_website_policy.py -q`

## Notes
- This intentionally uses Scrapling's lightweight `Fetcher` path for stability rather than introducing browser-only fallback as the default first step.
