### PR TITLE
fix(tts): improve Opus encoding quality for Telegram voice messages

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -710,7 +710,7 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     try:
         result = subprocess.run(
             ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+             "-ac", "1", "-b:a", "48k", "-vbr", "on", "-application", "voip", "-compression_level", "10", ogg_path, "-y"],
             capture_output=True, timeout=30,
         )
         if result.returncode != 0:
@@ -1199,7 +1199,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
                 cmd = [
                     ffmpeg, "-i", wav_path,
                     "-acodec", "libopus", "-ac", "1",
-                    "-b:a", "64k", "-vbr", "off",
+                    "-b:a", "48k", "-vbr", "on", "-application", "voip", "-compression_level", "10",
                     "-y", "-loglevel", "error",
                     output_path,
                 ]


### PR DESCRIPTION
## Summary

Fixes #18818 — suboptimal Opus encoding for Gemini/Edge TTS causing quality loss in Telegram voice messages.

## Problem

Both `_convert_to_opus()` and `_generate_gemini_tts()` use ffmpeg with suboptimal Opus encoding settings:

```bash
ffmpeg -i input -acodec libopus -ac 1 -b:a 64k -vbr off output.ogg -y
```

Issues:
- **`-vbr off`** forces Constant Bitrate (CBR) — wastes bits on silence, starves complex segments
- **Missing `-application voip`** — Opus encoder defaults to `audio` mode, not optimized for speech
- **Missing `-compression_level 10`** — lower compression quality

This causes:
1. Noticeably lower speech quality compared to properly-encoded Opus
2. Inconsistent Telegram voice bubble rendering (some files appear as regular audio instead of voice messages)

## Fix

Changed ffmpeg encoding parameters at both call sites:

| Parameter | Before | After | Why |
|-----------|--------|-------|-----|
| `-b:a` | `64k` | `48k` | 48k VBR is standard for VoIP; VBR uses bits more efficiently |
| `-vbr` | `off` (CBR) | `on` (VBR) | VBR allocates bits where needed for speech |
| `-application` | _(missing)_ | `voip` | Optimizes Opus for voice intelligibility |
| `-compression_level` | _(missing)_ | `10` | Maximum encoding quality |

## Testing

- ffmpeg `-application voip` is a standard libopus option (value 2048) that enables CELT+SILK hybrid mode optimized for speech
- 48k VBR is the standard bitrate for high-quality VoIP Opus
- No functional changes to the conversion pipeline — only encoding parameters changed

## Affected Code

- `tools/tts_tool.py:712` — `_convert_to_opus()` (used by Edge TTS, xAI TTS, and other providers)
- `tools/tts_tool.py:1201` — `_generate_gemini_tts()` inline conversion