### PR TITLE
fix(openclaw-migration): upsert custom_providers by name on --overwrite

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -2507,9 +2507,15 @@ class Migrator:
 
             # For non-well-known providers, create custom_providers entry
             if prov_name.lower() not in WELL_KNOWN and prov_cfg.get("baseUrl"):
-                # Check if already exists
-                existing_names = {p.get("name", "").lower() for p in custom_providers}
-                if prov_name.lower() in existing_names and not self.overwrite:
+                # Find every existing entry matching this name (case-insensitive).
+                # The list-of-indices form covers the case where a user already
+                # hit the pre-#18097 bug and has 2+ duplicate entries on disk —
+                # the upsert below collapses them down to one.
+                existing_indices = [
+                    i for i, p in enumerate(custom_providers)
+                    if p.get("name", "").lower() == prov_name.lower()
+                ]
+                if existing_indices and not self.overwrite:
                     self.record("full-providers", f"models.providers.{prov_name}",
                                 "config.yaml custom_providers", "conflict",
                                 f"Provider '{prov_name}' already exists")
@@ -2531,7 +2537,15 @@ class Migrator:
                     "api_key": "",  # referenced from .env
                     "api_mode": api_mode_map.get(api_type, "chat_completions"),
                 }
-                custom_providers.append(entry)
+                # Upsert: replace at the first existing position, drop any
+                # later duplicates (left behind by old buggy --overwrite runs),
+                # and append when no entry exists.
+                if existing_indices:
+                    custom_providers[existing_indices[0]] = entry
+                    for i in reversed(existing_indices[1:]):
+                        del custom_providers[i]
+                else:
+                    custom_providers.append(entry)
                 added += 1
                 self.record("full-providers", f"models.providers.{prov_name}",
                             f"config.yaml custom_providers[{prov_name}]", "migrated")

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -1107,3 +1107,223 @@ def test_migrate_model_config_no_catalog_leaves_value_alone(tmp_path: Path):
         {"agents": {"defaults": {"model": "some-model-id"}}},
     )
     assert _extract_model(parsed) == "some-model-id"
