### PR TITLE
fix(cli): guard quick_commands against non-dict values

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6581,7 +6581,9 @@ class HermesCLI:
             quick_commands = self.config.get("quick_commands", {})
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
-                if qcmd.get("type") == "exec":
+                if not isinstance(qcmd, dict):
+                    self._console_print(f"[bold red]Quick command '{base_cmd}' has invalid value (expected dict, got {type(qcmd).__name__}), skipping[/]")
+                elif qcmd.get("type") == "exec":
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:


### PR DESCRIPTION
## Fix: Guard quick_commands against non-dict values

### Problem
`cli.py:6584` calls `qcmd.get("type")` on whatever value is in `quick_commands` — no validation that it's actually a dict. If a user has a string, int, or null value in their quick_commands config, all slash commands matching that key crash with `AttributeError: 'str' object has no attribute 'get'`.

Even worse, a broken quick_commands entry **poisons** any overlapping skill command, because quick_commands is checked BEFORE skill commands in the dispatch chain.

### Reproduction
```yaml
# ~/.hermes/config.yaml
quick_commands:
  foo: ''  # string instead of dict
```
Then `/foo` → `Error: 'str' object has no attribute 'get'`

### Fix
Added `isinstance(qcmd, dict)` guard before accessing dict methods, matching the pattern already used in `gateway/run.py:5214-5215`. If the value is not a dict, we log a warning and fall through to plugin/skill command dispatch instead of crashing.

### Testing
- Verified the fix applies cleanly on top of current `origin/main`
- The gateway already has this guard (lines 5214-5215), so this brings CLI parity with gateway

Fixes #18816