### PR TITLE
fix(agent): remove hardcoded 30s timeout in title_generator

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -28,7 +28,7 @@ _TITLE_PROMPT = (
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: float = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:
@@ -36,6 +36,9 @@ def generate_title(
 
     Uses the main runtime's model when available, falling back to the
     auxiliary LLM client (cheapest/fastest available model).
+    When timeout is None (default), falls through to the configured
+    auxiliary LLM timeout from config.yaml, allowing users to tune
+    the timeout for slow models (e.g. local models with long cold starts).
     Returns the title string or None on failure.
 
     ``failure_callback`` is invoked with ``(task, exception)`` when the


### PR DESCRIPTION
## Problem

The `generate_title()` function in `agent/title_generator.py` hardcoded `timeout=30.0`, bypassing the configured auxiliary LLM timeout from `config.yaml`. This caused title generation to fail when using slow local models with cold start times exceeding 30 seconds (e.g., qwen3.6-27b at ~88s cold start).

## Solution

Changed default to `timeout=None` so it falls through to the configured value, allowing users to tune the timeout for their model response time characteristics.

## Changes

- `agent/title_generator.py`: Changed `timeout: float = 30.0` → `timeout: float = None`
- Updated docstring to explain the behavior