### PR TITLE
fix: support packaged memory provider skills

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -1,13 +1,15 @@
 """Memory provider plugin discovery.
 
-Scans two directories for memory provider plugins:
+Scans three sources for memory provider plugins:
 
 1. Bundled providers: ``plugins/memory/<name>/`` (shipped with hermes-agent)
 2. User-installed providers: ``$HERMES_HOME/plugins/<name>/``
+3. Pip-installed providers: ``hermes_agent.memory_providers`` entry points
 
-Each subdirectory must contain ``__init__.py`` with a class implementing
-the MemoryProvider ABC.  On name collisions, bundled providers take
-precedence.
+Directory providers must contain ``__init__.py`` with a class implementing
+the MemoryProvider ABC. Pip packages expose a provider or ``register(ctx)``
+callback through the entry-point group. On name collisions, bundled providers
+take precedence, followed by user-installed directories, then entry points.
 
 Only ONE provider can be active at a time, selected via
 ``memory.provider`` in config.yaml.
@@ -23,16 +25,22 @@ from __future__ import annotations
 
 import importlib
 import importlib.machinery
+import importlib.metadata
 import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TYPE_CHECKING
 from hermes_cli.config import cfg_get
+
+if TYPE_CHECKING:
+    from agent.memory_provider import MemoryProvider
 
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
+ENTRY_POINTS_GROUP = "hermes_agent.memory_providers"
+_REGISTERED_MEMORY_PROVIDER_SKILLS: dict[str, Path] = {}
 
 # Synthetic parent package for user-installed providers, so they don't
 # collide with bundled providers in sys.modules.
@@ -121,6 +129,20 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     return dirs
 
 
+def _iter_entry_points():
+    """Yield pip-installed memory provider entry points."""
+    try:
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            return list(eps.select(group=ENTRY_POINTS_GROUP))
+        if isinstance(eps, dict):
+            return list(eps.get(ENTRY_POINTS_GROUP, []))
+        return [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+    except Exception as exc:
+        logger.debug("Memory provider entry-point scan failed: %s", exc)
+        return []
+
+
 def find_provider_dir(name: str) -> Optional[Path]:
     """Resolve a provider name to its directory.
 
@@ -139,17 +161,27 @@ def find_provider_dir(name: str) -> Optional[Path]:
     return None
 
 
+def find_provider_entry_point(name: str):
+    """Resolve a provider name to a pip entry point, if installed."""
+    for entry_point in _iter_entry_points():
+        if entry_point.name == name:
+            return entry_point
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
-    """Scan bundled and user-installed directories for available providers.
+    """Scan directory and pip entry-point memory providers.
 
     Returns list of (name, description, is_available) tuples.
-    Bundled providers take precedence on name collisions.
+    Bundled providers take precedence on name collisions, followed by
+    user-installed directory providers, then pip entry-point providers.
     """
     results = []
+    seen: set[str] = set()
 
     for name, child in _iter_provider_dirs():
         # Read description from plugin.yaml if available
@@ -167,7 +199,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         # Quick availability check — try loading and calling is_available()
         available = True
         try:
-            provider = _load_provider_from_dir(child)
+            provider = _load_provider_from_dir(child, register_skills=False)
             if provider:
                 available = provider.is_available()
             else:
@@ -176,26 +208,70 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
             available = False
 
         results.append((name, desc, available))
+        seen.add(name)
+
+    for entry_point in _iter_entry_points():
+        name = entry_point.name
+        if name in seen:
+            continue
+        desc = ""
+        available = True
+        try:
+            provider = _load_provider_from_entry_point(
+                entry_point,
+                register_skills=False,
+            )
+            if provider:
+                available = provider.is_available()
+            else:
+                available = False
+        except Exception:
+            available = False
+
+        results.append((name, desc, available))
+        seen.add(name)
 
     return results
 
 
-def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
+def load_memory_provider(
+    name: str,
+    *,
+    register_skills: Optional[bool] = None,
+) -> Optional["MemoryProvider"]:
     """Load and return a MemoryProvider instance by name.
 
