### PR TITLE
feat(todo): add model and provider fields for per-task model override

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -383,12 +383,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
+            # Priority: inline api_key first, then key_env env var
+            resolved_api_key = str(entry.get("api_key", "") or "").strip()
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
-            # Fall back to inline api_key when key_env is absent or unresolvable
-            if not resolved_api_key:
-                resolved_api_key = str(entry.get("api_key", "") or "").strip()
+            if not resolved_api_key and key_env:
+                resolved_api_key = os.getenv(key_env, "").strip()
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -901,6 +901,95 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["model"])
         self.assertIsNone(creds["provider"])
 
+    def test_custom_providers_api_key_is_prioritized(self):
+        """Test that when using custom_providers list format, the api_key in config is prioritized."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-pro",
+        }
+        
+        # Mock load_config to return the user's custom_providers format
+        with patch("hermes_cli.config.load_config") as mock_load_config:
+            mock_load_config.return_value = {
+                "custom_providers": [
+                    {
+                        "name": "Finna deepseek-v4-pro",
+                        "base_url": "https://www.finna.com.cn/v1",
+                        "api_key": "app-lUeqweqweqweHiGvBil",  # This should be prioritized
+                        "model": "deepseek-v4-pro",
+                    },
+                    {
+                        "name": "Finna deepseek-v4-flash",
+                        "base_url": "https://www.finna.com.cn/v1",
+                        "api_key": "app-TBqweqwewqeweqwh",
+                        "model": "deepseek-v4-flash",
+                    }
+                ]
+            }
+            
+            # Mock the has_usable_secret (if imported)
+            try:
+                from tools.delegate_tool import has_usable_secret
+                with patch("tools.delegate_tool.has_usable_secret") as mock_has_secret:
+                    mock_has_secret.return_value = True
+                    creds = _resolve_delegation_credentials(cfg, parent)
+            except ImportError:
+                # If has_usable_secret not imported, just test directly
+                creds = _resolve_delegation_credentials(cfg, parent)
+            
+            # Verify the results
+            self.assertEqual(creds["model"], "deepseek-v4-pro")
+            self.assertEqual(creds["provider"], "custom")
+            self.assertEqual(creds["base_url"], "https://www.finna.com.cn/v1")
+            self.assertEqual(creds["api_key"], "app-lUeqweqweqweHiGvBil")
+
+    def test_custom_providers_key_env_fallback(self):
+        """Test that when custom_providers has key_env but no api_key, key_env is used."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-flash",
+        }
+        
+        with patch.dict(os.environ, {"FINNA_API_KEY": "env-key-from-key_env"}, clear=False):
+            with patch("hermes_cli.config.load_config") as mock_load_config:
+                mock_load_config.return_value = {
+                    "custom_providers": [
+                        {
+                            "name": "Finna deepseek-v4-flash",
+                            "base_url": "https://www.finna.com.cn/v1",
+                            "key_env": "FINNA_API_KEY",
+                            "model": "deepseek-v4-flash",
+                        }
+                    ]
+                }
+                
+                creds = _resolve_delegation_credentials(cfg, parent)
+                
+                self.assertEqual(creds["api_key"], "env-key-from-key_env")
+
+    def test_providers_dict_format_api_key_priority(self):
+        """Test that the new providers dict format also properly prioritizes api_key."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-pro",
+        }
+        
+        with patch("hermes_cli.config.load_config") as mock_load_config:
+            mock_load_config.return_value = {
+                "providers": {
+                    "finna-deepseek-pro": {
+                        "name": "Finna deepseek-v4-pro",
+                        "api": "https://www.finna.com.cn/v1",
+                        "api_key": "app-lUeqweqweqweHiGvBil",
+                        "model": "deepseek-v4-pro",
+                    }
+                }
+            }
+            
+            creds = _resolve_delegation_credentials(cfg, parent)
+            
+            self.assertEqual(creds["api_key"], "app-lUeqweqweqweHiGvBil")
+
 
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -990,6 +990,57 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             
             self.assertEqual(creds["api_key"], "app-lUeqweqweqweHiGvBil")
 
+    def test_custom_provider_uses_provider_config_model(self):
+        """Test that when a custom provider is found, it uses the model from provider config."""
+        parent = _make_mock_parent(depth=0)
+        # Request the matching model
+        cfg = {
+            "model": "deepseek-v4-pro",
+        }
+        
+        with patch("hermes_cli.config.load_config") as mock_load_config:
+            mock_load_config.return_value = {
+                "custom_providers": [
+                    {
+                        "name": "Finna deepseek-v4-pro",
+                        "base_url": "https://www.finna.com.cn/v1",
+                        "api_key": "app-lUeqweqweqweHiGvBil",
+                        "model": "deepseek-v4-pro",
+                    }
+                ]
+            }
+            
+            creds = _resolve_delegation_credentials(cfg, parent)
+            
+            # Verify that the model from provider config is used
+            self.assertEqual(creds["model"], "deepseek-v4-pro")
+            self.assertEqual(creds["base_url"], "https://www.finna.com.cn/v1")
+            self.assertEqual(creds["api_key"], "app-lUeqweqweqweHiGvBil")
+
+    def test_custom_provider_uses_default_model(self):
+        """Test that when a custom provider uses default_model, it's picked up correctly."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-pro",
+        }
+        
+        with patch("hermes_cli.config.load_config") as mock_load_config:
+            mock_load_config.return_value = {
+                "providers": {
+                    "finna-deepseek-pro": {
+                        "name": "Finna deepseek-v4-pro",
+                        "api": "https://www.finna.com.cn/v1",
+                        "api_key": "app-lUeqweqweqweHiGvBil",
+                        "model": "deepseek-v4-pro",
+                        "default_model": "deepseek-v4-pro",
+                    }
+                }
+            }
+            
+            creds = _resolve_delegation_credentials(cfg, parent)
+            
+            self.assertEqual(creds["model"], "deepseek-v4-pro")
+
 
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -98,6 +98,60 @@ class TestMergeMode:
         assert len(items) == 2
 
 
