### PR TITLE
fix(cron): extend #16265 never-silently-disable defense to get_due_jobs()

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -797,21 +797,66 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 
         next_run = job.get("next_run_at")
         if not next_run:
+            schedule = job.get("schedule", {})
             recovered_next = _recoverable_oneshot_run_at(
-                job.get("schedule", {}),
+                schedule,
                 now,
                 last_run_at=job.get("last_run_at"),
             )
+            recurring_recovery = False
+
+            if not recovered_next and schedule.get("kind") in ("cron", "interval"):
+                # Recurring jobs (cron/interval) that lost their next_run_at
+                # would otherwise be skipped silently on every tick forever.
+                # Self-heal by computing the next future occurrence from the
+                # schedule expression. Any outcome (success, exception, or
+                # None) is logged at WARNING so the unexpected null-state is
+                # surfaced — a healthy recurring job should never enter this
+                # branch, and a hand-edited or malformed schedule must not
+                # crash the scheduler tick.
+                kind = schedule.get("kind")
+                job_label = job.get("name", job["id"])
+                try:
+                    recovered_next = compute_next_run(schedule)
+                except Exception as exc:
+                    logger.warning(
+                        "Job '%s' (%s schedule) had no next_run_at and "
+                        "recovery failed: %s",
+                        job_label,
+                        kind,
+                        exc,
+                    )
+                    recovered_next = None
+                else:
+                    if not recovered_next:
+                        logger.warning(
+                            "Job '%s' (%s schedule) had no next_run_at and "
+                            "compute_next_run returned no future occurrence; "
+                            "job remains unprocessed this tick.",
+                            job_label,
+                            kind,
+                        )
+                recurring_recovery = bool(recovered_next)
+
             if not recovered_next:
                 continue
 
             job["next_run_at"] = recovered_next
             next_run = recovered_next
-            logger.info(
-                "Job '%s' had no next_run_at; recovering one-shot run at %s",
-                job.get("name", job["id"]),
-                recovered_next,
-            )
+            if recurring_recovery:
+                logger.warning(
+                    "Job '%s' (%s schedule) had no next_run_at; "
+                    "self-healing to next run at %s",
+                    job.get("name", job["id"]),
+                    schedule.get("kind"),
+                    recovered_next,
+                )
+            else:
+                logger.info(
+                    "Job '%s' had no next_run_at; recovering one-shot run at %s",
+                    job.get("name", job["id"]),
+                    recovered_next,
+                )
             for rj in raw_jobs:
                 if rj["id"] == job["id"]:
                     rj["next_run_at"] = recovered_next

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -647,6 +647,287 @@ class TestGetDueJobs:
         assert get_due_jobs() == []
         assert get_job("oneshot-stale")["next_run_at"] is None
 
