### PR TITLE
fix(tui): normalize structured history content in session resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -254,6 +254,36 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
     ]
 
 
+def test_history_to_messages_accepts_multimodal_list_content():
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello from list"},
+                {"type": "image_url", "image_url": {"url": "file:///tmp/demo.png"}},
+                "tail text",
+            ],
+        }
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "hello from list\ntail text"},
+    ]
+
+
+def test_history_to_messages_accepts_structured_dict_content():
+    history = [
+        {
+            "role": "assistant",
+            "content": {"type": "message", "content": [{"type": "text", "text": "hello from dict"}]},
+        }
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "assistant", "text": "hello from dict"},
+    ]
+
+
 def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1910,6 +1910,29 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
 
 
 def _history_to_messages(history: list[dict]) -> list[dict]:
+    def _content_to_text(content) -> str:
+        """Return a best-effort plain-text view for transcript rendering."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                text = _content_to_text(item)
+                if text:
+                    parts.append(text)
+            return "\n".join(parts)
+        if isinstance(content, dict):
+            text = content.get("text")
+            if isinstance(text, str):
+                return text
+            nested = content.get("content")
+            if nested is not None and nested is not content:
+                return _content_to_text(nested)
+            return ""
+        return str(content)
+
     messages = []
     tool_call_args = {}
 
@@ -1929,7 +1952,8 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-            if not (m.get("content") or "").strip():
+            content_text = _content_to_text(m.get("content")).strip()
+            if not content_text:
                 continue
         if role == "tool":
             tc_id = m.get("tool_call_id", "")
@@ -1940,9 +1964,10 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                 {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
             )
             continue
-        if not (m.get("content") or "").strip():
+        content_text = _content_to_text(m.get("content")).strip()
+        if not content_text:
             continue
-        messages.append({"role": role, "text": m.get("content") or ""})
+        messages.append({"role": role, "text": content_text})
 
     return messages
 


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI resume crash when stored session history contains structured or multimodal `content` values instead of plain strings.

`_history_to_messages()` in `tui_gateway/server.py` assumed every message content was string-like and called `.strip()` directly. That breaks on valid list/dict-shaped history entries, including multimodal text blocks and structured assistant/user messages.

This change adds a small best-effort text normalizer for resume transcript rendering so the TUI can safely display:
- multimodal list content with text blocks
- structured dict content with nested text/content fields

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Updated [tui_gateway/server.py](/C:/Users/ysfdu/OneDrive/Desktop/DEV/H4rry/hr3/tui_gateway/server.py) to normalize non-string history content before filtering/rendering it in `_history_to_messages()`
- Added regression tests in [tests/test_tui_gateway_server.py](/C:/Users/ysfdu/OneDrive/Desktop/DEV/H4rry/hr3/tests/test_tui_gateway_server.py) for:
  - multimodal list content
  - structured dict content
  - existing tool-call resume behavior

## How to Test

1. Run:
   ```bash
   uv run pytest tests/test_tui_gateway_server.py::test_history_to_messages_preserves_tool_calls_for_resume_display tests/test_tui_gateway_server.py::test_history_to_messages_accepts_multimodal_list_content tests/test_tui_gateway_server.py::test_history_to_messages_accepts_structured_dict_content

-Verify all 3 tests pass.
-Optionally reproduce the original failure by feeding _history_to_messages() a history entry with list/dict content and confirm it no longer raises AttributeError.