+class TestModelProviderFields:
+    def test_write_with_model_and_provider(self):
+        store = TodoStore()
+        items = [
+            {"id": "1", "content": "Task with model", "status": "pending", "model": "gemini-flash", "provider": "openrouter"},
+        ]
+        result = store.write(items)
+        assert len(result) == 1
+        assert result[0]["model"] == "gemini-flash"
+        assert result[0]["provider"] == "openrouter"
+
+    def test_write_with_model_only(self):
+        store = TodoStore()
+        items = [
+            {"id": "1", "content": "Task with model only", "status": "pending", "model": "gpt-4o"},
+        ]
+        result = store.write(items)
+        assert len(result) == 1
+        assert result[0]["model"] == "gpt-4o"
+        assert "provider" not in result[0]
+
+    def test_write_with_provider_only(self):
+        store = TodoStore()
+        items = [
+            {"id": "1", "content": "Task with provider only", "status": "pending", "provider": "openai"},
+        ]
+        result = store.write(items)
+        assert len(result) == 1
+        assert result[0]["provider"] == "openai"
+        assert "model" not in result[0]
+
+    def test_merge_updates_model_provider(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Original", "status": "pending"}])
+        store.write(
+            [{"id": "1", "model": "claude-3-sonnet", "provider": "anthropic"}],
+            merge=True,
+        )
+        items = store.read()
+        assert len(items) == 1
+        assert items[0]["model"] == "claude-3-sonnet"
+        assert items[0]["provider"] == "anthropic"
+        assert items[0]["content"] == "Original"
+
+    def test_model_provider_strip_whitespace(self):
+        store = TodoStore()
+        items = [
+            {"id": "1", "content": "Task", "status": "pending", "model": "  gemini-flash  ", "provider": "  openai  "},
+        ]
+        result = store.write(items)
+        assert result[0]["model"] == "gemini-flash"
+        assert result[0]["provider"] == "openai"
+
+
 class TestTodoToolFunction:
     def test_read_mode(self):
         store = TodoStore()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1818,19 +1818,26 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, model, provider, base_url)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, model, provider, base_url}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    Per-task model/provider/base_url overrides the top-level ones, which in turn
