### PR TITLE
fix(cli): expand show_config messaging platforms to include all adapters

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4530,11 +4530,32 @@ def show_config():
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
     
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
+    platforms = {
+        "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
+        "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
+        "WhatsApp": ("WHATSAPP_ENABLED", None),
+        "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
+        "Slack": ("SLACK_BOT_TOKEN", None),
+        "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
+        "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
+        "DingTalk": ("DINGTALK_CLIENT_ID", None),
+        "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
+        "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
+        "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
+        "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
+        "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
+    }
+
+    for name, (token_var, home_var) in platforms.items():
+        token = get_env_value(token_var)
+        has_token = bool(token)
+
+        home_channel = get_env_value(home_var) if home_var else ""
+        status = "configured" if has_token else color("not configured", Colors.DIM)
+        if has_token and home_channel:
+            status += color(f" (home: {home_channel})", Colors.DIM)
+
+        print(f"  {name:15s} {status}")
     
     # Skill config
     try:

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -40,6 +40,21 @@ def test_show_config_marks_placeholders(tmp_path, capsys):
     assert "hermes config set <key> <value>" in out
 
 
+def test_show_config_lists_feishu_platform_status(tmp_path, capsys):
+    env = {
+        "HERMES_HOME": str(tmp_path),
+        "FEISHU_APP_ID": "cli_test_app",
+        "FEISHU_HOME_CHANNEL": "oc_test_home",
+    }
+    with patch.dict(os.environ, env):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "Feishu" in out
+    assert "configured" in out
+    assert "oc_test_home" in out
+
+
 def test_setup_summary_marks_placeholders(tmp_path, capsys):
     with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
         _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)


### PR DESCRIPTION
## What changed and why

`show_config()` (the `hermes config` command) only listed Telegram and Discord. Every other configured platform — including Feishu, Signal, WhatsApp, Slack, Email, SMS, DingTalk, WeCom, Weixin, and BlueBubbles — was silently omitted. This made it impossible to tell from `hermes config` whether Feishu (or any other adapter) was actually set up, which contributed to the confusion in issue #8173 where users couldn't distinguish a startup crash from a misconfiguration.

This PR replaces the two hard-coded print lines in `show_config()` with a platform table driven by each adapter's credential env-var, matching what `show_status()` already displays. If a platform is configured and has a home channel set, the home channel is shown inline.

The `gateway/run.py` missing-import crash (the primary bug in #8173) was already fixed via a prior commit on `main`; this PR addresses only the related visibility gap in `hermes config`.

Per the collaborator's note on 2026-04-28, PR #8178 covered the same hermes_cli/config.py change but had merge conflicts (the gateway/run.py hunk had already landed). This branch carries the still-unmerged improvements forward cleanly.

## How to test

```bash
# Set a Feishu env var and confirm it appears in config output
export FEISHU_APP_ID=cli_test FEISHU_HOME_CHANNEL=oc_testchan
python -c "from hermes_cli.config import show_config; show_config()" | grep Feishu
# Should show: Feishu          configured (home: oc_testchan)

# Run the regression test
pytest tests/hermes_cli/test_placeholder_usage.py -v
```

## What platforms tested on

- macOS (Darwin 24.6.0)
- pytest: 5 tests pass in `tests/hermes_cli/test_placeholder_usage.py` (4 pre-existing + 1 new)

## CI note

The "test" check shows failures in `test_gateway_service.py`, `test_gateway_wsl.py`, and `test_update_gateway_restart.py`. These 11 failures are pre-existing on `main` (verified locally — same failures reproduce on `main` without this branch's changes) and are unrelated to the `hermes_cli/config.py` changes here.

Fixes #8173

<!-- autocontrib:worker-id=issue-followup-125cc1e4 kind=pr-open -->