### PR TITLE
fix(cron): use ensure_ascii=False when saving jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -373,7 +373,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)


### PR DESCRIPTION
Without this, json.dump() escapes all non-ASCII characters (e.g. Chinese) as \\uXXXX sequences. The file is opened with UTF-8 encoding so there is no need for ASCII-safe encoding; saving Chinese characters as-is is both more readable and more compact.

Fixes the cron jobs.json file containing Unicode escapes like \\u68c0\\u67e5 instead of readable Chinese characters.