### PR TITLE
feat(pricing): detect upstream model pricing through LiteLLM proxies

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import json
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
+from urllib.request import Request, urlopen
 
-from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
+from agent.model_metadata import (
+    _extract_pricing,
+    fetch_endpoint_model_metadata,
+    fetch_model_metadata,
+)
 from utils import base_url_host_matches
 
 DEFAULT_PRICING = {"input": 0.0, "output": 0.0}
@@ -77,6 +84,9 @@ class CostResult:
 
 
 _UTC_NOW = lambda: datetime.now(timezone.utc)
+_PROXY_MODEL_INFO_CACHE_TTL = 300
+_PROXY_MODEL_INFO_TIMEOUT = 2.0
+_proxy_model_info_cache: Dict[str, tuple[float, Optional[Dict[str, Any]]]] = {}
 
 
 # Official docs snapshot entries. Models whose published pricing and cache
@@ -429,7 +439,7 @@ def resolve_billing_route(
         return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
-    if provider_name in {"custom", "local"} or (base and "localhost" in base):
+    if provider_name in {"custom", "local", "litellm"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")
 
@@ -491,6 +501,38 @@ def _pricing_entry_from_metadata(
     )
 
 
+def _proxy_info_base_url(base_url: str) -> str:
+    raw_base = (base_url or "").rstrip("/")
+    if raw_base.endswith("/v1"):
+        raw_base = raw_base[:-3]
+    return raw_base
+
+
+def _fetch_proxy_model_info(base_url: str, api_key: str = "") -> Optional[Dict[str, Any]]:
+    """Fetch and cache LiteLLM-compatible /model/info responses."""
+    raw_base = _proxy_info_base_url(base_url)
+    if not raw_base:
+        return None
+
+    cached = _proxy_model_info_cache.get(raw_base)
+    if cached is not None:
+        cached_at, payload = cached
+        if (time.time() - cached_at) < _PROXY_MODEL_INFO_CACHE_TTL:
+            return payload
+
+    info_url = f"{raw_base}/model/info"
+    try:
+        req = Request(info_url)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        with urlopen(req, timeout=_PROXY_MODEL_INFO_TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        payload = None
+
+    _proxy_model_info_cache[raw_base] = (time.time(), payload)
+    return payload
+
 
 def _try_proxy_upstream_pricing(
     route: "BillingRoute",
@@ -510,32 +552,32 @@ def _try_proxy_upstream_pricing(
     upstream -- which already handles OpenRouter models API, Anthropic
     official-docs snapshots, subscription-included routes, etc.
     """
-    import json as _json
-    from urllib.request import Request, urlopen
-
     base_url = (route.base_url or "").rstrip("/")
     if not base_url:
         return None
 
-    # LiteLLM's /model/info lives at the proxy root, not under /v1.
-    raw_base = base_url
-    if raw_base.endswith("/v1"):
-        raw_base = raw_base[:-3]
-    info_url = f"{raw_base}/model/info"
-
-    try:
-        req = Request(info_url)
-        if api_key:
-            req.add_header("Authorization", f"Bearer {api_key}")
-        with urlopen(req, timeout=10) as resp:
-            info_data = _json.loads(resp.read().decode())
-    except Exception:
+    info_data = _fetch_proxy_model_info(base_url, api_key=api_key)
+    if not isinstance(info_data, dict):
         return None
 
     model_name = route.model
     for entry in info_data.get("data", ()):
+        if not isinstance(entry, dict):
+            continue
         if entry.get("model_name") != model_name:
             continue
+
+        pricing = _extract_pricing(entry)
+        if pricing:
+            direct_entry = _pricing_entry_from_metadata(
+                {model_name: {"pricing": pricing}},
+                model_name,
+                source_url=f"{_proxy_info_base_url(base_url)}/model/info",
+                pricing_version="litellm-model-info",
+            )
+            if direct_entry:
+                return direct_entry
+
         upstream = entry.get("litellm_params", {}).get("model", "")
         if not upstream:
             return None

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -407,18 +407,26 @@ def resolve_billing_route(
     model = (model_name or "").strip()
     if not provider_name and "/" in model:
         inferred_provider, bare_model = model.split("/", 1)
-        if inferred_provider in {"anthropic", "openai", "google"}:
+        if inferred_provider in {"anthropic", "openai", "google", "openrouter", "chatgpt", "deepseek", "minimax", "minimax-cn", "bedrock", "openai-codex"}:
             provider_name = inferred_provider
             model = bare_model
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=base_url or "", billing_mode="subscription_included")
+    if provider_name == "chatgpt":
+        return BillingRoute(provider="chatgpt", model=model.split("/")[-1] if "/" in model else model, base_url=base_url or "", billing_mode="subscription_included")
     if provider_name == "openrouter" or base_url_host_matches(base_url or "", "openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=base_url or "", billing_mode="official_models_api")
     if provider_name == "anthropic":
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "deepseek":
+        return BillingRoute(provider="deepseek", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "bedrock":
+        return BillingRoute(provider="bedrock", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "google":
+        return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
@@ -483,6 +491,63 @@ def _pricing_entry_from_metadata(
     )
 
 
+
+def _try_proxy_upstream_pricing(
+    route: "BillingRoute",
+    api_key: str = "",
+) -> "Optional[PricingEntry]":
+    """Probe a proxy (LiteLLM or compatible) for upstream model pricing.
+
+    Some local proxies expose full model metadata on a non-OpenAI endpoint.
+    LiteLLM's /model/info includes the real upstream model ID (e.g.
+    "openrouter/x-ai/grok-4.3") and per-token pricing.  The standard
+    OpenAI-compatible /v1/models endpoint returns only {id, object, created,
+    owned_by} -- no pricing fields -- so the standard endpoint probe in
+    get_pricing_entry() comes up empty.
+
+    This function probes /model/info as a secondary source.  When the
+    upstream model is found, it delegates to get_pricing_entry() for the
+    upstream -- which already handles OpenRouter models API, Anthropic
+    official-docs snapshots, subscription-included routes, etc.
+    """
+    import json as _json
+    from urllib.request import Request, urlopen
+
+    base_url = (route.base_url or "").rstrip("/")
+    if not base_url:
+        return None
+
+    # LiteLLM's /model/info lives at the proxy root, not under /v1.
+    raw_base = base_url
+    if raw_base.endswith("/v1"):
+        raw_base = raw_base[:-3]
+    info_url = f"{raw_base}/model/info"
+
+    try:
+        req = Request(info_url)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        with urlopen(req, timeout=10) as resp:
+            info_data = _json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+    model_name = route.model
+    for entry in info_data.get("data", ()):
+        if entry.get("model_name") != model_name:
+            continue
+        upstream = entry.get("litellm_params", {}).get("model", "")
+        if not upstream:
+            return None
+
+        # upstream is e.g. "openrouter/x-ai/grok-4.3" or "anthropic/claude-sonnet-4"
+        # Recurse into standard pricing -- the resolved route will handle
+        # OpenRouter, subscription-included, official-docs snapshots, etc.
+        return get_pricing_entry(model_name=upstream)
+
+    return None
+
+
 def get_pricing_entry(
     model_name: str,
     provider: Optional[str] = None,
@@ -510,6 +575,15 @@ def get_pricing_entry(
         )
         if entry:
             return entry
+
+    # Secondary probe: some proxies expose real upstream model IDs and
+    # pricing on a non-OpenAI endpoint.  LiteLLM's /model/info is the
+    # canonical example.  The helper extracts the upstream and delegates
+    # to the existing pricing machinery.
+    proxy_entry = _try_proxy_upstream_pricing(route, api_key=api_key or "")
+    if proxy_entry:
+        return proxy_entry
+
     return _lookup_official_docs_pricing(route)
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -190,3 +190,57 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
 
     assert float(entry.input_cost_per_million) == 0.5
     assert float(entry.output_cost_per_million) == 2.0
+
+def test_proxy_upstream_pricing_hook_invoked_after_standard_probe(monkeypatch):
+    """When a proxy's /v1/models returns no pricing, the fallback hook is called.
+
+    LiteLLM and similar proxies follow the OpenAI spec: /v1/models returns
+    only {id, object, created, owned_by} with no cost fields.  The standard
+    fetch_endpoint_model_metadata probe comes up empty.  The secondary
+    _try_proxy_upstream_pricing hook must be called so upstream model IDs
+    and pricing can be resolved from the proxy's own metadata endpoint.
+    """
+    # Standard endpoint probe returns empty pricing
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {},
+    )
+
+    # Simulate a LiteLLM proxy lookup: model "grok" → upstream "openrouter/x-ai/grok-4.3"
+    def _fake_proxy_probe(route, api_key=""):
+        if route.model == "grok":
+            from agent.usage_pricing import get_pricing_entry as _gpe
+            return _gpe("openrouter/x-ai/grok-4.3")
+        return None
+
+    monkeypatch.setattr(
+        "agent.usage_pricing._try_proxy_upstream_pricing",
+        _fake_proxy_probe,
+    )
+
+    # OpenRouter models API pricing for the upstream
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {
+            "x-ai/grok-4.3": {
+                "pricing": {
+                    "prompt": "0.00000125",
+                    "completion": "0.0000025",
+                    "input_cache_read": "0.0000002",
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "grok",
+        provider="litellm",
+        base_url="http://127.0.0.1:4000/v1",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.25
+    assert float(entry.output_cost_per_million) == 2.5
+    assert float(entry.cache_read_cost_per_million) == 0.2
+    assert entry.source == "provider_models_api"
+    assert "openrouter" in (entry.source_url or "")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -5,6 +5,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
 
 
@@ -244,3 +245,73 @@ def test_proxy_upstream_pricing_hook_invoked_after_standard_probe(monkeypatch):
     assert float(entry.cache_read_cost_per_million) == 0.2
     assert entry.source == "provider_models_api"
     assert "openrouter" in (entry.source_url or "")
+
+
+def test_litellm_route_preserves_slash_model_alias():
+    route = resolve_billing_route(
+        "team/grok",
+        provider="litellm",
+        base_url="http://127.0.0.1:4000/v1",
+    )
+
+    assert route.provider == "litellm"
+    assert route.model == "team/grok"
+
+
+def test_proxy_model_info_pricing_is_used_directly(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {},
+    )
+    monkeypatch.setattr(
+        "agent.usage_pricing._fetch_proxy_model_info",
+        lambda base_url, api_key="": {
+            "data": [
+                {
+                    "model_name": "internal-alias",
+                    "litellm_params": {"model": "internal/model"},
+                    "model_info": {
+                        "input_cost_per_token": "0.0000007",
+                        "output_cost_per_token": "0.000003",
+                    },
+                }
+            ]
+        },
+    )
+
+    entry = get_pricing_entry(
+        "internal-alias",
+        provider="litellm",
+        base_url="http://127.0.0.1:4000/v1",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.7
+    assert float(entry.output_cost_per_million) == 3.0
+    assert entry.pricing_version == "litellm-model-info"
+
+
+def test_proxy_model_info_negative_result_is_cached(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {},
+    )
+
+    calls = []
+
+    def _fake_urlopen(req, timeout=0):
+        calls.append((req.full_url, timeout))
+        raise TimeoutError("slow proxy")
+
+    monkeypatch.setattr("agent.usage_pricing.urlopen", _fake_urlopen)
+
+    for _ in range(2):
+        entry = get_pricing_entry(
+            "missing-model",
+            provider="litellm",
+            base_url="http://127.0.0.1:4000/v1",
+        )
+        assert entry is None
+
+    assert len(calls) == 1
+    assert calls[0][1] <= 2


### PR DESCRIPTION
This patch was designed and written by DeepSeek V4 Pro and reviewed by GPT-5.5. User @mbac does not have the necessary competence to fully review the patch himself, so please take extra care reviewing the implementation, especially the proxy-pricing fallback paths and any latency/caching implications.

## Problem

When auxiliary models are routed through a local LiteLLM proxy, the dashboard shows "unknown" cost for every proxied model.

**Root cause:** `get_pricing_entry()` probes `{base_url}/v1/models` for pricing fields, but LiteLLM follows the OpenAI-compatible `/v1/models` shape and can return only model identity fields there. For proxied aliases, Hermes then falls through to official-docs lookup, finds no match for arbitrary proxy model names, and returns `None`.

**Result:** `run_agent.py` calls `estimate_usage_cost()` per API call, receives `amount_usd=None`, and the dashboard/session cost tracker cannot accumulate useful cost information for those proxied calls.

## Fix

### Primary: Proxy upstream pricing detection

Adds `_try_proxy_upstream_pricing()`, which probes a LiteLLM-compatible `/model/info` endpoint for the public proxy model. When the endpoint exposes the upstream model ID, such as `openrouter/x-ai/grok-4.3`, the helper delegates back into `get_pricing_entry()` so the existing pricing routes can resolve OpenRouter, official-docs snapshots, and subscription-included models.

The fallback is wired after the standard OpenAI-compatible `/models` probe returns no usable pricing. Users do not need new configuration when the proxy exposes compatible metadata.

### Review hardening follow-up

GPT-5.5 reviewed the first draft and found three fallback-path risks. Commit `4a921bbbe` addresses them by:

- Caching positive and negative `/model/info` responses for 5 minutes and reducing the probe timeout from 10s to 2s.
- Treating `provider="litellm"` like a proxy/custom route so public model aliases containing `/` are preserved for `/model/info` matching.
- Reading direct LiteLLM pricing from `/model/info` before falling back to upstream model recursion, so custom-priced/internal upstreams can still resolve when the proxy has usable per-token costs.

### Secondary: Complete provider routing

`resolve_billing_route()` was missing routing handlers for several providers that already have pricing entries or known zero-cost subscription semantics. This patch adds routing for:

| Provider | Routing | Pricing source |
|---|---|---|
| `deepseek` | `official_docs_snapshot` | `_OFFICIAL_DOCS_PRICING` |
| `bedrock` | `official_docs_snapshot` | `_OFFICIAL_DOCS_PRICING` |
| `google` | `official_docs_snapshot` | `_OFFICIAL_DOCS_PRICING` |
| `chatgpt` | `subscription_included` | zero-cost |

It also expands provider/model prefix auto-detection to include providers with pricing pathways, including `openrouter`, `chatgpt`, `deepseek`, `minimax`, `minimax-cn`, `bedrock`, and `openai-codex`.

## Related upstream issues/PRs

I searched upstream issues and PRs before submission. I did not find an exact duplicate for LiteLLM proxy cost detection, but this patch directly follows several adjacent reports and prior fixes:

- Related to #8465 and #8509: LiteLLM custom-provider metadata can require `/model/info` because OpenAI-compatible `/v1/models` may not expose enough metadata.
- Related to #10007: prior closed PR documenting the same `/v1/models` limitation and `/model/info` fallback approach for LiteLLM context metadata.
- Related to #3525: cost estimation can fail when provider/model alias resolution misses known pricing routes.
- Related to #16825 and #17423: missing billing routes/pricing entries caused provider usage to show `unknown`/zero cost until route coverage was added.
- Related to #17035: custom providers and OpenAI-compatible proxies need pricing/billing metadata without source patches.
- Related to #4913 and #18468: authenticated LiteLLM/OpenAI-compatible metadata probes are already a known fragile area for custom endpoints.

## Testing

- `scripts/run_tests.sh tests/agent/test_usage_pricing.py` — 13 passed in 3.66s.
- `python3 -m py_compile agent/usage_pricing.py tests/agent/test_usage_pricing.py` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Added `test_proxy_upstream_pricing_hook_invoked_after_standard_probe`, covering the fallback chain after the standard endpoint metadata probe returns no pricing.
- Added regression coverage for preserving slash-containing LiteLLM aliases, using direct `/model/info` pricing, and caching negative proxy probe results with the shorter timeout.
- Author reports live verification against a running LiteLLM instance with several proxied models, including OpenRouter-backed models and a subscription-included ChatGPT route.
