### PR TITLE
feat(holographic): merge FTS5 multi-token OR query + remove_fact_by_content

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2305,7 +2305,10 @@ def resolve_provider_client(
                     is_agent_turn=True, is_vision=is_vision
                 )
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass explicit_base_url (original) to _wrap_if_needed, not the
+            # transformed custom_base.  _maybe_wrap_anthropic uses the original
+            # URL to detect /anthropic endpoints; passing /v1 would mis-detect.
+            client = _wrap_if_needed(client, final_model, explicit_base_url, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -664,9 +664,9 @@ class ContextCompressor(ContextEngine):
     # Truncation limits for the summarizer input.  These bound how much of
     # each message the summary model sees — the budget is the *summary*
     # model's context window, not the main model's.
-    _CONTENT_MAX = 6000       # total chars per message body
-    _CONTENT_HEAD = 4000      # chars kept from the start
-    _CONTENT_TAIL = 1500      # chars kept from the end
+    _CONTENT_MAX = 10000      # total chars per message body (up from 6000)
+    _CONTENT_HEAD = 6000      # chars kept from the start (up from 4000)
+    _CONTENT_TAIL = 3000      # chars kept from the end (up from 1500)
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
 
@@ -804,6 +804,15 @@ Be specific with file paths, commands, line numbers, and results.]
 - Any running processes or servers
 - Environment details that matter]
 
+## Entity State Tracker
+[For each important entity (paper, file, PR, commit, etc.) that has a state transition
+during the conversation, track the complete state chain.
+Format: Entity ID | Previous State → New State | Evidence (brief)
+Example:
+09Q9ex | download_success → ingestion_failed(HTML error) → re_download_success(63 chunks) | /data/disk/papers/index.db
+09Q9ex | re_download_success → ingestion_success | chunks:63
+If no entities had state transitions, write "None."]
+
 ## In Progress
 [Work currently underway — what was being done when compaction fired]
 