-    Checks both bundled (``plugins/memory/<name>/``) and user-installed
-    (``$HERMES_HOME/plugins/<name>/``) directories.  Bundled takes
-    precedence on name collisions.
+    Checks bundled (``plugins/memory/<name>/``), user-installed
+    (``$HERMES_HOME/plugins/<name>/``), and pip entry-point providers.
+    Bundled providers take precedence on name collisions.
+
+    Skills register only when *name* is the configured active provider unless
+    ``register_skills`` is passed explicitly. This keeps status and setup
+    inspection of inactive providers free of registry side effects.
 
     Returns None if the provider is not found or fails to load.
     """
+    if register_skills is None:
+        register_skills = name == _get_active_memory_provider()
+
     provider_dir = find_provider_dir(name)
-    if not provider_dir:
-        logger.debug("Memory provider '%s' not found in bundled or user plugins", name)
+    entry_point = None if provider_dir else find_provider_entry_point(name)
+    if not provider_dir and entry_point is None:
+        logger.debug(
+            "Memory provider '%s' not found in bundled, user plugins, or entry points",
+            name,
+        )
         return None
 
     try:
-        provider = _load_provider_from_dir(provider_dir)
+        provider = (
+            _load_provider_from_dir(provider_dir, register_skills=register_skills)
+            if provider_dir
+            else _load_provider_from_entry_point(
+                entry_point,
+                register_skills=register_skills,
+            )
+        )
         if provider:
             return provider
         logger.warning("Memory provider '%s' loaded but no provider instance found", name)
@@ -205,7 +281,61 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
         return None
 
 
-def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
+def _load_provider_from_entry_point(
+    entry_point,
+    *,
+    register_skills: bool = True,
+) -> Optional["MemoryProvider"]:
+    """Import a provider entry point and extract the MemoryProvider instance."""
+    from agent.memory_provider import MemoryProvider
+
+    loaded = entry_point.load()
+
+    if isinstance(loaded, MemoryProvider):
+        return loaded
+
+    if isinstance(loaded, type) and issubclass(loaded, MemoryProvider):
+        try:
+            return loaded()
+        except Exception:
+            pass
+
+    if hasattr(loaded, "register"):
+        collector = _ProviderCollector(entry_point.name, register_skills=register_skills)
+        loaded.register(collector)
+        if collector.provider:
+            return collector.provider
+
+    if callable(loaded):
+        try:
+            provider = loaded()
+            if isinstance(provider, MemoryProvider):
+                return provider
+        except TypeError:
+            pass
+
+        collector = _ProviderCollector(entry_point.name, register_skills=register_skills)
+        loaded(collector)
+        return collector.provider
+
+    for attr_name in dir(loaded):
+        attr = getattr(loaded, attr_name, None)
+        if (isinstance(attr, type) and issubclass(attr, MemoryProvider)
+                and attr is not MemoryProvider):
+            try:
+                return attr()
+            except Exception:
+                pass
+
+    logger.debug("Memory provider entry point '%s' loaded no provider", entry_point.name)
+    return None
+
+
+def _load_provider_from_dir(
+    provider_dir: Path,
+    *,
+    register_skills: bool = True,
+) -> Optional["MemoryProvider"]:
     """Import a provider module and extract the MemoryProvider instance.
 
     The module must have either:
@@ -294,7 +424,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 
     # Try register(ctx) pattern first (how our plugins are written)
     if hasattr(mod, "register"):
-        collector = _ProviderCollector()
+        collector = _ProviderCollector(name, register_skills=register_skills)
         try:
             mod.register(collector)
             if collector.provider:
@@ -319,11 +449,37 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 class _ProviderCollector:
     """Fake plugin context that captures register_memory_provider calls."""
 
-    def __init__(self):
+    def __init__(self, name: str, *, register_skills: bool = True):
+        self.name = name
         self.provider = None
+        self._register_skills = register_skills
 
     def register_memory_provider(self, provider):
         self.provider = provider
+
+    def register_skill(self, *args, **kwargs):
+        """Forward plugin-provided skills to the general plugin registry.
+
+        Memory provider discovery uses this lightweight collector instead of
+        the general PluginContext. Forwarding keeps skills registered by memory
+        provider shims visible to skill_view() while preserving the exclusive
+        memory-provider activation path.
+        """
+        if not self._register_skills:
+            return
+        try:
+            from hermes_cli.plugins import PluginManifest, PluginContext, get_plugin_manager
+
+            manager = get_plugin_manager()
+            manifest = PluginManifest(name=self.name, key=self.name)
+            PluginContext(manifest, manager).register_skill(*args, **kwargs)
+            skill_name = args[0] if args else kwargs.get("name")
+            qualified_name = f"{self.name}:{skill_name}"
+            registered_path = manager.find_plugin_skill(qualified_name)
+            if registered_path is not None:
+                _REGISTERED_MEMORY_PROVIDER_SKILLS[qualified_name] = registered_path
+        except Exception as exc:
+            logger.debug("Memory provider '%s' failed to register skill: %s", self.name, exc)
 
     # No-op for other registration methods
     def register_tool(self, *args, **kwargs):
