### PR TITLE
feat(agent): propagate custom_providers thinking config to DeepSeek API

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -380,13 +380,16 @@ class ChatCompletionsTransport(ProviderTransport):
             options["num_ctx"] = ollama_ctx
             extra_body["options"] = options
 
-        # Ollama/custom think=false
+        # Ollama/custom think=false + DeepSeek thinking=disabled
         if params.get("is_custom_provider", False):
             if reasoning_config and isinstance(reasoning_config, dict):
                 _effort = (reasoning_config.get("effort") or "").strip().lower()
                 _enabled = reasoning_config.get("enabled", True)
                 if _effort == "none" or _enabled is False:
                     extra_body["think"] = False
+                    # DeepSeek V4 uses {type: disabled} instead of Ollama's think: false.
+                    # Sending both is safe — providers ignore unknown extra_body fields.
+                    extra_body["thinking"] = {"type": "disabled"}
 
         if is_qwen:
             extra_body["vl_high_resolution_images"] = True

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2532,7 +2532,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "thinking",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2623,6 +2623,13 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    # Pass through DeepSeek/Kimi per-provider thinking mode override.
+    # This allows custom providers targeting DeepSeek to set
+    # thinking: {type: "disabled"} so the model skips reasoning_content.
+    thinking = entry.get("thinking")
+    if isinstance(thinking, dict):
+        normalized["thinking"] = thinking
 
     return normalized
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1860,6 +1860,7 @@ class AIAgent:
             _custom_providers = _agent_cfg.get("custom_providers")
             if not isinstance(_custom_providers, list):
                 _custom_providers = []
+        self._custom_providers = _custom_providers
 
         # Check custom_providers per-model context_length
         if _config_context_length is None and _custom_providers:
@@ -8398,6 +8399,7 @@ class AIAgent:
             supports_reasoning=self._supports_reasoning_extra_body(),
             github_reasoning_extra=self._github_models_reasoning_extra_body() if _is_gh else None,
             lmstudio_reasoning_options=self._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
+            extra_body_additions=self._get_custom_provider_extra_body(),
             anthropic_max_output=_ant_max,
             provider_name=self.provider,
         )
@@ -8522,6 +8524,49 @@ class AIAgent:
                 requested_effort = supported_efforts[0]
 
         return {"effort": requested_effort}
