### PR TITLE
fix(image-gen): forward reference images to providers

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,7 +19,10 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import logging
+import mimetypes
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -32,6 +35,30 @@ from agent.image_gen_provider import (
 )
 
 logger = logging.getLogger(__name__)
+
+_MAX_REFERENCE_IMAGES = 8
+_MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024
+_MAX_DATA_IMAGE_URL_LENGTH = 30 * 1024 * 1024
+_IMAGE_MIME_BY_KIND = {
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+    "gif": "image/gif",
+}
+_SUPPORTED_DATA_IMAGE_MIMES = set(_IMAGE_MIME_BY_KIND.values())
+
+
+def _detect_image_mime(raw: bytes) -> Optional[str]:
+    """Return a supported image MIME type from file magic, or None."""
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if raw.startswith(b"RIFF") and len(raw) >= 12 and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +188,68 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _coerce_reference_image_url(ref: str) -> Optional[str]:
+    """Return a Responses-compatible image_url from URL/data URL/local path."""
+    value = (ref or "").strip()
+    if not value:
+        return None
+    if value.startswith(("http://", "https://")):
+        return value
+    if value.startswith("data:image/"):
+        if len(value) > _MAX_DATA_IMAGE_URL_LENGTH:
+            raise ValueError("Reference image data URL is too large")
+        header, sep, _ = value.partition(",")
+        if not sep or ";base64" not in header:
+            raise ValueError("Reference image data URL must be base64-encoded")
+        mime = header.removeprefix("data:").split(";", 1)[0]
+        if mime not in _SUPPORTED_DATA_IMAGE_MIMES:
+            raise ValueError(f"Unsupported reference image MIME type: {mime}")
+        return value
+
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise ValueError("Local reference images must use absolute paths")
+    try:
+        if not path.is_file():
+            logger.warning("Skipping missing reference image: %s", path.name)
+            return None
+        if path.stat().st_size > _MAX_REFERENCE_IMAGE_BYTES:
+            raise ValueError("Local reference image is too large")
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"Could not read local reference image: {path.name}") from exc
+
+    mime = _detect_image_mime(raw)
+    if not mime:
+        guessed_mime, _ = mimetypes.guess_type(str(path))
+        raise ValueError(
+            f"Unsupported or invalid reference image: {guessed_mime or path.suffix or 'unknown'}"
+        )
+    encoded = base64.b64encode(raw).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _build_input_content(prompt: str, reference_images: Optional[List[str]] = None) -> List[Dict[str, str]]:
+    """Build multimodal Responses input content for prompt + optional refs."""
+    content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+    refs = reference_images or []
+    if len(refs) > _MAX_REFERENCE_IMAGES:
+        raise ValueError(f"At most {_MAX_REFERENCE_IMAGES} reference images are supported")
+    for ref in refs:
+        image_url = _coerce_reference_image_url(str(ref))
+        if image_url:
+            content.append({"type": "input_image", "image_url": image_url})
+    return content
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_images: Optional[List[str]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
 
@@ -172,7 +260,7 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": _build_input_content(prompt, reference_images),
         }],
         tools=[{
             "type": "image_generation",
@@ -306,6 +394,13 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        raw_refs = kwargs.get("reference_images") or []
+        if isinstance(raw_refs, str):
+            reference_images = [raw_refs]
+        elif isinstance(raw_refs, list):
+            reference_images = [str(ref) for ref in raw_refs if ref]
+        else:
+            reference_images = []
 
         client = _build_codex_client()
         if client is None:
@@ -324,6 +419,16 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                reference_images=reference_images,
+            )
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
@@ -364,7 +469,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra={
+                "size": size,
+                "quality": meta["quality"],
+                "reference_images": len(reference_images),
+            },
         )
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -199,6 +199,102 @@ class TestGenerate:
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
 
