### PR TITLE
fix(gateway): translate document cache paths for docker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5519,16 +5519,28 @@ class GatewayRunner:
                 display_name = parts[2] if len(parts) >= 3 else basename
                 display_name = re.sub(r'[^\w.\- ]', '_', display_name)
 
+                agent_visible_path = path
+                try:
+                    _doc_cfg = _load_gateway_config()
+                    _doc_terminal_cfg = _doc_cfg.get("terminal", {}) if isinstance(_doc_cfg, dict) else {}
+                    _doc_backend = str(_doc_terminal_cfg.get("backend") or "local").strip().lower()
+                    if _doc_backend == "docker":
+                        from tools.credential_files import to_agent_visible_cache_path
+
+                        agent_visible_path = to_agent_visible_cache_path(path)
+                except Exception:
+                    agent_visible_path = path
+
                 if mtype.startswith("text/"):
                     context_note = (
                         f"[The user sent a text document: '{display_name}'. "
                         f"Its content has been included below. "
-                        f"The file is also saved at: {path}]"
+                        f"The file is also saved at: {agent_visible_path}]"
                     )
                 else:
                     context_note = (
                         f"[The user sent a document: '{display_name}'. "
-                        f"The file is saved at: {path}. "
+                        f"The file is saved at: {agent_visible_path}. "
                         f"Ask the user what they'd like you to do with it.]"
                     )
                 message_text = f"{context_note}\n\n{message_text}"

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -13,6 +13,7 @@ from tools.credential_files import (
     get_cache_directory_mounts,
     get_skills_directory_mount,
     iter_cache_files,
+    to_agent_visible_cache_path,
     iter_skills_files,
     register_credential_file,
     register_credential_files,
@@ -422,6 +423,44 @@ class TestCacheDirectoryMounts:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert get_cache_directory_mounts() == []
+
+    def test_agent_visible_cache_path_translates_document_file(self, tmp_path, monkeypatch):
+        """Host cache files map to the path mounted inside the Docker sandbox."""
+        hermes_home = tmp_path / ".hermes"
+        doc_dir = hermes_home / "cache" / "documents"
+        doc_dir.mkdir(parents=True)
+        uploaded = doc_dir / "upload.pdf"
+        uploaded.write_bytes(b"%PDF")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert (
+            to_agent_visible_cache_path(str(uploaded))
+            == "/root/.hermes/cache/documents/upload.pdf"
+        )
+
+    def test_agent_visible_cache_path_preserves_nested_cache_file(self, tmp_path, monkeypatch):
+        """Relative subdirectories are preserved in translated cache paths."""
+        hermes_home = tmp_path / ".hermes"
+        screenshot_dir = hermes_home / "cache" / "screenshots" / "session-1"
+        screenshot_dir.mkdir(parents=True)
+        screenshot = screenshot_dir / "screen.png"
+        screenshot.write_bytes(b"PNG")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert (
+            to_agent_visible_cache_path(str(screenshot), container_base="/sandbox/.hermes")
+            == "/sandbox/.hermes/cache/screenshots/session-1/screen.png"
+        )
+
+    def test_agent_visible_cache_path_leaves_non_cache_path_unchanged(self, tmp_path, monkeypatch):
+        """Only files under auto-mounted cache directories are translated."""
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "cache" / "documents").mkdir(parents=True)
+        outside = tmp_path / "outside.pdf"
+        outside.write_bytes(b"%PDF")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert to_agent_visible_cache_path(str(outside)) == str(outside)
 
 
 class TestIterCacheFiles:

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -374,6 +374,33 @@ def get_cache_directory_mounts(
     return mounts
 
 
+def to_agent_visible_cache_path(
+    host_path: str,
+    container_base: str = "/root/.hermes",
+) -> str:
+    """Translate a host cache path to its mounted path inside a sandbox.
+
+    Remote backends mount Hermes cache directories into the sandbox using
+    :func:`get_cache_directory_mounts`. Gateway prompts should reference the
+    container-side path for files the agent is expected to open. Paths outside
+    known cache mounts are returned unchanged.
+    """
+    try:
+        candidate = Path(host_path).resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return host_path
+
+    for mount in get_cache_directory_mounts(container_base=container_base):
+        try:
+            host_root = Path(mount["host_path"]).resolve(strict=False)
+            relative = candidate.relative_to(host_root)
+        except (KeyError, OSError, RuntimeError, ValueError):
+            continue
+        return str(Path(mount["container_path"]) / relative)
+
+    return host_path
+
+
 def iter_cache_files(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:


### PR DESCRIPTION
Closes #18787

## Summary
- add `to_agent_visible_cache_path()` to map host-side Hermes cache files to their sandbox mount paths
- use the translated path in gateway document prompt context when `terminal.backend` is `docker`
- cover document, nested cache, and non-cache path behavior in credential file tests

## Test Plan
- `python3 -m pytest tests/tools/test_credential_files.py -q -o 'addopts='`
- `python3 -m py_compile tools/credential_files.py gateway/run.py`

Note: `scripts/run_tests.sh tests/tools/test_credential_files.py -q` could not run because this checkout has no `.venv` or `venv`; used the documented system `python3` fallback.