### PR TITLE
fix: recompute runtime context length across runtime switches

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1826,29 +1826,9 @@ class AIAgent:
                 _aux_context_config = None
         self._aux_compression_context_length_config = _aux_context_config
 
-        # Read explicit context_length override from model config
         _model_cfg = _agent_cfg.get("model", {})
-        if isinstance(_model_cfg, dict):
-            _config_context_length = _model_cfg.get("context_length")
-        else:
-            _config_context_length = None
-        if _config_context_length is not None:
-            try:
-                _config_context_length = int(_config_context_length)
-            except (TypeError, ValueError):
-                logger.warning(
-                    "Invalid model.context_length in config.yaml: %r — "
-                    "must be a plain integer (e.g. 256000, not '256K'). "
-                    "Falling back to auto-detection.",
-                    _config_context_length,
-                )
-                print(
-                    f"\n⚠ Invalid model.context_length in config.yaml: {_config_context_length!r}\n"
-                    f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                    f"  Falling back to auto-detected context window.\n",
-                    file=sys.stderr,
-                )
-                _config_context_length = None
+        if not isinstance(_model_cfg, dict):
+            _model_cfg = {}
 
         # Resolve custom_providers list once for reuse below (startup
         # context-length override and plugin context-engine init).
@@ -1860,57 +1840,12 @@ class AIAgent:
             if not isinstance(_custom_providers, list):
                 _custom_providers = []
 
-        # Check custom_providers per-model context_length
-        if _config_context_length is None and _custom_providers:
-            try:
-                from hermes_cli.config import get_custom_provider_context_length
-                _cp_ctx_resolved = get_custom_provider_context_length(
-                    model=self.model,
-                    base_url=self.base_url,
-                    custom_providers=_custom_providers,
-                )
-                if _cp_ctx_resolved:
-                    _config_context_length = int(_cp_ctx_resolved)
-            except Exception:
-                _cp_ctx_resolved = None
-
-            # Surface a clear warning if the user set a context_length but it
-            # wasn't a valid positive int — the helper silently skips those.
-            if _config_context_length is None:
-                _target = self.base_url.rstrip("/") if self.base_url else ""
-                for _cp_entry in _custom_providers:
-                    if not isinstance(_cp_entry, dict):
-                        continue
-                    _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                    if _target and _cp_url == _target:
-                        _cp_models = _cp_entry.get("models", {})
-                        if isinstance(_cp_models, dict):
-                            _cp_model_cfg = _cp_models.get(self.model, {})
-                            if isinstance(_cp_model_cfg, dict):
-                                _cp_ctx = _cp_model_cfg.get("context_length")
-                                if _cp_ctx is not None:
-                                    try:
-                                        _parsed = int(_cp_ctx)
-                                        if _parsed <= 0:
-                                            raise ValueError
-                                    except (TypeError, ValueError):
-                                        logger.warning(
-                                            "Invalid context_length for model %r in "
-                                            "custom_providers: %r — must be a positive "
-                                            "integer (e.g. 256000, not '256K'). "
-                                            "Falling back to auto-detection.",
-                                            self.model, _cp_ctx,
-                                        )
-                                        print(
-                                            f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
-                                            f"  Must be a positive integer (e.g. 256000, not '256K').\n"
-                                            f"  Falling back to auto-detected context window.\n",
-                                            file=sys.stderr,
-                                        )
-                        break
-
-        # Persist for reuse on switch_model / fallback activation. Must come
-        # AFTER the custom_providers branch so per-model overrides aren't lost.
+        # Resolve the runtime config context length once for startup, then
+        # persist it for later runtime refreshes.
+        _config_context_length = self._resolve_runtime_config_context_length(
+            config=_agent_cfg,
+            custom_providers=_custom_providers,
+        )
         self._config_context_length = _config_context_length
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
@@ -2223,6 +2158,120 @@ class AIAgent:
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
 
