### PR TITLE
[codex] Add profile expert delegation tool

### DIFF
--- a/tests/tools/test_profile_delegation_tool.py
+++ b/tests/tools/test_profile_delegation_tool.py
@@ -1,0 +1,108 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.profile_delegation_tool import (
+    _build_profile_prompt,
+    _resolve_profile_home,
+    _resolve_timeout,
+    ask_profile,
+)
+
+
+def _profile_home(tmp_path: Path) -> Path:
+    home = tmp_path / "expert-home"
+    home.mkdir()
+    (home / "config.yaml").write_text("model:\n  default: test\n", encoding="utf-8")
+    return home
+
+
+def test_resolves_configured_profile_home(tmp_path):
+    home = _profile_home(tmp_path)
+    cfg = {"profile_experts": {"architect": {"hermes_home": str(home)}}}
+
+    assert _resolve_profile_home("architect", cfg) == home.resolve()
+
+
+def test_rejects_unconfigured_profile_when_named_profiles_disabled():
+    cfg = {"allow_named_profile_experts": False}
+
+    try:
+        _resolve_profile_home("missing", cfg)
+    except ValueError as exc:
+        assert "not allowlisted" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_timeout_is_capped():
+    cfg = {"profile_timeout_seconds": 10, "profile_max_timeout_seconds": 30}
+
+    assert _resolve_timeout("architect", 999, cfg) == 30
+    assert _resolve_timeout("architect", None, cfg) == 10
+
+
+def test_prompt_contains_evidence_contract():
+    prompt = _build_profile_prompt("architect", "Review this.", "Extra context")
+
+    assert "specialist Hermes profile" in prompt
+    assert "Separate verified facts from assumptions" in prompt
+    assert "Extra context" in prompt
+
+
+@patch("tools.profile_delegation_tool.subprocess.run")
+@patch("tools.profile_delegation_tool._load_delegation_config")
+def test_ask_profile_invokes_hermes_subprocess(mock_load_config, mock_run, tmp_path):
+    home = _profile_home(tmp_path)
+    mock_load_config.return_value = {
+        "profile_experts": {
+            "architect": {
+                "hermes_home": str(home),
+                "toolsets": ["skills", "mcp-qmd"],
+                "timeout_seconds": 12,
+            }
+        }
+    }
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["hermes"],
+        returncode=0,
+        stdout="expert answer\n",
+        stderr="",
+    )
+
+    result = json.loads(ask_profile("architect", "Review this."))
+
+    assert result["status"] == "completed"
+    assert result["profile"] == "architect"
+    assert result["output"] == "expert answer"
+    _, kwargs = mock_run.call_args
+    assert kwargs["env"]["HERMES_HOME"] == str(home.resolve())
+    assert kwargs["timeout"] == 12
+    command = mock_run.call_args.args[0]
+    assert command[1:3] == ["-m", "hermes_cli.main"]
+    assert "--toolsets" in command
+    assert "skills,mcp-qmd" in command
+
+
+@patch("tools.profile_delegation_tool.subprocess.run")
+@patch("tools.profile_delegation_tool._load_delegation_config")
+def test_ask_profile_reports_timeout(mock_load_config, mock_run, tmp_path):
+    home = _profile_home(tmp_path)
+    mock_load_config.return_value = {
+        "profile_experts": {"architect": {"hermes_home": str(home)}},
+        "profile_timeout_seconds": 5,
+    }
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["hermes"],
+        timeout=5,
+        output="partial",
+        stderr="slow",
+    )
+
+    result = json.loads(ask_profile("architect", "Review this."))
+
+    assert result["status"] == "timed_out"
+    assert result["exit_code"] == 124
+    assert result["output"] == "partial"
+    assert result["error"] == "slow"