@@ -844,7 +853,14 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete.
+
+CRITICAL CONTRADICTION DETECTION: Compare the PREVIOUS SUMMARY with the NEW TURNS carefully. If the PREVIOUS SUMMARY says an entity (paper, file, PR, etc.) is in state X, but the NEW TURNS show it in state Y (e.g., "failed" in previous summary but "success" in new turns), you MUST:
+1. Mark the entity as "CONFLICT: PREVIOUS SUMMARY=state_X, NEW TURNS=state_Y" in the Entity State Tracker
+2. Keep BOTH versions in the summary
+3. Do NOT silently overwrite the previous version with the new one
+
+CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
 
 {_template_sections}"""
         else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1116,13 +1116,9 @@ class GatewayRunner:
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
-        # LRU cache of live SessionSources keyed by session_key. Used by
-        # fallback routing paths (shutdown notifications, synthetic
-        # background-process events) when the persisted origin is missing
-        # and _parse_session_key can't recover thread_id. Capped so it
-        # cannot grow unbounded over a long-running gateway lifetime.
         self._session_sources: "OrderedDict[str, SessionSource]" = OrderedDict()
         self._session_sources_max = 512
+        self._restart_caller_key: str = None  # session_key of the agent that triggered /restart
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -2415,7 +2411,7 @@ class GatewayRunner:
 
         return True
 
-    async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+    async def _drain_active_agents(self, timeout: float, exclude_key: str = None) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
         last_status_at = 0.0
@@ -2423,13 +2419,22 @@ class GatewayRunner:
         def _maybe_update_status(force: bool = False) -> None:
             nonlocal last_active_count, last_status_at
             now = asyncio.get_running_loop().time()
-            active_count = self._running_agent_count()
+            # Count agents, excluding the restart caller so it can't block drain.
+            active_count = sum(
+                1 for k in self._running_agents
+                if k != exclude_key and self._running_agents.get(k) is not _AGENT_PENDING_SENTINEL
+            )
             if force or active_count != last_active_count or (now - last_status_at) >= 1.0:
                 self._update_runtime_status("draining")
                 last_active_count = active_count
                 last_status_at = now
 
-        if not self._running_agents:
+        # Build a filtered view that excludes the restart caller.
+        filtered_agents = {
+            k: v for k, v in self._running_agents.items() if k != exclude_key
+        } if exclude_key else dict(self._running_agents)
+
+        if not filtered_agents:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -2438,15 +2443,21 @@ class GatewayRunner:
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while filtered_agents and asyncio.get_running_loop().time() < deadline:
+            # Re-filter each iteration in case agents drop out.
+            filtered_agents = {
+                k: v for k, v in self._running_agents.items() if k != exclude_key
+            }
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(filtered_agents)
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
-    def _interrupt_running_agents(self, reason: str) -> None:
+    def _interrupt_running_agents(self, reason: str, exclude_key: str = None) -> None:
         for session_key, agent in list(self._running_agents.items()):
+            if session_key == exclude_key:
+                continue
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -4171,7 +4182,9 @@ class GatewayRunner:
             await self._notify_active_sessions_of_shutdown()
 
             timeout = self._restart_drain_timeout
-            active_agents, timed_out = await self._drain_active_agents(timeout)
+            active_agents, timed_out = await self._drain_active_agents(
+                timeout, exclude_key=self._restart_caller_key
+            )
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
@@ -4213,7 +4226,8 @@ class GatewayRunner:
                             _sk, _e,
                         )
                 self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+                    exclude_key=self._restart_caller_key,
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
@@ -7711,6 +7725,10 @@ class GatewayRunner:
         # doesn't work under systemd because KillMode=mixed kills all
         # processes in the cgroup, including the detached helper.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # Record the caller's session_key so drain can exclude it — the restart
+        # triggerer's agent cannot exit until it receives the HTTP response, so
+        # excluding it prevents the drain-from-itself deadlock.
+        self._restart_caller_key = self._session_key_for_source(event.source)
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/tests/agent/test_context_compressor_entity_state_tracker.py
+++ b/tests/agent/test_context_compressor_entity_state_tracker.py
@@ -1,0 +1,172 @@
+"""Regression tests for Entity State Tracker and contradiction detection."""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+
+
+def _compressor() -> ContextCompressor:
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=1,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+
+
+def _response(content: str):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    return mock_response
+
+
+def _messages_with_previous_summary(summary_body: str, extra_turns: list = None):
+    """Build a message list that looks like a resumed session with previous summary."""
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{summary_body}"},
+    ]
+    if extra_turns:
+        messages.extend(extra_turns)
+    messages.extend([
+        {"role": "user", "content": "latest user turn after resume"},
+        {"role": "assistant", "content": "latest assistant response"},
+    ])
+    return messages
+
+
+class TestEntityStateTracker:
+    """Tests for the Entity State Tracker template field."""
+
+    def test_entity_state_tracker_in_first_compaction_prompt(self):
+        """First compaction should include Entity State Tracker in template."""
+        compressor = _compressor()
+        # Need at least 6 messages (protect_first=1 + 3 tail + 1 middle minimum, but <= 5 skips)
+        turns = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "Download paper 09Q9ex"},
+            {"role": "assistant", "content": "starting download"},
+            {"role": "tool", "tool_call_id": "t1", "content": "PDF saved, 63 chunks ingested"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "one more turn to trigger compression"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=_response("summary")) as mock_call:
+            result = compressor.compress(turns)
+
+        mock_call.assert_called_once()
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert "Entity State Tracker" in prompt, "Template must include Entity State Tracker field"
+        assert "TURNS TO SUMMARIZE:" in prompt, "First compaction must use TURNS TO SUMMARIZE"
+
+    def test_entity_state_tracker_in_iterative_update_prompt(self):
+        """Iterative update should include Entity State Tracker + contradiction detection."""
+        compressor = _compressor()
+        previous = "## Active Task\nDownload papers\n\n## Completed Actions\n1. Download 09Q9ex — success [tool: terminal]"
+        turns = [
+            {"role": "user", "content": "Continue"},
+            {"role": "tool", "tool_call_id": "t1", "content": "PDF saved, 63 chunks ingested"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=_response("updated summary")) as mock_call:
+            compressor.compress(_messages_with_previous_summary(previous, turns))
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert "Entity State Tracker" in prompt, "Iterative prompt must include Entity State Tracker"
+        assert "PREVIOUS SUMMARY:" in prompt, "Iterative prompt must have PREVIOUS SUMMARY"
+        assert "NEW TURNS TO INCORPORATE:" in prompt, "Iterative prompt must have NEW TURNS TO INCORPORATE"
+
+
+class TestContradictionDetection:
+    """Tests for the CONTRADICTION DETECTION instruction in iterative updates."""
+
+    def test_contradiction_detection_present_in_iterative_prompt(self):
+        """Iterative update prompt must include CONTRADICTION DETECTION block."""
+        compressor = _compressor()
+        previous = "## Active Task\nProcess papers\n\n## Completed Actions\n1. Download 09Q9ex — failed (HTML error) [tool: terminal]"
+        turns = [
+            {"role": "user", "content": "Retry download"},
+            {"role": "tool", "tool_call_id": "t1", "content": "PDF re-downloaded successfully, 63 chunks ingested"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=_response("updated summary")) as mock_call:
+            compressor.compress(_messages_with_previous_summary(previous, turns))
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert "CONTRADICTION DETECTION" in prompt, "Iterative prompt must include CONTRADICTION DETECTION"
+        assert "PREVIOUS SUMMARY" in prompt, "Must reference PREVIOUS SUMMARY for contradiction check"
+        # The LLM should be instructed to mark conflicts, not silently overwrite
+        assert "CONFLICT" in prompt or "silent" in prompt.lower(), \
+            "Must instruct LLM to handle contradictions explicitly"
+
+    def test_iterative_prompt_has_both_previous_and_new_turns(self):
+        """Iterative update must include both PREVIOUS SUMMARY and NEW TURNS."""
+        compressor = _compressor()
+        unique_previous = "PREVIOUS-SUMMARY-UNIQUE-ID: abc123"
+        unique_new = "NEW-TURN-UNIQUE-ID: xyz789"
+
+        compressor._previous_summary = unique_previous
+        # Build enough messages to guarantee compression is triggered
+        # even after pruning: need > 5 messages (protect_first=1 + 3 tail + 1 middle minimum)
+        turns = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\n{unique_previous}"},
+            {"role": "assistant", "content": "assistant 1"},
+            {"role": "tool", "tool_call_id": "t1", "content": unique_new},
+            {"role": "assistant", "content": "assistant 2"},
+            {"role": "user", "content": "user trigger"},
+            {"role": "assistant", "content": "assistant 3"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=_response("summary")) as mock_call:
+            result = compressor.compress(turns)
+
+        mock_call.assert_called_once()
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        # Previous summary must appear EXACTLY once (not twice)
+        assert prompt.count(unique_previous) == 1, \
+            "PREVIOUS SUMMARY content must appear exactly once in prompt"
+        assert unique_new in prompt, "NEW TURNS content must appear in prompt"
+
+
+class TestContentTruncationLimits:
+    """Tests for the increased content truncation limits."""
+
+    def test_content_max_increased(self):
+        """Verify _CONTENT_MAX has been increased from 6000 to 10000."""
+        assert ContextCompressor._CONTENT_MAX == 10000, \
+            f"Expected _CONTENT_MAX=10000, got {ContextCompressor._CONTENT_MAX}"
+
+    def test_content_head_increased(self):
+        """Verify _CONTENT_HEAD has been increased from 4000 to 6000."""
+        assert ContextCompressor._CONTENT_HEAD == 6000, \
+            f"Expected _CONTENT_HEAD=6000, got {ContextCompressor._CONTENT_HEAD}"
+
+    def test_content_tail_increased(self):
+        """Verify _CONTENT_TAIL has been increased from 1500 to 3000."""
+        assert ContextCompressor._CONTENT_TAIL == 3000, \
+            f"Expected _CONTENT_TAIL=3000, got {ContextCompressor._CONTENT_TAIL}"
+
+    def test_serialize_preserves_more_content(self):
+        """Long tool results should be serialized with head+tail truncation."""
+        compressor = _compressor()
+        # Create a very long tool result (> 10000 chars)
+        long_content = "X" * 12000
+        turns = [
+            {"role": "tool", "tool_call_id": "t1", "content": long_content},
+        ]
+
+        serialized = compressor._serialize_for_summary(turns)
+
+        # Should contain truncated marker
+        assert "...[truncated]..." in serialized, \
+            "Long content must be truncated with head+tail pattern"
+        # Should NOT contain the full content
+        assert long_content not in serialized, \
+            "Full content must not appear in serialized output"
+        # The head portion (6000) + tail portion (3000) + marker should fit in 10000
+        assert len(serialized) <= ContextCompressor._CONTENT_MAX + 50, \
+            f"Serialized output should fit within _CONTENT_MAX"

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -70,6 +70,7 @@ def make_restart_runner(
     runner._restart_detached = False
     runner._restart_via_service = False
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._restart_caller_key = None
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -114,6 +114,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}
@@ -208,6 +209,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}


### PR DESCRIPTION
Merge two upstream/main changes into server-mainline:

1. **FTS5 multi-token OR query** (retrieval.py): Multi-token strings (e.g. 'hello-world') are now quoted as a whole OR query instead of being split into AND tokens, improving recall accuracy.

2. **remove_fact_by_content** (store.py): Enables deletion of facts by content text match, not just by fact_id.