### PR TITLE
fix(hindsight): sync bank_mission and bank_retain_mission to Banks API

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1117,6 +1117,48 @@ class HindsightMemoryProvider(MemoryProvider):
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()
 
+        # Sync bank_mission / bank_retain_mission to the Hindsight API in the
+        # background so the live bank state matches the Hermes config file.
+        if self._bank_mission or self._bank_retain_mission:
+            t_sync = threading.Thread(
+                target=self._sync_bank_settings, daemon=True,
+                name="hindsight-bank-sync",
+            )
+            t_sync.start()
+
+    def _sync_bank_settings(self) -> None:
+        """Sync bank_mission and bank_retain_mission to the Hindsight Banks API.
+
+        Called once during initialize() on a background thread so it doesn't
+        block startup.  Errors are logged at warning level and swallowed —
+        the plugin continues to work even if the sync fails (e.g. the
+        Hindsight server is temporarily unreachable).
+        """
+        try:
+            if self._bank_mission:
+                logger.debug("Syncing bank_mission to Hindsight bank %s", self._bank_id)
+                self._run_hindsight_operation(
+                    lambda client: client.aset_mission(
+                        bank_id=self._bank_id, mission=self._bank_mission
+                    )
+                )
+                logger.info("Hindsight bank %s: mission synced", self._bank_id)
+
+            if self._bank_retain_mission:
+                logger.debug("Syncing bank_retain_mission to Hindsight bank %s", self._bank_id)
+                self._run_hindsight_operation(
+                    lambda client: client._aupdate_bank_config(
+                        bank_id=self._bank_id,
+                        updates={"retain_mission": self._bank_retain_mission},
+                    )
+                )
+                logger.info("Hindsight bank %s: retain_mission synced", self._bank_id)
+        except Exception as exc:
+            logger.warning(
+                "Failed to sync bank settings to Hindsight (bank=%s): %s",
+                self._bank_id, exc,
+            )
+
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":
             return (

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1445,3 +1445,64 @@ class TestShutdown:
         assert embedded._client is None
         assert provider._client is None
 
+
+
+class TestSyncBankSettings:
+    """Tests for _sync_bank_settings — syncing bank_mission / bank_retain_mission
+    to the Hindsight Banks API during initialize()."""
+
+    def test_sync_mission_calls_aset_mission(self, provider_with_config):
+        p = provider_with_config(bank_mission="Test mission for the bank")
+        p._client.aset_mission = AsyncMock(return_value={"ok": True})
+        p._client._aupdate_bank_config = AsyncMock(return_value={"ok": True})
+
+        p._sync_bank_settings()
+
+        p._client.aset_mission.assert_awaited_once_with(
+            bank_id="test-bank", mission="Test mission for the bank"
+        )
+
+    def test_sync_retain_mission_calls_aupdate_bank_config(self, provider_with_config):
+        p = provider_with_config(bank_retain_mission="Extract durable facts only")
+        p._client.aset_mission = AsyncMock(return_value={"ok": True})
+        p._client._aupdate_bank_config = AsyncMock(return_value={"ok": True})
+
+        p._sync_bank_settings()
+
+        p._client._aupdate_bank_config.assert_awaited_once_with(
+            bank_id="test-bank",
+            updates={"retain_mission": "Extract durable facts only"},
+        )
+
+    def test_sync_both_missions(self, provider_with_config):
+        p = provider_with_config(
+            bank_mission="Identity mission",
+            bank_retain_mission="Retain mission",
+        )
+        p._client.aset_mission = AsyncMock(return_value={"ok": True})
+        p._client._aupdate_bank_config = AsyncMock(return_value={"ok": True})
+
+        p._sync_bank_settings()
+
+        p._client.aset_mission.assert_awaited_once()
+        p._client._aupdate_bank_config.assert_awaited_once()
+
+    def test_sync_skipped_when_no_missions(self, provider):
+        """No API calls when neither mission is configured."""
+        provider._bank_mission = ""
+        provider._bank_retain_mission = None
+        provider._client.aset_mission = AsyncMock()
+        provider._client._aupdate_bank_config = AsyncMock()
+
+        provider._sync_bank_settings()
+
+        provider._client.aset_mission.assert_not_awaited()
+        provider._client._aupdate_bank_config.assert_not_awaited()
+
+    def test_sync_failure_is_logged_not_raised(self, provider_with_config):
+        p = provider_with_config(bank_mission="Will fail")
+        p._client.aset_mission = AsyncMock(side_effect=Exception("Connection refused"))
+        p._client._aupdate_bank_config = AsyncMock()
+
+        # Should not raise
+        p._sync_bank_settings()


### PR DESCRIPTION
## Summary

Fixes #18774

The Hindsight memory plugin reads `bank_mission` and `bank_retain_mission` from config (`~/.hermes/hindsight/config.json`) but never syncs these values to the live Hindsight Banks API. This causes the Hindsight WebUI and Banks API to show empty `mission` / `retain_mission` even when configured in Hermes.

## Changes

- **`plugins/memory/hindsight/__init__.py`**: Add `_sync_bank_settings()` method that:
  - Calls `client.aset_mission(bank_id, mission)` when `bank_mission` is configured
  - Calls `client._aupdate_bank_config(bank_id, updates={"retain_mission": ...})` when `bank_retain_mission` is configured
  - Runs on a background thread during `initialize()` to avoid blocking startup
  - Logs warnings on failure without raising (graceful degradation)

- **`tests/plugins/memory/test_hindsight_provider.py`**: Add `TestSyncBankSettings` class with 5 tests covering:
  - Mission sync via `aset_mission`
  - Retain mission sync via `_aupdate_bank_config`
  - Both missions synced together
  - No-op when neither mission is configured
  - Graceful error handling (logged, not raised)

## Testing

```bash
pytest tests/plugins/memory/test_hindsight_provider.py -x -q
# 96 passed
```

## Scope

1 file changed (+ test file). No changes to public API or config schema.