### PR TITLE
fix(skills): skill_view fallback to frontmatter name lookup (fixes #18872)

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -976,6 +976,25 @@ def skill_view(
                 if skill_md:
                     break
 
+        # Fallback: search by frontmatter name (fixes #18872)
+        # skills_list() returns frontmatter `name:` which may differ from
+        # the directory name — skill_view must resolve both.
+        if not skill_md:
+            for search_dir in all_dirs:
+                for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                    try:
+                        fm, _ = _parse_frontmatter(
+                            found_skill_md.read_text(encoding="utf-8")[:4000]
+                        )
+                        if fm.get("name") == name:
+                            skill_dir = found_skill_md.parent
+                            skill_md = found_skill_md
+                            break
+                    except Exception:
+                        continue
+                if skill_md:
+                    break
+
         # Legacy: flat .md files
         if not skill_md:
             for search_dir in all_dirs:


### PR DESCRIPTION
## Fix: skill_view/skills_list name mismatch breaks agent tool-calling loop

Fixes #18872

### Problem

When a skill's directory name differs from its frontmatter `name:` field (e.g., directory `foo/` with `name: bar` in `SKILL.md`), `skills_list()` returns the frontmatter name (`"bar"`) but `skill_view()` only looks up by directory name (`"foo"`). This causes `skill_view("bar")` → `"Skill 'bar' not found"`, breaking the agent's tool-calling loop when it tries to load a discovered skill.

### Root Cause

`_find_all_skills()` (line 588) uses `frontmatter.get("name", skill_dir.name)` — frontmatter name takes priority. But `skill_view()` searches by directory name via `found_skill_md.parent.name == name` and direct path matching, with no frontmatter name fallback.

### Fix

Add a fallback search in `skill_view()` that scans all skill SKILL.md files and matches by frontmatter `name:` field when directory-name lookup fails. This makes `skill_view()` accept both directory names and frontmatter names, ensuring consistent resolution regardless of which name `skills_list()` returns.

### Testing

- `skills_list()` → returns frontmatter name ✓ (unchanged)
- `skill_view("directory_name")` → works ✓ (existing path)
- `skill_view("frontmatter_name")` → works ✓ (new fallback)
- Slash commands: `/frontmatter_name` still works via command map ✓ (unchanged)