### PR TITLE
fix(telegram): support image files sent as documents

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3197,6 +3197,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
+                # Images sent as documents (PNG/JPG/WEBP/GIF) → cache for vision
+                SUPPORTED_IMAGE_TYPES = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp", ".gif": "image/gif"}
+                if ext in SUPPORTED_IMAGE_TYPES:
+                    file_obj = await doc.get_file()
+                    image_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [SUPPORTED_IMAGE_TYPES[ext]]
+                    event.message_type = MessageType.PHOTO
+                    logger.info("[Telegram] Cached user image document at %s", cached_path)
+                    await self.handle_message(event)
+                    return
+
                 # Check if supported
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))


### PR DESCRIPTION
## Problem

When users send image files (PNG, JPG, WEBP, GIF) as Telegram **documents** (file attachments) rather than as **photos**, the gateway rejects them with "Unsupported document type" because the image extensions are not in `SUPPORTED_DOCUMENT_TYPES`.

## Solution

Add image format detection in the `elif msg.document:` branch of `_handle_media_message`, routing `.png/.jpg/.jpeg/.webp/.gif` files through the existing `cache_image_from_bytes` pipeline — the same path used for native Telegram photos.

## Testing

Verified by sending a PNG as a document attachment to the Hermes Telegram bot — the image is now cached and accessible for vision analysis.

## Related

- Telegram Bot API sends images as `msg.photo` (compressed) or `msg.document` (full quality). This fix handles the latter case.