### PR TITLE
fix: use get_env_value() for base_url_env_var resolution

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3404,7 +3404,8 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        from hermes_cli.config import get_env_value
+        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3436,7 +3437,10 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = ""
+    if pconfig.base_url_env_var:
+        from hermes_cli.config import get_env_value
+        base_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -3508,7 +3512,8 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        from hermes_cli.config import get_env_value
+        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3537,7 +3542,10 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = ""
+    if pconfig.base_url_env_var:
+        from hermes_cli.config import get_env_value
+        base_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
     if not base_url:
         base_url = pconfig.inference_base_url
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -828,7 +828,8 @@ def _resolve_explicit_runtime(
     if pconfig and pconfig.auth_type == "api_key":
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+            from hermes_cli.config import get_env_value
+            env_url = (get_env_value(pconfig.base_url_env_var) or "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:


### PR DESCRIPTION
## Summary

`resolve_api_key_provider_credentials()` and related functions used
`os.getenv()` for `base_url_env_var`, which does NOT read
\~/.hermes/.env. Providers with custom base URLs stored only in .env
hit the wrong endpoint.

## Root Cause

API key resolution already correctly uses `get_env_value()` — this was
an inconsistency where keys were found but base URLs were not.

## Fix

Replace `os.getenv()` with `get_env_value()` at all 5 occurrences:

| File | Function |
|------|----------|
| auth.py | `get_api_key_provider_status()` |
| auth.py | `get_external_process_provider_status()` |
| auth.py | `resolve_api_key_provider_credentials()` |
| auth.py | `resolve_external_process_provider_credentials()` |
| runtime_provider.py | `_resolve_explicit_runtime()` |

## Same Bug Class

- #15914 → PR #16101 (api_key + credential_pool)
- #17140 → PR #17434 (TTS/STT tools)

The `base_url_env_var` resolution was missed in both prior fixes.

## Scope

- 2 files, +14 / -5 lines
- No behavioral change for env vars already in `os.environ`
- Purely fixes the .env file reading gap

Fixes #18757