### PR TITLE
docs(telegram): document frontpage photo overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity, and Telegram media-triggered workflows like single-photo frontpage overrides.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -81,6 +81,26 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |
 
 For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
+
+## Telegram Photo Caption Overrides
+
+Telegram can do more than plain chat commands. Hermes can intercept a single photo plus a caption command and hand it off to an external workflow before the normal agent turn runs.
+
+One built-in example is a frontpage inspiration override:
+
+```text
+/frontpage urgent trend seed
+bias: election, breaking
+note: Keep source discovery broad.
+```
+
+- Supported caption commands: `/frontpage`, `/frontpage-override`, `/fp`
+- Send exactly one image. Albums are rejected for this flow.
+- First line: command plus optional title
+- `bias:`: comma-separated steering terms passed through to the downstream workflow
+- `note:` plus any extra body lines: freeform guidance
+
+For setup details, config hooks, and exact behavior, see the [Telegram guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/telegram).
 
 ---
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -232,6 +232,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all`. Matches the Discord pattern. |
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
+| `HERMES_FRONTPAGE_ENGINE_DIR` | Override the Telegram frontpage-photo handoff repo directory. Defaults to `/Users/nickgeorge-studio/Projects/hermes-frontpage-engine` when that adapter feature is used. |
+| `HERMES_FRONTPAGE_OVERRIDE_MANIFEST` | Override the manifest path written by Telegram single-photo `/frontpage`, `/frontpage-override`, or `/fp` caption triggers. |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_ALLOWED_ROLES` | Comma-separated Discord role IDs allowed to use the bot (OR with `DISCORD_ALLOWED_USERS`). Auto-enables the Members intent. Useful when moderation teams churn — role grants propagate automatically. |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -160,6 +160,80 @@ The gateway extracts `MEDIA:/path/to/file` tags from agent replies and ships the
 
 Anything on this list delivered as a native attachment on platforms that support it (Telegram, Discord, Signal, Slack, WhatsApp, Feishu, Matrix, etc.); on platforms without native support it falls back to a link or plain-text indicator. The **bold** categories were added in the last few releases — if you were relying on the model saying `here is the file: /path/to/report.docx` instead, swap to `MEDIA:/path/to/report.docx` for native delivery.
 
+## Single-Photo Caption Commands
+
+Telegram photo captions can trigger adapter-level workflows before Hermes hands the message to the normal agent loop. The current built-in flow is a **frontpage inspiration override** for downstream daily/frontpage pipelines.
+
+### Frontpage override command
+
+Send **one photo** with a caption like this:
+
+```text
+/frontpage urgent trend seed
+bias: election, breaking
+note: Keep source discovery broad.
+```
+
+Accepted command aliases on the first line:
+
+- `/frontpage`
+- `/frontpage-override`
+- `/fp`
+
+Behavior:
+
+- The first line may include the title directly after the command
+- `title:` on a later line can override that title
+- `bias:` becomes a comma-separated list of steering terms for downstream source discovery
+- `note:` and any extra body lines become the freeform note
+- If no title is provided, Hermes falls back to `Telegram inspiration override`
+- **Albums/media groups are rejected** for this path. Use a single image.
+
+Think of the fields like this:
+
+- `title`: what this override is about
+- `bias`: keywords that tilt discovery or ranking
+- `note`: broader editorial guidance
+
+### Confirmation behavior
+
+When Hermes accepts the photo, it:
+
+1. downloads and caches the image locally
+2. invokes the existing frontpage-engine helper script
+3. writes the override manifest for the next run
+4. replies in Telegram with confirmation
+
+If the caption matches one of the override commands, Hermes consumes the photo for this workflow instead of sending it through the normal photo batching/album pipeline.
+
+### Config hooks
+
+Default frontpage repo directory:
+
+```text
+/Users/nickgeorge-studio/Projects/hermes-frontpage-engine
+```
+
+Optional environment variables:
+
+```bash
+HERMES_FRONTPAGE_ENGINE_DIR=/absolute/path/to/hermes-frontpage-engine
+HERMES_FRONTPAGE_OVERRIDE_MANIFEST=/absolute/path/to/override-manifest.json
+```
+
+Optional `config.yaml` overrides under Telegram platform `extra`:
+
+```yaml
+platforms:
+  telegram:
+    enabled: true
+    extra:
+      frontpage_engine_dir: /absolute/path/to/hermes-frontpage-engine
+      frontpage_override_manifest: /absolute/path/to/override-manifest.json
+```
+
+Environment variables take precedence over `config.yaml` values.
+
 ## Webhook Mode
 
 By default, Hermes connects to Telegram using **long polling** — the gateway makes outbound requests to Telegram's servers to fetch new updates. This works well for local and always-on deployments.


### PR DESCRIPTION
## Summary
- document Telegram single-photo frontpage override caption commands in the README
- add detailed Telegram guide coverage for command syntax, bias/note fields, and single-image limitations
- document the related override environment variables

## Testing
- git diff --check -- README.md website/docs/user-guide/messaging/telegram.md website/docs/reference/environment-variables.md
