### PR TITLE
fix: reduce default 429 cooldown from 1 hour to 3 minutes

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -68,9 +68,10 @@ SUPPORTED_POOL_STRATEGIES = {
 }
 
 # Cooldown before retrying an exhausted credential.
-# 429 (rate-limited) and 402 (billing/quota) both cool down after 1 hour.
-# Provider-supplied reset_at timestamps override these defaults.
-EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
+# 429 (rate-limited) cooldown reduced to 3 minutes — burst rate limits typically
+# reset within 1-2 minutes, and the previous 1-hour default caused prolonged lockouts
+# for single-key users. Provider-supplied reset_at timestamps still override this.
+EXHAUSTED_TTL_429_SECONDS = 60 * 3           # 3 minutes
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 
 # Pool key prefix for custom OpenAI-compatible endpoints.


### PR DESCRIPTION
Closes #18697

## Problem
The default 429 rate-limit cooldown in `agent/credential_pool.py` is **1 hour**. For users with a single API key, a single 429 response locks them out for an entire hour. Burst rate limits typically reset within 1-2 minutes.

We have been running with a 3-minute cooldown for GLM-5.1 in production for 2+ weeks with zero issues.

## Fix
- Changed `EXHAUSTED_TTL_429_SECONDS` from `60 * 60` (1 hour) to `60 * 3` (3 minutes)
- Updated comments to reflect the change
- Provider-supplied `reset_at` timestamps still override this default
- `EXHAUSTED_TTL_DEFAULT_SECONDS` (for 402/billing) remains at 1 hour — unchanged

## Testing
All existing tests pass (`tests/agent/test_credential_pool.py` — 25/25 passed).