### PR TITLE
fix(agent): scale stream timeouts by max_tokens output budget

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2851,7 +2851,9 @@ class AIAgent:
 
         return 300.0, True
 
-    def _compute_non_stream_stale_timeout(self, messages: list[dict[str, Any]]) -> float:
+    def _compute_non_stream_stale_timeout(
+        self, messages: list[dict[str, Any]], *, max_output_tokens: int = 0,
+    ) -> float:
         """Compute the effective non-stream stale timeout for this request."""
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
@@ -2860,10 +2862,17 @@ class AIAgent:
 
         est_tokens = sum(len(str(v)) for v in messages) // 4
         if est_tokens > 100_000:
-            return max(stale_base, 600.0)
-        if est_tokens > 50_000:
-            return max(stale_base, 450.0)
-        return stale_base
+            timeout = max(stale_base, 600.0)
+        elif est_tokens > 50_000:
+            timeout = max(stale_base, 450.0)
+        else:
+            timeout = stale_base
+        # Scale by output budget for thinking/reasoning models.
+        if max_output_tokens > 65536:
+            timeout = max(timeout, 600.0)
+        elif max_output_tokens > 32768:
+            timeout = max(timeout, 450.0)
+        return timeout
 
     def _is_openrouter_url(self) -> bool:
         """Return True when the base URL targets OpenRouter."""
@@ -6400,7 +6409,12 @@ class AIAgent:
         # detector kills the connection early so the main retry loop can
         # apply richer recovery (credential rotation, provider fallback).
         _stale_timeout = self._compute_non_stream_stale_timeout(
-            api_kwargs.get("messages", [])
+            api_kwargs.get("messages", []),
+            max_output_tokens=(
+                api_kwargs.get("max_tokens")
+                or api_kwargs.get("max_completion_tokens")
+                or 0
+            ),
         )
 
         _call_start = time.time()
@@ -6754,6 +6768,17 @@ class AIAgent:
                         "Local provider detected (%s) — stream read timeout raised to %.0fs",
                         self.base_url, _stream_read_timeout,
                     )