+    override the config. api_key is always resolved from config or provider system
+    (never from task overrides for security reasons).
 
     Returns JSON with results array, one entry per task.
     """
@@ -1895,7 +1902,8 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role,
+             "model": model, "provider": provider, "base_url": base_url}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -1911,10 +1919,12 @@ def delegate_task(
     # Resolve delegation credentials for each task
     for i, t in enumerate(task_list):
         try:
-            # First resolve task-specific model/provider overrides
+            # First resolve task-specific model/provider/base_url overrides
+            # (api_key is never from task overrides for security reasons)
             task_model = t.get("model")
             task_provider = t.get("provider")
-            model_override = _resolve_task_model(task_model, task_provider, cfg, parent_agent)
+            task_base_url = t.get("base_url")
+            model_override = _resolve_task_model(task_model, task_provider, task_base_url, cfg, parent_agent)
             
             # Then resolve full credentials using the override
             task_creds = _resolve_delegation_credentials(cfg, parent_agent, model_override)
@@ -2234,6 +2244,7 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
 def _resolve_task_model(
     task_model: Optional[str],
     task_provider: Optional[str],
+    task_base_url: Optional[str],
     cfg: dict,
     parent_agent,
 ) -> dict:
@@ -2243,9 +2254,10 @@ def _resolve_task_model(
     1. Separate format: provider field + model field — use directly
     2. Pure model name: "model-slug" — use task_provider or global provider
 
-    Returns a dict with {model, provider} that overrides delegation config.
+    Returns a dict with {model, provider, base_url} that overrides delegation config.
+    (api_key is resolved from config or provider system, not from task overrides for security reasons.
     """
-    if not task_model and not task_provider:
+    if not task_model and not task_provider and not task_base_url:
         return {}
 
     result: Dict[str, Any] = {}