@@ -349,6 +505,27 @@ def _get_active_memory_provider() -> Optional[str]:
         return cfg_get(config, "memory", "provider") or None
     except Exception:
         return None
+
+
+def _prune_inactive_memory_provider_skills(
+    active_provider: Optional[str] = None,
+) -> None:
+    """Remove tracked skills that no longer belong to the active provider."""
+    if active_provider is None:
+        active_provider = _get_active_memory_provider()
+
+    from hermes_cli.plugins import get_plugin_manager
+
+    manager = get_plugin_manager()
+    for qualified_name, registered_path in list(
+        _REGISTERED_MEMORY_PROVIDER_SKILLS.items()
+    ):
+        namespace, _, _ = qualified_name.partition(":")
+        if namespace == active_provider:
+            continue
+        if manager.find_plugin_skill(qualified_name) == registered_path:
+            manager.remove_plugin_skill(qualified_name)
+        _REGISTERED_MEMORY_PROVIDER_SKILLS.pop(qualified_name, None)
 
 
 def discover_plugin_cli_commands() -> List[dict]:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -679,6 +679,208 @@ class TestUserInstalledProviderCli:
         assert p.name == "extcliload"
 
 
+class TestEntryPointMemoryProviderDiscovery:
+    """Memory providers installed as Python packages should be discoverable."""
+
+    class FakeEntryPoint:
+        def __init__(self, name, module, exposure="register"):
+            self.name = name
+            self.value = f"{module}:{exposure}"
+            self.group = "hermes_agent.memory_providers"
+            self._module = module
+            self._exposure = exposure
+
+        def load(self):
+            import importlib
+
+            return getattr(importlib.import_module(self._module), self._exposure)
+
+    class FakeEntryPoints(list):
+        def select(self, *, group):
+            return [ep for ep in self if ep.group == group]
+
+    def _make_entrypoint_module(
+        self,
+        tmp_path,
+        module_name="ep_memory_provider",
+        exposure="register",
+        include_skill=False,
+    ):
+        module_file = tmp_path / f"{module_name}.py"
+        register_skill = ""
+        if include_skill:
+            skill_md = tmp_path / "skills" / "maintenance" / "SKILL.md"
+            skill_md.parent.mkdir(parents=True)
+            skill_md.write_text(
+                "---\nname: maintenance\ndescription: Memory maintenance\n---\n\n"
+                "Packaged provider maintenance body.\n"
+            )
+            register_skill = (
+                "    ctx.register_skill(\n"
+                "        'maintenance',\n"
+                "        Path(__file__).parent / 'skills' / 'maintenance' / 'SKILL.md',\n"
+                "    )\n"
+            )
+        module_file.write_text(
+            "from pathlib import Path\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class Provider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'entrymem'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(Provider())\n"
+            f"{register_skill}"
+            "def make_provider():\n"
+            "    return Provider()\n"
+        )
+        return module_name, exposure
+
+    def test_discover_finds_entry_point_provider(self, tmp_path, monkeypatch):
+        from plugins.memory import discover_memory_providers
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(tmp_path)
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+
+        providers = discover_memory_providers()
+
+        assert ("entrymem", "", True) in providers
+
+    @pytest.mark.parametrize("exposure", ["register", "Provider", "make_provider"])
+    def test_load_entry_point_provider(self, tmp_path, monkeypatch, exposure):
+        from plugins.memory import load_memory_provider
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(tmp_path, exposure=exposure)
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+
+        provider = load_memory_provider("entrymem")
+
+        assert provider is not None
+        assert provider.name == "entrymem"
+        assert provider.is_available()
+
+    def test_active_entry_point_provider_registers_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: "entrymem",
+        )
+
+        result = json.loads(skill_view("entrymem:maintenance"))
+
+        assert result["success"] is True
+        assert result["name"] == "entrymem:maintenance"
+        assert "Packaged provider maintenance body." in result["content"]
+
+    def test_inactive_entry_point_load_does_not_register_skill(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.plugins import get_plugin_manager
+        from plugins.memory import load_memory_provider
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_inactive_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: "other-provider",
+        )
+
+        provider = load_memory_provider("entrymem")
+
+        assert provider is not None
+        assert get_plugin_manager().find_plugin_skill("entrymem:maintenance") is None
+
+    def test_switching_provider_prunes_registered_entry_point_skill(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.plugins import get_plugin_manager
+        from tools.skills_tool import skill_view
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_switched_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        active = {"name": "entrymem"}
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: active["name"],
+        )
+
+        loaded = json.loads(skill_view("entrymem:maintenance"))
+        active["name"] = "other-provider"
+        switched = json.loads(skill_view("entrymem:maintenance"))
+
+        assert loaded["success"] is True
+        assert switched["success"] is False
+        assert "not found" in switched["error"].lower()
+        assert get_plugin_manager().find_plugin_skill("entrymem:maintenance") is None
+
+
 # ---------------------------------------------------------------------------
 # Sequential dispatch routing tests
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -255,6 +255,91 @@ class TestSkillViewQualifiedName:
         assert result["name"] == "ticktick"
         assert "TickTick body." in result["content"]
 
