### PR TITLE
feat(model_switch): use custom_providers entry credentials on exact name match

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -856,6 +856,31 @@ def switch_model(
         except Exception:
             pass
 
+    # --- Custom providers entry override: if raw_input matches a custom_providers
+    #     entry by name, use its base_url/api_key so the request goes direct
+    #     instead of through the inherited proxy (e.g. SkillClaw → MiniMax).
+    #     Only triggers on exact name match, does not affect normal proxy routing.
+    if custom_providers and isinstance(custom_providers, list):
+        _raw_lower = raw_input.strip().lower()
+        for _cp in custom_providers:
+            if not isinstance(_cp, dict):
+                continue
+            _cp_name = (_cp.get("name") or "").strip().lower()
+            if _cp_name and _cp_name == _raw_lower:
+                _cp_base = (_cp.get("base_url") or "").strip()
+                _cp_key = (_cp.get("api_key") or "").strip()
+                if _cp_base:
+                    base_url = _cp_base
+                    api_key = _cp_key or api_key
+                    api_mode = ""  # clear so determine_api_mode re-detects from URL
+                    provider_label = _cp.get("name") or provider_label
+                    logger.info(
+                        "Custom providers entry '%s' matched raw_input, "
+                        "overriding base_url to %s",
+                        _cp_name, _cp_base,
+                    )
+                break
+
     # --- Direct alias override: use exact base_url from the alias if set ---
     if resolved_alias:
         _ensure_direct_aliases()


### PR DESCRIPTION
## PR 3: 模型切换时匹配 custom_providers 的独立凭据

### 🇬🇧 English

**Title**: `feat(model_switch): use custom_providers entry credentials on exact name match`

**Description**:

#### Why

When users configure a `custom_providers` entry with its own `base_url` and `api_key` (separate from the main model config), they expect `/model <name>` to route requests through that entry's endpoint. However, `switch_model()` in `hermes_cli/model_switch.py` does not check `custom_providers` entries when determining credentials in the COMMON PATH (the `else` branch for same-provider switches).

Concrete scenario: A user has their main model routing through a local proxy (e.g., SkillClaw at `http://127.0.0.1:30000/v1`). They configure a `custom_providers` entry for direct DeepSeek access:

```yaml
model:
  base_url: http://127.0.0.1:30000/v1   # main proxy
  provider: custom

custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    api_key: sk-xxx
    thinking:
      type: disabled
```

When the user runs `/model deepseek`:

- **Before this PR**: `base_url` stays `http://127.0.0.1:30000/v1` (the inherited proxy), `api_key` stays the proxy's key. The request goes through the proxy, which may forward to a different model entirely. Even if it reaches DeepSeek, the `thinking` parameter meant for DeepSeek might be rejected by the intermediate proxy.
- **After this PR**: `base_url` becomes `https://api.deepseek.com`, `api_key` becomes `sk-xxx`. The request goes directly to DeepSeek's API, where `thinking: {type: disabled}` is correctly interpreted.

This is a prerequisite for PR 2's `thinking` propagation to work correctly when the user's main route differs from the target provider.

#### What Changed

Inserted a `custom_providers` name-matching block in `switch_model()` between the `except Exception: pass` and the `Direct alias override` section:

```python
if custom_providers and isinstance(custom_providers, list):
    _raw_lower = raw_input.strip().lower()
    for _cp in custom_providers:
        _cp_name = (_cp.get("name") or "").strip().lower()
        if _cp_name and _cp_name == _raw_lower:
            _cp_base = (_cp.get("base_url") or "").strip()
            _cp_key = (_cp.get("api_key") or "").strip()
            if _cp_base:
                base_url = _cp_base
                api_key = _cp_key or api_key
                api_mode = ""  # re-detect from new URL
                provider_label = _cp.get("name") or provider_label
            break
```

Key design decisions:

- **Exact name match only**: The user must type the exact `name` from the `custom_providers` entry. No fuzzy matching — this keeps behavior predictable.
- **Only overrides when `base_url` is set**: If the entry has no `base_url`, the existing credentials are preserved — no accidental breakage.
- **Clears `api_mode`**: Setting `api_mode = ""` forces `determine_api_mode()` to re-detect from the new URL, handling cases where the proxy uses `openai` format but the direct endpoint uses `deepseek` headers.
- **Placed AFTER runtime resolution but BEFORE alias override**: This ordering ensures that explicit alias configuration still takes precedence, but custom_providers entries get a chance to override before the default alias logic.

#### Scope & Safety

- **Only triggers on exact name match** — no effect on normal `/model` usage
- **No credential leakage** — uses only the entry's explicitly configured `api_key`, falls back to existing key if not set
- **Logged at INFO level** — the override is recorded: `"Custom providers entry 'X' matched raw_input, overriding base_url to Y"`

---

### 🇨🇳 中文

**标题**: `feat(model_switch): 精确名称匹配时使用 custom_providers 条目的独立凭据`

**描述**:

#### 为什么

当用户配置了带有独立 `base_url` 和 `api_key` 的 `custom_providers` 条目时，他们期望 `/model <name>` 将通过该条目的端点路由请求。然而，`hermes_cli/model_switch.py` 中的 `switch_model()` 在 COMMON PATH（同一 provider 切换的 `else` 分支）中确定凭据时不会检查 `custom_providers` 条目。

具体场景：用户的主模型通过本地代理路由（如 SkillClaw，地址为 `http://127.0.0.1:30000/v1`）。他们配置了直连 DeepSeek 的 `custom_providers` 条目：

```yaml
model:
  base_url: http://127.0.0.1:30000/v1   # 主代理
  provider: custom

custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    api_key: sk-xxx
    thinking:
      type: disabled
```

当用户运行 `/model deepseek` 时：

- **此 PR 之前**：`base_url` 保持 `http://127.0.0.1:30000/v1`（继承的代理），`api_key` 保持代理的密钥。请求经过代理，可能转发到完全不同的模型。即使到达 DeepSeek，意图给 DeepSeek 的 `thinking` 参数可能被中间代理拒绝。
- **此 PR 之后**：`base_url` 变为 `https://api.deepseek.com`，`api_key` 变为 `sk-xxx`。请求直连 DeepSeek API，`thinking: {type: disabled}` 被正确解释。

这是 PR 2 的 `thinking` 传播在用户主路由与目标 provider 不同时正常工作的前提条件。

#### 改动内容

在 `switch_model()` 的 `except Exception: pass` 和 `Direct alias override` 部分之间插入 `custom_providers` 名称匹配块：

```python
if custom_providers and isinstance(custom_providers, list):
    _raw_lower = raw_input.strip().lower()
    for _cp in custom_providers:
        _cp_name = (_cp.get("name") or "").strip().lower()
        if _cp_name and _cp_name == _raw_lower:
            _cp_base = (_cp.get("base_url") or "").strip()
            _cp_key = (_cp.get("api_key") or "").strip()
            if _cp_base:
                base_url = _cp_base
                api_key = _cp_key or api_key
                api_mode = ""  # 从新 URL 重新检测
                provider_label = _cp.get("name") or provider_label
            break
```

关键设计决策：

- **仅精确名称匹配**：用户必须键入 `custom_providers` 条目的确切 `name`。不做模糊匹配——保持行为可预测。
- **仅当 `base_url` 设置时才覆盖**：如果条目没有 `base_url`，保留现有凭据——避免意外破坏。
- **清除 `api_mode`**：设置 `api_mode = ""` 强制 `determine_api_mode()` 从新 URL 重新检测，处理代理使用 `openai` 格式但直连端点使用 `deepseek` 头部的情况。
- **置于运行时解析之后、别名覆盖之前**：此顺序确保显式别名配置仍然优先，但 custom_providers 条目在默认别名逻辑之前获得覆盖机会。

#### 影响范围与安全性

- **仅在精确名称匹配时触发**——不影响正常的 `/model` 使用
- **无凭据泄露**——仅使用条目中显式配置的 `api_key`，未设置时回退到现有密钥
- **INFO 级别日志记录**——覆盖被记录：`"Custom providers entry 'X' matched raw_input, overriding base_url to Y"`

---