@@ -2255,6 +2267,9 @@ def _resolve_task_model(
 
     if task_model:
         result["model"] = str(task_model).strip()
+
+    if task_base_url:
+        result["base_url"] = str(task_base_url).strip()
 
     return result
 
@@ -2272,8 +2287,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
     If neither base_url nor provider is configured, returns None values so the
     child inherits everything from the parent agent.
 
-    task_override: optional dict with {model, provider} from per-task specification.
-    When provided, these override the configured delegation.model/provider.
+    task_override: optional dict with {model, provider, base_url} from per-task specification.
+    (api_key is NOT accepted from task overrides for security reasons;
+    it is always resolved from config or provider system.)
 
     Raises ValueError with a user-friendly message on credential failure.
     """
@@ -2285,10 +2301,88 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
+    # Apply task overrides - task_override has higher priority than config
     effective_model = task_override.get("model") or configured_model
     effective_provider = task_override.get("provider") or configured_provider
+    effective_base_url = task_override.get("base_url") or configured_base_url
 
-    if configured_base_url and not task_override.get("provider"):
+    # First, check if we have a model but no provider/base_url - try to find matching custom provider
+    found_provider_data = None
+    if effective_model and not effective_provider and not effective_base_url:
+        try:
+            from hermes_cli.config import load_config
+
+            full_config = load_config()
+            providers = full_config.get("providers", {})
+            custom_providers = full_config.get("custom_providers", [])
+
+            # Check custom_providers list first (old format) - PRIORITY
+            if isinstance(custom_providers, list):
+                for cp in custom_providers:
+                    if isinstance(cp, dict) and cp.get("model") == effective_model:
+                        base_url = cp.get("base_url")
+                        if base_url:
+                            found_provider_data = cp
+                            break
+
+            # Then check providers dict (new format) if not found
+            if not found_provider_data and isinstance(providers, dict):
+                for provider_name, provider_data in providers.items():
+                    if isinstance(provider_data, dict) and provider_data.get("model") == effective_model:
+                        # Found a matching custom provider by model!
+                        base_url = provider_data.get("api") or provider_data.get("url") or provider_data.get("base_url")
+                        if base_url:
+                            found_provider_data = provider_data
+                            found_provider_data["name"] = provider_name
+                            break
+        except Exception:
+            # If anything fails, continue with normal logic
+            pass
+
+    # If we found provider data, use it directly
+    if found_provider_data:
+        base_url = found_provider_data.get("api") or found_provider_data.get("url") or found_provider_data.get("base_url")
+        key_env = found_provider_data.get("key_env", "")
+        api_key = None
+        if key_env:
+            api_key = os.getenv(key_env, "").strip()
+        if not api_key:
+            api_key = str(found_provider_data.get("api_key", "") or "").strip()
+        if not api_key:
+            api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
+
+        if not api_key:
+            raise ValueError(
+                f"Custom provider for model '{effective_model}' configured but no API key was found. "
+                "Set the api_key or key_env in providers/custom_providers config."
+            )
+
+        effective_base_url = str(base_url).strip()
+        base_lower = effective_base_url.lower()
+
+        provider = "custom"
+        api_mode = "chat_completions"
+
+        # Try to get api_mode from provider data
+        from hermes_cli.runtime_provider import _parse_api_mode, _detect_api_mode_for_url
+        provider_api_mode = _parse_api_mode(found_provider_data.get("api_mode") or found_provider_data.get("transport"))
+        if provider_api_mode:
+            api_mode = provider_api_mode
+        else:
+            detected_api_mode = _detect_api_mode_for_url(effective_base_url)
+            if detected_api_mode:
+                api_mode = detected_api_mode
+
+        return {
+            "model": effective_model,
+            "provider": provider,
+            "base_url": effective_base_url,
+            "api_key": api_key,
+            "api_mode": api_mode,
+        }
+
+    # If task_override has base_url, use that directly
+    if effective_base_url and not effective_provider:
         api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
         if not api_key:
             raise ValueError(
@@ -2296,16 +2390,16 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
                 "Set delegation.api_key or OPENAI_API_KEY."
             )
 
-        base_lower = configured_base_url.lower()
+        base_lower = effective_base_url.lower()
         provider = "custom"
         api_mode = "chat_completions"
         if (
-            base_url_hostname(configured_base_url) == "chatgpt.com"
+            base_url_hostname(effective_base_url) == "chatgpt.com"
             and "/backend-api/codex" in base_lower
         ):
             provider = "openai-codex"
             api_mode = "codex_responses"
-        elif base_url_hostname(configured_base_url) == "api.anthropic.com":
+        elif base_url_hostname(effective_base_url) == "api.anthropic.com":
             provider = "anthropic"
             api_mode = "anthropic_messages"
         elif "api.kimi.com/coding" in base_lower:
@@ -2315,49 +2409,52 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
         return {
             "model": effective_model,
             "provider": provider,
-            "base_url": configured_base_url,
+            "base_url": effective_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
         }
 
-    if not effective_provider:
-        # No provider override — child inherits everything from parent
+    # If we have a provider, resolve full credentials
+    if effective_provider:
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(
+                requested=effective_provider,
+                target_model=effective_model
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"Cannot resolve delegation provider '{effective_provider}': {exc}. "
+                f"Check that the provider is configured (API key set, valid provider name), "
+                f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
+                f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
+            ) from exc
+
+        api_key = configured_api_key or runtime.get("api_key", "")
+        if not api_key:
+            raise ValueError(
+                f"Delegation provider '{effective_provider}' resolved but has no API key. "
+                f"Set the appropriate environment variable or run 'hermes auth'."
+            )
+
         return {
-            "model": effective_model,
-            "provider": None,
-            "base_url": None,
-            "api_key": None,
-            "api_mode": None,
+            "model": effective_model or runtime.get("model") or None,
+            "provider": runtime.get("provider"),
+            "base_url": effective_base_url or runtime.get("base_url"),
+            "api_key": api_key,
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
         }
 
-    # Provider is configured — resolve full credentials
-    try:
-        from hermes_cli.runtime_provider import resolve_runtime_provider
-
-        runtime = resolve_runtime_provider(requested=effective_provider)
-    except Exception as exc:
-        raise ValueError(
-            f"Cannot resolve delegation provider '{effective_provider}': {exc}. "
-            f"Check that the provider is configured (API key set, valid provider name), "
-            f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
-            f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
-        ) from exc
-
-    api_key = runtime.get("api_key", "")
-    if not api_key:
-        raise ValueError(
-            f"Delegation provider '{effective_provider}' resolved but has no API key. "
-            f"Set the appropriate environment variable or run 'hermes auth'."
-        )
-
+    # No provider or base_url override — child inherits everything from parent
     return {
-        "model": effective_model or runtime.get("model") or None,
-        "provider": runtime.get("provider"),
-        "base_url": runtime.get("base_url"),
-        "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
-        "command": runtime.get("command"),
-        "args": list(runtime.get("args") or []),
+        "model": effective_model,
+        "provider": None,
+        "base_url": effective_base_url,
+        "api_key": configured_api_key,
+        "api_mode": None,
     }
 
 
@@ -2505,6 +2602,10 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "description": "Override the global provider for this subagent (e.g. 'openrouter', 'openai'). Use together with model.",
                         },
+                        "base_url": {
+                            "type": "string",
+                            "description": "Direct OpenAI-compatible API endpoint URL for this subagent (e.g. https://api.openai.com/v1). Overrides delegation.base_url for this task only. (API key is resolved from config or provider system, not from task overrides.)",
+                        },
                         "role": {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
@@ -2534,6 +2635,18 @@ DELEGATE_TASK_SCHEMA = {
                     "max_spawn_depth or when "
                     "delegation.orchestrator_enabled=false."
                 ),
+            },
+            "model": {
+                "type": "string",
+                "description": "Model for the subagent (e.g. 'gpt-4o', 'claude-3-sonnet'). Overrides delegation.model. Per-task model in the tasks array takes precedence.",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Override the global provider for the subagent (e.g. 'openrouter', 'openai'). Use together with model.",
+            },
+            "base_url": {
+                "type": "string",
+                "description": "Direct OpenAI-compatible API endpoint URL for the subagent (e.g. https://api.openai.com/v1). Overrides delegation.base_url. (API key is resolved from config or provider system, not from task overrides for security reasons.)",
             },
             "acp_command": {
                 "type": "string",
@@ -2574,6 +2687,9 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
+        provider=args.get("provider"),
+        base_url=args.get("base_url"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2387,8 +2387,11 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
             if detected_api_mode:
                 api_mode = detected_api_mode
 
+        # Use the model from provider config if available, otherwise use effective_model
+        final_model = found_provider_data.get("model") or found_provider_data.get("default_model") or effective_model
+        
         return {
-            "model": effective_model,
+            "model": final_model,
             "provider": provider,
             "base_url": effective_base_url,
             "api_key": api_key,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2351,8 +2351,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
         
         # Follow the same priority as runtime_provider.py!
         api_key_candidates = [
-            os.getenv(str(found_provider_data.get("key_env", "") or "").strip(), "").strip(),
             str(found_provider_data.get("api_key", "") or "").strip(),
+            os.getenv(str(found_provider_data.get("key_env", "") or "").strip(), "").strip(),
             configured_api_key or "",
             os.getenv("OPENAI_API_KEY", "").strip(),
             os.getenv("OPENROUTER_API_KEY", "").strip(),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1881,16 +1881,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     if tasks and isinstance(tasks, list):
@@ -1918,6 +1908,20 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Resolve delegation credentials for each task
+    for i, t in enumerate(task_list):
+        try:
+            # First resolve task-specific model/provider overrides
+            task_model = t.get("model")
+            task_provider = t.get("provider")
+            model_override = _resolve_task_model(task_model, task_provider, cfg, parent_agent)
+            
+            # Then resolve full credentials using the override
+            task_creds = _resolve_delegation_credentials(cfg, parent_agent, model_override)
+            t["_creds"] = task_creds
+        except ValueError as exc:
+            return tool_error(str(exc))
+
     overall_start = time.monotonic()
     results = []
 
@@ -1942,26 +1946,27 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_creds = t.get("_creds", {})
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds.get("model"),
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds.get("provider"),
+                override_base_url=task_creds.get("base_url"),
+                override_api_key=task_creds.get("api_key"),
+                override_api_mode=task_creds.get("api_mode"),
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2226,7 +2231,35 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _resolve_task_model(
+    task_model: Optional[str],
+    task_provider: Optional[str],
+    cfg: dict,
+    parent_agent,
+) -> dict:
+    """Resolve model credentials for a single task.
+
+    Handles two formats:
+    1. Separate format: provider field + model field — use directly
+    2. Pure model name: "model-slug" — use task_provider or global provider
+
+    Returns a dict with {model, provider} that overrides delegation config.
+    """
+    if not task_model and not task_provider:
+        return {}
+
+    result: Dict[str, Any] = {}
+
+    if task_provider:
+        result["provider"] = str(task_provider).strip()
+
+    if task_model:
+        result["model"] = str(task_model).strip()
+
+    return result
+
+
+def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Optional[dict] = None) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
@@ -2239,14 +2272,23 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     If neither base_url nor provider is configured, returns None values so the
     child inherits everything from the parent agent.
 
+    task_override: optional dict with {model, provider} from per-task specification.
+    When provided, these override the configured delegation.model/provider.
+
     Raises ValueError with a user-friendly message on credential failure.
     """
+    if task_override is None:
+        task_override = {}
+
     configured_model = str(cfg.get("model") or "").strip() or None
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
-    if configured_base_url:
+    effective_model = task_override.get("model") or configured_model
+    effective_provider = task_override.get("provider") or configured_provider
+
+    if configured_base_url and not task_override.get("provider"):
         api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
         if not api_key:
             raise ValueError(
@@ -2271,17 +2313,17 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             api_mode = "anthropic_messages"
 
         return {
-            "model": configured_model,
+            "model": effective_model,
             "provider": provider,
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
         }
 
-    if not configured_provider:
+    if not effective_provider:
         # No provider override — child inherits everything from parent
         return {
-            "model": configured_model,
+            "model": effective_model,
             "provider": None,
             "base_url": None,
             "api_key": None,
@@ -2292,10 +2334,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider)
+        runtime = resolve_runtime_provider(requested=effective_provider)
     except Exception as exc:
         raise ValueError(
-            f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
+            f"Cannot resolve delegation provider '{effective_provider}': {exc}. "
             f"Check that the provider is configured (API key set, valid provider name), "
             f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
             f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
@@ -2304,12 +2346,12 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     api_key = runtime.get("api_key", "")
     if not api_key:
         raise ValueError(
-            f"Delegation provider '{configured_provider}' resolved but has no API key. "
+            f"Delegation provider '{effective_provider}' resolved but has no API key. "
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
     return {
-        "model": configured_model or runtime.get("model") or None,
+        "model": effective_model or runtime.get("model") or None,
         "provider": runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
@@ -2454,6 +2496,14 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Per-task ACP args override.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Model for this subagent (e.g. 'gpt-4o', 'claude-3-sonnet'). Overrides delegation.model for this task only.",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Override the global provider for this subagent (e.g. 'openrouter', 'openai'). Use together with model.",
                         },
                         "role": {
                             "type": "string",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2351,8 +2351,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
         
         # Follow the same priority as runtime_provider.py!
         api_key_candidates = [
-            str(found_provider_data.get("api_key", "") or "").strip(),
             os.getenv(str(found_provider_data.get("key_env", "") or "").strip(), "").strip(),
+            str(found_provider_data.get("api_key", "") or "").strip(),
             configured_api_key or "",
             os.getenv("OPENAI_API_KEY", "").strip(),
             os.getenv("OPENROUTER_API_KEY", "").strip(),
@@ -2362,7 +2362,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
         if has_usable_secret:
             api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
         else:
-            # Fallback to just checking for non-empty
+            # Fall back to just checking for non-empty
             api_key = next((candidate for candidate in api_key_candidates if candidate), "")
 
         if not api_key:
@@ -2445,7 +2445,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
                 f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
             ) from exc
 
-        api_key = configured_api_key or runtime.get("api_key", "")
+        api_key = runtime.get("api_key", "") or configured_api_key
         if not api_key:
             raise ValueError(
                 f"Delegation provider '{effective_provider}' resolved but has no API key. "

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -35,6 +35,12 @@ from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
 
+# For custom provider API key resolution
+try:
+    from hermes_cli.runtime_provider import has_usable_secret
+except ImportError:
+    has_usable_secret = None
+
 
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset(
@@ -2342,14 +2348,22 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, task_override: Opti
     # If we found provider data, use it directly
     if found_provider_data:
         base_url = found_provider_data.get("api") or found_provider_data.get("url") or found_provider_data.get("base_url")
-        key_env = found_provider_data.get("key_env", "")
-        api_key = None
-        if key_env:
-            api_key = os.getenv(key_env, "").strip()
-        if not api_key:
-            api_key = str(found_provider_data.get("api_key", "") or "").strip()
-        if not api_key:
-            api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
+        
+        # Follow the same priority as runtime_provider.py!
+        api_key_candidates = [
+            str(found_provider_data.get("api_key", "") or "").strip(),
+            os.getenv(str(found_provider_data.get("key_env", "") or "").strip(), "").strip(),
+            configured_api_key or "",
+            os.getenv("OPENAI_API_KEY", "").strip(),
+            os.getenv("OPENROUTER_API_KEY", "").strip(),
+        ]
+        
+        # Get the first usable secret
+        if has_usable_secret:
+            api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
+        else:
+            # Fallback to just checking for non-empty
+            api_key = next((candidate for candidate in api_key_candidates if candidate), "")
 
         if not api_key:
             raise ValueError(

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -42,7 +42,7 @@ class TodoStore:
         Write todos. Returns the full current list after writing.
 
         Args:
-            todos: list of {id, content, status, model?, provider?} dicts
+            todos: list of {id, content, status, model, provider, base_url} dicts
             merge: if False, replace the entire list. If True, update
                    existing items by id and append new ones.
         """
@@ -69,8 +69,10 @@ class TodoStore:
                         existing[item_id]["model"] = str(t["model"]).strip() if t["model"] else None
                     if "provider" in t:
                         existing[item_id]["provider"] = str(t["provider"]).strip() if t["provider"] else None
+                    if "base_url" in t:
+                        existing[item_id]["base_url"] = str(t["base_url"]).strip() if t["base_url"] else None
                 else:
-                    # New item -- validate fully and append to end
+                    # New item — validate fully and append to end
                     validated = self._validate(t)
                     existing[validated["id"]] = validated
                     self._items.append(validated)
@@ -133,7 +135,8 @@ class TodoStore:
         Validate and normalize a todo item.
 
         Ensures required fields exist and status is valid.
-        Returns a clean dict with {id, content, status} plus optional {model, provider}.
+        Returns a clean dict with {id, content, status} plus optional {model, provider, base_url}.
+        (api_key is NOT accepted from todo items for security reasons.)
         """
         item_id = str(item.get("id", "")).strip()
         if not item_id:
@@ -158,6 +161,11 @@ class TodoStore:
             provider = str(item["provider"]).strip()
             if provider:
                 result["provider"] = provider
+
+        if item.get("base_url"):
+            base_url = str(item["base_url"]).strip()
+            if base_url:
+                result["base_url"] = base_url
 
         return result
 
@@ -236,7 +244,10 @@ TODO_SCHEMA = {
         "- merge=true: update existing items by id, add any new ones\n\n"
         "Each item: {id: string, content: string, "
         "status: pending|in_progress|completed|cancelled}\n"
-        "Optional overrides (use together): model (e.g. 'gpt-4o'), provider (e.g. 'openrouter').\n"
+        "Optional overrides: model (e.g. 'gpt-4o'), provider (e.g. 'openrouter'), "
+        "base_url (direct API endpoint).\n"
+        "(api_key is never accepted from todo items for security reasons; "
+        "it is always resolved from config or provider system.)\n"
         "List order is priority. Only ONE item in_progress at a time.\n"
         "Mark items completed immediately when done. If something fails, "
         "cancel it and add a revised item.\n\n"
@@ -271,6 +282,10 @@ TODO_SCHEMA = {
                         "provider": {
                             "type": "string",
                             "description": "Override the global provider for this subagent (e.g. 'openrouter', 'openai'). Use together with model."
+                        },
+                        "base_url": {
+                            "type": "string",
+                            "description": "Direct OpenAI-compatible API endpoint URL for this subagent (e.g. https://api.openai.com/v1). (API key is resolved from config or provider system, not from todo items for security reasons.)"
                         }
                     },
                     "required": ["id", "content", "status"]

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -30,17 +30,19 @@ class TodoStore:
       - id: unique string identifier (agent-chosen)
       - content: task description
       - status: pending | in_progress | completed | cancelled
+      - model: optional model for subagent (e.g. 'gpt-4o', 'claude-3-sonnet')
+      - provider: optional provider for subagent (e.g. 'openrouter', 'openai')
     """
 
     def __init__(self):
-        self._items: List[Dict[str, str]] = []
+        self._items: List[Dict[str, Any]] = []
 
     def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
         """
         Write todos. Returns the full current list after writing.
 
         Args:
-            todos: list of {id, content, status} dicts
+            todos: list of {id, content, status, model?, provider?} dicts
             merge: if False, replace the entire list. If True, update
                    existing items by id and append new ones.
         """
@@ -63,6 +65,10 @@ class TodoStore:
                         status = str(t["status"]).strip().lower()
                         if status in VALID_STATUSES:
                             existing[item_id]["status"] = status
+                    if "model" in t:
+                        existing[item_id]["model"] = str(t["model"]).strip() if t["model"] else None
+                    if "provider" in t:
+                        existing[item_id]["provider"] = str(t["provider"]).strip() if t["provider"] else None
                 else:
                     # New item -- validate fully and append to end
                     validated = self._validate(t)
@@ -127,7 +133,7 @@ class TodoStore:
         Validate and normalize a todo item.
 
         Ensures required fields exist and status is valid.
-        Returns a clean dict with only {id, content, status}.
+        Returns a clean dict with {id, content, status} plus optional {model, provider}.
         """
         item_id = str(item.get("id", "")).strip()
         if not item_id:
@@ -141,7 +147,19 @@ class TodoStore:
         if status not in VALID_STATUSES:
             status = "pending"
 
-        return {"id": item_id, "content": content, "status": status}
+        result = {"id": item_id, "content": content, "status": status}
+
+        if item.get("model"):
+            model = str(item["model"]).strip()
+            if model:
+                result["model"] = model
+
+        if item.get("provider"):
+            provider = str(item["provider"]).strip()
+            if provider:
+                result["provider"] = provider
+
+        return result
 
     @staticmethod
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -218,6 +236,7 @@ TODO_SCHEMA = {
         "- merge=true: update existing items by id, add any new ones\n\n"
         "Each item: {id: string, content: string, "
         "status: pending|in_progress|completed|cancelled}\n"
+        "Optional overrides (use together): model (e.g. 'gpt-4o'), provider (e.g. 'openrouter').\n"
         "List order is priority. Only ONE item in_progress at a time.\n"
         "Mark items completed immediately when done. If something fails, "
         "cancel it and add a revised item.\n\n"
@@ -244,6 +263,14 @@ TODO_SCHEMA = {
                             "type": "string",
                             "enum": ["pending", "in_progress", "completed", "cancelled"],
                             "description": "Current status"
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Model for subagent (e.g. 'gpt-4o', 'claude-3-sonnet')"
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Override the global provider for this subagent (e.g. 'openrouter', 'openai'). Use together with model."
                         }
                     },
                     "required": ["id", "content", "status"]


### PR DESCRIPTION
## Summary

- Add optional `model` and `provider` fields to todo items
- Allow per-task model override when delegating to subagents
- Resolve credentials per-task instead of globally
- Add tests for new model/provider fields

## Changes

### `tools/todo_tool.py`
- Extended `TodoStore` to support optional `model` and `provider` fields
- Updated schema to include new fields with descriptions
- Validation handles the new optional fields

### `tools/delegate_tool.py`
- Added `_resolve_task_model()` function to resolve per-task model credentials
- Modified `_resolve_delegation_credentials()` to accept task-level overrides
- Each task now resolves its own credentials independently
- Updated `DELEGATE_TASK_SCHEMA` with model/provider properties

### `tests/tools/test_todo_tool.py`
- Added tests for model and provider field handling
- Tests cover write, merge, and validation scenarios

## Use Case

When delegating tasks to subagents, you can now specify a different model/provider per task:

```json
{
  "id": "1",
  "content": "Use GPT-4 for this task",
  "status": "pending",
  "model": "gpt-4o",
  "provider": "openai"
}
```

This enables mixed-model workflows where different tasks use different models based on their requirements.