### PR TITLE
feat(achievements): full Chinese (zh-CN) i18n for Achievements plugin

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -15,7 +15,100 @@
 
   const LUCIDE = {"flame":"<path d=\"M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z\" />","avalanche":"<path d=\"m8 3 4 8 5-5 5 15H2L8 3z\" />\n  <path d=\"M4.14 15.08c2.62-1.57 5.24-1.43 7.86.42 2.74 1.94 5.49 2 8.23.19\" />","nodes":"<rect x=\"16\" y=\"16\" width=\"6\" height=\"6\" rx=\"1\" />\n  <rect x=\"2\" y=\"16\" width=\"6\" height=\"6\" rx=\"1\" />\n  <rect x=\"9\" y=\"2\" width=\"6\" height=\"6\" rx=\"1\" />\n  <path d=\"M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3\" />\n  <path d=\"M12 12V8\" />","rocket":"<path d=\"M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z\" />\n  <path d=\"m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z\" />\n  <path d=\"M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0\" />\n  <path d=\"M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5\" />","branch":"<line x1=\"6\" x2=\"6\" y1=\"3\" y2=\"15\" />\n  <circle cx=\"18\" cy=\"6\" r=\"3\" />\n  <circle cx=\"6\" cy=\"18\" r=\"3\" />\n  <path d=\"M18 9a9 9 0 0 1-9 9\" />","daemon":"<path d=\"M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8\" />\n  <path d=\"M21 3v5h-5\" />","clock":"<circle cx=\"12\" cy=\"12\" r=\"10\" />\n  <polyline points=\"12 6 12 12 16 14\" />","warning":"<path d=\"m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3\" />\n  <path d=\"M12 9v4\" />\n  <path d=\"M12 17h.01\" />","wine":"<path d=\"M8 22h8\" />\n  <path d=\"M7 10h10\" />\n  <path d=\"M12 15v7\" />\n  <path d=\"M12 15a5 5 0 0 0 5-5c0-2-.5-4-2-8H9c-1.5 4-2 6-2 8a5 5 0 0 0 5 5Z\" />","scroll":"<path d=\"M15 12h-5\" />\n  <path d=\"M15 8h-5\" />\n  <path d=\"M19 17V5a2 2 0 0 0-2-2H4\" />\n  <path d=\"M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3\" />","plug":"<path d=\"m19 5 3-3\" />\n  <path d=\"m2 22 3-3\" />\n  <path d=\"M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4Z\" />\n  <path d=\"M7.5 13.5 10 11\" />\n  <path d=\"M10.5 16.5 13 14\" />\n  <path d=\"m12 6 6 6 2.3-2.3a2.4 2.4 0 0 0 0-3.4l-2.6-2.6a2.4 2.4 0 0 0-3.4 0Z\" />","lock":"<circle cx=\"12\" cy=\"16\" r=\"1\" />\n  <rect x=\"3\" y=\"10\" width=\"18\" height=\"12\" rx=\"2\" />\n  <path d=\"M7 10V7a5 5 0 0 1 10 0v3\" />","package_skull":"<path d=\"M21 10V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l2-1.14\" />\n  <path d=\"m7.5 4.27 9 5.15\" />\n  <polyline points=\"3.29 7 12 12 20.71 7\" />\n  <line x1=\"12\" x2=\"12\" y1=\"22\" y2=\"12\" />\n  <path d=\"m17 13 5 5m-5 0 5-5\" />","restart":"<path d=\"M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8\" />\n  <path d=\"M21 3v5h-5\" />\n  <path d=\"M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16\" />\n  <path d=\"M8 16H3v5\" />","key":"<path d=\"M2.586 17.414A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814a6.5 6.5 0 1 0-4-4z\" />\n  <circle cx=\"16.5\" cy=\"7.5\" r=\".5\" fill=\"currentColor\" />","colon":"<path d=\"M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1\" />\n  <path d=\"M16 21h1a2 2 0 0 0 2-2v-5c0-1.1.9-2 2-2a2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1\" />","container":"<path d=\"M22 7.7c0-.6-.4-1.2-.8-1.5l-6.3-3.9a1.72 1.72 0 0 0-1.7 0l-10.3 6c-.5.2-.9.8-.9 1.4v6.6c0 .5.4 1.2.8 1.5l6.3 3.9a1.72 1.72 0 0 0 1.7 0l10.3-6c.5-.3.9-1 .9-1.5Z\" />\n  <path d=\"M10 21.9V14L2.1 9.1\" />\n  <path d=\"m10 14 11.9-6.9\" />\n  <path d=\"M14 19.8v-8.1\" />\n  <path d=\"M18 17.5V9.4\" />","melting_clock":"<line x1=\"10\" x2=\"14\" y1=\"2\" y2=\"2\" />\n  <line x1=\"12\" x2=\"15\" y1=\"14\" y2=\"11\" />\n  <circle cx=\"12\" cy=\"14\" r=\"8\" />","pencil":"<path d=\"M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z\" />\n  <path d=\"m15 5 4 4\" />","blueprint":"<path d=\"m12.99 6.74 1.93 3.44\" />\n  <path d=\"M19.136 12a10 10 0 0 1-14.271 0\" />\n  <path d=\"m21 21-2.16-3.84\" />\n  <path d=\"m3 21 8.02-14.26\" />\n  <circle cx=\"12\" cy=\"5\" r=\"2\" />","pixel":"<path d=\"M3 7V5a2 2 0 0 1 2-2h2\" />\n  <path d=\"M17 3h2a2 2 0 0 1 2 2v2\" />\n  <path d=\"M21 17v2a2 2 0 0 1-2 2h-2\" />\n  <path d=\"M7 21H5a2 2 0 0 1-2-2v-2\" />\n  <path d=\"M7 12h10\" />","ship":"<path d=\"M12 10.189V14\" />\n  <path d=\"M12 2v3\" />\n  <path d=\"M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6\" />\n  <path d=\"M19.38 20A11.6 11.6 0 0 0 21 14l-8.188-3.639a2 2 0 0 0-1.624 0L3 14a11.6 11.6 0 0 0 2.81 7.76\" />\n  <path d=\"M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1s1.2 1 2.5 1c2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1\" />","spark_cursor":"<path d=\"M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z\" />\n  <path d=\"M20 3v4\" />\n  <path d=\"M22 5h-4\" />\n  <path d=\"M4 17v2\" />\n  <path d=\"M5 18H3\" />","needle":"<path d=\"M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z\" />","hammer_scroll":"<path d=\"m15 12-8.373 8.373a1 1 0 1 1-3-3L12 9\" />\n  <path d=\"m18 15 4-4\" />\n  <path d=\"m21.5 11.5-1.914-1.914A2 2 0 0 1 19 8.172V7l-2.26-2.26a6 6 0 0 0-4.202-1.756L9 2.96l.92.82A6.18 6.18 0 0 1 12 8.4V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5\" />","anvil":"<path d=\"M7 10H6a4 4 0 0 1-4-4 1 1 0 0 1 1-1h4\" />\n  <path d=\"M7 5a1 1 0 0 1 1-1h13a1 1 0 0 1 1 1 7 7 0 0 1-7 7H8a1 1 0 0 1-1-1z\" />\n  <path d=\"M9 12v5\" />\n  <path d=\"M15 12v5\" />\n  <path d=\"M5 20a3 3 0 0 1 3-3h8a3 3 0 0 1 3 3 1 1 0 0 1-1 1H6a1 1 0 0 1-1-1\" />","crystal":"<path d=\"M6 3h12l4 6-10 13L2 9Z\" />\n  <path d=\"M11 3 8 9l4 13 4-13-3-6\" />\n  <path d=\"M2 9h20\" />","palace":"<line x1=\"3\" x2=\"21\" y1=\"22\" y2=\"22\" />\n  <line x1=\"6\" x2=\"6\" y1=\"18\" y2=\"11\" />\n  <line x1=\"10\" x2=\"10\" y1=\"18\" y2=\"11\" />\n  <line x1=\"14\" x2=\"14\" y1=\"18\" y2=\"11\" />\n  <line x1=\"18\" x2=\"18\" y1=\"18\" y2=\"11\" />\n  <polygon points=\"12 2 20 7 4 7\" />","dragon":"<path d=\"M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z\" />","antenna":"<path d=\"M4.9 16.1C1 12.2 1 5.8 4.9 1.9\" />\n  <path d=\"M7.8 4.7a6.14 6.14 0 0 0-.8 7.5\" />\n  <circle cx=\"12\" cy=\"9\" r=\"2\" />\n  <path d=\"M16.2 4.8c2 2 2.26 5.11.8 7.47\" />\n  <path d=\"M19.1 1.9a9.96 9.96 0 0 1 0 14.1\" />\n  <path d=\"M9.5 18h5\" />\n  <path d=\"m8 22 4-11 4 11\" />","puzzle":"<path d=\"M15.39 4.39a1 1 0 0 0 1.68-.474 2.5 2.5 0 1 1 3.014 3.015 1 1 0 0 0-.474 1.68l1.683 1.682a2.414 2.414 0 0 1 0 3.414L19.61 15.39a1 1 0 0 1-1.68-.474 2.5 2.5 0 1 0-3.014 3.015 1 1 0 0 1 .474 1.68l-1.683 1.682a2.414 2.414 0 0 1-3.414 0L8.61 19.61a1 1 0 0 0-1.68.474 2.5 2.5 0 1 1-3.014-3.015 1 1 0 0 0 .474-1.68l-1.683-1.682a2.414 2.414 0 0 1 0-3.414L4.39 8.61a1 1 0 0 1 1.68.474 2.5 2.5 0 1 0 3.014-3.015 1 1 0 0 1-.474-1.68l1.683-1.682a2.414 2.414 0 0 1 3.414 0z\" />","rewind":"<path d=\"M9 14 4 9l5-5\" />\n  <path d=\"M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11\" />","spiral":"<path d=\"M13 16a3 3 0 0 1 2.24 5\" />\n  <path d=\"M18 12h.01\" />\n  <path d=\"M18 21h-8a4 4 0 0 1-4-4 7 7 0 0 1 7-7h.2L9.6 6.4a1 1 0 1 1 2.8-2.8L15.8 7h.2c3.3 0 6 2.7 6 6v1a2 2 0 0 1-2 2h-1a3 3 0 0 0-3 3\" />\n  <path d=\"M20 8.54V4a2 2 0 1 0-4 0v3\" />\n  <path d=\"M7.612 12.524a3 3 0 1 0-1.6 4.3\" />","quote":"<path d=\"M16 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z\" />\n  <path d=\"M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z\" />","compass":"<path d=\"m16.24 7.76-1.804 5.411a2 2 0 0 1-1.265 1.265L7.76 16.24l1.804-5.411a2 2 0 0 1 1.265-1.265z\" />\n  <circle cx=\"12\" cy=\"12\" r=\"10\" />","browser":"<circle cx=\"12\" cy=\"12\" r=\"10\" />\n  <path d=\"M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20\" />\n  <path d=\"M2 12h20\" />","terminal":"<polyline points=\"4 17 10 11 4 5\" />\n  <line x1=\"12\" x2=\"20\" y1=\"19\" y2=\"19\" />","wand":"<path d=\"m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72\" />\n  <path d=\"m14 7 3 3\" />\n  <path d=\"M5 6v4\" />\n  <path d=\"M19 14v4\" />\n  <path d=\"M10 2v2\" />\n  <path d=\"M7 8H3\" />\n  <path d=\"M21 16h-4\" />\n  <path d=\"M11 3H9\" />","folder":"<path d=\"M10.7 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v4.1\" />\n  <path d=\"m21 21-1.9-1.9\" />\n  <circle cx=\"17\" cy=\"17\" r=\"3\" />","eye":"<path d=\"M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0\" />\n  <circle cx=\"12\" cy=\"12\" r=\"3\" />","wave":"<path d=\"M2 13a2 2 0 0 0 2-2V7a2 2 0 0 1 4 0v13a2 2 0 0 0 4 0V4a2 2 0 0 1 4 0v13a2 2 0 0 0 4 0v-4a2 2 0 0 1 2-2\" />","swap":"<path d=\"m17 2 4 4-4 4\" />\n  <path d=\"M3 11v-1a4 4 0 0 1 4-4h14\" />\n  <path d=\"m7 22-4-4 4-4\" />\n  <path d=\"M21 13v1a4 4 0 0 1-4 4H3\" />","router":"<rect width=\"20\" height=\"8\" x=\"2\" y=\"14\" rx=\"2\" />\n  <path d=\"M6.01 18H6\" />\n  <path d=\"M10.01 18H10\" />\n  <path d=\"M15 10v4\" />\n  <path d=\"M17.84 7.17a4 4 0 0 0-5.66 0\" />\n  <path d=\"M20.66 4.34a8 8 0 0 0-11.31 0\" />","codex":"<path d=\"M10 9.5 8 12l2 2.5\" />\n  <path d=\"m14 9.5 2 2.5-2 2.5\" />\n  <rect width=\"18\" height=\"18\" x=\"3\" y=\"3\" rx=\"2\" />","prism":"<path d=\"M6 3h12l4 6-10 13L2 9Z\" />\n  <path d=\"M11 3 8 9l4 13 4-13-3-6\" />\n  <path d=\"M2 9h20\" />","marathon":"<line x1=\"10\" x2=\"14\" y1=\"2\" y2=\"2\" />\n  <line x1=\"12\" x2=\"15\" y1=\"14\" y2=\"11\" />\n  <circle cx=\"12\" cy=\"14\" r=\"8\" />","calendar":"<path d=\"M8 2v4\" />\n  <path d=\"M16 2v4\" />\n  <rect width=\"18\" height=\"18\" x=\"3\" y=\"4\" rx=\"2\" />\n  <path d=\"M3 10h18\" />\n  <path d=\"M8 14h.01\" />\n  <path d=\"M12 14h.01\" />\n  <path d=\"M16 14h.01\" />\n  <path d=\"M8 18h.01\" />\n  <path d=\"M12 18h.01\" />\n  <path d=\"M16 18h.01\" />","moon":"<path d=\"M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z\" />","cache":"<ellipse cx=\"12\" cy=\"5\" rx=\"9\" ry=\"3\" />\n  <path d=\"M3 5V19A9 3 0 0 0 21 19V5\" />\n  <path d=\"M3 12A9 3 0 0 0 21 12\" />","secret":"<path d=\"M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z\" />\n  <path d=\"M9.1 9a3 3 0 0 1 5.82 1c0 2-3 3-3 3\" />\n  <path d=\"M12 17h.01\" />"};
 
