### PR TITLE
Fix: exclude .archive, .git, .github, .hub dirs from _find_skill rglob

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -283,11 +283,13 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import get_all_skills_dirs, EXCLUDED_SKILL_DIRS
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
+            if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parent.parts):
+                continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None


### PR DESCRIPTION
## Fix: Exclude `.archive`, `.git`, `.github`, `.hub` from `_find_skill` rglob

Fixes #18900

### Problem

`_find_skill` in `tools/skill_manager_tool.py` uses a bare `rglob("SKILL.md")` with no exclusion filtering. This is inconsistent with `iter_skill_index_files` (`agent/skill_utils.py`) which correctly filters `EXCLUDED_SKILL_DIRS = {.git, .github, .hub, .archive}`.

All five `skill_manage` mutating actions (`edit`, `patch`, `delete`, `write_file`, `remove_file`) call `_find_skill` to locate the skill directory. Since `_find_skill` has no exclusion filter, it can match skills inside `.archive/`, `.git/`, `.github/`, or `.hub/` — silently operating on archived or version-control copies instead of the live skill.

### Fix

Imports `EXCLUDED_SKILL_DIRS` from `agent.skill_utils` and adds a guard in the rglob loop:

```python
if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parent.parts):
    continue
```

This makes `_find_skill` consistent with the exclusion behavior already used by `iter_skill_index_files`, `skill_view`, and `skills_list`.

### Reproduction

1. Archive a skill `foo` → `.archive/foo/SKILL.md`
2. Agent calls `skill_manage(name="foo", action="patch", old_string="...", new_string="...")`
3. `_find_skill("foo")` matches `.archive/foo/SKILL.md` via `skill_md.parent.name == "foo"` and modifies the archived copy

### Testing

- Verified the import resolves correctly (`EXCLUDED_SKILL_DIRS` is a `frozenset` at `agent/skill_utils.py:27`)
- Path parts check works for nested paths (e.g., `~/.hermes/skills/.archive/foo/SKILL.md` → parent parts include `.archive`)