--- a/tools/profile_delegation_tool.py
+++ b/tools/profile_delegation_tool.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Profile-backed expert delegation tool.
+
+Runs another Hermes profile in a fresh subprocess and returns its final output
+as evidence for the current agent.  This deliberately uses a process boundary:
+Hermes profiles are selected before most Hermes modules import, so changing
+``HERMES_HOME`` inside the current process is not safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tools.registry import registry
+
+
+DEFAULT_PROFILE_TIMEOUT_SECONDS = 600
+DEFAULT_PROFILE_MAX_TIMEOUT_SECONDS = 1800
+
+
+def _load_delegation_config() -> dict:
+    """Load the ``delegation`` config section."""
+    try:
+        from cli import CLI_CONFIG
+
+        cfg = CLI_CONFIG.get("delegation", {})
+        if cfg:
+            return cfg
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import load_config
+
+        full = load_config()
+        return full.get("delegation", {}) or {}
+    except Exception:
+        return {}
+
+
+def _expand_path(value: str) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(value))).resolve()
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return []
+
+
+def _profile_expert_entry(cfg: dict, profile: str) -> dict:
+    experts = cfg.get("profile_experts") or cfg.get("profiles") or {}
+    if not isinstance(experts, dict):
+        return {}
+    entry = experts.get(profile) or {}
+    if isinstance(entry, str):
+        return {"hermes_home": entry}
+    if isinstance(entry, dict):
+        return dict(entry)
+    return {}
+
+
+def _resolve_profile_home(profile: str, cfg: Optional[dict] = None) -> Path:
+    """Resolve a target expert profile to a HERMES_HOME directory.
+
+    Named Hermes profiles are supported by default.  Custom homes outside
+    Hermes' named-profile directory must be explicitly allowlisted in:
+
+        delegation:
+          profile_experts:
+            reviewer:
+              hermes_home: ~/.hermes-reviewer
+    """
+    cfg = cfg if cfg is not None else _load_delegation_config()
+    entry = _profile_expert_entry(cfg, profile)
+    configured_home = (
+        entry.get("hermes_home")
+        or entry.get("home")
+        or entry.get("path")
+        or entry.get("profile_home")
+    )
+    if configured_home:
+        home = _expand_path(str(configured_home))
+    else:
+        if cfg.get("allow_named_profile_experts", True) is False:
+            raise ValueError(f"Profile expert '{profile}' is not allowlisted.")
+        from hermes_cli.profiles import resolve_profile_env
+
+        home = _expand_path(resolve_profile_env(profile))
+
+    if not (home / "config.yaml").is_file():
+        raise ValueError(f"Profile expert '{profile}' has no config.yaml at {home}")
+    return home
+
+
+def _resolve_profile_toolsets(profile: str, cfg: dict) -> Optional[str]:
+    entry = _profile_expert_entry(cfg, profile)
+    toolsets = _as_list(entry.get("toolsets"))
+    if not toolsets:
+        return None
+    return ",".join(toolsets)
+
+
+def _resolve_timeout(profile: str, requested: Optional[int], cfg: dict) -> int:
+    entry = _profile_expert_entry(cfg, profile)
+    default_timeout = entry.get(
+        "timeout_seconds",
+        cfg.get("profile_timeout_seconds", DEFAULT_PROFILE_TIMEOUT_SECONDS),
+    )
+    max_timeout = cfg.get("profile_max_timeout_seconds", DEFAULT_PROFILE_MAX_TIMEOUT_SECONDS)
+    try:
+        timeout = int(requested if requested is not None else default_timeout)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_PROFILE_TIMEOUT_SECONDS
+    try:
+        max_timeout_i = int(max_timeout)
+    except (TypeError, ValueError):
+        max_timeout_i = DEFAULT_PROFILE_MAX_TIMEOUT_SECONDS
+    return max(1, min(timeout, max_timeout_i))
+
+
+def _build_profile_prompt(profile: str, task: str, context: Optional[str] = None) -> str:
+    parts = [
+        f'You are being asked as the "{profile}" specialist Hermes profile.',
+        "",
+        "Contract:",
+        "- Stay inside this specialist lane and its available tools.",
+        "- Return evidence, findings, recommendations, and uncertainty for the caller to synthesize.",
+        "- Separate verified facts from assumptions.",
+        "- Cite files, tools, issues, docs, or source paths when available.",
+        "- State tool failures or unavailable sources plainly.",
+        "- Prefer plain ASCII text in headings and evidence labels.",
+        "- Do not update durable memory or external systems unless the task explicitly asks and your profile allows it.",
+        "- Do not claim durable truth. Your output is evidence for the caller.",
+        "",
+        "Task:",
+        task.strip(),
+    ]
+    if context and context.strip():
+        parts.extend(["", "Additional context:", context.strip()])
+    return "\n".join(parts)
+
+
+def _build_command(prompt: str, profile: str, cfg: dict) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "hermes_cli.main",
+        "chat",
+        "-Q",
+        "--source",
+        f"profile-expert:{profile}",
+        "-q",
+        prompt,
+    ]
+    toolsets = _resolve_profile_toolsets(profile, cfg)
+    if toolsets:
+        command.extend(["--toolsets", toolsets])
+    return command
+
+
+def ask_profile(
+    profile: str,
+    task: str,
+    context: Optional[str] = None,
+    timeout_seconds: Optional[int] = None,
+) -> str:
+    """Ask a configured Hermes profile to perform a bounded expert task."""
+    profile = (profile or "").strip()
+    task = (task or "").strip()
+    if not profile:
+        return json.dumps({"error": "profile is required"})
+    if not task:
+        return json.dumps({"error": "task is required"})
+
+    cfg = _load_delegation_config()
+    try:
+        profile_home = _resolve_profile_home(profile, cfg)
+    except Exception as exc:
+        return json.dumps({"error": str(exc)})
+
+    timeout = _resolve_timeout(profile, timeout_seconds, cfg)
+    prompt = _build_profile_prompt(profile, task, context)
+    command = _build_command(prompt, profile, cfg)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(profile_home)
+    env["HERMES_PROFILE_EXPERT_PROFILE"] = profile
+    parent_home = os.environ.get("HERMES_HOME")
+    if parent_home:
+        env["HERMES_PROFILE_EXPERT_PARENT_HOME"] = parent_home
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        if not env.get("PYTHONPATH")
+        else str(repo_root) + os.pathsep + env["PYTHONPATH"]
+    )
+
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=os.getcwd(),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration = round(time.monotonic() - started, 3)
+        return json.dumps(
+            {
+                "profile": profile,
+                "status": "timed_out",
+                "exit_code": 124,
+                "duration_seconds": duration,
+                "timeout_seconds": timeout,
+                "hermes_home": str(profile_home),
+                "output": (exc.stdout or "").strip(),
+                "error": (exc.stderr or "").strip() or f"Timed out after {timeout}s",
+            }
+        )
+
+    duration = round(time.monotonic() - started, 3)
+    status = "completed" if completed.returncode == 0 else "failed"
+    result: Dict[str, Any] = {
+        "profile": profile,
+        "status": status,
+        "exit_code": completed.returncode,
+        "duration_seconds": duration,
+        "timeout_seconds": timeout,
+        "hermes_home": str(profile_home),
+        "output": (completed.stdout or "").strip(),
+    }
+    stderr = (completed.stderr or "").strip()
+    if stderr:
+        result["stderr"] = stderr
+    return json.dumps(result)
+
+
+ASK_PROFILE_SCHEMA = {
+    "name": "ask_profile",
+    "description": (
+        "Ask another Hermes profile to act as a bounded expert and return its "
+        "answer as evidence. This uses a fresh Hermes subprocess with that "
+        "profile's HERMES_HOME, rather than switching the current runtime. "
+        "Use this when you need a specialist profile's narrower tools, "
+        "identity, or operating rules."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Target Hermes profile name or configured profile expert "
+                    "alias from delegation.profile_experts."
+                ),
+            },
+            "task": {
+                "type": "string",
+                "description": "The bounded task or question for the expert profile.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Optional concise context to pass to the expert profile.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": (
+                    "Optional timeout for this expert run. Capped by "
+                    "delegation.profile_max_timeout_seconds."
+                ),
+            },
+        },
+        "required": ["profile", "task"],
+    },
+}
+
+
+registry.register(
+    name="ask_profile",
+    toolset="delegation",
+    schema=ASK_PROFILE_SCHEMA,
+    handler=lambda args, **kw: ask_profile(
+        profile=args.get("profile", ""),
+        task=args.get("task", ""),
+        context=args.get("context"),
+        timeout_seconds=args.get("timeout_seconds"),
+    ),
+    emoji="🧭",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "ask_profile",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -193,8 +193,8 @@ TOOLSETS = {
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Spawn subagents or ask specialist profiles for complex subtasks",
+        "tools": ["delegate_task", "ask_profile"],
         "includes": []
     },
 
@@ -309,7 +309,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "ask_profile",
         ],
         "includes": []
     },
