### PR TITLE
fix: recognize WhatsApp JID formats in send_message target parsing

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -894,6 +894,64 @@ class TestParseTargetRefSlack:
         assert _parse_target_ref("telegram", "C0B0QV5434G")[2] is False
 
 
+class TestParseTargetRefWhatsAppJID:
+    """_parse_target_ref recognizes WhatsApp JID formats (groups, direct, lid)."""
+
+    def test_group_jid_gus_is_explicit(self):
+        """WhatsApp group JIDs (numeric@g.us) are explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "120363428509584443@g.us")
+        assert chat_id == "120363428509584443@g.us"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_direct_chat_jid_is_explicit(self):
+        """WhatsApp direct chat JIDs (numeric@s.whatsapp.net) are explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "6285177551373@s.whatsapp.net")
+        assert chat_id == "6285177551373@s.whatsapp.net"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_lid_jid_is_explicit(self):
+        """WhatsApp linked device JIDs (numeric@lid) are explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "106356325519366@lid")
+        assert chat_id == "106356325519366@lid"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_companion_device_jid_is_explicit(self):
+        """WhatsApp companion device JIDs (numeric:device@s.whatsapp.net) are explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "6285177551373:4@s.whatsapp.net")
+        assert chat_id == "6285177551373:4@s.whatsapp.net"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_broadcast_jid_is_explicit(self):
+        """WhatsApp broadcast JIDs (numeric@broadcast) are explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "123456@broadcast")
+        assert chat_id == "123456@broadcast"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_whitespace_stripped(self):
+        """Whitespace around JIDs is stripped."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "  120363428509584443@g.us  ")
+        assert chat_id == "120363428509584443@g.us"
+        assert is_explicit is True
+
+    def test_invalid_jid_not_explicit(self):
+        """Malformed or non-WhatsApp JIDs are not explicit."""
+        assert _parse_target_ref("whatsapp", "something@g.us")[2] is False
+        assert _parse_target_ref("whatsapp", "@g.us")[2] is False
+        assert _parse_target_ref("whatsapp", "123@invalid")[2] is False
+        assert _parse_target_ref("whatsapp", "123@")[2] is False
+
+    def test_gus_only_matches_whatsapp(self):
+        """@g.us JID format must NOT be explicit for non-WhatsApp platforms."""
+        assert _parse_target_ref("signal", "120363428509584443@g.us")[2] is False
+        assert _parse_target_ref("sms", "120363428509584443@g.us")[2] is False
+        assert _parse_target_ref("telegram", "120363428509584443@g.us")[2] is False
+
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -37,6 +37,12 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # resolve a raw phone number. Keeping the '+' preserves the E.164 form that
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"signal", "sms", "whatsapp"})
+
+# WhatsApp JID suffixes used by Baileys bridge for group and direct chats.
+# Groups use @g.us, personal chats use @s.whatsapp.net, linked devices use @lid.
+_WHATSAPP_JID_RE = re.compile(
+    r"^\s*(\d+(?::\d+)?)@((?:g\.us)|(?:s\.whatsapp\.net)|(?:lid)|(?:broadcast))\s*$"
+)
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
@@ -341,6 +347,12 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
+            return target_ref.strip(), None, True
+    # WhatsApp JID formats: groups (123@g.us), direct chats (123@s.whatsapp.net),
+    # linked devices (123@lid), and broadcasts (123@broadcast).
+    if platform_name == "whatsapp":
+        jid_match = _WHATSAPP_JID_RE.fullmatch(target_ref)
+        if jid_match:
             return target_ref.strip(), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True


### PR DESCRIPTION
## Problem

`send_message_tool.py` `_parse_target_ref()` cannot parse WhatsApp JID formats that include a suffix (`@g.us`, `@s.whatsapp.net`, `@lid`, `@broadcast`).

The function uses `.lstrip("-").isdigit()` to detect explicit numeric chat IDs:

```python
if target_ref.lstrip("-").isdigit():
    return target_ref, None, True
```

WhatsApp group JIDs look like `120363428509584443@g.us` — the `@g.us` suffix causes `.isdigit()` to return `False`, so `chat_id` resolves to `None` and the message falls back to the WhatsApp home channel.

### Symptoms

| Target | Result |
|--------|--------|
| `whatsapp:120363428509584443@g.us` | Routed to home channel ❌ |
| `whatsapp:120363428509584443` | Bridge error 500: `jidDecode undefined` ❌ |

## Fix

Add a regex-based WhatsApp JID matcher (`_WHATSAPP_JID_RE`) that recognizes all four Baileys JID suffixes:

- `numeric@g.us` — groups
- `numeric@s.whatsapp.net` — direct chats
- `numeric:device@s.whatsapp.net` — companion devices
- `numeric@lid` — linked identity devices
- `numeric@broadcast` — broadcast lists

The matcher is scoped to `platform_name == "whatsapp"` so it does not affect Signal, SMS, or other phone-based platforms.

## Test Plan

Added `TestParseTargetRefWhatsAppJID` with 8 test cases covering:
- ✅ Group JID (`@g.us`)
- ✅ Direct chat JID (`@s.whatsapp.net`)
- ✅ Linked device JID (`@lid`)
- ✅ Companion device JID (`:device@s.whatsapp.net`)
- ✅ Broadcast JID (`@broadcast`)
- ✅ Whitespace stripping
- ✅ Invalid/malformed JID rejection
- ✅ No cross-platform leakage (signal/sms/telegram)

All existing tests pass (E164, Discord, Matrix, Slack — 15/15 ✅).

## Files Changed

- `tools/send_message_tool.py` — added `_WHATSAPP_JID_RE` regex and platform-scoped JID matching in `_parse_target_ref()`
- `tests/tools/test_send_message_tool.py` — added `TestParseTargetRefWhatsAppJID` test class