### PR TITLE
fix(models-dev): let modalities.input take precedence over attachment flag

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -85,7 +85,11 @@ class ModelInfo:
         return self.cost_input > 0 or self.cost_output > 0
 
     def supports_vision(self) -> bool:
-        return self.attachment or "image" in self.input_modalities
+        # When input_modalities is explicitly provided, it takes precedence
+        # over the attachment flag (see get_model_capabilities for rationale).
+        if self.input_modalities:
+            return "image" in self.input_modalities
+        return self.attachment
 
     def supports_pdf(self) -> bool:
         return "pdf" in self.input_modalities
@@ -381,14 +385,20 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
 
     # Extract capability flags (default to False if missing)
     supports_tools = bool(entry.get("tool_call", False))
-    # Vision: check both the `attachment` flag and `modalities.input` for "image".
-    # Some models (e.g. gemma-4) list image in input modalities but not attachment.
+    # Vision: when modalities.input is explicitly provided, it takes precedence
+    # over the attachment flag.  Some models.dev entries have incorrect
+    # attachment flags (e.g. mimo-v2.5-pro on xiaomi-token-plan-cn has
+    # attachment:true but modalities.input:["text"]).  When modalities.input
+    # is absent, fall back to the attachment flag.
     input_mods = entry.get("modalities", {})
     if isinstance(input_mods, dict):
         input_mods = input_mods.get("input", [])
     else:
         input_mods = []
-    supports_vision = bool(entry.get("attachment", False)) or "image" in input_mods
+    if input_mods:
+        supports_vision = "image" in input_mods
+    else:
+        supports_vision = bool(entry.get("attachment", False))
     supports_reasoning = bool(entry.get("reasoning", False))
 
     # Extract limits

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -264,6 +264,29 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is False
 
+    def test_modalities_input_text_only_overrides_attachment(self):
+        """When modalities.input is explicitly provided without 'image',
+        the model should NOT be vision-capable even if attachment=True.
+
+        This is the fix for NousResearch/hermes-agent#18884: mimo-v2.5-pro
+        on xiaomi-token-plan-cn has attachment:true but
+        modalities.input:["text"]. The modalities should take precedence.
+        """
+        registry = {
+            "xiaomi": {"id": "xiaomi", "models": {
+                "mimo-v2.5-pro": {
+                    "id": "mimo-v2.5-pro",
+                    "attachment": True,
+                    "modalities": {"input": ["text"]},
+                    "limit": {"context": 128000, "output": 8192},
+                },
+            }},
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("xiaomi", "mimo-v2.5-pro")
+        assert caps is not None
+        assert caps.supports_vision is False
+
     def test_modalities_non_dict_handled(self):
         """Non-dict modalities field should not crash."""
         registry = {


### PR DESCRIPTION
## What does this PR do?

The models.dev data marks **mimo-v2.5-pro** on `xiaomi-token-plan-cn` with `attachment: true`, but the model's `modalities.input` only contains `["text"]`.  mimo-v2.5-pro is a **text-only** model — the actual omnimodal model is mimo-2.5.

The current code in `get_model_capabilities()` uses OR logic:
```python
supports_vision = bool(entry.get("attachment", False)) or "image" in input_mods
```

This means `attachment: true` overrides the explicit `modalities.input`, causing `image_routing.py` to select `native` mode and send base64 images to a text-only model that silently drops them.

## Related Issue

Fixes #18884

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A