### PR TITLE
feat(copy): add copy button to install command

### DIFF
--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -126,6 +126,7 @@ function SkillCard({
 }) {
   const src = SOURCE_CONFIG[skill.source] || SOURCE_CONFIG["optional"];
   const icon = CATEGORY_ICONS[skill.category] || "\u{1F4E6}";
+  const [copied, setCopied] = useState(false);
 
   return (
     <div
@@ -209,6 +210,16 @@ function SkillCard({
             )}
             <div className={styles.installHint}>
               <code>hermes skills install {skill.name}</code>
+              <button
+              className={`${styles.copyBtn} ${copied ? styles.copied : ""}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(`hermes skills install ${skill.name}`);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 1500);
+                }}>
+                {copied ? "Copied" : "Copy"}
+                </button>
             </div>
           </div>
         )}

--- a/website/src/pages/skills/styles.module.css
+++ b/website/src/pages/skills/styles.module.css
@@ -729,6 +729,36 @@
   color: rgba(255, 215, 0, 0.8);
 }
 
+.copyBtn {
+  margin-left: 10px;
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(212, 132, 90, 0.25);
+  background: rgba(212, 132, 90, 0.08);
+  color: #d4845a;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+/* hover = subtle glow */
+.copyBtn:hover {
+  background: rgba(212, 132, 90, 0.15);
+  border-color: rgba(212, 132, 90, 0.4);
+}
+
+/* copied state = green success */
+.copied {
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.4);
+  background: rgba(74, 222, 128, 0.1);
+}
+
+/* optional: slight glow when copied */
+.copied:hover {
+  background: rgba(74, 222, 128, 0.18);
+}
+
 
 @media (max-width: 900px) {
   .layout {
@@ -817,3 +847,5 @@
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }
 }
+
+


### PR DESCRIPTION
## What does this PR do?

- Adds a copy button next to the "install" command on each skill card in the website UI.
- Provides visual feedback (a "Copied" label with green styling) when the command is copied to the clipboard.
- Uses React useState to manage the copied state, showing the button changes to "Copied" for ~1.5 seconds before reverting.
- Includes hover effects and success-state styling for the button, improving usability without affecting existing functionality.

## Related Issue

No existing issue; this is a new UI enhancement.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

| File | Change |
|------|--------|
| `website/src/pages/skills/index.tsx` | Added a `<button>` element with an onClick handler that copies the install command to the clipboard and toggles a copied state. |
| `website/src/pages/skills/styles.module.css` | Added `.copyBtn` base style, hover style, and `.copied` success style (color, border, background adjustments). |

## How to Test

1. Run the website locally (e.g., `npm start` in the `website/` directory).
2. Navigate to any skill card. A Copy button should appear next to the install command.
3. Click the button: the command is copied to the clipboard and the button text changes to "Copied" with a green background for ~1.5 seconds, then reverts to "Copy".
4. Verify that the UI works on other skill cards and that no other functionality is broken.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and found none that add this UI feature.
- [x] My PR contains only changes related to this feature (no unrelated commits).
- [x] I've run `pytest tests/ -q` and all existing tests pass.
- [ ] I've added tests for my changes (optional for UI-only enhancements).
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2) – UI works in the local dev server.

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings).
- [N/A] I've updated `cli-config.yaml.example` (no config keys added/changed).
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` (no architectural changes).
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility).
- [N/A] I've updated tool descriptions/schemas (no tool behavior changes).

### For New Skills

- [N/A] This skill is broadly useful to most users (if bundled).
- [N/A] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format).
- [N/A] No external dependencies beyond stdlib, curl, and existing Hermes tools.
- [N/A] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`.

## Screenshots / Logs

No screenshots provided (attach if available).
<img width="557" height="438" alt="Screenshot 2026-05-02 222540" src="https://github.com/user-attachments/assets/a570923a-cb98-49c9-bbc6-db0c5ee31678" />
<img width="567" height="447" alt="Screenshot 2026-05-02 222547" src="https://github.com/user-attachments/assets/26d6e817-3b86-4a28-bbdd-4d5444d556df" />
