### PR TITLE
fix(cron): bump skill usage when cron jobs load skills

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -759,6 +759,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         return prompt
 
     from tools.skills_tool import skill_view
+    from tools.skill_usage import bump_use
 
     parts = []
     skipped: list[str] = []
@@ -769,6 +770,12 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)
             skipped.append(skill_name)
             continue
+
+        # Bump usage so the curator sees this skill as actively used.
+        try:
+            bump_use(skill_name)
+        except Exception:
+            logger.debug("Cron job: failed to bump skill usage for '%s'", skill_name, exc_info=True)
 
         content = str(loaded.get("content") or "").strip()
         if parts:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1824,6 +1824,54 @@ class TestBuildJobPromptMissingSkill:
         assert "go" in result
 
 
+class TestBuildJobPromptBumpUse:
+    """Verify that cron jobs bump skill usage counters so the curator sees them as active."""
+
+    def test_bump_use_called_for_loaded_skill(self):
+        """bump_use is called for each successfully loaded skill."""
+
+        def _skill_view(name: str) -> str:
+            return json.dumps({"success": True, "content": f"Content for {name}."})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
+             patch("tools.skill_usage.bump_use") as mock_bump:
+            _build_job_prompt({"skills": ["alpha", "beta"], "prompt": "go"})
+
+        assert mock_bump.call_count == 2
+        calls = [c[0][0] for c in mock_bump.call_args_list]
+        assert "alpha" in calls
+        assert "beta" in calls
+
+    def test_bump_use_not_called_for_missing_skill(self):
+        """bump_use is NOT called when a skill fails to load."""
+
+        def _missing_view(name: str) -> str:
+            return json.dumps({"success": False, "error": "not found"})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_missing_view), \
+             patch("tools.skill_usage.bump_use") as mock_bump:
+            _build_job_prompt({"skills": ["ghost"], "prompt": "go"})
+
+        assert mock_bump.call_count == 0
+
+    def test_bump_failure_does_not_break_prompt(self, caplog):
+        """If bump_use raises, the prompt still builds — error is logged at DEBUG."""
+
+        def _skill_view(name: str) -> str:
+            return json.dumps({"success": True, "content": "Works."})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
+             patch("tools.skill_usage.bump_use", side_effect=RuntimeError("boom")), \
+             caplog.at_level(logging.DEBUG, logger="cron.scheduler"):
+            result = _build_job_prompt({"skills": ["good-skill"], "prompt": "go"})
+
+        # Prompt should still contain the skill content and original instruction
+        assert "Works." in result
+        assert "go" in result
+        # The error should be logged at DEBUG level, not crash
+        assert any("failed to bump" in r.message for r in caplog.records)
+
+
 class TestSendMediaViaAdapter:
     """Unit tests for _send_media_via_adapter — routes files to typed adapter methods."""
 


### PR DESCRIPTION
## What does this PR do?

Cron jobs that reference skills via their `skills:` config never bumped the usage counters in `.usage.json`, so the curator could auto-archive skills actively used by cron jobs based on stale timestamps.

The `_build_job_prompt()` function calls `skill_view(name)` to load each skill's content, but it didn't call `bump_use(skill_name)` to update the usage telemetry. This meant a skill loaded exclusively by cron jobs would show zero activity and get archived by the curator's automatic transitions (90-day inactivity rule).

This fix adds `bump_use(skill_name)` after each successful skill load, wrapped in try/except so telemetry failures never break prompt building.


## Related Issue

Fixes #18810


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)


## Changes Made

- `cron/scheduler.py` — Added `bump_use(skill_name)` call after each successful skill load in `_build_job_prompt()` (line 776). Wrapped in try/except with DEBUG-level logging on failure.
- `tests/cron/test_scheduler.py` — Added `TestBuildJobPromptBumpUse` class with three tests:
  - `test_bump_use_called_for_loaded_skill` — verifies bump is called for each valid skill
  - `test_bump_use_not_called_for_missing_skill` — verifies bump is skipped when skill loading fails
  - `test_bump_failure_does_not_break_prompt` — verifies prompt builds even if bump raises


## How to Test

1. Create a cron job with `skills: ["some-skill"]` configured
2. Run the job — verify `.usage.json` shows updated `last_used_at` for that skill
3. Alternatively, run the new tests: `pytest tests/cron/test_scheduler.py::TestBuildJobPromptBumpUse -v`


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran full cron test suite (`tests/cron/test_scheduler.py`): 106 passed, 1 pre-existing failure unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04


### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (purely Python scheduler logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
