### PR TITLE
fix(auth): persist detected z.ai endpoint cache safely

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -667,14 +667,18 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     if detected and detected.get("base_url"):
         # Persist the detection result keyed on the API key hash.
         key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
-        state["detected_endpoint"] = {
-            "base_url": detected["base_url"],
-            "endpoint_id": detected.get("id", ""),
-            "model": detected.get("model", ""),
-            "label": detected.get("label", ""),
-            "key_hash": key_hash,
-        }
-        _save_provider_state(auth_store, "zai", state)
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+            state = _load_provider_state(auth_store, "zai") or {}
+            state["detected_endpoint"] = {
+                "base_url": detected["base_url"],
+                "endpoint_id": detected.get("id", ""),
+                "model": detected.get("model", ""),
+                "label": detected.get("label", ""),
+                "key_hash": key_hash,
+            }
+            _store_provider_state(auth_store, "zai", state, set_active=False)
+            _save_auth_store(auth_store)
         logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
         return detected["base_url"]
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1,6 +1,8 @@
 """Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway)."""
 
+import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -17,6 +19,7 @@ from hermes_cli.auth import (
     KIMI_CODE_BASE_URL,
     STEPFUN_STEP_PLAN_INTL_BASE_URL,
     STEPFUN_STEP_PLAN_CN_BASE_URL,
+    _load_auth_store as _REAL_LOAD_AUTH_STORE,
     _resolve_kimi_base_url,
 )
 from hermes_cli.copilot_auth import _try_gh_cli_token
@@ -995,6 +998,45 @@ class TestZaiEndpointAutoDetect:
         )
         creds = resolve_api_key_provider_credentials("zai")
         assert creds["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+    def test_probe_success_persists_detected_endpoint(self, monkeypatch):
+        monkeypatch.setenv("GLM_API_KEY", "glm-coding-key")
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", _REAL_LOAD_AUTH_STORE)
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        previous_active_provider = "previous-provider"
+        previous_provider_state = {
+            "tokens": {
+                "access_token": "previous-at",
+                "refresh_token": "previous-rt",
+            }
+        }
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "active_provider": previous_active_provider,
+            "providers": {
+                previous_active_provider: previous_provider_state,
+            },
+        }))
+        monkeypatch.setattr(
+            "hermes_cli.auth.detect_zai_endpoint",
+            lambda *a, **kw: {
+                "id": "coding-global",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "model": "glm-5.1",
+                "label": "Global (Coding Plan)",
+            },
+        )
+
+        creds = resolve_api_key_provider_credentials("zai")
+
+        assert creds["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+        payload = json.loads((hermes_home / "auth.json").read_text())
+        detected = payload["providers"]["zai"]["detected_endpoint"]
+        assert detected["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+        assert detected["endpoint_id"] == "coding-global"
+        assert detected["model"] == "glm-5.1"
+        assert payload.get("active_provider") == previous_active_provider
+        assert payload["providers"][previous_active_provider] == previous_provider_state
 
     def test_probe_failure_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("GLM_API_KEY", "glm-key")


### PR DESCRIPTION
## What does this PR do?

Fixes Z.AI endpoint detection so a discovered coding-plan endpoint is actually persisted to `auth.json`, while avoiding an accidental switch of the user's active provider to `zai` during passive endpoint resolution.

## Related Issue

No existing issue found/linked. This came from debugging Z.AI / GLM coding-plan endpoint selection where keys can work on the coding endpoint but fail or show insufficient balance on the generic endpoint.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`
  - Persist detected Z.AI endpoint metadata under the auth-store lock.
  - Reload the auth store inside the lock before writing the cache entry.
  - Store `providers.zai.detected_endpoint` with `_store_provider_state(..., set_active=False)`.
  - Flush the updated auth store with `_save_auth_store(auth_store)`.
- `tests/hermes_cli/test_api_key_providers.py`
  - Add regression coverage verifying the detected endpoint is persisted.
  - Verify passive Z.AI endpoint detection preserves an arbitrary pre-existing active provider and its provider state exactly.

## How to Test

1. Configure a Z.AI / GLM API key with coding-plan access and no explicit `GLM_BASE_URL` override.
2. Resolve Z.AI API-key provider credentials, e.g. by selecting/using a `zai/...` GLM model.
3. Confirm `auth.json` contains `providers.zai.detected_endpoint` for the detected coding endpoint.
4. Confirm the existing active provider is not silently switched to `zai` unless the user explicitly selects it.

Regression test runs:

```bash
python -m pytest tests/hermes_cli/test_api_key_providers.py::TestZaiEndpointAutoDetect::test_probe_success_persists_detected_endpoint -q -o addopts=''
python -m pytest tests/hermes_cli/test_api_key_providers.py -q -o addopts=''
```

Latest targeted local verification on EndeavourOS x86_64 with Python 3.11.14:

```text
1 passed in 0.61s
158 passed in 8.80s
```

Full-suite attempt after rebasing on current `origin/main`:

```bash
HERMES_TEST_WORKERS=4 scripts/run_tests.sh -q
```

Current local result is not green due failures outside this PR's touched files:

```text
27 failed, 20011 passed, 59 skipped, 214 warnings in 279.42s
```

The full-suite checkbox below is intentionally left unchecked until CI or a maintainer-confirmed local environment produces a green full-suite run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: EndeavourOS x86_64, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression output:

```text
1 passed in 0.61s
158 passed in 8.80s
```