+
+
+# ── full-providers: --overwrite must upsert by name (#18097) ──────────────────
+
+
+def test_full_providers_overwrite_upserts_existing_entry(tmp_path: Path):
+    """Re-running with --overwrite against an existing custom_providers entry
+    must replace it in place, not append a duplicate. Reported in #18097.
+    """
+    import yaml
+
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir()
+    target.mkdir()
+
+    # Pre-existing config.yaml with one custom provider entry.
+    (target / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "custom_providers": [
+                    {
+                        "name": "claude-max",
+                        "base_url": "https://stale.example.com/v1",
+                        "api_key": "",
+                        "api_mode": "chat_completions",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Source openclaw.json describes the same provider with an updated base_url.
+    (source / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "models": {
+                    "providers": {
+                        "claude-max": {
+                            "apiKey": "sk-cm-fresh",
+                            "baseUrl": "https://fresh.example.com/v1",
+                            "apiType": "anthropic-messages",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=True,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options={"full-providers"},
+    )
+    migrator.migrate()
+
+    cfg = yaml.safe_load((target / "config.yaml").read_text(encoding="utf-8"))
+    providers = cfg.get("custom_providers", [])
+    matches = [p for p in providers if p.get("name") == "claude-max"]
+    assert len(matches) == 1, f"expected exactly one claude-max entry, got {len(matches)}: {providers}"
+    # The replacement must carry the new base_url and api_mode.
+    assert matches[0]["base_url"] == "https://fresh.example.com/v1"
+    assert matches[0]["api_mode"] == "anthropic_messages"
+
+
+def test_full_providers_overwrite_collapses_preexisting_duplicates(tmp_path: Path):
+    """A user who already hit #18097 has TWO claude-max entries from prior
+    buggy runs. Re-running with the fixed --overwrite must collapse the list
+    so exactly one entry survives, not just stop adding a third.
+    """
+    import yaml
+
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir()
+    target.mkdir()
+
+    # Pre-existing config.yaml with TWO duplicate entries left behind by the
+    # old buggy --overwrite path. The reporter's repro is exactly this state.
+    (target / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "custom_providers": [
+                    {
+                        "name": "claude-max",
+                        "base_url": "https://stale.example.com/v1",
+                        "api_key": "",
+                        "api_mode": "chat_completions",
+                    },
+                    {
+                        "name": "other-provider",
+                        "base_url": "https://other.example.com/v1",
+                        "api_key": "",
+                        "api_mode": "chat_completions",
+                    },
+                    {
+                        "name": "claude-max",
+                        "base_url": "https://stale.example.com/v1",
+                        "api_key": "",
+                        "api_mode": "chat_completions",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (source / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "models": {
+                    "providers": {
+                        "claude-max": {
+                            "apiKey": "sk-cm-fresh",
+                            "baseUrl": "https://fresh.example.com/v1",
+                            "apiType": "anthropic-messages",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=True,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options={"full-providers"},
+    )
+    migrator.migrate()
+
+    cfg = yaml.safe_load((target / "config.yaml").read_text(encoding="utf-8"))
+    providers = cfg.get("custom_providers", [])
+    matches = [p for p in providers if p.get("name") == "claude-max"]
+    assert len(matches) == 1, f"expected exactly one claude-max entry, got {len(matches)}: {providers}"
+    assert matches[0]["base_url"] == "https://fresh.example.com/v1"
+    # Unrelated providers must be preserved.
+    others = [p for p in providers if p.get("name") == "other-provider"]
+    assert len(others) == 1
+    assert others[0]["base_url"] == "https://other.example.com/v1"
+
+
+def test_full_providers_no_overwrite_records_conflict_for_existing_entry(tmp_path: Path):
+    """Without --overwrite, an existing custom_providers entry stays untouched
+    and the migrator records a conflict — not a silent duplicate (#18097).
+    """
+    import yaml
+
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir()
+    target.mkdir()
+
+    (target / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "custom_providers": [
+                    {
+                        "name": "claude-max",
+                        "base_url": "https://existing.example.com/v1",
+                        "api_key": "",
+                        "api_mode": "chat_completions",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (source / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "models": {
+                    "providers": {
+                        "claude-max": {
+                            "apiKey": "sk-cm-fresh",
+                            "baseUrl": "https://fresh.example.com/v1",
+                            "apiType": "anthropic-messages",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options={"full-providers"},
+    )
+    report = migrator.migrate()
+
+    cfg = yaml.safe_load((target / "config.yaml").read_text(encoding="utf-8"))
+    providers = cfg.get("custom_providers", [])
+    matches = [p for p in providers if p.get("name") == "claude-max"]
+    assert len(matches) == 1
+    # Existing entry preserved, not overwritten.
+    assert matches[0]["base_url"] == "https://existing.example.com/v1"
+    # Migrator recorded the conflict.
+    fp_items = [i for i in report["items"] if i["kind"] == "full-providers"]
+    assert any(i.get("status") == "conflict" for i in fp_items)


### PR DESCRIPTION
## What does this PR do?

`migrate_full_providers()` in `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` guards the "already exists" branch with `not self.overwrite`, but the `--overwrite` path then falls through to `custom_providers.append(entry)` rather than replacing the existing entry. Re-running `hermes claw migrate --overwrite --migrate-secrets` produces two entries with the same name in `config.yaml`'s `custom_providers:` list — exactly the bug reported in #18097 (sub-bug 2 of 3).

This PR replaces the set-of-names existence check with a list of all matching indices, then upserts in place: replace at the first existing position, delete any later duplicates in reverse index order, and append only when no entry exists. The list-of-indices form covers the case where a user already hit the bug and has 2+ duplicate entries on disk — the upsert collapses them down to one, repairing the damaged config in the same run that fixes the bug going forward. Behavior without `--overwrite` is unchanged: the migrator still records a conflict and skips.

This addresses the second of three sub-bugs in #18097:
- Sub-bug 1 (WhatsApp config block silently dropped) — covered by #18337.
- Sub-bug 2 (this PR) — `--overwrite` provider duplication.
- Sub-bug 3 (`hermes gateway status` reports stale PIDs) — current `get_running_pid()` validates the runtime lock, `os.kill` aliveness, recorded `start_time`, and `_looks_like_gateway_process` cmdline match. I couldn't identify a reproducible code path from inspection; commented on the issue asking the reporter for diagnostic details before submitting a fix.

`Refs` (not `Fixes`) so the issue stays open until sub-bugs 1 and 3 land.

## Related Issue

Refs #18097

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` — replace the set-of-names existence check with `existing_indices`; on `--overwrite` with one or more existing entries, replace at the first index and delete subsequent duplicates; preserve original behavior (record conflict, skip) when `--overwrite` is not set
- `tests/skills/test_openclaw_migration.py` — add 3 tests:
  - `test_full_providers_overwrite_upserts_existing_entry` — single existing entry is replaced in place
  - `test_full_providers_overwrite_collapses_preexisting_duplicates` — two pre-existing duplicates from prior buggy runs collapse to one (regression for the reporter's actual on-disk state)
  - `test_full_providers_no_overwrite_records_conflict_for_existing_entry` — locks in the no-overwrite path so a future change can't accidentally make it lossy

## How to Test

1. `python -m pytest tests/skills/test_openclaw_migration.py -q` — 44/44 pass
2. Manual: pre-populate `~/.hermes/config.yaml` with one or two `custom_providers: [{name: claude-max, ...}]` entries, then run `hermes claw migrate --overwrite --migrate-secrets` against an OpenClaw source containing `models.providers.claude-max` — exactly one `claude-max` entry survives, with the freshly migrated values

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comment explains the collapse semantics) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest tests/skills/test_openclaw_migration.py -q
44 passed
```
