### PR TITLE
fix(web/dashboard): skip xterm.js WebGL renderer on Safari to fix Unicode box-drawing glyphs

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -88,6 +88,37 @@ function terminalTierWidthPx(host: HTMLElement | null): number {
   return Math.max(1, Math.round(layout));
 }
 
+/**
+ * Detect Safari (the WebKit-based browser shipped with macOS/iOS).
+ *
+ * Safari's WebGL implementation mangles Unicode box-drawing glyphs
+ * (╔╗║╚╝, ██╗, etc.) used by the HERMES AGENT banner and TUI borders —
+ * the texture-atlas path renders fragmented blocks instead of forming proper
+ * shapes, while Chrome and Firefox WebGL render the same glyphs correctly
+ * (#18773). The default DOM renderer handles these glyphs faithfully on
+ * Safari, so we skip the WebGL addon there.
+ *
+ * Detection rules:
+ *  - User-Agent must contain `Safari/`.
+ *  - User-Agent must NOT contain any Chromium fingerprint (`Chrome/`,
+ *    `Chromium/`, `CriOS/`) — Chromium-based browsers all advertise
+ *    `Safari/` in their UA for legacy compat.
+ *  - User-Agent must NOT contain other WebKit-wrapping shells we know don't
+ *    hit the bug (`FxiOS/` for Firefox iOS, `EdgiOS/`, `Android` UAs).
+ *
+ * That gives us actual macOS/iOS Safari (and Safari Technology Preview)
+ * without false positives on Chromium derivatives.
+ */
+function isSafariBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent || "";
+  if (!ua.includes("Safari/")) return false;
+  if (/Chrom(e|ium)\/|CriOS\/|FxiOS\/|EdgiOS\/|Android/.test(ua)) {
+    return false;
+  }
+  return true;
+}
+
 function terminalFontSizeForWidth(layoutWidthPx: number): number {
   if (layoutWidthPx < 300) return 7;
   if (layoutWidthPx < 360) return 8;
@@ -370,7 +401,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // than `fontSize` suggests — users see "huge" text even at 7–9px settings.
     // The canvas/DOM renderer tracks `fontSize` faithfully; use it for narrow
     // hosts.  Wide layouts still get WebGL for crisp box-drawing.
-    const useWebgl = terminalTierWidthPx(host) >= 768;
+    //
+    // Safari is also excluded: its WebGL renderer mangles Unicode
+    // box-drawing glyphs (╔╗║╚╝, ██╗) so the HERMES AGENT banner and TUI
+    // borders fragment visually, even though Chrome/Firefox WebGL renders
+    // them correctly. The default DOM renderer handles these glyphs faithfully
+    // on Safari, so skip the WebGL addon there (#18773).
+    const useWebgl = terminalTierWidthPx(host) >= 768 && !isSafariBrowser();
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();


### PR DESCRIPTION
## Summary

Fixes #18773. In the dashboard Chat tab, Safari's WebGL renderer mangles Unicode box-drawing characters (`╔╗║╚╝`, `██╗`, etc.) used by the HERMES AGENT banner and TUI borders — they fragment into blocks instead of forming proper shapes. Chrome and Firefox WebGL render the same glyphs correctly.

This is a known xterm.js + Safari WebKit interaction (also affects VS Code Server, JupyterLab, etc.).

## Fix

`web/src/pages/ChatPage.tsx`: skip the `WebglAddon` on Safari and let xterm.js fall back to the default DOM renderer, which renders the box-drawing glyphs faithfully on Safari.

A short `isSafariBrowser()` helper detects macOS/iOS Safari without false positives on Chromium derivatives:

- Requires the `Safari/` UA token.
- Excludes Chromium fingerprints (`Chrome/`, `Chromium/`, `CriOS/`) — Chromium-based browsers all advertise `Safari/` in their UA for legacy compat.
- Excludes other WebKit-wrapping shells we know don't hit the bug (`FxiOS/`, `EdgiOS/`, `Android` UAs).

Existing WebGL gate (`terminalTierWidthPx(host) >= 768`) is preserved, so wide layouts on Chrome/Firefox/Edge still get the crisp WebGL rendering. Only Safari at any width goes to the DOM renderer.

## Why not the issue's proposed `rendererType: 'dom'`?

The proposed `new Terminal({ rendererType: 'dom' })` option is from xterm.js v4 and was removed in v5+. The repo is on `@xterm/xterm@^6.0.0`, where renderer choice is controlled via addons (`WebglAddon`, `CanvasAddon`). Skipping the `WebglAddon` is the modern equivalent.

## Verification

- `tsc -b`: clean.
- `vite build`: clean (1.65s).
- Diff scope: `web/src/pages/ChatPage.tsx` only, +38/-1.

## What I did NOT change

- Chrome/Firefox/Edge WebGL path (still active for wide layouts).
- Mobile/narrow layout fallback (`< 768px` → DOM renderer; unchanged).
- The Safari path uses the default DOM renderer, not the canvas addon — adding `@xterm/addon-canvas` would be a bigger dependency change and the DOM renderer already renders box-drawing correctly on Safari per the issue and xterm.js docs.

cc @bb @W0921

Closes #18773
