### PR TITLE
feat(gateway): add full context runtime footer field

### DIFF
--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,7 +1,7 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
+Renders a compact footer showing runtime state (model, context %, context tokens,
+cwd) and appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
@@ -9,7 +9,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, context_pct, cwd]   # context_full also supported
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -52,6 +52,24 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _context_pct(context_tokens: int, context_length: int) -> int:
+    """Return a clamped integer context percentage."""
+    return max(0, min(100, round((context_tokens / context_length) * 100)))
+
+
+def _format_k_tokens(tokens: int) -> str:
+    """Render token counts in compact thousands for footer display."""
+    return f"{round(tokens / 1000)}k"
+
+
+def _context_full(context_tokens: int, context_length: Optional[int]) -> str:
+    """Render compact used/max context, or empty string when unavailable."""
+    if not context_length or context_length <= 0 or context_tokens < 0:
+        return ""
+    pct = _context_pct(context_tokens, context_length)
+    return f"ctx {_format_k_tokens(context_tokens)}/{_format_k_tokens(context_length)} ({pct}%)"
 
 
 def resolve_footer_config(
@@ -110,8 +128,11 @@ def format_runtime_footer(
                 parts.append(m)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
-                pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
+                parts.append(f"{_context_pct(context_tokens, context_length)}%")
+        elif field == "context_full":
+            full = _context_full(context_tokens, context_length)
+            if full:
+                parts.append(full)
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -95,6 +95,39 @@ def test_format_footer_context_pct_clamped_to_100():
     assert out == "100%"
 
 
+def test_format_footer_context_full_shows_used_max_and_percent():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=87_000,
+        context_length=400_000,
+        cwd="",
+        fields=("context_full",),
+    )
+    assert out == "ctx 87k/400k (22%)"
+
+
+def test_format_footer_context_full_skips_missing_context_length():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=87_000,
+        context_length=None,
+        cwd="/tmp/wd",
+        fields=("model", "context_full", "cwd"),
+    )
+    assert out == "gpt-5.4 · /tmp/wd"
+
+
+def test_format_footer_context_full_skips_zero_context_length():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=87_000,
+        context_length=0,
+        cwd="/tmp/wd",
+        fields=("model", "context_full", "cwd"),
+    )
+    assert out == "gpt-5.4 · /tmp/wd"
+
+
 def test_format_footer_context_pct_never_negative():
     out = format_runtime_footer(
         model="m",
@@ -135,6 +168,17 @@ def test_format_footer_custom_field_order():
         fields=("context_pct", "model"),  # swapped + no cwd
     )
     assert out == "50% · gpt-5.4"
+
+
+def test_format_footer_custom_field_order_with_context_full():
+    out = format_runtime_footer(
+        model="openai/gpt-5.5",
+        context_tokens=87_000,
+        context_length=400_000,
+        cwd="/opt/project",
+        fields=("model", "context_full", "cwd"),
+    )
+    assert out == "gpt-5.5 · ctx 87k/400k (22%) · /opt/project"
 
 
 def test_format_footer_unknown_field_silently_ignored():
@@ -229,6 +273,25 @@ def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
     (tmp_path / "proj").mkdir(exist_ok=True)
     assert "gpt-5.4" in out
     assert "25%" in out
+
+
+def test_build_footer_context_full_when_configured():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "context_full", "cwd"],
+                },
+            },
+        },
+        platform_key="telegram",
+        model="openai/gpt-5.5",
+        context_tokens=87_000,
+        context_length=400_000,
+        cwd="/tmp/projects",
+    )
+    assert out == "gpt-5.5 · ctx 87k/400k (22%) · /tmp/projects"
 
 
 def test_build_footer_per_platform_off_suppresses():


### PR DESCRIPTION
## Summary
- Adds a `context_full` runtime footer field for used/max context tokens plus percentage.
- Keeps existing `context_pct` behavior and field ordering intact.
- Adds gateway runtime footer tests for formatting and config-driven rendering.

## Test Plan
- `pytest tests/gateway/test_runtime_footer.py -q`
- `git diff --check`
