### PR TITLE
fix(auth): use get_env_value for base_url_env_var instead of os.getenv (#18757)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3422,9 +3422,11 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
+    from hermes_cli.config import get_env_value
+
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3456,7 +3458,8 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    from hermes_cli.config import get_env_value
+    base_url = (get_env_value(pconfig.base_url_env_var) or "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -3526,9 +3529,11 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
         key_source = key_source or "default"
 
+    from hermes_cli.config import get_env_value
+
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3557,7 +3562,9 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    from hermes_cli.config import get_env_value
+
+    base_url = (get_env_value(pconfig.base_url_env_var) or "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -842,9 +842,11 @@ def _resolve_explicit_runtime(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
+        from hermes_cli.config import get_env_value
+
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+            env_url = (get_env_value(pconfig.base_url_env_var) or "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:


### PR DESCRIPTION
## Fix #18757: Use `get_env_value()` for `base_url_env_var` instead of `os.getenv()`

### Problem
`resolve_api_key_provider_credentials()` in `hermes_cli/auth.py` resolves `base_url_env_var` using `os.getenv()`, which does **not** read from `~/.hermes/.env`. Providers with a custom base URL stored only in `.env` (not exported in the shell environment) silently fall back to the wrong endpoint — the default `inference_base_url` from `PROVIDER_REGISTRY`.

### Fix
- Replace `os.getenv()` with `get_env_value()` for `base_url_env_var` in `auth.py` (4 sites) and `runtime_provider.py` (1 site)
- This ensures custom base URLs stored in `~/.hermes/.env` are properly resolved

### Testing
- Verified that providers with `base_url_env_var` set in `~/.hermes/.env` now correctly resolve their custom endpoints
- `get_env_value()` already handles both `os.environ` and `.env` file lookups
