### PR TITLE
fix(openviking): support local file paths in viking_add_resource via temp_upload

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -744,9 +744,41 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not url:
             return tool_error("url is required")
 
-        payload: Dict[str, Any] = {"path": url}
-        if args.get("reason"):
-            payload["reason"] = args["reason"]
+        # Detect local paths (absolute or relative file paths)
+        is_local = url.startswith("/") or url.startswith(".") or url.startswith("~")
+
+        if is_local:
+            # Local file: upload via temp_upload, then add via temp_file_id
+            try:
+                import pathlib
+                file_path = pathlib.Path(url).expanduser().resolve()
+                if not file_path.exists():
+                    return tool_error(f"Local file not found: {file_path}")
+                with open(file_path, "rb") as f:
+                    upload_resp = self._client._httpx.post(
+                        self._client._url("/api/v1/resources/temp_upload"),
+                        files={"file": (file_path.name, f, "application/octet-stream")},
+                        headers={k: v for k, v in self._client._headers().items()
+                                 if k != "Content-Type"},  # Let httpx set Content-Type for multipart
+                        timeout=_TIMEOUT,
+                    )
+                upload_resp.raise_for_status()
+                upload_data = upload_resp.json()
+                temp_file_id = upload_data.get("result", {}).get("temp_file_id")
+                if not temp_file_id:
+                    return tool_error(f"temp_upload failed: {upload_data}")
+
+                payload: Dict[str, Any] = {
+                    "temp_file_id": temp_file_id,
+                    "reason": args.get("reason", ""),
+                }
+            except Exception as e:
+                return tool_error(f"Local file upload failed: {e}")
+        else:
+            # Remote URL or GitHub raw content: pass path directly
+            payload = {"path": url}
+            if args.get("reason"):
+                payload["reason"] = args["reason"]
 
         resp = self._client.post("/api/v1/resources", payload)
         result = resp.get("result", {})

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, mock_open, patch
 
 from plugins.memory.openviking import OpenVikingMemoryProvider
 
@@ -60,3 +60,93 @@ def test_tool_search_sorts_missing_raw_score_after_negative_scores():
     ]
     assert [entry["score"] for entry in result["results"]] == [0.1, 0.0, -0.25]
     assert result["total"] == 3
+
+
+def test_tool_add_resource_remote_url_passes_path_directly():
+    """Remote URLs should pass 'path' directly to /api/v1/resources (unchanged)."""
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client._url.return_value = "http://127.0.0.1:1933/api/v1/resources"
+    provider._client.post.return_value = {
+        "result": {"root_uri": "viking://resources/docs/my-doc.md"},
+    }
+
+    result = json.loads(provider._tool_add_resource({
+        "url": "https://example.com/doc.md",
+        "reason": "test reason",
+    }))
+
+    assert result["status"] == "added"
+    assert result["root_uri"] == "viking://resources/docs/my-doc.md"
+
+    # Should call post with 'path' field, NOT temp_file_id
+    provider._client.post.assert_called_once_with(
+        "/api/v1/resources",
+        {"path": "https://example.com/doc.md", "reason": "test reason"},
+    )
+    # _httpx.post should NOT be called for remote URLs
+    provider._client._httpx.post.assert_not_called()
+
+
+def test_tool_add_resource_local_file_uploads_via_temp_upload():
+    """Local file paths should upload via temp_upload, then pass temp_file_id."""
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client._headers.return_value = {
+        "Content-Type": "application/json",
+        "X-OpenViking-Account": "default",
+        "X-OpenViking-User": "default",
+        "X-OpenViking-Agent": "hermes",
+    }
+    provider._client._url.return_value = "http://127.0.0.1:1933/api/v1/resources/temp_upload"
+
+    # Mock httpx temp_upload response
+    mock_httpx_resp = MagicMock()
+    mock_httpx_resp.json.return_value = {
+        "result": {"temp_file_id": "upload_abc123.md"},
+    }
+    provider._client._httpx.post.return_value = mock_httpx_resp
+
+    # Mock final resource registration response
+    provider._client.post.return_value = {
+        "result": {"root_uri": "viking://resources/docs/my-local.md"},
+    }
+
+    with patch("pathlib.Path.exists", return_value=True), \
+         patch("builtins.open", mock_open(read_data=b"file content")):
+        result = json.loads(provider._tool_add_resource({
+            "url": "/home/user/notes.md",
+            "reason": "local test",
+        }))
+
+    assert result["status"] == "added"
+    assert result["root_uri"] == "viking://resources/docs/my-local.md"
+
+    # Should have called temp_upload (multipart upload via _httpx.post)
+    provider._client._httpx.post.assert_called_once()
+    call_args = provider._client._httpx.post.call_args
+    assert call_args[0] == ("http://127.0.0.1:1933/api/v1/resources/temp_upload",)
+    assert "files" in call_args[1]
+    assert call_args[1]["files"]["file"][0] == "notes.md"
+
+    # Final post should use temp_file_id, NOT path
+    provider._client.post.assert_called_once_with(
+        "/api/v1/resources",
+        {"temp_file_id": "upload_abc123.md", "reason": "local test"},
+    )
+
+
+def test_tool_add_resource_local_file_not_found():
+    """Local file that doesn't exist should return an error."""
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+
+    with patch("pathlib.Path.exists", return_value=False):
+        result = json.loads(provider._tool_add_resource({
+            "url": "/nonexistent/file.md",
+        }))
+
+    assert "error" in result
+    assert "not found" in result["error"]
+    # _httpx.post should NOT be called for missing files
+    provider._client._httpx.post.assert_not_called()


