### PR TITLE
fix: avoid re-injecting todo subjects after compression

### DIFF
--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -285,22 +285,24 @@ class TestSearchLoopDetection(unittest.TestCase):
 
 
 class TestTodoInjectionFiltering(unittest.TestCase):
-    """Verify that format_for_injection filters completed/cancelled todos."""
+    """Verify that format_for_injection avoids re-injecting todo subjects."""
 
-    def test_filters_completed_and_cancelled(self):
+    def test_filters_completed_cancelled_and_active_subjects(self):
         from tools.todo_tool import TodoStore
         store = TodoStore()
         store.write([
             {"id": "1", "content": "Read codebase", "status": "completed"},
-            {"id": "2", "content": "Write fix", "status": "in_progress"},
-            {"id": "3", "content": "Run tests", "status": "pending"},
+            {"id": "2", "content": "Write fix for client ACME", "status": "in_progress"},
+            {"id": "3", "content": "Run secret-token rotation tests", "status": "pending"},
             {"id": "4", "content": "Abandoned", "status": "cancelled"},
         ])
         injection = store.format_for_injection()
         self.assertNotIn("Read codebase", injection)
         self.assertNotIn("Abandoned", injection)
-        self.assertIn("Write fix", injection)
-        self.assertIn("Run tests", injection)
+        self.assertNotIn("Write fix for client ACME", injection)
+        self.assertNotIn("Run secret-token rotation tests", injection)
+        self.assertIn("1 in_progress", injection)
+        self.assertIn("1 pending", injection)
 
     def test_all_completed_returns_none(self):
         from tools.todo_tool import TodoStore
@@ -316,7 +318,7 @@ class TestTodoInjectionFiltering(unittest.TestCase):
         store = TodoStore()
         self.assertIsNone(store.format_for_injection())
 
-    def test_all_active_included(self):
+    def test_all_active_injects_counts_only(self):
         from tools.todo_tool import TodoStore
         store = TodoStore()
         store.write([
@@ -324,8 +326,10 @@ class TestTodoInjectionFiltering(unittest.TestCase):
             {"id": "2", "content": "Task B", "status": "in_progress"},
         ])
         injection = store.format_for_injection()
-        self.assertIn("Task A", injection)
-        self.assertIn("Task B", injection)
+        self.assertNotIn("Task A", injection)
+        self.assertNotIn("Task B", injection)
+        self.assertIn("1 pending", injection)
+        self.assertIn("1 in_progress", injection)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -53,22 +53,21 @@ class TestFormatForInjection:
         store = TodoStore()
         assert store.format_for_injection() is None
 
-    def test_non_empty_has_markers(self):
+    def test_non_empty_injects_counts_without_subjects(self):
         store = TodoStore()
         store.write([
             {"id": "1", "content": "Do thing", "status": "completed"},
-            {"id": "2", "content": "Next", "status": "pending"},
-            {"id": "3", "content": "Working", "status": "in_progress"},
+            {"id": "2", "content": "Client ACME launch", "status": "pending"},
+            {"id": "3", "content": "Rotate secret token", "status": "in_progress"},
         ])
         text = store.format_for_injection()
-        # Completed items are filtered out of injection
-        assert "[x]" not in text
+        # Completed items are filtered out of injection.
         assert "Do thing" not in text
-        # Active items are included
-        assert "[ ]" in text
-        assert "[>]" in text
-        assert "Next" in text
-        assert "Working" in text
+        # Active subjects are not re-injected after compression.
+        assert "Client ACME launch" not in text
+        assert "Rotate secret token" not in text
+        assert "1 pending" in text
+        assert "1 in_progress" in text
         assert "context compression" in text.lower()
 
 

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -4,8 +4,8 @@ Todo Tool Module - Planning & Task Management
 
 Provides an in-memory task list the agent uses to decompose complex tasks,
 track progress, and maintain focus across long conversations. The state
