### PR TITLE
fix(env_loader): prune previously-seeded keys when removed from .env

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from utils import atomic_replace
 
 
@@ -20,6 +20,16 @@ _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 # load_hermes_dotenv() calls (user env + project env, gateway hot-reload,
 # tests) don't spam the same warning multiple times.
 _WARNED_KEYS: set[str] = set()
+
+# Per-process registry of env var names that load_hermes_dotenv itself
+# placed into os.environ (i.e. they were absent before our load).  On
+# reload, any name in this set that is no longer declared by any loaded
+# .env file is removed from os.environ — preventing "ghost" values from
+# surviving after the user deletes a key from .env.  Long-running
+# processes (gateway, dashboard, CLI sessions) used to keep stale values
+# forever because python-dotenv only writes keys it sees in the file.
+# Names we never seeded (genuine shell exports) are never popped.
+_HERMES_SEEDED_KEYS: set[str] = set()
 
 
 def _format_offending_chars(value: str, limit: int = 3) -> str:
@@ -139,6 +149,39 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         pass  # best-effort — don't block gateway startup
 
 
+def _gather_declared_keys(*paths: Path) -> tuple[set[str], bool]:
+    """Return (keys declared by these .env files, all_parsed flag).
+
+    Uses python-dotenv's parser without mutating os.environ.  If any
+    file fails to parse, all_parsed=False so callers can skip pruning
+    rather than risk popping keys whose declaration we couldn't read.
+
+    A key only counts as "declared" when its parsed value is non-None.
+    A bare ``FOO`` line (no ``=``) parses as ``FOO -> None`` but is not
+    actually seeded into ``os.environ`` by ``load_dotenv``, so treating
+    it as declared would let a previously-seeded value linger as a
+    ghost.  ``FOO=`` (empty value) parses as ``FOO -> ""`` and IS
+    seeded, so it correctly counts as declared.
+    """
+    keys: set[str] = set()
+    all_parsed = True
+    for path in paths:
+        if not path or not path.exists():
+            continue
+        try:
+            try:
+                values = dotenv_values(dotenv_path=path, encoding="utf-8")
+            except UnicodeDecodeError:
+                values = dotenv_values(dotenv_path=path, encoding="latin-1")
+        except Exception:
+            all_parsed = False
+            continue
+        for key, value in values.items():
+            if key and value is not None:
+                keys.add(key)
+    return keys, all_parsed
+
+
 def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
