### PR TITLE
feat(cloud): materialize macOS iCloud/CloudStorage placeholders before reads

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -423,6 +423,11 @@ def _is_binary_file(path: Path) -> bool:
         path.name.endswith(ext) for ext in (".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".js", ".ts")
     ):
         return True
+    try:
+        from tools.cloud_file_materializer import materialize_for_read
+        path = materialize_for_read(path)
+    except Exception:
+        pass
     chunk = path.read_bytes()[:4096]
     return b"\x00" in chunk
 

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -218,6 +218,8 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     denied, etc.); the caller reports those paths in ``skipped``.
     """
     try:
+        from tools.cloud_file_materializer import materialize_for_read
+        path = materialize_for_read(path)
         raw = path.read_bytes()
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)

--- a/tests/tools/test_cloud_file_materializer.py
+++ b/tests/tools/test_cloud_file_materializer.py
@@ -1,0 +1,73 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.cloud_file_materializer import is_cloud_file_path, materialize_for_read
+from tools.code_execution_tool import _cloud_file_sitecustomize_source
+
+
+def test_is_cloud_file_path_recognizes_macos_providers():
+    assert is_cloud_file_path(
+        "/Users/alice/Library/Mobile Documents/com~apple~CloudDocs/case.pdf"
+    )
+    assert is_cloud_file_path(
+        "/Users/alice/Library/CloudStorage/OneDrive-Example/case.pdf"
+    )
+    assert not is_cloud_file_path("/Users/alice/project/case.pdf")
+
+
+def test_materialize_for_read_copies_cloud_file_to_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    source_dir = tmp_path / "Library" / "Mobile Documents" / "com~apple~CloudDocs"
+    source_dir.mkdir(parents=True)
+    source = source_dir / "note.txt"
+    source.write_text("hello from icloud", encoding="utf-8")
+
+    cached = materialize_for_read(source)
+
+    assert cached != source
+    assert cached.read_text(encoding="utf-8") == "hello from icloud"
+    assert str(cached).startswith(str(tmp_path / "hermes" / "cache" / "cloud_files"))
+
+
+def test_materialize_for_read_leaves_normal_file_unchanged(tmp_path):
+    source = tmp_path / "plain.txt"
+    source.write_text("plain", encoding="utf-8")
+
+    assert materialize_for_read(source) == source
+
+
+def test_execute_code_sitecustomize_intercepts_read_only_cloud_open(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    cloud_dir = tmp_path / "Library" / "Mobile Documents" / "com~apple~CloudDocs"
+    cloud_dir.mkdir(parents=True)
+    source = cloud_dir / "note.txt"
+    source.write_text("sitecustomize ok", encoding="utf-8")
+
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(_cloud_file_sitecustomize_source(), encoding="utf-8")
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), env.get("PYTHONPATH", "")])
+
+    code = (
+        "from pathlib import Path\n"
+        f"p = Path({str(source)!r})\n"
+        "print(open(p).read())\n"
+        "print(p.read_text())\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=True,
+    )
+
+    assert proc.stdout.splitlines() == ["sitecustomize ok", "sitecustomize ok"]
+    assert (hermes_home / "cache" / "cloud_files").exists()
+

--- a/tools/cloud_file_materializer.py
+++ b/tools/cloud_file_materializer.py
@@ -1,0 +1,129 @@
+"""Materialize macOS cloud-provider files before reading them.
+
+iCloud Drive and File Provider backed folders (OneDrive, Dropbox, etc.) can
+surface placeholder files that fail with ``OSError: [Errno 11] Resource
+deadlock avoided`` when read from Hermes child processes.  This helper keeps
+the fix centralized: for known cloud paths, make a plain local cache copy and
+return that path for read-only consumers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_CLOUD_MARKERS = (
+    "/Library/Mobile Documents/",
+    "/Library/CloudStorage/",
+)
+
+
+def is_cloud_file_path(path: str | os.PathLike[str]) -> bool:
+    """Return True when *path* is under a known macOS cloud-file location."""
+    try:
+        raw = os.fspath(path)
+    except TypeError:
+        return False
+    expanded = os.path.expanduser(raw)
+    return any(marker in expanded for marker in _CLOUD_MARKERS)
+
+
+def _cache_path_for(path: Path) -> Path:
+    """Build a stable cache path for a cloud file."""
+    try:
+        st = path.stat()
+        fingerprint = f"{path}|{st.st_mtime_ns}|{st.st_size}"
+    except OSError:
+        fingerprint = str(path)
+    digest = hashlib.sha256(fingerprint.encode("utf-8", "surrogateescape")).hexdigest()
+    suffix = path.suffix[:32]
+    return get_hermes_home() / "cache" / "cloud_files" / f"{digest}{suffix}"
+
+
+def _request_icloud_download(path: Path) -> None:
+    """Ask iCloud Drive to download a placeholder file, if applicable."""
+    if "/Library/Mobile Documents/" not in str(path):
+        return
+    brctl = shutil.which("brctl")
+    if not brctl:
+        return
+    try:
+        subprocess.run(
+            [brctl, "download", str(path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+    except Exception as exc:
+        logger.debug("cloud materializer: brctl download failed for %s: %s", path, exc)
+
+
+def _copy_streaming(src: Path, dst: Path) -> None:
+    """Copy without macOS fcopyfile/clonefile fast paths."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_name(f".{dst.name}.{os.getpid()}.tmp")
+    try:
+        with src.open("rb") as fin, tmp.open("wb") as fout:
+            shutil.copyfileobj(fin, fout, length=1024 * 1024)
+        try:
+            shutil.copystat(src, tmp, follow_symlinks=True)
+        except OSError:
+            pass
+        os.replace(tmp, dst)
+    finally:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def materialize_for_read(path: str | os.PathLike[str], *, retries: int = 3) -> Path:
+    """Return a local readable copy for cloud-provider files.
+
+    Non-cloud paths are returned unchanged.  If materialization fails, the
+    original expanded path is returned so callers preserve their existing error
+    behavior.
+    """
+    source = Path(os.path.expanduser(os.fspath(path)))
+    if not is_cloud_file_path(source):
+        return source
+
+    cache_path = _cache_path_for(source)
+    try:
+        if cache_path.exists() and cache_path.stat().st_size > 0:
+            return cache_path
+    except OSError:
+        pass
+
+    last_error: Exception | None = None
+    for attempt in range(max(1, retries)):
+        _request_icloud_download(source)
+        try:
+            _copy_streaming(source, cache_path)
+            logger.info("Materialized cloud file for read: %s -> %s", source, cache_path)
+            return cache_path
+        except OSError as exc:
+            last_error = exc
+            if attempt + 1 < retries:
+                time.sleep(0.35 * (attempt + 1))
+        except Exception as exc:
+            last_error = exc
+            break
+
+    logger.warning(
+        "Could not materialize cloud file %s; falling back to original path: %s",
+        source,
+        last_error,
+    )
+    return source
+

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -175,6 +175,88 @@ def check_sandbox_requirements() -> bool:
     return True
 
 
+def _cloud_file_sitecustomize_source() -> str:
+    """Return a narrow read-only cloud-file hook for execute_code children."""
+    return r'''
+import builtins
+import io
+import os
+from pathlib import Path
+
+_ORIGINAL_OPEN = builtins.open
+_ORIGINAL_IO_OPEN = io.open
+_ORIGINAL_PATH_OPEN = Path.open
+_ORIGINAL_PATH_READ_BYTES = Path.read_bytes
+_ORIGINAL_PATH_READ_TEXT = Path.read_text
+_CLOUD_MARKERS = ("/Library/Mobile Documents/", "/Library/CloudStorage/")
+
+
+def _is_cloud_path(path):
+    try:
+        raw = os.fspath(path)
+    except TypeError:
+        return False
+    expanded = os.path.expanduser(raw)
+    return any(marker in expanded for marker in _CLOUD_MARKERS)
+
+
+def _is_read_mode(mode):
+    mode = mode or "r"
+    return not any(flag in mode for flag in ("w", "a", "x", "+"))
+
+
+def _materialize(path):
+    if not _is_cloud_path(path):
+        return path
+    try:
+        from tools.cloud_file_materializer import materialize_for_read
+        return os.fspath(materialize_for_read(path))
+    except Exception:
+        return path
+
+
+def open(file, mode="r", buffering=-1, encoding=None, errors=None,
+         newline=None, closefd=True, opener=None):
+    if _is_read_mode(mode):
+        file = _materialize(file)
+    return _ORIGINAL_OPEN(file, mode, buffering, encoding, errors, newline, closefd, opener)
+
+
+def io_open(file, mode="r", buffering=-1, encoding=None, errors=None,
+            newline=None, closefd=True, opener=None):
+    if _is_read_mode(mode):
+        file = _materialize(file)
+    return _ORIGINAL_IO_OPEN(file, mode, buffering, encoding, errors, newline, closefd, opener)
+
+
+def path_open(self, mode="r", buffering=-1, encoding=None, errors=None,
+              newline=None):
+    if _is_read_mode(mode):
+        return _ORIGINAL_OPEN(_materialize(self), mode, buffering, encoding, errors, newline)
+    return _ORIGINAL_PATH_OPEN(self, mode, buffering, encoding, errors, newline)
+
+
+def path_read_bytes(self):
+    if _is_cloud_path(self):
+        return _ORIGINAL_OPEN(_materialize(self), "rb").read()
+    return _ORIGINAL_PATH_READ_BYTES(self)
+
+
+def path_read_text(self, encoding=None, errors=None):
+    if _is_cloud_path(self):
+        with _ORIGINAL_OPEN(_materialize(self), "r", encoding=encoding, errors=errors) as f:
+            return f.read()
+    return _ORIGINAL_PATH_READ_TEXT(self, encoding=encoding, errors=errors)
+
+
+builtins.open = open
+io.open = io_open
+Path.open = path_open
+Path.read_bytes = path_read_bytes
+Path.read_text = path_read_text
+'''
+
+
 # ---------------------------------------------------------------------------
 # hermes_tools.py code generator
 # ---------------------------------------------------------------------------
@@ -1127,6 +1209,9 @@ def execute_code(
         tools_src = generate_hermes_tools_module(list(sandbox_tools))
         with open(os.path.join(tmpdir, "hermes_tools.py"), "w", encoding="utf-8") as f:
             f.write(tools_src)
+
+        with open(os.path.join(tmpdir, "sitecustomize.py"), "w") as f:
+            f.write(_cloud_file_sitecustomize_source())
 
         # Write the user's script
         with open(os.path.join(tmpdir, "script.py"), "w", encoding="utf-8") as f:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
+from tools.cloud_file_materializer import materialize_for_read
 
 from agent.file_safety import (
     build_write_denied_paths,
@@ -629,6 +630,7 @@ class ShellFileOperations(FileOperations):
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
+        path = str(self._materialize_cloud_path(path))
         
         offset, limit = normalize_read_pagination(offset, limit)
         
@@ -766,6 +768,7 @@ class ShellFileOperations(FileOperations):
         Uses cat so the full file is returned regardless of size.
         """
         path = self._expand_path(path)
+        path = str(self._materialize_cloud_path(path))
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:
@@ -791,6 +794,12 @@ class ShellFileOperations(FileOperations):
             content=_strip_terminal_fence_leaks(cat_result.stdout),
             file_size=file_size,
         )
+
+    def _materialize_cloud_path(self, path: str) -> Path:
+        """Return a readable local cache copy for macOS cloud files on local backends."""
+        if self.env.__class__.__name__ != "LocalEnvironment":
+            return Path(path)
+        return materialize_for_read(path)
 
     def delete_file(self, path: str) -> WriteResult:
         """Delete a file via rm."""

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -40,6 +40,7 @@ import httpx
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 from hermes_constants import get_hermes_dir
 from tools.debug_helpers import DebugSession
+from tools.cloud_file_materializer import materialize_for_read
 from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
@@ -478,7 +479,7 @@ async def vision_analyze_tool(
         if local_path.is_file():
             # Local file path (e.g. from platform image cache) -- skip download
             logger.info("Using local image file: %s", image_url)
-            temp_image_path = local_path
+            temp_image_path = materialize_for_read(local_path)
             should_cleanup = False  # Don't delete cached/local files
         elif _validate_image_url(image_url):
             # Remote URL -- download to a temporary location


### PR DESCRIPTION
## Summary

iCloud Drive and File Provider–backed folders (OneDrive, Dropbox, Box, etc.) on macOS surface placeholder files that fail with `OSError: [Errno 11] Resource deadlock avoided` when read from Hermes child processes. This is a known macOS quirk: cloud-provided files may have only a placeholder on disk until something actively materializes them.

This PR adds `tools/cloud_file_materializer.py`, a small helper that:

1. Detects paths under `/Library/Mobile Documents/` (iCloud Drive) or `/Library/CloudStorage/` (File Provider hosts).
2. If applicable, asks `brctl download` to bring the file local.
3. Streams a copy into `~/.hermes/cache/cloud_files/<sha>.<ext>` (cache key derived from path + mtime + size, so the cache invalidates when the source changes).
4. Returns the cache path. Non-cloud paths and non-macOS environments are pass-throughs.

## Where it's wired in

All five read entry points where Hermes touches user files are updated to materialize before reading:

- `tools/file_operations.py` — `read()` and `read_full()` (gated on `LocalEnvironment`, so docker/sandbox backends are unaffected)
- `tools/vision_tools.py` — `vision_analyze_tool` for local image paths
- `agent/image_routing.py` — `_file_to_data_url` when embedding images into LLM messages
- `agent/context_references.py` — `_is_binary_file` content-type sniffing
- `tools/code_execution_tool.py` — sitecustomize hook so `open()` inside user-executed Python also benefits

The materializer itself is best-effort: if `brctl` isn't available, or the copy fails, we log a warning and fall back to the original path so callers preserve their existing error behavior.

## Tests

`tests/tools/test_cloud_file_materializer.py` covers:

- `is_cloud_file_path` recognition for both macOS cloud-provider roots
- Materialization copies a synthetic cloud file into the cache
- Non-cloud paths are returned unchanged (no needless I/O)
- The sitecustomize intercept works for read-only `open()` calls inside the code-execution tool

All 4 tests pass on macOS 14 / Python 3.11.

## Manual verification

End-to-end on a real iCloud file (29 KB `.docx` under `~/Library/Mobile Documents/...`):

- `is_cloud_file_path` → `True`
- Materializes to `~/.hermes/cache/cloud_files/<sha>.docx`
- SHA256 of source and cache match
- Second call returns the same cache path (idempotent, no redundant copy)
- A `/etc/hosts` probe is returned unchanged

## Test plan

- [x] Run `pytest tests/tools/test_cloud_file_materializer.py`
- [x] Manually verify materialization round-trip on a real iCloud file
- [ ] Verify behavior in a non-local backend (docker/modal) — gating keeps it inert there, but a maintainer with that setup may want to confirm