### PR TITLE
feat(command): add start alias for new sessions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -64,7 +64,7 @@ class CommandDef:
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
-               aliases=("reset",), args_hint="[name]"),
+               aliases=("reset", "start"), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -446,6 +446,12 @@ class TestPendingCommandSafetyNet:
         assert resolve_command("reset") is not None
         assert resolve_command("reset").name == "new"  # alias
 
+    def test_start_alias_detected(self):
+        from hermes_cli.commands import resolve_command
+
+        assert resolve_command("start") is not None
+        assert resolve_command("start").name == "new"  # alias
+
     def test_unknown_command_not_detected(self):
         from hermes_cli.commands import resolve_command
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -102,6 +102,7 @@ class TestResolveCommand:
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
         assert resolve_command("reset").name == "new"
+        assert resolve_command("start").name == "new"
         assert resolve_command("q").name == "queue"
         assert resolve_command("exit").name == "quit"
         assert resolve_command("gateway").name == "platforms"
@@ -327,12 +328,13 @@ class TestSlackNativeSlashes:
             )
 
     def test_includes_aliases_as_first_class_slashes(self):
-        """Aliases (/btw, /bg, /reset, /q) must be registered as standalone
+        """Aliases (/btw, /bg, /reset, /start, /q) must be registered as standalone
         slashes — this is the whole point of native-slashes parity."""
         names = {n for n, _d, _h in slack_native_slashes()}
         assert "btw" in names
         assert "bg" in names
         assert "reset" in names
+        assert "start" in names
         assert "q" in names
 
     def test_telegram_parity(self):


### PR DESCRIPTION
## Summary

This adds `/start` as an alias for the existing `/new` command in the central slash-command registry. Because command resolution, gateway dispatch, help text, and native slash-command surfaces derive from this registry, `/start` now follows the same fresh-session path as `/new` and `/reset`.

## Why

Telegram commonly presents a Start button during bot cleanup, onboarding, or restarted-chat flows. Mapping `/start` to `/new` lets that button create a clean Hermes chat session with fresh history instead of falling through as a normal prompt. This keeps the Telegram workflow intuitive while preserving the existing `/new` behavior across gateway command handling.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/gateway/test_command_bypass_active_session.py`