+    def test_does_not_lazy_load_inactive_memory_provider_skill(self, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        def fail_if_loaded(name):
+            raise AssertionError(f"unexpected provider load: {name}")
+
+        monkeypatch.setattr("plugins.memory._get_active_memory_provider", lambda: "active")
+        monkeypatch.setattr("plugins.memory.load_memory_provider", fail_if_loaded)
+
+        result = json.loads(skill_view("inactive:maintenance"))
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def _make_memory_provider_with_skill(self, tmp_path, name, body="Provider skill body."):
+        plugin_dir = tmp_path / ".hermes" / "plugins" / name
+        skill_dir = plugin_dir / "skills" / "maintenance"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: maintenance\ndescription: Memory maintenance\n---\n\n{body}\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "from pathlib import Path\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class Provider(MemoryProvider):\n"
+            "    @property\n"
+            f"    def name(self): return {name!r}\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(Provider())\n"
+            "    ctx.register_skill('maintenance', Path(__file__).parent / 'skills' / 'maintenance' / 'SKILL.md')\n"
+        )
+        return plugin_dir
+
+    def test_lazily_loads_memory_provider_registered_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        self._make_memory_provider_with_skill(tmp_path, "memtest")
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / ".hermes" / "plugins",
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_active_memory_provider",
+            lambda: "memtest",
+        )
+
+        result = json.loads(skill_view("memtest:maintenance"))
+
+        assert result["success"] is True
+        assert result["name"] == "memtest:maintenance"
+        assert "Provider skill body." in result["content"]
+
+    def test_discovery_does_not_pre_register_inactive_memory_provider_skills(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.memory import discover_memory_providers
+        from tools.skills_tool import skill_view
+
+        self._make_memory_provider_with_skill(tmp_path, "memactive", "Active body.")
+        self._make_memory_provider_with_skill(tmp_path, "meminactive", "Inactive body.")
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / ".hermes" / "plugins",
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_active_memory_provider",
+            lambda: "memactive",
+        )
+
+        discover_memory_providers()
+
+        inactive = json.loads(skill_view("meminactive:maintenance"))
+        assert inactive["success"] is False
+        assert "not found" in inactive["error"].lower()
+
+        active = json.loads(skill_view("memactive:maintenance"))
+        assert active["success"] is True
+        assert active["name"] == "memactive:maintenance"
+        assert "Active body." in active["content"]
+
     def test_stale_entry_self_heals(self, tmp_path):
         from tools.skills_tool import skill_view
 
@@ -364,7 +449,7 @@ class TestBundleContextBanner:
         content = result["content"]
 
         sibling_line = next(
-            (l for l in content.split("\n") if "Sibling skills:" in l), None
+            (line for line in content.split("\n") if "Sibling skills:" in line), None
         )
         assert sibling_line is not None
         assert "bar" in sibling_line

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1018,7 +1018,41 @@ def skill_view(
 
             discover_plugins()  # idempotent
             pm = get_plugin_manager()
+            active_memory_provider = None
+            try:
+                from plugins.memory import (
+                    _get_active_memory_provider,
+                    _prune_inactive_memory_provider_skills,
+                )
+
+                active_memory_provider = _get_active_memory_provider()
+                _prune_inactive_memory_provider_skills(active_memory_provider)
+            except Exception as exc:
+                logger.debug(
+                    "Failed pruning inactive memory-provider skills: %s",
+                    exc,
+                )
+
             plugin_skill_md = pm.find_plugin_skill(name)
+
+            # Memory provider plugins are loaded through plugins.memory rather
+            # than the general PluginManager. If a memory provider shim also
+            # registers skills, load the namespaced provider once so its
+            # collector can forward those skills into the plugin skill registry
+            # before declaring the qualified skill missing.
+            if plugin_skill_md is None:
+                try:
+                    from plugins.memory import load_memory_provider
+
+                    if namespace == active_memory_provider:
+                        load_memory_provider(namespace)
+                        plugin_skill_md = pm.find_plugin_skill(name)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed lazy memory-provider skill load for %s: %s",
+                        namespace,
+                        exc,
+                    )
 
             if plugin_skill_md is not None:
                 if not plugin_skill_md.exists():

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -12,9 +12,17 @@ Memory provider plugins give Hermes Agent persistent, cross-session knowledge be
 Memory providers are one of two **provider plugin** types. The other is [Context Engine Plugins](/developer-guide/context-engine-plugin), which replace the built-in context compressor. Both follow the same pattern: single-select, config-driven, managed via `hermes plugins`.
 :::
 