### PR DESCRIPTION
## Summary

`viking_add_resource` currently only accepts remote URLs. Passing a local
file path (e.g., `/home/user/doc.md`, `~/notes/research.pdf`, `./README.md`)
results in a `403 PERMISSION_DENIED` error from the OpenViking server.

This fix adds local file path detection and transparently uploads local
files via the `/api/v1/resources/temp_upload` endpoint before registering
them as resources.

**Tested with OpenViking server v0.3.14.** The `/api/v1/resources/temp_upload`
endpoint is required — older server versions that lack this endpoint will
continue to reject local files with the existing error message.

## Root Cause

The OpenViking `/api/v1/resources` endpoint only accepts two input formats:
1. Remote URLs (`https://...`) passed via the `path` field
2. Temp file IDs (from `POST /api/v1/resources/temp_upload`) passed via `temp_file_id`

The plugin currently always sends `path`, which works for URLs but fails
for local filesystem paths.

## Fix

In `_tool_add_resource()` in `plugins/memory/openviking/__init__.py`:

1. Detect local paths: starts with `/`, `.`, or `~`
2. For local paths:
   - Resolve the path (`expanduser` + `resolve`)
   - Upload via `POST /api/v1/resources/temp_upload` (multipart form)
   - Extract `temp_file_id` from response
   - Send `temp_file_id` + `reason` to `POST /api/v1/resources`
3. For remote URLs: behavior unchanged (pass `path` directly)

## Changes

| File | Description |
|---|---|
| `plugins/memory/openviking/__init__.py` | `_tool_add_resource()` — 35 lines added, 3 removed |
| `tests/plugins/memory/test_openviking_provider.py` | 3 new tests — 90 lines |

## Test Plan

- [x] Remote URLs pass `path` directly (regression)
- [x] Local file paths upload via `temp_upload` → `temp_file_id`
- [x] Missing local files return descriptive error
- [x] All 5 tests pass: `pytest tests/plugins/memory/test_openviking_provider.py -v`

## Environment

- Hermes Agent: current `main` (f98b5d00a)
- OpenViking server: v0.3.14
- Python 3.11

## Related

- Related to [#5627](https://github.com/NousResearch/hermes-agent/issues/5627) (expanding OpenViking plugin API surface)