### PR TITLE
fix(gateway): respect reply_in_thread=false for Slack progress messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11977,7 +11977,20 @@ class GatewayRunner:
             if slack_reply_in_thread:
                 _progress_thread_id = source.thread_id or event_message_id
             else:
-                _progress_thread_id = source.thread_id
+                # The Slack adapter sets source.thread_id to the user's own
+                # message ts for top-level DMs (synthetic thread used for
+                # session keying). When reply_in_thread is false, treat that
+                # synthetic thread_id as "no thread" so progress messages
+                # stay at the channel/DM top level instead of starting a
+                # thread that subsequent messages would inherit.
+                if (
+                    source.thread_id
+                    and event_message_id
+                    and source.thread_id == event_message_id
+                ):
+                    _progress_thread_id = None
+                else:
+                    _progress_thread_id = source.thread_id
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11961,7 +11961,23 @@ class GatewayRunner:
         #   normal DM/group message id as thread_id causes send failures
         # - Other platforms should use explicit source.thread_id only
         if source.platform == Platform.SLACK:
-            _progress_thread_id = source.thread_id or event_message_id
+            # The Slack adapter falls back to event_message_id so progress
+            # messages can be edited inside a thread. Honour
+            # platforms.slack.extra.reply_in_thread=false: if the user has
+            # opted out of threaded replies, don't synthesise a thread for
+            # progress messages either — the very first progress message
+            # would otherwise create a thread that all subsequent replies
+            # (including the final answer) would inherit.
+            slack_adapter = (self.adapters or {}).get(Platform.SLACK)
+            slack_reply_in_thread = True
+            if slack_adapter is not None:
+                slack_reply_in_thread = slack_adapter.config.extra.get(
+                    "reply_in_thread", True
+                )
+            if slack_reply_in_thread:
+                _progress_thread_id = source.thread_id or event_message_id
+            else:
+                _progress_thread_id = source.thread_id
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None


### PR DESCRIPTION
## What does this PR do?

When `platforms.slack.extra.reply_in_thread: false` is set, the Slack
adapter correctly avoids creating threads for the *final* reply
(`SlackAdapter._resolve_thread_ts` already honours the flag). But the
Gateway's progress-message path still synthesises a thread via the
Slack-specific `event_message_id` fallback in `gateway/run.py`, so the
very first progress message ("terminal: …", "Processing…") creates a
thread that all subsequent edits and the final answer inherit.

Net effect: users who set `reply_in_thread: false` still get every
multi-tool agent response wrapped in a thread, defeating the setting.

This patch checks the live Slack adapter's `reply_in_thread` flag
before applying the `event_message_id` fallback. When threading is
disabled, progress messages are sent top-level just like the final
reply.

## Related Issue

(none — opening as direct fix)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: in `_progress_thread_id` resolution for Slack, look
  up the active Slack adapter's `config.extra.reply_in_thread` and skip
  the `event_message_id` fallback when it's false.

## How to Test

1. Configure Slack with `platforms.slack.extra.reply_in_thread: false`
   and `display.tool_progress: new`.
2. Send a top-level DM/mention that triggers at least one tool call.
3. Before the fix: the response (progress + final answer) appears in a
   newly-created thread.
4. After the fix: the response appears as top-level messages in the
   channel/DM.

## Notes

- Patch deployed and verified in production on a Slack-bot install
  (Oscar, qmd document-search agent on Slack); behaviour matches the
  description above.
- No new tests added — the surrounding code path doesn't currently
  have unit coverage for platform-specific progress-thread resolution
  and I didn't want to scope-creep this PR. Happy to add test scaffolding
  in a follow-up if maintainers want it.