-  const tierClass = function (tier) {
+  // ---------------------------------------------------------------------------
+  // i18n — Chinese translations for UI chrome
+  // ---------------------------------------------------------------------------
+  const useI18n = SDK.useI18n;
+  const I18N = {
+    en: {
+      kicker: "Agentic Gamerscore",
+      title: "Hermes Achievements",
+      scanDesc: "Scanning Hermes session history. First scan can take 5\u201310 seconds on large histories.",
+      buildingProfile: "Building achievement profile\u2026",
+      readingSessions: "Reading sessions, tool calls, model metadata, and unlock state.",
+      rescan: "Rescan",
+      unlocked: "Unlocked",
+      discovered: "Discovered",
+      secrets: "Secrets",
+      secret: "Secret",
+      hidden: "Hidden",
+      complete: "Complete",
+      objective: "Objective",
+      target: "Target",
+      earnedBadges: "earned badges",
+      knownNotEarned: "known, not earned yet",
+      hiddenUntilSignal: "hidden until first signal",
+      highestTier: "Highest tier",
+      latest: "Latest",
+      noneYet: "None yet",
+      runHermesMore: "run Hermes more",
+      tiers: "Tiers",
+      secretAchievements: "Secret achievements",
+      secretDesc: "Secrets hide their exact trigger. Once Hermes sees a related signal, the card becomes Discovered and shows its requirement.",
+      recentUnlocks: "Recent unlocks",
+      noSecretsLeft: "No hidden secrets left in this scan.",
+      secretClue: "Clue: secrets usually start from unusual failure or power-user patterns \u2014 port conflicts, permission walls, missing env vars, YAML mistakes, Docker collisions, rollback/checkpoint use, cache hits, or tiny fixes after lots of red text.",
+      evidence: "Evidence",
+      noEvidence: "No evidence yet",
+      whatCounts: "What counts",
+      howToReveal: "How to reveal",
+      scanStatus: "Scan status",
+      scanStatusDesc: "Hermes is scanning local history once, then cards will appear automatically. Nothing is stuck if this takes a few seconds.",
+      whatIsScanned: "What is scanned",
+      whatIsScannedDesc: "Sessions, tool calls, model metadata, errors, achievements, and local unlock state.",
+      startingScan: "Starting achievement scan\u2026",
+      all: "All",
+      allFilter: "all",
+      unlockedFilter: "unlocked",
+      discoveredFilter: "discovered",
+      secretFilter: "secret",
+    },
+    zh: {
+      kicker: "\u6e38\u620f\u5316\u6210\u5c31\u79ef\u5206",
+      title: "Hermes \u6210\u5c31\u7cfb\u7edf",
+      scanDesc: "\u6b63\u5728\u626b\u63cf Hermes \u4f1a\u8bdd\u5386\u53f2\u8bb0\u5f55\uff0c\u9996\u6b21\u626b\u63cf\u53ef\u80fd\u9700\u8981 5\u201310 \u79d2\u3002",
+      buildingProfile: "\u6b63\u5728\u6784\u5efa\u6210\u5c31\u6863\u6848\u2026",
+      readingSessions: "\u6b63\u5728\u8bfb\u53d6\u4f1a\u8bdd\u3001\u5de5\u5177\u8c03\u7528\u3001\u6a21\u578b\u5143\u6570\u636e\u548c\u89e3\u9501\u72b6\u6001\u3002",
+      rescan: "\u91cd\u65b0\u626b\u63cf",
+      unlocked: "\u5df2\u89e3\u9501",
+      discovered: "\u5df2\u53d1\u73b0",
+      secrets: "\u9690\u85cf\u6210\u5c31",
+      secret: "\u9690\u85cf",
+      hidden: "\u9690\u85cf",
+      complete: "\u5df2\u5b8c\u6210",
+      objective: "\u76ee\u6807",
+      target: "\u76ee\u6807",
+      earnedBadges: "\u5df2\u83b7\u5f97\u5fbd\u7ae0",
+      knownNotEarned: "\u5df2\u77e5\u4f46\u672a\u83b7\u5f97",
+      hiddenUntilSignal: "\u9690\u85cf\uff0c\u76f4\u5230\u89e6\u53d1\u6761\u4ef6",
+      highestTier: "\u6700\u9ad8\u7b49\u7ea7",
+      latest: "\u6700\u8fd1\u83b7\u5f97",
+      noneYet: "\u6682\u65e0",
+      runHermesMore: "\u591a\u4f7f\u7528 Hermes",
+      tiers: "\u7b49\u7ea7",
+      secretAchievements: "\u9690\u85cf\u6210\u5c31",
+      secretDesc: "\u9690\u85cf\u6210\u5c31\u4f1a\u9690\u85cf\u5176\u5177\u4f53\u89e6\u53d1\u6761\u4ef6\u3002\u5f53 Hermes \u68c0\u6d4b\u5230\u76f8\u5173\u4fe1\u53f7\u65f6\uff0c\u5361\u7247\u5c06\u53d8\u4e3a\u5df2\u53d1\u73b0\u72b6\u6001\u5e76\u663e\u793a\u5176\u8981\u6c42\u3002",
+      recentUnlocks: "\u6700\u8fd1\u89e3\u9501",
+      noSecretsLeft: "\u672c\u6b21\u626b\u63cf\u4e2d\u6ca1\u6709\u5269\u4f59\u7684\u9690\u85cf\u6210\u5c31\u3002",
+      secretClue: "\u63d0\u793a\uff1a\u9690\u85cf\u6210\u5c31\u901a\u5e38\u6765\u6e90\u4e8e\u5f02\u5e38\u5931\u8d25\u6216\u9ad8\u7ea7\u7528\u6237\u64cd\u4f5c\u6a21\u5f0f\u2014\u2014\u7aef\u53e3\u51b2\u7a81\u3001\u6743\u9650\u95ee\u9898\u3001\u73af\u5883\u53d8\u91cf\u7f3a\u5931\u3001YAML \u8bed\u6cd5\u9519\u8bef\u3001Docker \u547d\u540d\u51b2\u7a81\u3001\u56de\u6eda/\u68c0\u67e5\u70b9\u4f7f\u7528\u3001\u7f13\u5b58\u547d\u4e2d\uff0c\u6216\u5927\u91cf\u7ea2\u8272\u9519\u8bef\u6587\u672c\u540e\u7684\u5c0f\u4fee\u590d\u3002",
+      evidence: "\u8bc1\u636e",
+      noEvidence: "\u6682\u65e0\u8bc1\u636e",
+      whatCounts: "\u8fbe\u6210\u6761\u4ef6",
+      howToReveal: "\u5982\u4f55\u89e6\u53d1",
+      scanStatus: "\u626b\u63cf\u72b6\u6001",
+      scanStatusDesc: "Hermes \u6b63\u5728\u626b\u63cf\u672c\u5730\u5386\u53f2\u8bb0\u5f55\uff0c\u626b\u63cf\u5b8c\u6210\u540e\u5361\u7247\u5c06\u81ea\u52a8\u51fa\u73b0\u3002\u5982\u679c\u8017\u65f6\u8f83\u957f\uff0c\u8bf7\u8010\u5fc3\u7b49\u5f85\u3002",
+      whatIsScanned: "\u626b\u63cf\u5185\u5bb9",
+      whatIsScannedDesc: "\u4f1a\u8bdd\u3001\u5de5\u5177\u8c03\u7528\u3001\u6a21\u578b\u5143\u6570\u636e\u3001\u9519\u8bef\u4fe1\u606f\u3001\u6210\u5c31\u6570\u636e\u548c\u672c\u5730\u89e3\u9501\u72b6\u6001\u3002",
+      startingScan: "\u6b63\u5728\u542f\u52a8\u6210\u5c31\u626b\u63cf\u2026",
+      all: "\u5168\u90e8",
+      allFilter: "\u5168\u90e8",
+      unlockedFilter: "\u5df2\u89e3\u9501",
+      discoveredFilter: "\u5df2\u53d1\u73b0",
+      secretFilter: "\u9690\u85cf",
+    },
+  };
+
+  function tierClass (tier) {
     return tier ? "ha-tier-" + tier.toLowerCase() : "ha-tier-pending";
   };
 
@@ -77,12 +170,16 @@
   }
 
   function TierLegend() {
+    const { locale } = useI18n();
+    const L = I18N[locale] || I18N.en;
+    const TIER_I18N = {Copper: locale === "zh" ? "\u94dc" : "Copper", Silver: locale === "zh" ? "\u94f6" : "Silver", Gold: locale === "zh" ? "\u91d1" : "Gold", Diamond: locale === "zh" ? "\u94bb\u77f3" : "Diamond", Olympian: locale === "zh" ? "\u5965\u6797\u5339\u65af" : "Olympian"};
     return React.createElement("div", { className: "ha-tier-legend" },
+      React.createElement("strong", null, L.tiers),
       ["Copper", "Silver", "Gold", "Diamond", "Olympian"].map(function (tier, index, arr) {
         return React.createElement(React.Fragment, { key: tier },
           React.createElement("span", { className: "ha-tier-step ha-tier-" + tier.toLowerCase() },
             React.createElement("i", null),
-            tier
+            TIER_I18N[tier] || tier
           ),
           index < arr.length - 1 && React.createElement("span", { className: "ha-tier-arrow" }, "→")
         );
@@ -118,23 +215,25 @@
   }
 
   function LoadingPage() {
+    const { locale } = useI18n();
+    const L = I18N[locale] || I18N.en;
     return React.createElement("div", { className: "ha-page ha-page-loading" },
       React.createElement("section", { className: "ha-hero ha-loading-hero" },
         React.createElement("div", null,
-          React.createElement("div", { className: "ha-kicker" }, "Agentic Gamerscore"),
-          React.createElement("h1", null, "Hermes Achievements"),
-          React.createElement("p", null, "Scanning Hermes session history. First scan can take 5–10 seconds on large histories.")
+          React.createElement("div", { className: "ha-kicker" }, L.kicker),
+          React.createElement("h1", null, L.title),
+          React.createElement("p", null, L.scanDesc)
         ),
         React.createElement("div", { className: "ha-scan-status", role: "status", "aria-live": "polite" },
           React.createElement("span", { className: "ha-scan-pulse", "aria-hidden": "true" }),
           React.createElement("div", null,
-            React.createElement("strong", null, "Building achievement profile…"),
-            React.createElement("p", null, "Reading sessions, tool calls, model metadata, and unlock state.")
+            React.createElement("strong", null, L.buildingProfile),
+            React.createElement("p", null, L.readingSessions)
           )
         )
       ),
       React.createElement("div", { className: "ha-stats" },
-        ["Unlocked", "Discovered", "Secrets", "Highest tier", "Latest"].map(function (label) {
+        [L.unlocked, L.discovered, L.secrets, L.highestTier, L.latest].map(function (label) {
           return React.createElement(C.Card, { key: label, className: "ha-stat ha-skeleton-stat" },
             React.createElement(C.CardContent, { className: "ha-stat-content" },
               React.createElement("div", { className: "ha-stat-label" }, label),
@@ -146,12 +245,12 @@
       ),
       React.createElement("section", { className: "ha-guide ha-loading-guide" },
         React.createElement("div", null,
-          React.createElement("strong", null, "Scan status"),
-          React.createElement("p", null, "Hermes is scanning local history once, then cards will appear automatically. Nothing is stuck if this takes a few seconds.")
+          React.createElement("strong", null, L.scanStatus),
+          React.createElement("p", null, L.scanStatusDesc)
         ),
         React.createElement("div", null,
-          React.createElement("strong", null, "What is scanned"),
-          React.createElement("p", null, "Sessions, tool calls, model metadata, errors, achievements, and local unlock state.")
+          React.createElement("strong", null, L.whatIsScanned),
+          React.createElement("p", null, L.whatIsScannedDesc)
         )
       ),
       React.createElement("section", { className: "ha-grid" }, [0, 1, 2, 3, 4, 5].map(function (i) {
@@ -162,37 +261,44 @@
 
 
   function AchievementCard({ achievement }) {
+    const { locale } = useI18n();
+    const L = I18N[locale] || I18N.en;
     const unlocked = achievement.unlocked;
     const progress = achievement.progress || 0;
     const pct = achievement.progress_pct || (unlocked ? 100 : 0);
     const state = achievement.state || (unlocked ? "unlocked" : "discovered");
-    const stateLabel = state === "unlocked" ? "Unlocked" : (state === "secret" ? "Secret" : "Discovered");
+    const stateLabel = state === "unlocked" ? L.unlocked : (state === "secret" ? L.secret : L.discovered);
+    const TIER_ZH = {Copper: "\u94dc", Silver: "\u94f6", Gold: "\u91d1", Diamond: "\u94bb\u77f3", Olympian: "\u5965\u6797\u5339\u65af"};
+    function tierName(t) { return locale === "zh" ? (TIER_ZH[t] || t) : t; }
     const targetTier = achievement.next_tier || achievement.tier;
-    const tierLabel = achievement.tier ? achievement.tier : (targetTier ? "Target " + targetTier : (state === "secret" ? "Hidden" : (unlocked ? "Complete" : "Objective")));
-    const progressText = state === "secret" ? "hidden" : (progress + (achievement.next_threshold ? " / " + achievement.next_threshold : ""));
+    const tierLabel = achievement.tier ? tierName(achievement.tier) : (targetTier ? L.target + " " + tierName(targetTier) : (state === "secret" ? L.hidden : (unlocked ? L.complete : L.objective)));
+    const progressText = state === "secret" ? L.hidden : (progress + (achievement.next_threshold ? " / " + achievement.next_threshold : ""));
+    const displayName = locale === "zh" ? (achievement.name_zh || achievement.name) : achievement.name;
+    const displayDesc = locale === "zh" ? (achievement.description_zh || achievement.description) : achievement.description;
+    const displayCategory = locale === "zh" ? (achievement.category_zh || achievement.category) : achievement.category;
     return React.createElement(C.Card, { className: cn("ha-card", "ha-state-" + state, tierClass(achievement.tier || achievement.next_tier)) },
       React.createElement(C.CardContent, { className: "ha-card-content" },
         React.createElement("div", { className: "ha-card-head" },
           React.createElement("div", { className: "ha-icon" }, React.createElement(AchievementIcon, { icon: achievement.icon || "secret" })),
           React.createElement("div", { className: "ha-card-title-wrap" },
-            React.createElement("div", { className: "ha-card-title" }, achievement.name),
-            React.createElement("div", { className: "ha-card-category" }, achievement.category)
+            React.createElement("div", { className: "ha-card-title" }, displayName),
+            React.createElement("div", { className: "ha-card-category" }, displayCategory)
           ),
           React.createElement("div", { className: "ha-badges" },
             React.createElement("span", { className: "ha-state-badge" }, stateLabel),
             React.createElement("span", { className: "ha-tier-badge" }, tierLabel)
           )
         ),
-        React.createElement("p", { className: "ha-description" }, achievement.description),
+        React.createElement("p", { className: "ha-description" }, displayDesc),
         achievement.criteria && React.createElement("details", { className: "ha-criteria" },
-          React.createElement("summary", null, state === "secret" ? "How to reveal" : "What counts"),
-          React.createElement("p", null, achievement.criteria)
+          React.createElement("summary", null, state === "secret" ? L.howToReveal : L.whatCounts),
+          React.createElement("p", null, locale === "zh" ? (achievement.criteria_zh || achievement.criteria) : achievement.criteria)
         ),
         React.createElement("div", { className: "ha-evidence-slot" },
           achievement.evidence ? React.createElement("div", { className: "ha-evidence" },
-            React.createElement("span", { className: "ha-evidence-label" }, "Evidence"),
+            React.createElement("span", { className: "ha-evidence-label" }, L.evidence),
             React.createElement("span", { className: "ha-evidence-title" }, achievement.evidence.title || achievement.evidence.session_id || "session")
-          ) : React.createElement("div", { className: "ha-evidence ha-evidence-empty", "aria-hidden": "true" }, "No evidence yet")
+          ) : React.createElement("div", { className: "ha-evidence ha-evidence-empty", "aria-hidden": "true" }, L.noEvidence)
         ),
         React.createElement("div", { className: "ha-progress-row" },
           React.createElement("div", { className: "ha-progress-track" },
@@ -205,10 +311,12 @@
   }
 
   function AchievementsPage() {
+    const { locale } = useI18n();
+    const L = I18N[locale] || I18N.en;
     const [data, setData] = hooks.useState(null);
     const [loading, setLoading] = hooks.useState(true);
     const [error, setError] = hooks.useState(null);
-    const [category, setCategory] = hooks.useState("All");
+    const [category, setCategory] = hooks.useState(L.all);
     const [visibility, setVisibility] = hooks.useState("all");
 
     function load() {
@@ -241,9 +349,10 @@
     }, [scanInFlight]);
 
     const achievements = (data && data.achievements) || [];
-    const categories = ["All"].concat(Array.from(new Set(achievements.map(function (a) { return a.category; }))));
+    const catField = locale === "zh" ? "category_zh" : "category";
+    const categories = [L.all].concat(Array.from(new Set(achievements.map(function (a) { return a[catField] || a.category; }))));
     const visible = achievements.filter(function (a) {
-      if (category !== "All" && a.category !== category) return false;
+      if (category !== L.all && (a[catField] || a.category) !== category) return false;
       if (visibility === "unlocked" && a.state !== "unlocked") return false;
       if (visibility === "discovered" && a.state !== "discovered") return false;
       if (visibility === "secret" && a.state !== "secret") return false;
@@ -253,7 +362,9 @@
     const discovered = achievements.filter(function (a) { return a.state === "discovered"; });
     const secret = achievements.filter(function (a) { return a.state === "secret"; });
     const latest = unlocked.slice().sort(function (a, b) { return (b.unlocked_at || 0) - (a.unlocked_at || 0); }).slice(0, 5);
-    const highest = ["Olympian", "Diamond", "Gold", "Silver", "Copper"].find(function (tier) { return unlocked.some(function (a) { return a.tier === tier; }); }) || "None yet";
+    const TIER_ZH2 = {Copper: "\u94dc", Silver: "\u94f6", Gold: "\u91d1", Diamond: "\u94bb\u77f3", Olympian: "\u5965\u6797\u5339\u65af"};
+    const highestRaw = ["Olympian", "Diamond", "Gold", "Silver", "Copper"].find(function (tier) { return unlocked.some(function (a) { return a.tier === tier; }); });
+    const highest = highestRaw ? (locale === "zh" ? (TIER_ZH2[highestRaw] || highestRaw) : highestRaw) : L.noneYet;
 
     // Build the in-progress scan banner once so the JSX below stays readable.
     // Shows nothing when the scan is idle. When a scan is running it renders
@@ -267,11 +378,11 @@
       const total = Number(meta.sessions_expected_total || 0);
       const pct = total > 0 ? Math.max(0, Math.min(100, Math.floor((scanned / total) * 100))) : 0;
       const headline = scanMode === "pending"
-        ? "Starting achievement scan…"
-        : "Building achievement profile…";
+        ? L.startingScan
+        : L.buildingProfile;
       const detail = total > 0
-        ? ("Scanned " + scanned.toLocaleString() + " of " + total.toLocaleString() + " sessions · " + pct + "%. Badges unlock as more history streams in.")
-        : "Reading sessions, tool calls, model metadata, and unlock state. Badges appear here as they unlock.";
+        ? ("\u5DF2\u626B\u63CF " + scanned.toLocaleString() + " / " + total.toLocaleString() + " \u4E2A\u4F1A\u8BDD \u00B7 " + pct + "%\u3002\u968F\u7740\u5386\u53F2\u8BB0\u5F55\u7684\u52A0\u8F7D\uFF0C\u5FBD\u7AE0\u5C06\u9010\u6B65\u89E3\u9501\u3002")
+        : L.readingSessions + (locale === "zh" ? "\u5FBD\u7AE0\u89E3\u9501\u540E\u5C06\u5728\u6B64\u663E\u793A\u3002" : " Badges appear here as they unlock.");
       scanBanner = React.createElement("section", { className: "ha-scan-banner", role: "status", "aria-live": "polite" },
         React.createElement("div", { className: "ha-scan-banner-head" },
           React.createElement("span", { className: "ha-scan-pulse", "aria-hidden": "true" }),
@@ -293,29 +404,29 @@
     return React.createElement("div", { className: "ha-page" },
       React.createElement("section", { className: "ha-hero" },
         React.createElement("div", null,
-          React.createElement("div", { className: "ha-kicker" }, "Agentic Gamerscore"),
-          React.createElement("h1", null, "Hermes Achievements"),
-          React.createElement("p", null, "Collectible Hermes badges earned from real session history. Known unfinished achievements are shown as Discovered; Secret achievements stay hidden until the first matching behavior appears.")
+          React.createElement("div", { className: "ha-kicker" }, L.kicker),
+          React.createElement("h1", null, L.title),
+          React.createElement("p", null, locale === "zh" ? "\u6765\u81EA\u771F\u5B9E\u4F1A\u8BDD\u5386\u53F2\u7684\u53EF\u6536\u96C6 Hermes \u5FBD\u7AE0\u3002\u5DF2\u77E5\u7684\u672A\u5B8C\u6210\u6210\u5C31\u663E\u793A\u4E3A\u5DF2\u53D1\u73B0\uFF1B\u9690\u85CF\u6210\u5C31\u5728\u7B2C\u4E00\u6B21\u5339\u914D\u884C\u4E3A\u51FA\u73B0\u524D\u4FDD\u6301\u9690\u85CF\u3002" : "Collectible Hermes badges earned from real session history. Known unfinished achievements are shown as Discovered; Secret achievements stay hidden until the first matching behavior appears.")
         ),
-        React.createElement(C.Button, { onClick: load, className: "ha-refresh" }, "Rescan")
+        React.createElement(C.Button, { onClick: load, className: "ha-refresh" }, L.rescan)
       ),
       scanBanner,
       error && React.createElement(C.Card, { className: "ha-error" }, React.createElement(C.CardContent, null, String(error))),
       React.createElement("div", { className: "ha-stats" },
-        React.createElement(StatCard, { label: "Unlocked", value: (data ? data.unlocked_count : 0) + " / " + (data ? data.total_count : 0), hint: "earned badges" }),
-        React.createElement(StatCard, { label: "Discovered", value: discovered.length, hint: "known, not earned yet" }),
-        React.createElement(StatCard, { label: "Secrets", value: secret.length, hint: "hidden until first signal" }),
-        React.createElement(StatCard, { label: "Highest tier", value: highest, hint: "Copper → Silver → Gold → Diamond → Olympian" }),
-        React.createElement(StatCard, { label: "Latest", value: latest[0] ? latest[0].name : "None yet", hint: latest[0] ? latest[0].category : "run Hermes more" })
+        React.createElement(StatCard, { label: L.unlocked, value: (data ? data.unlocked_count : 0) + " / " + (data ? data.total_count : 0), hint: L.earnedBadges }),
+        React.createElement(StatCard, { label: L.discovered, value: discovered.length, hint: L.knownNotEarned }),
+        React.createElement(StatCard, { label: L.secrets, value: secret.length, hint: L.hiddenUntilSignal }),
+        React.createElement(StatCard, { label: L.highestTier, value: highest, hint: (locale === "zh" ? "\u94DC \u2192 \u94F6 \u2192 \u91D1 \u2192 \u94BB\u77F3 \u2192 \u5965\u6797\u5339\u65AF" : "Copper \u2192 Silver \u2192 Gold \u2192 Diamond \u2192 Olympian") }),
+        React.createElement(StatCard, { label: L.latest, value: latest[0] ? (locale === "zh" ? (latest[0].name_zh || latest[0].name) : latest[0].name) : L.noneYet, hint: latest[0] ? (locale === "zh" ? (latest[0].category_zh || latest[0].category) : latest[0].category) : L.runHermesMore })
       ),
       React.createElement("section", { className: "ha-guide" },
         React.createElement("div", null,
-          React.createElement("strong", null, "Tiers"),
+          React.createElement("strong", null, L.tiers),
           React.createElement(TierLegend, null)
         ),
         React.createElement("div", null,
-          React.createElement("strong", null, "Secret achievements"),
-          React.createElement("p", null, "Secrets hide their exact trigger. Once Hermes sees a related signal, the card becomes Discovered and shows its requirement.")
+          React.createElement("strong", null, L.secretAchievements),
+          React.createElement("p", null, L.secretDesc)
         )
       ),
       React.createElement("div", { className: "ha-toolbar" },
@@ -323,22 +434,23 @@
           return React.createElement("button", { key: cat, onClick: function () { setCategory(cat); }, className: cat === category ? "active" : "" }, cat);
         })),
         React.createElement("div", { className: "ha-pills" }, ["all", "unlocked", "discovered", "secret"].map(function (v) {
-          return React.createElement("button", { key: v, onClick: function () { setVisibility(v); }, className: v === visibility ? "active" : "" }, v);
+          const label = v === "all" ? L.allFilter : v === "unlocked" ? L.unlockedFilter : v === "discovered" ? L.discoveredFilter : L.secretFilter;
+          return React.createElement("button", { key: v, onClick: function () { setVisibility(v); }, className: v === visibility ? "active" : "" }, label);
         }))
       ),
       latest.length > 0 && React.createElement("section", { className: "ha-latest" },
-        React.createElement("h2", null, "Recent unlocks"),
+        React.createElement("h2", null, L.recentUnlocks),
         React.createElement("div", { className: "ha-latest-row" }, latest.map(function (a) {
           return React.createElement("div", { key: a.id, className: cn("ha-chip", tierClass(a.tier)) },
             React.createElement("span", { className: "ha-chip-icon" }, React.createElement(AchievementIcon, { icon: a.icon || "secret" })),
-            a.name
+            locale === "zh" ? (a.name_zh || a.name) : a.name
           );
         }))
       ),
       visibility === "secret" && visible.length === 0 && React.createElement(C.Card, { className: "ha-secret-empty" },
         React.createElement(C.CardContent, { className: "ha-secret-empty-content" },
-          React.createElement("strong", null, "No hidden secrets left in this scan."),
-          React.createElement("p", null, "Clue: secrets usually start from unusual failure or power-user patterns — port conflicts, permission walls, missing env vars, YAML mistakes, Docker collisions, rollback/checkpoint use, cache hits, or tiny fixes after lots of red text.")
+          React.createElement("strong", null, L.noSecretsLeft),
+          React.createElement("p", null, L.secretClue)
         )
       ),
       React.createElement("section", { className: "ha-grid" }, visible.map(function (a) {

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -146,6 +146,97 @@ def state_path() -> Path:
     return get_hermes_home() / "plugins" / "hermes-achievements" / "state.json"
 
 
+# ---------------------------------------------------------------------------
+# Chinese (zh) translations for achievement names, descriptions, and categories.
+# The frontend reads *_zh fields when the dashboard locale is set to "zh".
+# ---------------------------------------------------------------------------
+
+CATEGORY_ZH: Dict[str, str] = {
+    "Agent Autonomy": "智能体自主",
+    "Debugging Chaos": "调试混沌",
+    "Vibe Coding": "氛围编程",
+    "Hermes Native": "Hermes 原生",
+    "Research/Web": "研究/网络",
+    "Tool Mastery": "工具精通",
+    "Model Lore": "模型传说",
+    "Lifestyle": "生活方式",
+}
+
+ACHIEVEMENT_ZH: Dict[str, Dict[str, str]] = {
+    # Agent Autonomy
+    "let_him_cook": {"name": "放手去做", "description": "让 Hermes 在单次会话中运行一整套严肃的自主工具链。"},
+    "autonomous_avalanche": {"name": "自主雪崩", "description": "跨会话累积海量 Hermes 工具调用。"},
+    "toolchain_maxxer": {"name": "工具链达人", "description": "在单次会话中使用大量不同的 Hermes 工具。"},
+    "full_send": {"name": "全力输出", "description": "终端、文件和网页/浏览器在同一轮任务中全部上阵。"},
+    "subagent_commander": {"name": "子任务指挥官", "description": "协调委派给子智能体的工作。"},
+    "background_process_enjoyer": {"name": "后台进程爱好者", "description": "启动或控制足够多的长时间运行进程。"},
+    "cron_necromancer": {"name": "定时任务亡灵法师", "description": "唤醒足够多的定时自动任务。"},
+    # Debugging Chaos
+    "red_text_connoisseur": {"name": "红色文本鉴赏家", "description": "遇到足够多的错误，培养出对红色文本的品味。"},
+    "stack_trace_sommelier": {"name": "堆栈追踪侍酒师", "description": "不是小口品尝异常，而是一杯杯地品味堆栈追踪。"},
+    "actually_read_the_logs": {"name": "居然去读日志了", "description": "反复检查日志而不是靠猜测。"},
+    "port_3000_taken": {"name": "3000 端口被占了", "description": "发现开发服务器端口冲突的次数多到麻木。"},
+    "permission_denied_any_percent": {"name": "权限拒绝速通", "description": "速通撞上权限墙。"},
+    "dependency_hell_tourist": {"name": "依赖地狱游客", "description": "包安装失败了，然后生活还得继续。"},
+    "the_fix_was_restarting": {"name": "修好了，靠重启", "description": "在足够多的错误聚集后重启，把它变成一种技巧。"},
+    "forgot_the_env_var": {"name": "忘了设环境变量", "description": "因为缺少环境变量导致认证或配置失败。"},
+    "yaml_colon_incident": {"name": "YAML 冒号事件", "description": "配置语法反咬一口。"},
+    "docker_name_collision": {"name": "Docker 命名冲突", "description": "容器名已存在。当然了。"},
+    # Vibe Coding
+    "supposed_to_be_quick": {"name": "说好的很快搞定", "description": "一个小需求变成了一整场远征。"},
+    "one_more_small_change": {"name": "再改一个小地方", "description": "在单次会话中做了足够多的文件编辑，让'小改动'这个词失去意义。"},
+    "vibe_architect": {"name": "氛围架构师", "description": "在一次项目会话中触及足够广的代码范围。"},
+    "pixel_goblin": {"name": "像素小妖精", "description": "持续进行前端、CSS、SVG 或视觉微调。"},
+    "ship_first_ask_later": {"name": "先发布，后提问", "description": "在一轮严肃的工具链操作后有 Git 活动。"},
+    "css_exorcist": {"name": "CSS 驱魔师", "description": "反复从界面中驱除样式恶魔。"},
+    "one_character_fix": {"name": "一个字符的修复", "description": "在一堆错误之后做了一个微小的编辑。痛苦。优美。"},
+    # Hermes Native
+    "skillsmith": {"name": "技能铁匠", "description": "与 Hermes 技能打交道多到留下指纹。"},
+    "skill_issue_skill_created": {"name": "技能不足？技能创建。", "description": "创建或修补持久化流程，而不是重复自己。"},
+    "memory_keeper": {"name": "记忆守护者", "description": "用 memory 或 Mnemosyne 持久化知识。"},
+    "memory_palace": {"name": "记忆宫殿", "description": "建立一条严肃的持久记忆链。"},
+    "context_dragon": {"name": "上下文巨龙", "description": "反复接触上下文压缩、巨大上下文或 token 压力。"},
+    "gateway_dweller": {"name": "网关居民", "description": "经历足够多的网关连接的 Hermes 工作流。"},
+    "plugin_goblin": {"name": "插件小精灵", "description": "使用或开发插件多到被仪表盘注意到。"},
+    "rollback_wizard": {"name": "回滚巫师", "description": "施展回滚/检查点恢复魔法。"},
+    "toolset_cartographer": {"name": "工具集制图师", "description": "有目的地导航 Hermes 工具集，而不是把工具当一团模糊的东西。"},
+    "config_surgeon": {"name": "配置外科医生", "description": "对真实的配置文件、清单、环境文件和仪表盘设置动手术，毫不退缩。"},
+    # Research/Web
+    "rabbit_hole_certified": {"name": "兔子洞认证", "description": "搜索或提取足够多的网页内容，有资格称为一次研究漩涡。"},
+    "citation_goblin": {"name": "引用小精灵", "description": "提取足够多的网页，成为一个小图书管理员。"},
+    "docs_archaeologist": {"name": "文档考古学家", "description": "反复挖掘文档源。"},
+    "browser_possession": {"name": "浏览器附身", "description": "通过自动化反复操控浏览器。"},
+    # Tool Mastery
+    "terminal_goblin": {"name": "终端小妖精", "description": "在 Shell 世界中投入大量时间。"},
+    "patch_wizard": {"name": "补丁巫师", "description": "用精准的补丁让文件服从你的意志。"},
+    "file_archaeologist": {"name": "文件考古学家", "description": "通过读取和搜索反复挖掘文件系统。"},
+    "image_whisperer": {"name": "图像低语者", "description": "使用图像生成或视觉工具进行足够多的视觉工作。"},
+    "voice_of_the_machine": {"name": "机器之声", "description": "反复使用文字转语音或语音工具。"},
+    "test_suite_tamer": {"name": "测试套件驯服者", "description": "运行足够多的验证命令，让绿色文本成为仪式的一部分。"},
+    "screenshot_hunter": {"name": "截图猎人", "description": "捕获、检查和打磨视觉证据，而不是只说'能用'。"},
+    # Model Lore
+    "model_hopper": {"name": "模型跳跃者", "description": "切换或检查 provider/模型的次数多到成为习惯。"},
+    "openrouter_enjoyer": {"name": "OpenRouter 爱好者", "description": "反复通过 OpenRouter 路由模型工作。"},
+    "codex_conjurer": {"name": "Codex 召唤师", "description": "召唤 Codex 风格的辅助多到像在做仪式。"},
+    "multi_model_mage": {"name": "多模型法师", "description": "在 Hermes 历史中使用过大量不同的模型名称。"},
+    "five_model_flight": {"name": "五模型飞行", "description": "尝试至少五个不同的 LLM，而不是跟第一个回复的模型结婚。"},
+    "provider_polyglot": {"name": "Provider 多语者", "description": "在 Hermes 历史中使用过多个 provider 的模型。"},
+    "model_sommelier": {"name": "模型侍酒师", "description": "品尝足够多的模型/provider 对话，培养出偏好。"},
+    "claude_confidant": {"name": "Claude 知己", "description": "反复将 Claude 风格的推理引入工作流。"},
+    "gemini_cartographer": {"name": "Gemini 制图师", "description": "绘制足够多的 Gemini 相关工作流，了解这片地形。"},
+    "open_weights_pilgrim": {"name": "开放权重朝圣者", "description": "通过 Hermes 会话元数据与本地/开放权重模型交谈。"},
+    "rebase_acrobat": {"name": "变基杂技演员", "description": "处理真实的 Git 历史手术：变基、冲突、合并、拉取、推送。"},
+    # Lifestyle
+    "marathon_operator": {"name": "马拉松操作员", "description": "累积大量 Hermes 会话。"},
+    "weekend_warrior": {"name": "周末战士", "description": "在周末运行 Hermes 的次数多到成为一种生活方式。"},
+    "night_shift_operator": {"name": "夜班操作员", "description": "在深夜时段反复运行会话。"},
+    "cache_hit_appreciator": {"name": "缓存命中鉴赏家", "description": "注意到或受益于 prompt/缓存行为。"},
+}
+
+# Secret achievement reveal text (zh)
+SECRET_REVEAL_ZH = "隐藏成就：在 Hermes 检测到你会话历史中的第一个相关行为之前保持隐藏。"
+
+
 def snapshot_path() -> Path:
     return get_hermes_home() / "plugins" / "hermes-achievements" / "scan_snapshot.json"
 
@@ -527,8 +618,104 @@ METRIC_LABELS = {
 }
 
 
+METRIC_LABELS_ZH = {
+    "agent_full_loop_events": "\u81ea\u4e3b\u5faa\u73af\u4e8b\u4ef6",
+    "agent_full_loop_sessions": "\u81ea\u4e3b\u5faa\u73af\u4f1a\u8bdd",
+    "tool_call_events": "\u5de5\u5177\u8c03\u7528\u4e8b\u4ef6",
+    "terminal_events": "\u7ec8\u7aef\u4e8b\u4ef6",
+    "debugging_events": "\u8c03\u8bd5\u4e8b\u4ef6",
+    "planning_events": "\u89c4\u5212\u4e8b\u4ef6",
+    "bug_hunt_events": "\u6355\u86ce\u4e8b\u4ef6",
+    "tiny_patch_after_errors_events": "\u9519\u8bef\u540e\u7684\u5c0f\u4fee\u590d",
+    "skill_events": "\u6280\u80fd/\u5de5\u5177\u4f7f\u7528",
+    "skill_manage_events": "\u6280\u80fd\u7ba1\u7406\u64cd\u4f5c",
+    "memory_events": "\u8bb0\u5fc6/\u5de5\u5177\u4e8b\u4ef6",
+    "memory_write_events": "\u6301\u4e45\u8bb0\u5fc6\u5199\u5165",
+    "context_events": "\u4e0a\u4e0b\u6587/\u7f13\u5b58\u4e8b\u4ef6",
+    "gateway_events": "\u7f51\u5173/API \u6d3b\u52a8",
+    "plugin_events": "\u63d2\u4ef6\u5f00\u53d1/\u4f7f\u7528",
+    "rollback_events": "\u56de\u6eda/\u68c0\u67e5\u70b9\u6062\u590d",
+    "docs_activity_events": "\u6587\u6863\u6d3b\u52a8",
+    "model_events": "\u6a21\u578b/\u63d0\u4f9b\u5546\u6d3b\u52a8",
+    "openrouter_events": "OpenRouter \u6d3b\u52a8",
+    "codex_events": "Codex \u6d3b\u52a8",
+    "cache_events": "\u7f13\u5b58\u547d\u4e2d",
+    "total_web_calls": "\u7f51\u7edc\u8c03\u7528\u603b\u6570",
+    "total_web_extract_calls": "web_extract \u8c03\u7528\u603b\u6570",
+    "browser_calls": "\u6d4f\u89c8\u5668\u81ea\u52a8\u5316\u8c03\u7528",
+    "total_tool_calls": "\u5de5\u5177\u8c03\u7528\u603b\u6570",
+    "total_terminal_calls": "\u7ec8\u7aef\u8c03\u7528\u603b\u6570",
+    "total_patch_calls": "\u8865\u4e01\u7f16\u8f91\u603b\u6570",
+    "total_file_reads_searches": "\u6587\u4ef6\u8bfb\u53d6/\u641c\u7d22\u603b\u6570",
+    "image_vision_calls": "\u56fe\u50cf/\u89c6\u89c9\u5de5\u5177\u8c03\u7528",
+    "tts_calls": "\u8bed\u97f3\u5408\u6210\u8c03\u7528",
+    "distinct_model_count": "\u4f7f\u7528\u8fc7\u7684\u4e0d\u540c\u6a21\u578b\u6570",
+    "distinct_provider_count": "\u4f7f\u7528\u8fc7\u7684\u4e0d\u540c\u63d0\u4f9b\u5546\u6570",
+    "claude_events": "Claude/Anthropic \u6d3b\u52a8",
+    "gemini_events": "Gemini/Google \u6d3b\u52a8",
+    "local_model_events": "\u672c\u5730/\u5f00\u6e90\u6a21\u578b\u6d3b\u52a8",
+    "local_model_chat_sessions": "\u672c\u5730\u6a21\u578b\u4f1a\u8bdd\u6570",
+    "toolset_events": "\u5de5\u5177\u96c6\u6d3b\u52a8",
+    "config_events": "\u914d\u7f6e\u6d3b\u52a8",
+    "git_history_events": "git \u5386\u53f2\u64cd\u4f5c",
+    "test_events": "\u6d4b\u8bd5/\u9a8c\u8bc1\u6d3b\u52a8",
+    "screenshot_events": "\u622a\u56fe/\u89c6\u89c9\u68c0\u67e5",
+    "release_events": "\u53d1\u5e03/\u7248\u672c\u6d3b\u52a8",
+    "session_count": "Hermes \u4f1a\u8bdd\u6570",
+    "weekend_sessions": "\u5468\u672b\u4f1a\u8bdd",
+    "night_sessions": "\u6df1\u591c\u4f1a\u8bdd",
+    "css_activity_events": "CSS/\u6837\u5f0f/Tailwind \u6d3b\u52a8",
+    "docker_conflict_events": "Docker/\u5bb9\u5668\u540d\u51b2\u7a81",
+    "env_var_error_events": "\u73af\u5883\u53d8\u91cf/\u8ba4\u8bc1\u914d\u7f6e\u7f3a\u5931",
+    "frontend_activity_events": "\u524d\u7aef/CSS/SVG/React \u6d3b\u52a8",
+    "git_events": "git \u5de5\u4f5c\u6d41\u547d\u4ee4",
+    "install_error_events": "\u5305\u5b89\u88c5\u5931\u8d25",
+    "install_success_events": "\u5305\u5b89\u88c5\u6210\u529f",
+    "log_read_events": "\u65e5\u5fd7\u67e5\u770b",
+    "max_distinct_tools_in_session": "\u5355\u6b21\u4f1a\u8bdd\u4f7f\u7528\u7684\u4e0d\u540c\u5de5\u5177\u6570",
+    "max_file_tool_calls_in_session": "\u5355\u6b21\u4f1a\u8bdd\u6587\u4ef6/\u641c\u7d22/\u8865\u4e01\u8c03\u7528\u6570",
+    "max_files_touched_in_session": "\u5355\u6b21\u4f1a\u8bdd\u64cd\u4f5c\u7684\u6587\u4ef6\u6570",
+    "max_messages_in_session": "\u5355\u6b21\u4f1a\u8bdd\u6d88\u606f\u6570",
+    "max_terminal_calls_in_session": "\u5355\u6b21\u4f1a\u8bdd\u7ec8\u7aef\u8c03\u7528\u6570",
+    "max_tool_calls_in_session": "\u5355\u6b21\u4f1a\u8bdd\u5de5\u5177\u8c03\u7528\u6570",
+    "max_web_browser_calls_in_session": "\u5355\u6b21\u4f1a\u8bdd\u7f51\u7edc/\u6d4f\u89c8\u5668\u8c03\u7528\u6570",
+    "permission_denied_events": "\u6743\u9650\u62d2\u7edd\u9519\u8bef",
+    "port_conflict_events": "\u7aef\u53e3\u51b2\u7a81",
+    "restart_after_error_events": "\u9519\u8bef\u540e\u91cd\u542f/\u91cd\u8f7d",
+    "total_cron_calls": "\u5b9a\u65f6\u4efb\u52a1\u64cd\u4f5c\u603b\u6570",
+    "total_delegate_calls": "delegate_task \u8c03\u7528\u603b\u6570",
+    "total_errors": "\u9519\u8bef/\u5931\u8d25\u6d88\u606f\u603b\u6570",
+    "total_process_calls": "\u540e\u53f0\u8fdb\u7a0b\u64cd\u4f5c\u603b\u6570",
+    "traceback_events": "\u5f02\u5e38/\u5806\u6808\u8ddf\u8e2a",
+    "yaml_error_events": "YAML/\u914d\u7f6e\u89e3\u6790\u9519\u8bef",
+}
+
+TIER_NAME_ZH = {"Copper": "\u94dc", "Silver": "\u94f6", "Gold": "\u91d1", "Diamond": "\u94bb\u77f3", "Olympian": "\u5965\u6797\u5339\u65af"}
+
+
 def metric_label(metric: str) -> str:
     return METRIC_LABELS.get(metric, metric.replace("_", " "))
+
+
+def metric_label_zh(metric: str) -> str:
+    return METRIC_LABELS_ZH.get(metric, METRIC_LABELS.get(metric, metric.replace("_", " ")))
+
+
+def criteria_zh_for(definition: Dict[str, Any]) -> str:
+    if definition.get("secret") and definition.get("state") == "secret":
+        return "\u9690\u85cf\uff1a\u5177\u4f53\u89e6\u53d1\u6761\u4ef6\u5c06\u5728 Hermes \u68c0\u6d4b\u5230\u7b2c\u4e00\u4e2a\u5339\u914d\u4fe1\u53f7\u540e\u663e\u793a\u3002\u7ee7\u7eed\u4f7f\u7528 Hermes \u8fdb\u884c\u8c03\u8bd5\u3001\u5de5\u5177\u8c03\u7528\u3001\u8bb0\u5fc6\u3001\u6280\u80fd\u3001\u63d2\u4ef6\u548c\u6a21\u578b\u5de5\u4f5c\u6d41\u4ee5\u89e3\u9501\u3002"
+    if "threshold_metric" in definition:
+        tiers_list = sorted(definition.get("tiers", []), key=lambda t: t["threshold"])
+        if not tiers_list:
+            return "\u8981\u6c42\uff1a\u5728\u5339\u914d\u7684\u5de5\u4f5c\u6d41\u4e2d\u4f7f\u7528 Hermes\u3002"
+        metric = metric_label_zh(definition["threshold_metric"])
+        ladder = ", ".join(f"{TIER_NAME_ZH.get(t['name'], t['name'])} {t['threshold']}" for t in tiers_list)
+        return f"\u8981\u6c42\uff1a{metric}\u3002\u7b49\u7ea7\u9636\u68af\uff1a{ladder}\u3002"
+    requirements = definition.get("requirements") or []
+    if requirements:
+        parts = [f"{metric_label_zh(r['metric'])} \u2265 {int(r.get('gte', 1))}" for r in requirements]
+        return "\u8981\u6c42\uff1a" + "\uff1b".join(parts) + "\u3002"
+    return "\u8981\u6c42\uff1a\u5b8c\u6210\u5339\u914d\u7684 Hermes \u884c\u4e3a\u3002"
 
 
 def criteria_for(definition: Dict[str, Any]) -> str:
@@ -551,9 +738,16 @@ def criteria_for(definition: Dict[str, Any]) -> str:
 
 def display_achievement(item: Dict[str, Any]) -> Dict[str, Any]:
     clean = dict(item)
+    aid = clean.get("id", "")
+    zh = ACHIEVEMENT_ZH.get(aid, {})
+    cat_zh = CATEGORY_ZH.get(clean.get("category", ""), clean.get("category", ""))
     if clean.get("state") == "secret":
-        return {**clean, "name": "???", "description": "Secret achievement: hidden until Hermes detects the first relevant behavior in your session history.", "criteria": criteria_for(clean), "icon": "secret"}
+        return {**clean, "name": "???", "description": "Secret achievement: hidden until Hermes detects the first relevant behavior in your session history.", "criteria": criteria_for(clean), "criteria_zh": criteria_zh_for(clean), "icon": "secret", "name_zh": "???", "description_zh": SECRET_REVEAL_ZH, "category_zh": cat_zh}
     clean["criteria"] = criteria_for(clean)
+    clean["criteria_zh"] = criteria_zh_for(clean)
+    clean["name_zh"] = zh.get("name", clean.get("name", ""))
+    clean["description_zh"] = zh.get("description", clean.get("description", ""))
+    clean["category_zh"] = cat_zh
     return clean
 
 


### PR DESCRIPTION
## What

Adds complete Chinese (zh-CN) localization to the Achievements plugin — both backend API and frontend UI.

## Backend changes (plugin_api.py)

- **ACHIEVEMENT_ZH**: Chinese names + descriptions for all 60 achievements
- **CATEGORY_ZH**: Chinese translations for 8 achievement categories
- **METRIC_LABELS_ZH**: Chinese labels for all 60 metric keys used in criteria
- **TIER_NAME_ZH**: tier names (铜/银/金/钻石/奥林匹斯)
- **criteria_zh_for()**: generates Chinese criteria text with translated metric labels and tier names
- display_achievement() now returns name_zh, description_zh, category_zh, criteria_zh fields

## Frontend changes (dist/index.js)

- **I18N dict**: 50+ Chinese UI string translations (kicker, title, stats, filters, scan status, etc.)
- **AchievementCard**: uses _zh fields when locale is zh
- **TierLegend**: tier names translated via TIER_I18N
- **Tier badge** in cards: uses translated tier names
- **Highest tier stat**: displays Chinese tier name
- **Filter buttons**: 全部/已解锁/已发现/隐藏
- **Category pills**: uses category_zh when locale is zh
- **Scan banner**: inline Chinese text for progress display
- **Criteria section**: shows criteria_zh when locale is zh

## How it works

- Uses the dashboard built-in SDK.useI18n() hook to detect locale
- Falls back to English gracefully if locale is not zh
- Backend returns both English and Chinese fields; frontend picks based on locale
- No breaking changes to English users

## Testing

- Verified API returns all 4 _zh fields for all 60 achievements
- Verified criteria_zh contains Chinese text with translated metric labels
- Dashboard tested in Chinese locale: stats, filters, cards, tiers all display Chinese