### PR TITLE
fix(security): strip credentials from request debug dumps

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3974,12 +3974,26 @@ class AIAgent:
         Dump a debug-friendly HTTP request record for the active inference API.
 
         Captures the request body from api_kwargs (excluding transport-only keys
-        like timeout). Intended for debugging provider-side 4xx failures where
-        retries are not useful.
+        like timeout and any credential material). Intended for debugging
+        provider-side 4xx failures where retries are not useful.
+
+        Security: all credential material is stripped before writing to disk.
+        See #8518 / #18707.
         """
         try:
             body = copy.deepcopy(api_kwargs)
             body.pop("timeout", None)
+
+            # Strip credential material from body — some SDK/client combos
+            # pass api_key or auth headers inside api_kwargs.
+            for _secret_key in ("api_key", "x_api_key", "api_token", "auth_token"):
+                body.pop(_secret_key, None)
+            # extra_headers / headers dicts may contain Authorization or
+            # X-API-Key values; drop them entirely rather than sanitising
+            # nested dicts.
+            for _header_key in ("extra_headers", "headers"):
+                body.pop(_header_key, None)
+
             body = {k: v for k, v in body.items() if v is not None}
 
             api_key = None

--- a/tests/run_agent/test_dump_credential_sanitisation.py
+++ b/tests/run_agent/test_dump_credential_sanitisation.py
@@ -1,0 +1,163 @@
+"""Tests for request debug dump credential sanitisation (#8518, #18707).
+
+Verify that _dump_api_request_debug never writes credential material to disk.
+"""
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import only what we need — run_agent is the module under test.
+from run_agent import AIAgent
+
+
+@pytest.fixture()
+def agent(tmp_path):
+    """Minimal AIAgent with mocked client, logs_dir pointed at tmp_path."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a.client.api_key = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
+        a.logs_dir = tmp_path
+        a.session_id = "test-dump-sanitise"
+        a.api_mode = "chat_completions"
+        return a
+
+
+class TestDumpCredentialSanitisation:
+    """Ensure no plaintext credentials leak into request_dump_*.json files."""
+
+    def _dump_and_read(self, agent, api_kwargs, *, reason="test", error=None):
+        path = agent._dump_api_request_debug(
+            api_kwargs, reason=reason, error=error
+        )
+        assert path is not None, "dump returned None"
+        assert path.exists(), f"dump file not created: {path}"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_api_key_stripped_from_body(self, agent):
+        """api_key inside api_kwargs body must not appear in dump."""
+        secret = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
+        payload = self._dump_and_read(
+            agent,
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}],
+                "api_key": secret,
+            },
+        )
+        body_text = json.dumps(payload["request"]["body"])
+        assert secret not in body_text
+        assert "api_key" not in body_text
+
+    def test_x_api_key_stripped_from_body(self, agent):
+        """x_api_key inside api_kwargs body must not appear in dump."""
+        secret = "xai-abc123def456ghi789jkl012mno345pqr678"
+        payload = self._dump_and_read(
+            agent,
+            {
+                "model": "grok-3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "x_api_key": secret,
+            },
+        )
+        body_text = json.dumps(payload["request"]["body"])
+        assert secret not in body_text
+
+    def test_extra_headers_stripped_from_body(self, agent):
+        """extra_headers dict (may contain Authorization) must be removed."""
+        secret = "Bearer sk-ant-secret1234567890"
+        payload = self._dump_and_read(
+            agent,
+            {
+                "model": "claude-3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "extra_headers": {"Authorization": secret, "X-API-Key": "key-123"},
+            },
+        )
+        body_text = json.dumps(payload["request"]["body"])
+        assert "extra_headers" not in body_text
+        assert secret not in body_text
+        assert "key-123" not in body_text
+
+    def test_headers_dict_stripped_from_body(self, agent):
+        """Top-level headers dict in body must be removed."""
+        payload = self._dump_and_read(
+            agent,
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "headers": {"Authorization": "Bearer secret-token-here"},
+            },
+        )
+        body_text = json.dumps(payload["request"]["body"])
+        assert "headers" not in body_text
+        assert "secret-token-here" not in body_text
+
+    def test_auth_header_masked_in_request_headers(self, agent):
+        """Authorization in the synthetic request headers must be masked."""
+        payload = self._dump_and_read(
+            agent,
+            {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        auth = payload["request"]["headers"].get("Authorization", "")
+        # Must not contain the full key
+        assert "sk-proj-abc123def456ghi789jkl012mno345pqr678" not in auth
+        # Must either be masked or absent
+        if auth:
+            assert "..." in auth or "***" in auth
+
+    def test_no_timeout_in_body(self, agent):
+        """timeout is transport-only and must not appear in dump."""
+        payload = self._dump_and_read(
+            agent,
+            {"model": "gpt-4", "messages": [], "timeout": 120},
+        )
+        body_text = json.dumps(payload["request"]["body"])
+        assert "timeout" not in body_text
+
+    def test_normal_fields_preserved(self, agent):
+        """Non-sensitive fields (model, messages, temperature) must survive."""
+        payload = self._dump_and_read(
+            agent,
+            {
+                "model": "gpt-4-turbo",
+                "messages": [{"role": "user", "content": "hello world"}],
+                "temperature": 0.7,
+                "max_tokens": 4096,
+            },
+        )
+        body = payload["request"]["body"]
+        assert body["model"] == "gpt-4-turbo"
+        assert body["temperature"] == 0.7
+        assert body["max_tokens"] == 4096
+        assert body["messages"][0]["content"] == "hello world"
+
+    def test_full_serialised_dump_contains_no_secrets(self, agent):
+        """End-to-end: the entire serialised JSON must contain no raw secrets."""
+        secret_key = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
+        payload = self._dump_and_read(
+            agent,
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}],
+                "api_key": secret_key,
+                "extra_headers": {"Authorization": f"Bearer {secret_key}"},
+            },
+        )
+        full_text = json.dumps(payload)
+        assert secret_key not in full_text, (
+            f"Raw secret found in dump: {secret_key[:12]}..."
+        )