@@ -337,7 +337,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "ask_profile",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -1,12 +1,14 @@
 ---
 sidebar_position: 7
 title: "Subagent Delegation"
-description: "Spawn isolated child agents for parallel workstreams with delegate_task"
+description: "Spawn isolated child agents and ask specialist profiles for bounded work"
 ---
 
-# Subagent Delegation
+# Delegation
 
 The `delegate_task` tool spawns child AIAgent instances with isolated context, restricted toolsets, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
+
+The `ask_profile` tool asks another Hermes profile to act as a bounded expert. It starts a fresh Hermes subprocess with that profile's `HERMES_HOME`, then returns the specialist profile's output as evidence for the parent to synthesize. Use it when the task should run under another profile's identity, memory, configuration, or tool boundaries rather than inside the current profile.
 
 ## Single Task
 
@@ -56,6 +58,22 @@ delegate_task(
 The subagent receives a focused system prompt built from your goal and context, instructing it to complete the task and provide a structured summary of what it did, what it found, any files modified, and any issues encountered.
 
 ## Practical Examples
+
+### Ask a Specialist Profile
+
+Ask a named profile for evidence without switching the current runtime:
+
+```python
+ask_profile(
+    profile="reviewer",
+    task="Review the API design for auth and tenant-boundary risks.",
+    context="The design doc is at /home/user/project/docs/auth-api.md"
+)
+```
+
+`ask_profile` is intentionally subprocess-backed. Hermes profiles are selected before most profile-scoped modules import, so the child process gets the target profile's config, memory, skills, sessions, and tool settings from startup.
+
+The expert profile's response is evidence, not durable truth. The parent profile remains responsible for deciding what to accept, what to tell the user, and whether to update memory or external systems.
 
 ### Parallel Research
 
@@ -161,6 +179,8 @@ Certain toolsets are blocked for subagents regardless of what you specify:
 - `code_execution` — children should reason step-by-step
 - `send_message` — no cross-platform side effects (e.g., sending Telegram messages)
 
+For `ask_profile`, toolset control happens through the expert profile's own config. You can also set a per-expert `toolsets` list in the parent profile's `delegation.profile_experts` entry; Hermes passes that list to the child process.
+
 ## Max Iterations
 
 Each subagent has an iteration limit (default: 50) that controls how many tool-calling turns it can take:
@@ -237,6 +257,7 @@ For **durable long-running work** that must survive interrupts or outlive the cu
 ## Key Properties
 
 - Each subagent gets its **own terminal session** (separate from the parent)
+- `ask_profile` gets a **separate Hermes process** with the target profile's `HERMES_HOME`
 - **Nested delegation is opt-in** — only `role="orchestrator"` children can delegate further, and only when `max_spawn_depth` is raised from its default of 1 (flat). Disable globally with `orchestrator_enabled: false`.
 - Leaf subagents **cannot** call: `delegate_task`, `clarify`, `memory`, `send_message`, `execute_code`. Orchestrator subagents retain `delegate_task` but still cannot use the other four.
 - **Interrupt propagation** — interrupting the parent interrupts all active children (including grandchildren under orchestrators)
@@ -274,6 +295,23 @@ delegation:
   model: "qwen2.5-coder"
   base_url: "http://localhost:1234/v1"
   api_key: "local-key"
+```
+
+Profile expert delegation can target Hermes named profiles by default. Custom profile homes should be allowlisted in the parent profile:
+
+```yaml
+delegation:
+  profile_experts:
+    reviewer:
+      hermes_home: ~/.hermes-reviewer
+      toolsets:
+        - web
+        - terminal
+        - file
+      timeout_seconds: 300
+  profile_timeout_seconds: 600
+  profile_max_timeout_seconds: 1800
+  # allow_named_profile_experts: false      # Require every expert alias to be configured
 ```
 
 :::tip


### PR DESCRIPTION
## Summary
- add `ask_profile`, a delegation tool that asks another Hermes profile through a fresh subprocess with that profile's `HERMES_HOME`
- wire `ask_profile` into the delegation/core/ACP/API-server toolsets
- document profile expert delegation and add focused tests for profile resolution, timeout handling, prompt contract, and subprocess invocation

## Why
`delegate_task` is useful for same-profile child work, but some workflows need a specialist profile with its own memory, skills, config, and tool boundaries. `ask_profile` keeps the current runtime as coordinator while returning the specialist response as evidence.

## Validation
- `python3 -m pytest tests/tools/test_profile_delegation_tool.py tests/test_toolsets.py -q`
- `python3 - <<'PY' ... get_tool_definitions(enabled_toolsets=['delegation']) ... PY` returned `ask_profile` and `delegate_task`
