### PR TITLE
feat: add Cory control plane worker

### DIFF
--- a/cory_runtime/__init__.py
+++ b/cory_runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Cory-on-Hermes runtime integration for the Cory control plane."""
+
+from .config import CoryWorkerConfig
+from .control_plane import ControlPlaneClient
+from .executor import HermesCoryExecutor, InterpretationExecutionError
+from .worker import CoryControlPlaneWorker, WorkerOutcome
+
+__all__ = [
+    "ControlPlaneClient",
+    "CoryControlPlaneWorker",
+    "CoryWorkerConfig",
+    "HermesCoryExecutor",
+    "InterpretationExecutionError",
+    "WorkerOutcome",
+]

--- a/cory_runtime/cli.py
+++ b/cory_runtime/cli.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import logging
+
+from hermes_logging import setup_logging
+
+from .config import CoryWorkerConfig
+from .control_plane import ControlPlaneClient
+from .executor import HermesCoryExecutor
+from .worker import CoryControlPlaneWorker
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hermes-cory-worker",
+        description="Run Cory request-interpretation jobs against a Cory control plane using Hermes as the execution runtime.",
+    )
+    parser.add_argument("--control-plane-base-url")
+    parser.add_argument("--internal-api-token")
+    parser.add_argument("--model")
+    parser.add_argument("--provider")
+    parser.add_argument("--poll-interval-seconds", type=float)
+    parser.add_argument("--max-backoff-seconds", type=float)
+    parser.add_argument("--max-completion-attempts", type=int)
+    parser.add_argument("--request-timeout-seconds", type=float)
+    parser.add_argument("--once", action="store_true")
+    return parser
+
+
+def load_config(args: argparse.Namespace) -> CoryWorkerConfig:
+    try:
+        config = CoryWorkerConfig.from_env()
+    except ValueError:
+        base_url = args.control_plane_base_url
+        token = args.internal_api_token
+        if not base_url or not token:
+            raise
+        config = CoryWorkerConfig(
+            control_plane_base_url=base_url.rstrip("/"),
+            internal_api_token=token,
+        )
+
+    if args.control_plane_base_url:
+        config.control_plane_base_url = args.control_plane_base_url.rstrip("/")
+    if args.internal_api_token:
+        config.internal_api_token = args.internal_api_token
+    if args.model:
+        config.model = args.model
+    if args.provider:
+        config.provider = args.provider
+    if args.poll_interval_seconds is not None:
+        config.poll_interval_seconds = args.poll_interval_seconds
+    if args.max_backoff_seconds is not None:
+        config.max_backoff_seconds = args.max_backoff_seconds
+    if args.max_completion_attempts is not None:
+        config.max_completion_attempts = args.max_completion_attempts
+    if args.request_timeout_seconds is not None:
+        config.request_timeout_seconds = args.request_timeout_seconds
+    if args.once:
+        config.once = True
+
+    return config
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    config = load_config(args)
+
+    setup_logging(mode="cli")
+    logging.getLogger(__name__).info(
+        "Starting hermes-cory-worker against %s",
+        config.control_plane_base_url,
+    )
+
+    with ControlPlaneClient(
+        base_url=config.control_plane_base_url,
+        token=config.internal_api_token,
+        timeout_seconds=config.request_timeout_seconds,
+    ) as client:
+        executor = HermesCoryExecutor(
+            model=config.model,
+            provider=config.provider,
+            max_completion_attempts=config.max_completion_attempts,
+        )
+        worker = CoryControlPlaneWorker(
+            client=client,
+            executor=executor,
+            poll_interval_seconds=config.poll_interval_seconds,
+            max_backoff_seconds=config.max_backoff_seconds,
+        )
+
+        if config.once:
+            worker.run_once()
+            return
+
+        worker.run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/cory_runtime/config.py
+++ b/cory_runtime/config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+def _env(name: str, *fallbacks: str) -> str | None:
+    for key in (name, *fallbacks):
+        value = os.getenv(key)
+        if value is not None and value.strip():
+            return value.strip()
+    return None
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    return float(value)
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    return int(value)
+
+
+@dataclass(slots=True)
+class CoryWorkerConfig:
+    control_plane_base_url: str
+    internal_api_token: str
+    model: str | None = None
+    provider: str | None = None
+    poll_interval_seconds: float = 5.0
+    max_backoff_seconds: float = 60.0
+    max_completion_attempts: int = 2
+    request_timeout_seconds: float = 30.0
+    once: bool = False
+
+    @classmethod
+    def from_env(cls) -> "CoryWorkerConfig":
+        base_url = _env("CORY_CONTROL_PLANE_BASE_URL", "CONTROL_PLANE_BASE_URL")
+        if not base_url:
+            raise ValueError(
+                "CORY_CONTROL_PLANE_BASE_URL or CONTROL_PLANE_BASE_URL is required",
+            )
+
+        token = _env(
+            "CORY_CONTROL_PLANE_INTERNAL_API_TOKEN",
+            "CONTROL_PLANE_INTERNAL_API_TOKEN",
+        )
+        if not token:
+            raise ValueError(
+                "CORY_CONTROL_PLANE_INTERNAL_API_TOKEN or CONTROL_PLANE_INTERNAL_API_TOKEN is required",
+            )
+
+        return cls(
+            control_plane_base_url=base_url.rstrip("/"),
+            internal_api_token=token,
+            model=_env("HERMES_CORY_MODEL"),
+            provider=_env("HERMES_CORY_PROVIDER"),
+            poll_interval_seconds=_env_float("HERMES_CORY_POLL_INTERVAL_SECONDS", 5.0),
+            max_backoff_seconds=_env_float("HERMES_CORY_MAX_BACKOFF_SECONDS", 60.0),
+            max_completion_attempts=_env_int("HERMES_CORY_MAX_COMPLETION_ATTEMPTS", 2),
+            request_timeout_seconds=_env_float("HERMES_CORY_REQUEST_TIMEOUT_SECONDS", 30.0),
+        )

--- a/cory_runtime/control_plane.py
+++ b/cory_runtime/control_plane.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .models import ClaimedJobEnvelope, InterpretationSubmission
+
+
+class ControlPlaneApiError(RuntimeError):
+    """Raised when the control plane returns a non-success response."""
+
+
+class ControlPlaneClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._client = httpx.Client(
+            base_url=base_url.rstrip("/"),
+            timeout=timeout_seconds,
+            headers={
+                "authorization": f"Bearer {token}",
+                "content-type": "application/json",
+            },
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "ControlPlaneClient":
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def claim_next_job(self) -> ClaimedJobEnvelope | None:
+        payload = self._request("POST", "/api/internal/request-interpretation-jobs/claim")
+        envelope = ClaimedJobEnvelope.model_validate(payload)
+        return envelope if envelope.claimed else None
+
+    def complete_job(
+        self,
+        claim: ClaimedJobEnvelope,
+        submission: InterpretationSubmission,
+    ) -> dict[str, Any]:
+        assert claim.harness is not None
+        return self._request(
+            "POST",
+            claim.harness.outputContract.completeEndpoint,
+            json=submission.model_dump(exclude_none=True),
+        )
+
+    def fail_job(self, claim: ClaimedJobEnvelope, error_message: str) -> dict[str, Any]:
+        assert claim.harness is not None
+        return self._request(
+            "POST",
+            claim.harness.outputContract.failEndpoint,
+            json={"errorMessage": error_message.strip()},
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        response = self._client.request(method, path, json=json)
+        if response.status_code >= 400:
+            message = self._extract_error(response)
+            raise ControlPlaneApiError(f"{method} {path} failed: {message}")
+        return response.json()
+
+    @staticmethod
+    def _extract_error(response: httpx.Response) -> str:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict):
+            message = payload.get("error")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+        return response.text.strip() or f"http_{response.status_code}"

--- a/cory_runtime/executor.py
+++ b/cory_runtime/executor.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Protocol
+
+from run_agent import AIAgent
+
+from .models import ClaimedJobEnvelope, InterpretationSubmission
+from .parser import OutputValidationError, parse_submission
+from .prompting import build_repair_prompt, build_system_message, build_user_message
+
+logger = logging.getLogger(__name__)
+
+
+class AgentProtocol(Protocol):
+    def run_conversation(
+        self,
+        user_message: str,
+        system_message: str | None = None,
+        conversation_history: list[dict[str, Any]] | None = None,
+        task_id: str | None = None,
+    ) -> dict[str, Any]:
+        ...
+
+
+class InterpretationExecutionError(RuntimeError):
+    """Raised when the Hermes runtime cannot produce a valid interpretation payload."""
+
+
+class HermesCoryExecutor:
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+        max_completion_attempts: int = 2,
+        agent_factory: Callable[[], AgentProtocol] | None = None,
+    ) -> None:
+        self._model = model
+        self._provider = provider
+        self._max_completion_attempts = max_completion_attempts
+        self._agent_factory = agent_factory
+
+    def run(self, claim: ClaimedJobEnvelope) -> InterpretationSubmission:
+        if claim.job is None or claim.harness is None:
+            raise InterpretationExecutionError("claimed job payload is incomplete")
+
+        system_message = build_system_message(claim)
+        user_message = build_user_message(claim)
+        history: list[dict[str, Any]] | None = None
+        agent = self._create_agent()
+        last_error: str | None = None
+
+        for attempt in range(1, self._max_completion_attempts + 1):
+            prompt = (
+                user_message
+                if history is None
+                else build_repair_prompt(claim, last_error or "invalid output")
+            )
+            result = agent.run_conversation(
+                user_message=prompt,
+                system_message=system_message if history is None else None,
+                conversation_history=history,
+                task_id=f"cory-request-interpretation-{claim.job.id}-attempt-{attempt}",
+            )
+
+            response_text = str(result.get("final_response") or "").strip()
+            history = result.get("messages")
+            try:
+                return parse_submission(response_text, claim.harness)
+            except OutputValidationError as exc:
+                last_error = str(exc)
+                logger.warning(
+                    "Cory interpretation output failed validation for job %s on attempt %s/%s: %s",
+                    claim.job.id,
+                    attempt,
+                    self._max_completion_attempts,
+                    last_error,
+                )
+
+        raise InterpretationExecutionError(
+            f"failed to produce a valid interpretation payload after {self._max_completion_attempts} attempt(s): {last_error}",
+        )
+
+    def _create_agent(self) -> AgentProtocol:
+        if self._agent_factory is not None:
+            return self._agent_factory()
+
+        agent_kwargs: dict[str, Any] = {
+            "quiet_mode": True,
+            "enabled_toolsets": [],
+            "skip_context_files": True,
+            "skip_memory": True,
+        }
+        if self._model:
+            agent_kwargs["model"] = self._model
+        if self._provider:
+            agent_kwargs["provider"] = self._provider
+        return AIAgent(**agent_kwargs)

--- a/cory_runtime/models.py
+++ b/cory_runtime/models.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+RequestType = Literal[
+    "advisory_discussion",
+    "governed_change_request",
+    "execution_task",
+    "km_candidate",
+]
+WorkflowState = Literal[
+    "received",
+    "interpretation_pending",
+    "needs_clarification",
+    "draft_ready",
+    "awaiting_approval",
+    "approved",
+    "rejected",
+    "in_progress",
+    "blocked",
+    "completed",
+    "archived",
+]
+InterpretationStatus = Literal["completed", "needs_human_review"]
+
+
+class CoryBaseModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class SkillRequirement(CoryBaseModel):
+    id: str
+    required: bool
+    why: str
+
+
+class PromptBlueprint(CoryBaseModel):
+    systemIntent: list[str] = Field(default_factory=list)
+    operatingRules: list[str] = Field(default_factory=list)
+    taskPrompt: str
+    deliverables: list[str] = Field(default_factory=list)
+
+
+class OutputField(CoryBaseModel):
+    key: str
+    required: bool
+    description: str
+
+
+class WorkflowStateOption(CoryBaseModel):
+    state: WorkflowState
+    useWhen: str
+
+
+class OutputContract(CoryBaseModel):
+    completeEndpoint: str
+    failEndpoint: str
+    responseLanguage: str
+    artifactKeyLanguage: str
+    interpretationFields: list[OutputField] = Field(default_factory=list)
+    nextWorkflowStateOptions: list[WorkflowStateOption] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class HarnessContextSummary(CoryBaseModel):
+    sourceType: str
+    requestType: RequestType
+    workflowState: WorkflowState
+    interpretationCount: int
+    openClarificationCount: int
+    linkedExecutionTask: bool
+
+
+class CoryHermesHarness(CoryBaseModel):
+    version: str
+    runtime: str
+    agent: str
+    mode: str
+    scenario: str
+    preferredResponseLanguage: str
+    artifactKeyLanguage: str
+    contextSummary: HarnessContextSummary
+    skills: list[SkillRequirement] = Field(default_factory=list)
+    prompt: PromptBlueprint
+    guardrails: list[str] = Field(default_factory=list)
+    outputContract: OutputContract
+
+
+class JobRecord(CoryBaseModel):
+    id: str
+    requestId: str | None = None
+    interpreter: str | None = None
+    triggerSource: str | None = None
+    requestedBy: str | None = None
+    status: str
+
+
+class RequestRecord(CoryBaseModel):
+    id: str
+    title: str | None = None
+    routingText: str | None = None
+    sourceType: str
+    sourceUrl: str | None = None
+    sourceEventId: str | None = None
+    sourcePayload: Any = None
+    projectId: str | None = None
+    repoId: str | None = None
+    activeInterpretationId: str | None = None
+    requestType: RequestType
+    workflowState: WorkflowState
+    requestedBy: str | None = None
+
+
+class InterpretationRecord(CoryBaseModel):
+    id: str
+    producedBy: str | None = None
+    interpretationStatus: str | None = None
+    summary: str | None = None
+    proposedRequestType: RequestType | None = None
+    proposedScope: str | None = None
+    proposedNonGoals: str | None = None
+    proposedClarifications: list[str] = Field(default_factory=list)
+    rawResponse: dict[str, Any] | None = None
+
+
+class ClarificationRecord(CoryBaseModel):
+    id: str
+    prompt: str
+    status: str
+    response: str | None = None
+    answeredBy: str | None = None
+
+
+class LinkedTaskRecord(CoryBaseModel):
+    id: str
+    title: str | None = None
+    status: str | None = None
+
+
+class ClaimedJobEnvelope(CoryBaseModel):
+    ok: bool
+    claimed: bool
+    job: JobRecord | None = None
+    request: RequestRecord | None = None
+    interpretations: list[InterpretationRecord] = Field(default_factory=list)
+    clarifications: list[ClarificationRecord] = Field(default_factory=list)
+    linkedTask: LinkedTaskRecord | None = None
+    harness: CoryHermesHarness | None = None
+
+    @model_validator(mode="after")
+    def validate_claim(self) -> "ClaimedJobEnvelope":
+        if self.claimed and (self.job is None or self.request is None or self.harness is None):
+            raise ValueError("claimed response must include job, request, and harness")
+        return self
+
+
+class InterpretationPayload(CoryBaseModel):
+    producedBy: str = "cory_hermes"
+    interpretationStatus: InterpretationStatus
+    summary: str
+    proposedRequestType: RequestType
+    proposedProjectId: str | None = None
+    proposedRepoId: str | None = None
+    proposedScope: str | None = None
+    proposedNonGoals: str | None = None
+    proposedClarifications: list[str] = Field(default_factory=list)
+    proposedBrief: dict[str, Any] | None = None
+    rawResponse: dict[str, Any]
+
+    @model_validator(mode="after")
+    def validate_strings(self) -> "InterpretationPayload":
+        self.producedBy = self.producedBy.strip()
+        self.summary = self.summary.strip()
+        if not self.producedBy:
+            raise ValueError("interpretation.producedBy must be non-empty")
+        if not self.summary:
+            raise ValueError("interpretation.summary must be non-empty")
+
+        normalized: list[str] = []
+        for item in self.proposedClarifications:
+            value = item.strip()
+            if not value:
+                raise ValueError("interpretation.proposedClarifications cannot contain blank items")
+            normalized.append(value)
+        self.proposedClarifications = normalized
+        return self
+
+
+class InterpretationSubmission(CoryBaseModel):
+    interpretation: InterpretationPayload
+    nextWorkflowState: WorkflowState | None = None

--- a/cory_runtime/parser.py
+++ b/cory_runtime/parser.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from pydantic import ValidationError
+
+from .models import CoryHermesHarness, InterpretationSubmission
+
+
+class OutputValidationError(ValueError):
+    """Raised when the Hermes response cannot be normalized into the runtime contract."""
+
+
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(\{[\s\S]*\})\s*```", re.IGNORECASE)
+
+
+def extract_json_object(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if not stripped:
+        raise OutputValidationError("model returned an empty response")
+
+    candidates = [stripped]
+    fenced = _FENCED_JSON_RE.findall(stripped)
+    candidates.extend(item.strip() for item in fenced)
+
+    decoder = json.JSONDecoder()
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+        for index, char in enumerate(candidate):
+            if char != "{":
+                continue
+            try:
+                parsed, _ = decoder.raw_decode(candidate[index:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+
+    raise OutputValidationError("model response did not contain a valid JSON object")
+
+
+def normalize_submission(
+    payload: dict[str, Any],
+    harness: CoryHermesHarness,
+) -> InterpretationSubmission:
+    envelope = payload
+    if "interpretation" not in envelope:
+        envelope = {"interpretation": payload}
+
+    interpretation = envelope.setdefault("interpretation", {})
+    if not isinstance(interpretation, dict):
+        raise OutputValidationError("interpretation must be an object")
+
+    interpretation.setdefault("producedBy", "cory_hermes")
+
+    allowed_states = [option.state for option in harness.outputContract.nextWorkflowStateOptions]
+    next_state = envelope.get("nextWorkflowState")
+    clarifications = interpretation.get("proposedClarifications") or []
+    if next_state is None:
+        if clarifications and "needs_clarification" in allowed_states:
+            envelope["nextWorkflowState"] = "needs_clarification"
+        elif "draft_ready" in allowed_states:
+            envelope["nextWorkflowState"] = "draft_ready"
+        elif len(allowed_states) == 1:
+            envelope["nextWorkflowState"] = allowed_states[0]
+
+    try:
+        submission = InterpretationSubmission.model_validate(envelope)
+    except ValidationError as exc:
+        raise OutputValidationError(exc.errors()[0]["msg"]) from exc
+
+    if submission.nextWorkflowState and submission.nextWorkflowState not in allowed_states:
+        raise OutputValidationError(
+            f"nextWorkflowState must be one of: {', '.join(allowed_states)}",
+        )
+
+    if (
+        submission.nextWorkflowState == "needs_clarification"
+        and not submission.interpretation.proposedClarifications
+    ):
+        raise OutputValidationError(
+            "nextWorkflowState=needs_clarification requires proposedClarifications",
+        )
+
+    return submission
+
+
+def parse_submission(text: str, harness: CoryHermesHarness) -> InterpretationSubmission:
+    payload = extract_json_object(text)
+    return normalize_submission(payload, harness)

--- a/cory_runtime/prompting.py
+++ b/cory_runtime/prompting.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .models import ClaimedJobEnvelope
+from .skill_loader import load_skill_bundle
+
+_MAX_CONTEXT_CHARS = 8000
+
+
+def _bullet_list(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items) if items else "- none"
+
+
+def _truncate(text: str, limit: int = _MAX_CONTEXT_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    head = text[: int(limit * 0.7)].rstrip()
+    tail = text[-int(limit * 0.2) :].lstrip()
+    return f"{head}\n...\n[truncated]\n...\n{tail}"
+
+
+def _pretty_json(data: Any) -> str:
+    try:
+        return _truncate(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True))
+    except TypeError:
+        return _truncate(repr(data))
+
+
+def _render_skills(claim: ClaimedJobEnvelope) -> str:
+    rendered: list[str] = []
+    for skill in load_skill_bundle(claim.harness.skills):
+        requirement = "required" if skill.required else "optional"
+        rendered.append(
+            "\n".join(
+                [
+                    f"### {skill.id} ({requirement})",
+                    f"Why it matters: {skill.why}",
+                    skill.content,
+                ],
+            ),
+        )
+    return "\n\n".join(rendered)
+
+
+def build_system_message(claim: ClaimedJobEnvelope) -> str:
+    assert claim.harness is not None
+    allowed_states = [option.state for option in claim.harness.outputContract.nextWorkflowStateOptions]
+
+    return "\n\n".join(
+        [
+            "# Cory Request Interpretation Runtime",
+            f"Harness version: {claim.harness.version}",
+            "## Identity",
+            _bullet_list(claim.harness.prompt.systemIntent),
+            "## Operating Rules",
+            _bullet_list(claim.harness.prompt.operatingRules),
+            "## Guardrails",
+            _bullet_list(claim.harness.guardrails),
+            "## Deliverables",
+            _bullet_list(claim.harness.prompt.deliverables),
+            "## Output Contract",
+            "\n".join(
+                [
+                    "Return only a single JSON object. Do not wrap it in markdown fences. Do not add commentary before or after the JSON.",
+                    'Set `interpretation.producedBy` to `"cory_hermes"`.',
+                    "Allowed interpretationStatus values: completed, needs_human_review.",
+                    "Allowed proposedRequestType values: advisory_discussion, governed_change_request, execution_task, km_candidate.",
+                    f"Allowed nextWorkflowState values: {', '.join(allowed_states) if allowed_states else 'none'}; you may also use null.",
+                    "Use zh-TW for human-facing strings like summary, scope, non-goals, and clarification prompts.",
+                    "Keep machine-facing keys, enums, and identifiers in English.",
+                    "Do not claim that approval has happened or that execution has started.",
+                    "Do not call tools or attempt code execution in this runtime step.",
+                    "rawResponse must be an object with machine-readable rationale, evidence, and decision notes.",
+                ],
+            ),
+            "## Cory Skills",
+            _render_skills(claim),
+        ],
+    )
+
+
+def build_user_message(claim: ClaimedJobEnvelope) -> str:
+    assert claim.job is not None
+    assert claim.request is not None
+    assert claim.harness is not None
+
+    interpretations = [
+        {
+            "id": item.id,
+            "producedBy": item.producedBy,
+            "interpretationStatus": item.interpretationStatus,
+            "summary": item.summary,
+            "proposedRequestType": item.proposedRequestType,
+            "proposedScope": item.proposedScope,
+            "proposedNonGoals": item.proposedNonGoals,
+            "proposedClarifications": item.proposedClarifications,
+        }
+        for item in claim.interpretations
+    ]
+    clarifications = [
+        {
+            "id": item.id,
+            "prompt": item.prompt,
+            "status": item.status,
+            "response": item.response,
+            "answeredBy": item.answeredBy,
+        }
+        for item in claim.clarifications
+    ]
+
+    return "\n\n".join(
+        [
+            "Interpret the following control-plane request using the supplied harness and return only valid JSON.",
+            "## Task Prompt",
+            claim.harness.prompt.taskPrompt,
+            "## Request",
+            _pretty_json(
+                {
+                    "jobId": claim.job.id,
+                    "requestId": claim.request.id,
+                    "title": claim.request.title,
+                    "routingText": claim.request.routingText,
+                    "sourceType": claim.request.sourceType,
+                    "sourceUrl": claim.request.sourceUrl,
+                    "sourceEventId": claim.request.sourceEventId,
+                    "requestType": claim.request.requestType,
+                    "workflowState": claim.request.workflowState,
+                    "requestedBy": claim.request.requestedBy,
+                    "projectId": claim.request.projectId,
+                    "repoId": claim.request.repoId,
+                },
+            ),
+            "## Source Payload",
+            _pretty_json(claim.request.sourcePayload),
+            "## Prior Interpretations",
+            _pretty_json(interpretations),
+            "## Clarifications",
+            _pretty_json(clarifications),
+            "## Linked Execution Task",
+            _pretty_json(
+                None
+                if claim.linkedTask is None
+                else {
+                    "id": claim.linkedTask.id,
+                    "title": claim.linkedTask.title,
+                    "status": claim.linkedTask.status,
+                },
+            ),
+            "## Required JSON Shape",
+            _pretty_json(
+                {
+                    "interpretation": {
+                        "producedBy": "cory_hermes",
+                        "interpretationStatus": "completed",
+                        "summary": "zh-TW summary",
+                        "proposedRequestType": "advisory_discussion",
+                        "proposedProjectId": None,
+                        "proposedRepoId": None,
+                        "proposedScope": None,
+                        "proposedNonGoals": None,
+                        "proposedClarifications": [],
+                        "proposedBrief": None,
+                        "rawResponse": {
+                            "scenario": claim.harness.scenario,
+                            "decision": "short English artifact key or enum-safe label",
+                            "evidence": [],
+                            "notes": [],
+                        },
+                    },
+                    "nextWorkflowState": claim.harness.outputContract.nextWorkflowStateOptions[0].state
+                    if claim.harness.outputContract.nextWorkflowStateOptions
+                    else None,
+                },
+            ),
+        ],
+    )
+
+
+def build_repair_prompt(claim: ClaimedJobEnvelope, error_message: str) -> str:
+    assert claim.harness is not None
+    allowed_states = [option.state for option in claim.harness.outputContract.nextWorkflowStateOptions]
+    return "\n".join(
+        [
+            "Your previous response did not satisfy the Cory interpretation contract.",
+            f"Validation error: {error_message}",
+            "Return a corrected JSON object only. No markdown fences. No extra prose.",
+            "Required top-level key: interpretation.",
+            "Allowed interpretationStatus values: completed, needs_human_review.",
+            f"Allowed nextWorkflowState values: {', '.join(allowed_states) if allowed_states else 'none'}; you may also use null.",
+        ],
+    )

--- a/cory_runtime/skill_loader.py
+++ b/cory_runtime/skill_loader.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .models import SkillRequirement
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SKILLS_ROOT = _REPO_ROOT / "skills" / "cory"
+
+_SKILL_FILE_MAP = {
+    "coding-agent-delegation": _SKILLS_ROOT / "coding-agent-delegation" / "SKILL.md",
+    "discussion-interpretation": _SKILLS_ROOT / "discussion-interpretation" / "SKILL.md",
+    "execution-planning": _SKILLS_ROOT / "execution-planning" / "SKILL.md",
+    "governed-change-analysis": _SKILLS_ROOT / "governed-change-analysis" / "SKILL.md",
+    "knowledge-compounding": _SKILLS_ROOT / "knowledge-compounding" / "SKILL.md",
+    "repo-resolution": _SKILLS_ROOT / "repo-resolution" / "SKILL.md",
+    "requirement-clarification": _SKILLS_ROOT / "requirement-clarification" / "SKILL.md",
+    "review-synthesis": _SKILLS_ROOT / "review-synthesis" / "SKILL.md",
+    "spec-reasoning": _SKILLS_ROOT / "spec-reasoning" / "SKILL.md",
+    "structured-event-triage": _SKILLS_ROOT / "structured-event-triage" / "SKILL.md",
+    "technical-option-analysis": _SKILLS_ROOT / "technical-option-analysis" / "SKILL.md",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedSkill:
+    id: str
+    required: bool
+    why: str
+    content: str
+
+
+def _strip_frontmatter(markdown: str) -> str:
+    if markdown.startswith("---\n"):
+        end = markdown.find("\n---\n", 4)
+        if end != -1:
+            return markdown[end + 5 :].strip()
+    return markdown.strip()
+
+
+def load_skill_text(skill_id: str) -> str:
+    path = _SKILL_FILE_MAP.get(skill_id)
+    if path is None:
+        raise KeyError(f"unknown Cory skill: {skill_id}")
+    if not path.is_file():
+        raise FileNotFoundError(f"missing Cory skill file: {path}")
+    return _strip_frontmatter(path.read_text(encoding="utf-8"))
+
+
+def load_skill_bundle(requirements: list[SkillRequirement]) -> list[LoadedSkill]:
+    return [
+        LoadedSkill(
+            id=requirement.id,
+            required=requirement.required,
+            why=requirement.why,
+            content=load_skill_text(requirement.id),
+        )
+        for requirement in requirements
+    ]

--- a/cory_runtime/worker.py
+++ b/cory_runtime/worker.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+import time
+from enum import Enum
+from typing import Callable
+
+from .control_plane import ControlPlaneApiError, ControlPlaneClient
+from .executor import HermesCoryExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerOutcome(str, Enum):
+    NO_JOB = "no_job"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class CoryControlPlaneWorker:
+    def __init__(
+        self,
+        *,
+        client: ControlPlaneClient,
+        executor: HermesCoryExecutor,
+        poll_interval_seconds: float = 5.0,
+        max_backoff_seconds: float = 60.0,
+        sleep_fn: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._client = client
+        self._executor = executor
+        self._poll_interval_seconds = poll_interval_seconds
+        self._max_backoff_seconds = max_backoff_seconds
+        self._sleep = sleep_fn
+
+    def run_once(self) -> WorkerOutcome:
+        claim = self._client.claim_next_job()
+        if claim is None:
+            logger.debug("No queued interpretation job available")
+            return WorkerOutcome.NO_JOB
+
+        assert claim.job is not None
+        logger.info("Claimed Cory interpretation job %s", claim.job.id)
+
+        try:
+            submission = self._executor.run(claim)
+        except Exception as exc:
+            message = str(exc).strip() or exc.__class__.__name__
+            logger.exception("Hermes failed while interpreting job %s", claim.job.id)
+            try:
+                self._client.fail_job(claim, message)
+            except Exception:
+                logger.exception("Failed to report interpretation failure for job %s", claim.job.id)
+                raise
+            return WorkerOutcome.FAILED
+
+        self._client.complete_job(claim, submission)
+        logger.info("Completed Cory interpretation job %s", claim.job.id)
+        return WorkerOutcome.COMPLETED
+
+    def run_forever(self) -> None:
+        backoff = self._poll_interval_seconds
+        while True:
+            try:
+                outcome = self.run_once()
+            except ControlPlaneApiError:
+                logger.exception("Control-plane API error while running Cory worker")
+                self._sleep(backoff)
+                backoff = min(backoff * 2, self._max_backoff_seconds)
+                continue
+            except Exception:
+                logger.exception("Unexpected Cory worker failure")
+                self._sleep(backoff)
+                backoff = min(backoff * 2, self._max_backoff_seconds)
+                continue
+
+            backoff = self._poll_interval_seconds
+            self._sleep(self._poll_interval_seconds if outcome == WorkerOutcome.NO_JOB else 0.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-cory-worker = "cory_runtime.cli:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "rl_cli", "utils"]
@@ -141,7 +142,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "agent.*", "cory_runtime", "cory_runtime.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/skills/cory/DESCRIPTION.md
+++ b/skills/cory/DESCRIPTION.md
@@ -1,0 +1,5 @@
+# Cory Skills
+
+Skills in this category support Cory's governed request-interpretation role on top of Hermes.
+
+They are written for ambiguous product, delivery, webhook, and KM inputs where the runtime must turn partial context into a reviewable interpretation without pretending execution or approval has already happened.

--- a/skills/cory/coding-agent-delegation/SKILL.md
+++ b/skills/cory/coding-agent-delegation/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: coding-agent-delegation
+description: Prepare bounded delegation framing for future coding agents without starting execution inside interpretation.
+---
+
+# Coding Agent Delegation
+
+Use this skill when the request is moving toward implementation and future coding-agent handoff is likely.
+
+Rules:
+- Do not delegate from the interpretation step.
+- Identify the likely work slices, dependencies, and approval boundaries that a later delegation step will need.
+- Keep the decomposition reversible until a human reviews it.
+
+Output expectations:
+- Explain what would need to be delegated later.
+- Preserve boundaries between planning, approval, and implementation.

--- a/skills/cory/discussion-interpretation/SKILL.md
+++ b/skills/cory/discussion-interpretation/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: discussion-interpretation
+description: Turn ambiguous PM or CTO discussion into a concrete interpreted request, preserving uncertainty instead of fabricating certainty.
+---
+
+# Discussion Interpretation
+
+Use this skill when the input is a human discussion, not yet a precise task.
+
+Rules:
+- Identify the real intent behind the discussion before proposing workflow state.
+- Separate observed facts from inferred intent.
+- Preserve ambiguity explicitly when the project, repo, scope, or action is still unclear.
+- Prefer a small set of high-signal clarification prompts over many low-value questions.
+
+Output expectations:
+- Summarize the request in concise zh-TW.
+- Propose a request type that reflects the real next workflow shape.
+- Explain the rationale in machine-readable form so the control plane can preserve context.

--- a/skills/cory/execution-planning/SKILL.md
+++ b/skills/cory/execution-planning/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: execution-planning
+description: Frame software-delivery work as a first reviewable plan with scope, non-goals, and downstream execution boundaries.
+---
+
+# Execution Planning
+
+Use this skill when the interpreted request is likely to become delivery work.
+
+Rules:
+- Produce planning-oriented framing, not runnable implementation instructions.
+- Identify scope, non-goals, and the most likely sequencing constraints.
+- Preserve governance boundaries: interpretation first, execution later.
+- If the request is not ready for coding agents, say so through clarifications or review notes.
+
+Output expectations:
+- A reviewable scope statement.
+- A non-goals statement when the request risks expanding.
+- A rationale that helps later planning or delegation steps.

--- a/skills/cory/governed-change-analysis/SKILL.md
+++ b/skills/cory/governed-change-analysis/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: governed-change-analysis
+description: Treat policy, routing, or workflow changes as governed proposals that need approval, not direct mutation.
+---
+
+# Governed Change Analysis
+
+Use this skill when the request changes how Cory or the control plane should behave.
+
+Rules:
+- Frame the request as a proposal to governance, workflow, or policy.
+- Identify impact, risk, and what explicit human approval is required.
+- Do not act as if the new behavior is already canonical.
+
+Output expectations:
+- Summarize the proposed change in review-ready language.
+- Explain who or what would be affected.
+- Surface unresolved policy questions when the requested behavior is underspecified.

--- a/skills/cory/knowledge-compounding/SKILL.md
+++ b/skills/cory/knowledge-compounding/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: knowledge-compounding
+description: Turn discussions, documents, or outcomes into reusable team knowledge rather than disposable chat output.
+---
+
+# Knowledge Compounding
+
+Use this skill when the request should become reusable organizational knowledge.
+
+Rules:
+- Preserve the conclusion and why it matters, not only raw source text.
+- Prefer reusable principles, decisions, and runbook guidance.
+- Do not confuse KM extraction with execution planning.
+
+Output expectations:
+- Explain the reusable knowledge value.
+- Make it clear whether the result should be retained as a summary, runbook, or decision record.

--- a/skills/cory/repo-resolution/SKILL.md
+++ b/skills/cory/repo-resolution/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: repo-resolution
+description: Resolve project or repository mapping only when there is enough evidence; otherwise preserve uncertainty.
+---
+
+# Repo Resolution
+
+Use this skill when the request or event may belong to a specific project or repository.
+
+Rules:
+- Prefer deterministic evidence over fuzzy guesses.
+- If multiple mappings are plausible, say so and ask for clarification.
+- Never invent project ids or repo ids.
+- Keep the interpretation useful even when exact routing is unresolved.
+
+Output expectations:
+- State whether routing appears clear or ambiguous.
+- Explain the evidence behind any proposed mapping.

--- a/skills/cory/requirement-clarification/SKILL.md
+++ b/skills/cory/requirement-clarification/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: requirement-clarification
+description: Generate the minimum clarifying questions needed to move a request from vague to reviewable.
+---
+
+# Requirement Clarification
+
+Use this skill when ambiguity would materially change routing, scope, or approval posture.
+
+Rules:
+- Ask only questions whose answers unlock a different workflow or decision.
+- Prefer fewer, sharper questions.
+- Phrase clarification prompts in zh-TW and make them easy for a busy stakeholder to answer.
+- If the request is already reviewable, return no clarification prompts.
+
+Output expectations:
+- Clarification prompts should be actionable and non-overlapping.
+- Each clarification should map to a real source of uncertainty in the interpretation.

--- a/skills/cory/review-synthesis/SKILL.md
+++ b/skills/cory/review-synthesis/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: review-synthesis
+description: Produce approval-facing synthesis that helps humans review scope, tradeoffs, and risk without rereading the whole request history.
+---
+
+# Review Synthesis
+
+Use this skill when the interpretation is meant to support human review or approval.
+
+Rules:
+- Compress the important signal without dropping the decision boundary.
+- Highlight risk, impact, and the main tradeoff.
+- Keep human-facing language readable in zh-TW.
+
+Output expectations:
+- A concise review-ready summary.
+- The most important risks or dependencies.
+- Clear reasoning for the proposed next workflow state.

--- a/skills/cory/spec-reasoning/SKILL.md
+++ b/skills/cory/spec-reasoning/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: spec-reasoning
+description: Reason over specs, requirements, and uploaded context to identify goals, constraints, and open design questions.
+---
+
+# Spec Reasoning
+
+Use this skill when the request includes product or technical specification material.
+
+Rules:
+- Distinguish goals, constraints, and assumptions.
+- Call out missing information that blocks a reviewable draft.
+- Do not jump straight to implementation details unless the source material demands them.
+- Treat attached or embedded documents as evidence, not as automatic truth about intent.
+
+Output expectations:
+- Summarize what the spec is actually asking for.
+- Identify likely scope boundaries and unresolved questions.
+- Keep the interpretation reviewable by PM, CTO, and engineering leads.

--- a/skills/cory/structured-event-triage/SKILL.md
+++ b/skills/cory/structured-event-triage/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: structured-event-triage
+description: Interpret webhook or structured event payloads in product and project context instead of treating them as self-explanatory.
+---
+
+# Structured Event Triage
+
+Use this skill when the source is a webhook or other structured event.
+
+Rules:
+- Read the event as a signal that still needs project context.
+- Do not assume the downstream workflow solely from event type.
+- Differentiate between advisory follow-up, execution preparation, governed change, and KM promotion.
+- Escalate ambiguity instead of guessing when repository or project mapping is uncertain.
+
+Output expectations:
+- Explain what happened and why it matters.
+- Propose the most plausible request type and workflow state transition.

--- a/skills/cory/technical-option-analysis/SKILL.md
+++ b/skills/cory/technical-option-analysis/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: technical-option-analysis
+description: Compare candidate technical approaches and explain tradeoffs, risks, and recommendation posture.
+---
+
+# Technical Option Analysis
+
+Use this skill when the user is exploring how a requirement could be implemented.
+
+Rules:
+- Compare options in terms of leverage, complexity, risk, and fit.
+- Avoid false precision when key assumptions are missing.
+- If one option is currently preferable, explain why without pretending the decision is final.
+- Keep recommendations grounded in the product context rather than tool fashion.
+
+Output expectations:
+- Present the most plausible option set.
+- Highlight the dominant tradeoff.
+- Make it clear what follow-up clarification would change the recommendation.

--- a/tests/cory_runtime/test_control_plane.py
+++ b/tests/cory_runtime/test_control_plane.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from cory_runtime.control_plane import ControlPlaneClient
+from cory_runtime.models import ClaimedJobEnvelope, InterpretationSubmission
+
+
+def _claim_payload(claimed: bool = True) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "claimed": claimed,
+        "job": None
+        if not claimed
+        else {"id": "job-1", "requestId": "request-1", "status": "running"},
+        "request": None
+        if not claimed
+        else {
+            "id": "request-1",
+            "title": "Need architecture options",
+            "sourceType": "slack",
+            "sourcePayload": {"text": "compare architecture options"},
+            "requestType": "advisory_discussion",
+            "workflowState": "interpretation_pending",
+        },
+        "interpretations": [],
+        "clarifications": [],
+        "linkedTask": None,
+        "harness": None
+        if not claimed
+        else {
+            "version": "2026-05-02",
+            "runtime": "hermes_agent",
+            "agent": "cory",
+            "mode": "request_interpretation",
+            "scenario": "collaboration",
+            "preferredResponseLanguage": "zh-TW",
+            "artifactKeyLanguage": "en",
+            "contextSummary": {
+                "sourceType": "slack",
+                "requestType": "advisory_discussion",
+                "workflowState": "interpretation_pending",
+                "interpretationCount": 0,
+                "openClarificationCount": 0,
+                "linkedExecutionTask": False,
+            },
+            "skills": [],
+            "prompt": {
+                "systemIntent": [],
+                "operatingRules": [],
+                "taskPrompt": "Interpret the request.",
+                "deliverables": [],
+            },
+            "guardrails": [],
+            "outputContract": {
+                "completeEndpoint": "/api/internal/request-interpretation-jobs/job-1/complete",
+                "failEndpoint": "/api/internal/request-interpretation-jobs/job-1/fail",
+                "responseLanguage": "zh-TW",
+                "artifactKeyLanguage": "en",
+                "interpretationFields": [],
+                "nextWorkflowStateOptions": [
+                    {"state": "needs_clarification", "useWhen": "ambiguity remains"},
+                    {"state": "draft_ready", "useWhen": "draft is reviewable"},
+                ],
+                "notes": [],
+            },
+        },
+    }
+
+
+def _submission() -> InterpretationSubmission:
+    return InterpretationSubmission.model_validate(
+        {
+            "interpretation": {
+                "producedBy": "cory_hermes",
+                "interpretationStatus": "completed",
+                "summary": "整理成 reviewable draft。",
+                "proposedRequestType": "advisory_discussion",
+                "proposedClarifications": [],
+                "rawResponse": {"decision": "analysis"},
+            },
+            "nextWorkflowState": "draft_ready",
+        },
+    )
+
+
+def test_claim_next_job_returns_none_when_queue_empty() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json=_claim_payload(claimed=False)),
+    )
+
+    with ControlPlaneClient(
+        base_url="http://control-plane.test",
+        token="secret-token",
+        transport=transport,
+    ) as client:
+        assert client.claim_next_job() is None
+
+
+def test_complete_job_posts_bearer_token_and_submission_payload() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/claim"):
+            return httpx.Response(200, json=_claim_payload(claimed=True))
+
+        captured["path"] = request.url.path
+        captured["authorization"] = request.headers.get("authorization")
+        captured["json"] = request.read().decode("utf-8")
+        return httpx.Response(200, json={"ok": True})
+
+    with ControlPlaneClient(
+        base_url="http://control-plane.test",
+        token="secret-token",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        claim = client.claim_next_job()
+        assert isinstance(claim, ClaimedJobEnvelope)
+        client.complete_job(claim, _submission())
+
+    assert captured["path"] == "/api/internal/request-interpretation-jobs/job-1/complete"
+    assert captured["authorization"] == "Bearer secret-token"
+    assert '"nextWorkflowState":"draft_ready"' in captured["json"]

--- a/tests/cory_runtime/test_executor.py
+++ b/tests/cory_runtime/test_executor.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from cory_runtime.executor import HermesCoryExecutor
+from cory_runtime.models import ClaimedJobEnvelope
+
+
+class FakeAgent:
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, object]] = []
+
+    def run_conversation(
+        self,
+        user_message: str,
+        system_message: str | None = None,
+        conversation_history: list[dict[str, object]] | None = None,
+        task_id: str | None = None,
+    ) -> dict[str, object]:
+        self.calls.append(
+            {
+                "user_message": user_message,
+                "system_message": system_message,
+                "conversation_history": conversation_history,
+                "task_id": task_id,
+            },
+        )
+        return {
+            "final_response": self._responses.pop(0),
+            "messages": [{"role": "assistant", "content": "stub"}],
+        }
+
+
+def _claim() -> ClaimedJobEnvelope:
+    return ClaimedJobEnvelope.model_validate(
+        {
+            "ok": True,
+            "claimed": True,
+            "job": {"id": "job-1", "requestId": "request-1", "status": "running"},
+            "request": {
+                "id": "request-1",
+                "title": "Need architecture options",
+                "routingText": "Please compare options.",
+                "sourceType": "slack",
+                "sourcePayload": {"text": "compare architecture options"},
+                "requestType": "advisory_discussion",
+                "workflowState": "interpretation_pending",
+            },
+            "interpretations": [],
+            "clarifications": [],
+            "linkedTask": None,
+            "harness": {
+                "version": "2026-05-02",
+                "runtime": "hermes_agent",
+                "agent": "cory",
+                "mode": "request_interpretation",
+                "scenario": "collaboration",
+                "preferredResponseLanguage": "zh-TW",
+                "artifactKeyLanguage": "en",
+                "contextSummary": {
+                    "sourceType": "slack",
+                    "requestType": "advisory_discussion",
+                    "workflowState": "interpretation_pending",
+                    "interpretationCount": 0,
+                    "openClarificationCount": 0,
+                    "linkedExecutionTask": False,
+                },
+                "skills": [],
+                "prompt": {
+                    "systemIntent": ["You are Cory."],
+                    "operatingRules": ["Do not start execution."],
+                    "taskPrompt": "Interpret the collaboration request.",
+                    "deliverables": ["Return valid JSON."],
+                },
+                "guardrails": ["Do not invent project ids."],
+                "outputContract": {
+                    "completeEndpoint": "/api/internal/request-interpretation-jobs/job-1/complete",
+                    "failEndpoint": "/api/internal/request-interpretation-jobs/job-1/fail",
+                    "responseLanguage": "zh-TW",
+                    "artifactKeyLanguage": "en",
+                    "interpretationFields": [],
+                    "nextWorkflowStateOptions": [
+                        {"state": "needs_clarification", "useWhen": "ambiguity remains"},
+                        {"state": "draft_ready", "useWhen": "draft is reviewable"},
+                    ],
+                    "notes": [],
+                },
+            },
+        },
+    )
+
+
+def test_executor_retries_invalid_output_and_returns_normalized_submission() -> None:
+    agent = FakeAgent(
+        [
+            "not json at all",
+            """
+            {
+              "interpretation": {
+                "interpretationStatus": "completed",
+                "summary": "先整理成可 review 的分析。",
+                "proposedRequestType": "advisory_discussion",
+                "proposedClarifications": [],
+                "rawResponse": {"decision": "analysis"}
+              }
+            }
+            """,
+        ],
+    )
+    executor = HermesCoryExecutor(
+        max_completion_attempts=2,
+        agent_factory=lambda: agent,
+    )
+
+    submission = executor.run(_claim())
+
+    assert submission.interpretation.producedBy == "cory_hermes"
+    assert submission.nextWorkflowState == "draft_ready"
+    assert len(agent.calls) == 2
+    assert "Validation error:" in str(agent.calls[1]["user_message"])

--- a/tests/cory_runtime/test_parser.py
+++ b/tests/cory_runtime/test_parser.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from cory_runtime.models import CoryHermesHarness
+from cory_runtime.parser import OutputValidationError, parse_submission
+
+
+@pytest.fixture
+def harness() -> CoryHermesHarness:
+    return CoryHermesHarness.model_validate(
+        {
+            "version": "2026-05-02",
+            "runtime": "hermes_agent",
+            "agent": "cory",
+            "mode": "request_interpretation",
+            "scenario": "collaboration",
+            "preferredResponseLanguage": "zh-TW",
+            "artifactKeyLanguage": "en",
+            "contextSummary": {
+                "sourceType": "slack",
+                "requestType": "advisory_discussion",
+                "workflowState": "interpretation_pending",
+                "interpretationCount": 0,
+                "openClarificationCount": 0,
+                "linkedExecutionTask": False,
+            },
+            "skills": [],
+            "prompt": {
+                "systemIntent": [],
+                "operatingRules": [],
+                "taskPrompt": "Interpret the request.",
+                "deliverables": [],
+            },
+            "guardrails": [],
+            "outputContract": {
+                "completeEndpoint": "/api/internal/request-interpretation-jobs/job-1/complete",
+                "failEndpoint": "/api/internal/request-interpretation-jobs/job-1/fail",
+                "responseLanguage": "zh-TW",
+                "artifactKeyLanguage": "en",
+                "interpretationFields": [],
+                "nextWorkflowStateOptions": [
+                    {"state": "needs_clarification", "useWhen": "ambiguity remains"},
+                    {"state": "draft_ready", "useWhen": "draft is reviewable"},
+                ],
+                "notes": [],
+            },
+        },
+    )
+
+
+def test_parse_submission_extracts_fenced_json_and_normalizes_defaults(
+    harness: CoryHermesHarness,
+) -> None:
+    submission = parse_submission(
+        """```json
+        {
+          "interpretation": {
+            "interpretationStatus": "completed",
+            "summary": "以 API 契約為主軸整理需求。",
+            "proposedRequestType": "advisory_discussion",
+            "proposedClarifications": [],
+            "rawResponse": {
+              "decision": "discussion",
+              "evidence": ["slack discussion"]
+            }
+          }
+        }
+        ```""",
+        harness,
+    )
+
+    assert submission.interpretation.producedBy == "cory_hermes"
+    assert submission.nextWorkflowState == "draft_ready"
+
+
+def test_parse_submission_requires_clarifications_for_clarification_state(
+    harness: CoryHermesHarness,
+) -> None:
+    with pytest.raises(OutputValidationError):
+        parse_submission(
+            """
+            {
+              "interpretation": {
+                "interpretationStatus": "needs_human_review",
+                "summary": "需要更多資訊",
+                "proposedRequestType": "advisory_discussion",
+                "proposedClarifications": [],
+                "rawResponse": {"decision": "clarify"}
+              },
+              "nextWorkflowState": "needs_clarification"
+            }
+            """,
+            harness,
+        )

--- a/tests/cory_runtime/test_prompting.py
+++ b/tests/cory_runtime/test_prompting.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from cory_runtime.models import ClaimedJobEnvelope
+from cory_runtime.prompting import build_system_message, build_user_message
+
+
+def _claim() -> ClaimedJobEnvelope:
+    return ClaimedJobEnvelope.model_validate(
+        {
+            "ok": True,
+            "claimed": True,
+            "job": {
+                "id": "job-1",
+                "requestId": "request-1",
+                "status": "running",
+            },
+            "request": {
+                "id": "request-1",
+                "title": "Need architecture options",
+                "routingText": "Please compare options.",
+                "sourceType": "slack",
+                "sourcePayload": {"text": "compare architecture options"},
+                "requestType": "advisory_discussion",
+                "workflowState": "interpretation_pending",
+            },
+            "interpretations": [],
+            "clarifications": [],
+            "linkedTask": None,
+            "harness": {
+                "version": "2026-05-02",
+                "runtime": "hermes_agent",
+                "agent": "cory",
+                "mode": "request_interpretation",
+                "scenario": "collaboration",
+                "preferredResponseLanguage": "zh-TW",
+                "artifactKeyLanguage": "en",
+                "contextSummary": {
+                    "sourceType": "slack",
+                    "requestType": "advisory_discussion",
+                    "workflowState": "interpretation_pending",
+                    "interpretationCount": 0,
+                    "openClarificationCount": 0,
+                    "linkedExecutionTask": False,
+                },
+                "skills": [
+                    {
+                        "id": "discussion-interpretation",
+                        "required": True,
+                        "why": "Interpret PM discussion before locking workflow.",
+                    },
+                    {
+                        "id": "technical-option-analysis",
+                        "required": False,
+                        "why": "Compare candidate approaches.",
+                    },
+                ],
+                "prompt": {
+                    "systemIntent": ["You are Cory."],
+                    "operatingRules": ["Do not start execution."],
+                    "taskPrompt": "Interpret the collaboration request.",
+                    "deliverables": ["Return valid JSON."],
+                },
+                "guardrails": ["Do not invent project ids."],
+                "outputContract": {
+                    "completeEndpoint": "/api/internal/request-interpretation-jobs/job-1/complete",
+                    "failEndpoint": "/api/internal/request-interpretation-jobs/job-1/fail",
+                    "responseLanguage": "zh-TW",
+                    "artifactKeyLanguage": "en",
+                    "interpretationFields": [],
+                    "nextWorkflowStateOptions": [
+                        {"state": "needs_clarification", "useWhen": "ambiguity remains"},
+                        {"state": "draft_ready", "useWhen": "draft is reviewable"},
+                    ],
+                    "notes": [],
+                },
+            },
+        },
+    )
+
+
+def test_build_system_message_includes_skill_content() -> None:
+    message = build_system_message(_claim())
+
+    assert "discussion-interpretation (required)" in message
+    assert "technical-option-analysis (optional)" in message
+    assert "Do not start execution." in message
+    assert "Allowed nextWorkflowState values: needs_clarification, draft_ready" in message
+
+
+def test_build_user_message_includes_request_and_contract_shape() -> None:
+    message = build_user_message(_claim())
+
+    assert '"jobId": "job-1"' in message
+    assert '"sourceType": "slack"' in message
+    assert '"proposedRequestType": "advisory_discussion"' in message
+    assert "Interpret the collaboration request." in message

--- a/tests/cory_runtime/test_worker.py
+++ b/tests/cory_runtime/test_worker.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+
+from cory_runtime.models import ClaimedJobEnvelope, InterpretationSubmission
+from cory_runtime.worker import CoryControlPlaneWorker, WorkerOutcome
+
+
+class FakeClient:
+    def __init__(self, claim: ClaimedJobEnvelope | None) -> None:
+        self.claim = claim
+        self.completed: list[InterpretationSubmission] = []
+        self.failed: list[str] = []
+
+    def claim_next_job(self) -> ClaimedJobEnvelope | None:
+        claim, self.claim = self.claim, None
+        return claim
+
+    def complete_job(
+        self,
+        claim: ClaimedJobEnvelope,
+        submission: InterpretationSubmission,
+    ) -> dict[str, object]:
+        self.completed.append(submission)
+        return {"ok": True}
+
+    def fail_job(self, claim: ClaimedJobEnvelope, error_message: str) -> dict[str, object]:
+        self.failed.append(error_message)
+        return {"ok": True}
+
+
+class FakeExecutor:
+    def __init__(self, result: InterpretationSubmission | None = None, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+
+    def run(self, claim: ClaimedJobEnvelope) -> InterpretationSubmission:
+        if self.error is not None:
+            raise self.error
+        assert self.result is not None
+        return self.result
+
+
+def _claim() -> ClaimedJobEnvelope:
+    return ClaimedJobEnvelope.model_validate(
+        {
+            "ok": True,
+            "claimed": True,
+            "job": {"id": "job-1", "requestId": "request-1", "status": "running"},
+            "request": {
+                "id": "request-1",
+                "title": "Need architecture options",
+                "sourceType": "slack",
+                "sourcePayload": {"text": "compare architecture options"},
+                "requestType": "advisory_discussion",
+                "workflowState": "interpretation_pending",
+            },
+            "interpretations": [],
+            "clarifications": [],
+            "linkedTask": None,
+            "harness": {
+                "version": "2026-05-02",
+                "runtime": "hermes_agent",
+                "agent": "cory",
+                "mode": "request_interpretation",
+                "scenario": "collaboration",
+                "preferredResponseLanguage": "zh-TW",
+                "artifactKeyLanguage": "en",
+                "contextSummary": {
+                    "sourceType": "slack",
+                    "requestType": "advisory_discussion",
+                    "workflowState": "interpretation_pending",
+                    "interpretationCount": 0,
+                    "openClarificationCount": 0,
+                    "linkedExecutionTask": False,
+                },
+                "skills": [],
+                "prompt": {
+                    "systemIntent": [],
+                    "operatingRules": [],
+                    "taskPrompt": "Interpret the request.",
+                    "deliverables": [],
+                },
+                "guardrails": [],
+                "outputContract": {
+                    "completeEndpoint": "/api/internal/request-interpretation-jobs/job-1/complete",
+                    "failEndpoint": "/api/internal/request-interpretation-jobs/job-1/fail",
+                    "responseLanguage": "zh-TW",
+                    "artifactKeyLanguage": "en",
+                    "interpretationFields": [],
+                    "nextWorkflowStateOptions": [
+                        {"state": "needs_clarification", "useWhen": "ambiguity remains"},
+                        {"state": "draft_ready", "useWhen": "draft is reviewable"},
+                    ],
+                    "notes": [],
+                },
+            },
+        },
+    )
+
+
+def _submission() -> InterpretationSubmission:
+    return InterpretationSubmission.model_validate(
+        {
+            "interpretation": {
+                "producedBy": "cory_hermes",
+                "interpretationStatus": "completed",
+                "summary": "整理成 reviewable draft。",
+                "proposedRequestType": "advisory_discussion",
+                "proposedClarifications": [],
+                "rawResponse": {"decision": "analysis"},
+            },
+            "nextWorkflowState": "draft_ready",
+        },
+    )
+
+
+def test_worker_run_once_completes_successfully() -> None:
+    client = FakeClient(_claim())
+    worker = CoryControlPlaneWorker(
+        client=client,
+        executor=FakeExecutor(result=_submission()),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    outcome = worker.run_once()
+
+    assert outcome == WorkerOutcome.COMPLETED
+    assert len(client.completed) == 1
+    assert client.failed == []
+
+
+def test_worker_run_once_reports_runtime_failure() -> None:
+    client = FakeClient(_claim())
+    worker = CoryControlPlaneWorker(
+        client=client,
+        executor=FakeExecutor(error=RuntimeError("provider timeout")),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    outcome = worker.run_once()
+
+    assert outcome == WorkerOutcome.FAILED
+    assert client.completed == []
+    assert client.failed == ["provider timeout"]
+
+
+def test_worker_run_once_returns_no_job_when_queue_empty() -> None:
+    client = FakeClient(None)
+    worker = CoryControlPlaneWorker(
+        client=client,
+        executor=FakeExecutor(result=_submission()),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert worker.run_once() == WorkerOutcome.NO_JOB
+    assert client.completed == []
+    assert client.failed == []

--- a/website/docs/guides/cory-control-plane-worker.md
+++ b/website/docs/guides/cory-control-plane-worker.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 6
+title: "Cory Control Plane Worker"
+description: "Run Hermes as the Cory request-interpretation worker behind a Cory control plane."
+---
+
+# Cory Control Plane Worker
+
+Hermes can run as the execution runtime behind Cory's request-interpretation loop.
+
+This integration is intentionally thin:
+
+- the **control plane** owns request intake, workflow state, approval, and the canonical runtime contract
+- **Hermes** owns LLM execution, prompt assembly, retries, and model/provider configuration
+- the **Cory worker** is the bridge that claims jobs, runs Hermes, validates output, and writes results back
+
+## What ships in Hermes
+
+This repository now includes:
+
+- `hermes-cory-worker` — a long-running worker process for request interpretation jobs
+- `cory_runtime/` — the integration package
+- `skills/cory/` — Cory-specific interpretation skills used to build deterministic runtime prompts
+
+The worker currently targets **request interpretation** only. It does not yet execute downstream delivery workflows, review loops, or shipping.
+
+## Runtime flow
+
+```text
+control plane
+  -> POST /api/internal/request-interpretation-jobs/claim
+  -> returns request + prior state + Cory Hermes harness
+
+hermes-cory-worker
+  -> builds a deterministic system prompt from the harness + Cory skills
+  -> runs Hermes AIAgent
+  -> validates the JSON output against the harness contract
+  -> POST /complete or /fail back to the control plane
+```
+
+## Environment
+
+Required:
+
+- `CORY_CONTROL_PLANE_BASE_URL` or `CONTROL_PLANE_BASE_URL`
+- `CORY_CONTROL_PLANE_INTERNAL_API_TOKEN` or `CONTROL_PLANE_INTERNAL_API_TOKEN`
+
+Optional:
+
+- `HERMES_CORY_MODEL`
+- `HERMES_CORY_PROVIDER`
+- `HERMES_CORY_POLL_INTERVAL_SECONDS`
+- `HERMES_CORY_MAX_BACKOFF_SECONDS`
+- `HERMES_CORY_MAX_COMPLETION_ATTEMPTS`
+- `HERMES_CORY_REQUEST_TIMEOUT_SECONDS`
+
+## Usage
+
+Run continuously:
+
+```bash
+hermes-cory-worker
+```
+
+Run one job and exit:
+
+```bash
+hermes-cory-worker --once
+```
+
+Override model or provider for the worker profile:
+
+```bash
+hermes-cory-worker --model anthropic/claude-sonnet-4 --provider anthropic
+```
+
+## Prompting model
+
+The worker does **not** wait for the model to discover Cory skills dynamically.
+
+Instead it:
+
+1. takes the control-plane harness
+2. loads the mapped skill documents from `skills/cory/`
+3. assembles a deterministic system prompt
+4. asks Hermes to return a single JSON object
+
+This is deliberate. Background workers need stronger contract reliability than an interactive chat session.
+
+## Safety and contract behavior
+
+- The worker runs Hermes with `enabled_toolsets=[]` for interpretation. This step is analysis-only.
+- The worker skips Hermes memory and project-context injection so the control-plane harness stays authoritative.
+- `interpretationStatus=failed` is never sent through `/complete`; runtime failures go through `/fail`.
+- If Hermes returns invalid JSON, the worker retries with a repair prompt before failing the job.
+
+## Current boundary
+
+This is the **first runtime bridge**, not the full Cory product.
+
+What it solves now:
+
+- control-plane jobs can be executed by Hermes
+- prompt, skills, and output validation live in versioned code
+- deployment can start on a single VPS as a long-running worker
+
+What remains for later phases:
+
+- clarification application loops
+- approval-aware downstream planning
+- coding-agent dispatch and PR workflow execution
+- KM writeback and richer artifact generation


### PR DESCRIPTION
## Summary
- add a dedicated hermes-cory-worker runtime that claims Cory interpretation jobs from the control plane and writes validated results back
- add deterministic Cory prompt and skill assembly, output normalization, and retry-on-invalid-output handling for request interpretation
- add Cory-specific skills, runtime docs, and test coverage for the worker, parser, prompt builder, executor, and control-plane client

## Testing
- uv run --extra dev pytest tests/cory_runtime/test_parser.py tests/cory_runtime/test_prompting.py tests/cory_runtime/test_executor.py tests/cory_runtime/test_worker.py tests/cory_runtime/test_control_plane.py
- uv run --extra dev python -m compileall cory_runtime tests/cory_runtime