+    def _resolve_runtime_config_context_length(
+        self,
+        *,
+        model: Optional[str] = None,
+        base_url: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        custom_providers: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[int]:
+        """Resolve explicit runtime context_length config for the active model.
+
+        Precedence intentionally mirrors ``agent.model_metadata.get_model_context_length``
+        step 0 / 0b:
+        1. top-level ``model.context_length``
+        2. matching ``custom_providers[].models.<model>.context_length``
+        3. otherwise ``None`` (let probing/defaults decide)
+        """
+        model = model or getattr(self, "model", "")
+        base_url = base_url if base_url is not None else getattr(self, "base_url", "")
+
+        if config is None:
+            try:
+                from hermes_cli.config import load_config as _load_agent_config
+                config = _load_agent_config()
+            except Exception:
+                config = {}
+        if not isinstance(config, dict):
+            config = {}
+
+        def _warn_invalid_root_context(raw_value: Any) -> None:
+            logger.warning(
+                "Invalid model.context_length in config.yaml: %r — "
+                "must be a plain positive integer (e.g. 256000, not '256K'). "
+                "Falling back to auto-detection.",
+                raw_value,
+            )
+            print(
+                f"\n⚠ Invalid model.context_length in config.yaml: {raw_value!r}\n"
+                f"  Must be a plain positive integer (e.g. 256000, not '256K').\n"
+                f"  Falling back to auto-detected context window.\n",
+                file=sys.stderr,
+            )
+
+        def _warn_invalid_custom_context(raw_value: Any) -> None:
+            logger.warning(
+                "Invalid context_length for model %r in custom_providers: %r — "
+                "must be a positive integer (e.g. 256000, not '256K'). "
+                "Falling back to auto-detection.",
+                model,
+                raw_value,
+            )
+            print(
+                f"\n⚠ Invalid context_length for model {model!r} in custom_providers: {raw_value!r}\n"
+                f"  Must be a positive integer (e.g. 256000, not '256K').\n"
+                f"  Falling back to auto-detected context window.\n",
+                file=sys.stderr,
+            )
+
+        model_cfg = config.get("model", {})
+        raw_root_context = model_cfg.get("context_length") if isinstance(model_cfg, dict) else None
+        if raw_root_context is not None:
+            try:
+                parsed_root_context = int(raw_root_context)
+                if parsed_root_context <= 0:
+                    raise ValueError
+                return parsed_root_context
+            except (TypeError, ValueError):
+                _warn_invalid_root_context(raw_root_context)
+
+        if custom_providers is None:
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+                custom_providers = get_compatible_custom_providers(config)
+            except Exception:
+                raw_custom = config.get("custom_providers")
+                custom_providers = raw_custom if isinstance(raw_custom, list) else []
+        if not isinstance(custom_providers, list):
+            custom_providers = []
+
+        if custom_providers and model and base_url:
+            try:
+                from hermes_cli.config import get_custom_provider_context_length
+
+                resolved_custom_context = get_custom_provider_context_length(
+                    model=model,
+                    base_url=base_url,
+                    custom_providers=custom_providers,
+                )
+                if resolved_custom_context:
+                    return int(resolved_custom_context)
+            except Exception:
+                pass
+
+            target_url = base_url.rstrip("/") if isinstance(base_url, str) else ""
+            for entry in custom_providers:
+                if not isinstance(entry, dict):
+                    continue
+                entry_url = (entry.get("base_url") or "").rstrip("/")
+                if target_url and entry_url == target_url:
+                    entry_models = entry.get("models", {})
+                    if isinstance(entry_models, dict):
+                        entry_model_cfg = entry_models.get(model, {})
+                        if isinstance(entry_model_cfg, dict):
+                            raw_custom_context = entry_model_cfg.get("context_length")
+                            if raw_custom_context is not None:
+                                try:
+                                    parsed_custom_context = int(raw_custom_context)
+                                    if parsed_custom_context <= 0:
+                                        raise ValueError
+                                except (TypeError, ValueError):
+                                    _warn_invalid_custom_context(raw_custom_context)
+                    break
+
+        return None
+
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
 
@@ -2269,6 +2318,10 @@ class AIAgent:
             self._transport_cache.clear()
         if api_key:
             self.api_key = api_key
+        self._config_context_length = self._resolve_runtime_config_context_length(
+            model=self.model,
+            base_url=self.base_url,
+        )
 
         # ── Build new client ──
         if api_mode == "anthropic_messages":
@@ -7504,6 +7557,10 @@ class AIAgent:
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self._fallback_activated = True
+            self._config_context_length = self._resolve_runtime_config_context_length(
+                model=self.model,
+                base_url=self.base_url,
+            )
 
             # Honor per-provider / per-model request_timeout_seconds for the
             # fallback target (same knob the primary client uses).  None = use
@@ -7627,6 +7684,10 @@ class AIAgent:
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
+            self._config_context_length = self._resolve_runtime_config_context_length(
+                model=self.model,
+                base_url=self.base_url,
+            )
             self._client_kwargs = dict(rt["client_kwargs"])
             self._use_prompt_caching = rt["use_prompt_caching"]
             # Default to native layout when the restored snapshot predates the

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -1,4 +1,4 @@
-"""Tests that _try_activate_fallback updates the context compressor."""
+"""Tests that _try_activate_fallback updates the context compressor and runtime config context."""
 
 from unittest.mock import MagicMock, patch
 
@@ -6,86 +6,154 @@ from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
 
+YUNFEI_BASE_URL = "https://ai.yunfei.best/v1"
+
+
+def _runtime_cfg():
+    return {
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "yunfei",
+                "base_url": YUNFEI_BASE_URL,
+                "models": {
+                    "gpt-5.4": {"context_length": 272_000},
+                    "gpt-5.3-codex": {"context_length": 200_000},
+                },
+            }
+        ],
+    }
+
+
 def _make_agent_with_compressor() -> AIAgent:
     """Build a minimal AIAgent with a context_compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
 
-    # Primary model settings
-    agent.model = "primary-model"
-    agent.provider = "openrouter"
-    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.model = "gpt-5.4"
+    agent.provider = "yunfei"
+    agent.base_url = YUNFEI_BASE_URL
     agent.api_key = "sk-primary"
     agent.api_mode = "chat_completions"
     agent.client = MagicMock()
     agent.quiet_mode = True
+    agent._transport_cache = {}
+    agent._config_context_length = 272_000
+    agent._client_kwargs = {}
+    agent._primary_runtime = {
+        "provider": "yunfei",
+        "model": "gpt-5.4",
+        "base_url": YUNFEI_BASE_URL,
+        "api_mode": "chat_completions",
+        "api_key": "sk-primary",
+        "client_kwargs": {},
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "compressor_model": "gpt-5.4",
+        "compressor_base_url": YUNFEI_BASE_URL,
+        "compressor_api_key": "sk-primary",
+        "compressor_provider": "yunfei",
+        "compressor_context_length": 272_000,
+        "compressor_threshold_tokens": 136_000,
+    }
 
-    # Fallback config
     agent._fallback_activated = False
     agent._fallback_model = {
-        "provider": "openai",
-        "model": "gpt-4o",
+        "provider": "yunfei",
+        "model": "gpt-5.3-codex",
     }
     agent._fallback_chain = [agent._fallback_model]
     agent._fallback_index = 0
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._emit_status = lambda msg: None
+    agent._is_direct_openai_url = lambda url: False
+    agent._provider_model_requires_responses_api = lambda *args, **kwargs: False
 
-    # Context compressor with primary model values
     compressor = ContextCompressor(
-        model="primary-model",
+        model="gpt-5.4",
         threshold_percent=0.50,
-        base_url="https://openrouter.ai/api/v1",
+        base_url=YUNFEI_BASE_URL,
         api_key="sk-primary",
-        provider="openrouter",
+        provider="yunfei",
         quiet_mode=True,
+        config_context_length=272_000,
     )
     agent.context_compressor = compressor
 
     return agent
 
 
+@patch("run_agent.get_provider_request_timeout", return_value=None)
+@patch.object(AIAgent, "_anthropic_prompt_cache_policy", return_value=(False, False))
+@patch.object(AIAgent, "_ensure_lmstudio_runtime_loaded", return_value=None)
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
 @patch("agent.auxiliary_client.resolve_provider_client")
-@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
-def test_compressor_updated_on_fallback(mock_ctx_len, mock_resolve):
-    """After fallback activation, the compressor must reflect the fallback model."""
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_compressor_updated_on_fallback_and_recomputes_config_context_length(
+    mock_ctx_len,
+    mock_resolve,
+    mock_load_config,
+    mock_get_compatible,
+    _mock_lmstudio,
+    _mock_cache_policy,
+    _mock_timeout,
+):
+    """Fallback activation must recompute config_context_length for the fallback runtime."""
+    cfg = _runtime_cfg()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
     agent = _make_agent_with_compressor()
 
-    assert agent.context_compressor.model == "primary-model"
-
     fb_client = MagicMock()
-    fb_client.base_url = "https://api.openai.com/v1"
+    fb_client.base_url = YUNFEI_BASE_URL
     fb_client.api_key = "sk-fallback"
     mock_resolve.return_value = (fb_client, None)
-
-    agent._is_direct_openai_url = lambda url: "api.openai.com" in url
-    agent._emit_status = lambda msg: None
 
     result = agent._try_activate_fallback()
 
     assert result is True
     assert agent._fallback_activated is True
+    assert agent._config_context_length == 200_000
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] == 200_000
 
     c = agent.context_compressor
-    assert c.model == "gpt-4o"
-    assert c.base_url == "https://api.openai.com/v1"
+    assert c.model == "gpt-5.3-codex"
+    assert c.base_url == YUNFEI_BASE_URL
     assert c.api_key == "sk-fallback"
-    assert c.provider == "openai"
-    assert c.context_length == 128_000
-    assert c.threshold_tokens == int(128_000 * c.threshold_percent)
+    assert c.provider == "yunfei"
+    assert c.context_length == 200_000
+    assert c.threshold_tokens == int(200_000 * c.threshold_percent)
 
 
+@patch("run_agent.get_provider_request_timeout", return_value=None)
+@patch.object(AIAgent, "_anthropic_prompt_cache_policy", return_value=(False, False))
+@patch.object(AIAgent, "_ensure_lmstudio_runtime_loaded", return_value=None)
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
 @patch("agent.auxiliary_client.resolve_provider_client")
-@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
-def test_compressor_not_present_does_not_crash(mock_ctx_len, mock_resolve):
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_compressor_not_present_does_not_crash(
+    mock_ctx_len,
+    mock_resolve,
+    mock_load_config,
+    mock_get_compatible,
+    _mock_lmstudio,
+    _mock_cache_policy,
+    _mock_timeout,
+):
     """If the agent has no compressor, fallback should still succeed."""
+    cfg = _runtime_cfg()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
     agent = _make_agent_with_compressor()
     agent.context_compressor = None
 
     fb_client = MagicMock()
-    fb_client.base_url = "https://api.openai.com/v1"
+    fb_client.base_url = YUNFEI_BASE_URL
     fb_client.api_key = "sk-fallback"
     mock_resolve.return_value = (fb_client, None)
 
-    agent._is_direct_openai_url = lambda url: "api.openai.com" in url
-    agent._emit_status = lambda msg: None
-
     result = agent._try_activate_fallback()
     assert result is True
+    assert agent._config_context_length == 200_000

--- a/tests/run_agent/test_runtime_context_length_refresh.py
+++ b/tests/run_agent/test_runtime_context_length_refresh.py
@@ -1,0 +1,153 @@
+"""Focused regression tests for runtime _config_context_length refresh."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from agent.context_compressor import ContextCompressor
+
+
+YUNFEI_BASE_URL = "https://ai.yunfei.best/v1"
+
+
+def _cfg_with_top_level():
+    return {
+        "model": {"context_length": 200_000},
+        "custom_providers": [
+            {
+                "name": "yunfei",
+                "base_url": YUNFEI_BASE_URL,
+                "models": {
+                    "gpt-5.4": {"context_length": 272_000},
+                    "gpt-5.3-codex": {"context_length": 200_000},
+                },
+            }
+        ],
+    }
+
+
+def _cfg_without_top_level():
+    return {
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "yunfei",
+                "base_url": YUNFEI_BASE_URL,
+                "models": {
+                    "gpt-5.4": {"context_length": 272_000},
+                    "gpt-5.3-codex": {"context_length": 200_000},
+                },
+            }
+        ],
+    }
+
+
+def _make_restore_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "gpt-5.3-codex"
+    agent.provider = "yunfei"
+    agent.base_url = YUNFEI_BASE_URL
+    agent.api_mode = "chat_completions"
+    agent.api_key = "sk-fallback"
+    agent._transport_cache = {}
+    agent._fallback_activated = True
+    agent._fallback_index = 1
+    agent._rate_limited_until = 0
+    agent._config_context_length = 200_000
+    agent._client_kwargs = {}
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent.client = MagicMock()
+
+    agent.context_compressor = ContextCompressor(
+        model="gpt-5.3-codex",
+        threshold_percent=0.50,
+        base_url=YUNFEI_BASE_URL,
+        api_key="sk-fallback",
+        provider="yunfei",
+        quiet_mode=True,
+        config_context_length=200_000,
+    )
+
+    agent._primary_runtime = {
+        "model": "gpt-5.4",
+        "provider": "yunfei",
+        "base_url": YUNFEI_BASE_URL,
+        "api_mode": "chat_completions",
+        "api_key": "sk-primary",
+        "client_kwargs": {},
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "compressor_model": "gpt-5.4",
+        "compressor_base_url": YUNFEI_BASE_URL,
+        "compressor_api_key": "sk-primary",
+        "compressor_provider": "yunfei",
+        "compressor_context_length": 272_000,
+        "compressor_threshold_tokens": 136_000,
+    }
+    return agent
+
+
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
+def test_helper_prefers_top_level_context_length(
+    mock_load_config,
+    mock_get_compatible,
+):
+    """Top-level model.context_length must outrank per-model custom overrides."""
+    cfg = _cfg_with_top_level()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
+    agent = AIAgent.__new__(AIAgent)
+
+    result = agent._resolve_runtime_config_context_length(
+        model="gpt-5.4",
+        base_url=YUNFEI_BASE_URL,
+    )
+
+    assert result == 200_000
+
+
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
+def test_helper_uses_matching_custom_provider_when_top_level_absent(
+    mock_load_config,
+    mock_get_compatible,
+):
+    """When top-level override is absent, helper must return the matching model override."""
+    cfg = _cfg_without_top_level()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
+    agent = AIAgent.__new__(AIAgent)
+
+    result = agent._resolve_runtime_config_context_length(
+        model="gpt-5.4",
+        base_url=YUNFEI_BASE_URL,
+    )
+
+    assert result == 272_000
+
+
+@patch("run_agent.get_provider_request_timeout", return_value=None)
+@patch.object(AIAgent, "_create_openai_client", return_value=MagicMock())
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
+def test_restore_primary_runtime_recomputes_config_context_length(
+    mock_load_config,
+    mock_get_compatible,
+    _mock_create_client,
+    _mock_timeout,
+):
+    """Restoring the primary runtime must replace fallback context_length with the primary one."""
+    cfg = _cfg_without_top_level()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
+    agent = _make_restore_agent()
+
+    restored = agent._restore_primary_runtime()
+
+    assert restored is True
+    assert agent.model == "gpt-5.4"
+    assert agent._config_context_length == 272_000
+    assert agent.context_compressor.context_length == 272_000
+    assert agent._fallback_activated is False
+    assert agent._fallback_index == 0

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -1,4 +1,4 @@
-"""Tests that switch_model preserves config_context_length."""
+"""Tests that switch_model recomputes runtime config_context_length."""
 
 from unittest.mock import MagicMock, patch
 
