### PR TITLE
Fix: Handle empty acp_args list correctly in CopilotACPClient

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -329,7 +329,8 @@ class CopilotACPClient:
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        # Use None check instead of truthiness: empty list [] is valid (no args)
+        self._acp_args = list(acp_args if acp_args is not None else (args if args is not None else _resolve_args()))
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False


### PR DESCRIPTION
## Problem
The `CopilotACPClient` in `agent/copilot_acp_client.py` uses `acp_args or args or _resolve_args()` to determine the ACP arguments. However, Python treats an empty list `[]` as falsy, so when users explicitly pass `acp_args=[]`, it falls back to the default `['--acp', '--stdio']`.

This breaks OpenCode ACP delegation because `opencode acp` doesn't support the `--stdio` flag.

## Solution
Changed the logic to use explicit `is not None` checks instead of truthiness evaluation:

```python
# Before (buggy):
self._acp_args = list(acp_args or args or _resolve_args())

# After (fixed):
self._acp_args = list(acp_args if acp_args is not None else (args if args is not None else _resolve_args()))
```

## Testing
- ✅ Tested OpenCode ACP delegation with `acp_args=[]` - now works correctly
- ✅ Text-based ACP tasks work with `acp_command="opencode"`, `acp_args=["acp"]`
- ✅ Default behavior preserved when no args are specified

## Notes
OpenCode ACP server (`opencode acp`) doesn't support tool calls (no `tools/list` JSON-RPC method), but text-based tasks work correctly after this fix.