### PR TITLE
fix(cli): guard quick_commands against non-dict values

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6581,7 +6581,11 @@ class HermesCLI:
             quick_commands = self.config.get("quick_commands", {})
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
-                if qcmd.get("type") == "exec":
+                if not isinstance(qcmd, dict):
+                    logger.warning(f"quick_commands entry for {base_cmd!r} is not a dict (got {type(qcmd).__name__}), skipping")
+                    # fall through to plugin commands / skill commands checks
+                    pass
+                elif qcmd.get("type") == "exec":
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:


### PR DESCRIPTION
## Fix: Guard `quick_commands` against non-dict values

### Problem

When `quick_commands` values in `~/.hermes/config.yaml` are not dicts (e.g., strings like `foo: ''`), the slash command dispatch at `cli.py:6583` crashes with:

```
Error: 'str' object has no attribute 'get'
```

This blocks **all** matching slash commands — even valid skill commands — because `quick_commands` is checked before the skill dispatch chain.

### Reproduction

```yaml
# ~/.hermes/config.yaml
quick_commands:
  foo: ''
```

Then type `/foo` — crash.

### Fix

Add `isinstance(qcmd, dict)` guard before accessing `.get()`. Non-dict entries now get a warning log and fall through to plugin/skill command checks instead of crashing.

Fixes #18816