+
+    def _get_custom_provider_extra_body(self) -> dict | None:
+        """Look up custom_providers per-provider extra_body fields (e.g. DeepSeek thinking).
+
+        Matches the current request against custom_providers entries by URL,
+        provider name, or model name — whichever matches first.  Supports
+        per-model overrides via ``models.<id>.thinking``, falling back to
+        provider-level ``thinking``.
+        """
+        if self.provider != "custom":
+            return None
+        _cps = getattr(self, "_custom_providers", None)
+        if not _cps or not isinstance(_cps, list):
+            return None
+        _target_url = (self.base_url or "").rstrip("/")
+        if not _target_url:
+            return None
+        _model_lower = (self.model or "").lower()
+        for _cp in _cps:
+            if not isinstance(_cp, dict):
+                continue
+            _cp_url = (_cp.get("base_url") or "").rstrip("/")
+            _cp_name = (_cp.get("name") or "").strip().lower()
+            _cp_model = (_cp.get("model") or "").strip().lower()
+            # Match by URL, entry name, or model field.  The three-way OR
+            # is necessary when the agent's base_url differs from the
+            # custom_providers entry (e.g. routing through a local proxy).
+            _url_match = _cp_url == _target_url
+            _name_match = _cp_name and _cp_name == _model_lower
+            _model_match = _cp_model and _cp_model == _model_lower
+            if not (_url_match or _name_match or _model_match):
+                continue
+            # Per-model override first
+            _cp_models = _cp.get("models", {})
+            if isinstance(_cp_models, dict):
+                _mcfg = _cp_models.get(self.model or "", {})
+                if isinstance(_mcfg, dict) and "thinking" in _mcfg:
+                    return {"thinking": _mcfg["thinking"]}
+            # Provider-level fallback
+            if "thinking" in _cp:
+                return {"thinking": _cp["thinking"]}
+            break
+        return None
 
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
         """Build a normalized assistant message dict from an API response message.


### PR DESCRIPTION
## PR 2: 将 custom_providers 的 thinking 配置传递到 DeepSeek API

### 🇬🇧 English

**Title**: `feat(agent): propagate custom_providers thinking config to DeepSeek API`

**Description**:

#### Why

DeepSeek's API uses `thinking: {type: "disabled"}` in the request body to suppress reasoning_content. This is different from Ollama's `think: false` — DeepSeek ignores the `think` field, and Ollama ignores `thinking`.

Currently, even with `reasoning_effort: "none"` configured, Hermes only sends Ollama's `extra_body["think"] = False` for custom providers. DeepSeek receives no `thinking` field and defaults to its built-in behavior — which for V4 Flash is `thinking: enabled`. This means the model still generates hidden reasoning_content that wastes tokens and is invisible to the user.

This PR bridges the gap: it reads `thinking` from the matching `custom_providers` entry and passes it through to the API as `extra_body["thinking"]`.

#### Problem Chain (Before This PR)

The user writes this in `~/.hermes/config.yaml`:

```yaml
custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    api_key: ${DEEPSEEK_API_KEY}
    thinking:
      type: disabled
```

What happens:
1. ✅ `config.py` normalizes `thinking` into the entry (fixed in PR 1)
2. ❌ `run_agent.py` never reads `thinking` from the entry — it only uses `reasoning_config` (which is a different concept)
3. ❌ `_build_api_kwargs()` doesn't pass any `extra_body_additions` to the transport
4. ❌ `chat_completions.py` only sets `extra_body["think"] = False` (Ollama format) — DeepSeek ignores this
5. ❌ The API request contains **no thinking control** → DeepSeek defaults to `thinking: enabled`

Result: `reasoning_content` still appears in the response, wasting tokens.

#### What Changed

**`run_agent.py`** (2 insertions + new method):

1. **Save custom_providers to instance**: `self._custom_providers = _custom_providers`

2. **New method `_get_custom_provider_extra_body()`** (~40 lines):
   - Matches the current request (by `base_url`, `provider name`, or `model name`) against `custom_providers` entries
   - Supports three matching modes (OR logic):
     - **URL match**: current `base_url` equals the entry's `base_url`
     - **Name match**: current `model` matches the entry's `name`
     - **Model match**: current `model` matches the entry's `model` field
   - This three-way matching is necessary because the agent's `base_url` may differ from the custom_providers entry's `base_url` (e.g., when routing through a local proxy like SkillClaw)
   - Supports per-model overrides: `models.<id>.thinking` takes priority over provider-level `thinking`

3. **Wire into `_build_api_kwargs()`**: Passes `extra_body_additions=self._get_custom_provider_extra_body()` to the chat_completions transport

**`agent/transports/chat_completions.py`** (2 lines):

4. **Add DeepSeek `thinking` format**: When reasoning is disabled for a custom provider, now sends BOTH:
   - `extra_body["think"] = False` (Ollama compat)
   - `extra_body["thinking"] = {"type": "disabled"}` (DeepSeek compat)

   This is safe because providers ignore unknown `extra_body` fields.

#### Full Flow (After This PR)

```
config.yaml: thinking: {type: disabled}
  → config.py: _normalize_custom_provider_entry() preserves thinking ✓
  → run_agent.py: self._custom_providers stores entries ✓
  → run_agent.py: _get_custom_provider_extra_body() matches by URL/name/model ✓
  → run_agent.py: _build_api_kwargs() passes extra_body_additions ✓
  → chat_completions.py: extra_body.update() merges {"thinking": {"type": "disabled"}} ✓
  → OpenAI SDK → POST /v1/chat/completions with thinking: {type: disabled} ✓
  → DeepSeek API: no reasoning_content returned ✓
```

#### Configuration Examples

Works with both provider-level and per-model thinking:

```yaml
# Provider-level: all models on this provider have thinking disabled
custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    api_key: ${DEEPSEEK_API_KEY}
    thinking:
      type: disabled

# Per-model: only specific models have thinking disabled
custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    api_key: ${DEEPSEEK_API_KEY}
    models:
      deepseek-v4-flash:
        thinking:
          type: disabled
```

#### Scope & Safety

- **Only triggered when `provider == "custom"`** — does not affect built-in providers
- **Only injects fields when `thinking` is explicitly configured** — no implicit behavior change
- **Sends BOTH `think` and `thinking`** — backward compatible with Ollama, forward compatible with DeepSeek
- **Three-way matching with early break** — deterministic: first matching entry wins

---

### 🇨🇳 中文

**标题**: `feat(agent): 将 custom_providers 的 thinking 配置传递到 DeepSeek API`

**描述**:

#### 为什么

DeepSeek 的 API 使用请求体中的 `thinking: {type: "disabled"}` 来抑制 reasoning_content。这与 Ollama 的 `think: false` 不同——DeepSeek 忽略 `think` 字段，Ollama 忽略 `thinking`。

目前，即使配置了 `reasoning_effort: "none"`，Hermes 对自定义 provider 仅发送 Ollama 的 `extra_body["think"] = False`。DeepSeek 收不到 `thinking` 字段，默认使用其内置行为——对 V4 Flash 而言就是 `thinking: enabled`。这意味着模型仍然生成隐藏的 reasoning_content，浪费 token 且用户看不到。

此 PR 填补了这一缺口：从匹配的 `custom_providers` 条目中读取 `thinking`，并通过 `extra_body["thinking"]` 传递到 API。

#### 问题链（此 PR 之前）

用户在 `~/.hermes/config.yaml` 中写入：

```yaml
custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    api_key: ${DEEPSEEK_API_KEY}
    thinking:
      type: disabled
```

实际发生的是：
1. ✅ `config.py` 将 `thinking` 规范化到条目中（PR 1 修复）
2. ❌ `run_agent.py` 从未从条目中读取 `thinking`——只使用 `reasoning_config`（不同的概念）
3. ❌ `_build_api_kwargs()` 不向传输层传递任何 `extra_body_additions`
4. ❌ `chat_completions.py` 只设置 `extra_body["think"] = False`（Ollama 格式）——DeepSeek 忽略此字段
5. ❌ API 请求中**没有 thinking 控制** → DeepSeek 默认 `thinking: enabled`

结果：reasoning_content 仍然出现在响应中，浪费 token。

#### 改动内容

**`run_agent.py`**（2 处插入 + 新方法）：

1. **保存 custom_providers 到实例**：`self._custom_providers = _custom_providers`

2. **新方法 `_get_custom_provider_extra_body()`**（~40 行）：
   - 将当前请求（通过 `base_url`、`provider name` 或 `model name`）与 `custom_providers` 条目匹配
   - 支持三种匹配模式（OR 逻辑）：
     - **URL 匹配**：当前 `base_url` 等于条目的 `base_url`
     - **名称匹配**：当前 `model` 匹配条目的 `name`
     - **模型匹配**：当前 `model` 匹配条目的 `model` 字段
   - 三路匹配是必要的，因为 agent 的 `base_url` 可能与 custom_providers 条目的 `base_url` 不同（例如通过 SkillClaw 等本地代理路由时）
   - 支持按模型覆盖：`models.<id>.thinking` 优先于 provider 级别的 `thinking`

3. **连接到 `_build_api_kwargs()`**：向 chat_completions 传输层传递 `extra_body_additions=self._get_custom_provider_extra_body()`

**`agent/transports/chat_completions.py`**（2 行）：

4. **添加 DeepSeek `thinking` 格式**：当自定义 provider 的推理被禁用时，现在同时发送：
   - `extra_body["think"] = False`（Ollama 兼容）
   - `extra_body["thinking"] = {"type": "disabled"}`（DeepSeek 兼容）

   这是安全的，因为 provider 会忽略未知的 `extra_body` 字段。

#### 完整链路（此 PR 之后）

```
config.yaml: thinking: {type: disabled}
  → config.py: _normalize_custom_provider_entry() 保留 thinking ✓
  → run_agent.py: self._custom_providers 存储条目 ✓
  → run_agent.py: _get_custom_provider_extra_body() 按 URL/名称/模型匹配 ✓
  → run_agent.py: _build_api_kwargs() 传递 extra_body_additions ✓
  → chat_completions.py: extra_body.update() 合并 {"thinking": {"type": "disabled"}} ✓
  → OpenAI SDK → POST /v1/chat/completions（含 thinking: {type: disabled}）✓
  → DeepSeek API：无 reasoning_content 返回 ✓
```

#### 影响范围与安全性

- **仅在 `provider == "custom"` 时触发**——不影响内置 provider
- **仅当显式配置了 `thinking` 时才注入字段**——无隐式行为变更
- **同时发送 `think` 和 `thinking`**——向后兼容 Ollama，向前兼容 DeepSeek
- **三路匹配含提前 break**——确定性：第一个匹配的条目胜出

---