### PR TITLE
feat: add legacy SSE transport support for MCP servers

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -180,6 +180,11 @@ try:
         _MCP_HTTP_AVAILABLE = True
     except ImportError:
         _MCP_HTTP_AVAILABLE = False
+    try:
+        from mcp.client.sse import sse_client as _sse_client
+        _MCP_SSE_AVAILABLE = True
+    except ImportError:
+        _MCP_SSE_AVAILABLE = False
     # Prefer the non-deprecated API (mcp >= 1.24.0); fall back to the
     # deprecated wrapper for older SDK versions.
     try:
@@ -904,6 +909,10 @@ class MCPServerTask:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
 
+    def _is_sse(self) -> bool:
+        """Check if this server uses legacy SSE transport."""
+        return self._config.get("transport", "").lower() == "sse"
+
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
     async def _refresh_tools_task(self):
@@ -1250,6 +1259,41 @@ class MCPServerTask:
                             "tearing down legacy HTTP session", self.name,
                         )
 
+    async def _run_sse(self, config: dict):
+        """Run the server using legacy SSE transport (GET /sse + POST /messages/)."""
+        if not _MCP_SSE_AVAILABLE:
+            raise ImportError(
+                f"MCP server '{self.name}' requires SSE transport but "
+                "mcp.client.sse is not available. "
+                "Upgrade the mcp package to get SSE support."
+            )
+
+        url = config["url"]
+        headers = dict(config.get("headers") or {})
+        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+
+        sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
+        if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
+            sampling_kwargs["message_handler"] = self._make_message_handler()
+
+        async with _sse_client(
+            url,
+            headers=headers,
+            timeout=float(connect_timeout),
+            sse_read_timeout=300.0,
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                await session.initialize()
+                self.session = session
+                await self._discover_tools()
+                self._ready.set()
+                reason = await self._wait_for_lifecycle_event()
+                if reason == "reconnect":
+                    logger.info(
+                        "MCP server '%s': reconnect requested — "
+                        "tearing down SSE session", self.name,
+                    )
+
     async def _discover_tools(self):
         """Discover tools from the connected session."""
         if self.session is None:
@@ -1294,7 +1338,10 @@ class MCPServerTask:
         while True:
             try:
                 if self._is_http():
-                    await self._run_http(config)
+                    if self._is_sse():
+                        await self._run_sse(config)
+                    else:
+                        await self._run_http(config)
                 else:
                     await self._run_stdio(config)
                 # Transport returned cleanly. Two cases:


### PR DESCRIPTION
## Summary

Adds `transport: sse` config option for HTTP MCP servers that use the legacy Server-Sent Events transport (`GET /sse` + `POST /messages/`) instead of StreamableHTTP.

## Problem

Some MCP servers (e.g. [Windows-MCP](https://github.com/AgentDeskAI/windows-mcp), older community servers) only implement the old SSE protocol. Hermes currently only uses `streamablehttp_client` for HTTP transport, causing `405 Method Not Allowed` errors when connecting to these servers.

## Solution

When `transport: sse` is set in the MCP server config, Hermes uses `mcp.client.sse.sse_client` instead of `mcp.client.streamable_http.streamablehttp_client`.

## Config

```yaml
mcp_servers:
  windows-mcp:
    url: "http://host.docker.internal:8899/sse"
    transport: sse  # Use legacy SSE transport
    connect_timeout: 15
    timeout: 60
```

## Changes

- Import `mcp.client.sse.sse_client` with `_MCP_SSE_AVAILABLE` availability flag
- Add `_is_sse()` config check method
- Add `_run_sse()` transport method using SSE client
- Route to SSE path in `run()` when `transport: sse` is set

## Testing

Verified against Windows-MCP v3.2.4 (SSE transport on port 8899). Connection succeeds with `transport: sse`, fails with `405 Method Not Allowed` without it.