@@ -151,6 +194,9 @@ def load_hermes_dotenv(
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+    - keys we previously placed into os.environ that no longer appear in any
+      loaded .env file are popped.  Shell-exported keys we never seeded are
+      left alone, even when they appear in .env.
     """
     loaded: list[Path] = []
 
@@ -164,6 +210,18 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _sanitize_env_file_if_needed(project_env_path)
 
+    # Snapshot which Hermes-seeded keys are still declared by any loaded
+    # .env file.  Anything we previously seeded that is now absent gets
+    # pruned from os.environ so deletions in .env take effect on reload.
+    declared_keys, all_parsed = _gather_declared_keys(user_env, project_env_path)
+    if all_parsed:
+        stale = _HERMES_SEEDED_KEYS - declared_keys
+        for key in stale:
+            os.environ.pop(key, None)
+        _HERMES_SEEDED_KEYS.difference_update(stale)
+
+    pre_load_keys = set(os.environ.keys())
+
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
@@ -171,5 +229,13 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
+
+    # Track keys we just placed into os.environ.  A key qualifies as
+    # "seeded by Hermes" only if it was absent before this load — keys
+    # already present (genuine shell exports, or values an earlier load
+    # already seeded) are not added a second time, and shell exports
+    # remain ineligible for pruning.
+    newly_seeded = (set(os.environ.keys()) - pre_load_keys) & declared_keys
+    _HERMES_SEEDED_KEYS.update(newly_seeded)
 
     return loaded

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -3,7 +3,27 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
+from hermes_cli import env_loader
 from hermes_cli.env_loader import load_hermes_dotenv
+
+
+@pytest.fixture(autouse=True)
+def _reset_seeded_keys():
+    """Each test starts with a clean Hermes-seeded-keys registry.
+
+    The module-level _HERMES_SEEDED_KEYS set persists across pytest tests
+    in the same process, which would let one test's seeded keys affect
+    another's pruning behavior.  Snapshot and restore around every test.
+    """
+    snapshot = set(env_loader._HERMES_SEEDED_KEYS)
+    env_loader._HERMES_SEEDED_KEYS.clear()
+    try:
+        yield
+    finally:
+        env_loader._HERMES_SEEDED_KEYS.clear()
+        env_loader._HERMES_SEEDED_KEYS.update(snapshot)
 
 
 def test_user_env_overrides_stale_shell_values(tmp_path, monkeypatch):
@@ -68,6 +88,149 @@ def test_user_env_takes_precedence_over_project_env(tmp_path, monkeypatch):
     assert loaded == [user_env, project_env]
     assert os.getenv("OPENAI_BASE_URL") == "https://user.example/v1"
     assert os.getenv("OPENAI_API_KEY") == "project-key"
+
+
+def test_seeded_key_removed_from_file_is_pruned_on_reload(tmp_path, monkeypatch):
+    """A key we placed into os.environ should disappear when removed from .env.
+
+    Regression for the long-standing "ghost env var" bug where a deleted
+    key kept its stale value for the lifetime of every long-running
+    Hermes process (gateway, dashboard, CLI sessions).
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("HERMES_TEST_GHOST_KEY=initial-value\n", encoding="utf-8")
+
+    monkeypatch.delenv("HERMES_TEST_GHOST_KEY", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("HERMES_TEST_GHOST_KEY") == "initial-value"
+
+    env_file.write_text("OPENAI_BASE_URL=https://example/v1\n", encoding="utf-8")
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("HERMES_TEST_GHOST_KEY") is None
+    assert os.getenv("OPENAI_BASE_URL") == "https://example/v1"
+
+
+def test_shell_exported_key_never_pruned(tmp_path, monkeypatch):
+    """Keys we never seeded (genuine shell exports) must survive reloads.
+
+    Even after the user's .env briefly declared then dropped the key,
+    we must not pop the shell-exported value out of os.environ.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("OPENAI_BASE_URL=https://example/v1\n", encoding="utf-8")
+
+    # Shell-exported value the user expects us to leave alone.
+    monkeypatch.setenv("HERMES_USER_SHELL_VAR", "from-shell")
+
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("HERMES_USER_SHELL_VAR") == "from-shell"
+
+    # Reload: still untouched, still present.
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("HERMES_USER_SHELL_VAR") == "from-shell"
+
+
+def test_bare_key_without_value_is_pruned_on_reload(tmp_path, monkeypatch):
+    """A bare ``KEY`` line (no ``=``) does not seed os.environ — previously
+    seeded values for that key should still be pruned.
+
+    ``dotenv_values`` reports ``KEY -> None`` for a bare ``KEY`` line, but
+    ``load_dotenv`` does NOT actually update os.environ for it.  Without
+    filtering None-valued declarations, the pruner would treat the key as
+    "still declared" and skip it, leaving a ghost value behind.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("MY_FLAG=enabled\n", encoding="utf-8")
+
+    monkeypatch.delenv("MY_FLAG", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("MY_FLAG") == "enabled"
+
+    # Rewrite to a bare key with no value.
+    env_file.write_text("MY_FLAG\n", encoding="utf-8")
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("MY_FLAG") is None, (
+        "bare KEY (no =) does not seed os.environ; the previously seeded "
+        "value must be pruned to avoid a ghost"
+    )
+
+
+def test_empty_value_keeps_key_declared(tmp_path, monkeypatch):
+    """A ``KEY=`` line (empty value) IS seeded by load_dotenv as ``""`` and
+    must be treated as declared, not pruned.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("MY_FLAG=enabled\n", encoding="utf-8")
+
+    monkeypatch.delenv("MY_FLAG", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("MY_FLAG") == "enabled"
+
+    env_file.write_text("MY_FLAG=\n", encoding="utf-8")
+    load_hermes_dotenv(hermes_home=home)
+
+    # Empty string, not None — load_dotenv overwrote with "".
+    assert os.getenv("MY_FLAG") == ""
+
+
+def test_seeded_key_pruned_when_only_in_one_of_two_files(tmp_path, monkeypatch):
+    """A key declared by user_env then dropped, while a project_env never
+    declared it, must be pruned on reload.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    user_env = home / ".env"
+    project_env = tmp_path / ".env"
+    project_env.write_text("OPENAI_BASE_URL=https://project.example/v1\n", encoding="utf-8")
+
+    user_env.write_text(
+        "OPENAI_BASE_URL=https://user.example/v1\nMY_USER_FLAG=on\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("MY_USER_FLAG", raising=False)
+
+    load_hermes_dotenv(hermes_home=home, project_env=project_env)
+    assert os.getenv("OPENAI_BASE_URL") == "https://user.example/v1"
+    assert os.getenv("MY_USER_FLAG") == "on"
+
+    # Drop MY_USER_FLAG from user_env; project_env never had it.
+    user_env.write_text("OPENAI_BASE_URL=https://user.example/v1\n", encoding="utf-8")
+    load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert os.getenv("MY_USER_FLAG") is None
+    assert os.getenv("OPENAI_BASE_URL") == "https://user.example/v1"
+
+
+def test_seeded_key_value_change_propagates_on_reload(tmp_path, monkeypatch):
+    """Editing a key's value in .env still updates os.environ on reload."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("OPENAI_BASE_URL=https://v1.example/v1\n", encoding="utf-8")
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("OPENAI_BASE_URL") == "https://v1.example/v1"
+
+    env_file.write_text("OPENAI_BASE_URL=https://v2.example/v1\n", encoding="utf-8")
+    load_hermes_dotenv(hermes_home=home)
+    assert os.getenv("OPENAI_BASE_URL") == "https://v2.example/v1"
 
 
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`load_hermes_dotenv()` calls `python-dotenv`'s `load_dotenv(override=True)`, which **writes** keys present in the file but never **removes** keys you deleted from `.env`. Long-running Hermes processes (gateway, dashboard, CLI sessions) keep stale values in `os.environ` for the lifetime of the process. The same key can ghost across SIGUSR1-triggered config reloads and explicit re-invocations of `load_hermes_dotenv()` inside the same process. Restarting the process is the only mitigation today.

## Real-world failure mode

A key deleted from `~/.hermes/.env` continued routing `browser_navigate` calls to its old endpoint for 8 days across three long-lived CLI processes. macOS `ps eEww -p <pid>` returns nothing for env on non-self processes, so detecting the ghost requires `lldb` or a process restart — there is no surfaced signal.

## Fix

Track keys that `load_hermes_dotenv` itself put into `os.environ` in a per-process `_HERMES_SEEDED_KEYS` set, populated only when a key was absent from `os.environ` before our load. Before each subsequent load:

1. Parse the `.env` file(s) with `dotenv_values` to compute declared keys.
2. Pop any seeded key not in that declared set, and drop it from the registry.
3. Then run `load_dotenv` as before.

Genuine shell exports (keys we never seeded) are never popped — only keys whose presence in `os.environ` originated from one of our own `load_dotenv` calls. If any `.env` file fails to parse, pruning is skipped to avoid clobbering keys whose declaration we couldn't read.

A bare `FOO` line (no `=`) is treated as undeclared. `dotenv_values` returns it as `FOO -> None` but `load_dotenv` does not actually seed it, so counting it as declared would let a previously-seeded value linger. `FOO=` (empty value) parses as `FOO -> \"\"` and IS seeded, so it stays declared.

## Relationship to #18734

#18734 addresses a related but distinct bug: 12-factor precedence between shell-exported env vars and `.env` file values. That PR flips the default to `override=False` with a `HERMES_DOTENV_OVERRIDE=1` opt-in.

This PR is **complementary**. It fixes the multi-load-in-same-process ghost under either precedence default — when `override=True` is in effect (or when `override=False` but `.env` did originally seed a value), a deletion in `.env` now actually takes effect on reload instead of pinning the old value forever.

## Test plan

Six new test cases plus an autouse fixture that snapshots and restores the seeded-keys registry between tests:

- [x] `test_seeded_key_removed_from_file_is_pruned_on_reload`
- [x] `test_shell_exported_key_never_pruned`
- [x] `test_seeded_key_value_change_propagates_on_reload`
- [x] `test_bare_key_without_value_is_pruned_on_reload`
- [x] `test_empty_value_keeps_key_declared`
- [x] `test_seeded_key_pruned_when_only_in_one_of_two_files`

All 11 tests in `tests/hermes_cli/test_env_loader.py` pass:

\`\`\`
$ pytest tests/hermes_cli/test_env_loader.py
11 passed in 1.51s
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)