--- a/tests/run_agent/test_dump_credential_sanitisation.py
+++ b/tests/run_agent/test_dump_credential_sanitisation.py
@@ -3,14 +3,18 @@
 Verify that _dump_api_request_debug never writes credential material to disk.
 """
 import json
-import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Import only what we need — run_agent is the module under test.
 from run_agent import AIAgent
+
+# Realistic-looking fake keys — long enough to exercise the masking logic
+# (_mask_api_key_for_logs: >12 chars -> prefix...suffix, >18 chars -> 6+4).
+_FAKE_OPENAI_KEY = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
+_FAKE_XAI_KEY = "xai-ABCDefghIJKLmnopQRSTuvwxYZ1234567890abcd"
+_FAKE_ANTHROPIC_KEY = "sk-ant-api03-1234567890abcdef1234567890abcdef"
 
 
 @pytest.fixture()
@@ -29,7 +33,7 @@ def agent(tmp_path):
             skip_memory=True,
         )
         a.client = MagicMock()
-        a.client.api_key = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
+        a.client.api_key = _FAKE_OPENAI_KEY
         a.logs_dir = tmp_path
         a.session_id = "test-dump-sanitise"
         a.api_mode = "chat_completions"
@@ -49,48 +53,48 @@ class TestDumpCredentialSanitisation:
 
     def test_api_key_stripped_from_body(self, agent):
         """api_key inside api_kwargs body must not appear in dump."""
-        secret = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
         payload = self._dump_and_read(
             agent,
             {
                 "model": "gpt-4",
                 "messages": [{"role": "user", "content": "hi"}],
-                "api_key": secret,
+                "api_key": _FAKE_OPENAI_KEY,
             },
         )
         body_text = json.dumps(payload["request"]["body"])
-        assert secret not in body_text
+        assert _FAKE_OPENAI_KEY not in body_text
         assert "api_key" not in body_text
 
     def test_x_api_key_stripped_from_body(self, agent):
         """x_api_key inside api_kwargs body must not appear in dump."""
-        secret = "xai-abc123def456ghi789jkl012mno345pqr678"
         payload = self._dump_and_read(
             agent,
             {
                 "model": "grok-3",
                 "messages": [{"role": "user", "content": "hi"}],
-                "x_api_key": secret,
+                "x_api_key": _FAKE_XAI_KEY,
             },
         )
         body_text = json.dumps(payload["request"]["body"])
-        assert secret not in body_text
+        assert _FAKE_XAI_KEY not in body_text
 
     def test_extra_headers_stripped_from_body(self, agent):
         """extra_headers dict (may contain Authorization) must be removed."""
-        secret = "Bearer sk-ant-secret1234567890"
         payload = self._dump_and_read(
             agent,
             {
                 "model": "claude-3",
                 "messages": [{"role": "user", "content": "hi"}],
-                "extra_headers": {"Authorization": secret, "X-API-Key": "key-123"},
+                "extra_headers": {
+                    "Authorization": f"Bearer {_FAKE_ANTHROPIC_KEY}",
+                    "X-API-Key": "some-key-value",
+                },
             },
         )
         body_text = json.dumps(payload["request"]["body"])
         assert "extra_headers" not in body_text
-        assert secret not in body_text
-        assert "key-123" not in body_text
+        assert _FAKE_ANTHROPIC_KEY not in body_text
+        assert "some-key-value" not in body_text
 
     def test_headers_dict_stripped_from_body(self, agent):
         """Top-level headers dict in body must be removed."""
@@ -99,25 +103,31 @@ class TestDumpCredentialSanitisation:
             {
                 "model": "test",
                 "messages": [{"role": "user", "content": "hi"}],
-                "headers": {"Authorization": "Bearer secret-token-here"},
+                "headers": {"Authorization": f"Bearer {_FAKE_OPENAI_KEY}"},
             },
         )
         body_text = json.dumps(payload["request"]["body"])
         assert "headers" not in body_text
-        assert "secret-token-here" not in body_text
+        assert _FAKE_OPENAI_KEY not in body_text
 
     def test_auth_header_masked_in_request_headers(self, agent):
-        """Authorization in the synthetic request headers must be masked."""
+        """Authorization in the synthetic request headers must be masked.
+
+        _mask_api_key_for_logs preserves first 8 + last 4 chars for keys
+        > 12 chars. The full key must never appear.
+        """
         payload = self._dump_and_read(
             agent,
             {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
         )
         auth = payload["request"]["headers"].get("Authorization", "")
-        # Must not contain the full key
-        assert "sk-proj-abc123def456ghi789jkl012mno345pqr678" not in auth
-        # Must either be masked or absent
+        # Full key must not appear
+        assert _FAKE_OPENAI_KEY not in auth
+        # Masked format: first 8 chars + "..." + last 4 chars
         if auth:
-            assert "..." in auth or "***" in auth
+            assert _FAKE_OPENAI_KEY[:8] in auth
+            assert _FAKE_OPENAI_KEY[-4:] in auth
+            assert "..." in auth
 
     def test_no_timeout_in_body(self, agent):
         """timeout is transport-only and must not appear in dump."""
@@ -147,17 +157,16 @@ class TestDumpCredentialSanitisation:
 
     def test_full_serialised_dump_contains_no_secrets(self, agent):
         """End-to-end: the entire serialised JSON must contain no raw secrets."""
-        secret_key = "sk-proj-abc123def456ghi789jkl012mno345pqr678"
         payload = self._dump_and_read(
             agent,
             {
                 "model": "gpt-4",
                 "messages": [{"role": "user", "content": "hi"}],
-                "api_key": secret_key,
-                "extra_headers": {"Authorization": f"Bearer {secret_key}"},
+                "api_key": _FAKE_OPENAI_KEY,
+                "extra_headers": {"Authorization": f"Bearer {_FAKE_OPENAI_KEY}"},
             },
         )
         full_text = json.dumps(payload)
-        assert secret_key not in full_text, (
-            f"Raw secret found in dump: {secret_key[:12]}..."
+        assert _FAKE_OPENAI_KEY not in full_text, (
+            f"Raw secret found in dump"
         )


### PR DESCRIPTION
## Summary

`_dump_api_request_debug()` wrote the full `api_kwargs` body to
`~/.hermes/sessions/request_dump_*.json`, including credential material.
These files are commonly shared in bug reports, exposing API keys.

## Root Cause

The dump function only stripped `timeout` from the body before writing.
Any credential material in `api_kwargs` (e.g. `api_key`,
`extra_headers` with Authorization) was written in plaintext.

## Fix

Strip known credential keys from the body before serialising:

| Stripped from body | Reason |
|---|---|
| `api_key` | SDK may pass key in kwargs |
| `x_api_key` | Gemini-style header key |
| `api_token` | Generic auth token |
| `auth_token` | Generic auth token |
| `extra_headers` | Dict may contain Authorization/X-API-Key |
| `headers` | Same as extra_headers |

Authorization header in the synthetic request section was already
masked via `_mask_api_key_for_logs()` — no change there.

## Testing

8 new tests in `test_dump_credential_sanitisation.py`:
- api_key stripped from body
- x_api_key stripped from body
- extra_headers dict stripped from body
- headers dict stripped from body
- Authorization header masked in request headers
- timeout stripped from body
- normal fields (model, messages, temperature) preserved
- end-to-end: entire serialised JSON contains no raw secrets

307 existing run_agent tests: all pass, zero regression.

## Relation to prior PRs

- #8533 (OPEN) — only pops body keys, misses headers dict
- #8768 (OPEN) — removes Authorization header but also removes api_key extraction

This PR is a superset: strips both body keys AND header dicts, keeps the
masked Authorization for debug utility.

Closes #8518
Fixes #18707