### PR TITLE
fix(skills): prevent infinite loop on cyclic symlinks in iter_skill_index_files

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -441,9 +441,17 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
     Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+    Uses ``os.path.realpath`` tracking to prevent infinite loops when
+    ``followlinks=True`` encounters cyclic symlinks.
     """
     matches = []
+    visited: set[str] = set()
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
+        real_root = os.path.realpath(root)
+        if real_root in visited:
+            dirs.clear()
+            continue
+        visited.add(real_root)
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
         if filename in files:
             matches.append(Path(root) / filename)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -100,6 +100,7 @@ AUTHOR_MAP = {
     "260878550+beenherebefore@users.noreply.github.com": "beenherebefore",
     "79389617+txbxxx@users.noreply.github.com": "txbxxx",
     "liuhao03@bilibili.com": "liuhao1024",
+    "sunsky.lau@gmail.com": "liuhao1024",
     "130918800+devorun@users.noreply.github.com": "devorun",
     "surat.s@itm.kmutnb.ac.th": "beesrsj2500",
     "beesr@bee.localdomain": "beesrsj2500",

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,8 @@
 """Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
 
-from agent.skill_utils import extract_skill_conditions
+from pathlib import Path
+
+from agent.skill_utils import extract_skill_conditions, iter_skill_index_files
 
 
 def test_metadata_as_dict_with_hermes():
@@ -56,3 +58,96 @@ def test_metadata_missing_entirely():
         "fallback_for_tools": [],
         "requires_tools": [],
     }
+
+
+# ── iter_skill_index_files tests ──────────────────────────────────────────
+
+
+class TestIterSkillIndexFiles:
+    """Tests for iter_skill_index_files symlink cycle protection."""
+
+    def test_finds_files_normally(self, tmp_path):
+        """Baseline: finds SKILL.md in a flat directory."""
+        skill = tmp_path / "my-skill" / "SKILL.md"
+        skill.parent.mkdir()
+        skill.write_text("---\nname: my-skill\n---\n")
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert results[0] == skill
+
+    def test_cyclic_symlink_does_not_loop(self, tmp_path):
+        """A → B → A symlink cycle must not cause an infinite loop."""
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        # Create cyclic symlinks: a/link -> b, b/link -> a
+        (dir_a / "link").symlink_to(dir_b)
+        (dir_b / "link").symlink_to(dir_a)
+
+        # Place a SKILL.md in dir_a so there's something to find
+        (dir_a / "SKILL.md").write_text("---\nname: a\n---\n")
+
+        # This must terminate (not hang)
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert results[0] == dir_a / "SKILL.md"
+
+    def test_non_cyclic_symlink_still_followed(self, tmp_path):
+        """Non-cyclic symlinks should still be followed and yield files."""
+        real = tmp_path / "real-skills"
+        real.mkdir()
+        skill = real / "linked-skill" / "SKILL.md"
+        skill.parent.mkdir()
+        skill.write_text("---\nname: linked\n---\n")
+
+        # Create a symlink that points to real-skills (no cycle)
+        link = tmp_path / "skills-link"
+        link.symlink_to(real)
+
+        results = list(iter_skill_index_files(link, "SKILL.md"))
+        assert len(results) == 1
+        assert results[0] == link / "linked-skill" / "SKILL.md"
+
+    def test_self_referencing_symlink(self, tmp_path):
+        """A directory that symlinks to itself must not loop."""
+        d = tmp_path / "self-ref"
+        d.mkdir()
+        (d / "loop").symlink_to(d)
+        (d / "SKILL.md").write_text("---\nname: self\n---\n")
+
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert results[0] == d / "SKILL.md"
+
+    def test_excluded_dirs_still_skipped(self, tmp_path):
+        """Excluded dirs (.git, .github, etc.) are still skipped."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "SKILL.md").write_text("---\nname: git\n---\n")
+
+        normal = tmp_path / "real" / "SKILL.md"
+        normal.parent.mkdir()
+        normal.write_text("---\nname: real\n---\n")
+
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert results[0] == normal
+
+    def test_diamond_symlink_pattern(self, tmp_path):
+        """Diamond pattern: A→C, B→C. Both symlinks should resolve without duplication."""
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_c = tmp_path / "c"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        dir_c.mkdir()
+
+        (dir_a / "link").symlink_to(dir_c)
+        (dir_b / "link").symlink_to(dir_c)
+        (dir_c / "SKILL.md").write_text("---\nname: c\n---\n")
+
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        # The skill should be found via both paths but realpath dedup keeps it to 1
+        assert len(results) == 1

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -92,7 +92,10 @@ class TestIterSkillIndexFiles:
         # This must terminate (not hang)
         results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
         assert len(results) == 1
-        assert results[0] == dir_a / "SKILL.md"
+        # Use resolve() — os.walk traversal order varies by platform,
+        # so the reported path may be a/SKILL.md or b/link/SKILL.md
+        # (both resolve to the same file).
+        assert results[0].resolve() == (dir_a / "SKILL.md").resolve()
 
     def test_non_cyclic_symlink_still_followed(self, tmp_path):
         """Non-cyclic symlinks should still be followed and yield files."""


### PR DESCRIPTION
## What does this PR do?

`iter_skill_index_files()` uses `os.walk(followlinks=True)` but has no cycle detection. When the skill directory tree contains cyclic symlinks (e.g. `A → B → A` or self-referencing directories), `os.walk` enters an infinite loop, causing the agent to hang during skill scanning.
## Related Issue

Fixes #18809

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A