### PR TITLE
fix(agent): keep local stream timeouts finite

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2833,6 +2833,58 @@ class AIAgent:
             return max(stale_base, 450.0)
         return stale_base
 
+    def _stream_output_budget(self, api_kwargs: Optional[dict] = None) -> int:
+        """Return the requested stream output budget when one is configured."""
+        candidates = []
+        if api_kwargs:
+            candidates.extend(
+                api_kwargs.get(name)
+                for name in ("max_tokens", "max_completion_tokens", "max_output_tokens")
+            )
+        candidates.append(getattr(self, "max_tokens", None))
+        for value in candidates:
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+        return 0
+
+    def _resolved_stream_read_timeout(self, api_kwargs: Optional[dict] = None) -> float:
+        """Resolve the httpx streaming read timeout for chat completions."""
+        provider_timeout = get_provider_request_timeout(self.provider, self.model)
+        if provider_timeout is not None:
+            return provider_timeout
+
+        stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+        output_budget = self._stream_output_budget(api_kwargs)
+        if output_budget > 32768:
+            # Large local/custom generations can legitimately pause longer
+            # between chunks, but the timeout must remain finite so a stalled
+            # provider can recover through the retry path.
+            return max(stream_read_timeout, 180.0)
+        return stream_read_timeout
+
+    def _compute_stream_stale_timeout(self, api_kwargs: dict) -> float:
+        """Compute the stale-stream reconnect threshold for streaming calls."""
+        stale_timeout = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+
+        output_budget = self._stream_output_budget(api_kwargs)
+        if output_budget > 65536:
+            stale_timeout = max(stale_timeout, 420.0)
+        elif output_budget > 32768:
+            stale_timeout = max(stale_timeout, 300.0)
+
+        # Scale the stale timeout for large contexts: slow models can
+        # legitimately think for minutes before producing the first token.
+        est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
+        if est_tokens > 100_000:
+            return max(stale_timeout, 300.0)
+        if est_tokens > 50_000:
+            return max(stale_timeout, 240.0)
+        return stale_timeout
+
     def _is_openrouter_url(self) -> bool:
         """Return True when the base URL targets OpenRouter."""
         return base_url_host_matches(self._base_url_lower, "openrouter.ai")
@@ -6700,28 +6752,11 @@ class AIAgent:
             import httpx as _httpx
             # Per-provider / per-model request_timeout_seconds (from config.yaml)
             # wins over the HERMES_API_TIMEOUT env default if the user set it.
-            _provider_timeout_cfg = get_provider_request_timeout(self.provider, self.model)
-            _base_timeout = (
-                _provider_timeout_cfg
-                if _provider_timeout_cfg is not None
-                else float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
-            )
-            # Read timeout: config wins here too.  Otherwise use
-            # HERMES_STREAM_READ_TIMEOUT (default 120s) for cloud providers.
-            if _provider_timeout_cfg is not None:
-                _stream_read_timeout = _provider_timeout_cfg
-            else:
-                _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-                # Local providers (Ollama, llama.cpp, vLLM) can take minutes for
-                # prefill on large contexts before producing the first token.
-                # Auto-increase the httpx read timeout unless the user explicitly
-                # overrode HERMES_STREAM_READ_TIMEOUT.
-                if _stream_read_timeout == 120.0 and self.base_url and is_local_endpoint(self.base_url):
-                    _stream_read_timeout = _base_timeout
-                    logger.debug(
-                        "Local provider detected (%s) — stream read timeout raised to %.0fs",
-                        self.base_url, _stream_read_timeout,
-                    )
+            _base_timeout = self._resolved_api_call_timeout()
+            # Keep stream reads finite for local/custom endpoints so stalled
+            # providers recover through retry logic instead of waiting on the
+            # long request timeout fallback.
+            _stream_read_timeout = self._resolved_stream_read_timeout(api_kwargs)
             stream_kwargs = {
                 **api_kwargs,
                 "stream": True,
@@ -7268,26 +7303,7 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="stream_request_complete")
 
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
-        # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-        # for prefill on large contexts.  Disable the stale detector unless
-        # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-        if _stream_stale_timeout_base == 180.0 and self.base_url and is_local_endpoint(self.base_url):
-            _stream_stale_timeout = float("inf")
-            logger.debug("Local provider detected (%s) — stale stream timeout disabled", self.base_url)
-        else:
-            # Scale the stale timeout for large contexts: slow models (like Opus)
-            # can legitimately think for minutes before producing the first token
-            # when the context is large.  Without this, the stale detector kills
-            # healthy connections during the model's thinking phase, producing
-            # spurious RemoteProtocolError ("peer closed connection").
-            _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
-            if _est_tokens > 100_000:
-                _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-            elif _est_tokens > 50_000:
-                _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-            else:
-                _stream_stale_timeout = _stream_stale_timeout_base
+        _stream_stale_timeout = self._compute_stream_stale_timeout(api_kwargs)
 
         t = threading.Thread(target=_call, daemon=True)
         t.start()

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -1,16 +1,22 @@
-"""Tests for local provider stream read timeout auto-detection.
-
-When a local LLM provider is detected (Ollama, llama.cpp, vLLM, etc.),
-the httpx stream read timeout should be automatically increased from the
-default 60s to HERMES_API_TIMEOUT (1800s) to avoid premature connection
-kills during long prefill phases.
-"""
+"""Tests for local provider stream timeout handling."""
 
 import os
 import pytest
 from unittest.mock import patch
 
 from agent.model_metadata import is_local_endpoint