-## Directory Structure
+## Installation Layouts
 
-Each memory provider lives in `plugins/memory/<name>/`:
+Hermes discovers memory providers from bundled directories, user-installed
+directories, and installed Python package entry points. Bundled providers take
+precedence over a user directory with the same name, which takes precedence
+over a package entry point.
+
+### Directory Provider
+
+A directory provider lives in `plugins/memory/<name>/` when bundled with
+Hermes, or in `$HERMES_HOME/plugins/<name>/` when installed by a user:
 
 ```
 plugins/memory/my-provider/
@@ -22,6 +30,22 @@ plugins/memory/my-provider/
 ├── plugin.yaml      # Metadata (name, description, hooks)
 └── README.md        # Setup instructions, config reference, tools
 ```
+
+### Packaged Provider
+
+A pip-installed provider publishes an entry point in the
+`hermes_agent.memory_providers` group. The entry-point name is the provider
+name users select in `memory.provider`; its value points to the provider's
+`register(ctx)` function:
+
+```toml title="pyproject.toml"
+[project.entry-points."hermes_agent.memory_providers"]
+my-provider = "my_provider:register"
+```
+
+The package can keep its provider implementation, skills, and other resources
+inside its normal Python package layout. No copy under
+`$HERMES_HOME/plugins/` is required.
 
 ## The MemoryProvider ABC
 
@@ -138,6 +162,27 @@ def register(ctx) -> None:
     """Called by the memory plugin discovery system."""
     ctx.register_memory_provider(MyMemoryProvider())
 ```
+
+A provider may also expose read-only skills from the same callback. Skills are
+qualified by the entry-point name and are loaded only when that memory provider
+is active:
+
+```python
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).parent / "skills"
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(MyMemoryProvider())
+    ctx.register_skill(
+        "maintenance",
+        SKILLS_DIR / "maintenance" / "SKILL.md",
+        "Maintain the provider's memory store",
+    )
+```
+
+With the `my-provider` entry point active, the skill is available as
+`my-provider:maintenance` through `skill_view()`.
 
 ## plugin.yaml
 


### PR DESCRIPTION
## Summary
- add `hermes_agent.memory_providers` entry-point discovery/loading for pip-installed memory providers
- allow memory provider registration contexts to forward `register_skill(...)` into the plugin skill registry
- lazily load only the active memory provider namespace when `skill_view("provider:skill")` misses the plugin registry
- add regression tests for entry-point providers, provider-packaged skills, and inactive provider guardrails

## Why
Memory providers use the exclusive `plugins.memory` activation path rather than the general `PluginManager`. That means provider packages can register a memory provider, but provider-packaged skills are not visible to `skill_view()` unless the provider is loaded through another path. This also makes pip-installed memory providers less complete than directory-installed plugins.

This keeps the exclusive provider model intact while letting packaged memory providers expose read-only skills such as maintenance/runbook workflows.

## Test Plan
- `python -m pytest tests/test_plugin_skills.py tests/agent/test_memory_provider.py -q`
- `ruff check plugins/memory/__init__.py tools/skills_tool.py tests/test_plugin_skills.py tests/agent/test_memory_provider.py`
- `python -m compileall -q plugins/memory tools/skills_tool.py tests/test_plugin_skills.py tests/agent/test_memory_provider.py`
- `git diff --check -- plugins/memory/__init__.py tools/skills_tool.py tests/test_plugin_skills.py tests/agent/test_memory_provider.py`
- independent reviewer subagent re-reviewed the final diff and passed it