+    def test_codex_stream_request_includes_remote_reference_images(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate(
+            "turn this into a poster",
+            aspect_ratio="square",
+            reference_images=["https://example.com/reference.png"],
+        )
+
+        assert result["success"] is True
+        assert result["reference_images"] == 1
+        assert captured["input"][0]["content"] == [
+            {"type": "input_text", "text": "turn this into a poster"},
+            {"type": "input_image", "image_url": "https://example.com/reference.png"},
+        ]
+
+    def test_codex_stream_request_embeds_local_reference_images(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        ref = tmp_path / "ref.png"
+        ref.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        result = provider.generate(
+            "edit local image",
+            reference_images=[str(ref)],
+        )
+
+        assert result["success"] is True
+        image_part = captured["input"][0]["content"][1]
+        assert image_part["type"] == "input_image"
+        assert image_part["image_url"].startswith("data:image/png;base64,")
+
+    def test_local_reference_images_must_be_real_images(self, tmp_path):
+        ref = tmp_path / "not-image.png"
+        ref.write_text("not actually an image")
+
+        with pytest.raises(ValueError, match="Unsupported or invalid reference image"):
+            codex_plugin._build_input_content("edit", [str(ref)])
+
+    def test_local_reference_images_must_be_absolute(self):
+        with pytest.raises(ValueError, match="absolute paths"):
+            codex_plugin._build_input_content("edit", ["relative/ref.png"])
+
+    def test_reference_image_count_is_limited(self):
+        refs = ["https://example.com/ref.png"] * (codex_plugin._MAX_REFERENCE_IMAGES + 1)
+
+        with pytest.raises(ValueError, match="At most"):
+            codex_plugin._build_input_content("edit", refs)
+
+    def test_invalid_reference_images_return_invalid_argument(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+        ref = tmp_path / "not-image.png"
+        ref.write_text("not actually an image")
+
+        result = provider.generate("edit", reference_images=[str(ref)])
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "Unsupported or invalid reference image" in result["error"]
+
     def test_partial_image_event_used_when_done_missing(self, provider, monkeypatch):
         """If the stream never emits output_item.done, fall back to the
         partial_image event so users at least get the latest preview frame."""

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -15,11 +15,14 @@ def _reset_registry():
 
 
 class _FakeCodexProvider(ImageGenProvider):
+    last_kwargs = None
+
     @property
     def name(self) -> str:
         return "codex"
 
     def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        type(self).last_kwargs = kwargs
         return {
             "success": True,
             "image": "/tmp/codex-test.png",
@@ -97,3 +100,28 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_handle_forwards_reference_images_to_configured_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+        _FakeCodexProvider.last_kwargs = None
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._handle_image_generate({
+            "prompt": "use this reference",
+            "aspect_ratio": "square",
+            "reference_images": ["https://example.com/ref.png"],
+        })
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert _FakeCodexProvider.last_kwargs == {
+            "reference_images": ["https://example.com/ref.png"]
+        }

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -873,6 +873,15 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional image references for backends that support multimodal image generation. "
+                    "Each item can be an absolute local path, http(s) URL, or data:image URL. "
+                    "Unsupported backends may ignore this field."
+                ),
+            },
         },
         "required": ["prompt"],
     },
@@ -900,7 +909,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, reference_images=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -950,7 +959,11 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        result = provider.generate(
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+            reference_images=reference_images or [],
+        )
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
@@ -977,10 +990,15 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images") or []
+    if isinstance(reference_images, str):
+        reference_images = [reference_images]
+    elif not isinstance(reference_images, list):
+        reference_images = []
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, reference_images)
     if dispatched is not None:
         return dispatched
 


### PR DESCRIPTION
## Summary

Fixes `image_generate` reference image routing for plugin-backed image providers, with concrete support for the OpenAI Codex / GPT Image 2 provider.

Before this change, the tool schema could expose image references, but plugin dispatch did not reliably pass those references into the configured image provider. In practice, providers such as OpenAI Codex / GPT Image 2 received only the text prompt and aspect ratio, so multimodal image generation/editing requests could not use attached/reference images.

This patch:

- Adds `reference_images` to the `image_generate` tool schema.
- Normalizes `reference_images` in the tool handler.
- Forwards `reference_images` through plugin provider dispatch.
- Adds OpenAI Codex image provider support for:
  - HTTP(S) reference image URLs.
  - `data:image/...;base64,...` image URLs.
  - local absolute image paths converted to data URLs.
- Validates local references before reading/sending them:
  - absolute paths only;
  - supported image magic only (`png`, `jpeg`, `webp`, `gif`);
  - bounded count and file/data size;
  - clear `invalid_argument` errors for invalid inputs.
- Adds regression tests covering dispatch forwarding, remote refs, local refs, and invalid local refs.

## Problem

Users can configure image generation through different backends, including FAL-backed models and OpenAI/Codex-backed GPT Image 2. Text-only image generation worked, but image input/reference workflows were incomplete for the plugin path: references could be present at the tool boundary but not delivered to the provider.

That meant requests such as “generate an image using these attached logos/references” degraded into prompt-only generation, causing models to approximate or hallucinate logos instead of using the provided image inputs.

## Implementation notes

### Tool layer

`tools/image_generation_tool.py` now exposes and normalizes `reference_images`, then forwards them to the selected plugin provider:

```python
provider.generate(
    prompt=prompt,
    aspect_ratio=aspect_ratio,
    reference_images=reference_images or [],
)
```

The base `ImageGenProvider.generate()` contract already accepts `**kwargs`, so this remains forward-compatible for providers that ignore unknown keys.

### OpenAI Codex / GPT Image 2 provider

`plugins/image_gen/openai-codex/__init__.py` builds multimodal Responses input content:

```python
[
    {"type": "input_text", "text": prompt},
    {"type": "input_image", "image_url": image_url},
]
```

Local images are read only after validation and encoded as `data:image/...;base64,...`.

## Validation

Targeted test run:

```bash
./venv/bin/python -m pytest \
  tests/plugins/image_gen/test_openai_codex_provider.py \
  tests/plugins/image_gen/test_openai_provider.py \
  tests/tools/test_image_generation_plugin_dispatch.py \
  tests/hermes_cli/test_image_gen_picker.py \
  -q -o 'addopts='
```

Result:

```text
64 passed
```

Additional checks:

```bash
./venv/bin/python -m py_compile \
  tools/image_generation_tool.py \
  plugins/image_gen/openai-codex/__init__.py
```

Static scan of added lines found no hardcoded credentials, shell execution, `eval`/`exec`, pickle deserialization, or SQL formatting patterns.

## Privacy / safety

This PR intentionally avoids including any local deployment paths, credentials, generated user assets, or installation-specific configuration.

Local reference image handling is constrained to reduce accidental file exfiltration:

- local refs must be absolute paths;
- files must pass supported image magic checks;
- max reference count and file/data URL sizes are enforced;
- missing paths are logged by basename only.
