### PR TITLE
feat(cli): add unified hermes migrate workflow

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9008,6 +9008,11 @@ Examples:
         "--device-id",
         help="Device identifier for device-local config (default: derived from host)",
     )
+    migrate_export.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing non-empty migration bundle directory",
+    )
 
     migrate_import = migrate_subparsers.add_parser(
         "import",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5103,6 +5103,13 @@ def cmd_import(args):
     run_import(args)
 
 
+def cmd_migrate(args):
+    """First-class portable Hermes migration workflow."""
+    from hermes_cli.migration import run_migrate
+
+    run_migrate(args)
+
+
 def cmd_version(args):
     """Show version."""
     print(f"Hermes Agent v{__version__} ({__release_date__})")
@@ -8972,6 +8979,76 @@ Examples:
         help="Overwrite existing files without confirmation",
     )
     import_parser.set_defaults(func=cmd_import)
+
+    # =========================================================================
+    # migrate command
+    # =========================================================================
+    migrate_parser = subparsers.add_parser(
+        "migrate",
+        help="Export/import portable Hermes migration bundles",
+        description=(
+            "First-class migration workflow for moving portable Hermes profile "
+            "state between machines, OS environments, reinstalls, and path "
+            "changes. This is local portability, not cloud sync; plaintext "
+            "secrets and runtime state are excluded."
+        ),
+    )
+    migrate_subparsers = migrate_parser.add_subparsers(dest="migrate_action")
+
+    migrate_export = migrate_subparsers.add_parser(
+        "export",
+        help="Export portable profile state to a migration bundle directory",
+    )
+    migrate_export.add_argument(
+        "--out",
+        required=True,
+        help="Output directory for the structured migration bundle",
+    )
+    migrate_export.add_argument(
+        "--device-id",
+        help="Device identifier for device-local config (default: derived from host)",
+    )
+
+    migrate_import = migrate_subparsers.add_parser(
+        "import",
+        help="Import portable profile state from a migration bundle directory",
+    )
+    migrate_import.add_argument(
+        "--from",
+        dest="source_dir",
+        required=True,
+        help="Migration bundle directory to import from",
+    )
+    migrate_import.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the exact local write plan without changing files",
+    )
+    migrate_import.add_argument(
+        "--device-id",
+        help="Device identifier for device-local config (default: derived from host)",
+    )
+
+    migrate_verify = migrate_subparsers.add_parser(
+        "verify",
+        help="Validate a migration bundle before import",
+    )
+    migrate_verify.add_argument(
+        "--repo",
+        required=True,
+        help="Migration bundle directory to validate",
+    )
+
+    migrate_doctor = migrate_subparsers.add_parser(
+        "doctor",
+        help="Diagnose a migration bundle and explain what is portable",
+    )
+    migrate_doctor.add_argument(
+        "--repo",
+        required=True,
+        help="Migration bundle directory to diagnose",
+    )
+    migrate_parser.set_defaults(func=cmd_migrate)
 
     # =========================================================================
     # config command

--- a/hermes_cli/migration.py
+++ b/hermes_cli/migration.py
@@ -27,10 +27,10 @@ from hermes_constants import get_hermes_home
 from utils import atomic_yaml_write
 
 
-SYNC_FORMAT = "hermes-profile-sync"
+LEGACY_SYNC_FORMAT = "hermes-profile-sync"
 MIGRATION_FORMAT = "hermes-profile-migration"
-SUPPORTED_FORMATS = frozenset({SYNC_FORMAT, MIGRATION_FORMAT})
-SYNC_VERSION = 1
+SUPPORTED_FORMATS = frozenset({LEGACY_SYNC_FORMAT, MIGRATION_FORMAT})
+MIGRATION_VERSION = 1
 MEMORY_CREATED_AT = "1970-01-01T00:00:00Z"
 
 _MISSING = object()
