### PR TITLE
fix(cli, gateway): migrate /goal across all session_id rebind sites

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9685,6 +9685,12 @@ class HermesCLI:
                     getattr(self.agent, "session_id", None)
                     and self.agent.session_id != self.session_id
                 ):
+                    # Carry any in-flight /goal across the rebind. SessionDB
+                    # stores goals under goal:<sid>; without this the judge
+                    # loop silently dies under the orphaned parent (#18467).
+                    from hermes_cli.goals import migrate_goal
+
+                    migrate_goal(self.session_id, self.agent.session_id)
                     self.session_id = self.agent.session_id
                     self._pending_title = None
                     # Manual /compress replaces conversation_history with a new
@@ -11759,6 +11765,12 @@ class HermesCLI:
                 and getattr(self.agent, "session_id", None)
                 and self.agent.session_id != self.session_id
             ):
+                # Auto-compression rebinds the same way manual /compress
+                # does — carry any in-flight goal across so the judge loop
+                # doesn't silently die under the orphaned parent (#18467).
+                from hermes_cli.goals import migrate_goal
+
+                migrate_goal(self.session_id, self.agent.session_id)
                 self.session_id = self.agent.session_id
                 self._pending_title = None
 
@@ -14871,6 +14883,12 @@ def main(
                         getattr(cli.agent, "session_id", None)
                         and cli.agent.session_id != cli.session_id
                     ):
+                        # Carry any in-flight goal — same rebind shape as
+                        # the interactive /compress and auto-compress paths
+                        # (#18467).
+                        from hermes_cli.goals import migrate_goal
+
+                        migrate_goal(cli.session_id, cli.agent.session_id)
                         cli.session_id = cli.agent.session_id
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                     # Surface backend errors that produced no visible output

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8691,6 +8691,13 @@ class GatewayRunner:
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
+                # Carry any in-flight /goal across the rebind — gateway
+                # GoalManager keys on session_id same as CLI (#18467).
+                try:
+                    from hermes_cli.goals import migrate_goal as _migrate_goal
+                    _migrate_goal(session_entry.session_id, agent_result["session_id"])
+                except Exception as _mg_exc:
+                    logger.debug("[Gateway] goal migration failed (non-fatal): %s", _mg_exc)
                 session_entry.session_id = agent_result["session_id"]
                 self.session_store._save()
 
@@ -17042,6 +17049,13 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
+                # Carry any in-flight /goal across the rebind — gateway
+                # GoalManager keys on session_id same as CLI (#18467).
+                try:
+                    from hermes_cli.goals import migrate_goal as _migrate_goal
+                    _migrate_goal(session_id, agent.session_id)
+                except Exception as _mg_exc:
+                    logger.debug("[Gateway] goal migration failed (non-fatal): %s", _mg_exc)
                 entry = self.session_store._entries.get(session_key)
                 if entry:
                     entry.session_id = agent.session_id

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -279,6 +279,26 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
+def migrate_goal(old_session_id: str, new_session_id: str) -> None:
+    """Carry an in-flight goal across a session_id rebind (e.g. /compress).
+
+    When ``cli._compress_context`` ends the parent session and mints a child
+    session_id, the goal row keyed by ``goal:<old>`` is orphaned and the judge
+    loop silently dies (#18467). Copy the live state to ``goal:<new>`` and
+    mark the parent cleared so /goal status under the parent reflects reality.
+
+    Terminal states (``done``/``cleared``) are not migrated — they're audit
+    trail tied to the session that completed them.
+    """
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return
+    state = load_goal(old_session_id)
+    if state is None or state.status in ("done", "cleared"):
+        return
+    save_goal(new_session_id, state)
+    clear_goal(old_session_id)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Judge
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -182,3 +182,61 @@ def test_manual_compress_no_sync_when_session_id_unchanged():
 
     # No split → pending title untouched.
     assert shell._pending_title == "keep me"
