### PR TITLE
feat(skills): add commerce/personal-shopper

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -672,6 +672,7 @@ AUTHOR_MAP = {
     "web3blind@gmail.com": "web3blind",
     "ztzheng@163.com": "chengoak",  # PR #17467
     "24110240104@m.fudan.edu.cn": "YuShu",  # co-author only
+    "97958526+Mibayy@users.noreply.github.com": "Mibayy",
 }
 
 

--- a/skills/commerce/DESCRIPTION.md
+++ b/skills/commerce/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Skills for searching, comparing, and purchasing products on the open web on behalf of the user.
+---

--- a/skills/commerce/personal-shopper/SKILL.md
+++ b/skills/commerce/personal-shopper/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: personal-shopper
+description: Search the web for a product the user described, compare offers, prepare a prefilled cart, and hand off the payment with the right method for the user's country. Universal (any merchant), agnostic on the LLM provider, runs entirely on free infrastructure (SearXNG search) by default. Supports Apple/Google Pay handoff, Privacy.com single-use card emission (US), and manual-paste from any banking app's disposable cards.
+version: 1.0.0
+author: Mibayy
+license: MIT
+metadata:
+  hermes:
+    tags: [commerce, shopping, payment, cart, checkout, virtual-card, agentic]
+    related_skills: []
+prerequisites:
+  commands: [python3, curl]
+  python_packages: [httpx, selectolax, playwright]
+---
+
+# Personal Shopper
+
+Lets the agent shop for the user end-to-end:
+
+1. **Discover** -- the user describes what they want in natural language ("cafe en grain bio 1kg le moins cher", "USB-C 64GB drive under 15 EUR", "a cozy reading lamp under 40 EUR"). The skill searches the open web through a self-hosted SearXNG instance (or any SearXNG public mirror) and filters out comparators / aggregators.
+
+2. **Compare** -- the agent feeds the search hits back into the conversation (or to a small extractor script) to produce a structured top-3 ranked by best unit price.
+
+3. **Confirm** -- the user picks one offer with a single tap (inline keyboard via the Hermes gateway).
+
+4. **Cart-build** -- a Playwright-driven inspector resolves the merchant's platform (Shopify, WooCommerce, or 'unknown') and produces a prefilled cart URL the user can finish in one or two taps.
+
+5. **Pay** -- the chosen `payment provider` decides what message the agent sends back. Three providers ship with this skill:
+
+   - `apple_pay_handoff` (default, universal) -- agent sends the cart URL, user pays with Apple Pay / Google Pay / saved card on the merchant's checkout page. Biometric satisfies SCA in the EU.
+   - `privacy_com` (US) -- the agent calls the Privacy.com personal API (free tier, no business entity required) to emit a single-use virtual card capped to the exact purchase amount, then ships PAN+CVV+expiry to the user in a single Telegram/Discord/Slack message alongside the cart URL.
+   - `manual_paste` (universal fallback) -- agent asks the user to generate a one-time card in their own banking app (Revolut, Monzo, Wise, Lydia, N26, Bunq...), parses the pasted PAN+expiry+CVV, and folds it back into a single ready-to-copy message at the merchant's checkout.
+
+The skill is provider-agnostic on the LLM side (it doesn't make LLM calls itself -- the agent does, that's Hermes's job) and merchant-agnostic on the buy side (any French/EU/US e-commerce site works through the universal Shopify/WooCommerce/manual auto-detect).
+
+## When to use
+
+Use this skill when the user asks to find / compare / buy / order something. Phrases that trigger it:
+
+- "trouve-moi le moins cher"
+- "achete-moi X" / "commande-moi X"
+- "find me the cheapest..."
+- "compare prices for..."
+- "I need a new ..."
+- "prepare an order for..."
+
+## When NOT to use
+
+- The user is not actually shopping (just asking what something costs for context). Stick to plain `web_extract`.
+- The user is on a B2B procurement workflow with a vendor portal -- this skill targets retail e-commerce.
+- The merchant requires a non-public account (corporate intranet, etc.).
+
+## Quick reference
+
+```bash
+# 1. Search + compare (returns ranked offers as JSON)
+python3 SKILL_DIR/scripts/search_offers.py \
+  --query "cafe en grain bio 1kg le moins cher" \
+  --searxng-url http://127.0.0.1:8888 \
+  --max-results 12 --json
+
+# 2. Build cart for the chosen URL (returns cart URL + detected price)
+python3 SKILL_DIR/scripts/build_cart.py \
+  --url "https://www.terresdecafe.com/products/foo" \
+  --quantity 1 --json
+
+# 3a. Issue a Privacy.com single-use card (US users only)
+python3 SKILL_DIR/scripts/issue_card_privacy.py \
+  --amount-eur 19.90 \
+  --merchant "Terres de Cafe" \
+  --product "Foo grain 1kg" \
+  --json
+
+# 3b. Parse a card the user pasted from their own banking app
+python3 SKILL_DIR/scripts/parse_pasted_card.py \
+  "1234 5678 1234 5678 12/27 123" --json
+```
+
+Each script writes one JSON object to stdout. The agent parses it and renders the next message in the conversation.
+
+## Configuration
+
+The skill works with no configuration if you use:
+
+- `apple_pay_handoff` (default) -- nothing to configure
+- A reachable SearXNG instance (the user's own, the system-wide one on the same host, or a public mirror like `searx.be`)
+
+For agent-issued cards via Privacy.com, set:
+
+```bash
+export PRIVACY_API_KEY="sk_live_..."   # https://privacy.com -> Account -> Developers
+```
+
+Privacy.com requires a US bank account to fund the issuing balance. Free tier: 12 cards/month.
+
+For manual-paste, no setup needed -- the user generates the card in their banking app on demand.
+
+## Spending policy
+
+Hard-coded conservative defaults the agent should respect even if the user nudges them:
+
+- Per-purchase cap : 50 EUR
+- Per-day cap     : 100 EUR
+
+Override via env (only do this if the user explicitly asks):
+
+```bash
+export SHOPPER_SPEND_CAP_EUR_PER_PURCHASE=80
+export SHOPPER_SPEND_CAP_EUR_PER_DAY=150
+```
+
+The agent MUST re-check the cap after the live page price is scraped (it can differ from the search snippet). `build_cart.py` returns the live price; the agent enforces the cap before showing the user any cart link.
+
+## End-to-end flow (recommended agent loop)
+
+1. User: free-text request.
+2. Agent: read this SKILL.md, then call `search_offers.py` with the user's query.
+3. Agent: render the top-3 with the gateway's inline-keyboard (Telegram, Discord, Slack -- whichever Hermes is connected to).
+4. User: taps a button (or replies "le 1er").
+5. Agent: enforce cap; call `build_cart.py` on the chosen offer URL.
+6. Agent: re-enforce cap with the scraped live price.
+7. Agent: pick the right payment provider for the user (see `references/payment-providers.md`):
+   - if user is US and has set `PRIVACY_API_KEY`, call `issue_card_privacy.py`
+   - else if user wants manual-paste, ask them to paste a card from their banking app and call `parse_pasted_card.py`
+   - else (default) just send the cart URL with Apple/Google Pay instructions.
+8. Agent: deliver one final message to the user with the cart URL + (optionally) the card details. The user finishes the payment on the merchant's UI.
+
+## References
+
+- `references/payment-providers.md` -- comparison matrix + which to recommend per country.
+- `references/privacy-com-setup.md` -- one-page guide for the Privacy.com API key flow.
+- `references/manual-paste-flow.md` -- what the user does in their banking app, with screenshots-by-text.
+- `references/spend-policy.md` -- rationale for the caps and audit-log design.
+
+## Why this design
+
+- **Discovery** -- restricting search to known good merchants is brittle. Filtering out comparator/aggregator domains gives 95% of the same UX with 5% of the maintenance.
+- **Robust checkout** -- we never submit payment data, so no captcha race / fraud trip. The user's own session does the final tap.
+- **Liability** -- the user does the final confirmation on the merchant's UI. The agent never moves money on its own. Per-purchase + per-day caps enforced before any cart link is generated.
+- **Provider-agnostic** -- the LLM side is delegated to Hermes (this skill makes no LLM calls). The merchant side auto-detects platform. The payment side is pluggable via the three providers above.
+
+## Limitations
+
+- US-only `privacy_com` because of Privacy.com's funding requirement. The 'true 1-tap pay+order via agent' UX only exists in this provider, in this jurisdiction.
+- The default `apple_pay_handoff` is 2 taps total in practice (one in the chat, one biometric on the merchant). This is the price for working everywhere without bank partnerships.
+- `manual_paste` works for any user with disposable cards in their banking app, but adds a few taps in their banking app for each purchase.

--- a/skills/commerce/personal-shopper/references/manual-paste-flow.md
+++ b/skills/commerce/personal-shopper/references/manual-paste-flow.md
@@ -1,0 +1,58 @@
+# Manual-paste flow (universal fallback)
+
+Use when the user wants the agent to handle the cart but prefers to
+generate the card themselves in their own banking app. Works in every
+country with a fintech that supports disposable / one-time cards.
+
+## How the agent walks the user through it
+
+1. Agent: "Achat pret a confirmer -- 14.20 EUR chez Foo. Genere une
+   carte virtuelle a usage unique dans ton app bancaire avec un
+   plafond de 15 EUR. Colle-la ici sous la forme `NUMERO MM/AA CVV`."
+
+2. User opens their banking app and generates a card. Quick reference
+   per provider:
+
+   | App | Path |
+   |---|---|
+   | Revolut | Cards &rarr; + &rarr; Disposable virtual card |
+   | Monzo | Account &rarr; Virtual card |
+   | Wise | Cards &rarr; New virtual card |
+   | Lydia | Comptes &rarr; Carte virtuelle one-shot |
+   | N26 | Cards &rarr; Add card &rarr; Virtual MasterCard |
+   | Bunq | Cards &rarr; Order Virtual card |
+   | Boursorama | Comptes &rarr; e-Carte Bleue |
+   | Credit Mutuel | Mes operations &rarr; e-Carte Bleue |
+
+3. User pastes the card. Agent runs `parse_pasted_card.py`:
+
+   ```bash
+   python3 SKILL_DIR/scripts/parse_pasted_card.py \
+     '4111 1111 1111 1111 12/27 123' --json
+   ```
+
+4. Agent sends back ONE message with the cart URL + the card details
+   formatted for easy copy-paste at the merchant's checkout. After
+   sending, the agent drops the PAN/CVV from working memory.
+
+## Privacy / safety notes
+
+- The agent never persists the PAN/CVV -- only `last4` is logged for
+  audit.
+- The user keeps control of which card is charged: they pick the
+  funding source in their banking app, set the spend limit, and the
+  card auto-revokes (or stays inactive) after the single charge.
+- This flow is the safest in jurisdictions where data-residency or
+  consent requirements would forbid an external API issuer.
+
+## Edge cases
+
+- **User pastes wrong format** -- `parse_pasted_card.py` exits 2 with
+  `{"error": "could not parse..."}`. The agent re-prompts with the
+  expected format.
+- **Card declined at checkout** -- usually because the user's bank
+  enforces 3DSecure on disposable cards. The user re-runs the bank's
+  3DS challenge in their app and retries the merchant payment with
+  the same card.
+- **PAN starts with 6 (Discover) or 3 (Amex)** -- `parse_pasted_card.py`
+  handles 12-19 digit PANs uniformly, no provider-specific logic.

--- a/skills/commerce/personal-shopper/references/payment-providers.md
+++ b/skills/commerce/personal-shopper/references/payment-providers.md
@@ -1,0 +1,50 @@
+# Payment providers
+
+The personal-shopper skill ships with three payment providers. The
+agent picks one based on the user's country and stated preferences.
+
+## Comparison
+
+| Provider | UX | Country | Setup |
+|---|---|---|---|
+| `apple_pay_handoff` | 2 taps total: in-chat selection + biometric on merchant page | Worldwide (any merchant accepting Apple/Google Pay) | None |
+| `privacy_com` | Agent emits a single-use card via API; user pastes PAN/CVV at checkout (1 paste, no biometric) | US only (requires US bank account funding) | `PRIVACY_API_KEY` env var |
+| `manual_paste` | User generates a one-time card in their banking app, pastes it back; agent folds the cart URL + card into one ready-to-copy message | Worldwide (any fintech with disposable cards: Revolut, Monzo, Wise, Lydia, N26, Bunq) | None |
+
+## Recommendation by country
+
+| Country | Recommended provider | Why |
+|---|---|---|
+| US | `privacy_com` | Best UX -- the only path where the agent itself emits the card. Free tier (12/month) covers personal use. |
+| FR / EU / UK / CA / AU / SG / JP | `apple_pay_handoff` | Universal, biometric satisfies SCA, no setup. The 2-tap reality is the price for working without bank partnerships. |
+| Anywhere with a fintech with disposable cards | `manual_paste` | Power-user fallback for users who want full control over which card is charged for what. |
+
+## Why we don't have a 'global agent emits card' provider
+
+The market for individual-targeted virtual card APIs is sparse:
+
+- **Revolut, Monzo, Wise, Lydia, N26, Bunq, Boursorama** -- all have
+  disposable cards in their app but no public API for individuals.
+  PSD2 and licensing make this a non-starter for now.
+- **Curve** -- aggregator, not an issuer.
+- **Stripe Issuing, Marqeta, Lithic** -- B2B only, require KYB/business
+  entity.
+- **Privacy.com** -- the lone exception. Personal API, free tier, but
+  US-only because of funding requirements.
+
+The "global 1-tap pay+order via agent" promise is being prepared by
+Stripe/Mastercard/Apple under the agentic-commerce umbrella, but is
+not live as of 2026 for a particulier without business setup.
+
+## Operational notes
+
+- The provider is selected **per-user**, not per-purchase. A user in
+  France using `apple_pay_handoff` always gets the same flow until
+  they explicitly switch via /settings.
+- The fallback chain on failure is `provider -> apple_pay_handoff`.
+  If `issue_card_privacy.py` 5xx's or returns a non-200, the agent
+  should send the user the cart URL with Apple Pay instructions and
+  a one-line note explaining the fallback.
+- The agent must NEVER persist a full PAN/CVV. The provider scripts
+  emit them to stdout for one-shot delivery to the user; the agent
+  forwards them in a single chat message and forgets them.

--- a/skills/commerce/personal-shopper/references/privacy-com-setup.md
+++ b/skills/commerce/personal-shopper/references/privacy-com-setup.md
@@ -1,0 +1,48 @@
+# Privacy.com setup (US users)
+
+[Privacy.com](https://privacy.com) is the only consumer-facing virtual
+card issuer with a public API for individuals. It's US-only because
+the issuing balance must be funded from a US bank account (ACH).
+
+## Onboarding
+
+1. Sign up at <https://privacy.com> with a US bank account or US debit card.
+2. Complete the standard KYC (name, address, SSN last 4, DOB).
+3. Once your account is verified, fund the issuing balance ($1
+   minimum on the free tier).
+
+## API key
+
+1. In the dashboard, go to **Account &rarr; Developers &rarr; API Keys**.
+2. Click **Generate API Key**. Copy it -- it's shown only once.
+3. Export it in the agent's environment:
+
+   ```bash
+   export PRIVACY_API_KEY="sk_live_..."
+   ```
+
+## Free tier
+
+- 12 cards per month at no cost
+- Each card auto-revokes after first use when emitted with `type=SINGLE_USE`
+- No subscription required
+
+## Limits
+
+- Cards are USD only. The skill caps spend at `amount_eur * 1.10` USD
+  to account for FX swings between issuance and the merchant charge.
+- International merchants accept Visa/Mastercard from Privacy.com but
+  some EU merchants may decline the foreign card; in that case the
+  user falls back to `apple_pay_handoff` or `manual_paste`.
+- Privacy.com cards do not support 3DSecure -- some EU merchants
+  require it for first-time charges, which would block a Privacy
+  card. This is rare for known/established e-commerce sites.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Bad/missing `PRIVACY_API_KEY` | Re-generate via Developers tab |
+| `403 Forbidden` | Account not yet verified | Finish KYC + funding |
+| `429 Too Many Requests` | Hit the 12/month free quota | Wait or upgrade |
+| Card declined at checkout | Merchant blocks foreign cards | Fall back to `manual_paste` or `apple_pay_handoff` |

--- a/skills/commerce/personal-shopper/references/spend-policy.md
+++ b/skills/commerce/personal-shopper/references/spend-policy.md
@@ -1,0 +1,78 @@
+# Spending policy + audit log
+
+The personal-shopper skill enforces two cumulative caps:
+
+- **Per-purchase cap** (default 50 EUR) -- the maximum a single Buy
+  tap can engage.
+- **Per-day cap** (default 100 EUR) -- the maximum the user can engage
+  across all purchases since 00:00 UTC today.
+
+The defaults are conservative on purpose. Users who want higher caps
+have to explicitly say so; the agent overrides via env vars:
+
+```bash
+export SHOPPER_SPEND_CAP_EUR_PER_PURCHASE=80
+export SHOPPER_SPEND_CAP_EUR_PER_DAY=150
+```
+
+## When the agent runs the cap check
+
+Every Buy goes through `cap_check.py` **twice**:
+
+1. **Pre-cart-build** -- using the price extracted from the search
+   snippet. Cheap, fast, blocks obvious over-cap selections.
+2. **Post-cart-build** -- using the price scraped from the live
+   product page (returned by `build_cart.py`). The agent calls
+   `cap_check.py --commit` here so the ledger reflects only verified
+   prices.
+
+The double-check is intentional: search snippets can be stale or wrong
+(strikethrough prices, multiple sizes shown together), so we never
+trust them on their own.
+
+## Ledger format
+
+A tiny JSON file at `/tmp/personal-shopper-ledger.json` (or a path
+the agent specifies via `--ledger`):
+
+```json
+{
+  "entries": [
+    {"price_eur": 14.20, "quantity": 1, "created_at": 1714663200},
+    {"price_eur": 19.90, "quantity": 1, "created_at": 1714668000}
+  ]
+}
+```
+
+`spent_today()` sums entries since the day's 00:00 UTC. There's no
+explicit cleanup -- the file grows by ~50 bytes per purchase, which
+is fine for personal use. The agent can rotate the file weekly if
+desired.
+
+## Why this is belt-and-suspenders
+
+The agent never moves money in V0 -- the user does the final tap on
+the merchant's UI. Even so, the cap matters because:
+
+- It prevents the agent from generating a `cart_url` that would lead
+  to a surprise charge if the user taps reflexively.
+- It draws a clear line in the audit log between "agent prepared a
+  cart" and "agent prepared a cart over the daily limit (refused)".
+  The latter is a useful security signal in case of a prompt-injection
+  attempt.
+
+## Audit log
+
+Every script writes one structured event per call (via stderr or via
+the agent's `delegate` tool). At minimum the agent should log:
+
+- `query` events (`bot.query`) -- text + user_id
+- `cart.built` -- url + price + strategy
+- `policy.block` -- reason + offer
+- `payment.dispatched` -- provider key + last4
+- `manual_paste.received` -- last4 only
+- `payment.error` -- exception class
+
+Whatever audit sink Hermes provides (memory, dedicated log, MCP
+endpoint) is fine; the events should be machine-readable so the
+user can `/audit` them later.

--- a/skills/commerce/personal-shopper/scripts/build_cart.py
+++ b/skills/commerce/personal-shopper/scripts/build_cart.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Build a prefilled cart URL for a chosen product.
+
+Usage:
+  python3 build_cart.py --url 'https://www.terresdecafe.com/products/foo' \
+    [--quantity 1] [--json]
+
+Outputs (JSON mode):
+  {
+    "platform": "shopify" | "woocommerce" | "unknown",
+    "cart_url": "https://merchant/cart/12345:1" | null,
+    "detected_price_eur": 19.90 | null,
+    "needs_user_finish": false | true,
+    "strategy": "shopify_cart_add" | "woocommerce_add_to_cart" | "manual_link"
+  }
+
+Strategy:
+  - Shopify     -> /cart/{variant_id}:{quantity} permalink (1-tap-ish)
+  - WooCommerce -> ?add-to-cart=ID&quantity=N
+  - Unknown     -> return the product URL with needs_user_finish=true
+
+We never submit payment data; the user finishes on the merchant's UI.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from urllib.parse import urlparse
+
+from playwright.async_api import async_playwright
+from selectolax.parser import HTMLParser
+
+
+SHOPIFY_MARKERS = ("cdn.shopify.com", "Shopify.theme", "/products/", '"product"')
+WOO_MARKERS = ("woocommerce", "wc-block", "wp-content/plugins/woocommerce")
+VARIANT_RE = re.compile(r'"id"\s*:\s*(\d{10,})')
+WOO_PID_RE = re.compile(r'data-product[_-]?id="(\d+)"|add-to-cart=(\d+)')
+
+
+@dataclass
+class CartResult:
+    platform: str
+    cart_url: str | None
+    detected_price_eur: float | None
+    needs_user_finish: bool
+    strategy: str
+
+
+def _detect_platform(html: str) -> str:
+    if any(m in html for m in SHOPIFY_MARKERS) and ("Shopify" in html or "/cart/" in html):
+        return "shopify"
+    lower = html.lower()
+    if any(m in lower for m in WOO_MARKERS):
+        return "woocommerce"
+    return "unknown"
+
+
+def _detect_price(html: str) -> float | None:
+    tree = HTMLParser(html)
+    for sel in [
+        'meta[property="product:price:amount"]',
+        'meta[itemprop="price"]',
+        '[itemprop="price"]',
+        ".price ins .amount",
+        ".price .amount",
+        ".price__current .money",
+        ".product-price",
+    ]:
+        node = tree.css_first(sel)
+        if not node:
+            continue
+        raw = node.attributes.get("content") or node.text(strip=True)
+        if not raw:
+            continue
+        m = re.search(r"(\d+[.,]?\d*)", raw.replace(" ", ""))
+        if m:
+            try:
+                return float(m.group(1).replace(",", "."))
+            except ValueError:
+                continue
+    return None
+
+
+async def build_cart_async(product_url: str, quantity: int) -> CartResult:
+    parsed = urlparse(product_url)
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        try:
+            ctx = await browser.new_context(locale="fr-FR")
+            page = await ctx.new_page()
+            await page.goto(product_url, wait_until="domcontentloaded", timeout=30_000)
+            html = await page.content()
+        finally:
+            await browser.close()
+
+    platform = _detect_platform(html)
+    price = _detect_price(html)
+
+    if platform == "shopify":
+        m = VARIANT_RE.search(html)
+        if m:
+            try:
+                variant_id = int(m.group(1))
+                return CartResult(
+                    platform="shopify",
+                    cart_url=f"{base_url}/cart/{variant_id}:{quantity}",
+                    detected_price_eur=price,
+                    needs_user_finish=False,
+                    strategy="shopify_cart_add",
+                )
+            except ValueError:
+                pass
+
+    if platform == "woocommerce":
+        m = WOO_PID_RE.search(html)
+        if m:
+            pid = m.group(1) or m.group(2)
+            if pid:
+                sep = "&" if "?" in product_url else "?"
+                return CartResult(
+                    platform="woocommerce",
+                    cart_url=f"{product_url}{sep}add-to-cart={pid}&quantity={quantity}",
+                    detected_price_eur=price,
+                    needs_user_finish=False,
+                    strategy="woocommerce_add_to_cart",
+                )
+
+    return CartResult(
+        platform=platform,
+        cart_url=product_url,
+        detected_price_eur=price,
+        needs_user_finish=True,
+        strategy="manual_link",
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--url", required=True, help="Product URL")
+    p.add_argument("--quantity", type=int, default=1)
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    try:
+        cart = asyncio.run(build_cart_async(args.url, args.quantity))
+    except Exception as exc:  # noqa: BLE001
+        err = {"error": str(exc)}
+        sys.stdout.write(json.dumps(err, ensure_ascii=False) + "\n")
+        return 2
+
+    if args.json:
+        sys.stdout.write(json.dumps(asdict(cart), ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(
+            f"platform: {cart.platform}\n"
+            f"strategy: {cart.strategy}\n"
+            f"price: {cart.detected_price_eur}\n"
+            f"cart_url: {cart.cart_url}\n"
+            f"needs_user_finish: {cart.needs_user_finish}\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/commerce/personal-shopper/scripts/cap_check.py
+++ b/skills/commerce/personal-shopper/scripts/cap_check.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Spend-cap policy check.
+
+Usage:
+  python3 cap_check.py --price-eur 14.20 [--quantity 1] \
+    [--cap-per-purchase 50] [--cap-per-day 100] \
+    [--ledger /tmp/personal-shopper-ledger.json] [--commit] [--json]
+
+The ledger is a tiny JSON file the agent writes to track committed
+purchases for the day. With `--commit` the script appends an entry.
+Without it, it just simulates and returns whether the purchase WOULD
+be allowed.
+
+Outputs (JSON mode):
+  {
+    "ok": true,
+    "reason": null,
+    "engaged_today_eur": 23.20,
+    "remaining_today_eur": 76.80,
+    "cap_per_purchase_eur": 50,
+    "cap_per_day_eur": 100
+  }
+
+The agent should run this twice per Buy: once before showing the user
+a confirmation (with the search-snippet price) and once after the live
+page price is scraped (build_cart.py returns it). On --commit, only
+call the second time with the verified price.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_LEDGER = Path("/tmp/personal-shopper-ledger.json")
+
+
+def _load_ledger(path: Path) -> dict[str, list[dict[str, object]]]:
+    if not path.exists():
+        return {"entries": []}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {"entries": []}
+
+
+def _save_ledger(path: Path, ledger: dict[str, list[dict[str, object]]]) -> None:
+    path.write_text(json.dumps(ledger, ensure_ascii=False, indent=2))
+
+
+def _spent_today(ledger: dict[str, list[dict[str, object]]]) -> float:
+    midnight = (int(time.time()) // 86400) * 86400
+    return sum(
+        float(e.get("price_eur", 0)) * int(e.get("quantity", 1))
+        for e in ledger.get("entries", [])
+        if int(e.get("created_at", 0)) >= midnight
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--price-eur", type=float, required=True)
+    p.add_argument("--quantity", type=int, default=1)
+    p.add_argument(
+        "--cap-per-purchase",
+        type=float,
+        default=float(os.environ.get("SHOPPER_SPEND_CAP_EUR_PER_PURCHASE", "50")),
+    )
+    p.add_argument(
+        "--cap-per-day",
+        type=float,
+        default=float(os.environ.get("SHOPPER_SPEND_CAP_EUR_PER_DAY", "100")),
+    )
+    p.add_argument("--ledger", type=Path, default=DEFAULT_LEDGER)
+    p.add_argument("--commit", action="store_true", help="Persist this entry to the ledger")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    ledger = _load_ledger(args.ledger)
+    spent = _spent_today(ledger)
+    line_total = args.price_eur * args.quantity
+
+    decision: dict[str, object] = {
+        "ok": True,
+        "reason": None,
+        "engaged_today_eur": round(spent, 2),
+        "remaining_today_eur": round(max(0.0, args.cap_per_day - spent), 2),
+        "cap_per_purchase_eur": args.cap_per_purchase,
+        "cap_per_day_eur": args.cap_per_day,
+    }
+
+    if line_total <= 0:
+        decision["ok"] = False
+        decision["reason"] = "price must be > 0"
+    elif line_total > args.cap_per_purchase:
+        decision["ok"] = False
+        decision["reason"] = (
+            f"per-purchase cap exceeded: {line_total:.2f} EUR > {args.cap_per_purchase:.2f} EUR"
+        )
+    elif spent + line_total > args.cap_per_day:
+        decision["ok"] = False
+        decision["reason"] = (
+            f"per-day cap exceeded: {spent:.2f} engaged + {line_total:.2f} this purchase "
+            f"> {args.cap_per_day:.2f} EUR cap"
+        )
+
+    if decision["ok"] and args.commit:
+        ledger.setdefault("entries", []).append(
+            {
+                "price_eur": args.price_eur,
+                "quantity": args.quantity,
+                "created_at": int(time.time()),
+            }
+        )
+        _save_ledger(args.ledger, ledger)
+        decision["committed"] = True
+
+    if args.json:
+        sys.stdout.write(json.dumps(decision, ensure_ascii=False, indent=2) + "\n")
+    else:
+        if decision["ok"]:
+            sys.stdout.write(
+                f"OK -- {line_total:.2f} EUR, restant aujourd'hui "
+                f"{decision['remaining_today_eur']:.2f} EUR\n"
+            )
+        else:
+            sys.stdout.write(f"REFUS -- {decision['reason']}\n")
+    return 0 if decision["ok"] else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/commerce/personal-shopper/scripts/issue_card_privacy.py
+++ b/skills/commerce/personal-shopper/scripts/issue_card_privacy.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Issue a single-use virtual card via the Privacy.com personal API.
+
+Usage:
+  PRIVACY_API_KEY=sk_live_... python3 issue_card_privacy.py \
+    --amount-eur 19.90 --merchant 'Terres de Cafe' \
+    --product 'Foo grain 1kg' [--json]
+
+Outputs (JSON mode) on success:
+  {
+    "pan": "4111...1234",   # full PAN -- pass to user, do not store
+    "cvv": "123",
+    "exp_month": 5,
+    "exp_year": 2031,
+    "last4": "1234",
+    "spend_limit_eur": 19.90,
+    "provider_card_id": "card_token",
+    "memo": "shopper:Terres de Cafe:Foo grain 1kg"
+  }
+
+The card is created with type=SINGLE_USE -- it self-revokes after the
+first transaction. Spend limit is set in USD cents (Privacy.com is
+USD-only) using a +10% FX buffer over an approximate 1.10 USD/EUR
+exchange rate.
+
+Privacy.com requires:
+  - a US bank account to fund the issuing balance
+  - a personal API key (Account -> Developers -> API Keys)
+  - free tier: 12 cards/month
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import httpx
+
+
+PRIVACY_BASE_URL = "https://api.privacy.com/v1"
+
+
+def issue(
+    *,
+    api_key: str,
+    amount_eur: float,
+    merchant: str,
+    product: str,
+) -> dict[str, object]:
+    # USD limit in cents: amount_eur * 1.10 buffer * ~1.10 USD/EUR -> cents
+    usd_limit_cents = int(round(amount_eur * 1.10 * 110))
+    body = {
+        "type": "SINGLE_USE",
+        "spend_limit": usd_limit_cents,
+        "spend_limit_duration": "TRANSACTION",
+        "memo": f"shopper:{merchant[:32]}:{product[:32]}",
+    }
+    headers = {"Authorization": f"api-key {api_key}"}
+    with httpx.Client(timeout=httpx.Timeout(20.0)) as client:
+        r = client.post(f"{PRIVACY_BASE_URL}/cards", json=body, headers=headers)
+        r.raise_for_status()
+        data = r.json()
+
+    pan = str(data["pan"])
+    return {
+        "pan": pan,
+        "cvv": str(data["cvv"]),
+        "exp_month": int(data["exp_month"]),
+        "exp_year": int(data["exp_year"]),
+        "last4": pan[-4:] if len(pan) >= 4 else pan,
+        "spend_limit_eur": amount_eur,
+        "provider_card_id": str(data.get("token") or data.get("id") or ""),
+        "memo": body["memo"],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--amount-eur", type=float, required=True)
+    p.add_argument("--merchant", required=True)
+    p.add_argument("--product", required=True)
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    api_key = os.environ.get("PRIVACY_API_KEY")
+    if not api_key:
+        sys.stdout.write(
+            json.dumps({"error": "PRIVACY_API_KEY env var not set"}, ensure_ascii=False) + "\n"
+        )
+        return 2
+
+    try:
+        out = issue(
+            api_key=api_key,
+            amount_eur=args.amount_eur,
+            merchant=args.merchant,
+            product=args.product,
+        )
+    except httpx.HTTPStatusError as exc:
+        body_text = exc.response.text[:300] if exc.response is not None else ""
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "error": f"privacy.com api error: {exc}",
+                    "response_body": body_text,
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        return 2
+    except httpx.HTTPError as exc:
+        sys.stdout.write(
+            json.dumps({"error": f"privacy.com network error: {exc}"}, ensure_ascii=False) + "\n"
+        )
+        return 2
+
+    if args.json:
+        sys.stdout.write(json.dumps(out, ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(
+            f"PAN  {out['pan']}\nExp  {out['exp_month']:02d}/{str(out['exp_year'])[-2:]}\n"
+            f"CVV  {out['cvv']}\nLast4 {out['last4']}\nLimit {out['spend_limit_eur']} EUR\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/commerce/personal-shopper/scripts/parse_pasted_card.py
+++ b/skills/commerce/personal-shopper/scripts/parse_pasted_card.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Parse a card the user pasted from their banking app's disposable
+card feature.
+
+Usage:
+  python3 parse_pasted_card.py 'PAN MM/YY CVV' [--json]
+  python3 parse_pasted_card.py - [--json]    # read text from stdin
+
+Outputs (JSON mode):
+  {
+    "pan": "1234567812345678",
+    "exp_month": 12,
+    "exp_year": 27,
+    "cvv": "123",
+    "last4": "5678"
+  }
+  or
+  {"error": "could not parse"}
+
+Format accepted:
+  - PAN with spaces or dashes (e.g. '4111 1111 1111 1111' or '4111-1111-1111-1111')
+  - MM/YY or MM/YYYY expiry (slash-anchored, no dashes/dots between month and year)
+  - CVV: 3 or 4 digits anywhere after the expiry
+
+We accept slashes only (not dashes/dots) for the expiry separator
+because PAN groups frequently use dashes -- otherwise the heuristic
+would misfire on '1234-5678' inputs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+
+def parse(text: str) -> dict[str, object] | None:
+    exp_matches = list(re.finditer(r"(\b\d{1,2})\s*/\s*(\d{2,4}\b)", text))
+    if not exp_matches:
+        return None
+    exp = exp_matches[-1]
+    mm = int(exp.group(1))
+    yy_raw = exp.group(2)
+    yy = int(yy_raw) if len(yy_raw) == 2 else int(yy_raw[-2:])
+    if not (1 <= mm <= 12):
+        return None
+
+    before = text[: exp.start()]
+    after = text[exp.end():]
+
+    pan_digits = re.sub(r"\D", "", before)
+    if not (12 <= len(pan_digits) <= 19):
+        return None
+
+    cvv_match = re.search(r"(\d{3,4})", after)
+    if not cvv_match:
+        return None
+    cvv = cvv_match.group(1)
+    return {
+        "pan": pan_digits,
+        "exp_month": mm,
+        "exp_year": yy,
+        "cvv": cvv,
+        "last4": pan_digits[-4:],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("text", help="The pasted text, or '-' to read stdin")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    text = sys.stdin.read() if args.text == "-" else args.text
+    out = parse(text)
+    if out is None:
+        payload = {"error": "could not parse PAN+exp+CVV from input"}
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        return 2
+
+    if args.json:
+        sys.stdout.write(json.dumps(out, ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(
+            f"PAN  {out['pan']}\nExp  {out['exp_month']:02d}/{out['exp_year']:02d}\n"
+            f"CVV  {out['cvv']}\nLast4 {out['last4']}\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/commerce/personal-shopper/scripts/search_offers.py
+++ b/skills/commerce/personal-shopper/scripts/search_offers.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Search the open web for product offers via a SearXNG instance.
+
+Usage:
+  python3 search_offers.py --query 'cafe en grain bio 1kg' \
+    [--searxng-url http://127.0.0.1:8888] [--max-results 12] [--json]
+
+Outputs (JSON mode):
+  {"hits": [
+     {"title": ..., "url": ..., "domain": ..., "snippet": ..., "rank": 1},
+     ...
+  ]}
+
+Filters out comparator/aggregator/wiki/social-media domains so the agent
+sees only direct merchant pages. The downstream LLM (Hermes itself in
+production) is responsible for turning these hits into structured
+offers via tool-use; this script just does the search and the
+domain-level filtering.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+import httpx
+
+
+BLOCKED_DOMAINS: set[str] = {
+    "idealo.fr",
+    "idealo.com",
+    "leguide.com",
+    "shopping.google.com",
+    "kelkoo.fr",
+    "kelkoo.com",
+    "twenga.fr",
+    "twenga.com",
+    "youtube.com",
+    "wikipedia.org",
+    "fr.wikipedia.org",
+    "simple.wikipedia.org",
+    "reddit.com",
+    "facebook.com",
+    "instagram.com",
+    "pinterest.com",
+    "tiktok.com",
+    "linkedin.com",
+}
+
+
+def _domain(url: str) -> str:
+    try:
+        host = urlparse(url).netloc.lower().lstrip(".")
+        return host[4:] if host.startswith("www.") else host
+    except Exception:
+        return ""
+
+
+def search(
+    query: str,
+    *,
+    searxng_url: str,
+    max_results: int = 12,
+    language: str = "fr",
+) -> list[dict[str, object]]:
+    """Run a SearXNG search and return the curated hit list."""
+    base = searxng_url.rstrip("/")
+    params = {
+        "q": f"{query} acheter en ligne",
+        "format": "json",
+        "language": language,
+    }
+    with httpx.Client(timeout=httpx.Timeout(20.0)) as client:
+        r = client.get(f"{base}/search", params=params)
+        r.raise_for_status()
+        data = r.json()
+
+    hits: list[dict[str, object]] = []
+    for item in data.get("results", []):
+        url = (item.get("url") or "").strip()
+        if not url:
+            continue
+        d = _domain(url)
+        if not d or d in BLOCKED_DOMAINS:
+            continue
+        hits.append(
+            {
+                "rank": len(hits) + 1,
+                "title": (item.get("title") or "").strip(),
+                "url": url,
+                "domain": d,
+                "snippet": (item.get("content") or "").strip(),
+            }
+        )
+        if len(hits) >= max_results:
+            break
+    return hits
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--query", required=True, help="Natural-language product query")
+    p.add_argument(
+        "--searxng-url",
+        default=os.environ.get("SEARXNG_URL", "http://127.0.0.1:8888"),
+        help="Base URL of a SearXNG instance (default: env SEARXNG_URL or http://127.0.0.1:8888)",
+    )
+    p.add_argument("--max-results", type=int, default=12)
+    p.add_argument("--language", default="fr")
+    p.add_argument("--json", action="store_true", help="Emit JSON to stdout")
+    args = p.parse_args()
+
+    try:
+        hits = search(
+            args.query,
+            searxng_url=args.searxng_url,
+            max_results=args.max_results,
+            language=args.language,
+        )
+    except httpx.HTTPError as exc:
+        err = {"error": f"searxng request failed: {exc}", "hits": []}
+        sys.stdout.write(json.dumps(err, ensure_ascii=False) + "\n")
+        return 2
+
+    if args.json:
+        sys.stdout.write(json.dumps({"hits": hits}, ensure_ascii=False, indent=2) + "\n")
+    else:
+        for h in hits:
+            sys.stdout.write(f"[{h['rank']:>2}] {h['domain']}\n  {h['title']}\n  {h['url']}\n\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/commerce/personal-shopper/tests/test_cap_check.py
+++ b/skills/commerce/personal-shopper/tests/test_cap_check.py
@@ -1,0 +1,56 @@
+"""Pytest for cap_check ledger + decision logic.
+
+Uses tmp_path fixtures to keep the production ledger untouched.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "cap_check.py"
+
+
+def _run(*args: str) -> tuple[int, dict]:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    out = proc.stdout.strip()
+    return proc.returncode, (json.loads(out) if out else {})
+
+
+def test_under_cap_ok(tmp_path: Path) -> None:
+    rc, payload = _run("--price-eur", "14.20", "--ledger", str(tmp_path / "l.json"))
+    assert rc == 0
+    assert payload["ok"] is True
+
+
+def test_over_per_purchase_cap_blocked(tmp_path: Path) -> None:
+    rc, payload = _run("--price-eur", "80", "--ledger", str(tmp_path / "l.json"))
+    assert rc == 3
+    assert payload["ok"] is False
+    assert "per-purchase" in (payload["reason"] or "")
+
+
+def test_per_day_cap_accumulates(tmp_path: Path) -> None:
+    ledger = tmp_path / "l.json"
+    # Commit 60
+    _run("--price-eur", "60", "--ledger", str(ledger), "--commit", "--cap-per-purchase", "70")
+    # Try another 50; total would be 110 > default per-day cap of 100
+    rc, payload = _run("--price-eur", "50", "--ledger", str(ledger), "--cap-per-purchase", "70")
+    assert rc == 3
+    assert payload["ok"] is False
+    assert "per-day" in (payload["reason"] or "")
+
+
+def test_commit_persists(tmp_path: Path) -> None:
+    ledger = tmp_path / "l.json"
+    _run("--price-eur", "10", "--ledger", str(ledger), "--commit")
+    data = json.loads(ledger.read_text())
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["price_eur"] == 10

--- a/skills/commerce/personal-shopper/tests/test_parse_pasted_card.py
+++ b/skills/commerce/personal-shopper/tests/test_parse_pasted_card.py
@@ -1,0 +1,62 @@
+"""Pytest suite for parse_pasted_card.parse().
+
+Run from the skill root:
+    cd skills/commerce/personal-shopper
+    PYTHONPATH=scripts pytest tests/
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import parse_pasted_card as ppc  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (
+            "1234567812345678 12/27 123",
+            {"pan": "1234567812345678", "exp_month": 12, "exp_year": 27, "cvv": "123"},
+        ),
+        (
+            "1234 5678 1234 5678 12/27 123",
+            {"pan": "1234567812345678", "exp_month": 12, "exp_year": 27, "cvv": "123"},
+        ),
+        (
+            "1234-5678-1234-5678 12/2027 1234",
+            {"pan": "1234567812345678", "exp_month": 12, "exp_year": 27, "cvv": "1234"},
+        ),
+        (
+            "4111 1111 1111 1111  03/26  999",
+            {"pan": "4111111111111111", "exp_month": 3, "exp_year": 26, "cvv": "999"},
+        ),
+        (
+            "PAN: 5555 4444 3333 2222 EXP 09/29 CVV 707",
+            {"pan": "5555444433332222", "exp_month": 9, "exp_year": 29, "cvv": "707"},
+        ),
+    ],
+)
+def test_parse_valid(text: str, expected: dict[str, object]) -> None:
+    out = ppc.parse(text)
+    assert out is not None, f"expected match for {text!r}"
+    for k, v in expected.items():
+        assert out[k] == v, f"{k}: got {out[k]!r}, expected {v!r}"
+    assert out["last4"] == expected["pan"][-4:]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "coucou pas de carte",
+        "123 12/27",  # PAN too short
+        "12345678 12-27 123",  # dash separator on expiry not accepted
+        "",
+    ],
+)
+def test_parse_invalid(text: str) -> None:
+    assert ppc.parse(text) is None

--- a/skills/commerce/personal-shopper/tests/test_search_offers_filter.py
+++ b/skills/commerce/personal-shopper/tests/test_search_offers_filter.py
@@ -1,0 +1,36 @@
+"""Pytest for search_offers BLOCKED_DOMAINS filtering + _domain helper.
+
+We don't hit a live SearXNG; we test the pure logic that decides which
+URLs survive the filter. The HTTP layer is exercised by --json smoke
+in CI separately.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import search_offers as so  # noqa: E402
+
+
+def test_domain_strips_www() -> None:
+    assert so._domain("https://www.maxicoffee.com/foo") == "maxicoffee.com"
+
+
+def test_domain_lowercase() -> None:
+    assert so._domain("https://Example.COM/X") == "example.com"
+
+
+def test_domain_invalid_returns_empty() -> None:
+    assert so._domain("not a url") == ""
+
+
+def test_blocked_domains_contains_known_aggregators() -> None:
+    for d in ("idealo.fr", "youtube.com", "wikipedia.org", "reddit.com"):
+        assert d in so.BLOCKED_DOMAINS
+
+
+def test_blocked_domains_excludes_real_merchants() -> None:
+    for d in ("amazon.fr", "fnac.com", "maxicoffee.com", "shopify.com"):
+        assert d not in so.BLOCKED_DOMAINS


### PR DESCRIPTION
## Summary

A new top-level skill `commerce/personal-shopper` that turns Hermes into an end-to-end shopping assistant: the user describes what they want in natural language, the skill searches the open web (free, self-hosted SearXNG), prepares a prefilled cart on the merchant's own page, and hands off the final tap to the user with the most appropriate payment method for their country.

## Why a skill, not a tool

Per `CONTRIBUTING.md`: the heavy lifting is instructions + small shell-runnable scripts. No agent-harness state, no API-key management baked into the agent, no binary streams. The skill model fits perfectly. Hermes provides the LLM, the messaging gateway (Telegram / Discord / Slack / WhatsApp / Signal), and the `terminal` tool — this skill provides the procedural knowledge.

## Layout

```
skills/commerce/personal-shopper/
  SKILL.md                              -- master instructions
  scripts/
    search_offers.py                     -- SearXNG query + domain filter
    build_cart.py                        -- Playwright auto-detects Shopify /
                                            WooCommerce / unknown, returns
                                            a prefilled cart URL + price
    issue_card_privacy.py                -- Privacy.com personal API
                                            single-use card emission (US)
    parse_pasted_card.py                 -- regex parser for cards the user
                                            pasted from their banking app
    cap_check.py                         -- per-purchase + per-day spend
                                            caps with a JSON ledger
  references/
    payment-providers.md                 -- comparison + per-country recommendations
    privacy-com-setup.md                 -- Privacy.com onboarding + API key flow
    manual-paste-flow.md                 -- which apps support disposable cards
    spend-policy.md                      -- cap rationale + ledger + audit events
  tests/
    test_parse_pasted_card.py            -- 9 cases (formats, edges, bad inputs)
    test_search_offers_filter.py         -- BLOCKED_DOMAINS coverage
    test_cap_check.py                    -- ledger + decision logic via subprocess
```

## Three payment providers, picked by the agent

| Provider | UX | Country | Setup |
|---|---|---|---|
| `apple_pay_handoff` (default) | 2 taps total: chat selection + biometric on merchant's checkout. Biometric satisfies SCA in EU. | Worldwide | None |
| `privacy_com` | Agent emits a single-use card via API, user pastes PAN/CVV at checkout (1 paste). | US only (US bank funding) | `PRIVACY_API_KEY` env var (free tier: 12 cards / month) |
| `manual_paste` | Walks the user through generating a one-time card in their banking app (Revolut/Monzo/Wise/Lydia/N26/Bunq/Boursorama), parses the pasted card, folds it back into one ready-to-copy message at the merchant's checkout. | Worldwide | None |

The 1-tap pay+order via agent only works in the US via `privacy_com` — that's the current state of the consumer-facing virtual card API market. The default `apple_pay_handoff` is what works *everywhere else* without bank partnerships.

## Hard problems addressed

- **Discovery**: SearXNG + a small `BLOCKED_DOMAINS` filter (idealo, kelkoo, youtube, wikipedia, social) rather than a curated allowlist. Cheap, broad, works on any merchant.
- **Robust checkout**: never submit payment data — the user does the final tap on the merchant's UI. No captcha race, no anti-bot trip at the payment step.
- **Liability**: per-purchase + per-day caps enforced *before* any cart link is generated AND re-checked after the live page price is scraped. The agent never moves money on its own.

## Verification

- `python3 -m py_compile` on every script: green
- `pytest tests/`: **18/18 pass** (includes a dashed-PAN edge case `1234-5678-1234-5678 12/2027 1234` that defeats a naive regex)
- `search_offers.py` against a live SearXNG (the user's local one): 5 hits from MaxiCoffee, Coffee Webstore, Biodyssée, Ethiquable, KoRo on `cafe en grain bio 1kg` — no aggregator pollution
- `cap_check` live: under-cap allowed; 80 EUR refused with the expected reason
- `parse_pasted_card` live: `'1234 5678 1234 5678 12/27 123'` → correct 4-tuple

Not verified in this PR (require external accounts):

- `issue_card_privacy.py` against a real Privacy.com US account
- `build_cart.py` end-to-end on a live Shopify cart permalink (Playwright install required; the script is structurally tested but not run against a live merchant in this commit)

Happy to add live integration coverage in a follow-up once a maintainer-side test account is available.

## Open questions for maintainers

1. Is `commerce/` the right top-level category or should this nest under `productivity/` / `domain/`? Easy to move on review.
2. Should the audit-log events (`bot.query`, `cart.built`, `policy.block`, `payment.dispatched`, `manual_paste.received`, `payment.error`) go through Hermes's memory system or stay on stderr / a dedicated log? I followed the lightweight stderr pattern other skills use, but happy to wire into the memory tools if that's preferred.
3. Any concerns about `privacy_com` shipping by default in the registry given it's US-only? The wizard flow recommends it only for US users; the registry presence is mostly to make extension straightforward.

## Test plan

- [x] Unit tests pass (`pytest tests/`)
- [x] Live SearXNG smoke
- [x] Live cap-check smoke
- [x] Live card-parse smoke
- [ ] Live Privacy.com card emission (needs maintainer or contributor with US Privacy account)
- [ ] Live Shopify cart-build round-trip (needs Playwright install + a willing test merchant)