-lives on the AIAgent instance (one per session) and is re-injected into
-the conversation after context compression events.
+lives on the AIAgent instance (one per session) and a privacy-preserving
+active-task summary is re-injected after context compression events.
 
 Design:
 - Single `todo` tool: provide `todos` param to write, omit to read
@@ -89,24 +89,16 @@ class TodoStore:
 
     def format_for_injection(self) -> Optional[str]:
         """
-        Render the todo list for post-compression injection.
+        Render a privacy-preserving task summary for post-compression injection.
 
-        Returns a human-readable string to append to the compressed
-        message history, or None if the list is empty.
+        Full todo subjects are already available to the model in the original
+        todo tool result. Re-injecting them after compression can resurface
+        sensitive project names, client context, credentials, or PII into fresh
+        model context. Preserve continuity by injecting counts only.
         """
         if not self._items:
             return None
 
-        # Status markers for compact display
-        markers = {
-            "completed": "[x]",
-            "in_progress": "[>]",
-            "pending": "[ ]",
-            "cancelled": "[~]",
-        }
-
-        # Only inject pending/in_progress items — completed/cancelled ones
-        # cause the model to re-do finished work after compression.
         active_items = [
             item for item in self._items
             if item["status"] in ("pending", "in_progress")
@@ -114,12 +106,20 @@ class TodoStore:
         if not active_items:
             return None
 
-        lines = ["[Your active task list was preserved across context compression]"]
-        for item in active_items:
-            marker = markers.get(item["status"], "[?]")
-            lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")
+        pending = sum(1 for item in active_items if item["status"] == "pending")
+        in_progress = sum(1 for item in active_items if item["status"] == "in_progress")
 
-        return "\n".join(lines)
+        parts = []
+        if in_progress:
+            parts.append(f"{in_progress} in_progress")
+        if pending:
+            parts.append(f"{pending} pending")
+        summary = ", ".join(parts)
+
+        return (
+            "[Your active task list was preserved across context compression: "
+            f"{summary}. Call the todo tool with no parameters to inspect details if needed.]"
+        )
 
     @staticmethod
     def _validate(item: Dict[str, Any]) -> Dict[str, str]:
@@ -212,6 +212,12 @@ TODO_SCHEMA = {
         "Manage your task list for the current session. Use for complex tasks "
         "with 3+ steps or when the user provides multiple tasks. "
         "Call with no parameters to read the current list.\n\n"
+        "Privacy:\n"
+        "- Do not put secrets, credentials, raw PII, or highly sensitive "
+        "client/project identifiers in todo content.\n"
+        "- Todo content can be visible in the UI and stored in tool results.\n"
+        "- After context compression, only active todo counts are re-injected; "
+        "call the todo tool to inspect details if needed.\n\n"
         "Writing:\n"
         "- Provide 'todos' array to create/update items\n"
         "- merge=false (default): replace the entire list with a fresh plan\n"


### PR DESCRIPTION
## Summary

Fixes a todo privacy boundary in Hermes' post-compression state recovery.

Before this change, `TodoStore.format_for_injection()` appended full pending and in-progress todo subjects back into the compressed conversation as a user message. Todo subjects are useful for local planning, but they can contain sensitive task details. Re-injecting them into fresh model context after compression can re-surface details that should stay local to the original tool result.

This PR keeps todo continuity without re-surfacing full subjects after compression:

- post-compression injection now includes active todo counts only
- the model can call `todo` with no parameters when it needs full details
- the todo tool schema now warns that todo content can be visible in UI and tool results
- tests now assert that active todo subjects are not re-injected

## Test plan

```bash
python -m pytest tests/tools/test_todo_tool.py tests/tools/test_read_loop_detection.py -q -o 'addopts='
```

Result:

```text
37 passed
```

## Risk / compatibility

This changes only the post-compression injection text. Normal todo reads/writes still return the full current list, and the live UI can still render todos from tool events.

The tradeoff is intentional: after compression, the model gets continuity counts and must explicitly call `todo` to inspect full task details rather than receiving all active subjects automatically.
