### PR TITLE
fix(cli): add timeout and progress output to npm install during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5266,6 +5266,7 @@ def _run_npm_install_deterministic(
     *,
     extra_args: tuple[str, ...] = (),
     capture_output: bool = True,
+    timeout: int = 300,
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
@@ -5275,29 +5276,47 @@ def _run_npm_install_deterministic(
     rewrites committed lockfiles (stripping ``"peer": true`` etc.), which leaves
     the working tree dirty and causes the next ``hermes update`` to stash the
     lockfile — repeatedly.
+
+    A ``timeout`` (seconds) prevents indefinite hangs during postinstall scripts
+    that download large binaries (e.g. Camofox browser fetch).  Defaults to 300s
+    (5 minutes) which is generous for most installations.
     """
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
         ci_cmd = [npm, "ci", *extra_args]
-        ci_result = subprocess.run(
-            ci_cmd,
-            cwd=cwd,
-            capture_output=capture_output,
-            text=True,
-            check=False,
-        )
+        try:
+            ci_result = subprocess.run(
+                ci_cmd,
+                cwd=cwd,
+                capture_output=capture_output,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"  ⚠ npm ci timed out after {timeout}s in {cwd.name}")
+            return subprocess.CompletedProcess(
+                args=ci_cmd, returncode=1, stdout="", stderr=f"Timed out after {timeout}s"
+            )
         if ci_result.returncode == 0:
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
     install_cmd = [npm, "install", *extra_args]
-    return subprocess.run(
-        install_cmd,
-        cwd=cwd,
-        capture_output=capture_output,
-        text=True,
-        check=False,
-    )
+    try:
+        return subprocess.run(
+            install_cmd,
+            cwd=cwd,
+            capture_output=capture_output,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  ⚠ npm install timed out after {timeout}s in {cwd.name}")
+        return subprocess.CompletedProcess(
+            args=install_cmd, returncode=1, stdout="", stderr=f"Timed out after {timeout}s"
+        )
 
 
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
@@ -5323,7 +5342,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",))
+    r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--loglevel=warn",), timeout=300)
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
@@ -6269,10 +6288,12 @@ def _update_node_dependencies() -> None:
         if not (path / "package.json").exists():
             continue
 
+        print(f"  Installing {label}... (this may take a moment during postinstall scripts)")
         result = _run_npm_install_deterministic(
             npm,
             path,
-            extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
+            extra_args=("--loglevel=warn", "--no-fund", "--no-audit", "--progress=false"),
+            timeout=300,
         )
         if result.returncode == 0:
             print(f"  ✓ {label}")


### PR DESCRIPTION
## Problem
`hermes update` appeared to hang indefinitely at "Updating Node.js dependencies..." because:
1. npm install ran with `--silent` flag, suppressing ALL output (including progress from postinstall scripts like `npx Camofox-js fetch`)
2. No timeout on `subprocess.run()` — if npm hangs, the update process hangs forever
3. No progress indication to the user that something is happening during long downloads

## Fix
1. **Added `timeout=300` to `_run_npm_install_deterministic()`** — prevents indefinite hangs. Both `npm ci` and `npm install` now have a 5-minute timeout per directory. `TimeoutExpired` exceptions are caught and converted to meaningful error messages instead of hanging.

2. **Replaced `--silent` with `--loglevel=warn`** — shows warnings and errors (useful for debugging) while still suppressing the noisy progress bars and audit messages. Users can now see if something goes wrong instead of staring at a blank screen.

3. **Added progress message** — prints "Installing {label}... (this may take a moment during postinstall scripts)" before each npm install so users know what's happening.

4. **Updated both call sites** — `_update_node_dependencies()` and `_build_web_ui()` both use the same function and both now pass timeout.

Fixes #18840