### PR TITLE
fix(tui): refresh transcript after undo

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2150,7 +2150,37 @@ def test_session_undo_allowed_when_idle():
         )
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert resp["result"]["removed"] == 2
+        assert resp["result"]["messages"] == []
         assert server._sessions["sid"]["history"] == []
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_redo_restores_last_undone_exchange():
+    server._sessions["sid"] = _session(
+        running=False,
+        history=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    )
+    try:
+        undo = server.handle_request(
+            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
+        )
+        assert undo["result"]["removed"] == 2
+
+        redo = server.handle_request(
+            {"id": "2", "method": "session.redo", "params": {"session_id": "sid"}}
+        )
+
+        assert redo.get("result"), f"got error: {redo.get('error')}"
+        assert redo["result"]["restored"] == 2
+        assert server._sessions["sid"]["history"] == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert [m["role"] for m in redo["result"]["messages"]] == ["user", "assistant"]
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2293,17 +2293,41 @@ def _(rid, params: dict) -> dict:
             rid, 4009, "session busy — /interrupt the current turn before /undo"
         )
     removed = 0
+    removed_messages: list[dict] = []
     with session["history_lock"]:
         history = session.get("history", [])
         while history and history[-1].get("role") in ("assistant", "tool"):
-            history.pop()
+            removed_messages.append(history.pop())
             removed += 1
         if history and history[-1].get("role") == "user":
-            history.pop()
+            removed_messages.append(history.pop())
             removed += 1
         if removed:
             session["history_version"] = int(session.get("history_version", 0)) + 1
-    return _ok(rid, {"removed": removed})
+            session["redo_stack"] = list(reversed(removed_messages))
+        messages = _history_to_messages(history)
+    return _ok(rid, {"removed": removed, "messages": messages})
+
+
+@method("session.redo")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    if session.get("running"):
+        return _err(
+            rid, 4009, "session busy — /interrupt the current turn before /redo"
+        )
+    with session["history_lock"]:
+        redo_stack = list(session.get("redo_stack") or [])
+        history = session.get("history", [])
+        if not redo_stack:
+            return _ok(rid, {"restored": 0, "messages": _history_to_messages(history)})
+        history.extend(redo_stack)
+        session["redo_stack"] = []
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+        messages = _history_to_messages(history)
+    return _ok(rid, {"restored": len(redo_stack), "messages": messages})
 
 
 @method("session.compress")
@@ -2816,6 +2840,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         history_version = int(session.get("history_version", 0))
         images = list(session.get("attached_images", []))
         session["attached_images"] = []
+        session["redo_stack"] = []
     agent = session["agent"]
     _emit("message.start", sid)
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -591,6 +591,59 @@ describe('createSlashHandler', () => {
       expect(ctx.transcript.sys).toHaveBeenCalledWith('title: demo title')
     })
   })
+
+  it('/undo replaces visible transcript from gateway history', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn(() =>
+          Promise.resolve({
+            removed: 2,
+            messages: [{ role: 'user', text: 'kept' }]
+          })
+        )
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/undo')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.gateway.rpc).toHaveBeenCalledWith('session.undo', { session_id: 'sid-abc' })
+      expect(ctx.transcript.setHistoryItems).toHaveBeenCalledWith([{ role: 'user', text: 'kept' }])
+    })
+    expect(ctx.transcript.sys).not.toHaveBeenCalledWith(expect.stringContaining('undid'))
+    expect(getUiState().status).toBe('undid 2 messages')
+  })
+
+  it('/redo restores visible transcript from gateway history', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn(() =>
+          Promise.resolve({
+            restored: 2,
+            messages: [
+              { role: 'user', text: 'hi' },
+              { role: 'assistant', text: 'hello' }
+            ]
+          })
+        )
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/redo')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.gateway.rpc).toHaveBeenCalledWith('session.redo', { session_id: 'sid-abc' })
+      expect(ctx.transcript.setHistoryItems).toHaveBeenCalledWith([
+        { role: 'user', text: 'hi' },
+        { role: 'assistant', text: 'hello' }
+      ])
+    })
+    expect(getUiState().status).toBe('redid 2 messages')
+  })
 })
 
 const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -2,6 +2,7 @@ import { NO_CONFIRM_DESTRUCTIVE } from '../../../config/env.js'
 import { dailyFortune, randomFortune } from '../../../content/fortunes.js'
 import { HOTKEYS } from '../../../content/hotkeys.js'
 import { isSectionName, nextDetailsMode, parseDetailsMode, SECTION_NAMES } from '../../../domain/details.js'
+import { toTranscriptMessages } from '../../../domain/messages.js'
 import type {
   ConfigGetValueResponse,
   ConfigSetResponse,
@@ -527,10 +528,35 @@ export const coreCommands: SlashCommand[] = [
       ctx.gateway.rpc<SessionUndoResponse>('session.undo', { session_id: ctx.sid }).then(
         ctx.guarded<SessionUndoResponse>(r => {
           if ((r.removed ?? 0) > 0) {
-            ctx.transcript.setHistoryItems((prev: Msg[]) => ctx.transcript.trimLastExchange(prev))
-            ctx.transcript.sys(`undid ${r.removed} messages`)
+            if (Array.isArray(r.messages)) {
+              ctx.transcript.setHistoryItems(toTranscriptMessages(r.messages))
+            } else {
+              ctx.transcript.setHistoryItems((prev: Msg[]) => ctx.transcript.trimLastExchange(prev))
+            }
+            patchUiState({ status: `undid ${r.removed} messages` })
           } else {
             ctx.transcript.sys('nothing to undo')
+          }
+        })
+      )
+    }
+  },
+
+  {
+    help: 'redo last undone exchange',
+    name: 'redo',
+    run: (_arg, ctx) => {
+      if (!ctx.sid) {
+        return ctx.transcript.sys('nothing to redo')
+      }
+
+      ctx.gateway.rpc<SessionUndoResponse>('session.redo', { session_id: ctx.sid }).then(
+        ctx.guarded<SessionUndoResponse>(r => {
+          if ((r.restored ?? 0) > 0) {
+            ctx.transcript.setHistoryItems(toTranscriptMessages(r.messages))
+            patchUiState({ status: `redid ${r.restored} messages` })
+          } else {
+            ctx.transcript.sys('nothing to redo')
           }
         })
       )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -151,7 +151,9 @@ export interface SessionSaveResponse {
 }
 
 export interface SessionUndoResponse {
+  messages?: GatewayTranscriptMessage[]
   removed?: number
+  restored?: number
 }
 
 export interface SessionUsageResponse {


### PR DESCRIPTION
## Summary
- return the post-undo transcript snapshot from the TUI gateway so the frontend replaces stale visible messages instead of guessing locally
- add a one-level TUI redo path that restores the last undone exchange
- show undo/redo confirmation in the status bar instead of appending a permanent transcript line

Fixes #18386

## Verification
- scripts/run_tests.sh tests/test_tui_gateway_server.py::test_session_undo_allowed_when_idle tests/test_tui_gateway_server.py::test_session_redo_restores_last_undone_exchange
- npm test -- createSlashHandler
- npm run type-check
- git diff --check origin/main...HEAD