### PR TITLE
fix(hindsight): guard against missing hindsight-client in cloud/external modes

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -93,6 +93,20 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _check_cloud_client() -> tuple[bool, str | None]:
+    """Return whether the hindsight-client package is importable.
+
+    Used by cloud and local_external modes to verify the client library is
+    installed before attempting to use it.  Without this check the gateway
+    crashes with an unhandled ImportError when the package is missing.
+    """
+    try:
+        importlib.import_module("hindsight_client")
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
 # ---------------------------------------------------------------------------
 # Dedicated event loop for Hindsight async calls (one per process, reused).
 # Avoids creating ephemeral loops that leak aiohttp sessions.
@@ -502,7 +516,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 available, _ = _check_local_runtime()
                 return available
             if mode == "local_external":
-                return True
+                available, _ = _check_cloud_client()
+                return available
+            # Cloud mode: need both hindsight-client package AND an API key
+            pkg_ok, _ = _check_cloud_client()
+            if not pkg_ok:
+                return False
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")
@@ -805,7 +824,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
             else:
-                from hindsight_client import Hindsight
+                try:
+                    from hindsight_client import Hindsight
+                except ImportError:
+                    raise RuntimeError(
+                        "hindsight-client is not installed. "
+                        "Install with: uv pip install 'hindsight-client>=0.4.22'"
+                    ) from None
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
@@ -989,6 +1014,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.warning(
                     "Hindsight local mode disabled because its runtime could not be imported: %s",
                     reason,
+                )
+                self._mode = "disabled"
+                return
+        elif self._mode in ("cloud", "local_external"):
+            available, reason = _check_cloud_client()
+            if not available:
+                logger.warning(
+                    "Hindsight %s mode disabled because hindsight-client could not be imported: %s",
+                    self._mode, reason,
                 )
                 self._mode = "disabled"
                 return

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -44,6 +44,15 @@ def _clean_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _mock_cloud_client(monkeypatch):
+    """#18875: Mock _check_cloud_client so cloud-mode tests pass without hindsight-client installed."""
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._check_cloud_client",
+        lambda: (True, None),
+    )
+
+
 def _make_mock_client():
     """Create a mock Hindsight client with async methods."""
     async def _aretain(
@@ -91,7 +100,7 @@ def provider(tmp_path, monkeypatch):
     """Create an initialized HindsightMemoryProvider with a mock client."""
     config = {
         "mode": "cloud",
-        "apiKey": "test-key",
+        "apiKey": "***",
         "api_url": "http://localhost:9999",
         "bank_id": "test-bank",
         "budget": "mid",
@@ -103,6 +112,11 @@ def provider(tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+    )
+    # Mock cloud client check so initialize() doesn't disable cloud mode
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._check_cloud_client",
+        lambda: (True, None),
     )
 
     p = HindsightMemoryProvider()
@@ -117,7 +131,7 @@ def provider_with_config(tmp_path, monkeypatch):
     def _make(**overrides):
         config = {
             "mode": "cloud",
-            "apiKey": "test-key",
+            "apiKey": "***",
             "api_url": "http://localhost:9999",
             "bank_id": "test-bank",
             "budget": "mid",
@@ -130,6 +144,11 @@ def provider_with_config(tmp_path, monkeypatch):
 
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        # Mock cloud client check so initialize() doesn't disable cloud mode
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (True, None),
         )
 
         p = HindsightMemoryProvider()
@@ -1277,6 +1296,10 @@ class TestAvailability:
             lambda: tmp_path / "nonexistent",
         )
         monkeypatch.setenv("HINDSIGHT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (True, None),
+        )
         p = HindsightMemoryProvider()
         assert p.is_available()
 
@@ -1311,6 +1334,10 @@ class TestAvailability:
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (True, None),
         )
 
         p = HindsightMemoryProvider()
@@ -1351,6 +1378,70 @@ class TestAvailability:
         monkeypatch.setattr(
             "plugins.memory.hindsight.importlib.import_module",
             _raise,
+        )
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        assert p._mode == "disabled"
+
+    def test_cloud_mode_unavailable_when_client_not_installed(self, tmp_path, monkeypatch):
+        """#18875: cloud mode must check hindsight_client is importable."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+        p = HindsightMemoryProvider()
+        assert not p.is_available()
+
+    def test_local_external_mode_unavailable_when_client_not_installed(self, tmp_path, monkeypatch):
+        """#18875: local_external mode also needs hindsight_client."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_MODE", "local_external")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+        p = HindsightMemoryProvider()
+        assert not p.is_available()
+
+    def test_initialize_disables_cloud_mode_when_client_not_installed(self, tmp_path, monkeypatch):
+        """#18875: initialize() must disable cloud mode when hindsight_client is missing."""
+        config = {"mode": "cloud", "apiKey": "test-key"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        assert p._mode == "disabled"
+
+    def test_initialize_disables_local_external_when_client_not_installed(self, tmp_path, monkeypatch):
+        """#18875: initialize() must disable local_external mode when hindsight_client is missing."""
+        config = {"mode": "local_external"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
         )
 
         p = HindsightMemoryProvider()


### PR DESCRIPTION
## What does this PR do?

When `hindsight-client` is not installed but the user has configured cloud or local_external mode (e.g. has an API key set from a previous install), the gateway crashes with an unhandled `ImportError` on the first memory operation.

**Root cause:** `_get_client()` (line 808) does a bare `from hindsight_client import Hindsight` without any guard. Meanwhile:
- `is_available()` for cloud mode only checks API key/URL, not package availability
- `initialize()` has a guard for `local_embedded` mode (`_check_local_runtime()`) but none for cloud/external modes

## Related Issue

Fixes #18875

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A