### PR TITLE
fix: decode config and state files as UTF-8 on non-UTF-8 locales

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -599,7 +599,7 @@ class CopilotACPClient:
                 block_error = get_read_block_error(str(path))
                 if block_error:
                     raise PermissionError(block_error)
-                content = path.read_text() if path.exists() else ""
+                content = path.read_text(encoding="utf-8") if path.exists() else ""
                 line = params.get("line")
                 limit = params.get("limit")
                 if isinstance(line, int) and line > 1:
@@ -626,7 +626,7 @@ class CopilotACPClient:
                         f"Write denied: '{path}' is a protected system/credential file."
                     )
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(str(params.get("content") or ""))
+                path.write_text(str(params.get("content") or ""), encoding="utf-8")
                 response = {
                     "jsonrpc": "2.0",
                     "id": message_id,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -743,7 +743,7 @@ def _load_context_cache() -> Dict[str, int]:
     if not path.exists():
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         return data.get("context_lengths", {})
     except Exception as e:
@@ -765,8 +765,8 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     path = _get_context_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.dump({"context_lengths": cache}, f, default_flow_style=False, allow_unicode=True)
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:
         logger.debug("Failed to save context length cache: %s", e)
@@ -789,8 +789,8 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     path = _get_context_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.dump({"context_lengths": cache}, f, default_flow_style=False, allow_unicode=True)
     except Exception as e:
         logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)
 

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:
@@ -144,7 +144,7 @@ def nous_rate_limit_remaining() -> Optional[float]:
     """
     path = _state_path()
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             state = json.load(f)
         reset_at = state.get("reset_at", 0)
         remaining = reset_at - time.time()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -920,7 +920,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
-                with open(_cfg_path) as _f:
+                with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -207,7 +207,7 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines))
+        output_path.write_text("\n".join(lines), encoding="utf-8")
         
         return {
             "path": str(output_path),
@@ -220,7 +220,7 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         return path
 
     async def _deliver_to_platform(

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -98,6 +98,84 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertNotIn("abc123def456", content)
         self.assertIn("OPENAI_API_KEY=", content)
 
+    def test_fs_read_text_file_decodes_as_utf8_under_non_utf8_locale(self) -> None:
+        """Regression for #18637 (bug 2): fs/read_text_file used
+        ``path.read_text()`` with no explicit encoding, so on Windows
+        GBK/CP932/CP949 locales the Copilot read_file tool crashed on any
+        source file with non-ASCII content (e.g. a CJK comment, an em dash,
+        or UTF-8 BOM)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "note.md"
+            target.write_text("# 中文标题\nem dash — here\n", encoding="utf-8")
+
+            original_read_text = Path.read_text
+
+            def strict_read_text(self, encoding=None, errors=None, **kwargs):
+                if self == target and encoding != "utf-8":
+                    raise UnicodeDecodeError(
+                        "gbk", b"\x94", 0, 1, "illegal multibyte sequence"
+                    )
+                return original_read_text(
+                    self, encoding=encoding, errors=errors, **kwargs
+                )
+
+            with patch.object(Path, "read_text", strict_read_text):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 10,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=str(root),
+                )
+
+        self.assertNotIn("error", response)
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertIn("中文标题", content)
+        self.assertIn("em dash —", content)
+
+    def test_fs_write_text_file_encodes_as_utf8(self) -> None:
+        """Regression for #18637 (bug 2): fs/write_text_file used
+        ``path.write_text()`` with no explicit encoding, so on non-UTF-8
+        locales the Copilot write tool could not emit code/config files
+        containing any char outside the platform codec."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "out.md"
+            payload = "# 中文标题\nem dash — here\n"
+
+            original_write_text = Path.write_text
+
+            def strict_write_text(
+                self, data, encoding=None, errors=None, **kwargs
+            ):
+                if self == target and encoding != "utf-8":
+                    raise UnicodeEncodeError(
+                        "gbk", data, 0, 1, "illegal multibyte sequence"
+                    )
+                return original_write_text(
+                    self, data, encoding=encoding, errors=errors, **kwargs
+                )
+
+            with patch.object(Path, "write_text", strict_write_text):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 11,
+                        "method": "fs/write_text_file",
+                        "params": {
+                            "path": str(target),
+                            "content": payload,
+                        },
+                    },
+                    cwd=str(root),
+                )
+
+            self.assertNotIn("error", response)
+            self.assertEqual(target.read_text(encoding="utf-8"), payload)
+
     def test_write_text_file_reuses_write_denylist(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir) / "home"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1022,3 +1022,65 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# Encoding regressions (Refs #18637)
+# =========================================================================
+
+
+class TestContextCacheEncoding:
+    """Regression for #18637: the context-length YAML cache was opened
+    without ``encoding="utf-8"`` on read and write. On Windows Chinese/
+    Japanese/Korean locales (GBK/CP932/CP949) the platform default decoder
+    rejects UTF-8 bytes and raises ``UnicodeDecodeError`` as soon as the
+    cache file contains any non-ASCII character (e.g. a model name with
+    a CJK alias, or a YAML comment with an em dash).
+    """
+
+    @staticmethod
+    def _install_gbk_like_open(monkeypatch, tracked_path: Path):
+        """Replace builtins.open so reads/writes against ``tracked_path``
+        only succeed when the caller explicitly passes encoding='utf-8'.
+        Mimics the effect of a GBK system locale on Windows."""
+        import builtins
+
+        real_open = builtins.open
+
+        def guarded_open(file, mode="r", *args, **kwargs):
+            same_path = False
+            try:
+                same_path = Path(file) == tracked_path
+            except TypeError:
+                same_path = False
+            text_mode = "b" not in mode
+            if same_path and text_mode and kwargs.get("encoding") != "utf-8":
+                raise UnicodeDecodeError(
+                    "gbk", b"\x94", 0, 1, "illegal multibyte sequence"
+                )
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", guarded_open)
+
+    def test_save_and_load_roundtrip_survives_non_utf8_locale(
+        self, monkeypatch, tmp_path
+    ):
+        cache_file = tmp_path / "context_cache.yaml"
+        with patch(
+            "agent.model_metadata._get_context_cache_path", return_value=cache_file
+        ):
+            # Pre-seed with non-ASCII content so the read path is
+            # exercised with actual UTF-8 bytes on disk.
+            cache_file.write_text(
+                "context_lengths:\n  # 中文注释 em dash —\n  foo@http://x: 4096\n",
+                encoding="utf-8",
+            )
+
+            self._install_gbk_like_open(monkeypatch, cache_file)
+
+            # Without encoding="utf-8" the read would raise here.
+            assert get_cached_context_length("foo", "http://x") == 4096
+
+            # And the write path must stay UTF-8 too.
+            save_context_length("bar", "http://x", 8192)
+            assert get_cached_context_length("bar", "http://x") == 8192

--- a/tests/agent/test_nous_rate_guard.py
+++ b/tests/agent/test_nous_rate_guard.py
@@ -389,3 +389,48 @@ class TestIsGenuineNousRateLimit:
         assert is_genuine_nous_rate_limit(
             headers=None, last_known_state=None
         ) is False
+
+
+class TestRateGuardStateEncoding:
+    """Regression for #18637: the cross-session rate-limit state file was
+    opened without ``encoding="utf-8"`` on both the atomic write (os.fdopen)
+    and the read. On Windows Chinese locales the platform default decoder
+    raises on UTF-8 bytes written by a peer process, silently losing the
+    rate-limit guard and re-enabling the retry amplification the module was
+    built to prevent.
+    """
+
+    def test_read_uses_utf8_under_non_utf8_locale(self, rate_guard_env, monkeypatch):
+        import builtins
+
+        from agent.nous_rate_guard import nous_rate_limit_remaining, _state_path
+
+        path = _state_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # State JSON written with a UTF-8 provider label. Python's json
+        # module itself escapes non-ASCII by default, but a peer writer
+        # (or human) using ensure_ascii=False produces raw UTF-8 bytes,
+        # which is what this guards against.
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                '{"reset_at": %d, "provider": "中文", "recorded_at": 0}'
+                % (int(time.time()) + 3600)
+            )
+
+        real_open = builtins.open
+
+        def guarded_open(file, mode="r", *args, **kwargs):
+            try:
+                is_target = str(file) == str(path)
+            except Exception:
+                is_target = False
+            if is_target and "b" not in mode and kwargs.get("encoding") != "utf-8":
+                raise UnicodeDecodeError(
+                    "gbk", b"\x94", 0, 1, "illegal multibyte sequence"
+                )
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", guarded_open)
+
+        remaining = nous_rate_limit_remaining()
+        assert remaining is not None and remaining > 0


### PR DESCRIPTION
## What does this PR do?

Extends the UTF-8 encoding fix from #18721 (which pinned `encoding="utf-8"` on the `.env` read path) to the remaining hot file-I/O call sites that still use the platform default codec. On Windows CN/JP/KR locales (GBK / CP932 / CP949) these crash on any non-ASCII byte — the same class of bug as [#18637](https://github.com/NousResearch/hermes-agent/issues/18637), which is currently labeled P1.

Specifically addresses **bug 2** from #18637 (Copilot's file-read tool crashing on non-ASCII files — `agent/copilot_acp_client.py` was reading via `Path.read_text()` with no encoding).

## Related Issue

Refs #18637 (partial — addresses bug 2 and hardens the other file-I/O hot paths in the same class).
Follow-up to #18721.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Added `encoding="utf-8"` to each read/write. For YAML writes also added `allow_unicode=True` so emitted YAML preserves CJK / emoji as-is instead of `\uXXXX` escapes.

| File | Sites | Why it matters on Windows |
|------|-------|---------------------------|
| `agent/copilot_acp_client.py` | `fs/read_text_file`, `fs/write_text_file` | User-content files (any source file with a CJK comment or em dash) — directly maps to #18637 bug 2 |
| `agent/model_metadata.py` | context-length cache load + 2 saves | On the call path of every model invocation; crashes if cache ever contains non-ASCII |
| `agent/nous_rate_guard.py` | cross-session rate-limit state read + atomic write (`os.fdopen`) | Silent loss of rate guard → re-enables the 9× retry amplification this module exists to prevent |
| `cron/scheduler.py` | `run_job` reading user `config.yaml` | Any user-authored YAML comment / description |
| `gateway/delivery.py` | cron output writes (2 sites) | AI-generated content, near-certain to contain non-ASCII |

No behaviour change on Linux / macOS (UTF-8 is already the platform default); only makes the already-implicit contract explicit.

## How to Test

```bash
python -m pytest \
  tests/agent/test_model_metadata.py::TestContextCacheEncoding \
  tests/agent/test_nous_rate_guard.py::TestRateGuardStateEncoding \
  tests/agent/test_copilot_acp_client.py::CopilotACPClientSafetyTests::test_fs_read_text_file_decodes_as_utf8_under_non_utf8_locale \
  tests/agent/test_copilot_acp_client.py::CopilotACPClientSafetyTests::test_fs_write_text_file_encodes_as_utf8 \
  -v
```

New regression tests follow the pattern established by #18721: monkeypatch `builtins.open` / `pathlib.Path.read_text` / `pathlib.Path.write_text` to simulate a GBK locale that rejects any caller that does not explicitly pass `encoding="utf-8"`.

- `tests/agent/test_model_metadata.py::TestContextCacheEncoding` — YAML round-trip
- `tests/agent/test_nous_rate_guard.py::TestRateGuardStateEncoding` — JSON state read
- `tests/agent/test_copilot_acp_client.py::test_fs_read_text_file_decodes_as_utf8_under_non_utf8_locale`
- `tests/agent/test_copilot_acp_client.py::test_fs_write_text_file_encodes_as_utf8`

Locally verified: reverting just the source edits makes all 4 tests **fail** with the expected `UnicodeDecodeError` / `UnicodeEncodeError`; reapplying the fix makes them pass. Full regression on the 5 touched modules stays green.

```
$ python -m pytest tests/agent/test_model_metadata.py tests/agent/test_nous_rate_guard.py \
                   tests/agent/test_copilot_acp_client.py tests/cron/test_scheduler.py \
                   tests/gateway/test_delivery.py
======================= 255 passed, 1 warning in 6.01s ========================
```

Tested on Windows 11, Python 3.12.3, system locale = Chinese (GBK). Should be a no-op on Linux / macOS.

## Checklist

- [x] Code follows the project style
- [x] Commit message follows Conventional Commits (`fix: ...`)
- [x] Added regression tests (verified fail → pass against the fix)
- [x] Tests pass locally (`pytest` on touched modules, 255/255)
- [x] No secrets / credentials in the diff
- [x] No unrelated changes
