### PR TITLE
fix(runtime): resolve custom_providers key_env for bare provider=custom

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -655,10 +655,32 @@ def _resolve_named_custom_runtime(
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result
+        # Also look up custom_providers by base_url so key_env / inline api_key
+        # configured on the provider are honored when the caller only passes
+        # provider="custom" + base_url (for example the default model config path).
+        _cp_api_key = ""
+        _cp_api_mode = ""
+        try:
+            _cp_list = get_compatible_custom_providers(load_config())
+            for _cp in (_cp_list or []):
+                if not isinstance(_cp, dict):
+                    continue
+                _cp_url = (_cp.get("base_url") or "").strip().rstrip("/")
+                if _cp_url and _cp_url == base_url:
+                    _cp_api_key = str(_cp.get("api_key", "") or "").strip()
+                    if not has_usable_secret(_cp_api_key):
+                        _kenv = str(_cp.get("key_env", "") or "").strip()
+                        if _kenv:
+                            _cp_api_key = os.getenv(_kenv, "").strip()
+                    _cp_api_mode = _parse_api_mode(_cp.get("api_mode")) or ""
+                    break
+        except Exception:
+            pass
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
         api_key_candidates = [
             (explicit_api_key or "").strip(),
+            _cp_api_key,
             # Gate env key fallbacks on authoritative hosts (#28660)
             (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
@@ -673,7 +695,7 @@ def _resolve_named_custom_runtime(
         ) or "no-key-required"
         return {
             "provider": "custom",
-            "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": _cp_api_mode or _detect_api_mode_for_url(base_url) or "chat_completions",
             "base_url": base_url,
             "api_key": api_key,
             "source": "direct-alias",


### PR DESCRIPTION
## Summary

- When `model.provider` is `custom` with `model.base_url` set in config.yaml, the `_resolve_named_custom_runtime` function short-circuits at the bare `provider="custom"` path (line 492) without consulting the `custom_providers` list
- This means `key_env` and inline `api_key` configured on a matching `custom_provider` entry are silently ignored, and the runtime only checks `OPENAI_API_KEY` / `OPENROUTER_API_KEY` as fallbacks
- Providers like Alibaba DashScope that use `key_env: DASHSCOPE_API_KEY` get 401 auth errors because the key is never resolved
- Fix: before falling back to generic env vars, look up `custom_providers` by `base_url` and resolve `key_env` / `api_key` from the matching entry. Also propagates `api_mode` from the matched provider.

## Reproduction

1. Configure a custom provider with `key_env`:
   ```yaml
   model:
     default: qwen3.5-plus-2026-02-15
     provider: custom
     base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
   custom_providers:
   - name: qwen
     base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
     key_env: DASHSCOPE_API_KEY
   ```
2. Set `DASHSCOPE_API_KEY` in `.env` but **not** `OPENAI_API_KEY`
3. `hermes chat` → 401 invalid_api_key from DashScope

After fix: the runtime resolves `DASHSCOPE_API_KEY` via the `key_env` on the matching `custom_providers` entry.

## Test plan

- [x] All 109 existing `test_runtime_provider_resolution.py` tests pass
- [x] Manually verified with DashScope/Qwen endpoint — `hermes -z "say hello"` returns a response