### PR TITLE
fix(telegram): honor disabled fallback IPs

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -841,8 +841,8 @@ class TelegramAdapter(BasePlatformAdapter):
             }
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in ("1", "true", "yes", "on"))
-            fallback_ips = self._fallback_ips()
-            if not fallback_ips:
+            fallback_ips = [] if disable_fallback else self._fallback_ips()
+            if not disable_fallback and not fallback_ips:
                 fallback_ips = await discover_fallback_ips()
                 logger.info(
                     "[%s] Auto-discovered Telegram fallback IPs: %s",

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -464,6 +464,74 @@ class TestAdapterFallbackIps:
         adapter = self._make_adapter(extra={"fallback_ips": ["149.154.167.220", "not-valid"]})
         assert adapter._fallback_ips() == ["149.154.167.220"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("extra", [None, {"fallback_ips": ["149.154.167.220"]}])
+    async def test_disable_env_skips_fallback_resolution_during_connect(self, monkeypatch, extra):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from gateway.platforms import telegram as telegram_mod
+
+        adapter = self._make_adapter(extra=extra)
+        monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *args: True)
+        monkeypatch.setattr(adapter, "_release_platform_lock", lambda: None)
+        monkeypatch.setattr(adapter, "_setup_dm_topics", AsyncMock())
+        monkeypatch.setenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "1")
+
+        discover = AsyncMock(return_value=["149.154.167.221"])
+        monkeypatch.setattr(telegram_mod, "discover_fallback_ips", discover)
+
+        resolved_targets = []
+
+        def fake_resolve_proxy_url(platform_env_var, *, target_hosts=None):
+            resolved_targets.append((platform_env_var, list(target_hosts or [])))
+            return None
+
+        monkeypatch.setattr(telegram_mod, "resolve_proxy_url", fake_resolve_proxy_url)
+
+        request_kwargs = []
+
+        def fake_httpx_request(**kwargs):
+            request_kwargs.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(telegram_mod, "HTTPXRequest", fake_httpx_request)
+
+        bot = SimpleNamespace(
+            delete_webhook=AsyncMock(),
+            set_my_commands=AsyncMock(),
+        )
+        updater = SimpleNamespace(
+            start_polling=AsyncMock(),
+            stop=AsyncMock(),
+            running=True,
+        )
+        app = SimpleNamespace(
+            bot=bot,
+            updater=updater,
+            add_handler=MagicMock(),
+            initialize=AsyncMock(),
+            start=AsyncMock(),
+        )
+        builder = MagicMock()
+        builder.token.return_value = builder
+        builder.request.return_value = builder
+        builder.get_updates_request.return_value = builder
+        builder.build.return_value = app
+        monkeypatch.setattr(
+            telegram_mod,
+            "Application",
+            SimpleNamespace(builder=MagicMock(return_value=builder)),
+        )
+
+        ok = await adapter.connect()
+
+        assert ok is True
+        discover.assert_not_awaited()
+        assert resolved_targets == [("TELEGRAM_PROXY", ["api.telegram.org"])]
+        assert request_kwargs
+        assert all("httpx_kwargs" not in kwargs for kwargs in request_kwargs)
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # DoH auto-discovery


### PR DESCRIPTION
## What does this PR do?

This PR fixes Telegram gateway startup when fallback IPs are explicitly disabled.

Previously, setting `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1` prevented fallback transport from being used later, but the adapter still read configured fallback IPs and could still call `discover_fallback_ips()` during `connect()`. In proxy-only network environments, this could cause startup delays or failures such as `telegram connect timed out after 30s`.

This change makes the disable flag behave consistently: when fallback IPs are disabled, Hermes skips fallback IP config, skips DoH discovery, and connects using the normal Telegram/proxy path only.

## Related Issue

N/A - no linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`
  - Respect `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1` before reading configured fallback IPs.
  - Skip `discover_fallback_ips()` entirely when fallback IPs are disabled.
- `tests/gateway/test_telegram_network.py`
  - Added regression coverage to ensure disabled fallback IPs are not discovered or attached during Telegram startup, even if fallback IPs exist in config.

## How to Test

1. Configure Telegram to use a proxy and disable fallback IPs:

   ```bash
   export TELEGRAM_PROXY=socks5://127.0.0.1:10808/
   export HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1
   ```

2. Start the gateway:

   ```bash
   hermes gateway run
   ```

3. Verify Telegram connects without fallback IP discovery or fallback transport being used.

4. Run the targeted test suite:

   ```bash
   pytest tests/gateway/test_telegram_network.py -q
   ```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: TODO, e.g. Windows 11 / Ubuntu 24.04 / macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — env-var behavior only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, startup could fail with:

```text
WARNING gateway.platforms.telegram: [Telegram] Connect attempt 2/8 failed: httpx.ConnectError
ERROR gateway.run: telegram connect timed out after 30s
ERROR gateway.run: Gateway failed to connect any configured messaging platform
```
