### PR TITLE
fix(cli): collapse multiline tool status previews

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -94,20 +94,21 @@ class LocalEditSnapshot:
     before: dict[str, str | None] = field(default_factory=dict)
 
 # =========================================================================
-# Configurable tool preview length (0 = no limit)
+# Configurable tool preview length. 0 = use compact per-tool defaults for
+# completion lines; positive values set a custom cap.
 # Set once at startup by CLI or gateway from display.tool_preview_length config.
 # =========================================================================
-_tool_preview_max_len: int = 0  # 0 = unlimited
+_tool_preview_max_len: int = 0  # 0 = compact per-tool defaults
 
 
 def set_tool_preview_max_len(n: int) -> None:
-    """Set the global max length for tool call previews. 0 = no limit."""
+    """Set the global max length for tool call previews. 0 = compact defaults."""
     global _tool_preview_max_len
     _tool_preview_max_len = max(int(n), 0) if n else 0
 
 
 def get_tool_preview_max_len() -> int:
-    """Return the configured max preview length (0 = unlimited)."""
+    """Return the configured max preview length (0 = compact defaults)."""
     return _tool_preview_max_len
 
 
@@ -848,23 +849,31 @@ def get_cute_tool_message(
     is_failure, failure_suffix = _detect_tool_failure(tool_name, result)
     skin_prefix = get_skin_tool_prefix()
 
+    def _ellipsis(limit: int) -> str:
+        return "." * max(limit, 0)
+
     def _trunc(s, n=40):
         # Completion lines must remain single-line even when the underlying
         # tool argument is a heredoc, pasted code block, or otherwise contains
-        # embedded newlines.  display.tool_preview_length=0 means "unlimited
-        # length", not "preserve raw whitespace".
+        # embedded newlines.  For completion lines, display.tool_preview_length=0
+        # means "use the tool-specific compact default"; positive values opt in
+        # to a custom cap.
         s = _oneline(str(s))
-        if _tool_preview_max_len == 0:
-            return s  # no length limit
-        limit = _tool_preview_max_len
-        return (s[:limit-3] + "...") if len(s) > limit else s
+        limit = _tool_preview_max_len or n
+        if len(s) <= limit:
+            return s
+        if limit <= 3:
+            return _ellipsis(limit)
+        return s[:limit - 3] + "..."
 
     def _path(p, n=35):
         p = _oneline(str(p))
-        if _tool_preview_max_len == 0:
-            return p  # no length limit
-        limit = _tool_preview_max_len
-        return ("..." + p[-(limit-3):]) if len(p) > limit else p
+        limit = _tool_preview_max_len or n
+        if len(p) <= limit:
+            return p
+        if limit <= 3:
+            return _ellipsis(limit)
+        return "..." + p[-(limit - 3):]
 
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""

--- a/agent/display.py
+++ b/agent/display.py
@@ -849,16 +849,20 @@ def get_cute_tool_message(
     skin_prefix = get_skin_tool_prefix()
 
     def _trunc(s, n=40):
-        s = str(s)
+        # Completion lines must remain single-line even when the underlying
+        # tool argument is a heredoc, pasted code block, or otherwise contains
+        # embedded newlines.  display.tool_preview_length=0 means "unlimited
+        # length", not "preserve raw whitespace".
+        s = _oneline(str(s))
         if _tool_preview_max_len == 0:
-            return s  # no limit
+            return s  # no length limit
         limit = _tool_preview_max_len
         return (s[:limit-3] + "...") if len(s) > limit else s
 
     def _path(p, n=35):
-        p = str(p)
+        p = _oneline(str(p))
         if _tool_preview_max_len == 0:
-            return p  # no limit
+            return p  # no length limit
         limit = _tool_preview_max_len
         return ("..." + p[-(limit-3):]) if len(p) > limit else p
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -854,7 +854,7 @@ DEFAULT_CONFIG = {
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
-        "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "tool_preview_length": 0,  # Max chars for normal tool previews (0 = compact per-tool defaults)
         # Auto-delete system-notice replies (e.g. "✨ New session started!",
         # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms
         # that support message deletion (currently Telegram; other platforms

--- a/tests/agent/test_display_tool_messages.py
+++ b/tests/agent/test_display_tool_messages.py
@@ -5,31 +5,51 @@ def teardown_function():
     set_tool_preview_max_len(0)
 
 
-def test_terminal_completion_preview_collapses_multiline_commands_when_unlimited():
+def test_terminal_completion_preview_collapses_and_caps_multiline_commands_by_default():
     set_tool_preview_max_len(0)
-    command = "python3 - <<'PY'\nprint('hello')\nPY"
-
-    line = get_cute_tool_message("terminal", {"command": command}, 0.2)
-
-    assert "\n" not in line
-    assert "python3 - <<'PY' print('hello') PY" in line
-
-
-def test_terminal_completion_preview_collapses_multiline_commands_before_truncating():
-    set_tool_preview_max_len(1)
-    command = "python3 - <<'PY'\n" + "print('hello') " * 5 + "\nPY"
+    command = "python3 - <<'PY'\n" + "print('hello') " * 8 + "\nPY"
 
     line = get_cute_tool_message("terminal", {"command": command}, 0.2)
 
     assert "\n" not in line
     assert "..." in line
-    assert "print('hello')" in line
+    assert "python3 - <<'PY'" in line
+    preview = line.split("$         ", 1)[1].rsplit("  0.2s", 1)[0]
+    assert len(preview) <= 42
 
 
-def test_path_completion_preview_stays_single_line_when_unlimited():
-    set_tool_preview_max_len(0)
+def test_terminal_completion_preview_respects_custom_preview_length():
+    set_tool_preview_max_len(80)
+    command = "python3 - <<'PY'\n" + "print('hello') " * 8 + "\nPY"
 
-    line = get_cute_tool_message("read_file", {"path": "/tmp/a\nweird/path.txt"}, 0.1)
+    line = get_cute_tool_message("terminal", {"command": command}, 0.2)
 
     assert "\n" not in line
-    assert "/tmp/a weird/path.txt" in line
+    assert "..." in line
+    preview = line.split("$         ", 1)[1].rsplit("  0.2s", 1)[0]
+    assert 42 < len(preview) <= 80
+
+
+def test_path_completion_preview_stays_single_line_and_capped_by_default():
+    set_tool_preview_max_len(0)
+    path = "/tmp/" + "very-long-segment/" * 5 + "a\nweird/path.txt"
+
+    line = get_cute_tool_message("read_file", {"path": path}, 0.1)
+
+    assert "\n" not in line
+    assert "..." in line
+    preview = line.split("read      ", 1)[1].rsplit("  0.1s", 1)[0]
+    assert len(preview) <= 35
+    assert preview.endswith("weird/path.txt")
+
+
+def test_path_completion_preview_respects_custom_preview_length():
+    set_tool_preview_max_len(60)
+    path = "/tmp/" + "very-long-segment/" * 5 + "a\nweird/path.txt"
+
+    line = get_cute_tool_message("read_file", {"path": path}, 0.1)
+
+    assert "\n" not in line
+    preview = line.split("read      ", 1)[1].rsplit("  0.1s", 1)[0]
+    assert 35 < len(preview) <= 60
+    assert preview.endswith("weird/path.txt")

--- a/tests/agent/test_display_tool_messages.py
+++ b/tests/agent/test_display_tool_messages.py
@@ -1,0 +1,35 @@
+from agent.display import get_cute_tool_message, set_tool_preview_max_len
+
+
+def teardown_function():
+    set_tool_preview_max_len(0)
+
+
+def test_terminal_completion_preview_collapses_multiline_commands_when_unlimited():
+    set_tool_preview_max_len(0)
+    command = "python3 - <<'PY'\nprint('hello')\nPY"
+
+    line = get_cute_tool_message("terminal", {"command": command}, 0.2)
+
+    assert "\n" not in line
+    assert "python3 - <<'PY' print('hello') PY" in line
+
+
+def test_terminal_completion_preview_collapses_multiline_commands_before_truncating():
+    set_tool_preview_max_len(1)
+    command = "python3 - <<'PY'\n" + "print('hello') " * 5 + "\nPY"
+
+    line = get_cute_tool_message("terminal", {"command": command}, 0.2)
+
+    assert "\n" not in line
+    assert "..." in line
+    assert "print('hello')" in line
+
+
+def test_path_completion_preview_stays_single_line_when_unlimited():
+    set_tool_preview_max_len(0)
+
+    line = get_cute_tool_message("read_file", {"path": "/tmp/a\nweird/path.txt"}, 0.1)
+
+    assert "\n" not in line
+    assert "/tmp/a weird/path.txt" in line

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -291,12 +291,12 @@ Cycle through display modes with `/verbose`: `off → new → all → verbose`. 
 
 ### Tool Preview Length
 
-The `display.tool_preview_length` config key controls the maximum number of characters shown in tool call preview lines (e.g. file paths, terminal commands). The default is `0`, which means no limit — full paths and commands are shown.
+The `display.tool_preview_length` config key controls the maximum number of characters shown in tool call preview lines (e.g. file paths, terminal commands). The default is `0`, which uses compact per-tool defaults for normal completion lines. Set a positive value to choose a wider or narrower cap. Verbose mode can still show full tool details.
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  tool_preview_length: 80   # Truncate tool previews to 80 chars (0 = no limit)
+  tool_preview_length: 80   # Truncate normal tool previews to 80 chars (0 = compact defaults)
 ```
 
 This is useful on narrow terminals or when tool arguments contain very long file paths.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1178,7 +1178,7 @@ display:
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
-  tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+  tool_preview_length: 0  # Max chars for normal tool previews (0 = compact per-tool defaults)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk
 ```


### PR DESCRIPTION
## Summary
- Collapse whitespace/newlines in tool completion previews before rendering CLI status lines
- Cap default CLI completion previews with per-tool compact defaults when display.tool_preview_length is 0
- Preserve positive display.tool_preview_length values as an explicit custom preview cap
- Add regression tests for multiline terminal command and path previews
- Update docs/config comments for the new compact-default behavior

## Test Plan
- python -m py_compile agent/display.py hermes_cli/config.py tests/agent/test_display_tool_messages.py
- python -m pytest tests/agent/test_display_tool_messages.py tests/hermes_cli/test_skin_engine.py -o 'addopts=' -q