### PR TITLE
fix(gateway): treat zombie PIDs as stale in scoped locks

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -516,9 +516,10 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still respond to os.kill(pid, 0) but are not
+                # Check if process is stopped (Ctrl+Z / SIGTSTP) or zombie —
+                # such processes still respond to os.kill(pid, 0) but are not
                 # actually running. Treat them as stale so --replace works.
+                # (kanban_db.py already does this — see _is_pid_alive there.)
                 if not stale:
                     try:
                         _proc_status = Path(f"/proc/{existing_pid}/status")
@@ -526,7 +527,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                             for _line in _proc_status.read_text().splitlines():
                                 if _line.startswith("State:"):
                                     _state = _line.split()[1]
-                                    if _state in ("T", "t"):  # stopped or tracing stop
+                                    if _state in ("T", "t", "Z"):  # stopped, tracing stop, or zombie
                                         stale = True
                                     break
                     except (OSError, PermissionError):
@@ -783,6 +784,21 @@ def get_running_pid(
             # Windows raises OSError with WinError 87 for an invalid pid
             # (process is definitely gone). Treat as "process doesn't exist".
             continue
+
+        # Zombie processes still respond to os.kill(pid, 0) but have empty
+        # /proc/<pid>/cmdline and are not running — skip them.
+        if sys.platform == "linux":
+            try:
+                _proc_status = Path(f"/proc/{pid}/status")
+                if _proc_status.exists():
+                    for _line in _proc_status.read_text().splitlines():
+                        if _line.startswith("State:"):
+                            _state = _line.split()[1]
+                            if _state == "Z":  # zombie
+                                continue
+                            break
+            except (OSError, PermissionError):
+                pass
 
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)


### PR DESCRIPTION
## Fix: Treat zombie PIDs as stale in gateway scoped locks

### Problem

The gateway scoped-lock stale detection treats zombie gateway processes as still owning a live platform lock. When a gateway process becomes a zombie (killed but not yet reaped), `os.kill(pid, 0)` succeeds because `/proc/<pid>` still exists. This prevents a replacement gateway from reclaiming Telegram/Slack locks.

### Root Cause

In `gateway/status.py`, `acquire_scoped_lock()` only checks for stopped/tracing-stop states (`"T"`, `"t"`) in `/proc/<pid>/status`. Zombie state (`"Z"`) is not in the check tuple, so zombie processes pass the liveness check and keep their locks.

Same class of vulnerability exists in `get_running_pid()` which could report a zombie gateway as "running".

### Fix

1. **`acquire_scoped_lock`** (line 529): Added `"Z"` to the State check tuple: `("T", "t", "Z")` — stopped, tracing stop, or zombie are all now treated as stale.

2. **`get_running_pid`** (line 785+): Added explicit zombie check via `/proc/<pid>/status` State field. Zombies are skipped (treated as dead) rather than returned as a running gateway PID.

This matches the existing implementation in `kanban_db.py:_is_pid_alive()` which already handles zombie detection correctly.

### Testing

Reproduced by creating a scoped-lock file owned by a zombie PID, then calling `acquire_scoped_lock()`. Before fix: lock is treated as live (returns `False, existing`). After fix: zombie PID is detected, lock is treated as stale.

Fixes #18822