### PR TITLE
fix(slack): expose shared-thread author mention

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5333,7 +5333,10 @@ class GatewayRunner:
             thread_sessions_per_user=_thread_sessions_per_user,
         )
         if _is_shared_multi_user and source.user_name:
-            message_text = f"[{source.user_name}] {message_text}"
+            sender_label = source.user_name
+            if source.platform == Platform.SLACK and source.user_id:
+                sender_label = f"{source.user_name} | Slack user <@{source.user_id}>"
+            message_text = f"[{sender_label}] {message_text}"
 
         if event.media_urls:
             image_paths = []

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -325,6 +325,13 @@ def build_session_context_prompt(
             "current message's Slack block/attachment payload when available, but "
             "you still cannot call Slack APIs yourself."
         )
+        if context.shared_multi_user_session:
+            lines.append(
+                "In shared Slack threads, use the current turn's sender prefix "
+                "as the only verified current-author mention target. Do not "
+                "guess or reuse `<@U...>` mentions from names, memory, or prior "
+                "conversation history."
+            )
     elif context.source.platform == Platform.DISCORD:
         # Inject the Discord IDs block only when the agent actually has
         # Discord tools loaded this session — i.e. the user opted into

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -256,6 +256,27 @@ class TestBuildSessionContextPrompt:
         assert "pin" in prompt.lower()
         assert "current message's slack block/attachment payload" in prompt.lower()
 
+    def test_shared_slack_prompt_warns_against_guessed_self_mentions(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_name="team-channel",
+            chat_type="group",
+            user_id="U123",
+            user_name="Alice",
+            thread_id="171.000",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "current turn's sender prefix" in prompt
+        assert "Do not guess or reuse `<@U...>` mentions" in prompt
+
     def test_discord_prompt_with_channel_topic(self):
         """Channel topic should appear in the session context prompt."""
         config = GatewayConfig(

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -68,3 +68,32 @@ async def test_preprocess_keeps_plain_text_for_default_group_sessions():
     )
 
     assert result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_preprocess_includes_slack_author_mention_for_shared_thread():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_name="team-channel",
+        chat_type="group",
+        user_id="U123",
+        user_name="Alice",
+        thread_id="171.000",
+    )
+    event = MessageEvent(text="mention me again", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "[Alice | Slack user <@U123>] mention me again"


### PR DESCRIPTION
## Summary
- include the verified Slack user mention token in shared-thread sender prefixes
- add a stable Slack session prompt warning not to guess or reuse <@U...> mentions
- cover the shared Slack inbound prefix and prompt behavior with regressions

Fixes #17916.

## Tests
- scripts/run_tests.sh tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_session.py
- git diff --check origin/main...HEAD