+                # Thinking/reasoning models can spend minutes in the reasoning
+                # phase without emitting any visible chunk.  Scale the read
+                # timeout by the output budget so large max_tokens values
+                # don't trigger premature httpx ReadTimeout kills.
+                _output_budget = (
+                    api_kwargs.get("max_tokens")
+                    or api_kwargs.get("max_completion_tokens")
+                    or 0
+                )
+                if _output_budget > 32768:
+                    _stream_read_timeout = max(_stream_read_timeout, 180.0)
             stream_kwargs = {
                 **api_kwargs,
                 "stream": True,
@@ -7320,6 +7345,18 @@ class AIAgent:
                 _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
             else:
                 _stream_stale_timeout = _stream_stale_timeout_base
+            # Also scale by output budget: thinking/reasoning models (GLM-5.1,
+            # DeepSeek-R1, etc.) can spend minutes in the reasoning phase
+            # without emitting visible chunks, regardless of input size.
+            _output_budget = (
+                api_kwargs.get("max_tokens")
+                or api_kwargs.get("max_completion_tokens")
+                or 0
+            )
+            if _output_budget > 65536:
+                _stream_stale_timeout = max(_stream_stale_timeout, 420.0)  # 7 min
+            elif _output_budget > 32768:
+                _stream_stale_timeout = max(_stream_stale_timeout, 300.0)  # 5 min
 
         t = threading.Thread(target=_call, daemon=True)
         t.start()

--- a/tests/agent/test_stream_timeout_max_tokens.py
+++ b/tests/agent/test_stream_timeout_max_tokens.py
@@ -1,0 +1,232 @@
+"""Tests for max_tokens-based stream timeout scaling.
+
+Thinking/reasoning models (GLM-5.1, DeepSeek-R1, etc.) can spend minutes
+in the reasoning phase without emitting visible chunks.  When max_tokens
+is large (>32k), both the httpx read timeout and the stream stale timeout
+must be scaled up to avoid premature connection kills.
+
+See: https://github.com/NousResearch/hermes-agent/issues/17913
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from agent.model_metadata import is_local_endpoint
+
+
+class TestStreamReadTimeoutMaxTokensScaling:
+    """Verify that the stream read timeout scales with max_tokens output budget."""
+
+    @staticmethod
+    def _compute_read_timeout(base_url: str, api_kwargs: dict) -> float:
+        """Reproduce the read timeout logic from run_agent.py streaming path."""
+        _provider_timeout_cfg = None  # no per-provider config
+        _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+        if _provider_timeout_cfg is not None:
+            _stream_read_timeout = _provider_timeout_cfg
+        else:
+            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+            if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
+                _stream_read_timeout = _base_timeout
+            # max_tokens scaling
+            _output_budget = (
+                api_kwargs.get("max_tokens")
+                or api_kwargs.get("max_completion_tokens")
+                or 0
+            )
+            if _output_budget > 32768:
+                _stream_read_timeout = max(_stream_read_timeout, 180.0)
+        return _stream_read_timeout
+
+    def test_large_max_tokens_bumps_read_timeout(self):
+        """max_tokens=65536 on remote provider -> read timeout >= 180s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            result = self._compute_read_timeout(
+                "https://api.deepseek.com",
+                {"max_tokens": 65536},
+            )
+            assert result >= 180.0
+
+    def test_large_max_completion_tokens_bumps_read_timeout(self):
+        """max_completion_tokens=65536 on remote provider -> read timeout >= 180s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            result = self._compute_read_timeout(
+                "https://api.openai.com",
+                {"max_completion_tokens": 65536},
+            )
+            assert result >= 180.0
+
+    def test_small_max_tokens_keeps_default(self):
+        """max_tokens=4096 on remote provider -> read timeout stays 120s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            result = self._compute_read_timeout(
+                "https://api.deepseek.com",
+                {"max_tokens": 4096},
+            )
+            assert result == 120.0
+
+    def test_no_max_tokens_keeps_default(self):
+        """No max_tokens on remote provider -> read timeout stays 120s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            result = self._compute_read_timeout(
+                "https://api.deepseek.com",
+                {},
+            )
+            assert result == 120.0
+
+    def test_threshold_boundary_32768(self):
+        """max_tokens=32768 should NOT bump (threshold is >32768)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            result = self._compute_read_timeout(
+                "https://api.deepseek.com",
+                {"max_tokens": 32768},
+            )
+            assert result == 120.0
+
+    def test_threshold_boundary_32769(self):
+        """max_tokens=32769 should bump to 180s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_READ_TIMEOUT", None)
+            result = self._compute_read_timeout(
+                "https://api.deepseek.com",
+                {"max_tokens": 32769},
+            )
+            assert result >= 180.0
+
+
+class TestStreamStaleTimeoutMaxTokensScaling:
+    """Verify that the stream stale timeout scales with max_tokens output budget."""
+
+    @staticmethod
+    def _compute_stale_timeout(api_kwargs: dict, *, is_local: bool = False) -> float:
+        """Reproduce the stale timeout logic from run_agent.py streaming path."""
+        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        base_url = "http://localhost:11434" if is_local else "https://api.deepseek.com"
+
+        if _stream_stale_timeout_base == 180.0 and base_url and is_local_endpoint(base_url):
+            return float("inf")
+
+        _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
+        if _est_tokens > 100_000:
+            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
+        elif _est_tokens > 50_000:
+            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
+        else:
+            _stream_stale_timeout = _stream_stale_timeout_base
+
+        # max_tokens scaling
+        _output_budget = (
+            api_kwargs.get("max_tokens")
+            or api_kwargs.get("max_completion_tokens")
+            or 0
+        )
+        if _output_budget > 65536:
+            _stream_stale_timeout = max(_stream_stale_timeout, 420.0)
+        elif _output_budget > 32768:
+            _stream_stale_timeout = max(_stream_stale_timeout, 300.0)
+
+        return _stream_stale_timeout
+
+    def test_large_max_tokens_bumps_stale_timeout(self):
+        """max_tokens=131072 on remote provider -> stale timeout >= 420s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            result = self._compute_stale_timeout({"max_tokens": 131072})
+            assert result >= 420.0
+
+    def test_medium_max_tokens_bumps_stale_timeout(self):
+        """max_tokens=65536 on remote provider -> stale timeout >= 300s."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            result = self._compute_stale_timeout({"max_tokens": 65536})
+            assert result >= 300.0
+
+    def test_small_max_tokens_keeps_base(self):
+        """max_tokens=4096 on remote provider -> stale timeout stays at base."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            result = self._compute_stale_timeout({"max_tokens": 4096})
+            assert result == 180.0
+
+    def test_max_tokens_scales_with_large_context(self):
+        """Large context + large max_tokens -> takes the higher of the two."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            # Large context (200k tokens) + large max_tokens
+            messages = [{"role": "user", "content": "x" * 800_000}]
+            result = self._compute_stale_timeout({
+                "messages": messages,
+                "max_tokens": 131072,
+            })
+            # Should be at least 420s (from max_tokens scaling)
+            assert result >= 420.0
+
+    def test_max_tokens_on_top_of_context_scaling(self):
+        """max_tokens scaling should be additive with context scaling."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            # Small context but large max_tokens
+            result = self._compute_stale_timeout({"max_tokens": 65537})
+            assert result >= 420.0  # 65537 > 65536 threshold
+
+    def test_threshold_boundary_65536(self):
+        """max_tokens=65536 should hit the 300s tier (not 420s)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            result = self._compute_stale_timeout({"max_tokens": 65536})
+            assert result == 300.0
+
+    def test_threshold_boundary_65537(self):
+        """max_tokens=65537 should hit the 420s tier."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_STREAM_STALE_TIMEOUT", None)
+            result = self._compute_stale_timeout({"max_tokens": 65537})
+            assert result == 420.0
+
+
+class TestNonStreamStaleTimeoutMaxTokensScaling:
+    """Verify that the non-stream stale timeout also scales with max_tokens."""
+
+    def _make_agent_mock(self):
+        """Create a minimal mock of AIAgent for testing _compute_non_stream_stale_timeout."""
+        from run_agent import AIAgent
+        # We can't easily instantiate AIAgent, so we'll test the method directly
+        # by calling it as an unbound method with a mock self
+        mock_self = MagicMock()
+        mock_self._resolved_api_call_stale_timeout_base.return_value = (300.0, True)
+        mock_self._base_url = "https://api.deepseek.com"
+        mock_self.base_url = "https://api.deepseek.com"
+        return mock_self
+
+    def test_large_max_tokens_bumps_non_stream_timeout(self):
+        """max_output_tokens=131072 -> non-stream stale timeout >= 600s."""
+        from run_agent import AIAgent
+        mock_self = self._make_agent_mock()
+        result = AIAgent._compute_non_stream_stale_timeout(
+            mock_self, [], max_output_tokens=131072,
+        )
+        assert result >= 600.0
+
+    def test_medium_max_tokens_bumps_non_stream_timeout(self):
+        """max_output_tokens=65536 -> non-stream stale timeout >= 450s."""
+        from run_agent import AIAgent
+        mock_self = self._make_agent_mock()
+        result = AIAgent._compute_non_stream_stale_timeout(
+            mock_self, [], max_output_tokens=65536,
+        )
+        assert result >= 450.0
+
+    def test_small_max_tokens_no_bump(self):
+        """max_output_tokens=4096 -> non-stream stale timeout stays at base."""
+        from run_agent import AIAgent
+        mock_self = self._make_agent_mock()
+        result = AIAgent._compute_non_stream_stale_timeout(
+            mock_self, [], max_output_tokens=4096,
+        )
+        assert result == 300.0  # base from mock


### PR DESCRIPTION
## What does this PR do?

Thinking/reasoning models (GLM-5.1, DeepSeek-R1, etc.) can spend **minutes** in the reasoning phase without emitting any visible stream chunk. When using custom/remote providers with large `max_tokens` values, two timeouts fire prematurely:

1. **httpx read timeout** (120s default) — kills the socket-level connection during the model's thinking phase
2. **Stream stale timeout** (180s default) — application-level detector that kills the connection when no chunks arrive

Both scale by **input** token count (large contexts get longer timeouts) but ignore the **output** budget entirely. A model with `max_tokens=131072` thinking for 3 minutes on a small context triggers both timeouts.

## Related Issue

Fixes #17913

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: 3 modifications
  - Stream read timeout: bump to ≥180s when `max_tokens > 32768`
  - Stream stale timeout: bump to ≥300s/420s based on output budget tiers
  - Non-stream stale timeout: add `max_output_tokens` parameter with same scaling
- `tests/agent/test_stream_timeout_max_tokens.py`: 16 new tests covering boundary conditions for all three scaling paths

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A