+
+
+def test_manual_compress_migrates_active_goal_to_child_session(tmp_path, monkeypatch):
+    """Regression for #18467: /compress used to orphan an active /goal.
+
+    The goal row is keyed by goal:<session_id> in SessionDB.state_meta. When
+    _compress_context mints a child session, the cli.session_id rebind must
+    also migrate the goal — otherwise /goal status under the child reports
+    "No active goal" and the judge loop silently dies.
+    """
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli import goals
+    goals._DB_CACHE.clear()
+    try:
+        from hermes_cli.goals import GoalManager, load_goal
+
+        shell = _make_cli()
+        history = _make_history()
+        old_id = shell.session_id
+        new_child_id = "20260101_000000_goalchild"
+
+        # Plant an active goal under the parent session.
+        mgr = GoalManager(session_id=old_id)
+        mgr.set("ship the change")
+
+        compressed = [{"role": "user", "content": "[summary]"}, history[-1]]
+        shell.conversation_history = history
+        shell.agent = MagicMock()
+        shell.agent.compression_enabled = True
+        shell.agent._cached_system_prompt = ""
+        shell.agent.tools = None
+
+        def _fake_compress(*args, **kwargs):
+            shell.agent.session_id = new_child_id
+            return (compressed, "")
+
+        shell.agent._compress_context.side_effect = _fake_compress
+        shell.agent.session_id = old_id
+
+        with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+            shell._manual_compress()
+
+        assert shell.session_id == new_child_id
+        carried = load_goal(new_child_id)
+        assert carried is not None
+        assert carried.goal == "ship the change"
+        assert carried.status == "active"
+        # Parent must not still own the active goal — it's a dead session.
+        residual = load_goal(old_id)
+        assert residual is None or residual.status == "cleared"
+    finally:
+        goals._DB_CACHE.clear()

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -341,6 +341,103 @@ class TestGoalManager:
 # ──────────────────────────────────────────────────────────────────────
 
 
+# ──────────────────────────────────────────────────────────────────────
+# migrate_goal — preserves /goal state across /compress session_id rebind (#18467)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestMigrateGoal:
+    def test_active_goal_carries_to_new_session(self, hermes_home):
+        """After /compress mints a child session_id, the active goal must follow."""
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal
+
+        old_sid = "parent-sid"
+        new_sid = "child-sid"
+
+        mgr = GoalManager(session_id=old_sid, default_max_turns=7)
+        mgr.set("port the thing")
+        mgr.state.turns_used = 3
+        mgr.state.last_verdict = "continue"
+        mgr.state.last_reason = "needs more"
+        from hermes_cli.goals import save_goal
+
+        save_goal(old_sid, mgr.state)
+
+        migrate_goal(old_sid, new_sid)
+
+        carried = load_goal(new_sid)
+        assert carried is not None
+        assert carried.goal == "port the thing"
+        assert carried.status == "active"
+        assert carried.turns_used == 3
+        assert carried.max_turns == 7
+        assert carried.last_verdict == "continue"
+        assert carried.last_reason == "needs more"
+
+    def test_old_session_goal_is_cleared_after_migration(self, hermes_home):
+        """The old session_id must not keep an 'active' goal — it's a dead session."""
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal
+
+        mgr = GoalManager(session_id="dead-parent")
+        mgr.set("ship it")
+
+        migrate_goal("dead-parent", "live-child")
+
+        residual = load_goal("dead-parent")
+        # Either fully cleared (None) or marked status=cleared — never still active.
+        assert residual is None or residual.status == "cleared"
+
+    def test_done_goal_is_not_migrated(self, hermes_home):
+        """Terminal goals (done/cleared) stay with the original session — they're audit trail."""
+        from hermes_cli.goals import GoalState, load_goal, migrate_goal, save_goal
+
+        save_goal("parent-done", GoalState(goal="finished work", status="done"))
+
+        migrate_goal("parent-done", "child")
+
+        assert load_goal("child") is None
+
+    def test_cleared_goal_is_not_migrated(self, hermes_home):
+        from hermes_cli.goals import GoalState, load_goal, migrate_goal, save_goal
+
+        save_goal("parent-cleared", GoalState(goal="abandoned", status="cleared"))
+
+        migrate_goal("parent-cleared", "child")
+
+        assert load_goal("child") is None
+
+    def test_no_goal_to_migrate_is_noop(self, hermes_home):
+        from hermes_cli.goals import load_goal, migrate_goal
+
+        migrate_goal("nothing-here", "child")
+
+        assert load_goal("child") is None
+
+    def test_paused_goal_carries_with_paused_status(self, hermes_home):
+        """A user-paused goal must survive /compress with its pause intact."""
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal
+
+        mgr = GoalManager(session_id="pause-parent")
+        mgr.set("paused work")
+        mgr.pause(reason="user-paused")
+
+        migrate_goal("pause-parent", "pause-child")
+
+        carried = load_goal("pause-child")
+        assert carried is not None
+        assert carried.status == "paused"
+        assert carried.paused_reason == "user-paused"
+
+    def test_empty_session_ids_are_noop(self, hermes_home):
+        """Defensive: empty old or new sid must not raise or corrupt state."""
+        from hermes_cli.goals import migrate_goal
+
+        # No exceptions, no side effects we can assert on directly — just must not raise.
+        migrate_goal("", "child")
+        migrate_goal("parent", "")
+        migrate_goal("", "")
+
+
 def test_goal_command_in_registry():
     from hermes_cli.commands import resolve_command
 


