### PR TITLE
fix(skills): add frontmatter-name fallback in skill_view to resolve name mismatch

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -986,6 +986,25 @@ def skill_view(
                 if skill_md:
                     break
 
+        # Frontmatter-name fallback: when directory-name lookup fails,
+        # try matching the frontmatter "name" field. This fixes the
+        # tool-calling loop where skills_list reports a frontmatter name
+        # but skill_view can only resolve by directory name (#18872).
+        if not skill_md:
+            for search_dir in all_dirs:
+                for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                    try:
+                        fm_content = found_skill_md.read_text(encoding="utf-8")[:4000]
+                        fm, _ = _parse_frontmatter(fm_content)
+                        if fm.get("name") == name:
+                            skill_dir = found_skill_md.parent
+                            skill_md = found_skill_md
+                            break
+                    except Exception:
+                        continue
+                if skill_md:
+                    break
+
         if not skill_md or not skill_md.exists():
             available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]
             return json.dumps(


### PR DESCRIPTION
## Summary

Fixes the skill discovery→loading loop where `skills_list` reports a frontmatter `name` but `skill_view` can only resolve by directory name, making mismatched skills silently undiscoverable by the agent.

## Problem

When a skill's frontmatter `name` differs from its directory name (e.g., directory `foo` but frontmatter `name: bar`):

1. `skills_list` → returns `"bar"` (from frontmatter)
2. Agent calls `skill_view("bar")` → `"Skill 'bar' not found."` (resolves by directory name)
3. Skill is **unusable** — no crash, no warning, just a dead entry

The agent's tool chain contradicts itself silently. The model can't self-correct because it has no way to know `skill_view` needs a different identifier than what `skills_list` reported.

## Fix

Added a **frontmatter-name fallback** in `skill_view()`: when directory-name lookup fails (steps 1-3), the function now iterates all `SKILL.md` files and checks if the frontmatter `name` field matches. If found, uses that skill's directory path.

This is backwards-compatible:
- `skill_view("foo")` still works (directory name lookup, existing behavior)
- `skill_view("bar")` now works (frontmatter name fallback, new behavior)
- No API changes to `skills_list` output

## Verification

```bash
mkdir -p ~/.hermes/skills/foo
cat > ~/.hermes/skills/foo/SKILL.md << 'EOF'
---
name: bar
description: Test skill with mismatched name
---
# Bar
Content here.
EOF
```

- `skills_list` → shows `bar`
- `skill_view("bar")` → loads the skill (was: "not found")
- `skill_view("foo")` → still loads the skill (unchanged)

Fixes #18872
