### PR TITLE
fix(cli): robust paste file expansion and process_loop error handling (salvage #17939)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2928,7 +2928,14 @@ class HermesCLI:
 
         def _expand_ref(match):
             path = Path(match.group(1))
-            return path.read_text(encoding="utf-8") if path.exists() else match.group(0)
+            # Use try/except instead of path.exists() to avoid TOCTOU race:
+            # the paste file may be deleted between check and read, causing
+            # the input to be silently dropped (#17666).
+            try:
+                return path.read_text(encoding="utf-8")
+            except (OSError, IOError):
+                logger.warning("Paste file gone or unreadable, returning placeholder: %s", path)
+                return match.group(0)
 
         return paste_ref_re.sub(_expand_ref, text)
 
@@ -11584,7 +11591,7 @@ class HermesCLI:
                             pass  # Non-fatal — don't break the main loop
 
                 except Exception as e:
-                    print(f"Error: {e}")
+                    logger.warning("process_loop unhandled error (msg may be lost): %s", e)
         
         # Start processing thread
         process_thread = threading.Thread(target=process_loop, daemon=True)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -372,6 +372,7 @@ AUTHOR_MAP = {
     "e.silacandmr@gmail.com": "Es1la",
     "h3057183414@gmail.com": "CoreyNoDream",
     "franksong2702@gmail.com": "franksong2702",
+    "673088860@qq.com": "ambition0802",
     # ── bulk addition: 75 emails resolved via API, PR salvage bodies, noreply
     #    crossref, and GH contributor list matching (April 2026 audit) ──
     "1115117931@qq.com": "aaronagent",


### PR DESCRIPTION
Long multi-line pasted messages no longer silently vanish. Two narrow fixes on the input-handling path, salvaged from @ambition0802's #17939 onto current main (the PR had a stale cherry-pick base around process_loop).

## What changed
- `cli.py` — `_expand_paste_references()`: replaced `path.exists() + read_text()` with `try/except (OSError, IOError)` to close the TOCTOU window. If the paste file is gone between check and read, return the placeholder text and log a warning instead of raising `FileNotFoundError` up through `process_loop`'s outer except (which silently swallowed the user's message).
- `cli.py` — `process_loop` outer `except Exception`: `logger.warning()` instead of `print()`. prompt_toolkit's TUI hides stdout, so "Error: …" was invisible. Logged errors are discoverable via `hermes logs`.

## What I dropped from the original PR
The PR also added an `_interrupt_queue` → `_pending_input` drain block in `process_loop`. That addresses a different class of input-drop (in-flight interrupt handling) unrelated to the paste-file TOCTOU in the reported issue, and the surrounding code on current main already has its own goal-continuation + process-notification drain sections that the drop-in conflicts with. Left it out here; happy to evaluate it as a separate PR with its own test + scenario description.

## Validation
- `scripts/run_tests.sh tests/ -k paste` → 48 passed.
- E2E: extracted the patched `_expand_paste_references` function, ran three scenarios against real files —
  1. Paste file exists → placeholder expanded to full content.
  2. Paste file unlinked between match and read (TOCTOU) → pre-fix path would raise, post-fix returns the original placeholder text and emits `logger.warning("Paste file gone…")`. User's message preserved, not silently dropped.
  3. No paste refs → passthrough unchanged.

Closes #17666.