### PR TITLE
fix(context): pass custom_providers in aux compression and fallback paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2652,12 +2652,29 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            # Load custom_providers so per-model context_length overrides
+            # are honored for the compression model — mirrors the
+            # switch_model() path. Without this, the auxiliary probe skips
+            # step 0b in get_model_context_length and falls back to the
+            # 256K default, even when the user set
+            # custom_providers[].models[].context_length in config.yaml.
+            _aux_custom_providers = None
+            try:
+                from hermes_cli.config import (
+                    load_config,
+                    get_compatible_custom_providers,
+                )
+                _aux_custom_providers = get_compatible_custom_providers(load_config())
+            except Exception:
+                _aux_custom_providers = None
+
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
                 provider=getattr(self, "provider", ""),
+                custom_providers=_aux_custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least
@@ -7632,10 +7649,24 @@ class AIAgent:
             # the fallback activation drops to 128K even when config says 204800.
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 from agent.model_metadata import get_model_context_length
+                # Pass custom_providers so per-model context_length overrides
+                # apply to the fallback model too — same fix as the aux
+                # compression path; otherwise a custom-provider fallback
+                # falls back to the 256K default.
+                _fb_custom_providers = None
+                try:
+                    from hermes_cli.config import (
+                        load_config,
+                        get_compatible_custom_providers,
+                    )
+                    _fb_custom_providers = get_compatible_custom_providers(load_config())
+                except Exception:
+                    _fb_custom_providers = None
                 fb_context_length = get_model_context_length(
                     self.model, base_url=self.base_url,
                     api_key=self.api_key, provider=self.provider,
                     config_context_length=getattr(self, "_config_context_length", None),
+                    custom_providers=_fb_custom_providers,
                 )
                 self.context_compressor.update_model(
                     model=self.model,


### PR DESCRIPTION
# fix(context): pass `custom_providers` in aux compression and fallback paths

## Problem

Users who pin `context_length` on a model in `custom_providers` see the main agent honor that override but the **auxiliary compression model** fall back to the default 256K — even when it's literally the same model. This produces a confusing startup warning and silently lowers the compression threshold every session.

## What goes wrong (user perspective)

Take a `custom_providers` entry with a per-model context override (typical for the 1M-context Opus variant against a custom proxy):

```yaml
model:
  default: claude-opus-4-7[1m]
  provider: my-vertex-proxy

custom_providers:
- name: my-vertex-proxy
  base_url: http://127.0.0.1:8788
  api_mode: anthropic_messages
  models:
    claude-opus-4-7[1m]:
      context_length: 1000000

compression:
  threshold: 0.5     # default — compress at 50% of context
```

Expected: compression triggers at 500K tokens (50% of 1M).

Actual: at session start, this warning appears:

```
⚠ Compression model claude-opus-4-7[1m] (127.0.0.1) context is 256,000 tokens,
  but the main model claude-opus-4-7[1m] (custom)'s compression threshold was
  500,000 tokens. Auto-lowered this session's threshold to 256,000 tokens so
  compression can run.
```

Both labels in that message are the **same model** — `claude-opus-4-7[1m]` against the same custom provider. Yet Hermes resolves it to two different context windows: 1M for the main agent (correct), 256K for the compression model (wrong). The session quietly runs at half the configured threshold and the user has to either ignore the warning every session or manually drop `compression.threshold` to 0.25.

## Root cause

`agent/model_metadata.py:1229`'s `get_model_context_length()` accepts a `custom_providers` keyword. When supplied, step 0b in its resolution order checks `custom_providers[].models[].context_length` for an explicit override. Without it, that step is skipped and resolution falls through (eventually) to the `DEFAULT_FALLBACK_CONTEXT` of 256K for unknown custom endpoints.

There are four call sites in `run_agent.py`. Two pass `custom_providers`; two don't:

| Line | What it computes | Passes `custom_providers`? |
|---:|---|:---:|
| 1995 | Initial context length when a plugin context engine is loaded | ✅ |
| 2392 | New context length after a `/model` switch (closes #15779) | ✅ |
| **2655** | **Auxiliary compression model context** — the symptom above | ❌ |
| **7635** | Fallback model context after primary failover | ❌ |

Site 2655 is what produces the warning. Site 7635 has the same bug but is latent — only triggers when a user has both a custom-provider main model AND a `fallback_model`; the symptom would be the fallback's compressor mis-sizing its threshold.

## Fix

Mirror the existing pattern already used at `run_agent.py:2382-2389` — load `custom_providers` from current config (defensively wrapped in `try/except` so a load failure doesn't break the path) and pass via the existing `custom_providers=` keyword:

```python
_aux_custom_providers = None
try:
    from hermes_cli.config import (
        load_config,
        get_compatible_custom_providers,
    )
    _aux_custom_providers = get_compatible_custom_providers(load_config())
except Exception:
    _aux_custom_providers = None

aux_context = get_model_context_length(
    aux_model,
    base_url=aux_base_url,
    api_key=aux_api_key,
    config_context_length=getattr(self, "_aux_compression_context_length_config", None),
    provider=getattr(self, "provider", ""),
    custom_providers=_aux_custom_providers,   # ← new
)
```

Same shape applied at site 7635 for the fallback path.

No new code paths. No behavior change for users not using `custom_providers`.

## Test plan

- [x] `uv run pytest` (existing suite passes)
- [x] **Repro case**: configure `custom_providers[].models[].context_length: 1000000` and `compression.threshold: 0.5` against a custom Anthropic-compatible endpoint; start a session → warning does **not** appear, `context_compressor.threshold_tokens` is 500,000.
- [x] **Fallback case**: configure as above plus a `fallback_model` pointing at the same custom provider; force the primary to fail (e.g. wrong port); confirm fallback's `context_compressor.context_length` reflects the per-model override (not the 256K default).
