### PR TITLE
fix(update): expand .pyc cache cleanup to cover ~/.hermes/ user dirs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5145,7 +5145,7 @@ def cmd_uninstall(args):
     run_uninstall(args)
 
 
-def _clear_bytecode_cache(root: Path) -> int:
+def _clear_bytecode_cache(root: Path, extra_skip: set[str] | None = None) -> int:
     """Remove all __pycache__ directories under *root*.
 
     Stale .pyc files can cause ImportError after code updates when Python
@@ -5153,16 +5153,19 @@ def _clear_bytecode_cache(root: Path) -> int:
     (or don't yet exist) in the updated source.  Clearing them forces Python
     to recompile from the .py source on next import.
 
+    *extra_skip* adds directory names to the default skip set so callers can
+    exclude subtrees already cleaned by a previous call (avoids redundant
+    traversal).
+
     Returns the number of directories removed.
     """
     removed = 0
+    skip = {"venv", ".venv", "node_modules", ".git", ".worktrees"}
+    if extra_skip:
+        skip |= extra_skip
     for dirpath, dirnames, _ in os.walk(root):
         # Skip venv / node_modules / .git entirely
-        dirnames[:] = [
-            d
-            for d in dirnames
-            if d not in ("venv", ".venv", "node_modules", ".git", ".worktrees")
-        ]
+        dirnames[:] = [d for d in dirnames if d not in skip]
         if os.path.basename(dirpath) == "__pycache__":
             try:
                 shutil.rmtree(dirpath)
@@ -5648,6 +5651,13 @@ def _update_via_zip(args):
 
     # Clear stale bytecode after ZIP extraction
     removed = _clear_bytecode_cache(PROJECT_ROOT)
