### PR TITLE
fix(update): stream npm install output so postinstall progress is visible (#18840)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6269,17 +6269,24 @@ def _update_node_dependencies() -> None:
         if not (path / "package.json").exists():
             continue
 
+        # Stream npm output (no `--silent`, no `capture_output`) so optional
+        # dependency postinstall scripts — e.g. `@askjo/camofox-browser`'s
+        # `npx camoufox-js fetch` browser-binary download — print progress
+        # instead of appearing to hang silently for minutes (#18840).  The
+        # `_UpdateOutputStream` wrapper installed by the updater mirrors
+        # streamed output to ``~/.hermes/logs/update.log`` so nothing is lost.
         result = _run_npm_install_deterministic(
             npm,
             path,
-            extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
+            extra_args=("--no-fund", "--no-audit", "--progress=false"),
+            capture_output=False,
         )
         if result.returncode == 0:
             print(f"  ✓ {label}")
             continue
 
         print(f"  ⚠ npm install failed in {label}")
-        stderr = (result.stderr or "").strip()
+        stderr = (result.stderr or "").strip() if result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -128,20 +128,42 @@ class TestCmdUpdateBranchFallback:
         #   1. repo root  — slash-command / TUI bridge deps
         #   2. ui-tui/    — Ink TUI deps
         #   3. web/       — install + "npm run build" for the web frontend
-        full_flags = [
+        #
+        # Repo-root and ui-tui installs intentionally omit `--silent` and run
+        # without `capture_output` so optional postinstall scripts (e.g.
+        # `@askjo/camofox-browser`'s browser-binary fetch) print progress —
+        # otherwise long downloads look like a hang (#18840).  The web/ install
+        # keeps `--silent` because its build step is short and noisy.
+        update_flags = [
             "/usr/bin/npm",
             "ci",
-            "--silent",
             "--no-fund",
             "--no-audit",
             "--progress=false",
         ]
         assert npm_calls == [
-            (full_flags, PROJECT_ROOT),
-            (full_flags, PROJECT_ROOT / "ui-tui"),
+            (update_flags, PROJECT_ROOT),
+            (update_flags, PROJECT_ROOT / "ui-tui"),
             (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
             (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
         ]
+
+        # Regression for #18840: repo root + ui-tui installs must stream output
+        # (capture_output=False) so postinstall progress is visible to the user.
+        repo_and_tui_calls = [
+            call
+            for call in mock_run.call_args_list
+            if call.args
+            and call.args[0][0] == "/usr/bin/npm"
+            and call.args[0][1] == "ci"
+            and call.kwargs.get("cwd") in (PROJECT_ROOT, PROJECT_ROOT / "ui-tui")
+        ]
+        assert len(repo_and_tui_calls) == 2
+        for call in repo_and_tui_calls:
+            assert call.kwargs.get("capture_output") is False, (
+                "repo-root / ui-tui npm install must stream output "
+                "(no capture_output) so Camofox postinstall progress is visible"
+            )
 
     def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
         """When stdin/stdout aren't TTYs, config migration prompt is skipped."""


### PR DESCRIPTION
## Summary

`hermes update` appeared to hang silently at `→ Updating Node.js dependencies...` for users on fresh installs, because the repo-root npm install ran with both `--silent` AND captured stdout/stderr — so the long-running postinstall script `@askjo/camofox-browser` → `npx camoufox-js fetch` (downloads a Firefox-fork browser binary, can take many minutes) printed nothing.

Reporter (#18840) verified the issue with the npm debug log and the captured traceback inside `_run_npm_install_deterministic()`:

```
info run @askjo/camofox-browser@1.5.2 postinstall node_modules/@askjo/camofox-browser npx camoufox-js fetch || true
info run agent-browser@0.26.0 postinstall { code: 0, signal: null }
info run @askjo/camofox-browser@1.5.2 postinstall { code: null, signal: 'SIGINT' }
```

## The bug

`hermes_cli/main.py:_update_node_dependencies()` ran:

```python
result = _run_npm_install_deterministic(
    npm,
    path,
    extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
)
```

`_run_npm_install_deterministic()` defaults to `capture_output=True`. Combined with `--silent`, npm produces zero output until the install completes — even when it is sitting inside a multi-minute postinstall download. From the user's perspective, the process is frozen, and Ctrl-C can leave `node_modules` partially installed.

## The fix

For the repo-root and ui-tui npm installs, drop `--silent` and pass `capture_output=False` so npm streams its `info run …` postinstall lines straight to the terminal as they happen. The `_UpdateOutputStream` wrapper installed earlier in `cmd_update` mirrors stdout/stderr to `~/.hermes/logs/update.log`, so SSH-disconnect safety is preserved and nothing is lost from the log.

The `web/` install path (build step) is intentionally untouched — it is short and does not run binary-fetching postinstalls, so the existing `--silent` keeps the update output tidy.

This is an output-visibility fix only — no install behavior changes, no flag like `--ignore-scripts` is introduced. Camofox still bootstraps automatically; users just see what it is doing.

## Test plan

- [x] Focused regression test: `tests/hermes_cli/test_cmd_update.py::test_update_refreshes_repo_and_tui_node_dependencies` updated to assert (a) `--silent` removed from repo-root + ui-tui flags and (b) those calls run with `capture_output=False`. Web install assertion preserved.
- [x] Adjacent suite: `tests/hermes_cli/test_cmd_update.py`, `tests/hermes_cli/test_web_ui_build.py`, `tests/hermes_cli/test_tui_npm_install.py` — 25/25 pass on rebased `origin/main` (`5d3be898a`).
- [x] Regression guard: with the production change reverted (`hermes_cli/main.py` only), the focused test fails with the expected flag mismatch; restoring the change makes it pass.

## Related

- Fixes #18840