### PR DESCRIPTION
## What does this PR do?

Carries an in-flight `/goal` across every session_id rebind so the goal judge loop doesn't silently die after compression. The goal row is keyed by `goal:<session_id>` in `SessionDB.state_meta`; when `_compress_context()` mints a child `session_id` on the agent, every site that syncs a stored session_id to the agent's new id must also migrate that row, otherwise `/goal status` reports "No active goal" with no warning.

The reporter localised one site exactly (`cli.py:7567-7572`, manual `/compress`). Code review surfaced four more sites with the same rebind pattern that all need the same treatment:

| Path | Trigger |
|---|---|
| `cli.py:7577` | manual `/compress` |
| `cli.py:9408` | auto-compression mid-turn (`run_conversation`) |
| `cli.py:12016` | single-query / non-interactive run mode |
| `gateway/run.py:6165` | gateway post-run `session_entry.session_id` sync |
| `gateway/run.py:12742` | gateway session split on compression |

This PR adds `migrate_goal(old_sid, new_sid)` in `hermes_cli/goals.py` and wires it at all five sites. Migration semantics:

- Active and paused goals carry over (with `turns_used`, `last_verdict`, `paused_reason` intact).
- Terminal goals (`done`, `cleared`) stay with the original session — they belong to the session that completed them.
- The old key is marked cleared via the existing `clear_goal()` helper so `/goal status` under the dead session reflects reality.
- No-ops on empty/identical session ids.

Gateway sites wrap the call in a defensive `try/except` since gateway logging deliberately swallows non-fatal errors.

## Related Issue

Fixes #18467

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/goals.py` — add `migrate_goal(old_session_id, new_session_id)`
- `cli.py` — wire `migrate_goal` at the manual `/compress`, auto-compression, and single-query rebind sites
- `gateway/run.py` — wire `migrate_goal` at the post-run sync and session-split sites (with `try/except` for non-fatal failure)
- `tests/hermes_cli/test_goals.py` — add `TestMigrateGoal` (7 unit cases: active carry, status preservation, old-cleared, done/cleared not migrated, paused state, no-goal noop, empty-sid noop)
- `tests/cli/test_manual_compress.py` — add `test_manual_compress_migrates_active_goal_to_child_session` integration test that plants a goal, runs `_manual_compress` end-to-end, and asserts migration

## How to Test

1. `python -m pytest tests/hermes_cli/test_goals.py tests/cli/test_manual_compress.py -q` — 38/38 pass
2. Manual: `hermes` → `/goal port the thing` → a few turns → `/compress` → `/goal status` should show the goal still active under the new session id (previously: "No active goal")

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_goals.py tests/cli/test_manual_compress.py -q
38/38 pass
```