+from run_agent import AIAgent
+
+
+def _agent(**kwargs):
+    return AIAgent(
+        api_key="test-key",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        **kwargs,
+    )
 
 
 class TestLocalStreamReadTimeout:
@@ -26,25 +32,46 @@ class TestLocalStreamReadTimeout:
         "http://host.containers.internal:11434",
         "http://host.lima.internal:11434",
     ])
-    def test_local_endpoint_bumps_read_timeout(self, base_url):
-        """Local endpoint + default timeout -> bumps to base_timeout."""
+    def test_local_endpoint_keeps_finite_read_timeout(self, base_url):
+        """Local endpoint + default timeout -> stays finite, not HERMES_API_TIMEOUT."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
-            _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
-                _stream_read_timeout = _base_timeout
-            assert _stream_read_timeout == 1800.0
+            agent = _agent(base_url=base_url)
+            assert agent._resolved_stream_read_timeout({}) == 120.0
 
     def test_user_override_respected_for_local(self):
         """User sets HERMES_STREAM_READ_TIMEOUT -> keep their value even for local."""
         with patch.dict(os.environ, {"HERMES_STREAM_READ_TIMEOUT": "300"}, clear=False):
-            _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-            base_url = "http://localhost:11434"
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
-                _stream_read_timeout = _base_timeout
-            assert _stream_read_timeout == 300.0
+            agent = _agent(base_url="http://localhost:11434")
+            assert agent._resolved_stream_read_timeout({}) == 300.0
+
+    def test_large_output_budget_scales_read_timeout(self):
+        """Large generations get more time between chunks without disabling timeout."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            agent = _agent(base_url="http://localhost:11434")
+            assert agent._resolved_stream_read_timeout({"max_tokens": 32769}) == 180.0
+
+    def test_local_endpoint_keeps_finite_stale_timeout(self):
+        """Local streams still reconnect when no chunks arrive."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            agent = _agent(base_url="http://localhost:11434")
+            assert agent._compute_stream_stale_timeout({"messages": []}) == 180.0
+
+    @pytest.mark.parametrize(
+        ("max_tokens", "expected"),
+        [
+            (32769, 300.0),
+            (65537, 420.0),
+        ],
+    )
+    def test_large_output_budget_scales_stale_timeout(self, max_tokens, expected):
+        """High output budgets get GLM-friendly finite stale thresholds."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            agent = _agent(base_url="http://localhost:11434")
+            assert agent._compute_stream_stale_timeout({"messages": [], "max_tokens": max_tokens}) == expected
 
     @pytest.mark.parametrize("base_url", [
         "https://api.openai.com",
@@ -55,22 +82,16 @@ class TestLocalStreamReadTimeout:
         """Remote endpoint -> keep 120s default."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
-            _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
-                _stream_read_timeout = _base_timeout
-            assert _stream_read_timeout == 120.0
+            agent = _agent(base_url=base_url)
+            assert agent._resolved_stream_read_timeout({}) == 120.0
 
     def test_empty_base_url_keeps_default(self):
         """No base_url set -> keep 120s default."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
-            _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
-            base_url = ""
-            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
-                _stream_read_timeout = _base_timeout
-            assert _stream_read_timeout == 120.0
+            agent = _agent(base_url="https://api.openai.com/v1")
+            agent.base_url = ""
+            assert agent._resolved_stream_read_timeout({}) == 120.0
 
 
 class TestIsLocalEndpoint:


### PR DESCRIPTION
## Summary
- keep chat-completions stream read timeouts finite for local/custom providers instead of inheriting the 1800s request timeout fallback
- keep the stale-stream detector enabled for local providers so stalled OmniRoute-style streams reconnect
- scale read and stale thresholds by output budget for long reasoning generations, matching the GLM-5.1 guidance in the issue thread

Fixes #17913

## Tests
- scripts/run_tests.sh tests/agent/test_local_stream_timeout.py
- scripts/run_tests.sh tests/run_agent/test_streaming.py
- git diff --check origin/main...HEAD