### PR TITLE
fix: harden delegation contracts and media extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1895,7 +1895,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)[^\s`"',;:)\]}]+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',.;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -384,17 +384,118 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
 # Status
 # ---------------------------------------------------------------------------
 
+_ENTRY_DELIMITER = "\n§\n"
+
+
+def _read_raw_memory_entries(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(_ENTRY_DELIMITER) if part.strip()]
+
+
+def _memory_usage(entries: list[str], limit: int) -> tuple[int, int]:
+    used = len(_ENTRY_DELIMITER.join(entries)) if entries else 0
+    pct = int(round((used / limit) * 100)) if limit else 0
+    return used, pct
+
+
+def _duplicate_count(entries: list[str]) -> int:
+    seen = set()
+    duplicates = 0
+    for entry in entries:
+        key = " ".join(entry.lower().split())
+        if key in seen:
+            duplicates += 1
+        else:
+            seen.add(key)
+    return duplicates
+
+
+def _fact_count(config: dict) -> int:
+    try:
+        import sqlite3
+
+        plugin_cfg = ((config.get("plugins") or {}).get("hermes-memory-store") or {})
+        db_path = str(plugin_cfg.get("db_path") or (get_hermes_home() / "memory_store.db"))
+        db_path = db_path.replace("$HERMES_HOME", str(get_hermes_home()))
+        db_path = db_path.replace("${HERMES_HOME}", str(get_hermes_home()))
+        path = Path(db_path).expanduser()
+        if not path.exists():
+            return 0
+        with sqlite3.connect(path) as conn:
+            row = conn.execute("SELECT COUNT(*) FROM facts").fetchone()
+            return int(row[0] if row else 0)
+    except Exception:
+        return 0
+
+
+def _status_line_for_usage(name: str, entries: list[str], limit: int) -> tuple[list[str], bool]:
+    used, pct = _memory_usage(entries, limit)
+    lines = [
+        f"  {name} entries:  {len(entries)}",
+        f"  {name} usage:    {pct}% — {used:,}/{limit:,} chars",
+    ]
+    return lines, pct >= 75
+
+
 def cmd_status(args) -> None:
     """Show current memory provider config."""
     from hermes_cli.config import load_config
 
     config = load_config()
-    mem_config = config.get("memory", {})
-    provider_name = mem_config.get("provider", "")
+    mem_config = config.get("memory", {}) if isinstance(config.get("memory", {}), dict) else {}
+    provider_name = str(mem_config.get("provider", "") or "").strip()
+    memory_enabled = bool(mem_config.get("memory_enabled", False))
+    user_profile_enabled = bool(mem_config.get("user_profile_enabled", False))
+    memory_limit = int(mem_config.get("memory_char_limit", 2200) or 2200)
+    user_limit = int(mem_config.get("user_char_limit", 1375) or 1375)
+
+    mem_dir = get_hermes_home() / "memories"
+    memory_entries = _read_raw_memory_entries(mem_dir / "MEMORY.md")
+    user_entries = _read_raw_memory_entries(mem_dir / "USER.md")
+    memory_used, memory_pct = _memory_usage(memory_entries, memory_limit)
+    user_used, user_pct = _memory_usage(user_entries, user_limit)
+    memory_dupes = _duplicate_count(memory_entries)
+    user_dupes = _duplicate_count(user_entries)
+    near_capacity = []
+    if memory_pct >= 75:
+        near_capacity.append("memory")
+    if user_pct >= 75:
+        near_capacity.append("user")
+
+    providers = _get_available_providers()
+    provider_status = "inactive"
+    active_provider = None
+    if provider_name:
+        for pname, _desc, provider in providers:
+            if pname == provider_name:
+                active_provider = provider
+                provider_status = "active" if provider.is_available() else "configured but unavailable"
+                break
+        else:
+            provider_status = "configured but not installed"
 
     print(f"\nMemory status\n" + "─" * 40)
-    print(f"  Built-in:  always active")
+    print(f"  Built-in:  {'active' if (memory_enabled or user_profile_enabled) else 'inactive'}")
     print(f"  Provider:  {provider_name or '(none — built-in only)'}")
+    print(f"  Provider status: {provider_status}")
+    print(f"  Memory entries:  {len(memory_entries)}")
+    print(f"  Memory usage:    {memory_pct}% — {memory_used:,}/{memory_limit:,} chars")
+    print(f"  User entries:    {len(user_entries)}")
+    print(f"  User usage:      {user_pct}% — {user_used:,}/{user_limit:,} chars")
+    print(f"  Fact count:      {_fact_count(config)}")
+    print(f"  Near capacity:   {', '.join(near_capacity) if near_capacity else 'no'}")
+    duplicate_notes = []
+    if memory_dupes:
+        duplicate_notes.append("memory has duplicate entries")
+    if user_dupes:
+        duplicate_notes.append("user profile has duplicate entries")
+    if memory_pct >= 90 or user_pct >= 90:
+        duplicate_notes.append("very high usage increases stale/noisy prompt risk")
+    print(f"  Duplicate/noise risk: {', '.join(duplicate_notes) if duplicate_notes else 'low'}")
 
     if provider_name:
         provider_config = mem_config.get(provider_name, {})
@@ -403,36 +504,29 @@ def cmd_status(args) -> None:
             for key, val in provider_config.items():
                 print(f"    {key}: {val}")
 
-        providers = _get_available_providers()
-        found = any(name == provider_name for name, _, _ in providers)
-        if found:
+        if active_provider is not None:
             print(f"\n  Plugin:    installed ✓")
-            for pname, _, p in providers:
-                if pname == provider_name:
-                    if p.is_available():
-                        print(f"  Status:    available ✓")
-                    else:
-                        print(f"  Status:    not available ✗")
-                        schema = p.get_config_schema() if hasattr(p, "get_config_schema") else []
-                        # Check all fields that have env_var (both secret and non-secret)
-                        required_fields = [f for f in schema if f.get("env_var")]
-                        if required_fields:
-                            print(f"  Missing:")
-                            for f in required_fields:
-                                env_var = f.get("env_var", "")
-                                url = f.get("url", "")
-                                is_set = bool(os.environ.get(env_var))
-                                mark = "✓" if is_set else "✗"
-                                line = f"    {mark} {env_var}"
-                                if url and not is_set:
-                                    line += f"  → {url}"
-                                print(line)
-                    break
+            if provider_status == "active":
+                print(f"  Status:    available ✓")
+            else:
+                print(f"  Status:    not available ✗")
+                schema = active_provider.get_config_schema() if hasattr(active_provider, "get_config_schema") else []
+                required_fields = [f for f in schema if f.get("env_var")]
+                if required_fields:
+                    print(f"  Missing:")
+                    for f in required_fields:
+                        env_var = f.get("env_var", "")
+                        url = f.get("url", "")
+                        is_set = bool(os.environ.get(env_var))
+                        mark = "✓" if is_set else "✗"
+                        line = f"    {mark} {env_var}"
+                        if url and not is_set:
+                            line += f"  → {url}"
+                        print(line)
         else:
             print(f"\n  Plugin:    NOT installed ✗")
             print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
 
-    providers = _get_available_providers()
     if providers:
         print(f"\n  Installed plugins:")
         for pname, desc, _ in providers:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1698,6 +1698,7 @@ class AIAgent:
         self._memory_store = None
         self._memory_enabled = False
         self._user_profile_enabled = False
+        self._background_review_memory_writes_enabled = False
         self._memory_nudge_interval = 10
         self._turns_since_memory = 0
         self._iters_since_skill = 0
@@ -1706,6 +1707,13 @@ class AIAgent:
                 mem_config = _agent_cfg.get("memory", {})
                 self._memory_enabled = mem_config.get("memory_enabled", False)
                 self._user_profile_enabled = mem_config.get("user_profile_enabled", False)
+                _bg_memory_raw = mem_config.get(
+                    "background_review_memory_writes_enabled",
+                    mem_config.get("allow_background_review_writes", False),
+                )
+                self._background_review_memory_writes_enabled = str(_bg_memory_raw).strip().lower() in (
+                    "1", "true", "yes", "on"
+                )
                 self._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
                 if self._memory_enabled or self._user_profile_enabled:
                     from tools.memory_tool import MemoryStore
@@ -3568,6 +3576,12 @@ class AIAgent:
         Never modifies the main conversation history or produces user-visible output.
         """
         import threading
+
+        if review_memory and not getattr(self, "_background_review_memory_writes_enabled", False):
+            logger.debug("Background memory review skipped: background writes are not enabled")
+            review_memory = False
+        if not review_memory and not review_skills:
+            return
 
         # Pick the right prompt based on which triggers fired
         if review_memory and review_skills:
@@ -10499,7 +10513,8 @@ class AIAgent:
         # Skill trigger is checked AFTER the agent loop completes, based on
         # how many tool iterations THIS turn used.
         _should_review_memory = False
-        if (self._memory_nudge_interval > 0
+        if (getattr(self, "_background_review_memory_writes_enabled", False)
+                and self._memory_nudge_interval > 0
                 and "memory" in self.valid_tool_names
                 and self._memory_store):
             self._turns_since_memory += 1

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -200,6 +200,8 @@ class TestSessionOps:
             "context",
             "reset",
             "compact",
+            "steer",
+            "queue",
             "version",
         ]
         model_cmd = next(

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -10,6 +10,37 @@ times per reply. (Regression test for #160)
 import pytest
 import re
 
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def test_extract_media_handles_multiple_same_line_tags():
+    content = "Files: MEDIA:/tmp/foo.mp3 and MEDIA:/tmp/bar.jpg"
+
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+
+    assert media == [("/tmp/foo.mp3", False), ("/tmp/bar.jpg", False)]
+    assert "MEDIA:" not in cleaned
+    assert "Files:" in cleaned
+
+
+def test_extract_media_does_not_span_invalid_unquoted_path_to_later_valid_tag():
+    content = "Example MEDIA:/tmp/not_a_media_path then MEDIA:/tmp/real.mp3"
+
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+
+    assert media == [("/tmp/real.mp3", False)]
+    assert "MEDIA:/tmp/not_a_media_path" in cleaned
+    assert "MEDIA:/tmp/real.mp3" not in cleaned
+
+
+def test_extract_media_accepts_quoted_path_with_spaces():
+    content = 'Attached MEDIA:"/tmp/voice note.mp3"'
+
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+
+    assert media == [("/tmp/voice note.mp3", False)]
+    assert "MEDIA:" not in cleaned
+
 
 def extract_media_tags_fixed(result_messages, history_len):
     """

--- a/tests/hermes_cli/test_memory_status.py
+++ b/tests/hermes_cli/test_memory_status.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_memory_status_reports_capacity_counts_and_noise(monkeypatch, tmp_path, capsys):
+    from hermes_cli import memory_setup
+
+    hermes_home = tmp_path / ".hermes"
+    memories = hermes_home / "memories"
+    memories.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    (hermes_home / "config.yaml").write_text(
+        """
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 100
+  user_char_limit: 100
+  provider: ''
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (memories / "MEMORY.md").write_text("alpha\n§\nalpha\n§\nbeta", encoding="utf-8")
+    (memories / "USER.md").write_text("x" * 80, encoding="utf-8")
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Built-in:  active" in out
+    assert "Provider:  (none — built-in only)" in out
+    assert "Provider status: inactive" in out
+    assert "Memory entries:  3" in out
+    assert "Memory usage:    20% — 20/100 chars" in out
+    assert "User entries:    1" in out
+    assert "User usage:      80% — 80/100 chars" in out
+    assert "Near capacity:   user" in out
+    assert "Duplicate/noise risk: memory has duplicate entries" in out

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -20,6 +20,7 @@ def _bare_agent() -> AIAgent:
     agent._memory_store = object()
     agent._memory_enabled = True
     agent._user_profile_enabled = False
+    agent._background_review_memory_writes_enabled = True
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
@@ -35,6 +36,28 @@ class ImmediateThread:
 
     def start(self):
         self._target()
+
+
+def test_background_review_memory_writes_are_skipped_unless_enabled(monkeypatch):
+    events = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            events.append(("init", kwargs))
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._background_review_memory_writes_enabled = False
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert events == []
 
 
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -20,6 +20,7 @@ def _make_agent_stub(agent_cls):
     agent._memory_store = None
     agent._memory_enabled = True
     agent._user_profile_enabled = False
+    agent._background_review_memory_writes_enabled = True
     agent._memory_nudge_interval = 5
     agent._skill_nudge_interval = 5
     agent.background_review_callback = None

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -75,6 +75,169 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
+    def test_schema_exposes_worker_contract_fields_top_level_and_per_task(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        task_props = props["tasks"]["items"]["properties"]
+        for field in (
+            "timeout_seconds",
+            "artifact_path",
+            "output_schema",
+            "job_id",
+            "phase",
+            "worker_role",
+        ):
+            self.assertIn(field, props)
+            self.assertIn(field, task_props)
+
+    def test_registry_dispatch_forwards_worker_contract_fields(self):
+        from tools import delegate_tool as delegate_module
+        from tools.registry import registry
+
+        parent = _make_mock_parent()
+        schema = {"type": "object", "required": ["ok"]}
+        args = {
+            "goal": "write artifact",
+            "timeout_seconds": 4.5,
+            "artifact_path": "/tmp/worker.json",
+            "output_schema": schema,
+            "job_id": "job-1",
+            "phase": "draft",
+            "worker_role": "writer",
+        }
+
+        with patch.object(delegate_module, "delegate_task", return_value='{"results": []}') as mock_delegate:
+            registry.dispatch("delegate_task", args, parent_agent=parent)
+
+        _, kwargs = mock_delegate.call_args
+        self.assertEqual(kwargs["timeout_seconds"], 4.5)
+        self.assertEqual(kwargs["artifact_path"], "/tmp/worker.json")
+        self.assertIs(kwargs["output_schema"], schema)
+        self.assertEqual(kwargs["job_id"], "job-1")
+        self.assertEqual(kwargs["phase"], "draft")
+        self.assertEqual(kwargs["worker_role"], "writer")
+        self.assertIs(kwargs["parent_agent"], parent)
+
+
+class TestDelegateWorkerContracts(unittest.TestCase):
+    def _completed_child(self):
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child.get_activity_summary.return_value = {
+            "current_tool": None,
+            "api_call_count": 1,
+            "max_iterations": 50,
+            "last_activity_desc": "done",
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "test"
+        return child
+
+    def test_run_single_child_validates_json_artifact_contract(self):
+        import tempfile
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        child = self._completed_child()
+        schema = {
+            "type": "object",
+            "required": ["ok"],
+            "properties": {"ok": {"type": "boolean"}},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = os.path.join(tmpdir, "worker.json")
+            with open(artifact, "w", encoding="utf-8") as fh:
+                json.dump({"ok": True}, fh)
+
+            result = _run_single_child(
+                task_index=0,
+                goal="write artifact",
+                child=child,
+                parent_agent=parent,
+                artifact_path=artifact,
+                output_schema=schema,
+                job_id="job-1",
+                phase="draft",
+                worker_role="writer",
+            )
+
+        self.assertEqual(result["status"], "completed")
+        self.assertTrue(result["artifact_exists"])
+        self.assertTrue(result["artifact_valid"])
+        self.assertEqual(result["job_id"], "job-1")
+        self.assertEqual(result["phase"], "draft")
+        self.assertEqual(result["worker_role"], "writer")
+
+    def test_completed_child_fails_when_required_artifact_missing(self):
+        import tempfile
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        child = self._completed_child()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = os.path.join(tmpdir, "missing.json")
+            result = _run_single_child(
+                task_index=0,
+                goal="write artifact",
+                child=child,
+                parent_agent=parent,
+                artifact_path=artifact,
+                output_schema={"type": "object"},
+            )
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["exit_reason"], "artifact_missing")
+        self.assertFalse(result["artifact_exists"])
+        self.assertFalse(result["artifact_valid"])
+        self.assertIn("Artifact not found", result["error"])
+
+    def test_delegate_task_passes_per_task_contract_to_child_runner(self):
+        parent = _make_mock_parent()
+        child = self._completed_child()
+        schema = {"type": "object", "required": ["ok"]}
+
+        def fake_run(**kwargs):
+            return {
+                "task_index": kwargs["task_index"],
+                "status": "completed",
+                "summary": "done",
+                "api_calls": 0,
+                "duration_seconds": 0,
+            }
+
+        with patch("tools.delegate_tool._build_child_agent", return_value=child), patch(
+            "tools.delegate_tool._run_single_child", side_effect=fake_run
+        ) as mock_run:
+            delegate_task(
+                tasks=[
+                    {
+                        "goal": "write artifact",
+                        "timeout_seconds": 3.25,
+                        "artifact_path": "/tmp/worker.json",
+                        "output_schema": schema,
+                        "job_id": "job-1",
+                        "phase": "draft",
+                        "worker_role": "writer",
+                    }
+                ],
+                parent_agent=parent,
+            )
+
+        _, kwargs = mock_run.call_args
+        self.assertEqual(kwargs["timeout_seconds"], 3.25)
+        self.assertEqual(kwargs["artifact_path"], "/tmp/worker.json")
+        self.assertIs(kwargs["output_schema"], schema)
+        self.assertEqual(kwargs["job_id"], "job-1")
+        self.assertEqual(kwargs["phase"], "draft")
+        self.assertEqual(kwargs["worker_role"], "writer")
+
 
 class TestChildSystemPrompt(unittest.TestCase):
     def test_goal_only(self):
@@ -1807,6 +1970,47 @@ class TestDelegateEventEnum(unittest.TestCase):
             "💭" in str(c)
             for c in parent._delegate_spinner.print_above.call_args_list
         )
+
+    def test_progress_callback_emits_lifecycle_contract_events(self):
+        parent = _make_mock_parent()
+        parent._delegate_spinner = MagicMock()
+        parent.tool_progress_callback = MagicMock()
+
+        cb = _build_child_progress_callback(
+            1,
+            "write artifact",
+            parent,
+            task_count=2,
+            job_id="job-1",
+            phase="draft",
+            worker_role="writer",
+            artifact_path="/tmp/worker.json",
+        )
+
+        cb("subagent.start", preview="starting")
+        cb(
+            "subagent.complete",
+            preview="done",
+            status="completed",
+            artifact_exists=True,
+            artifact_valid=True,
+        )
+
+        calls = parent.tool_progress_callback.call_args_list
+        event_names = [call.args[0] for call in calls]
+        self.assertIn(DelegateEvent.TASK_SPAWNED.value, event_names)
+        self.assertIn("subagent.start", event_names)
+        self.assertIn(DelegateEvent.TASK_COMPLETED.value, event_names)
+        self.assertIn("subagent.complete", event_names)
+        lifecycle_call = next(
+            call for call in calls if call.args[0] == DelegateEvent.TASK_COMPLETED.value
+        )
+        self.assertEqual(lifecycle_call.kwargs["job_id"], "job-1")
+        self.assertEqual(lifecycle_call.kwargs["phase"], "draft")
+        self.assertEqual(lifecycle_call.kwargs["worker_role"], "writer")
+        self.assertEqual(lifecycle_call.kwargs["artifact_path"], "/tmp/worker.json")
+        self.assertTrue(lifecycle_call.kwargs["artifact_exists"])
+        self.assertTrue(lifecycle_call.kwargs["artifact_valid"])
 
     def test_progress_callback_task_progress_not_misrendered(self):
         """'subagent_progress' (legacy name for TASK_PROGRESS) carries a

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -19,6 +19,7 @@ never the child's intermediate tool calls or reasoning.
 import enum
 import json
 import logging
+import math
 
 logger = logging.getLogger(__name__)
 import os
@@ -386,6 +387,212 @@ def _get_child_timeout() -> float:
     return float(DEFAULT_CHILD_TIMEOUT)
 
 
+def _coerce_timeout_seconds(value: Any, *, field: str = "timeout_seconds") -> float:
+    """Coerce a per-call/per-task timeout override to a positive finite float."""
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field} must be a positive number of seconds")
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError(f"{field} must be a positive number of seconds")
+    return timeout
+
+
+def _resolve_child_timeout(timeout_seconds: Any = None) -> float:
+    """Use a per-task timeout override when supplied, else the global config."""
+    if timeout_seconds is None:
+        return _get_child_timeout()
+    try:
+        return _coerce_timeout_seconds(timeout_seconds)
+    except ValueError as exc:
+        logger.warning("Invalid per-task timeout override %r: %s", timeout_seconds, exc)
+        return _get_child_timeout()
+
+
+def _optional_contract_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _matches_json_schema_type(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    return True
+
+
+def _validate_json_schema_subset(value: Any, schema: Any, path: str = "$") -> Optional[str]:
+    """Validate the small JSON-schema subset needed for worker artifacts."""
+    if not isinstance(schema, dict) or not schema:
+        return None
+    expected_type = schema.get("type")
+    expected_types = expected_type if isinstance(expected_type, list) else [expected_type]
+    expected_types = [t for t in expected_types if isinstance(t, str)]
+    if expected_types and not any(_matches_json_schema_type(value, t) for t in expected_types):
+        return f"{path} expected type {'/'.join(expected_types)}"
+    if isinstance(value, dict):
+        required = schema.get("required") or []
+        if isinstance(required, list):
+            for key in required:
+                if isinstance(key, str) and key not in value:
+                    return f"{path} missing required field {key!r}"
+        properties = schema.get("properties") or {}
+        if isinstance(properties, dict):
+            for key, child_schema in properties.items():
+                if key in value:
+                    child_error = _validate_json_schema_subset(value[key], child_schema, f"{path}.{key}")
+                    if child_error:
+                        return child_error
+    return None
+
+
+def _artifact_contract_metadata(
+    *,
+    artifact_path: Any = None,
+    output_schema: Any = None,
+    job_id: Any = None,
+    phase: Any = None,
+    worker_role: Any = None,
+) -> Dict[str, Any]:
+    meta: Dict[str, Any] = {}
+    for key, value in (
+        ("artifact_path", artifact_path),
+        ("job_id", job_id),
+        ("phase", phase),
+        ("worker_role", worker_role),
+    ):
+        text = _optional_contract_text(value)
+        if text is not None:
+            meta[key] = text
+    if output_schema is not None:
+        meta["output_schema"] = output_schema
+    return meta
+
+
+def _evaluate_artifact_contract(
+    *,
+    artifact_path: Any = None,
+    output_schema: Any = None,
+    job_id: Any = None,
+    phase: Any = None,
+    worker_role: Any = None,
+) -> Dict[str, Any]:
+    """Return artifact existence/validation fields for a worker contract."""
+    meta = _artifact_contract_metadata(
+        artifact_path=artifact_path,
+        output_schema=output_schema,
+        job_id=job_id,
+        phase=phase,
+        worker_role=worker_role,
+    )
+    if "artifact_path" not in meta:
+        return meta
+    path_text = meta["artifact_path"]
+    path = os.path.abspath(os.path.expanduser(path_text))
+    exists = os.path.isfile(path)
+    meta["artifact_exists"] = exists
+    meta["artifact_valid"] = False
+    if not exists:
+        meta["artifact_error"] = f"Artifact not found: {path_text}"
+        return meta
+    if output_schema is None:
+        meta["artifact_valid"] = True
+        return meta
+    schema = output_schema
+    if isinstance(schema, str):
+        try:
+            schema = json.loads(schema)
+        except Exception as exc:
+            meta["artifact_error"] = f"Invalid output_schema JSON: {exc}"
+            return meta
+    if not isinstance(schema, dict):
+        meta["artifact_error"] = "output_schema must be a JSON object"
+        return meta
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            artifact_data = json.load(fh)
+    except Exception as exc:
+        meta["artifact_error"] = f"Artifact is not valid JSON: {exc}"
+        return meta
+    error = _validate_json_schema_subset(artifact_data, schema)
+    if error:
+        meta["artifact_error"] = error
+        return meta
+    meta["artifact_valid"] = True
+    return meta
+
+
+def _apply_artifact_contract_result(
+    entry: Dict[str, Any],
+    *,
+    artifact_path: Any = None,
+    output_schema: Any = None,
+    job_id: Any = None,
+    phase: Any = None,
+    worker_role: Any = None,
+) -> Dict[str, Any]:
+    contract = _evaluate_artifact_contract(
+        artifact_path=artifact_path,
+        output_schema=output_schema,
+        job_id=job_id,
+        phase=phase,
+        worker_role=worker_role,
+    )
+    if contract:
+        entry.update(contract)
+    if artifact_path is not None and entry.get("status") == "completed" and not contract.get("artifact_valid"):
+        reason = "artifact_missing" if not contract.get("artifact_exists") else "artifact_invalid"
+        entry["status"] = "failed"
+        entry["exit_reason"] = reason
+        entry["error"] = contract.get("artifact_error") or reason.replace("_", "-")
+    return entry
+
+
+def _normalise_task_contracts(
+    task_list: List[Dict[str, Any]],
+    *,
+    top_timeout_seconds: Any = None,
+    top_job_id: Any = None,
+    top_phase: Any = None,
+) -> List[Dict[str, Any]]:
+    """Copy task specs and apply top-level defaults used by contract workers."""
+    normalised: List[Dict[str, Any]] = []
+    default_timeout = None
+    if top_timeout_seconds is not None:
+        default_timeout = _coerce_timeout_seconds(top_timeout_seconds)
+    default_job_id = _optional_contract_text(top_job_id)
+    default_phase = _optional_contract_text(top_phase)
+    for i, task in enumerate(task_list):
+        out = dict(task)
+        if default_timeout is not None and out.get("timeout_seconds") is None:
+            out["timeout_seconds"] = default_timeout
+        elif out.get("timeout_seconds") is not None:
+            out["timeout_seconds"] = _coerce_timeout_seconds(
+                out.get("timeout_seconds"), field=f"tasks[{i}].timeout_seconds"
+            )
+        if default_job_id is not None and not out.get("job_id"):
+            out["job_id"] = default_job_id
+        if default_phase is not None and not out.get("phase"):
+            out["phase"] = default_phase
+        if out.get("output_schema") is not None and not out.get("artifact_path"):
+            raise ValueError(f"tasks[{i}].output_schema requires artifact_path")
+        normalised.append(out)
+    return normalised
+
+
 def _get_max_spawn_depth() -> int:
     """Read delegation.max_spawn_depth from config, clamped to [1, 3].
 
@@ -501,8 +708,9 @@ class DelegateEvent(str, enum.Enum):
     ``_LEGACY_EVENT_MAP``.  External consumers (gateway SSE, ACP adapter,
     CLI) still receive the legacy strings during the deprecation window.
 
-    TASK_SPAWNED / TASK_COMPLETED / TASK_FAILED are reserved for
-    future orchestrator lifecycle events and are not currently emitted.
+    TASK_SPAWNED / TASK_COMPLETED / TASK_FAILED are emitted for
+    contract-driven worker lifecycle telemetry. Legacy subagent.start and
+    subagent.complete events are still relayed for existing consumers.
     """
 
     TASK_SPAWNED = "delegate.task_spawned"
@@ -655,6 +863,10 @@ def _build_child_progress_callback(
     depth: Optional[int] = None,
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    job_id: Optional[str] = None,
+    phase: Optional[str] = None,
+    worker_role: Optional[str] = None,
+    artifact_path: Optional[str] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -702,6 +914,15 @@ def _build_child_progress_callback(
             kw["model"] = model
         if toolsets is not None:
             kw["toolsets"] = list(toolsets)
+        for key, value in (
+            ("job_id", job_id),
+            ("phase", phase),
+            ("worker_role", worker_role),
+            ("artifact_path", artifact_path),
+        ):
+            text = _optional_contract_text(value)
+            if text is not None:
+                kw[key] = text
         kw["tool_count"] = _tool_count[0]
         return kw
 
@@ -731,10 +952,18 @@ def _build_child_progress_callback(
                     spinner.print_above(f" {prefix}├─ 🔀 {short}")
                 except Exception as e:
                     logger.debug("Spinner print_above failed: %s", e)
+            _relay(DelegateEvent.TASK_SPAWNED.value, preview=preview or goal_label or "", **kwargs)
             _relay("subagent.start", preview=preview or goal_label or "", **kwargs)
             return
 
         if event_type == "subagent.complete":
+            status = str(kwargs.get("status") or "").lower()
+            lifecycle_event = (
+                DelegateEvent.TASK_COMPLETED.value
+                if status == "completed"
+                else DelegateEvent.TASK_FAILED.value
+            )
+            _relay(lifecycle_event, preview=preview, **kwargs)
             _relay("subagent.complete", preview=preview, **kwargs)
             return
 
@@ -764,6 +993,14 @@ def _build_child_progress_callback(
             return
 
         if event == DelegateEvent.TASK_TOOL_COMPLETED:
+            return
+
+        if event in {
+            DelegateEvent.TASK_SPAWNED,
+            DelegateEvent.TASK_COMPLETED,
+            DelegateEvent.TASK_FAILED,
+        }:
+            _relay(event.value, preview=preview or tool_name or "", **kwargs)
             return
 
         if event == DelegateEvent.TASK_PROGRESS:
@@ -852,6 +1089,11 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Optional worker-contract metadata relayed through lifecycle callbacks.
+    job_id: Optional[str] = None,
+    phase: Optional[str] = None,
+    worker_role: Optional[str] = None,
+    artifact_path: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -958,6 +1200,10 @@ def _build_child_agent(
         depth=tui_depth,
         model=effective_model_for_cb,
         toolsets=child_toolsets,
+        job_id=job_id,
+        phase=phase,
+        worker_role=worker_role,
+        artifact_path=artifact_path,
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
@@ -1244,6 +1490,13 @@ def _run_single_child(
     goal: str,
     child=None,
     parent_agent=None,
+    *,
+    timeout_seconds: Any = None,
+    artifact_path: Any = None,
+    output_schema: Any = None,
+    job_id: Any = None,
+    phase: Any = None,
+    worker_role: Any = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -1409,7 +1662,7 @@ def _run_single_child(
 
         # Run child with a hard timeout to prevent indefinite blocking
         # when the child's API call or tool-level HTTP request hangs.
-        child_timeout = _get_child_timeout()
+        child_timeout = _resolve_child_timeout(timeout_seconds)
         _timeout_executor = ThreadPoolExecutor(
             max_workers=1,
             # Install a non-interactive approval callback in the worker thread
@@ -1513,7 +1766,7 @@ def _run_single_child(
             else:
                 _err = str(_timeout_exc)
 
-            return {
+            entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
@@ -1524,6 +1777,14 @@ def _run_single_child(
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            return _apply_artifact_contract_result(
+                entry,
+                artifact_path=artifact_path,
+                output_schema=output_schema,
+                job_id=job_id,
+                phase=phase,
+                worker_role=worker_role,
+            )
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -1640,6 +1901,17 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        _apply_artifact_contract_result(
+            entry,
+            artifact_path=artifact_path,
+            output_schema=output_schema,
+            job_id=job_id,
+            phase=phase,
+            worker_role=worker_role,
+        )
+        status = entry.get("status", status)
+        exit_reason = entry.get("exit_reason", exit_reason)
+
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent
         # knows to re-read before editing — the scenario that motivated
@@ -1727,6 +1999,17 @@ def _run_single_child(
                 complete_kwargs["cost_usd"] = float(_cost_usd)
             except (TypeError, ValueError):
                 pass
+        for _contract_key in (
+            "artifact_path",
+            "artifact_exists",
+            "artifact_valid",
+            "artifact_error",
+            "job_id",
+            "phase",
+            "worker_role",
+        ):
+            if _contract_key in entry:
+                complete_kwargs[_contract_key] = entry[_contract_key]
 
         if child_progress_cb:
             try:
@@ -1750,7 +2033,7 @@ def _run_single_child(
                 )
             except Exception as e:
                 logger.debug("Progress callback failure relay failed: %s", e)
-        return {
+        entry = {
             "task_index": task_index,
             "status": "error",
             "summary": None,
@@ -1759,6 +2042,14 @@ def _run_single_child(
             "duration_seconds": duration,
             "_child_role": getattr(child, "_delegate_role", None),
         }
+        return _apply_artifact_contract_result(
+            entry,
+            artifact_path=artifact_path,
+            output_schema=output_schema,
+            job_id=job_id,
+            phase=phase,
+            worker_role=worker_role,
+        )
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity
@@ -1818,6 +2109,12 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    timeout_seconds: Any = None,
+    artifact_path: Any = None,
+    output_schema: Any = None,
+    job_id: Any = None,
+    phase: Any = None,
+    worker_role: Any = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1905,13 +2202,34 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "timeout_seconds": timeout_seconds,
+                "artifact_path": artifact_path,
+                "output_schema": output_schema,
+                "job_id": job_id,
+                "phase": phase,
+                "worker_role": worker_role,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
     if not task_list:
         return tool_error("No tasks provided.")
+
+    try:
+        task_list = _normalise_task_contracts(
+            task_list,
+            top_timeout_seconds=timeout_seconds,
+            top_job_id=job_id,
+            top_phase=phase,
+        )
+    except ValueError as exc:
+        return tool_error(str(exc))
 
     # Validate each task has a goal
     for i, task in enumerate(task_list):
@@ -1964,6 +2282,10 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                job_id=t.get("job_id"),
+                phase=t.get("phase"),
+                worker_role=t.get("worker_role"),
+                artifact_path=t.get("artifact_path"),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -1975,7 +2297,18 @@ def delegate_task(
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
         _i, _t, child = children[0]
-        result = _run_single_child(0, _t["goal"], child, parent_agent)
+        result = _run_single_child(
+            task_index=_i,
+            goal=_t["goal"],
+            child=child,
+            parent_agent=parent_agent,
+            timeout_seconds=_t.get("timeout_seconds"),
+            artifact_path=_t.get("artifact_path"),
+            output_schema=_t.get("output_schema"),
+            job_id=_t.get("job_id"),
+            phase=_t.get("phase"),
+            worker_role=_t.get("worker_role"),
+        )
         results.append(result)
     else:
         # Batch -- run in parallel with per-task progress lines
@@ -1991,6 +2324,12 @@ def delegate_task(
                     goal=t["goal"],
                     child=child,
                     parent_agent=parent_agent,
+                    timeout_seconds=t.get("timeout_seconds"),
+                    artifact_path=t.get("artifact_path"),
+                    output_schema=t.get("output_schema"),
+                    job_id=t.get("job_id"),
+                    phase=t.get("phase"),
+                    worker_role=t.get("worker_role"),
                 )
                 futures[future] = i
 
@@ -2431,6 +2770,21 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "timeout_seconds": {
+                "type": "number",
+                "description": "Optional wall-clock timeout for this delegated task. In batch mode this is the default for tasks that do not set their own timeout_seconds.",
+            },
+            "artifact_path": {
+                "type": "string",
+                "description": "Expected worker artifact path for single-task mode. If supplied, completed workers are downgraded to failed when the artifact is missing or invalid.",
+            },
+            "output_schema": {
+                "type": "object",
+                "description": "Optional JSON-schema subset for validating a JSON worker artifact at artifact_path.",
+            },
+            "job_id": {"type": "string", "description": "Optional job identifier included in lifecycle events and results."},
+            "phase": {"type": "string", "description": "Optional workflow phase included in lifecycle events and results."},
+            "worker_role": {"type": "string", "description": "Optional worker role included in lifecycle events and results."},
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2460,6 +2814,21 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "timeout_seconds": {
+                            "type": "number",
+                            "description": "Per-task wall-clock timeout override in seconds.",
+                        },
+                        "artifact_path": {
+                            "type": "string",
+                            "description": "Expected worker artifact path for this task.",
+                        },
+                        "output_schema": {
+                            "type": "object",
+                            "description": "Optional JSON-schema subset for validating the JSON artifact.",
+                        },
+                        "job_id": {"type": "string", "description": "Optional job identifier for lifecycle events/results."},
+                        "phase": {"type": "string", "description": "Optional workflow phase for lifecycle events/results."},
+                        "worker_role": {"type": "string", "description": "Optional worker role for lifecycle events/results."},
                     },
                     "required": ["goal"],
                 },
@@ -2524,6 +2893,12 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        timeout_seconds=args.get("timeout_seconds"),
+        artifact_path=args.get("artifact_path"),
+        output_schema=args.get("output_schema"),
+        job_id=args.get("job_id"),
+        phase=args.get("phase"),
+        worker_role=args.get("worker_role"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Summary

- Fix gateway `MEDIA:` extraction so multiple same-line tags do not get over-captured as one path.
- Add `delegate_task` worker contract support for top-level and per-task `timeout_seconds`, `artifact_path`, `output_schema`, and metadata fields.
- Surface worker contract lifecycle events while preserving legacy delegate progress events.
- Harden background-review/toolset handling and memory-status reporting.
- Update ACP advertised-command expectations for `steer` and `queue`.

## Test Plan

- `git diff --check origin/main..HEAD`
- `python -m py_compile gateway/platforms/base.py tools/delegate_tool.py hermes_cli/memory_setup.py run_agent.py tests/acp/test_server.py tests/gateway/test_media_extraction.py tests/hermes_cli/test_memory_status.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_toolset_restriction.py tests/tools/test_delegate.py`
- `python -m pytest tests/gateway/test_media_extraction.py tests/tools/test_delegate.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_toolset_restriction.py tests/hermes_cli/test_memory_status.py tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update -q -p no:cacheprovider`

Local result: `142 passed in 9.47s`.