@@ -180,8 +180,8 @@ _DIAGNOSTIC_KEYS = (
 
 
 @dataclass
-class SyncResult:
-    """Result object returned by sync operations."""
+class MigrationResult:
+    """Result object returned by migration operations."""
 
     repo: Path
     ok: bool = True
@@ -209,11 +209,9 @@ def run_migrate(args) -> None:
 
     This is the user-facing product workflow from #6078: local portability
     across machines, operating systems, reinstalls, and path changes without
-    implying cloud or background sync.
+    implying cloud service, network transfer, or background multi-device behavior.
     """
     action = getattr(args, "migrate_action", None)
-    if action == "verify":
-        action = "doctor"
     _run_profile_transfer_command(
         action,
         args,
@@ -234,10 +232,11 @@ def _run_profile_transfer_command(
     """Dispatch shared portable profile export/import/validation commands."""
     try:
         if action == "export":
-            result = export_profile_sync(
+            result = export_migration_bundle(
                 Path(args.out),
                 device_id=getattr(args, "device_id", None),
                 manifest_format=manifest_format,
+                force=bool(getattr(args, "force", False)),
             )
             _print_export_result(result, bundle_label=bundle_label)
             if not result.ok:
@@ -245,11 +244,13 @@ def _run_profile_transfer_command(
             return
 
         if action == "import":
-            result = import_profile_sync(
+            result = import_migration_bundle(
                 Path(getattr(args, "source_dir")),
                 dry_run=bool(getattr(args, "dry_run", False)),
                 device_id=getattr(args, "device_id", None),
             )
+            if result.ok and _bundle_contains_skills(Path(getattr(args, "source_dir"))):
+                _print_import_safety_notice()
             _print_plan_result(
                 result,
                 dry_run=bool(getattr(args, "dry_run", False)),
@@ -259,13 +260,20 @@ def _run_profile_transfer_command(
                 sys.exit(1)
             return
 
+        if action == "verify":
+            result = doctor_migration_bundle(Path(args.repo))
+            _print_verify_result(result, bundle_label=bundle_label)
+            if not result.ok:
+                sys.exit(1)
+            return
+
         if action == "doctor":
-            result = doctor_sync_repo(Path(args.repo))
+            result = doctor_migration_bundle(Path(args.repo))
             _print_doctor_result(result, bundle_label=bundle_label)
             if not result.ok:
                 sys.exit(1)
             return
-    except SyncError as exc:
+    except MigrationError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -276,26 +284,27 @@ def _run_profile_transfer_command(
     sys.exit(2)
 
 
-class SyncError(RuntimeError):
+class MigrationError(RuntimeError):
     """Raised for invalid migration bundles or unsafe migration operations."""
 
 
-def export_profile_sync(
+def export_migration_bundle(
     out_dir: Path,
     *,
     hermes_home: Path | None = None,
     device_id: str | None = None,
     manifest_format: str = MIGRATION_FORMAT,
-) -> SyncResult:
+    force: bool = False,
+) -> MigrationResult:
     """Export portable Hermes profile state into *out_dir*."""
     hermes_home = hermes_home or get_hermes_home()
     out_dir = out_dir.expanduser().resolve()
     device_id = normalize_device_id(device_id or default_device_id(hermes_home))
     if manifest_format not in SUPPORTED_FORMATS:
-        raise SyncError(f"unsupported migration bundle format: {manifest_format}")
-    result = SyncResult(repo=out_dir)
+        raise MigrationError(f"unsupported migration bundle format: {manifest_format}")
+    result = MigrationResult(repo=out_dir)
 
-    out_dir.mkdir(parents=True, exist_ok=True)
+    _prepare_output_dir(out_dir, force=force, hermes_home=hermes_home)
 
     _export_home_state(
         hermes_home=hermes_home,
@@ -308,7 +317,7 @@ def export_profile_sync(
 
     manifest = {
         "format": manifest_format,
-        "version": SYNC_VERSION,
+        "version": MIGRATION_VERSION,
         "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         "source_device": device_id,
         "profiles": profile_names,
@@ -316,24 +325,24 @@ def export_profile_sync(
     _write_yaml_file(out_dir / "manifest.yaml", manifest)
     result.files_written.insert(0, "manifest.yaml")
 
-    doctor = doctor_sync_repo(out_dir)
+    doctor = doctor_migration_bundle(out_dir)
     result.errors.extend(doctor.errors)
     result.ok = not result.errors
     return result
 
 
-def import_profile_sync(
+def import_migration_bundle(
     source_dir: Path,
     *,
     hermes_home: Path | None = None,
     device_id: str | None = None,
     dry_run: bool = False,
-) -> SyncResult:
+) -> MigrationResult:
     """Import portable profile state from *source_dir* into HERMES_HOME."""
     hermes_home = hermes_home or get_hermes_home()
     source_dir = source_dir.expanduser().resolve()
     device_id = normalize_device_id(device_id or default_device_id(hermes_home))
-    result = doctor_sync_repo(source_dir)
+    result = doctor_migration_bundle(source_dir)
     result.repo = source_dir
     if not result.ok:
         return result
@@ -359,10 +368,10 @@ def import_profile_sync(
     return result
 
 
-def doctor_sync_repo(repo_dir: Path) -> SyncResult:
+def doctor_migration_bundle(repo_dir: Path) -> MigrationResult:
     """Validate a local migration bundle."""
     repo_dir = repo_dir.expanduser().resolve()
-    result = SyncResult(repo=repo_dir)
+    result = MigrationResult(repo=repo_dir)
     if not repo_dir.exists():
         result.ok = False
         result.errors.append(f"migration bundle does not exist: {repo_dir}")
@@ -375,7 +384,7 @@ def doctor_sync_repo(repo_dir: Path) -> SyncResult:
     manifest_path = repo_dir / "manifest.yaml"
     try:
         manifest = _read_yaml_file(manifest_path, required=True)
-    except SyncError as exc:
+    except MigrationError as exc:
         result.ok = False
         result.errors.append(str(exc))
         return result
@@ -383,14 +392,14 @@ def doctor_sync_repo(repo_dir: Path) -> SyncResult:
     bundle_format = manifest.get("format")
     if bundle_format not in SUPPORTED_FORMATS:
         result.errors.append("manifest.yaml has invalid or missing format")
-    if manifest.get("version") != SYNC_VERSION:
+    if manifest.get("version") != MIGRATION_VERSION:
         result.errors.append("manifest.yaml has unsupported version")
 
     for path in _iter_files_for_validation(repo_dir):
         rel = path.relative_to(repo_dir)
         if path.is_symlink():
             result.errors.append(f"symlink present in migration bundle: {rel.as_posix()}")
-        elif is_forbidden_sync_path(rel):
+        elif is_forbidden_migration_path(rel):
             result.errors.append(f"forbidden path present in migration bundle: {rel.as_posix()}")
         elif _file_contains_secret(path):
             result.errors.append(f"plaintext secret-like value present in migration bundle: {rel.as_posix()}")
@@ -414,7 +423,7 @@ def doctor_sync_repo(repo_dir: Path) -> SyncResult:
 
 
 def split_config_for_export(config: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
-    """Split raw config into portable and device-local sync config maps."""
+    """Split raw config into portable and device-local migration config maps."""
     portable: dict[str, Any] = {}
     device: dict[str, Any] = {}
     warnings: list[str] = []
@@ -447,7 +456,7 @@ def _export_home_state(
     hermes_home: Path,
     bundle_root: Path,
     device_id: str,
-    result: SyncResult,
+    result: MigrationResult,
     bundle_prefix: str,
 ) -> None:
     """Export the safe portable subset of one Hermes home into *bundle_root*."""
@@ -476,9 +485,10 @@ def _export_home_state(
             _copy_file(soul_src, soul_dst)
             result.files_written.append(_bundle_rel(bundle_prefix, "soul/SOUL.md"))
 
-    memory_entries = _load_memory_entries(bundle_root / "memory" / "entries.jsonl")
-    memory_entries.update(
-        _extract_local_memory_entries(hermes_home, device_id, result.warnings)
+    memory_entries = _extract_local_memory_entries(
+        hermes_home,
+        device_id,
+        result.warnings,
     )
     _write_memory_entries(bundle_root / "memory" / "entries.jsonl", memory_entries)
     result.files_written.append(_bundle_rel(bundle_prefix, "memory/entries.jsonl"))
@@ -514,7 +524,7 @@ def _export_named_profiles(
     hermes_home: Path,
     out_dir: Path,
     device_id: str,
-    result: SyncResult,
+    result: MigrationResult,
 ) -> list[str]:
     profiles_root = hermes_home / "profiles"
     if not profiles_root.is_dir():
@@ -540,7 +550,7 @@ def _export_named_profiles(
 
 
 def _queue_home_import(
-    result: SyncResult,
+    result: MigrationResult,
     *,
     source_root: Path,
     target_home: Path,
@@ -565,7 +575,7 @@ def _queue_home_import(
             source=soul_src,
             target=target_home / "SOUL.md",
             hermes_home=hermes_home,
-            conflict_suffix=".sync-conflict",
+            conflict_suffix=".migration-conflict",
         )
 
     memory_entries = _load_memory_entries(source_root / "memory" / "entries.jsonl")
@@ -596,10 +606,10 @@ def _queue_home_import(
     )
 
 
-def _bundle_profile_names(source_dir: Path, result: SyncResult) -> list[str]:
+def _bundle_profile_names(source_dir: Path, result: MigrationResult) -> list[str]:
     try:
         manifest = _read_yaml_file(source_dir / "manifest.yaml", required=True)
-    except SyncError as exc:
+    except MigrationError as exc:
         result.errors.append(str(exc))
         result.ok = False
         return []
@@ -611,7 +621,27 @@ def _bundle_profile_names(source_dir: Path, result: SyncResult) -> list[str]:
     return [name for name in raw_profiles if isinstance(name, str) and _is_valid_profile_name(name)]
 
 
-def _inspect_bundle_scope(repo_dir: Path, result: SyncResult, *, label: str) -> None:
+def _bundle_contains_skills(source_dir: Path) -> bool:
+    source_dir = source_dir.expanduser().resolve()
+    if _tree_has_files(source_dir / "skills" / "files"):
+        return True
+
+    profiles_root = source_dir / "profiles"
+    if not profiles_root.is_dir():
+        return False
+    for profile_dir in profiles_root.iterdir():
+        if profile_dir.is_dir() and _tree_has_files(profile_dir / "skills" / "files"):
+            return True
+    return False
+
+
+def _tree_has_files(root: Path) -> bool:
+    if not root.is_dir():
+        return False
+    return any(path.is_file() for path in _iter_files(root))
+
+
+def _inspect_bundle_scope(repo_dir: Path, result: MigrationResult, *, label: str) -> None:
     config_path = repo_dir / "config" / "global.yaml"
     if config_path.exists():
         _read_yaml_for_diagnostics(config_path, result)
@@ -644,7 +674,7 @@ def _inspect_bundle_scope(repo_dir: Path, result: SyncResult, *, label: str) -> 
     if memory_path.exists():
         try:
             memory_entries = _load_memory_entries(memory_path)
-        except SyncError as exc:
+        except MigrationError as exc:
             result.errors.append(str(exc))
         else:
             _diag(result, "migrated", f"{len(memory_entries)} memory entries for {label}")
@@ -661,7 +691,7 @@ def _inspect_bundle_scope(repo_dir: Path, result: SyncResult, *, label: str) -> 
         _diag(result, "skipped", f"Skins for {label} are not present")
 
 
-def _inspect_skill_manifest(repo_dir: Path, result: SyncResult, *, label: str) -> None:
+def _inspect_skill_manifest(repo_dir: Path, result: MigrationResult, *, label: str) -> None:
     manifest_path = repo_dir / "skills" / "manifest.yaml"
     files_root = repo_dir / "skills" / "files"
     if not manifest_path.exists():
@@ -689,7 +719,7 @@ def _inspect_skill_manifest(repo_dir: Path, result: SyncResult, *, label: str) -
         if rel is None:
             result.errors.append(f"unsafe skill path in skills/manifest.yaml for {label}: {item.get('path')}")
             continue
-        if is_forbidden_sync_path(rel):
+        if is_forbidden_migration_path(rel):
             result.errors.append(f"forbidden skill path in skills/manifest.yaml for {label}: {rel.as_posix()}")
             continue
         file_path = files_root / rel
@@ -706,7 +736,7 @@ def _inspect_skill_manifest(repo_dir: Path, result: SyncResult, *, label: str) -
 def _validate_bundle_profiles(
     repo_dir: Path,
     manifest: dict[str, Any],
-    result: SyncResult,
+    result: MigrationResult,
 ) -> list[str]:
     raw_profiles = manifest.get("profiles") or []
     if not isinstance(raw_profiles, list):
@@ -733,7 +763,7 @@ def _validate_bundle_profiles(
     return profile_names
 
 
-def _add_standard_diagnostics(result: SyncResult) -> None:
+def _add_standard_diagnostics(result: MigrationResult) -> None:
     _diag(
         result,
         "skipped",
@@ -746,10 +776,10 @@ def _add_standard_diagnostics(result: SyncResult) -> None:
     )
 
 
-def _read_yaml_for_diagnostics(path: Path, result: SyncResult) -> dict[str, Any]:
+def _read_yaml_for_diagnostics(path: Path, result: MigrationResult) -> dict[str, Any]:
     try:
         return _read_yaml_file(path, required=True)
-    except SyncError as exc:
+    except MigrationError as exc:
         result.errors.append(str(exc))
         return {}
 
@@ -768,10 +798,10 @@ def _safe_bundle_rel_path(value: Any, context: str) -> Path | None:
     try:
         return Path(*parts)
     except TypeError as exc:
-        raise SyncError(f"invalid path in {context}: {value}") from exc
+        raise MigrationError(f"invalid path in {context}: {value}") from exc
 
 
-def _diag(result: SyncResult, key: str, message: str) -> None:
+def _diag(result: MigrationResult, key: str, message: str) -> None:
     entries = result.diagnostics.setdefault(key, [])
     if message not in entries:
         entries.append(message)
@@ -785,10 +815,45 @@ def _is_valid_profile_name(name: str) -> bool:
     return bool(_PROFILE_NAME_RE.match(name)) and name != "default"
 
 
+def _prepare_output_dir(out_dir: Path, *, force: bool, hermes_home: Path) -> None:
+    if out_dir.exists() and not out_dir.is_dir():
+        raise MigrationError(f"migration bundle output path is not a directory: {out_dir}")
+
+    if not out_dir.exists():
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return
+
+    if not any(out_dir.iterdir()):
+        return
+
+    if not force:
+        raise MigrationError(
+            "migration bundle output directory is not empty. "
+            "Please choose an empty directory or rerun with --force to overwrite it."
+        )
+
+    _clear_existing_output_dir(out_dir, hermes_home=hermes_home)
+
+
+def _clear_existing_output_dir(out_dir: Path, *, hermes_home: Path) -> None:
+    out_dir = out_dir.resolve()
+    hermes_home = hermes_home.resolve()
+    home = Path.home().resolve()
+    root = Path(out_dir.anchor).resolve()
+    if out_dir in {root, home, hermes_home}:
+        raise MigrationError(f"refusing to clear unsafe migration output directory: {out_dir}")
+
+    for child in out_dir.iterdir():
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
 def normalize_device_id(value: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip()).strip("-").lower()
     if not slug:
-        raise SyncError("device id cannot be empty")
+        raise MigrationError("device id cannot be empty")
     if len(slug) > 80:
         slug = slug[:80].rstrip("-_")
     return slug
@@ -801,7 +866,7 @@ def default_device_id(hermes_home: Path) -> str:
     return f"{slug}-{digest}"
 
 
-def is_forbidden_sync_path(rel_path: Path) -> bool:
+def is_forbidden_migration_path(rel_path: Path) -> bool:
     parts = rel_path.parts
     if any(part in _FORBIDDEN_DIRS for part in parts):
         return True
@@ -991,14 +1056,14 @@ def _load_memory_entries(path: Path) -> dict[str, dict[str, Any]]:
             try:
                 entry = json.loads(line)
             except json.JSONDecodeError as exc:
-                raise SyncError(f"invalid memory JSONL at {path}:{line_no}: {exc}") from exc
+                raise MigrationError(f"invalid memory JSONL at {path}:{line_no}: {exc}") from exc
             if not isinstance(entry, dict):
-                raise SyncError(f"invalid memory entry at {path}:{line_no}: expected object")
+                raise MigrationError(f"invalid memory entry at {path}:{line_no}: expected object")
             entry_id = str(entry.get("id") or "")
             target = entry.get("target")
             content = entry.get("content")
             if not entry_id or target not in {"memory", "user"} or not isinstance(content, str):
-                raise SyncError(f"invalid memory entry at {path}:{line_no}: missing id/target/content")
+                raise MigrationError(f"invalid memory entry at {path}:{line_no}: missing id/target/content")
             entries[entry_id] = entry
     return entries
 
@@ -1053,7 +1118,7 @@ def _export_tree(
             if src.is_symlink():
                 warnings.append(f"Skipped {src_root.name}/{rel.as_posix()}: symlink")
                 continue
-            if is_forbidden_sync_path(rel):
+            if is_forbidden_migration_path(rel):
                 warnings.append(f"Skipped {src_root.name}/{rel.as_posix()}: forbidden path")
                 continue
             if _file_contains_secret(src):
@@ -1066,7 +1131,7 @@ def _export_tree(
 
 
 def _queue_tree_import(
-    result: SyncResult,
+    result: MigrationResult,
     src_root: Path,
     dst_root: Path,
     *,
@@ -1078,13 +1143,13 @@ def _queue_tree_import(
     skip_names = skip_names or set()
     for src in _iter_files(src_root):
         rel = src.relative_to(src_root)
-        if src.name in skip_names or is_forbidden_sync_path(rel):
+        if src.name in skip_names or is_forbidden_migration_path(rel):
             continue
         _queue_bytes_write(result, src, dst_root / rel, hermes_home=hermes_home)
 
 
 def _queue_yaml_write(
-    result: SyncResult,
+    result: MigrationResult,
     target: Path,
     data: dict[str, Any],
     *,
@@ -1095,7 +1160,7 @@ def _queue_yaml_write(
 
 
 def _queue_text_or_conflict(
-    result: SyncResult,
+    result: MigrationResult,
     *,
     source: Path,
     target: Path,
@@ -1126,7 +1191,7 @@ def _queue_text_or_conflict(
 
 
 def _queue_text_write(
-    result: SyncResult,
+    result: MigrationResult,
     target: Path,
     text: str,
     *,
@@ -1153,7 +1218,7 @@ def _queue_text_write(
 
 
 def _queue_bytes_write(
-    result: SyncResult,
+    result: MigrationResult,
     source: Path,
     target: Path,
     *,
@@ -1175,7 +1240,7 @@ def _queue_bytes_write(
     )
 
 
-def _apply_plan(result: SyncResult) -> None:
+def _apply_plan(result: MigrationResult) -> None:
     for op in result.plan:
         target = Path(op["_target"])
         if op["_kind"] == "text":
@@ -1196,14 +1261,14 @@ def _display_local_path(path: Path, hermes_home: Path) -> str:
 def _read_yaml_file(path: Path, *, required: bool) -> dict[str, Any]:
     if not path.exists():
         if required:
-            raise SyncError(f"missing required file: {path}")
+            raise MigrationError(f"missing required file: {path}")
         return {}
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except yaml.YAMLError as exc:
-        raise SyncError(f"invalid YAML in {path}: {exc}") from exc
+        raise MigrationError(f"invalid YAML in {path}: {exc}") from exc
     if not isinstance(data, dict):
-        raise SyncError(f"invalid YAML in {path}: expected mapping")
+        raise MigrationError(f"invalid YAML in {path}: expected mapping")
     return data
 
 
@@ -1272,7 +1337,7 @@ def _atomic_text_write(path: Path, content: str) -> None:
         raise
 
 
-def _print_export_result(result: SyncResult, *, bundle_label: str) -> None:
+def _print_export_result(result: MigrationResult, *, bundle_label: str) -> None:
     if result.ok:
         print(f"Exported Hermes {bundle_label} to {result.repo}")
     else:
@@ -1285,7 +1350,7 @@ def _print_export_result(result: SyncResult, *, bundle_label: str) -> None:
 
 
 def _print_plan_result(
-    result: SyncResult,
+    result: MigrationResult,
     *,
     dry_run: bool,
     bundle_label: str,
@@ -1298,7 +1363,24 @@ def _print_plan_result(
         print(f"Applied {len(result.files_written)} file changes.")
 
 
-def _print_doctor_result(result: SyncResult, *, bundle_label: str) -> None:
+def _print_import_safety_notice() -> None:
+    print("Security notice:")
+    print("  This migration bundle may modify local skills and agent behavior.")
+    print("  Only import bundles you created yourself or trust.")
+    print("  Secrets are not migrated; you may need to re-authenticate after import.")
+
+
+def _print_verify_result(result: MigrationResult, *, bundle_label: str) -> None:
+    title = bundle_label[:1].upper() + bundle_label[1:]
+    if result.ok:
+        print(f"{title} verified: {result.repo}")
+        return
+
+    print(f"{title} verification failed: {result.repo}")
+    _print_warnings_errors(result)
+
+
+def _print_doctor_result(result: MigrationResult, *, bundle_label: str) -> None:
     title = bundle_label[:1].upper() + bundle_label[1:]
     if result.ok:
         print(f"{title} OK: {result.repo}")
@@ -1308,7 +1390,7 @@ def _print_doctor_result(result: SyncResult, *, bundle_label: str) -> None:
     _print_warnings_errors(result)
 
 
-def _print_warnings_errors(result: SyncResult) -> None:
+def _print_warnings_errors(result: MigrationResult) -> None:
     if result.warnings:
         print("Warnings:")
         for warning in result.warnings:
@@ -1319,7 +1401,7 @@ def _print_warnings_errors(result: SyncResult) -> None:
             print(f"  {error}", file=sys.stderr)
 
 
-def _print_diagnostics(result: SyncResult) -> None:
+def _print_diagnostics(result: MigrationResult) -> None:
     print("Diagnostics:")
     labels = {
         "migrated": "Migrated",
@@ -1337,7 +1419,7 @@ def _print_diagnostics(result: SyncResult) -> None:
             print(f"    - {entry}")
 
 
-def _public_plan(result: SyncResult) -> dict[str, Any]:
+def _public_plan(result: MigrationResult) -> dict[str, Any]:
     operations = []
     for op in result.plan:
         operations.append(

--- a/hermes_cli/migration.py
+++ b/hermes_cli/migration.py
@@ -1,0 +1,1357 @@
+"""Portable Hermes profile migration export/import helpers.
+
+This module implements the local, no-network portability layer used by
+``hermes migrate``.  It is intentionally not a cloud drive for HERMES_HOME:
+it exports a structured, portable subset of profile state and rejects runtime
+state and plaintext secrets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
+
+import yaml
+
+from hermes_constants import get_hermes_home
+from utils import atomic_yaml_write
+
+
+SYNC_FORMAT = "hermes-profile-sync"
+MIGRATION_FORMAT = "hermes-profile-migration"
+SUPPORTED_FORMATS = frozenset({SYNC_FORMAT, MIGRATION_FORMAT})
+SYNC_VERSION = 1
+MEMORY_CREATED_AT = "1970-01-01T00:00:00Z"
+
+_MISSING = object()
+
+_PORTABLE_ROOT_KEYS = frozenset(
+    {
+        "model",
+        "providers",
+        "fallback_providers",
+        "credential_pool_strategies",
+        "toolsets",
+        "agent",
+        "compression",
+        "prompt_caching",
+        "auxiliary",
+        "display",
+        "dashboard",
+        "privacy",
+        "tts",
+        "stt",
+        "voice",
+        "human_delay",
+        "context",
+        "memory",
+        "delegation",
+        "skills",
+        "curator",
+        "timezone",
+        "personalities",
+        "security",
+        "cron",
+        "code_execution",
+        "model_catalog",
+        "network",
+        "sessions",
+        "onboarding",
+        "updates",
+        "_config_version",
+    }
+)
+
+_DEVICE_ROOT_KEYS = frozenset(
+    {
+        "terminal",
+        "browser",
+        "bedrock",
+        "discord",
+        "whatsapp",
+        "telegram",
+        "slack",
+        "mattermost",
+        "prefill_messages_file",
+        "approvals",
+        "command_allowlist",
+        "quick_commands",
+        "hooks",
+        "logging",
+        "checkpoints",
+        "file_read_max_chars",
+        "tool_output",
+        "honcho",
+    }
+)
+
+_DEVICE_CONFIG_PATHS = {
+    ("skills", "external_dirs"),
+    ("auxiliary", "vision", "base_url"),
+    ("auxiliary", "web_extract", "base_url"),
+    ("auxiliary", "compression", "base_url"),
+    ("auxiliary", "session_search", "base_url"),
+    ("auxiliary", "skills_hub", "base_url"),
+    ("auxiliary", "approval", "base_url"),
+    ("auxiliary", "mcp", "base_url"),
+    ("auxiliary", "title_generation", "base_url"),
+    ("delegation", "base_url"),
+}
+
+_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|secret|password|token|credential|private[_-]?key|client[_-]?secret)",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9][A-Za-z0-9_-]{12,}"),
+    re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[abprs]-[A-Za-z0-9-]{20,}"),
+    re.compile(r"AIza[0-9A-Za-z_-]{20,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+_FORBIDDEN_NAMES = frozenset(
+    {
+        ".env",
+        "auth.json",
+        "state.db",
+        "hermes_state.db",
+        "response_store.db",
+        "gateway.pid",
+        "cron.pid",
+        "gateway_state.json",
+        "processes.json",
+        "auth.lock",
+        ".hermes_history",
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+    }
+)
+_FORBIDDEN_DIRS = frozenset(
+    {
+        "logs",
+        "cache",
+        "tmp",
+        "temp",
+        "image_cache",
+        "audio_cache",
+        "document_cache",
+        "browser_screenshots",
+        "checkpoints",
+        "sandboxes",
+        ".ssh",
+        "__pycache__",
+        ".git",
+        "node_modules",
+    }
+)
+_FORBIDDEN_SUFFIXES = (
+    ".db-wal",
+    ".db-shm",
+    ".db-journal",
+    ".pyc",
+    ".pyo",
+    ".pid",
+    ".sock",
+    ".lock",
+    ".tmp",
+)
+_SKILL_EXPORT_SKIP_DIRS = frozenset({".hub", ".archive", "__pycache__"})
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_DIAGNOSTIC_KEYS = (
+    "migrated",
+    "skipped",
+    "manual_reauth",
+    "possibly_incompatible",
+)
+
+
+@dataclass
+class SyncResult:
+    """Result object returned by sync operations."""
+
+    repo: Path
+    ok: bool = True
+    files_written: list[str] = field(default_factory=list)
+    plan: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    diagnostics: dict[str, list[str]] = field(
+        default_factory=lambda: {key: [] for key in _DIAGNOSTIC_KEYS}
+    )
+
+    def as_plan_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "repo": str(self.repo),
+            "operations": self.plan,
+            "warnings": self.warnings,
+            "errors": self.errors,
+            "diagnostics": self.diagnostics,
+        }
+
+
+def run_migrate(args) -> None:
+    """Argparse entry point for ``hermes migrate``.
+
+    This is the user-facing product workflow from #6078: local portability
+    across machines, operating systems, reinstalls, and path changes without
+    implying cloud or background sync.
+    """
+    action = getattr(args, "migrate_action", None)
+    if action == "verify":
+        action = "doctor"
+    _run_profile_transfer_command(
+        action,
+        args,
+        usage="hermes migrate {export,import,verify,doctor} ...",
+        bundle_label="migration bundle",
+        manifest_format=MIGRATION_FORMAT,
+    )
+
+
+def _run_profile_transfer_command(
+    action: str | None,
+    args,
+    *,
+    usage: str,
+    bundle_label: str,
+    manifest_format: str,
+) -> None:
+    """Dispatch shared portable profile export/import/validation commands."""
+    try:
+        if action == "export":
+            result = export_profile_sync(
+                Path(args.out),
+                device_id=getattr(args, "device_id", None),
+                manifest_format=manifest_format,
+            )
+            _print_export_result(result, bundle_label=bundle_label)
+            if not result.ok:
+                sys.exit(1)
+            return
+
+        if action == "import":
+            result = import_profile_sync(
+                Path(getattr(args, "source_dir")),
+                dry_run=bool(getattr(args, "dry_run", False)),
+                device_id=getattr(args, "device_id", None),
+            )
+            _print_plan_result(
+                result,
+                dry_run=bool(getattr(args, "dry_run", False)),
+                bundle_label=bundle_label,
+            )
+            if not result.ok:
+                sys.exit(1)
+            return
+
+        if action == "doctor":
+            result = doctor_sync_repo(Path(args.repo))
+            _print_doctor_result(result, bundle_label=bundle_label)
+            if not result.ok:
+                sys.exit(1)
+            return
+    except SyncError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"usage: {usage}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+class SyncError(RuntimeError):
+    """Raised for invalid migration bundles or unsafe migration operations."""
+
+
+def export_profile_sync(
+    out_dir: Path,
+    *,
+    hermes_home: Path | None = None,
+    device_id: str | None = None,
+    manifest_format: str = MIGRATION_FORMAT,
+) -> SyncResult:
+    """Export portable Hermes profile state into *out_dir*."""
+    hermes_home = hermes_home or get_hermes_home()
+    out_dir = out_dir.expanduser().resolve()
+    device_id = normalize_device_id(device_id or default_device_id(hermes_home))
+    if manifest_format not in SUPPORTED_FORMATS:
+        raise SyncError(f"unsupported migration bundle format: {manifest_format}")
+    result = SyncResult(repo=out_dir)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    _export_home_state(
+        hermes_home=hermes_home,
+        bundle_root=out_dir,
+        device_id=device_id,
+        result=result,
+        bundle_prefix="",
+    )
+    profile_names = _export_named_profiles(hermes_home, out_dir, device_id, result)
+
+    manifest = {
+        "format": manifest_format,
+        "version": SYNC_VERSION,
+        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "source_device": device_id,
+        "profiles": profile_names,
+    }
+    _write_yaml_file(out_dir / "manifest.yaml", manifest)
+    result.files_written.insert(0, "manifest.yaml")
+
+    doctor = doctor_sync_repo(out_dir)
+    result.errors.extend(doctor.errors)
+    result.ok = not result.errors
+    return result
+
+
+def import_profile_sync(
+    source_dir: Path,
+    *,
+    hermes_home: Path | None = None,
+    device_id: str | None = None,
+    dry_run: bool = False,
+) -> SyncResult:
+    """Import portable profile state from *source_dir* into HERMES_HOME."""
+    hermes_home = hermes_home or get_hermes_home()
+    source_dir = source_dir.expanduser().resolve()
+    device_id = normalize_device_id(device_id or default_device_id(hermes_home))
+    result = doctor_sync_repo(source_dir)
+    result.repo = source_dir
+    if not result.ok:
+        return result
+
+    _queue_home_import(
+        result,
+        source_root=source_dir,
+        target_home=hermes_home,
+        hermes_home=hermes_home,
+        device_id=device_id,
+    )
+    for profile_name in _bundle_profile_names(source_dir, result):
+        _queue_home_import(
+            result,
+            source_root=source_dir / "profiles" / profile_name,
+            target_home=hermes_home / "profiles" / profile_name,
+            hermes_home=hermes_home,
+            device_id=device_id,
+        )
+
+    if result.ok and not dry_run:
+        _apply_plan(result)
+    return result
+
+
+def doctor_sync_repo(repo_dir: Path) -> SyncResult:
+    """Validate a local migration bundle."""
+    repo_dir = repo_dir.expanduser().resolve()
+    result = SyncResult(repo=repo_dir)
+    if not repo_dir.exists():
+        result.ok = False
+        result.errors.append(f"migration bundle does not exist: {repo_dir}")
+        return result
+    if not repo_dir.is_dir():
+        result.ok = False
+        result.errors.append(f"migration bundle is not a directory: {repo_dir}")
+        return result
+
+    manifest_path = repo_dir / "manifest.yaml"
+    try:
+        manifest = _read_yaml_file(manifest_path, required=True)
+    except SyncError as exc:
+        result.ok = False
+        result.errors.append(str(exc))
+        return result
+
+    bundle_format = manifest.get("format")
+    if bundle_format not in SUPPORTED_FORMATS:
+        result.errors.append("manifest.yaml has invalid or missing format")
+    if manifest.get("version") != SYNC_VERSION:
+        result.errors.append("manifest.yaml has unsupported version")
+
+    for path in _iter_files_for_validation(repo_dir):
+        rel = path.relative_to(repo_dir)
+        if path.is_symlink():
+            result.errors.append(f"symlink present in migration bundle: {rel.as_posix()}")
+        elif is_forbidden_sync_path(rel):
+            result.errors.append(f"forbidden path present in migration bundle: {rel.as_posix()}")
+        elif _file_contains_secret(path):
+            result.errors.append(f"plaintext secret-like value present in migration bundle: {rel.as_posix()}")
+
+    _inspect_bundle_scope(repo_dir, result, label="active profile")
+    profile_names = _validate_bundle_profiles(repo_dir, manifest, result)
+    if profile_names:
+        _diag(result, "migrated", f"{len(profile_names)} named profile(s): {', '.join(profile_names)}")
+        for profile_name in profile_names:
+            _inspect_bundle_scope(
+                repo_dir / "profiles" / profile_name,
+                result,
+                label=f"profile {profile_name}",
+            )
+    else:
+        _diag(result, "skipped", "No named profiles are included in this bundle")
+
+    _add_standard_diagnostics(result)
+    result.ok = not result.errors
+    return result
+
+
+def split_config_for_export(config: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Split raw config into portable and device-local sync config maps."""
+    portable: dict[str, Any] = {}
+    device: dict[str, Any] = {}
+    warnings: list[str] = []
+
+    for key, value in config.items():
+        path = (str(key),)
+        if _is_secret_key(str(key)):
+            warnings.append(f"Skipped config.{key}: secret-like key")
+            continue
+        if key in _DEVICE_ROOT_KEYS:
+            scrubbed = _scrub_export_value(value, path, warnings)
+            if scrubbed is not _MISSING:
+                device[key] = scrubbed
+            continue
+        if key not in _PORTABLE_ROOT_KEYS:
+            warnings.append(f"Kept config.{key} local: unknown migration ownership")
+            continue
+
+        p_value, d_value = _split_portable_value(value, path, warnings)
+        if p_value is not _MISSING:
+            portable[key] = p_value
+        if d_value is not _MISSING:
+            device[key] = d_value
+
+    return portable, device, warnings
+
+
+def _export_home_state(
+    *,
+    hermes_home: Path,
+    bundle_root: Path,
+    device_id: str,
+    result: SyncResult,
+    bundle_prefix: str,
+) -> None:
+    """Export the safe portable subset of one Hermes home into *bundle_root*."""
+    portable_config, device_config, config_warnings = split_config_for_export(
+        _read_raw_config_from_home(hermes_home)
+    )
+    result.warnings.extend(config_warnings)
+
+    _write_yaml_file(bundle_root / "config" / "global.yaml", portable_config)
+    result.files_written.append(_bundle_rel(bundle_prefix, "config/global.yaml"))
+    if device_config:
+        device_config_path = bundle_root / "config" / "devices" / f"{device_id}.yaml"
+        _write_yaml_file(device_config_path, device_config)
+        result.files_written.append(
+            _bundle_rel(bundle_prefix, f"config/devices/{device_id}.yaml")
+        )
+
+    soul_src = hermes_home / "SOUL.md"
+    if soul_src.is_file():
+        if _file_contains_secret(soul_src):
+            result.warnings.append(
+                f"Skipped {_bundle_rel(bundle_prefix, 'SOUL.md')}: secret-like content"
+            )
+        else:
+            soul_dst = bundle_root / "soul" / "SOUL.md"
+            _copy_file(soul_src, soul_dst)
+            result.files_written.append(_bundle_rel(bundle_prefix, "soul/SOUL.md"))
+
+    memory_entries = _load_memory_entries(bundle_root / "memory" / "entries.jsonl")
+    memory_entries.update(
+        _extract_local_memory_entries(hermes_home, device_id, result.warnings)
+    )
+    _write_memory_entries(bundle_root / "memory" / "entries.jsonl", memory_entries)
+    result.files_written.append(_bundle_rel(bundle_prefix, "memory/entries.jsonl"))
+
+    skill_manifest = _export_tree(
+        hermes_home / "skills",
+        bundle_root / "skills" / "files",
+        result.warnings,
+        skip_dirs=_SKILL_EXPORT_SKIP_DIRS,
+    )
+    _write_yaml_file(
+        bundle_root / "skills" / "manifest.yaml",
+        {"version": 1, "files": skill_manifest},
+    )
+    result.files_written.append(_bundle_rel(bundle_prefix, "skills/manifest.yaml"))
+    result.files_written.extend(
+        _bundle_rel(bundle_prefix, f"skills/files/{item['path']}")
+        for item in skill_manifest
+    )
+
+    skin_manifest = _export_tree(
+        hermes_home / "skins",
+        bundle_root / "skins",
+        result.warnings,
+        skip_dirs=frozenset({"__pycache__"}),
+    )
+    result.files_written.extend(
+        _bundle_rel(bundle_prefix, f"skins/{item['path']}") for item in skin_manifest
+    )
+
+
+def _export_named_profiles(
+    hermes_home: Path,
+    out_dir: Path,
+    device_id: str,
+    result: SyncResult,
+) -> list[str]:
+    profiles_root = hermes_home / "profiles"
+    if not profiles_root.is_dir():
+        return []
+
+    profile_names: list[str] = []
+    for profile_dir in sorted(profiles_root.iterdir(), key=lambda path: path.name):
+        if not profile_dir.is_dir() or profile_dir.is_symlink():
+            continue
+        profile_name = profile_dir.name
+        if not _is_valid_profile_name(profile_name):
+            result.warnings.append(f"Skipped profile {profile_name}: invalid profile name")
+            continue
+        _export_home_state(
+            hermes_home=profile_dir,
+            bundle_root=out_dir / "profiles" / profile_name,
+            device_id=device_id,
+            result=result,
+            bundle_prefix=f"profiles/{profile_name}",
+        )
+        profile_names.append(profile_name)
+    return profile_names
+
+
+def _queue_home_import(
+    result: SyncResult,
+    *,
+    source_root: Path,
+    target_home: Path,
+    hermes_home: Path,
+    device_id: str,
+) -> None:
+    local_config = _read_raw_config_from_home(target_home)
+    remote_config = _compose_remote_config(source_root, device_id)
+    merged_config = _deep_merge_dicts(local_config, remote_config)
+    if local_config or remote_config:
+        _queue_yaml_write(
+            result,
+            target_home / "config.yaml",
+            merged_config,
+            hermes_home=hermes_home,
+        )
+
+    soul_src = source_root / "soul" / "SOUL.md"
+    if soul_src.is_file():
+        _queue_text_or_conflict(
+            result,
+            source=soul_src,
+            target=target_home / "SOUL.md",
+            hermes_home=hermes_home,
+            conflict_suffix=".sync-conflict",
+        )
+
+    memory_entries = _load_memory_entries(source_root / "memory" / "entries.jsonl")
+    memory_entries.update(
+        _extract_local_memory_entries(target_home, device_id, result.warnings)
+    )
+    rendered_memory = _render_memory_entries(memory_entries)
+    for rel_path, content in rendered_memory.items():
+        _queue_text_write(
+            result,
+            target_home / rel_path,
+            content,
+            hermes_home=hermes_home,
+        )
+
+    _queue_tree_import(
+        result,
+        source_root / "skills" / "files",
+        target_home / "skills",
+        hermes_home=hermes_home,
+    )
+    _queue_tree_import(
+        result,
+        source_root / "skins",
+        target_home / "skins",
+        hermes_home=hermes_home,
+        skip_names={"manifest.yaml"},
+    )
+
+
+def _bundle_profile_names(source_dir: Path, result: SyncResult) -> list[str]:
+    try:
+        manifest = _read_yaml_file(source_dir / "manifest.yaml", required=True)
+    except SyncError as exc:
+        result.errors.append(str(exc))
+        result.ok = False
+        return []
+    raw_profiles = manifest.get("profiles") or []
+    if not isinstance(raw_profiles, list):
+        result.errors.append("manifest.yaml profiles must be a list")
+        result.ok = False
+        return []
+    return [name for name in raw_profiles if isinstance(name, str) and _is_valid_profile_name(name)]
+
+
+def _inspect_bundle_scope(repo_dir: Path, result: SyncResult, *, label: str) -> None:
+    config_path = repo_dir / "config" / "global.yaml"
+    if config_path.exists():
+        _read_yaml_for_diagnostics(config_path, result)
+        _diag(result, "migrated", f"Portable config for {label}")
+    else:
+        _diag(result, "skipped", f"Portable config for {label} is not present")
+
+    devices_root = repo_dir / "config" / "devices"
+    if devices_root.is_dir():
+        for device_config in sorted(devices_root.glob("*.yaml")):
+            _read_yaml_for_diagnostics(device_config, result)
+            rel = device_config.relative_to(repo_dir).as_posix()
+            _diag(result, "migrated", f"Device-local config for {label}: {rel}")
+            _diag(
+                result,
+                "possibly_incompatible",
+                f"{rel} may contain host-specific paths and is only applied when --device-id matches",
+            )
+
+    soul_path = repo_dir / "soul" / "SOUL.md"
+    if soul_path.exists():
+        if soul_path.is_file():
+            _diag(result, "migrated", f"SOUL.md for {label}")
+        else:
+            result.errors.append(f"soul/SOUL.md for {label} is not a file")
+    else:
+        _diag(result, "skipped", f"SOUL.md for {label} is not present")
+
+    memory_path = repo_dir / "memory" / "entries.jsonl"
+    if memory_path.exists():
+        try:
+            memory_entries = _load_memory_entries(memory_path)
+        except SyncError as exc:
+            result.errors.append(str(exc))
+        else:
+            _diag(result, "migrated", f"{len(memory_entries)} memory entries for {label}")
+    else:
+        _diag(result, "skipped", f"Memory entries for {label} are not present")
+
+    _inspect_skill_manifest(repo_dir, result, label=label)
+
+    skins_root = repo_dir / "skins"
+    if skins_root.is_dir():
+        skin_count = sum(1 for path in _iter_files(skins_root) if path.is_file())
+        _diag(result, "migrated", f"{skin_count} skin files for {label}")
+    else:
+        _diag(result, "skipped", f"Skins for {label} are not present")
+
+
+def _inspect_skill_manifest(repo_dir: Path, result: SyncResult, *, label: str) -> None:
+    manifest_path = repo_dir / "skills" / "manifest.yaml"
+    files_root = repo_dir / "skills" / "files"
+    if not manifest_path.exists():
+        if files_root.exists():
+            result.errors.append(f"skills/files exists without skills/manifest.yaml for {label}")
+        else:
+            _diag(result, "skipped", f"Skills for {label} are not present")
+        return
+
+    manifest = _read_yaml_for_diagnostics(manifest_path, result)
+    raw_files = manifest.get("files") if isinstance(manifest, dict) else None
+    if raw_files is None:
+        raw_files = []
+    if not isinstance(raw_files, list):
+        result.errors.append(f"skills/manifest.yaml files must be a list for {label}")
+        return
+
+    validated = 0
+    for idx, item in enumerate(raw_files):
+        if not isinstance(item, dict):
+            result.errors.append(f"skills/manifest.yaml files[{idx}] must be a mapping for {label}")
+            continue
+        rel = _safe_bundle_rel_path(item.get("path"), f"skills/manifest.yaml files[{idx}]")
+        expected_sha = item.get("sha256")
+        if rel is None:
+            result.errors.append(f"unsafe skill path in skills/manifest.yaml for {label}: {item.get('path')}")
+            continue
+        if is_forbidden_sync_path(rel):
+            result.errors.append(f"forbidden skill path in skills/manifest.yaml for {label}: {rel.as_posix()}")
+            continue
+        file_path = files_root / rel
+        if not file_path.is_file():
+            result.errors.append(f"missing skill file for {label}: {(Path('skills/files') / rel).as_posix()}")
+            continue
+        if expected_sha and expected_sha != _sha256_file(file_path):
+            result.errors.append(f"sha256 mismatch for skill file in {label}: {rel.as_posix()}")
+            continue
+        validated += 1
+    _diag(result, "migrated", f"{validated} skill files for {label}")
+
+
+def _validate_bundle_profiles(
+    repo_dir: Path,
+    manifest: dict[str, Any],
+    result: SyncResult,
+) -> list[str]:
+    raw_profiles = manifest.get("profiles") or []
+    if not isinstance(raw_profiles, list):
+        result.errors.append("manifest.yaml profiles must be a list")
+        return []
+
+    profile_names: list[str] = []
+    for raw_name in raw_profiles:
+        if not isinstance(raw_name, str) or not _is_valid_profile_name(raw_name):
+            result.errors.append(f"invalid profile name in manifest.yaml: {raw_name!r}")
+            continue
+        profile_dir = repo_dir / "profiles" / raw_name
+        if not profile_dir.is_dir():
+            result.errors.append(f"missing profile bundle directory: profiles/{raw_name}")
+            continue
+        profile_names.append(raw_name)
+
+    profiles_root = repo_dir / "profiles"
+    if profiles_root.is_dir():
+        declared = set(profile_names)
+        for child in profiles_root.iterdir():
+            if child.is_dir() and child.name not in declared:
+                result.errors.append(f"profile directory not listed in manifest.yaml: profiles/{child.name}")
+    return profile_names
+
+
+def _add_standard_diagnostics(result: SyncResult) -> None:
+    _diag(
+        result,
+        "skipped",
+        ".env, auth.json, state.db, logs, caches, sockets, pid files, and lock files are excluded by design",
+    )
+    _diag(
+        result,
+        "manual_reauth",
+        "API keys, OAuth tokens, provider credentials, and messaging tokens are not migrated; run setup/auth commands again on the target machine",
+    )
+
+
+def _read_yaml_for_diagnostics(path: Path, result: SyncResult) -> dict[str, Any]:
+    try:
+        return _read_yaml_file(path, required=True)
+    except SyncError as exc:
+        result.errors.append(str(exc))
+        return {}
+
+
+def _safe_bundle_rel_path(value: Any, context: str) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.replace("\\", "/")
+    posix_path = PurePosixPath(normalized)
+    windows_path = PureWindowsPath(value)
+    if posix_path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
+        return None
+    parts = [part for part in posix_path.parts if part not in ("", ".")]
+    if not parts or any(part == ".." for part in parts):
+        return None
+    try:
+        return Path(*parts)
+    except TypeError as exc:
+        raise SyncError(f"invalid path in {context}: {value}") from exc
+
+
+def _diag(result: SyncResult, key: str, message: str) -> None:
+    entries = result.diagnostics.setdefault(key, [])
+    if message not in entries:
+        entries.append(message)
+
+
+def _bundle_rel(prefix: str, rel_path: str) -> str:
+    return f"{prefix}/{rel_path}" if prefix else rel_path
+
+
+def _is_valid_profile_name(name: str) -> bool:
+    return bool(_PROFILE_NAME_RE.match(name)) and name != "default"
+
+
+def normalize_device_id(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip()).strip("-").lower()
+    if not slug:
+        raise SyncError("device id cannot be empty")
+    if len(slug) > 80:
+        slug = slug[:80].rstrip("-_")
+    return slug
+
+
+def default_device_id(hermes_home: Path) -> str:
+    host = platform.node() or "device"
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", host.lower()).strip("-") or "device"
+    digest = hashlib.sha256(str(hermes_home.expanduser().resolve()).encode("utf-8")).hexdigest()[:8]
+    return f"{slug}-{digest}"
+
+
+def is_forbidden_sync_path(rel_path: Path) -> bool:
+    parts = rel_path.parts
+    if any(part in _FORBIDDEN_DIRS for part in parts):
+        return True
+    name = rel_path.name
+    if name in _FORBIDDEN_NAMES:
+        return True
+    if name.endswith(_FORBIDDEN_SUFFIXES):
+        return True
+    if name.endswith((".history", "_history")) and "shell" in name:
+        return True
+    return False
+
+
+def _split_portable_value(
+    value: Any,
+    path: tuple[str, ...],
+    warnings: list[str],
+) -> tuple[Any, Any]:
+    if _is_secret_key(path[-1]):
+        warnings.append(f"Skipped config.{'.'.join(path)}: secret-like key")
+        return _MISSING, _MISSING
+    if _is_secret_scalar(value):
+        warnings.append(f"Skipped config.{'.'.join(path)}: secret-like value")
+        return _MISSING, _MISSING
+    if _is_device_config_path(path, value):
+        scrubbed = _scrub_export_value(value, path, warnings)
+        return _MISSING, scrubbed
+    if isinstance(value, dict):
+        p_map: dict[str, Any] = {}
+        d_map: dict[str, Any] = {}
+        for child_key, child_value in value.items():
+            p_child, d_child = _split_portable_value(
+                child_value, path + (str(child_key),), warnings
+            )
+            if p_child is not _MISSING:
+                p_map[child_key] = p_child
+            if d_child is not _MISSING:
+                d_map[child_key] = d_child
+        return (p_map if p_map else _MISSING, d_map if d_map else _MISSING)
+    if isinstance(value, list):
+        clean = []
+        for idx, item in enumerate(value):
+            scrubbed = _scrub_export_value(item, path + (str(idx),), warnings)
+            if scrubbed is not _MISSING:
+                clean.append(scrubbed)
+        return (clean, _MISSING)
+    return value, _MISSING
+
+
+def _scrub_export_value(value: Any, path: tuple[str, ...], warnings: list[str]) -> Any:
+    if _is_secret_key(path[-1]):
+        warnings.append(f"Skipped config.{'.'.join(path)}: secret-like key")
+        return _MISSING
+    if _is_secret_scalar(value):
+        warnings.append(f"Skipped config.{'.'.join(path)}: secret-like value")
+        return _MISSING
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, child in value.items():
+            scrubbed = _scrub_export_value(child, path + (str(key),), warnings)
+            if scrubbed is not _MISSING:
+                out[key] = scrubbed
+        return out
+    if isinstance(value, list):
+        out_list = []
+        for idx, child in enumerate(value):
+            scrubbed = _scrub_export_value(child, path + (str(idx),), warnings)
+            if scrubbed is not _MISSING:
+                out_list.append(scrubbed)
+        return out_list
+    return value
+
+
+def _is_device_config_path(path: tuple[str, ...], value: Any) -> bool:
+    if path in _DEVICE_CONFIG_PATHS:
+        return True
+    key = path[-1].lower()
+    if key in {"cwd", "path", "paths", "dir", "directory", "file", "files"}:
+        return True
+    if key.endswith(("_path", "_dir", "_file")):
+        return True
+    if isinstance(value, str):
+        expanded = os.path.expanduser(os.path.expandvars(value))
+        if os.path.isabs(expanded):
+            return True
+        lower = value.lower()
+        if lower.startswith(("http://localhost", "https://localhost", "http://127.", "https://127.")):
+            return True
+    return False
+
+
+def _is_secret_key(key: str) -> bool:
+    if key.lower() in {
+        "key_env",
+        "requires_env",
+        "env_passthrough",
+        "credential_pool_strategies",
+    }:
+        return False
+    return bool(_SECRET_KEY_RE.search(key))
+
+
+def _is_secret_scalar(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS)
+
+
+def _file_contains_secret(path: Path) -> bool:
+    try:
+        if path.stat().st_size > 2_000_000:
+            return False
+        content = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return _is_secret_scalar(content)
+
+
+def _compose_remote_config(source_dir: Path, device_id: str) -> dict[str, Any]:
+    global_cfg = _read_yaml_file(source_dir / "config" / "global.yaml", required=False)
+    device_cfg = _read_yaml_file(
+        source_dir / "config" / "devices" / f"{device_id}.yaml",
+        required=False,
+    )
+    return _deep_merge_dicts(global_cfg, device_cfg)
+
+
+def _deep_merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _extract_local_memory_entries(
+    hermes_home: Path,
+    device_id: str,
+    warnings: list[str],
+) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    for filename, target in (("MEMORY.md", "memory"), ("USER.md", "user")):
+        path = hermes_home / "memories" / filename
+        if not path.is_file():
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            warnings.append(f"Skipped memories/{filename}: {exc}")
+            continue
+        for raw_line in lines:
+            content = raw_line.strip()
+            if not content or content.startswith("#"):
+                continue
+            if _is_secret_scalar(content):
+                warnings.append(f"Skipped memories/{filename} entry: secret-like value")
+                continue
+            entry_id = _memory_id(target, content)
+            entries[entry_id] = {
+                "id": entry_id,
+                "target": target,
+                "content": content,
+                "source_device": device_id,
+                "created_at": MEMORY_CREATED_AT,
+                "updated_at": "",
+                "deleted": False,
+            }
+    return entries
+
+
+def _memory_id(target: str, content: str) -> str:
+    digest = hashlib.sha256(f"{target}\0{content}".encode("utf-8")).hexdigest()[:24]
+    return f"mem_{digest}"
+
+
+def _load_memory_entries(path: Path) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    if not path.is_file():
+        return entries
+    with path.open(encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SyncError(f"invalid memory JSONL at {path}:{line_no}: {exc}") from exc
+            if not isinstance(entry, dict):
+                raise SyncError(f"invalid memory entry at {path}:{line_no}: expected object")
+            entry_id = str(entry.get("id") or "")
+            target = entry.get("target")
+            content = entry.get("content")
+            if not entry_id or target not in {"memory", "user"} or not isinstance(content, str):
+                raise SyncError(f"invalid memory entry at {path}:{line_no}: missing id/target/content")
+            entries[entry_id] = entry
+    return entries
+
+
+def _write_memory_entries(path: Path, entries: dict[str, dict[str, Any]]) -> None:
+    lines = [
+        json.dumps(entries[key], sort_keys=True, ensure_ascii=False)
+        for key in sorted(entries)
+        if not entries[key].get("deleted")
+    ]
+    _atomic_text_write(path, "\n".join(lines) + ("\n" if lines else ""))
+
+
+def _render_memory_entries(entries: dict[str, dict[str, Any]]) -> dict[Path, str]:
+    by_target = {"memory": [], "user": []}
+    for key in sorted(entries):
+        entry = entries[key]
+        if entry.get("deleted"):
+            continue
+        target = entry.get("target")
+        content = str(entry.get("content", "")).strip()
+        if target in by_target and content:
+            by_target[target].append(content)
+
+    rendered: dict[Path, str] = {}
+    if by_target["memory"]:
+        rendered[Path("memories/MEMORY.md")] = "# Memory\n\n" + "\n".join(by_target["memory"]) + "\n"
+    if by_target["user"]:
+        rendered[Path("memories/USER.md")] = "# User Profile\n\n" + "\n".join(by_target["user"]) + "\n"
+    return rendered
+
+
+def _export_tree(
+    src_root: Path,
+    dst_root: Path,
+    warnings: list[str],
+    *,
+    skip_dirs: frozenset[str],
+) -> list[dict[str, str]]:
+    if dst_root.exists():
+        shutil.rmtree(dst_root)
+    manifest: list[dict[str, str]] = []
+    if not src_root.is_dir():
+        return manifest
+
+    for dirpath, dirnames, filenames in os.walk(src_root, followlinks=False):
+        dirnames[:] = [name for name in dirnames if name not in skip_dirs]
+        base = Path(dirpath)
+        for filename in filenames:
+            src = base / filename
+            rel = src.relative_to(src_root)
+            if src.is_symlink():
+                warnings.append(f"Skipped {src_root.name}/{rel.as_posix()}: symlink")
+                continue
+            if is_forbidden_sync_path(rel):
+                warnings.append(f"Skipped {src_root.name}/{rel.as_posix()}: forbidden path")
+                continue
+            if _file_contains_secret(src):
+                warnings.append(f"Skipped {src_root.name}/{rel.as_posix()}: secret-like content")
+                continue
+            dst = dst_root / rel
+            _copy_file(src, dst)
+            manifest.append({"path": rel.as_posix(), "sha256": _sha256_file(src)})
+    return sorted(manifest, key=lambda item: item["path"])
+
+
+def _queue_tree_import(
+    result: SyncResult,
+    src_root: Path,
+    dst_root: Path,
+    *,
+    hermes_home: Path,
+    skip_names: set[str] | None = None,
+) -> None:
+    if not src_root.is_dir():
+        return
+    skip_names = skip_names or set()
+    for src in _iter_files(src_root):
+        rel = src.relative_to(src_root)
+        if src.name in skip_names or is_forbidden_sync_path(rel):
+            continue
+        _queue_bytes_write(result, src, dst_root / rel, hermes_home=hermes_home)
+
+
+def _queue_yaml_write(
+    result: SyncResult,
+    target: Path,
+    data: dict[str, Any],
+    *,
+    hermes_home: Path,
+) -> None:
+    text = yaml.safe_dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True)
+    _queue_text_write(result, target, text, hermes_home=hermes_home)
+
+
+def _queue_text_or_conflict(
+    result: SyncResult,
+    *,
+    source: Path,
+    target: Path,
+    hermes_home: Path,
+    conflict_suffix: str,
+) -> None:
+    remote = source.read_text(encoding="utf-8")
+    if not target.exists():
+        _queue_text_write(result, target, remote, hermes_home=hermes_home)
+        return
+    local = target.read_text(encoding="utf-8", errors="ignore")
+    if local == remote:
+        return
+    digest = hashlib.sha256(remote.encode("utf-8")).hexdigest()[:8]
+    conflict_target = target.with_name(f"{target.name}{conflict_suffix}-{digest}")
+    _queue_text_write(
+        result,
+        conflict_target,
+        remote,
+        hermes_home=hermes_home,
+        action="write_conflict",
+        source=str(source),
+    )
+    result.warnings.append(
+        f"Conflict for {_display_local_path(target, hermes_home)}; wrote remote copy to "
+        f"{_display_local_path(conflict_target, hermes_home)}"
+    )
+
+
+def _queue_text_write(
+    result: SyncResult,
+    target: Path,
+    text: str,
+    *,
+    hermes_home: Path,
+    action: str = "write",
+    source: str | None = None,
+) -> None:
+    old = None
+    if target.exists():
+        old = target.read_text(encoding="utf-8", errors="ignore")
+    if old == text:
+        return
+    result.plan.append(
+        {
+            "action": action,
+            "target": _display_local_path(target, hermes_home),
+            "source": source,
+            "bytes": len(text.encode("utf-8")),
+            "_kind": "text",
+            "_target": str(target),
+            "_content": text,
+        }
+    )
+
+
+def _queue_bytes_write(
+    result: SyncResult,
+    source: Path,
+    target: Path,
+    *,
+    hermes_home: Path,
+) -> None:
+    new_bytes = source.read_bytes()
+    if target.exists() and target.read_bytes() == new_bytes:
+        return
+    result.plan.append(
+        {
+            "action": "write",
+            "target": _display_local_path(target, hermes_home),
+            "source": str(source),
+            "bytes": len(new_bytes),
+            "_kind": "bytes",
+            "_target": str(target),
+            "_source": str(source),
+        }
+    )
+
+
+def _apply_plan(result: SyncResult) -> None:
+    for op in result.plan:
+        target = Path(op["_target"])
+        if op["_kind"] == "text":
+            _atomic_text_write(target, op["_content"])
+        elif op["_kind"] == "bytes":
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(op["_source"], target)
+        result.files_written.append(op["target"])
+
+
+def _display_local_path(path: Path, hermes_home: Path) -> str:
+    try:
+        return path.relative_to(hermes_home).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _read_yaml_file(path: Path, *, required: bool) -> dict[str, Any]:
+    if not path.exists():
+        if required:
+            raise SyncError(f"missing required file: {path}")
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise SyncError(f"invalid YAML in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SyncError(f"invalid YAML in {path}: expected mapping")
+    return data
+
+
+def _read_raw_config_from_home(hermes_home: Path) -> dict[str, Any]:
+    path = hermes_home / "config.yaml"
+    if not path.exists():
+        return {}
+    return _read_yaml_file(path, required=False)
+
+
+def _write_yaml_file(path: Path, data: dict[str, Any]) -> None:
+    atomic_yaml_write(path, data, sort_keys=False)
+
+
+def _copy_file(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def _iter_files(root: Path):
+    if not root.exists():
+        return
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [name for name in dirnames if name not in {".git", "__pycache__"}]
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if not path.is_symlink():
+                yield path
+
+
+def _iter_files_for_validation(root: Path):
+    if not root.exists():
+        return
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [name for name in dirnames if name not in {".git", "__pycache__"}]
+        for filename in filenames:
+            yield Path(dirpath) / filename
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _atomic_text_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _print_export_result(result: SyncResult, *, bundle_label: str) -> None:
+    if result.ok:
+        print(f"Exported Hermes {bundle_label} to {result.repo}")
+    else:
+        print(f"Export failed for {result.repo}")
+    if result.files_written:
+        print("Files written:")
+        for path in result.files_written:
+            print(f"  {path}")
+    _print_warnings_errors(result)
+
+
+def _print_plan_result(
+    result: SyncResult,
+    *,
+    dry_run: bool,
+    bundle_label: str,
+) -> None:
+    label = "Import dry-run plan" if dry_run else "Import plan"
+    print(f"{label} for {bundle_label}:")
+    printable = _public_plan(result)
+    print(json.dumps(printable, indent=2, sort_keys=True))
+    if result.ok and not dry_run:
+        print(f"Applied {len(result.files_written)} file changes.")
+
+
+def _print_doctor_result(result: SyncResult, *, bundle_label: str) -> None:
+    title = bundle_label[:1].upper() + bundle_label[1:]
+    if result.ok:
+        print(f"{title} OK: {result.repo}")
+    else:
+        print(f"{title} invalid: {result.repo}")
+    _print_diagnostics(result)
+    _print_warnings_errors(result)
+
+
+def _print_warnings_errors(result: SyncResult) -> None:
+    if result.warnings:
+        print("Warnings:")
+        for warning in result.warnings:
+            print(f"  {warning}")
+    if result.errors:
+        print("Errors:", file=sys.stderr)
+        for error in result.errors:
+            print(f"  {error}", file=sys.stderr)
+
+
+def _print_diagnostics(result: SyncResult) -> None:
+    print("Diagnostics:")
+    labels = {
+        "migrated": "Migrated",
+        "skipped": "Skipped by design or absent",
+        "manual_reauth": "Needs manual re-authentication",
+        "possibly_incompatible": "May need review on this machine",
+    }
+    for key in _DIAGNOSTIC_KEYS:
+        entries = result.diagnostics.get(key) or []
+        print(f"  {labels[key]}:")
+        if not entries:
+            print("    - none")
+            continue
+        for entry in entries:
+            print(f"    - {entry}")
+
+
+def _public_plan(result: SyncResult) -> dict[str, Any]:
+    operations = []
+    for op in result.plan:
+        operations.append(
+            {
+                key: value
+                for key, value in op.items()
+                if not key.startswith("_") and value is not None
+            }
+        )
+    return {
+        "ok": result.ok,
+        "repo": str(result.repo),
+        "operations": operations,
+        "warnings": result.warnings,
+        "errors": result.errors,
+        "diagnostics": result.diagnostics,
+    }

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -132,7 +132,7 @@ _HERMES_SUBCOMMANDS = frozenset({
     "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
     "status", "cron", "doctor", "dump", "config", "pairing", "skills", "tools",
     "mcp", "sessions", "insights", "version", "update", "uninstall",
-    "profile", "plugins", "honcho", "acp",
+    "profile", "plugins", "honcho", "acp", "migrate",
 })
 
 

--- a/tests/hermes_cli/test_migrate.py
+++ b/tests/hermes_cli/test_migrate.py
@@ -1,0 +1,464 @@
+"""Tests for portable Hermes profile migration."""
+
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import yaml
+
+from hermes_cli.migration import (
+    MIGRATION_FORMAT,
+    doctor_sync_repo,
+    export_profile_sync,
+    import_profile_sync,
+    run_migrate,
+)
+
+
+def _write_legacy_sync_manifest(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "manifest.yaml").write_text(
+        "format: hermes-profile-sync\n"
+        "version: 1\n"
+        "created_at: '2026-04-29T00:00:00+00:00'\n"
+        "source_device: test-device\n",
+        encoding="utf-8",
+    )
+
+
+def _memory_entry(target: str, content: str) -> dict:
+    import hashlib
+
+    digest = hashlib.sha256(f"{target}\0{content}".encode("utf-8")).hexdigest()[:24]
+    return {
+        "id": f"mem_{digest}",
+        "target": target,
+        "content": content,
+        "source_device": "remote",
+        "created_at": "1970-01-01T00:00:00Z",
+        "updated_at": "",
+        "deleted": False,
+    }
+
+
+def _public_ops(result):
+    return [
+        {key: value for key, value in op.items() if not key.startswith("_")}
+        for op in result.plan
+    ]
+
+
+def test_export_writes_structured_repo_and_excludes_runtime_state(tmp_path):
+    home = tmp_path / "home"
+    repo = tmp_path / "sync-repo"
+    (home / "memories").mkdir(parents=True)
+    (home / "skills" / "my-skill").mkdir(parents=True)
+    (home / "skins").mkdir()
+    (home / "logs").mkdir()
+
+    (home / "config.yaml").write_text(
+        "model: openrouter/test-model\n"
+        "display:\n"
+        "  skin: slate\n"
+        "terminal:\n"
+        "  cwd: /home/amos/project\n"
+        "skills:\n"
+        "  template_vars: false\n"
+        "  external_dirs:\n"
+        "    - /shared/private-skills\n"
+        "providers:\n"
+        "  custom:\n"
+        "    base_url: https://models.example.test/v1\n"
+        "    api_key: sk-test-secret-value-1234567890\n"
+        "unknown_feature:\n"
+        "  enabled: true\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("OPENAI_API_KEY=sk-should-not-export\n", encoding="utf-8")
+    (home / "auth.json").write_text('{"access_token": "secret"}', encoding="utf-8")
+    (home / "state.db").write_bytes(b"sqlite")
+    (home / "logs" / "agent.log").write_text("log\n", encoding="utf-8")
+    (home / "SOUL.md").write_text("I prefer concise answers.\n", encoding="utf-8")
+    (home / "memories" / "MEMORY.md").write_text(
+        "# Memory\n- likes tea\nsk-secret-memory-value-123456789\n",
+        encoding="utf-8",
+    )
+    (home / "memories" / "USER.md").write_text("# User\n- uses vim\n", encoding="utf-8")
+    (home / "skills" / "my-skill" / "SKILL.md").write_text("# My Skill\n", encoding="utf-8")
+    (home / "skins" / "cyber.yaml").write_text("name: cyber\n", encoding="utf-8")
+
+    result = export_profile_sync(repo, hermes_home=home, device_id="Laptop 1")
+
+    assert result.ok
+    assert (repo / "manifest.yaml").exists()
+    assert (repo / "config" / "global.yaml").exists()
+    assert (repo / "config" / "devices" / "laptop-1.yaml").exists()
+    assert (repo / "soul" / "SOUL.md").read_text(encoding="utf-8") == "I prefer concise answers.\n"
+    assert (repo / "skills" / "files" / "my-skill" / "SKILL.md").exists()
+    assert (repo / "skins" / "cyber.yaml").exists()
+
+    global_cfg = yaml.safe_load((repo / "config" / "global.yaml").read_text(encoding="utf-8"))
+    device_cfg = yaml.safe_load(
+        (repo / "config" / "devices" / "laptop-1.yaml").read_text(encoding="utf-8")
+    )
+    assert global_cfg["model"] == "openrouter/test-model"
+    assert global_cfg["display"]["skin"] == "slate"
+    assert global_cfg["skills"]["template_vars"] is False
+    assert "external_dirs" not in global_cfg["skills"]
+    assert "terminal" not in global_cfg
+    assert "unknown_feature" not in global_cfg
+    assert "api_key" not in global_cfg["providers"]["custom"]
+    assert device_cfg["terminal"]["cwd"] == "/home/amos/project"
+    assert device_cfg["skills"]["external_dirs"] == ["/shared/private-skills"]
+
+    exported_paths = [p.relative_to(repo).as_posix() for p in repo.rglob("*") if p.is_file()]
+    assert ".env" not in exported_paths
+    assert "auth.json" not in exported_paths
+    assert "state.db" not in exported_paths
+    assert "logs/agent.log" not in exported_paths
+    exported_text = "\n".join(p.read_text(encoding="utf-8", errors="ignore") for p in repo.rglob("*") if p.is_file())
+    assert "sk-test-secret" not in exported_text
+    assert "sk-secret-memory" not in exported_text
+    assert any("unknown migration ownership" in warning for warning in result.warnings)
+    assert doctor_sync_repo(repo).ok
+
+
+def test_import_dry_run_does_not_write_and_actual_uses_same_plan(tmp_path):
+    home = tmp_path / "home"
+    repo = tmp_path / "sync-repo"
+    home.mkdir()
+    _write_legacy_sync_manifest(repo)
+    (repo / "config").mkdir()
+    (repo / "config" / "global.yaml").write_text(
+        "model: remote-model\n"
+        "display:\n"
+        "  skin: mono\n",
+        encoding="utf-8",
+    )
+    (repo / "soul").mkdir()
+    (repo / "soul" / "SOUL.md").write_text("remote soul\n", encoding="utf-8")
+
+    dry_run = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=True)
+
+    assert dry_run.ok
+    assert not (home / "config.yaml").exists()
+    assert not (home / "SOUL.md").exists()
+    assert {op["target"] for op in dry_run.plan} == {"config.yaml", "SOUL.md"}
+
+    actual = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+
+    assert actual.ok
+    assert _public_ops(actual) == _public_ops(dry_run)
+    assert yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))["model"] == "remote-model"
+    assert (home / "SOUL.md").read_text(encoding="utf-8") == "remote soul\n"
+
+
+def test_import_merges_remote_and_local_memory_entries(tmp_path):
+    home = tmp_path / "home"
+    repo = tmp_path / "sync-repo"
+    (home / "memories").mkdir(parents=True)
+    _write_legacy_sync_manifest(repo)
+    (repo / "memory").mkdir()
+    (repo / "memory" / "entries.jsonl").write_text(
+        json.dumps(_memory_entry("memory", "- remote memory"), sort_keys=True) + "\n"
+        + json.dumps(_memory_entry("user", "- remote user"), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (home / "memories" / "MEMORY.md").write_text("# Memory\n- local memory\n", encoding="utf-8")
+
+    result = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+
+    assert result.ok
+    memory_text = (home / "memories" / "MEMORY.md").read_text(encoding="utf-8")
+    user_text = (home / "memories" / "USER.md").read_text(encoding="utf-8")
+    assert "- local memory" in memory_text
+    assert "- remote memory" in memory_text
+    assert "- remote user" in user_text
+
+
+def test_import_keeps_local_soul_and_writes_conflict_file(tmp_path):
+    home = tmp_path / "home"
+    repo = tmp_path / "sync-repo"
+    home.mkdir()
+    _write_legacy_sync_manifest(repo)
+    (repo / "soul").mkdir()
+    (repo / "soul" / "SOUL.md").write_text("remote soul\n", encoding="utf-8")
+    (home / "SOUL.md").write_text("local soul\n", encoding="utf-8")
+
+    result = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+
+    assert result.ok
+    assert (home / "SOUL.md").read_text(encoding="utf-8") == "local soul\n"
+    conflicts = list(home.glob("SOUL.md.sync-conflict-*"))
+    assert len(conflicts) == 1
+    assert conflicts[0].read_text(encoding="utf-8") == "remote soul\n"
+    assert any("Conflict for SOUL.md" in warning for warning in result.warnings)
+
+
+def test_import_applies_matching_device_config_without_overwriting_other_device(tmp_path):
+    home = tmp_path / "home"
+    repo = tmp_path / "sync-repo"
+    home.mkdir()
+    _write_legacy_sync_manifest(repo)
+    (repo / "config" / "devices").mkdir(parents=True)
+    (repo / "config" / "global.yaml").write_text(
+        "display:\n"
+        "  skin: slate\n",
+        encoding="utf-8",
+    )
+    (repo / "config" / "devices" / "other.yaml").write_text(
+        "terminal:\n"
+        "  cwd: /other/device\n",
+        encoding="utf-8",
+    )
+    (repo / "config" / "devices" / "laptop.yaml").write_text(
+        "terminal:\n"
+        "  cwd: /this/device\n",
+        encoding="utf-8",
+    )
+
+    result = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+
+    assert result.ok
+    config = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert config["display"]["skin"] == "slate"
+    assert config["terminal"]["cwd"] == "/this/device"
+
+
+def test_doctor_rejects_malformed_manifest_forbidden_paths_and_plaintext_secrets(tmp_path):
+    repo = tmp_path / "sync-repo"
+    repo.mkdir()
+    (repo / "manifest.yaml").write_text("format: wrong\nversion: 1\n", encoding="utf-8")
+
+    result = doctor_sync_repo(repo)
+
+    assert not result.ok
+    assert any("invalid or missing format" in error for error in result.errors)
+
+    (repo / "manifest.yaml").write_text("format: hermes-profile-sync\nversion: 1\n", encoding="utf-8")
+    (repo / "state.db").write_bytes(b"sqlite")
+    (repo / "skills").mkdir()
+    (repo / "skills" / "leak.txt").write_text("sk-live-secret-value-1234567890\n", encoding="utf-8")
+
+    result = doctor_sync_repo(repo)
+
+    assert not result.ok
+    assert any("forbidden path" in error and "state.db" in error for error in result.errors)
+    assert any("plaintext secret-like" in error and "skills/leak.txt" in error for error in result.errors)
+
+
+def test_migrate_verify_and_doctor_accept_legacy_sync_manifest(tmp_path, capsys):
+    repo = tmp_path / "migration-bundle"
+    _write_legacy_sync_manifest(repo)
+
+    run_migrate(SimpleNamespace(migrate_action="verify", repo=str(repo)))
+    verify_output = capsys.readouterr().out
+
+    run_migrate(SimpleNamespace(migrate_action="doctor", repo=str(repo)))
+    doctor_output = capsys.readouterr().out
+
+    assert "Migration bundle OK" in verify_output
+    assert "Diagnostics:" in verify_output
+    assert "Migration bundle OK" in doctor_output
+    assert "Needs manual re-authentication" in doctor_output
+
+
+def test_migrate_cli_subcommands_are_registered():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "migrate", "export", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0
+    assert "--out" in result.stdout
+    assert "migration bundle" in result.stdout.lower()
+
+
+def test_migrate_export_writes_migration_manifest_and_excludes_unsafe_files(
+    tmp_path,
+    monkeypatch,
+):
+    source_home = tmp_path / "source-home"
+    bundle = tmp_path / "migration-bundle"
+    (source_home / "skills" / "portable").mkdir(parents=True)
+    (source_home / "cache").mkdir()
+
+    (source_home / "config.yaml").write_text(
+        "model: openrouter/test-model\n"
+        "providers:\n"
+        "  custom:\n"
+        "    api_key: sk-test-secret-value-1234567890\n",
+        encoding="utf-8",
+    )
+    (source_home / ".env").write_text("OPENAI_API_KEY=sk-should-not-export\n", encoding="utf-8")
+    (source_home / "state.db").write_bytes(b"sqlite")
+    (source_home / "gateway.pid").write_text("123\n", encoding="utf-8")
+    (source_home / "auth.lock").write_text("locked\n", encoding="utf-8")
+    (source_home / "cache" / "tmp.txt").write_text("cache\n", encoding="utf-8")
+    (source_home / "skills" / "portable" / "SKILL.md").write_text("# Portable\n", encoding="utf-8")
+    (source_home / "skills" / "portable" / "runtime.sock").write_text("sock\n", encoding="utf-8")
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: source_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="export",
+            out=str(bundle),
+            device_id="laptop",
+        )
+    )
+
+    manifest = yaml.safe_load((bundle / "manifest.yaml").read_text(encoding="utf-8"))
+    exported_paths = [p.relative_to(bundle).as_posix() for p in bundle.rglob("*") if p.is_file()]
+    exported_text = "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore")
+        for p in bundle.rglob("*")
+        if p.is_file()
+    )
+
+    assert manifest["format"] == MIGRATION_FORMAT
+    assert ".env" not in exported_paths
+    assert "state.db" not in exported_paths
+    assert "gateway.pid" not in exported_paths
+    assert "auth.lock" not in exported_paths
+    assert "cache/tmp.txt" not in exported_paths
+    assert "skills/files/portable/runtime.sock" not in exported_paths
+    assert "sk-test-secret" not in exported_text
+    assert "sk-should-not-export" not in exported_text
+
+
+def test_migrate_export_import_round_trip_uses_portable_bundle(tmp_path, monkeypatch):
+    source_home = tmp_path / "source-home"
+    target_home = tmp_path / "target-home"
+    bundle = tmp_path / "migration-bundle"
+    source_home.mkdir()
+    target_home.mkdir()
+
+    (source_home / "config.yaml").write_text(
+        "model: openrouter/test-model\n"
+        "terminal:\n"
+        "  cwd: /source/local/path\n",
+        encoding="utf-8",
+    )
+    (source_home / "SOUL.md").write_text("portable soul\n", encoding="utf-8")
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: source_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="export",
+            out=str(bundle),
+            device_id="laptop",
+        )
+    )
+    assert (bundle / "manifest.yaml").exists()
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: target_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="import",
+            source_dir=str(bundle),
+            dry_run=False,
+            device_id="laptop",
+        )
+    )
+
+    target_config = yaml.safe_load((target_home / "config.yaml").read_text(encoding="utf-8"))
+    assert target_config["model"] == "openrouter/test-model"
+    assert target_config["terminal"]["cwd"] == "/source/local/path"
+    assert (target_home / "SOUL.md").read_text(encoding="utf-8") == "portable soul\n"
+
+
+def test_migrate_export_import_includes_named_profiles(tmp_path, monkeypatch):
+    source_home = tmp_path / "source-home"
+    target_home = tmp_path / "target-home"
+    bundle = tmp_path / "migration-bundle"
+    profile_home = source_home / "profiles" / "coder"
+    (profile_home / "memories").mkdir(parents=True)
+    target_home.mkdir()
+
+    (source_home / "config.yaml").write_text("model: root-model\n", encoding="utf-8")
+    (profile_home / "config.yaml").write_text("model: profile-model\n", encoding="utf-8")
+    (profile_home / "SOUL.md").write_text("profile soul\n", encoding="utf-8")
+    (profile_home / "memories" / "MEMORY.md").write_text("# Memory\n- profile memory\n", encoding="utf-8")
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: source_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="export",
+            out=str(bundle),
+            device_id="laptop",
+        )
+    )
+
+    manifest = yaml.safe_load((bundle / "manifest.yaml").read_text(encoding="utf-8"))
+    assert manifest["profiles"] == ["coder"]
+    assert (bundle / "profiles" / "coder" / "soul" / "SOUL.md").exists()
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: target_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="import",
+            source_dir=str(bundle),
+            dry_run=False,
+            device_id="laptop",
+        )
+    )
+
+    imported_profile = target_home / "profiles" / "coder"
+    assert yaml.safe_load((imported_profile / "config.yaml").read_text(encoding="utf-8"))["model"] == "profile-model"
+    assert (imported_profile / "SOUL.md").read_text(encoding="utf-8") == "profile soul\n"
+    assert "- profile memory" in (imported_profile / "memories" / "MEMORY.md").read_text(encoding="utf-8")
+
+
+def test_migrate_doctor_outputs_structured_diagnostics(tmp_path, capsys):
+    repo = tmp_path / "migration-bundle"
+    _write_legacy_sync_manifest(repo)
+    (repo / "config" / "global.yaml").parent.mkdir(parents=True)
+    (repo / "config" / "global.yaml").write_text("model: remote-model\n", encoding="utf-8")
+    (repo / "memory").mkdir()
+    (repo / "memory" / "entries.jsonl").write_text(
+        json.dumps(_memory_entry("memory", "- remote memory"), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    run_migrate(SimpleNamespace(migrate_action="doctor", repo=str(repo)))
+    output = capsys.readouterr().out
+
+    assert "Diagnostics:" in output
+    assert "Migrated:" in output
+    assert "Portable config for active profile" in output
+    assert "Skipped by design or absent:" in output
+    assert "Needs manual re-authentication:" in output
+    assert ".env, auth.json, state.db" in output
+
+
+def test_migrate_verify_errors_are_clear_for_missing_or_bad_bundle(tmp_path, capsys):
+    missing = tmp_path / "missing"
+
+    try:
+        run_migrate(SimpleNamespace(migrate_action="verify", repo=str(missing)))
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("missing migration bundle should fail verification")
+
+    captured = capsys.readouterr()
+    assert "migration bundle does not exist" in captured.err
+
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "manifest.yaml").write_text("format: hermes-profile-migration\nversion: 1\n", encoding="utf-8")
+    (bad / "skills" / "files").mkdir(parents=True)
+
+    try:
+        run_migrate(SimpleNamespace(migrate_action="verify", repo=str(bad)))
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("malformed migration bundle should fail verification")
+
+    captured = capsys.readouterr()
+    assert "skills/files exists without skills/manifest.yaml" in captured.err

--- a/tests/hermes_cli/test_migrate.py
+++ b/tests/hermes_cli/test_migrate.py
@@ -6,13 +6,15 @@ import sys
 from types import SimpleNamespace
 from pathlib import Path
 
+import pytest
 import yaml
 
 from hermes_cli.migration import (
     MIGRATION_FORMAT,
-    doctor_sync_repo,
-    export_profile_sync,
-    import_profile_sync,
+    MigrationError,
+    doctor_migration_bundle,
+    export_migration_bundle,
+    import_migration_bundle,
     run_migrate,
 )
 
@@ -24,6 +26,18 @@ def _write_legacy_sync_manifest(repo: Path) -> None:
         "version: 1\n"
         "created_at: '2026-04-29T00:00:00+00:00'\n"
         "source_device: test-device\n",
+        encoding="utf-8",
+    )
+
+
+def _write_migration_manifest(bundle: Path) -> None:
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "manifest.yaml").write_text(
+        "format: hermes-profile-migration\n"
+        "version: 1\n"
+        "created_at: '2026-04-29T00:00:00+00:00'\n"
+        "source_device: test-device\n"
+        "profiles: []\n",
         encoding="utf-8",
     )
 
@@ -50,9 +64,17 @@ def _public_ops(result):
     ]
 
 
-def test_export_writes_structured_repo_and_excludes_runtime_state(tmp_path):
+def _assert_verify_and_doctor_fail(bundle: Path, capsys) -> None:
+    for action in ("verify", "doctor"):
+        with pytest.raises(SystemExit) as exc:
+            run_migrate(SimpleNamespace(migrate_action=action, repo=str(bundle)))
+        assert exc.value.code == 1
+        capsys.readouterr()
+
+
+def test_export_writes_structured_bundle_and_excludes_runtime_state(tmp_path):
     home = tmp_path / "home"
-    repo = tmp_path / "sync-repo"
+    repo = tmp_path / "migration-bundle"
     (home / "memories").mkdir(parents=True)
     (home / "skills" / "my-skill").mkdir(parents=True)
     (home / "skins").mkdir()
@@ -89,7 +111,7 @@ def test_export_writes_structured_repo_and_excludes_runtime_state(tmp_path):
     (home / "skills" / "my-skill" / "SKILL.md").write_text("# My Skill\n", encoding="utf-8")
     (home / "skins" / "cyber.yaml").write_text("name: cyber\n", encoding="utf-8")
 
-    result = export_profile_sync(repo, hermes_home=home, device_id="Laptop 1")
+    result = export_migration_bundle(repo, hermes_home=home, device_id="Laptop 1")
 
     assert result.ok
     assert (repo / "manifest.yaml").exists()
@@ -122,12 +144,12 @@ def test_export_writes_structured_repo_and_excludes_runtime_state(tmp_path):
     assert "sk-test-secret" not in exported_text
     assert "sk-secret-memory" not in exported_text
     assert any("unknown migration ownership" in warning for warning in result.warnings)
-    assert doctor_sync_repo(repo).ok
+    assert doctor_migration_bundle(repo).ok
 
 
 def test_import_dry_run_does_not_write_and_actual_uses_same_plan(tmp_path):
     home = tmp_path / "home"
-    repo = tmp_path / "sync-repo"
+    repo = tmp_path / "migration-bundle"
     home.mkdir()
     _write_legacy_sync_manifest(repo)
     (repo / "config").mkdir()
@@ -140,14 +162,14 @@ def test_import_dry_run_does_not_write_and_actual_uses_same_plan(tmp_path):
     (repo / "soul").mkdir()
     (repo / "soul" / "SOUL.md").write_text("remote soul\n", encoding="utf-8")
 
-    dry_run = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=True)
+    dry_run = import_migration_bundle(repo, hermes_home=home, device_id="laptop", dry_run=True)
 
     assert dry_run.ok
     assert not (home / "config.yaml").exists()
     assert not (home / "SOUL.md").exists()
     assert {op["target"] for op in dry_run.plan} == {"config.yaml", "SOUL.md"}
 
-    actual = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+    actual = import_migration_bundle(repo, hermes_home=home, device_id="laptop", dry_run=False)
 
     assert actual.ok
     assert _public_ops(actual) == _public_ops(dry_run)
@@ -157,7 +179,7 @@ def test_import_dry_run_does_not_write_and_actual_uses_same_plan(tmp_path):
 
 def test_import_merges_remote_and_local_memory_entries(tmp_path):
     home = tmp_path / "home"
-    repo = tmp_path / "sync-repo"
+    repo = tmp_path / "migration-bundle"
     (home / "memories").mkdir(parents=True)
     _write_legacy_sync_manifest(repo)
     (repo / "memory").mkdir()
@@ -168,7 +190,7 @@ def test_import_merges_remote_and_local_memory_entries(tmp_path):
     )
     (home / "memories" / "MEMORY.md").write_text("# Memory\n- local memory\n", encoding="utf-8")
 
-    result = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+    result = import_migration_bundle(repo, hermes_home=home, device_id="laptop", dry_run=False)
 
     assert result.ok
     memory_text = (home / "memories" / "MEMORY.md").read_text(encoding="utf-8")
@@ -180,18 +202,18 @@ def test_import_merges_remote_and_local_memory_entries(tmp_path):
 
 def test_import_keeps_local_soul_and_writes_conflict_file(tmp_path):
     home = tmp_path / "home"
-    repo = tmp_path / "sync-repo"
+    repo = tmp_path / "migration-bundle"
     home.mkdir()
     _write_legacy_sync_manifest(repo)
     (repo / "soul").mkdir()
     (repo / "soul" / "SOUL.md").write_text("remote soul\n", encoding="utf-8")
     (home / "SOUL.md").write_text("local soul\n", encoding="utf-8")
 
-    result = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+    result = import_migration_bundle(repo, hermes_home=home, device_id="laptop", dry_run=False)
 
     assert result.ok
     assert (home / "SOUL.md").read_text(encoding="utf-8") == "local soul\n"
-    conflicts = list(home.glob("SOUL.md.sync-conflict-*"))
+    conflicts = list(home.glob("SOUL.md.migration-conflict-*"))
     assert len(conflicts) == 1
     assert conflicts[0].read_text(encoding="utf-8") == "remote soul\n"
     assert any("Conflict for SOUL.md" in warning for warning in result.warnings)
@@ -199,7 +221,7 @@ def test_import_keeps_local_soul_and_writes_conflict_file(tmp_path):
 
 def test_import_applies_matching_device_config_without_overwriting_other_device(tmp_path):
     home = tmp_path / "home"
-    repo = tmp_path / "sync-repo"
+    repo = tmp_path / "migration-bundle"
     home.mkdir()
     _write_legacy_sync_manifest(repo)
     (repo / "config" / "devices").mkdir(parents=True)
@@ -219,7 +241,7 @@ def test_import_applies_matching_device_config_without_overwriting_other_device(
         encoding="utf-8",
     )
 
-    result = import_profile_sync(repo, hermes_home=home, device_id="laptop", dry_run=False)
+    result = import_migration_bundle(repo, hermes_home=home, device_id="laptop", dry_run=False)
 
     assert result.ok
     config = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
@@ -228,11 +250,11 @@ def test_import_applies_matching_device_config_without_overwriting_other_device(
 
 
 def test_doctor_rejects_malformed_manifest_forbidden_paths_and_plaintext_secrets(tmp_path):
-    repo = tmp_path / "sync-repo"
+    repo = tmp_path / "migration-bundle"
     repo.mkdir()
     (repo / "manifest.yaml").write_text("format: wrong\nversion: 1\n", encoding="utf-8")
 
-    result = doctor_sync_repo(repo)
+    result = doctor_migration_bundle(repo)
 
     assert not result.ok
     assert any("invalid or missing format" in error for error in result.errors)
@@ -242,7 +264,7 @@ def test_doctor_rejects_malformed_manifest_forbidden_paths_and_plaintext_secrets
     (repo / "skills").mkdir()
     (repo / "skills" / "leak.txt").write_text("sk-live-secret-value-1234567890\n", encoding="utf-8")
 
-    result = doctor_sync_repo(repo)
+    result = doctor_migration_bundle(repo)
 
     assert not result.ok
     assert any("forbidden path" in error and "state.db" in error for error in result.errors)
@@ -259,10 +281,11 @@ def test_migrate_verify_and_doctor_accept_legacy_sync_manifest(tmp_path, capsys)
     run_migrate(SimpleNamespace(migrate_action="doctor", repo=str(repo)))
     doctor_output = capsys.readouterr().out
 
-    assert "Migration bundle OK" in verify_output
-    assert "Diagnostics:" in verify_output
+    assert "Migration bundle verified" in verify_output
+    assert "Diagnostics:" not in verify_output
     assert "Migration bundle OK" in doctor_output
     assert "Needs manual re-authentication" in doctor_output
+    assert verify_output != doctor_output
 
 
 def test_migrate_cli_subcommands_are_registered():
@@ -275,6 +298,7 @@ def test_migrate_cli_subcommands_are_registered():
 
     assert result.returncode == 0
     assert "--out" in result.stdout
+    assert "--force" in result.stdout
     assert "migration bundle" in result.stdout.lower()
 
 
@@ -330,6 +354,44 @@ def test_migrate_export_writes_migration_manifest_and_excludes_unsafe_files(
     assert "sk-should-not-export" not in exported_text
 
 
+def test_export_to_non_empty_directory_fails_without_force(tmp_path):
+    home = tmp_path / "home"
+    bundle = tmp_path / "migration-bundle"
+    home.mkdir()
+    bundle.mkdir()
+    (bundle / "old.txt").write_text("old\n", encoding="utf-8")
+
+    with pytest.raises(MigrationError, match="choose an empty directory.*--force"):
+        export_migration_bundle(bundle, hermes_home=home, device_id="laptop")
+
+
+def test_export_force_clears_existing_bundle_and_does_not_merge_old_memory(tmp_path):
+    home = tmp_path / "home"
+    bundle = tmp_path / "migration-bundle"
+    (home / "memories").mkdir(parents=True)
+    (bundle / "memory").mkdir(parents=True)
+    (bundle / "old").mkdir()
+    (bundle / "old" / "stale.txt").write_text("stale\n", encoding="utf-8")
+    (bundle / "memory" / "entries.jsonl").write_text(
+        json.dumps(_memory_entry("memory", "- stale memory"), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (home / "memories" / "MEMORY.md").write_text("# Memory\n- fresh memory\n", encoding="utf-8")
+
+    result = export_migration_bundle(
+        bundle,
+        hermes_home=home,
+        device_id="laptop",
+        force=True,
+    )
+
+    assert result.ok
+    assert not (bundle / "old" / "stale.txt").exists()
+    entries_text = (bundle / "memory" / "entries.jsonl").read_text(encoding="utf-8")
+    assert "- fresh memory" in entries_text
+    assert "- stale memory" not in entries_text
+
+
 def test_migrate_export_import_round_trip_uses_portable_bundle(tmp_path, monkeypatch):
     source_home = tmp_path / "source-home"
     target_home = tmp_path / "target-home"
@@ -369,6 +431,42 @@ def test_migrate_export_import_round_trip_uses_portable_bundle(tmp_path, monkeyp
     assert target_config["model"] == "openrouter/test-model"
     assert target_config["terminal"]["cwd"] == "/source/local/path"
     assert (target_home / "SOUL.md").read_text(encoding="utf-8") == "portable soul\n"
+
+
+def test_migrate_import_warns_when_bundle_contains_skills(tmp_path, monkeypatch, capsys):
+    source_home = tmp_path / "source-home"
+    target_home = tmp_path / "target-home"
+    bundle = tmp_path / "migration-bundle"
+    (source_home / "skills" / "trusted").mkdir(parents=True)
+    target_home.mkdir()
+    (source_home / "skills" / "trusted" / "SKILL.md").write_text("# Trusted\n", encoding="utf-8")
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: source_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="export",
+            out=str(bundle),
+            device_id="laptop",
+            force=False,
+        )
+    )
+    capsys.readouterr()
+
+    monkeypatch.setattr("hermes_cli.migration.get_hermes_home", lambda: target_home)
+    run_migrate(
+        SimpleNamespace(
+            migrate_action="import",
+            source_dir=str(bundle),
+            dry_run=True,
+            device_id="laptop",
+        )
+    )
+    output = capsys.readouterr().out
+
+    assert "may modify local skills and agent behavior" in output
+    assert "Only import bundles you created yourself or trust" in output
+    assert "Secrets are not migrated" in output
+    assert "re-authenticate" in output
 
 
 def test_migrate_export_import_includes_named_profiles(tmp_path, monkeypatch):
@@ -435,6 +533,22 @@ def test_migrate_doctor_outputs_structured_diagnostics(tmp_path, capsys):
     assert ".env, auth.json, state.db" in output
 
 
+def test_migrate_verify_and_doctor_outputs_are_different(tmp_path, capsys):
+    bundle = tmp_path / "migration-bundle"
+    _write_migration_manifest(bundle)
+
+    run_migrate(SimpleNamespace(migrate_action="verify", repo=str(bundle)))
+    verify_output = capsys.readouterr().out
+
+    run_migrate(SimpleNamespace(migrate_action="doctor", repo=str(bundle)))
+    doctor_output = capsys.readouterr().out
+
+    assert "Migration bundle verified" in verify_output
+    assert "Diagnostics:" not in verify_output
+    assert "Diagnostics:" in doctor_output
+    assert verify_output != doctor_output
+
+
 def test_migrate_verify_errors_are_clear_for_missing_or_bad_bundle(tmp_path, capsys):
     missing = tmp_path / "missing"
 
@@ -462,3 +576,59 @@ def test_migrate_verify_errors_are_clear_for_missing_or_bad_bundle(tmp_path, cap
 
     captured = capsys.readouterr()
     assert "skills/files exists without skills/manifest.yaml" in captured.err
+
+
+def test_bundle_rejects_parent_traversal_skill_manifest_path(tmp_path, capsys):
+    bundle = tmp_path / "migration-bundle"
+    _write_migration_manifest(bundle)
+    (bundle / "skills").mkdir()
+    (bundle / "skills" / "manifest.yaml").write_text(
+        "version: 1\n"
+        "files:\n"
+        "  - path: ../evil.md\n"
+        "    sha256: ignored\n",
+        encoding="utf-8",
+    )
+
+    result = doctor_migration_bundle(bundle)
+
+    assert not result.ok
+    assert any("unsafe skill path" in error and "../evil.md" in error for error in result.errors)
+    _assert_verify_and_doctor_fail(bundle, capsys)
+
+
+def test_bundle_rejects_windows_absolute_skill_manifest_path(tmp_path, capsys):
+    bundle = tmp_path / "migration-bundle"
+    _write_migration_manifest(bundle)
+    (bundle / "skills").mkdir()
+    (bundle / "skills" / "manifest.yaml").write_text(
+        "version: 1\n"
+        "files:\n"
+        "  - path: C:\\\\Users\\\\alice\\\\SKILL.md\n"
+        "    sha256: ignored\n",
+        encoding="utf-8",
+    )
+
+    result = doctor_migration_bundle(bundle)
+
+    assert not result.ok
+    assert any("unsafe skill path" in error and "C:" in error for error in result.errors)
+    _assert_verify_and_doctor_fail(bundle, capsys)
+
+
+def test_bundle_rejects_symlink(tmp_path, capsys):
+    bundle = tmp_path / "migration-bundle"
+    _write_migration_manifest(bundle)
+    target = bundle / "target.txt"
+    link = bundle / "linked.txt"
+    target.write_text("target\n", encoding="utf-8")
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable in this environment: {exc}")
+
+    result = doctor_migration_bundle(bundle)
+
+    assert not result.ok
+    assert any("symlink present" in error and "linked.txt" in error for error in result.errors)
+    _assert_verify_and_doctor_fail(bundle, capsys)


### PR DESCRIPTION
## Summary

This PR introduces a unified `hermes migrate` CLI surface for local Hermes profile portability and migration.

Implemented commands:

- `hermes migrate export`
- `hermes migrate import`
- `hermes migrate verify`
- `hermes migrate doctor`

## Motivation

This follows the design direction from #6078: Hermes needs a first-class migration workflow for moving accumulated local state across machines, OS environments, reinstalls, and path changes.

The current feature scope is local portability / migration, not full multi-device sync.

This PR adopts #6078's unified migration UX and absorbs the reasonable local portability boundaries from #17912.

## Scope

This PR focuses on:

- safe local migration bundle export
- safe local bundle import
- post-import verification
- migration diagnostics
- explicit exclusion of secrets and runtime state
- safe migration of config, SOUL.md, memory, skills, skins, and named profile subsets

## Non-goals

This PR does not implement:

- cloud sync
- GitHub/network sync
- automatic background sync
- plaintext secret migration
- `.env` migration
- `state.db` migration
- hosted Hermes sync service

## Tests

Ran:

```bash
python -m py_compile hermes_cli/migration.py hermes_cli/main.py hermes_cli/profiles.py tests/hermes_cli/test_migrate.py
python -m pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/hermes_cli/test_migrate.py
python -m pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/hermes_cli/test_profiles.py::TestAliasCollision::test_subcommand_returns_message
```

Also attempted:

```bash
scripts/run_tests.sh tests/hermes_cli/
```

The canonical script could not run in this local Windows checkout because no `.venv` or `venv` exists for the script to activate. A direct full `tests/hermes_cli/` pytest run in the available Windows/Conda environment is blocked by missing optional/platform dependencies such as `prompt_toolkit`, `fire`, and `pwd`; the migration-focused tests above pass.

## Related issues / PRs

Related to #6078
Related to #17912