### PR TITLE
fix(proxy): support glob-style NO_PROXY entries and private-IP auto-bypass

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2817,12 +2817,42 @@ def probe_api_models(
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
 
+    def _build_opener_for(target_url: str):
+        # urllib's default proxy handler matches NO_PROXY by exact host or
+        # suffix only, so glob-style entries ("192.168.*") and private-IP
+        # literals are not bypassed. Without this, LAN endpoints under env
+        # HTTPS_PROXY get routed through the proxy and fail with 502.
+        import ipaddress as _ip
+        from urllib.parse import urlparse as _urlparse
+        host = (_urlparse(target_url).hostname or "").lower()
+        skip = False
+        if host:
+            try:
+                ip_obj = _ip.ip_address(host)
+                if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+                    skip = True
+            except ValueError:
+                if host == "localhost" or host.endswith(".local"):
+                    skip = True
+            if not skip:
+                np = (os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or "")
+                for pat in [p.strip().lower() for p in np.split(",") if p.strip()]:
+                    if pat.endswith("*"):
+                        prefix = pat[:-1].rstrip(".")
+                        if prefix and (host == prefix or host.startswith(prefix + ".") or host.startswith(prefix)):
+                            skip = True
+                            break
+        if skip:
+            return urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        return urllib.request.build_opener()
+
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            opener = _build_opener_for(url)
+            with opener.open(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
                     "models": [m.get("id", "") for m in data.get("data", [])],

--- a/run_agent.py
+++ b/run_agent.py
@@ -242,7 +242,17 @@ def _get_proxy_from_env() -> Optional[str]:
 
 
 def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
-    """Return an env-configured proxy unless NO_PROXY excludes this base URL."""
+    """Return an env-configured proxy unless NO_PROXY excludes this base URL.
+
+    Bypass is granted in any of these cases:
+      1. Stdlib urllib.request.proxy_bypass_environment says so (handles
+         exact host matches and suffix matches like .example.com).
+      2. The host is a private/loopback/link-local IP literal — proxies almost
+         never relay LAN traffic correctly, and users behind global TUN proxies
+         (clash, v2ray, etc.) hit this constantly.
+      3. NO_PROXY contains a glob entry that matches the host (192.168.*,
+         127.*). Stdlib ignores trailing wildcards, so we add it here.
+    """
     proxy = _get_proxy_from_env()
     if not proxy or not base_url:
         return proxy
@@ -256,6 +266,28 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
             return None
     except Exception:
         pass
+
+    # 2. Private / loopback / link-local IP literals — always bypass.
+    try:
+        import ipaddress as _ip
+        ip_obj = _ip.ip_address(host)
+        if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+            return None
+    except ValueError:
+        if host.lower() in ("localhost",) or host.lower().endswith(".local"):
+            return None
+
+    # 3. Glob-style NO_PROXY entries (e.g. 192.168.*) that stdlib misses.
+    no_proxy = (os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or "").strip()
+    if no_proxy:
+        host_lower = host.lower()
+        for entry in no_proxy.split(","):
+            pat = entry.strip().lower()
+            if not pat or not pat.endswith("*"):
+                continue
+            prefix = pat[:-1].rstrip(".")
+            if prefix and (host_lower == prefix or host_lower.startswith(prefix + ".") or host_lower.startswith(prefix)):
+                return None
 
     return proxy
 


### PR DESCRIPTION
## Problem

`_get_proxy_for_base_url()` (added in cbc39a86, "fix(proxy): honor no_proxy for local custom endpoints") relies on `urllib.request.proxy_bypass_environment`, which only handles exact host and suffix matches in `NO_PROXY`. Two real-world cases slip through:

1. **Glob entries** like `192.168.*` and `127.*` (default WSL2 config, common on corporate networks). Stdlib treats `*` as a literal character — it does not expand to a wildcard.
2. **Private-IP literals** (10.x, 172.16-31.x, 192.168.x, 127.x) when `NO_PROXY` doesn't list them at all. Most HTTP proxies cannot relay LAN traffic, so these should bypass automatically — especially relevant for users running global/TUN proxies (clash, v2ray, etc.) where every outbound connection goes through `127.0.0.1:7897` or similar.

## Repro

```bash
$ NO_PROXY="192.168.*,127.*" HTTPS_PROXY="http://127.0.0.1:7897" \
    python -c "import urllib.request; print(urllib.request.proxy_bypass_environment('192.168.1.2'))"
False
```

In Hermes this manifests as `APIConnectionError` / 502 Bad Gateway when a `custom_provider` points at a LAN endpoint while `HTTPS_PROXY` is set. The clash/v2ray proxy can't relay LAN traffic to `192.168.x.x`, so all attempts to use the LAN endpoint time out or 502.

## Fix

Adds two layers on top of stdlib detection in `_get_proxy_for_base_url`:

- **Private/loopback/link-local IP detection** via `ipaddress` module — auto-bypass regardless of `NO_PROXY` content
- **Glob suffix expansion** for trailing-`*` `NO_PROXY` entries — resolves the WSL2 default

The same logic is mirrored into `probe_api_models` so the model-picker catalog probe also bypasses correctly. Without this, `/model` picker (and `hermes model` CLI) returns 502 for any LAN endpoint when `HTTPS_PROXY` is set.

## Files changed

| File | Function | Change |
|------|----------|--------|
| `run_agent.py` | `_get_proxy_for_base_url` | +34 lines: ipaddress check + glob suffix matcher after stdlib check |
| `hermes_cli/models.py` | `probe_api_models` | +32 lines: helper `_build_opener_for(target_url)` that returns either default opener or one with empty `ProxyHandler` |

## Test

Verified end-to-end against a Mac LAN OpenAI-compatible endpoint at `192.168.1.2:8088`:

- **Pre-fix**: 502 Bad Gateway via clash proxy (timeout after retry)
- **Post-fix**: 200 OK, direct LAN connection (~5s for reasoning model response)

`probe_api_models` was tested separately against:
- `http://192.168.1.2:11434/v1` (Ollama) → 8 models returned (was 0/502 pre-fix)
- `http://192.168.1.2:8088` (no `/models` route) → fast 404 (no proxy detour)
- `https://api.openai.com/v1` → 200 OK via proxy (unchanged behavior)

Loopback (`127.0.0.1`), `localhost`, and `*.local` hosts also tested — all bypass correctly.

## Backward compatibility

- No behavior change for hosts not in `NO_PROXY` and not on private IP space → still uses proxy
- No behavior change for stdlib-handled `NO_PROXY` entries (exact host, suffix `.example.com`) → still bypasses correctly via stdlib path
- No new environment variables introduced
- No config schema changes