### PR TITLE
feat(config): recognize thinking in custom_providers entries

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2532,7 +2532,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "thinking",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2623,6 +2623,13 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    # Pass through DeepSeek/Kimi per-provider thinking mode override.
+    # This allows custom providers targeting DeepSeek to set
+    # thinking: {type: "disabled"} so the model skips reasoning_content.
+    thinking = entry.get("thinking")
+    if isinstance(thinking, dict):
+        normalized["thinking"] = thinking
 
     return normalized
 


### PR DESCRIPTION
## PR 1: 承认 custom_providers 中的 thinking 配置字段

### 🇬🇧 English

**Title**: `feat(config): recognize 'thinking' in custom_providers entries`

**Description**:

#### Why

When users configure a custom provider that targets DeepSeek, they may want to set `thinking: {type: "disabled"}` at the provider level to suppress the model's reasoning_content output. This is especially useful for DeepSeek V4 Flash, which defaults to `thinking: enabled` and consumes extra tokens for reasoning even when the user doesn't need it.

Currently, `_normalize_custom_provider_entry()` in `hermes_cli/config.py` does not include `"thinking"` in its `_KNOWN_KEYS` set. As a result:

1. The `thinking` key is flagged with an `"unknown config keys ignored"` warning
2. The value is silently dropped from the normalized entry — it never reaches the runtime

This is the first and smallest step: let the config system **acknowledge** the field exists and **preserve** its value.

#### What changed

- Added `"thinking"` to the `_KNOWN_KEYS` set in `_normalize_custom_provider_entry()`
- Added a passthrough block at the end of the normalizer:
  ```python
  thinking = entry.get("thinking")
  if isinstance(thinking, dict):
      normalized["thinking"] = thinking
  ```

The normalizer already validates the type — only `dict` values (e.g. `{type: "disabled"}` or `{type: "enabled"}`) are preserved. Invalid types are silently ignored.

#### Scope

- **Zero behavioral change** for existing users. This only prevents a config warning and preserves a field that was previously discarded.
- It does NOT yet make `thinking` affect API calls — that's wired up in PR 2.

#### Testing

Existing config normalizer tests continue to pass. No new test failures introduced — this is a pure additive change.

---

### 🇨🇳 中文

**标题**: `feat(config): 在 custom_providers 条目中识别 thinking 配置字段`

**描述**:

#### 为什么

当用户配置指向 DeepSeek 的自定义 provider 时，可能希望在 provider 级别设置 `thinking: {type: "disabled"}` 来抑制模型的 reasoning_content 输出。这对 DeepSeek V4 Flash 尤其有用——它默认 `thinking: enabled`，即使用户不需要思维链也会消耗额外 token。

目前 `hermes_cli/config.py` 中的 `_normalize_custom_provider_entry()` 在其 `_KNOWN_KEYS` 集合中不包含 `"thinking"`。后果：

1. `thinking` 键被标记为 `"unknown config keys ignored"` 警告
2. 该值从规范化条目中被静默丢弃——永远不会到达运行时

这是第一步也是最小的一步：让配置系统**承认**该字段存在并**保留**其值。

#### 改动内容

- 在 `_normalize_custom_provider_entry()` 的 `_KNOWN_KEYS` 集合中添加 `"thinking"`
- 在规范化函数末尾添加快透传块：
  ```python
  thinking = entry.get("thinking")
  if isinstance(thinking, dict):
      normalized["thinking"] = thinking
  ```

规范化器已进行类型验证——仅 `dict` 值（如 `{type: "disabled"}` 或 `{type: "enabled"}`）被保留。无效类型被静默忽略。

#### 影响范围

- **对现有用户零行为变更**。此改动仅消除一个配置警告，并保留一个之前被丢弃的字段。
- 目前还不会让 `thinking` 影响 API 调用——这将在 PR 2 中连接。

---