@@ -6,69 +6,126 @@ from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
 
-def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
+YUNFEI_BASE_URL = "https://ai.yunfei.best/v1"
+
+
+def _runtime_cfg():
+    return {
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "yunfei",
+                "base_url": YUNFEI_BASE_URL,
+                "models": {
+                    "gpt-5.4": {"context_length": 272_000},
+                    "gpt-5.3-codex": {"context_length": 200_000},
+                },
+            }
+        ],
+    }
+
+
+def _make_agent_with_compressor(config_context_length=272_000) -> AIAgent:
     """Build a minimal AIAgent with a context_compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
 
-    # Primary model settings
-    agent.model = "primary-model"
-    agent.provider = "openrouter"
-    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.model = "gpt-5.4"
+    agent.provider = "yunfei"
+    agent.base_url = YUNFEI_BASE_URL
     agent.api_key = "sk-primary"
     agent.api_mode = "chat_completions"
     agent.client = MagicMock()
     agent.quiet_mode = True
-
-    # Store config_context_length for later use in switch_model
+    agent._transport_cache = {}
     agent._config_context_length = config_context_length
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._cached_system_prompt = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
 
-    # Context compressor with primary model values
     compressor = ContextCompressor(
-        model="primary-model",
+        model="gpt-5.4",
         threshold_percent=0.50,
-        base_url="https://openrouter.ai/api/v1",
+        base_url=YUNFEI_BASE_URL,
         api_key="sk-primary",
-        provider="openrouter",
+        provider="yunfei",
         quiet_mode=True,
         config_context_length=config_context_length,
     )
     agent.context_compressor = compressor
-
-    # For switch_model
     agent._primary_runtime = {}
-
     return agent
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
-def test_switch_model_preserves_config_context_length(mock_ctx_len):
-    """When switching models, config_context_length should be passed to get_model_context_length."""
-    agent = _make_agent_with_compressor(config_context_length=32_768)
+@patch("run_agent.get_provider_request_timeout", return_value=None)
+@patch.object(AIAgent, "_anthropic_prompt_cache_policy", return_value=(False, False))
+@patch.object(AIAgent, "_ensure_lmstudio_runtime_loaded", return_value=None)
+@patch.object(AIAgent, "_create_openai_client", return_value=MagicMock())
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_switch_model_recomputes_config_context_length_for_new_model(
+    mock_ctx_len,
+    mock_load_config,
+    mock_get_compatible,
+    _mock_create_client,
+    _mock_lmstudio,
+    _mock_cache_policy,
+    _mock_timeout,
+):
+    """Switching models must recompute config_context_length for the new runtime."""
+    cfg = _runtime_cfg()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
+    agent = _make_agent_with_compressor(config_context_length=272_000)
 
-    assert agent.context_compressor.model == "primary-model"
-    assert agent.context_compressor.context_length == 32_768  # From config override
+    agent.switch_model(
+        "gpt-5.3-codex",
+        "yunfei",
+        api_key="sk-new",
+        base_url=YUNFEI_BASE_URL,
+        api_mode="chat_completions",
+    )
 
-    # Switch model
-    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
-
-    # Verify get_model_context_length was called with config_context_length
-    mock_ctx_len.assert_called_once()
+    assert agent._config_context_length == 200_000
     call_kwargs = mock_ctx_len.call_args.kwargs
-    assert call_kwargs.get("config_context_length") == 32_768
-
-    # Verify compressor was updated
-    assert agent.context_compressor.model == "new-model"
+    assert call_kwargs.get("config_context_length") == 200_000
+    assert agent.context_compressor.model == "gpt-5.3-codex"
 
 
-def test_switch_model_without_config_context_length():
-    """When switching models without config override, config_context_length should be None."""
-    agent = _make_agent_with_compressor(config_context_length=None)
+@patch("run_agent.get_provider_request_timeout", return_value=None)
+@patch.object(AIAgent, "_anthropic_prompt_cache_policy", return_value=(False, False))
+@patch.object(AIAgent, "_ensure_lmstudio_runtime_loaded", return_value=None)
+@patch.object(AIAgent, "_create_openai_client", return_value=MagicMock())
+@patch("hermes_cli.config.get_compatible_custom_providers")
+@patch("hermes_cli.config.load_config")
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_switch_model_without_top_level_override_uses_matching_custom_provider_value(
+    mock_ctx_len,
+    mock_load_config,
+    mock_get_compatible,
+    _mock_create_client,
+    _mock_lmstudio,
+    _mock_cache_policy,
+    _mock_timeout,
+):
+    """Per-model custom_provider value should replace the previous runtime value."""
+    cfg = _runtime_cfg()
+    mock_load_config.return_value = cfg
+    mock_get_compatible.return_value = cfg["custom_providers"]
+    agent = _make_agent_with_compressor(config_context_length=272_000)
 
-    with patch("agent.model_metadata.get_model_context_length", return_value=128_000) as mock_ctx_len:
-        # Switch model
-        agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+    agent.switch_model(
+        "gpt-5.3-codex",
+        "yunfei",
+        api_key="sk-new",
+        base_url=YUNFEI_BASE_URL,
+        api_mode="chat_completions",
+    )
 
-        # Verify get_model_context_length was called with None
-        mock_ctx_len.assert_called_once()
-        call_kwargs = mock_ctx_len.call_args.kwargs
-        assert call_kwargs.get("config_context_length") is None
+    assert agent._config_context_length != 272_000
+    assert agent._config_context_length == 200_000
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] == 200_000


### PR DESCRIPTION
## Summary
- add a shared helper to resolve runtime `_config_context_length`
- recompute `_config_context_length` in `switch_model()`, `_try_activate_fallback()`, and `_restore_primary_runtime()`
- keep top-level `model.context_length` precedence unchanged
- add focused regression coverage for init precedence, runtime switch, fallback, and restore

## Test Plan
- `pytest -q tests/run_agent/test_switch_model_context.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_runtime_context_length_refresh.py`
- `pytest -q tests/run_agent/test_provider_fallback.py tests/run_agent/test_switch_model_fallback_prune.py tests/hermes_cli/test_custom_provider_context_length.py`
- `pytest -q tests/run_agent/test_switch_model_context.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_runtime_context_length_refresh.py tests/hermes_cli/test_custom_provider_context_length.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_switch_model_fallback_prune.py`

## Notes
- excluded local-only files from the commit, including `.hermes/`, `docs/`, and `tests/gateway/test_run_progress_cards.py`
