### PR TITLE
[codex] Allow gateway to preserve suspended sessions

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -224,6 +224,7 @@ class SessionResetPolicy:
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
     notify_exclude_platforms: tuple = ("api_server", "webhook")  # Platforms that don't get reset notifications
+    reset_suspended: bool = True  # Reset sessions that were stopped/interrupted mid-turn
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -232,6 +233,7 @@ class SessionResetPolicy:
             "idle_minutes": self.idle_minutes,
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
+            "reset_suspended": self.reset_suspended,
         }
     
     @classmethod
@@ -242,12 +244,14 @@ class SessionResetPolicy:
         idle_minutes = data.get("idle_minutes")
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
+        reset_suspended = data.get("reset_suspended")
         return cls(
             mode=mode if mode is not None else "both",
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
+            reset_suspended=_coerce_bool(reset_suspended, True),
         )
 
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -873,12 +873,24 @@ class SessionStore:
                 entry = self._entries[session_key]
 
                 # Auto-reset sessions marked as suspended (e.g. after /stop
-                # broke a stuck loop — #7536).  ``suspended`` is the hard
-                # forced-wipe signal and always wins over ``resume_pending``,
-                # so repeated interrupted restarts that escalate via the
-                # existing ``.restart_failure_counts`` stuck-loop counter
-                # still converge to a clean slate.
+                # broke a stuck loop — #7536) unless the reset policy opts into
+                # preserving stopped/interrupted sessions.  The preserve path
+                # clears ``suspended`` and marks the session as resume_pending
+                # so the next turn gets the same recovery note as a restart
+                # interruption.
                 if entry.suspended:
+                    policy = self.config.get_reset_policy(
+                        platform=source.platform,
+                        session_type=source.chat_type,
+                    )
+                    if not getattr(policy, "reset_suspended", True):
+                        entry.suspended = False
+                        entry.resume_pending = True
+                        entry.resume_reason = entry.resume_reason or "suspended"
+                        entry.last_resume_marked_at = now
+                        entry.updated_at = now
+                        self._save()
+                        return entry
                     reset_reason = "suspended"
                 elif entry.resume_pending:
                     # Restart-interrupted session: preserve the session_id

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -136,18 +136,24 @@ class TestSessionResetPolicy:
         assert policy.mode == "both"
         assert policy.at_hour == 4
         assert policy.idle_minutes == 1440
+        assert policy.reset_suspended is True
 
     def test_from_dict_treats_null_values_as_defaults(self):
         restored = SessionResetPolicy.from_dict(
-            {"mode": None, "at_hour": None, "idle_minutes": None}
+            {"mode": None, "at_hour": None, "idle_minutes": None, "reset_suspended": None}
         )
         assert restored.mode == "both"
         assert restored.at_hour == 4
         assert restored.idle_minutes == 1440
+        assert restored.reset_suspended is True
 
     def test_from_dict_coerces_quoted_false_notify(self):
         restored = SessionResetPolicy.from_dict({"notify": "false"})
         assert restored.notify is False
+
+    def test_from_dict_coerces_quoted_false_reset_suspended(self):
+        restored = SessionResetPolicy.from_dict({"reset_suspended": "false"})
+        assert restored.reset_suspended is False
 
 
 class TestStreamingConfig:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -32,7 +32,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig, SessionResetPolicy
 from gateway.run import (
     _auto_continue_freshness_window,
     _coerce_gateway_timestamp,
@@ -333,6 +333,27 @@ class TestGetOrCreateResumePending:
         assert second.session_id != original_sid
         assert second.was_auto_reset is True
         assert second.auto_reset_reason == "suspended"
+
+    def test_suspended_can_resume_when_policy_disables_reset(self, tmp_path):
+        """Configured deployments can preserve stopped/interrupted sessions."""
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(
+                default_reset_policy=SessionResetPolicy(reset_suspended=False)
+            ),
+        )
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+        store.suspend_session(first.session_key)
+
+        second = store.get_or_create_session(source)
+        assert second.session_id == original_sid
+        assert second.was_auto_reset is False
+        assert second.auto_reset_reason is None
+        assert second.suspended is False
+        assert second.resume_pending is True
+        assert second.resume_reason == "suspended"
 
     def test_suspended_overrides_resume_pending(self, tmp_path):
         """Terminal escalation: a session that somehow has BOTH flags must

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -205,3 +205,4 @@ class TestResetPolicyNotify:
         assert restored.notify == original.notify
         assert restored.notify_exclude_platforms == original.notify_exclude_platforms
         assert restored.mode == original.mode
+        assert restored.reset_suspended == original.reset_suspended

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -362,6 +362,13 @@ Before a session is auto-reset, the agent is given a turn to save any important 
 
 Sessions with **active background processes** are never auto-reset, regardless of policy.
 
+Sessions interrupted by `/stop`, a gateway crash, or repeated restart failures are normally treated as suspended and reset on the next message so a stuck loop does not immediately resume. To keep those sessions resumable instead, set:
+
+```yaml
+session_reset:
+  reset_suspended: false
+```
+
 ## Storage Locations
 
 | What | Path | Description |


### PR DESCRIPTION
## Summary
- add `session_reset.reset_suspended` to control whether stopped/interrupted gateway sessions are hard-reset
- when disabled, clear the suspended flag and mark the session `resume_pending` so the next message continues with the existing transcript
- document the setting and cover the default and opt-in behavior with focused tests

## Why
The existing hard-suspend path was introduced to avoid unrecoverable stuck-session loops (#7536). Later restart-resume work added `resume_pending` for interrupted restarts (#11852), but explicit `suspended` sessions still always force a fresh session. That is safe, but it can be too destructive for deployments that prefer continuity and explicit `/reset`.

This PR keeps upstream default behavior unchanged (`reset_suspended: true`) and adds an opt-in for deployments that want stopped/interrupted sessions to continue automatically.

## Validation
- `/home/juan/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_config.py::TestSessionResetPolicy tests/gateway/test_restart_resume_pending.py::TestGetOrCreateResumePending tests/gateway/test_session_reset_notify.py::TestResetPolicyNotify -q`

Related: #7536, #4493, #9850, #9934, #11852