### PR TITLE
fix: exclude .archive/.git/.github/.hub from _find_skill rglob

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -185,6 +185,67 @@ class TestValidateFilePath:
 
 
 # ---------------------------------------------------------------------------
+# _find_skill exclusion filtering
+# ---------------------------------------------------------------------------
+
+
+class TestFindSkillExcludesArchiveAndVcs:
+    """_find_skill must skip .archive, .git, .github, and .hub directories,
+    matching the exclusion set used by iter_skill_index_files."""
+
+    EXCLUDED_DIRS = (".archive", ".git", ".github", ".hub")
+
+    def _create_skill_at(self, skills_root: Path, name: str, subdir: str):
+        """Create a minimal SKILL.md at skills_root/subdir/name/SKILL.md."""
+        skill_dir = skills_root / subdir / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: " + name + "\ndescription: desc.\n---\n\nbody\n", encoding="utf-8"
+        )
+
+    @pytest.mark.parametrize("excluded_dir", EXCLUDED_DIRS)
+    def test_find_skill_skips_excluded_dir(self, tmp_path, excluded_dir):
+        """_find_skill should NOT find a skill inside an excluded directory."""
+        self._create_skill_at(tmp_path, "my-skill", excluded_dir)
+        with _skill_dir(tmp_path):
+            result = _find_skill("my-skill")
+        assert result is None, (
+            f"_find_skill should skip {excluded_dir}/my-skill/SKILL.md"
+        )
+
+    def test_find_skill_still_finds_regular_skill(self, tmp_path):
+        """_find_skill should still find a skill at the root level."""
+        self._create_skill_at(tmp_path, "real-skill", "")
+        # Fixup: _create_skill_at(skills_root, name, "") writes to
+        # skills_root//name (double slash) which is fine for Path.
+        # But we need to ensure the dir name matches.
+        with _skill_dir(tmp_path):
+            result = _find_skill("real-skill")
+        assert result is not None
+        assert result["path"] == tmp_path / "real-skill"
+
+    def test_find_skill_skips_nested_excluded(self, tmp_path):
+        """_find_skill should skip skills even when the excluded dir is
+        nested inside a category directory."""
+        self._create_skill_at(tmp_path, "nested-skill", "devops/.archive")
+        with _skill_dir(tmp_path):
+            result = _find_skill("nested-skill")
+        assert result is None, (
+            "_find_skill should skip devops/.archive/nested-skill/SKILL.md"
+        )
+
+    def test_find_skill_not_confused_by_name_clash(self, tmp_path):
+        """If the same skill name exists in .archive/ AND at root level,
+        _find_skill should return the root-level one, not the archived one."""
+        self._create_skill_at(tmp_path, "clash", ".archive")
+        self._create_skill_at(tmp_path, "clash", "")
+        with _skill_dir(tmp_path):
+            result = _find_skill("clash")
+        assert result is not None
+        assert result["path"] == tmp_path / "clash"
+
+
+# ---------------------------------------------------------------------------
 # CRUD operations
 # ---------------------------------------------------------------------------
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -282,12 +282,20 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
+
+    Skips .archive, .git, .github, and .hub directories so archived or
+    version-control skills are never returned — matching the exclusion
+    set used by iter_skill_index_files for prompt building and skill
+    discovery.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import EXCLUDED_SKILL_DIRS, get_all_skills_dirs
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
+            # Skip any path whose parent chain crosses an excluded dir.
+            if any(p in EXCLUDED_SKILL_DIRS for p in skill_md.parent.parts):
+                continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None


### PR DESCRIPTION
## What does this PR do?

`_find_skill` in `tools/skill_manager_tool.py` uses bare `rglob("SKILL.md")` with no exclusion filtering — unlike `iter_skill_index_files` which filters `EXCLUDED_SKILL_DIRS = {.git, .github, .hub, .archive}`. This allows `skill_manage`'s five mutating actions (`edit`, `patch`, `delete`, `write_file`, `remove_file`) to silently match and modify archived skills or skills inside version-control directories.

Fix: import `EXCLUDED_SKILL_DIRS` from `agent.skill_utils` and skip any `SKILL.md` whose parent directory chain crosses an excluded dir.

## Related Issue

Fixes #18900

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`: Import `EXCLUDED_SKILL_DIRS` from `agent.skill_utils`; add exclusion guard in `_find_skill` rglob loop
- `tests/tools/test_skill_manager_tool.py`: Add `TestFindSkillExcludesArchiveAndVcs` with 7 tests

## How to Test

1. Create skill dirs inside `.archive/`, `.git/`, `.github/`, `.hub/` under a temp skills root
2. Call `_find_skill(name)` — returns `None` for all excluded dirs
3. Call `_find_skill(name)` for a regular skill — still returns correct path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (4595 passed, failures pre-existing)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (updated docstring)
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A