+    def test_broken_cron_recurring_without_next_run_is_recovered(self, tmp_cron_dir, monkeypatch, caplog):
+        """Recurring cron jobs with null next_run_at must self-heal, not be skipped silently.
+
+        Without recovery, a job in this state stays `scheduled` + `enabled`
+        forever, never fires, never logs a signal. This was observed in the
+        wild (e.g. the jarvis-automation-loop case 2026-04-20→2026-05-01).
+        """
+        import logging
+
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "cron-recover",
+                "name": "Daily 5am cron",
+                "prompt": "do the thing",
+                "schedule": {"kind": "cron", "expr": "0 5 * * *", "display": "0 5 * * *"},
+                "schedule_display": "0 5 * * *",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-01T00:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        # Capture logs around the call
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            due = get_due_jobs()
+
+        # The job's next_run_at must be populated (next 05:00 UTC after now=12:00 → tomorrow 05:00)
+        recovered = get_job("cron-recover")["next_run_at"]
+        assert recovered is not None, "next_run_at should self-heal for recurring jobs"
+        recovered_dt = datetime.fromisoformat(recovered)
+        assert recovered_dt > now, f"recovered next_run_at {recovered} should be in the future"
+
+        # Future occurrence is in the future, so the job is NOT immediately due.
+        assert [j["id"] for j in due] == [], (
+            "after self-heal, a recurring job whose next computed run is in the "
+            "future should not be returned as due on this same tick"
+        )
+
+        # Recovery is surfaced at WARNING level so silent-skip-forever is no longer silent.
+        assert any(
+            "self-healing" in record.getMessage() and record.levelno >= logging.WARNING
+            for record in caplog.records
+        ), "expected a WARNING log surfacing the recurring-job self-heal"
+
+    def test_broken_interval_recurring_without_next_run_is_recovered(self, tmp_cron_dir, monkeypatch):
+        """Same self-heal applies to interval-kind schedules."""
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "interval-recover",
+                "name": "Hourly poll",
+                "prompt": "poll something",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                "schedule_display": "every 60m",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-01T00:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        get_due_jobs()
+        recovered = get_job("interval-recover")["next_run_at"]
+        assert recovered is not None, "interval schedules must also self-heal"
+        recovered_dt = datetime.fromisoformat(recovered)
+        assert recovered_dt > now
+
+    def test_recurring_self_heal_does_not_disturb_valid_jobs(self, tmp_cron_dir, monkeypatch):
+        """The self-heal branch must not touch jobs whose next_run_at is set."""
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        valid_next = "2026-05-03T05:00:00+00:00"
+        save_jobs(
+            [{
+                "id": "cron-healthy",
+                "name": "Healthy cron",
+                "prompt": "do the thing",
+                "schedule": {"kind": "cron", "expr": "0 5 * * *", "display": "0 5 * * *"},
+                "schedule_display": "0 5 * * *",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-01T00:00:00+00:00",
+                "next_run_at": valid_next,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        get_due_jobs()
+        assert get_job("cron-healthy")["next_run_at"] == valid_next, (
+            "healthy jobs must not be touched by the self-heal branch"
+        )
+
+    def test_recurring_recovery_falls_through_to_continue_when_compute_returns_none(
+        self, tmp_cron_dir, monkeypatch, caplog
+    ):
+        """If compute_next_run returns None (e.g. croniter missing in the runtime
+        env), self-heal fails gracefully — the job stays unprocessed this tick
+        rather than crashing, and a WARNING surfaces the failed-recovery state."""
+        import logging
+
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        # Force compute_next_run to return None for this test
+        monkeypatch.setattr("cron.jobs.compute_next_run", lambda *a, **kw: None)
+
+        save_jobs(
+            [{
+                "id": "cron-uncomputable",
+                "name": "Bad schedule",
+                "prompt": "do the thing",
+                "schedule": {"kind": "cron", "expr": "0 5 * * *", "display": "0 5 * * *"},
+                "schedule_display": "0 5 * * *",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-01T00:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            due = get_due_jobs()
+
+        # Should not raise, should not return the job, should not corrupt state.
+        assert due == []
+        assert get_job("cron-uncomputable")["next_run_at"] is None
+        # Failed recovery is surfaced at WARNING so the null-state is no longer silent.
+        assert any(
+            "compute_next_run returned no future occurrence" in record.getMessage()
+            and record.levelno >= logging.WARNING
+            for record in caplog.records
+        ), "expected a WARNING when compute_next_run returns None for a recurring null-state job"
+
+    def test_recurring_recovery_handles_exception_gracefully(
+        self, tmp_cron_dir, monkeypatch, caplog
+    ):
+        """Hand-edited or migration-corrupted jobs.json can produce malformed
+        schedules. compute_next_run() raises (CroniterBadCronError, KeyError, etc.)
+        on those. The scheduler tick must NOT crash — the recovery wraps the call
+        in try/except, surfaces the failure as a WARNING, and leaves the job
+        unprocessed. This protects every other due job from collateral damage
+        when one job in jobs.json has a malformed schedule."""
+        import logging
+
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        # Job has a malformed cron expression that will make croniter raise.
+        save_jobs(
+            [{
+                "id": "cron-malformed",
+                "name": "Hand-edited bad cron",
+                "prompt": "do the thing",
+                "schedule": {"kind": "cron", "expr": "not-a-cron", "display": "not-a-cron"},
+                "schedule_display": "not-a-cron",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-01T00:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            # Must not raise — that would crash the scheduler tick.
+            due = get_due_jobs()
+
+        # Job is unprocessed; state is preserved, not corrupted.
+        assert due == []
+        assert get_job("cron-malformed")["next_run_at"] is None
+
+        # Failure surfaced as a WARNING containing the exception detail.
+        recovery_failed_warnings = [
+            r for r in caplog.records
+            if "recovery failed" in r.getMessage() and r.levelno >= logging.WARNING
+        ]
+        assert recovery_failed_warnings, (
+            "expected a WARNING log when compute_next_run raises during recovery"
+        )
+
+    def test_recurring_recovery_isolates_one_bad_job_from_others(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A malformed job in jobs.json must not prevent other due jobs from
+        being returned. Verifies the try/except hardening is per-job, not
+        per-tick."""
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [
+                {
+                    "id": "cron-malformed",
+                    "name": "Malformed",
+                    "prompt": "do the thing",
+                    "schedule": {"kind": "cron", "expr": "not-a-cron", "display": "not-a-cron"},
+                    "schedule_display": "not-a-cron",
+                    "repeat": {"times": None, "completed": 0},
+                    "enabled": True,
+                    "state": "scheduled",
+                    "paused_at": None,
+                    "paused_reason": None,
+                    "created_at": "2026-05-01T00:00:00+00:00",
+                    "next_run_at": None,
+                    "last_run_at": None,
+                    "last_status": None,
+                    "last_error": None,
+                    "deliver": "local",
+                    "origin": None,
+                },
+                {
+                    "id": "cron-healthy-due",
+                    "name": "Healthy and due",
+                    "prompt": "do the thing",
+                    "schedule": {"kind": "cron", "expr": "0 5 * * *", "display": "0 5 * * *"},
+                    "schedule_display": "0 5 * * *",
+                    "repeat": {"times": None, "completed": 0},
+                    "enabled": True,
+                    "state": "scheduled",
+                    "paused_at": None,
+                    "paused_reason": None,
+                    "created_at": "2026-05-01T00:00:00+00:00",
+                    # 5 minutes ago — within the dynamic grace window for daily
+                    "next_run_at": (now - timedelta(minutes=5)).isoformat(),
+                    "last_run_at": None,
+                    "last_status": None,
+                    "last_error": None,
+                    "deliver": "local",
+                    "origin": None,
+                },
+            ]
+        )
+
+        # Must not raise. Healthy job must still come back as due.
+        due = get_due_jobs()
+        assert [j["id"] for j in due] == ["cron-healthy-due"]
+
 
 class TestEnabledToolsets:
     def test_enabled_toolsets_stored(self, tmp_cron_dir):


### PR DESCRIPTION
## Why

Issue #16265 established that **recurring jobs must never be silently disabled** when the system can't compute a next run. The fix at `cron/jobs.py:722-738` (in `mark_job_run()`) enforces that for the **post-execution** path: if a recurring job's `compute_next_run` returns None after a run, the job is left enabled with `state="error"` and an ERROR log — not silently `state="completed"`.

But the same defense is missing from the **pre-execution** path (`get_due_jobs()`). When a recurring job is loaded with `next_run_at: null` for any reason, the function calls `_recoverable_oneshot_run_at()` to recover. That helper only handles `kind: "once"` schedules — for `kind: "cron"` or `kind: "interval"` it returns None, and the job is silently `continue`d. **Every tick. Forever. No log signal of any kind.**

Net effect: any path that lands a recurring job in `next_run_at: null` state — direct `jobs.json` edit, partially-failed migration, crash mid-write, or any future `create_job` regression — produces a job that stays `enabled: true`, `state: "scheduled"`, never fires, and emits no log entry. The same failure mode that #16265 was filed to prevent, just in a different code path.

Observed in the wild on a production cron that sat in this state for **11 days** before being noticed manually. No log entries at any level (INFO, WARNING, ERROR), no output directory, no signal whatsoever — the job was effectively deleted but appeared healthy in `hermes cron list`.

## What this PR does

When `_recoverable_oneshot_run_at()` returns None AND the schedule is `kind in ("cron", "interval")`, fall through to `compute_next_run(schedule)` to compute the next future occurrence, persist it, and continue.

The recovery call is wrapped in `try/except`: hand-edited or migration-corrupted `jobs.json` can produce malformed schedules (e.g. `{"kind": "cron", "expr": "not-a-cron"}` raising `CroniterBadCronError`, or `{"kind": "cron"}` raising `KeyError`), and a single bad job must not crash the scheduler tick or block other due jobs from running.

Every outcome (success, exception, or None return) emits a WARNING because a healthy recurring job should never reach this branch — the WARNING surfaces the previously-silent failure mode. This brings `get_due_jobs()` in line with the philosophy already enforced by `mark_job_run()`: recurring null-state = loud surface, not silent skip.

## How it compares to the existing fix

| Path | Trigger | Current behavior | This PR |
|---|---|---|---|
| `mark_job_run()` post-exec | After a run, `compute_next_run` returns None | `state="error"` + ERROR log (per #16265) | **unchanged** |
| `get_due_jobs()` pre-exec | Job loaded with `next_run_at: null` and `kind in ("cron", "interval")` | Silent `continue` forever | Self-heal via `compute_next_run`, persist, log WARNING |

If recovery fails — `compute_next_run` returns None (e.g. `croniter` missing) or raises (e.g. malformed schedule from a hand-edit) — the job stays unprocessed this tick (its state is preserved, not corrupted), the failure is logged at WARNING, and the rest of the due-job loop continues. The job is not skipped silently and the scheduler tick does not crash.

## Compatibility

Healthy jobs and one-shot recovery keep their existing behavior. The only changed code path is the previously-silent recurring `next_run_at: null` state, which now logs at WARNING and self-heals (or, on failed recovery, logs the failure and leaves the job unprocessed for that tick).

- One-shot recovery preserved exactly as-is (existing INFO log, existing tests stay green).
- Healthy recurring jobs (with valid `next_run_at`) take the same fast path as before.
- The new branch only fires on the previously-silent-skip case, where the prior behavior was a no-op forever.

## Tests

6 new tests in `tests/cron/test_jobs.py::TestGetDueJobs` (all green), 2 existing one-shot tests preserved:

- `test_broken_cron_recurring_without_next_run_is_recovered` — null-state cron job self-heals to next future occurrence + WARNING log emitted.
- `test_broken_interval_recurring_without_next_run_is_recovered` — same for interval-kind.
- `test_recurring_self_heal_does_not_disturb_valid_jobs` — guard: jobs with valid `next_run_at` are untouched.
- `test_recurring_recovery_falls_through_to_continue_when_compute_returns_none` — `compute_next_run` returning None (e.g. croniter missing) leaves the job unprocessed AND emits a WARNING.
- `test_recurring_recovery_handles_exception_gracefully` — `compute_next_run` raising (`CroniterBadCronError`, `KeyError`, etc.) does NOT crash the tick; failure is logged as a WARNING.
- `test_recurring_recovery_isolates_one_bad_job_from_others` — a malformed null-state job in `jobs.json` does not block sibling healthy due jobs from being returned.

Full `tests/cron/test_jobs.py` suite: 70/70 green.

## Out of scope

- Investigating *how* a recurring job ended up in `next_run_at: null` state in the first place (via `create_job` regression, partial migration, hand-edit, etc.). That's a separate prevention concern; this PR is detection + recovery.
- Adding the same recovery to `update_job` / `mark_job_run` — those paths already populate `next_run_at` correctly (per existing tests).
- Surfacing stuck jobs via `hermes doctor cron` — could be a follow-up, but the WARNING log here already addresses the immediate "no signal" problem.

## Related

- Issue #16265 (referenced in `cron/jobs.py:719-721` comment) — the motivating issue for the existing `mark_job_run` defense, extended here to `get_due_jobs`.