+    # Also clear user data dirs outside the hermes-agent source tree.
+    from hermes_constants import get_default_hermes_root as _get_hermes_root
+    _hermes_root = _get_hermes_root()
+    _source_skip: set[str] = set()
+    if _hermes_root.resolve() == PROJECT_ROOT.parent.resolve():
+        _source_skip = {PROJECT_ROOT.name}
+    removed += _clear_bytecode_cache(_hermes_root, extra_skip=_source_skip)
     if removed:
         print(
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
@@ -6949,6 +6959,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # restart when updated source references names that didn't exist in
         # the old bytecode (e.g. get_hermes_home added to hermes_constants).
         removed = _clear_bytecode_cache(PROJECT_ROOT)
+        # Also clear user data dirs (skills, plugins, per-profile dirs) which
+        # accumulate stale .pyc files outside the hermes-agent source tree.
+        # Skips PROJECT_ROOT.name if it's a direct child of hermes_root to
+        # avoid re-traversing what we just cleaned above.
+        from hermes_constants import get_default_hermes_root as _get_hermes_root
+        hermes_root = _get_hermes_root()
+        _source_skip: set[str] = set()
+        if hermes_root.resolve() == PROJECT_ROOT.parent.resolve():
+            _source_skip = {PROJECT_ROOT.name}
+        removed += _clear_bytecode_cache(hermes_root, extra_skip=_source_skip)
         if removed:
             print(
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"

--- a/tests/test_clear_bytecode_cache.py
+++ b/tests/test_clear_bytecode_cache.py
@@ -1,0 +1,92 @@
+"""Tests for _clear_bytecode_cache — stale .pyc cleanup after updates.
+
+Covers the fix for issue #6207: cleanup must reach user data directories
+(skills, plugins, per-profile dirs) under ~/.hermes/, not just the
+hermes-agent source tree (PROJECT_ROOT).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.main import _clear_bytecode_cache
+
+
+def _make_pycache(base: Path, *parts: str) -> Path:
+    """Create a __pycache__ dir (with a dummy .pyc) at base/parts/__pycache__."""
+    d = base.joinpath(*parts, "__pycache__")
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "module.cpython-312.pyc").write_bytes(b"\x00" * 16)
+    return d
+
+
+class TestClearBytecodeCache:
+    def test_cleans_pycache_under_root(self, tmp_path):
+        cache = _make_pycache(tmp_path, "package")
+        count = _clear_bytecode_cache(tmp_path)
+        assert count == 1
+        assert not cache.exists()
+
+    def test_cleans_nested_pycache(self, tmp_path):
+        _make_pycache(tmp_path, "a", "b", "c")
+        _make_pycache(tmp_path, "x")
+        count = _clear_bytecode_cache(tmp_path)
+        assert count == 2
+
+    def test_skips_venv(self, tmp_path):
+        _make_pycache(tmp_path, "venv", "lib")
+        _make_pycache(tmp_path, "src")
+        count = _clear_bytecode_cache(tmp_path)
+        # only src/__pycache__ removed; venv is skipped
+        assert count == 1
+
+    def test_skips_dotworktrees(self, tmp_path):
+        _make_pycache(tmp_path, ".worktrees", "feature")
+        count = _clear_bytecode_cache(tmp_path)
+        assert count == 0
+
+    def test_extra_skip_excludes_named_dir(self, tmp_path):
+        """extra_skip lets callers avoid re-walking already-cleaned subtrees."""
+        _make_pycache(tmp_path, "hermes-agent", "tools")
+        _make_pycache(tmp_path, "skills", "my_skill")
+        count = _clear_bytecode_cache(tmp_path, extra_skip={"hermes-agent"})
+        # skills/__pycache__ removed; hermes-agent/__pycache__ skipped
+        assert count == 1
+        assert not (tmp_path / "skills" / "my_skill" / "__pycache__").exists()
+        assert (tmp_path / "hermes-agent" / "tools" / "__pycache__").exists()
+
+    def test_user_data_dirs_cleaned_by_hermes_root_walk(self, tmp_path):
+        """Simulates the multi-profile scenario from issue #6207.
+
+        hermes_root (~/.hermes) contains:
+          hermes-agent/  — source tree (PROJECT_ROOT)
+          skills/        — default-profile skills
+          plugins/       — user plugins
+          profiles/dev/skills/  — per-profile skills
+
+        The second _clear_bytecode_cache call on hermes_root (with source
+        dir skipped) must reach skills, plugins, and per-profile dirs.
+        """
+        hermes_root = tmp_path / ".hermes"
+        project_root = hermes_root / "hermes-agent"
+
+        # Simulate what the first call (PROJECT_ROOT) already cleaned
+        # (no __pycache__ here — already gone)
+
+        # User data dirs that should be cleaned by the hermes_root call
+        skills_cache = _make_pycache(hermes_root, "skills", "my_skill")
+        plugins_cache = _make_pycache(hermes_root, "plugins", "myplugin")
+        profile_cache = _make_pycache(
+            hermes_root, "profiles", "dev", "skills", "custom_skill"
+        )
+
+        # PROJECT_ROOT is a direct child of hermes_root
+        assert project_root.parent.resolve() == hermes_root.resolve()
+
+        count = _clear_bytecode_cache(
+            hermes_root, extra_skip={project_root.name}
+        )
+        assert count == 3
+        assert not skills_cache.exists()
+        assert not plugins_cache.exists()
+        assert not profile_cache.exists()


### PR DESCRIPTION
## What changed and why

PR #3819 added `_clear_bytecode_cache(PROJECT_ROOT)` to the `hermes update` command, fixing stale `.pyc` crashes in the hermes-agent source tree. However, as reported in #6207 by @mordekai-lab (2026-05-02), **user data directories** outside the source tree — `~/.hermes/skills/`, `~/.hermes/plugins/`, and per-profile `~/.hermes/profiles/<name>/skills/` — accumulate stale bytecode independently and weren't covered by the existing cleanup.

This PR adds a second `_clear_bytecode_cache` call on `get_default_hermes_root()` (`~/.hermes` by default, honoring `HERMES_HOME`) after both update paths (git-pull and ZIP extraction). The hermes-agent source directory is passed via the new `extra_skip` parameter to avoid redundant traversal of the already-cleaned subtree.

**Changes:**
- `_clear_bytecode_cache` gains an optional `extra_skip: set[str] | None` parameter; the default skip set (`venv/.venv/node_modules/.git/.worktrees`) is unchanged
- Both `hermes update` code paths now call `_clear_bytecode_cache(get_default_hermes_root(), extra_skip={PROJECT_ROOT.name})` after cleaning the source tree
- The combined removed-dir count is reported in a single message

## How to test

1. Create a multi-profile setup: `hermes profile create dev`
2. Add a skill with a Python file to `~/.hermes/skills/` and `~/.hermes/profiles/dev/skills/`
3. Import the skill so Python writes `.pyc` to `__pycache__`
4. Run `hermes update` and confirm the output says `✓ Cleared N stale __pycache__ director...` with N > 1
5. Verify `find ~/.hermes -name __pycache__ -type d` returns nothing

Unit tests:
```
pytest tests/test_clear_bytecode_cache.py -v
```

## What platforms tested on

- macOS 14 (Darwin 24.6.0), Python 3.12

Fixes #6207

<!-- autocontrib:worker-id=issue-followup-0e21076a kind=pr-open -->