### PR TITLE
feat(plugin): Allow all GPT Image 2 sizes for Codex image gen

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -14,6 +14,14 @@ Selection precedence for the tier (first hit wins):
 3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
 
+Selection precedence for image size (first valid hit wins):
+
+1. ``size=`` / ``resolution=`` direct provider kwargs
+2. ``OPENAI_CODEX_IMAGE_SIZE`` or ``OPENAI_IMAGE_SIZE`` env var
+3. ``image_gen.openai-codex.size`` / ``resolution`` in ``config.yaml``
+4. ``image_gen.size`` / ``resolution`` in ``config.yaml``
+5. Legacy ``aspect_ratio`` mapping — landscape/square/portrait
+
 Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 """
 
@@ -64,10 +72,45 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 
 DEFAULT_MODEL = "gpt-image-2-medium"
 
+# Backward-compatible aspect-ratio aliases. Existing callers that pass only
+# ``aspect_ratio`` keep receiving these exact dimensions.
 _SIZES = {
     "landscape": "1536x1024",
     "square": "1024x1024",
     "portrait": "1024x1536",
+}
+
+SUPPORTED_SIZES: Tuple[str, ...] = (
+    "auto",
+    "1024x1024",
+    "1536x1024",
+    "1024x1536",
+    "2048x2048",
+    "2048x1152",
+    "3840x2160",
+    "2160x3840",
+)
+
+_SIZE_ALIASES = {
+    "square": "1024x1024",
+    "landscape": "1536x1024",
+    "portrait": "1024x1536",
+    "2k square": "2048x2048",
+    "2k-square": "2048x2048",
+    "2k_square": "2048x2048",
+    "2ksquare": "2048x2048",
+    "2k landscape": "2048x1152",
+    "2k-landscape": "2048x1152",
+    "2k_landscape": "2048x1152",
+    "2klandscape": "2048x1152",
+    "4k landscape": "3840x2160",
+    "4k-landscape": "3840x2160",
+    "4k_landscape": "3840x2160",
+    "4klandscape": "3840x2160",
+    "4k portrait": "2160x3840",
+    "4k-portrait": "2160x3840",
+    "4k_portrait": "2160x3840",
+    "4kportrait": "2160x3840",
 }
 
 # Codex Responses surface used for the request. The chat model itself is only
@@ -123,6 +166,59 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
         return candidate, _MODELS[candidate]
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _normalize_size(value: Any) -> Optional[str]:
+    """Return a GPT Image 2 size literal, or None for invalid input."""
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    if not candidate:
+        return None
+    candidate = candidate.replace(" ", "")
+    candidate = candidate.replace("×", "x")
+    if candidate in SUPPORTED_SIZES:
+        return candidate
+    return _SIZE_ALIASES.get(value.strip().lower()) or _SIZE_ALIASES.get(candidate)
+
+
+def _configured_size_from_mapping(cfg: Dict[str, Any]) -> Optional[str]:
+    """Read size/resolution keys from an ``image_gen`` config mapping."""
+    sub = cfg.get("openai-codex") if isinstance(cfg.get("openai-codex"), dict) else {}
+    if isinstance(sub, dict):
+        for key in ("size", "resolution"):
+            resolved = _normalize_size(sub.get(key))
+            if resolved:
+                return resolved
+
+    for key in ("size", "resolution"):
+        resolved = _normalize_size(cfg.get(key))
+        if resolved:
+            return resolved
+
+    return None
+
+
+def _resolve_size(aspect: str, overrides: Dict[str, Any]) -> str:
+    """Resolve the image size while preserving the legacy aspect fallback."""
+    import os
+
+    for key in ("size", "resolution", "image_size"):
+        resolved = _normalize_size(overrides.get(key))
+        if resolved:
+            return resolved
+
+    for env_name in ("OPENAI_CODEX_IMAGE_SIZE", "OPENAI_IMAGE_SIZE"):
+        resolved = _normalize_size(os.environ.get(env_name))
+        if resolved:
+            return resolved
+
+    cfg = _load_image_gen_config()
+    resolved = _configured_size_from_mapping(cfg)
+    if resolved:
+        return resolved
+
+    return _SIZES.get(aspect, _SIZES["square"])
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -366,7 +462,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             )
 
         tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        size = _resolve_size(aspect, kwargs)
 
         token = _read_codex_access_token()
         if not token:

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -68,6 +68,66 @@ class TestMetadata:
         assert schema["badge"] == "free"
 
 
+class TestSizeResolution:
+    def test_supported_sizes_cover_gpt_image_2_catalog(self):
+        assert codex_plugin.SUPPORTED_SIZES == (
+            "auto",
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "2048x2048",
+            "2048x1152",
+            "3840x2160",
+            "2160x3840",
+        )
+
+    @pytest.mark.parametrize("aspect,expected_size", [
+        ("landscape", "1536x1024"),
+        ("square", "1024x1024"),
+        ("portrait", "1024x1536"),
+    ])
+    def test_legacy_aspect_ratio_fallback_stays_stable(self, aspect, expected_size):
+        assert codex_plugin._resolve_size(aspect, {}) == expected_size
+
+    @pytest.mark.parametrize("raw,expected_size", [
+        ("auto", "auto"),
+        ("2048x2048", "2048x2048"),
+        ("2048 x 1152", "2048x1152"),
+        ("3840×2160", "3840x2160"),
+        ("4k_portrait", "2160x3840"),
+        ("2k landscape", "2048x1152"),
+    ])
+    def test_explicit_size_overrides_aspect_ratio(self, raw, expected_size):
+        assert codex_plugin._resolve_size("square", {"size": raw}) == expected_size
+
+    def test_resolution_kwarg_is_accepted(self):
+        assert (
+            codex_plugin._resolve_size("square", {"resolution": "2160x3840"})
+            == "2160x3840"
+        )
+
+    def test_invalid_explicit_size_falls_back_to_aspect_ratio(self):
+        assert codex_plugin._resolve_size("portrait", {"size": "bogus"}) == "1024x1536"
+
+    def test_env_size_override(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_CODEX_IMAGE_SIZE", "3840x2160")
+        assert codex_plugin._resolve_size("square", {}) == "3840x2160"
+
+    def test_config_openai_codex_size(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai-codex": {"size": "2048x2048"}}})
+        )
+        assert codex_plugin._resolve_size("landscape", {}) == "2048x2048"
+
+    def test_config_top_level_resolution(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"resolution": "auto"}})
+        )
+        assert codex_plugin._resolve_size("landscape", {}) == "auto"
+
+
 # ── Availability ────────────────────────────────────────────────────────────
 
 
@@ -159,6 +219,30 @@ class TestGenerate:
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
+
+    def test_generate_accepts_full_gpt_image_2_size(self, provider, monkeypatch):
+        monkeypatch.setattr(
+            codex_plugin, "_read_codex_access_token", lambda: "codex-token"
+        )
+
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality):
+            captured.update({"token": token, "prompt": prompt, "size": size, "quality": quality})
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", aspect_ratio="square", size="3840x2160")
+
+        assert result["success"] is True
+        assert result["size"] == "3840x2160"
+        assert captured == {
+            "token": "codex-token",
+            "prompt": "a cat",
+            "size": "3840x2160",
+            "quality": "medium",
+        }
 
     def test_partial_image_event_used_when_done_missing(self):
         """If output_item.done is missing, partial_image_b64 is accepted."""


### PR DESCRIPTION
## Summary

- Adds GPT Image 2 size resolution to the OpenAI Codex image generation backend.
- Supports `auto`, the documented 1K/2K/4K presets, and friendly aliases while preserving the existing aspect-ratio fallback.
- References the official OpenAI image generation guide for `gpt-image-2` size options and constraints: https://developers.openai.com/api/docs/guides/image-generation#size-and-quality-options
- Adds provider tests for supported sizes, env/config resolution, legacy fallback behavior, and request shape.

## Validation

- `python3 -m py_compile plugins/image_gen/openai-codex/__init__.py tests/plugins/image_gen/test_openai_codex_provider.py`
- `git diff --check HEAD~1..HEAD`
- Lightweight resolver smoke test via `python3` import assertions

Note: `scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py` could not run in this worktree because no `.venv`, `venv`, or `$HOME/.hermes/hermes-agent/venv` exists.
