### PR TITLE
Hydrate historical tool calls on chat resume

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -30,6 +30,7 @@ import { Card } from "@/components/ui/card";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ToolCall, type ToolEntry } from "@/components/ToolCall";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import { api } from "@/lib/api";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -70,10 +71,132 @@ const STATE_TONE: Record<
 
 interface ChatSidebarProps {
   channel: string;
+  resumeSessionId?: string | null;
   className?: string;
 }
 
-export function ChatSidebar({ channel, className }: ChatSidebarProps) {
+interface HistoricalToolFunction {
+  name?: string;
+  arguments?: string;
+}
+
+interface HistoricalToolCall {
+  id?: string;
+  call_id?: string;
+  function?: HistoricalToolFunction;
+  name?: string;
+  arguments?: string;
+}
+
+interface HistoricalSessionMessage {
+  role?: string;
+  content?: string | null;
+  tool_call_id?: string | null;
+  tool_calls?: HistoricalToolCall[] | null;
+  timestamp?: number | string | null;
+}
+
+interface HistoricalToolResult {
+  summary?: string;
+  error?: string;
+  completedAt?: number;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? value : value * 1000;
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed > 1_000_000_000_000 ? parsed : parsed * 1000;
+    }
+
+    const date = Date.parse(value);
+    if (Number.isFinite(date)) {
+      return date;
+    }
+  }
+
+  return undefined;
+}
+
+function formatToolContext(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}
+
+function parseToolResult(content: unknown): HistoricalToolResult {
+  if (typeof content !== "string" || !content.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    const error = typeof parsed.error === "string" ? parsed.error : undefined;
+    const summaryValue = parsed.summary ?? parsed.output ?? parsed.result ?? parsed.content ?? parsed.message;
+    const summary = typeof summaryValue === "string" ? summaryValue : JSON.stringify(parsed, null, 2);
+    return { summary, error };
+  } catch {
+    return { summary: content };
+  }
+}
+
+function hydrateToolsFromMessages(messages: HistoricalSessionMessage[]): ToolEntry[] {
+  const toolResults = new Map<string, HistoricalToolResult>();
+
+  for (const message of messages) {
+    if (message.role !== "tool" || !message.tool_call_id) continue;
+    const result = parseToolResult(message.content);
+    const completedAt = timestampMs(message.timestamp);
+    if (completedAt) result.completedAt = completedAt;
+    toolResults.set(message.tool_call_id, result);
+  }
+
+  const entries: ToolEntry[] = [];
+
+  for (const message of messages) {
+    const calls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+
+    for (const call of calls) {
+      const fn = call.function;
+      const toolId = call.call_id ?? call.id ?? `historical-${entries.length}`;
+      const result = toolResults.get(toolId);
+      const context = formatToolContext(fn?.arguments ?? call.arguments);
+
+      const entry: ToolEntry = {
+        kind: "tool",
+        id: `history-tool-${toolId}-${entries.length}`,
+        tool_id: toolId,
+        name: fn?.name ?? call.name ?? "tool",
+        context,
+        summary: result?.summary,
+        error: result?.error,
+        status: result?.error ? "error" : "done",
+        startedAt: 0,
+        completedAt: result?.completedAt,
+      };
+
+      entries.push(entry);
+    }
+  }
+
+  return entries.slice(-TOOL_LIMIT);
+}
+
+export function ChatSidebar({
+  channel,
+  resumeSessionId,
+  className,
+}: ChatSidebarProps) {
   // `version` bumps on reconnect; gw is derived so we never call setState
   // for it inside an effect (React 19's set-state-in-effect rule). The
   // counter is the dependency on purpose — it's not read in the memo body,
@@ -141,6 +264,41 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       gw.close();
     };
   }, [gw]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!resumeSessionId) {
+      setTools([]);
+      return;
+    }
+
+    api
+      .getSessionMessages(resumeSessionId)
+      .then((result) => {
+        if (cancelled) return;
+
+        const messages = Array.isArray(result?.messages) ? result.messages : [];
+        const historicalTools = hydrateToolsFromMessages(messages as HistoricalSessionMessage[]);
+
+        setTools((prev) =>
+          [
+            ...historicalTools,
+            ...prev.filter((tool) => tool.startedAt > 0),
+          ].slice(-TOOL_LIMIT),
+        );
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : String(e);
+          setError(`failed to load historical tool calls: ${message}`);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resumeSessionId, version]);
 
   // Event subscriber WebSocket — receives the rebroadcast of every
   // dispatcher emit from the PTY child's gateway.  See /api/pub +

--- a/web/src/components/ToolCall.tsx
+++ b/web/src/components/ToolCall.tsx
@@ -86,7 +86,7 @@ export function ToolCall({ tool }: { tool: ToolEntry }) {
 
   return (
     <div
-      className={`rounded-md border overflow-hidden ${STATUS_TONE[tool.status]}`}
+      className={`shrink-0 rounded-md border overflow-hidden ${STATUS_TONE[tool.status]}`}
     >
       <ListItem
         onClick={() => setUserOverride(!open)}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -750,7 +750,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
-            <ChatSidebar channel={channel} />
+            <ChatSidebar channel={channel} resumeSessionId={resumeRef.current} />
           </div>
         </div>
       </>,
@@ -817,7 +817,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="flex min-h-0 shrink-0 flex-col lg:h-full lg:w-80"
           >
             <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
-              <ChatSidebar channel={channel} />
+              <ChatSidebar channel={channel} resumeSessionId={resumeRef.current} />
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Hydrate historical tool calls in the dashboard Chat sidebar when resuming an existing session.

## Root cause

The Chat sidebar only subscribed to live `/api/events` tool events. When opening `/chat?resume=<session-id>`, historical assistant `tool_calls` and matching `role=tool` results were already present in the session history, but the sidebar did not load them, so it displayed "no tool calls yet" until a new tool call happened.

## Fix

- Pass the resumed session id from `ChatPage` into `ChatSidebar`.
- Load resumed session messages via `getSessionMessages`.
- Reconstruct historical `ToolEntry` rows from assistant `tool_calls` and matching tool result messages.
- Keep live event handling unchanged so new tool calls continue to append in real time.

## Validation

- `npm run build`
- Manual test:
  1. Open Sessions.
  2. Choose a session with historical tool calls.
  3. Continue it in Chat.
  4. Confirm the Tools panel shows historical tool calls immediately instead of "no tool calls yet".
  5. Trigger a new tool call and confirm live tool events still append.
