### PR TITLE
feat(picker): fall back to config catalog when /models probe fails

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3403,6 +3403,26 @@ def _model_flow_named_custom(config, provider_info):
         api_key, base_url, timeout=8.0,
         api_mode=api_mode or None,
     )
+    # Fallback: many OpenAI-compatible endpoints (DashScope coding plan,
+    # custom reverse-proxies) do not expose /models. When probing fails,
+    # use the catalog declared under custom_providers[].models in
+    # config.yaml so the user still gets a multi-model picker instead of
+    # being forced to type a model name.
+    if not models:
+        try:
+            _cfg_for_fallback = load_config()
+            for _entry in (_cfg_for_fallback.get("custom_providers") or []):
+                if isinstance(_entry, dict) and _entry.get("name") == name:
+                    _models_dict = _entry.get("models")
+                    if isinstance(_models_dict, dict) and _models_dict:
+                        models = list(_models_dict.keys())
+                        print(
+                            f"  (probe failed; using {len(models)} "
+                            f"models from config.yaml)"
+                        )
+                    break
+        except Exception:
+            pass
 
     if models:
         default_idx = 0


### PR DESCRIPTION
## Problem

When a `custom_providers` entry points at an OpenAI-compatible endpoint that doesn't expose `/models`, the named-provider picker in `hermes model` shows only the saved default model — even though the user has already declared the full catalog in `config.yaml` under `custom_providers[].models`.

Categories of endpoints affected in practice:

- **OpenAI-compatible APIs that implement chat completions but not the catalog endpoint** — many vendor SaaS APIs only expose `/chat/completions` and return 404 on `/models` or `/v1/models`.
- **Lightweight reverse proxies / API gateways** that whitelist a subset of routes (typically `/chat/completions` only) and reject the rest.
- **Self-hosted OpenAI shims** that haven't implemented the catalog endpoint, or implement it behind different auth.
- **Region-restricted mirrors** of upstream services where the catalog route is disabled or rate-limited.

In all these cases the user must type the model name manually each time they switch — which negates the whole point of having declared `models:` in config.yaml.

## Repro

1. Add a custom provider whose `base_url` returns 404 on `/models`:
   ```yaml
   custom_providers:
   - name: my-provider
     base_url: https://example.com/v1   # endpoint without /models route
     api_key: <KEY>
     model: model-a
     models:
       model-a: {}
       model-b: {}
       model-c: {}
       model-d: {}
       model-e: {}
   ```
2. Run `hermes model` → select `my-provider`
3. Observe: "Could not fetch models from endpoint. Enter model name manually." — only the saved one is offered, despite 5 declared.

## Fix

Read `entry.get("models")` as a fallback when `fetch_api_models` returns nothing, mirroring how `list_authenticated_providers` (and other downstream readers) already treat it. The user-facing message makes the fallback explicit so the user understands the live probe didn't run.

After the fix, the same repro shows:

```
Fetching available models...
  (probe failed; using 5 models from config.yaml)
Found 5 model(s):

  model-a (current)
  model-b
  model-c
  model-d
  model-e
  Cancel
```

## Affects

`hermes model` → select named custom provider, when the underlying endpoint returns 404/timeout for `/models` or `/v1/models`. Other provider flows (anthropic, openrouter, openai-codex, etc.) are not touched.

## Backward compatibility

- If `/models` probe succeeds → unchanged behavior (uses live list)
- If `/models` probe fails AND `custom_providers[].models` is empty/missing → unchanged behavior (manual entry prompt)
- If `/models` probe fails AND `custom_providers[].models` exists → new fallback path activates with explicit user-facing message

No config schema changes. No new env vars. No new dependencies.