### PR TITLE
fix(gateway): evict cached agent after context compression so system prompt refreshes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6055,6 +6055,12 @@ class GatewayRunner:
                                                 "Failed to deliver aux-model-fallback notice to user: %s",
                                                 _werr,
                                             )
+                                    # Evict the cached agent so the next turn
+                                    # rebuilds its system prompt from current
+                                    # SOUL.md, memory, and skills (not the stale
+                                    # pre-compression snapshot).
+                                    self._evict_cached_agent(session_key)
+
                                 finally:
                                     self._cleanup_agent_resources(_hyg_agent)
 
@@ -9105,6 +9111,9 @@ class GatewayRunner:
                 # note so they can fix their config.
                 _aux_fail_model = getattr(compressor, "_last_aux_model_failure_model", None)
                 _aux_fail_err = getattr(compressor, "_last_aux_model_failure_error", None)
+                # Evict cached agent so next turn rebuilds system prompt
+                # from current files (SOUL.md, memory, etc.).
+                self._evict_cached_agent(session_key)
             finally:
                 self._cleanup_agent_resources(tmp_agent)
             lines = [f"🗜️ {summary['headline']}"]


### PR DESCRIPTION
## Bug

The gateway caches `AIAgent` instances per session key for prompt prefix caching. When context compression fires (either automatic session hygiene or manual `/compress`), it creates a **temporary** agent to do the summarization, then cleans it up — but never evicts the cached agent.

This means the cached agent retains its stale `_cached_system_prompt` from when it was first created. Edits to `SOUL.md`, persistent memory updates, skill list changes, and config modifications are invisible until the user manually starts a fresh session.

**Three compression paths, three behaviors:**
- ✅ Mid-turn compression (`_compress_context` inside `run_agent.py`) — already calls `_build_system_prompt()` fresh
- ❌ Session hygiene compression (gateway) — cached agent untouched
- ❌ Manual `/compress` (gateway) — cached agent untouched

## Fix

Add `self._evict_cached_agent(session_key)` after successful compression in both gateway paths. The next turn builds a fresh agent with current files.

**Tradeoff:** One turn sends an uncached system prompt after each compression event. Cost is minimal (one prefix cache miss) compared to running stale prompts for potentially hours/days.

## Testing

- Running on production for the author's long-lived sessions (compression every few hours, rarely starting fresh sessions)
- The fix is opt-out compatible: users who prefer stale prompts can simply not compress, or the behavior could be made configurable in a follow-up

## Files Changed

- `gateway/run.py` — 2 calls to `_evict_cached_agent(session_key)` (session hygiene + manual compress), 9 lines added