### PR TITLE
fix: preserve skill command cache on scan failure in scan_skill_commands()

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -219,7 +219,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands
-    _skill_commands = {}
+    new_commands: Dict[str, Dict[str, Any]] = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
@@ -264,7 +264,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
-                    _skill_commands[f"/{cmd_name}"] = {
+                    new_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
@@ -273,7 +273,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                 except Exception:
                     continue
     except Exception:
-        pass
+        logger.warning("skill scan failed; preserving previous command cache", exc_info=True)
+    else:
+        _skill_commands = new_commands
     return _skill_commands
 
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -4,7 +4,10 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 import tools.skills_tool as skills_tool_module
+import agent.skill_commands as _sc_mod
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
@@ -583,3 +586,81 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestScanPreservesCacheOnFailure:
+    """scan_skill_commands must keep the previous _skill_commands cache when
+    the scan fails instead of unconditionally clearing it to ``{}``.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/18659
+    """
+
+    def test_outer_exception_preserves_existing_commands(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "cached-skill")
+            first = scan_skill_commands()
+        assert "/cached-skill" in first
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                side_effect=OSError("unreadable"),
+            ),
+        ):
+            second = scan_skill_commands()
+
+        assert "/cached-skill" in second
+        assert second == first
+
+    def test_outer_exception_logs_warning(self, tmp_path, caplog):
+        import logging
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "skill-a")
+            scan_skill_commands()
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                side_effect=OSError("boom"),
+            ),
+            caplog.at_level(logging.WARNING, logger="agent.skill_commands"),
+        ):
+            scan_skill_commands()
+
+        assert any("skill scan failed" in r.message for r in caplog.records)
+
+    def test_empty_scan_replaces_cache(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "old-skill")
+            first = scan_skill_commands()
+        assert "/old-skill" in first
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with patch("tools.skills_tool.SKILLS_DIR", empty_dir):
+            second = scan_skill_commands()
+
+        assert "/old-skill" not in second
+        assert second == {}
+
+    def test_reload_skills_preserves_commands_on_scan_failure(self, tmp_path):
+        from agent.skill_commands import reload_skills
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "survivor")
+            reload_skills()
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                side_effect=OSError("disk error"),
+            ),
+        ):
+            result = reload_skills()
+
+        assert "/survivor" not in result.get("removed", [])
+        assert result["total"] >= 1


### PR DESCRIPTION
## Summary

Fixes #18659

`scan_skill_commands()` unconditionally cleared the module-level `_skill_commands` dict to `{}` **before** entering the `try` block. When scanning failed (e.g. unreadable directory, broken import chain), the exception was silently swallowed by `except Exception: pass`, leaving the global empty — all 90+ skill slash commands were lost with zero user-facing error.

## Changes

**`agent/skill_commands.py`** — `scan_skill_commands()`:
- Build the new command dict in a **local variable** (`new_commands`) instead of writing directly to the global
- Assign to `_skill_commands` **only on success** (via `else` clause on the `try/except`)
- On failure, **log a warning** (`logger.warning("skill scan failed; preserving previous command cache", exc_info=True)`) instead of silently discarding the error

**`tests/agent/test_skill_commands.py`** — `TestScanPreservesCacheOnFailure`:
- `test_outer_exception_preserves_existing_commands` — verifies previously-cached commands survive a failed scan
- `test_outer_exception_logs_warning` — verifies the warning is logged (no more silent failure)
- `test_empty_scan_replaces_cache` — verifies successful empty scans still correctly replace the cache (no false preservation)
- `test_reload_skills_preserves_commands_on_scan_failure` — verifies `reload_skills()` diff does not report skills as "removed" when the scan fails

## Testing

All 45 existing + 4 new tests pass:

```
tests/agent/test_skill_commands.py  (39 tests — 35 existing + 4 new)
tests/agent/test_skill_commands_reload.py  (6 tests)
```

Zero regressions.

## Design rationale

The fix follows the pattern suggested in the issue: build locally, assign on success. This is the same atomicity pattern used by `reload_skills()` (which snapshots `before` state and diffs against it). The `else` clause ensures the global is only touched when the scan completes without raising — if any outer exception occurs, the previous cache is preserved intact.