### PR TITLE
fix(weixin): send_weixin_direct cross-loop session causes "Timeout context manager should be used inside a task"

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2030,7 +2030,9 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    if (live_adapter is not None and send_session is not None
+            and not send_session.closed
+            and send_session._loop is asyncio.get_running_loop()):
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:


### PR DESCRIPTION
## Problem

When `send_message` tool is invoked from inside a running gateway (e.g., CLI → send_message to weixin), the `send_message` tool handler is async and `_run_async()` spawns a worker thread with a separate event loop. `send_weixin_direct()` then prefers reusing the live adapter's aiohttp session — but that session was created on the gateway's main loop.

aiohttp 3.13.5's `TimerContext.__enter__()` calls:
```python
task = asyncio.current_task(loop=self._loop)
if task is None:
    raise RuntimeError("Timeout context manager should be used inside a task")
```

Since we are executing on the worker thread loop, `current_task(loop=gateway_loop)` returns `None`, and every send attempt fails (5 retries with backoff, then error).

This affects:
- `send_message` text delivery to weixin
- `send_message` MEDIA: file delivery to weixin
- cron job delivery to weixin

Normal inbound→reply works fine because it runs entirely on the gateway's main loop.

## Fix

Before using the live adapter path, verify the session's event loop matches the current execution loop:

```python
if (live_adapter is not None and send_session is not None
        and not send_session.closed
        and send_session._loop is asyncio.get_running_loop()):
```

When loops differ, fall through to the existing fresh-session path (new `aiohttp.ClientSession()`), which already works correctly.

The feishu adapter avoids this issue entirely by always creating a new adapter instance in `_send_feishu()` — it never touches the live adapter.

## Testing

- ✅ `send_message` text to weixin
- ✅ `send_message` MEDIA: file attachment to weixin
- Normal inbound→reply still works (untouched code path)

## Notes

Uses `session._loop` (aiohttp private attribute) for loop comparison. An alternative would be to fix this at the `_run_async` level so gateway-session-bound tools stay on the main loop, but that would be a wider change and we judged this targeted fix to be the right tradeoff.