### PR TITLE
fix: use named custom provider credentials

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1465,10 +1465,10 @@ def list_authenticated_providers(
     # that differ only by suffix. Entries with distinct endpoints still
     # produce separate rows.
     #
-    # When the grouped endpoint matches ``current_base_url`` the group's
-    # slug becomes ``current_provider`` so that selecting a model from the
-    # picker flows back through the runtime provider that already holds
-    # valid credentials — no re-resolution needed.
+    # Each group keeps the provider's own stable slug even when its endpoint
+    # matches ``current_base_url``. Several custom providers can share a gateway
+    # URL while requiring different API keys, so the picker must route back
+    # through the selected named custom provider instead of the current one.
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
 
@@ -1504,23 +1504,12 @@ def list_authenticated_providers(
                         break
                 if not display_name:
                     display_name = raw_name
-                # If this endpoint matches the currently active one, use
-                # ``current_provider`` as the slug so picker-driven switches
-                # route through the live credential pipeline.
-                if (
-                    current_base_url
-                    and api_url == current_base_url.strip().rstrip("/")
-                ):
-                    # Guard against bare "custom" slug left by a prior
-                    # failed switch — always resolve to the canonical
-                    # custom:<name> form.  (GH #17478)
-                    slug = (
-                        current_provider
-                        if current_provider and current_provider != "custom"
-                        else custom_provider_slug(display_name)
-                    )
-                else:
-                    slug = custom_provider_slug(display_name)
+                # Prefer the provider's own stable slug.  Do not reuse the current
+                # provider merely because the base_url matches: multiple custom
+                # providers may share one gateway URL but use different API keys
+                # and therefore expose different /models listings. This also avoids
+                # preserving a bare "custom" slug from a prior failed switch.
+                slug = custom_provider_slug(display_name)
                 groups[group_key] = {
                     "slug": slug,
                     "name": display_name,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -520,7 +520,45 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
-    # Check if a credential pool exists for this custom endpoint
+    # Prefer the named custom provider's own configured API key when present.
+    # Multiple custom_providers can share the same base_url but use different
+    # gateway keys (e.g. one key exposes GPT, another Claude, another DeepSeek).
+    # Looking up the credential pool by base_url alone can select the first
+    # matching pool (often the GPT key), causing /model validation to see the
+    # wrong /models listing.  Only fall back to the shared custom pool when the
+    # named entry does not carry a usable secret.
+    configured_api_key = str(custom_provider.get("api_key", "") or "").strip()
+    configured_key_env = str(custom_provider.get("key_env", "") or "").strip()
+    env_api_key = os.getenv(configured_key_env, "").strip() if configured_key_env else ""
+    direct_api_key = next(
+        (
+            candidate
+            for candidate in (
+                (explicit_api_key or "").strip(),
+                configured_api_key,
+                env_api_key,
+            )
+            if has_usable_secret(candidate)
+        ),
+        "",
+    )
+
+    if direct_api_key:
+        result = {
+            "provider": "custom",
+            "api_mode": custom_provider.get("api_mode")
+            or _detect_api_mode_for_url(base_url)
+            or "chat_completions",
+            "base_url": base_url,
+            "api_key": direct_api_key,
+            "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
+        }
+        if custom_provider.get("model"):
+            result["model"] = custom_provider["model"]
+        return result
+
+    # Check if a credential pool exists for this custom endpoint when no
+    # provider-specific API key is configured.
     pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
     if pool_result:
         # Propagate the model name even when using pooled credentials —
@@ -531,9 +569,6 @@ def _resolve_named_custom_runtime(
         return pool_result
 
     api_key_candidates = [
-        (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -293,30 +293,37 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
     assert group["name"] == "Ollama"
 
 
-def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeypatch):
-    """When current_base_url matches the grouped endpoint, the slug must
-    equal current_provider so picker selection routes through the live
-    credential pipeline — provided current_provider is a real slug, not
-    the corrupt bare "custom" (see #17478)."""
+def test_list_authenticated_providers_current_endpoint_keeps_provider_slug(monkeypatch):
+    """When custom providers share a gateway base_url, the picker must keep
+    each provider's own slug even if one endpoint matches the current runtime.
+
+    Reusing ``current_provider`` for every same-base-url row can route a
+    DeepSeek/Claude selection through the GPT key currently attached to the
+    shared gateway, so /models validation sees the wrong model listing.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
 
     providers = list_authenticated_providers(
-        current_provider="custom:ollama",
-        current_base_url="http://localhost:11434/v1",
+        current_provider="custom:gpt",
+        current_base_url="https://gateway.example.com/v1",
         user_providers={},
         custom_providers=[
-            {"name": "Ollama — GLM 5.1", "base_url": "http://localhost:11434/v1",
-             "api_key": "ollama", "model": "glm-5.1"},
+            {"name": "GPT", "base_url": "https://gateway.example.com/v1",
+             "api_key": "gpt-key", "model": "gpt-5-mini"},
+            {"name": "DeepSeek", "base_url": "https://gateway.example.com/v1",
+             "api_key": "deepseek-key", "model": "deepseek-chat"},
         ],
         max_models=50,
     )
 
-    matches = [p for p in providers if p.get("is_user_defined")]
-    assert len(matches) == 1
-    group = matches[0]
-    assert group["slug"] == "custom:ollama"
-    assert group["is_current"] is True
+    custom_groups = [p for p in providers if p.get("is_user_defined")]
+    slugs = {p["name"]: p["slug"] for p in custom_groups}
+    assert slugs["GPT"] == "custom:gpt"
+    assert slugs["DeepSeek"] == "custom:deepseek"
+    current = [p for p in custom_groups if p["is_current"]]
+    assert len(current) == 1
+    assert current[0]["slug"] == "custom:gpt"
 
 
 def test_list_authenticated_providers_bare_custom_slug_recovers(monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -751,6 +751,70 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["source"] == "custom_provider:Local"
 
 
+def test_named_custom_provider_direct_key_takes_priority_over_shared_custom_pool(monkeypatch):
+    """A named custom provider's own key must win over base_url pool lookup.
+
+    Multiple custom providers can share a gateway URL while each key exposes a
+    different /models listing. Choosing the first pool entry for the shared URL
+    makes model validation use the wrong provider's model list.
+    """
+
+    class _Entry:
+        runtime_api_key = "pool-gpt-key"
+        access_token = "pool-gpt-key"
+        source = "manual:gpt"
+        base_url = "https://gateway.example.com/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "GPT",
+                    "base_url": "https://gateway.example.com/v1",
+                    "api_key": "gpt-provider-key",
+                    "model": "gpt-5-mini",
+                },
+                {
+                    "name": "DeepSeek",
+                    "base_url": "https://gateway.example.com/v1",
+                    "api_key": "deepseek-provider-key",
+                    "model": "deepseek-chat",
+                },
+            ]
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:deepseek")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://gateway.example.com/v1"
+    assert resolved["api_key"] == "deepseek-provider-key"
+    assert resolved["source"] == "custom_provider:DeepSeek"
+    assert resolved["model"] == "deepseek-chat"
+    assert resolved.get("credential_pool") is None
+
+
 def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch):
     """After v11→v12 migration deletes custom_providers, resolution should
     still find entries in the providers dict via get_compatible_custom_providers."""
@@ -1631,7 +1695,6 @@ def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):
         lambda p: {
             "name": "my-server",
             "base_url": "http://localhost:8000/v1",
-            "api_key": "test-key",
             "model": "qwen3.6-plus",
         },
     )


### PR DESCRIPTION
## Summary
- keep custom provider picker rows tied to each provider's stable slug, even when multiple providers share the same gateway base URL
- resolve named custom providers with their configured `api_key` / `key_env` before falling back to a shared custom credential pool
- add regression coverage for same-base-url/different-key custom providers and the remaining pool fallback path

## Test plan
- `python -m py_compile hermes_cli/model_switch.py hermes_cli/runtime_provider.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_runtime_provider_resolution.py`
- `python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_runtime_provider_resolution.py -q`
