### PR TITLE
fix(delegation): pass target_model when resolving opencode-go provider

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -784,7 +784,10 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
         self.assertEqual(creds["api_key"], "sk-or-test-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
-        mock_resolve.assert_called_once_with(requested="openrouter")
+        mock_resolve.assert_called_once_with(
+            requested="openrouter",
+            target_model="google/gemini-3-flash-preview",
+        )
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_uses_runtime_model_when_config_model_missing(self, mock_resolve):
@@ -804,7 +807,10 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["model"], "server-default-model")
         self.assertEqual(creds["provider"], "custom")
         self.assertEqual(creds["base_url"], "https://my-server.example/v1")
-        mock_resolve.assert_called_once_with(requested="custom:my-server")
+        mock_resolve.assert_called_once_with(
+            requested="custom:my-server",
+            target_model=None,
+        )
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -865,7 +871,10 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["provider"], "nous")
         self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
         self.assertEqual(creds["api_key"], "nous-agent-key-xyz")
-        mock_resolve.assert_called_once_with(requested="nous")
+        mock_resolve.assert_called_once_with(
+            requested="nous",
+            target_model="hermes-3-llama-3.1-8b",
+        )
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
@@ -900,6 +909,29 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         creds = _resolve_delegation_credentials(cfg, parent)
         self.assertIsNone(creds["model"])
         self.assertIsNone(creds["provider"])
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_passes_target_model_for_opencode_go(self, mock_resolve):
+        """opencode-go routes models through different API surfaces, so target_model
+        must be forwarded to resolve_runtime_provider — otherwise api_mode/base_url
+        are derived from a stale config default and produce 404s for models like
+        deepseek-v4-flash. Refs #18586.
+        """
+        mock_resolve.return_value = {
+            "provider": "opencode-go",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "sk-opencode-test",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "deepseek-v4-flash", "provider": "opencode-go"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["base_url"], "https://opencode.ai/zen/go/v1")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        mock_resolve.assert_called_once_with(
+            requested="opencode-go",
+            target_model="deepseek-v4-flash",
+        )
 
 
 class TestDelegationProviderIntegration(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2292,7 +2292,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider)
+        runtime = resolve_runtime_provider(
+            requested=configured_provider,
+            target_model=configured_model,
+        )
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
## What does this PR do?

`delegate_task` was spawning subagents with the wrong `api_mode`/`base_url` whenever `delegation.provider: opencode-go` was set. The root cause is in `tools/delegate_tool.py::_resolve_delegation_credentials`, which called `resolve_runtime_provider(requested=configured_provider)` without forwarding `target_model`. For `opencode-go`, that resolution path falls back to `anthropic_messages` on `https://opencode.ai/zen/go` (no `/v1`), so subagents hit a non-existent Anthropic-compatible endpoint and got `HTTP 404 — Not Found | opencode`.

This PR forwards the configured model into the resolver so it picks `chat_completions` on `https://opencode.ai/zen/go/v1`, matching the main agent. It mirrors how `model_switch.py` already calls `resolve_runtime_provider`. The same fix also covers `opencode-zen`, which routes through `opencode_model_api_mode()` and likewise needs `target_model` to choose the right surface.

## Related Issue

Fixes #18586

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` — pass `target_model=configured_model` to `resolve_runtime_provider()` in `_resolve_delegation_credentials` (the exact one-liner from the issue's "Proposed Fix").
- `tests/tools/test_delegate.py` — add `TestDelegationCredentialResolution::test_provider_resolution_passes_target_model_for_opencode_go`, which patches `resolve_runtime_provider` and asserts `_resolve_delegation_credentials` invokes it with `target_model=configured_model`.

## How to Test

Reproduction (from the issue):

1. Set `delegation.provider: opencode-go` and `delegation.model: deepseek-v4-flash` in `config.yaml`.
2. Trigger any `delegate_task` call.
3. Before this PR: subagent fails with `HTTP 404 — Not Found | opencode` because credentials resolve to `anthropic_messages` on `https://opencode.ai/zen/go`. After this PR: subagent uses `chat_completions` on `https://opencode.ai/zen/go/v1`, same as the main agent.

Automated check:

```
pytest tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_passes_target_model_for_opencode_go
```

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(delegation): ...`)
- [x] My PR contains only changes related to this fix
- [x] I've added a test for the fix
- [x] I've tested on my platform: Ubuntu 24.04
