### PR TITLE
fix(gateway): send /new response before cancel_session_processing to avoid race (#18912)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2489,15 +2489,20 @@ class BasePlatformAdapter(ABC):
 
         try:
             response = await self._message_handler(event)
-            # Old adapter task (if any) is cancelled AFTER the runner has
-            # fully handled the command — keeps ordering deterministic.
-            await self.cancel_session_processing(
-                session_key,
-                release_guard=False,
-                discard_pending=False,
-            )
             _text, _eph_ttl = self._unwrap_ephemeral(response)
+            # Send the response BEFORE cancelling the old task so the send
+            # cannot be affected by task-cancellation side effects (race
+            # condition fix — issue #18912).  Previously the send happened
+            # after cancel_session_processing, which could silently drop the
+            # "/new" confirmation when an agent was actively running.
             if _text:
+                logger.info(
+                    "[%s] Sending command '/%s' response (%d chars) to %s",
+                    self.name,
+                    cmd,
+                    len(_text),
+                    event.source.chat_id,
+                )
                 _r = await self._send_with_retry(
                     chat_id=event.source.chat_id,
                     content=_text,
@@ -2510,6 +2515,13 @@ class BasePlatformAdapter(ABC):
                         message_id=_r.message_id,
                         ttl_seconds=_eph_ttl,
                     )
+            # Old adapter task (if any) is cancelled AFTER the response has
+            # been sent — keeps ordering deterministic and avoids the race.
+            await self.cancel_session_processing(
+                session_key,
+                release_guard=False,
+                discard_pending=False,
+            )
         except Exception:
             # On failure, restore the original guard if one still exists so
             # we don't leave the session in a half-reset state.


### PR DESCRIPTION
## Summary

Fixes #18912

When `/new` is issued via Telegram while an agent is actively processing a message, the session resets correctly but the "✨ Session reset!" confirmation is never sent. The bot shows "typing..." indefinitely with no reply.

## Root Cause

In `_dispatch_active_session_command()` (`gateway/platforms/base.py` line 2491-2512), the response send happens **after** `cancel_session_processing()`:

```python
response = await self._message_handler(event)
await self.cancel_session_processing(...)  # ← cancel first
_text, _eph_ttl = self._unwrap_ephemeral(response)
if _text:
    _r = await self._send_with_retry(...)   # ← send after cancel
```

Task cancellation side effects (the 5-second `asyncio.wait_for(asyncio.shield(task))` in `cancel_session_processing`, plus cleanup by the cancelled task's `finally` blocks) can interfere with the send, silently dropping the confirmation.

In contrast, when no agent is running, the response goes through `_process_message_background()` (which logs "Sending response") and works correctly.

## Fix

1. **Reorder**: Send the response **before** cancelling the old task. This eliminates the race — by the time cancellation runs, the confirmation is already sent.

2. **Add logging**: Added `logger.info("[%s] Sending command '/%s' response (%d chars) to %s", ...)` at the send point, matching the pattern at line 2800 in `_process_message_background`. This makes future send failures visible in logs instead of silently disappearing.

## Testing

Manual reproduction:
1. Send a long-running request to the bot on Telegram
2. While the agent is still processing, type `/new`
3. **Before fix**: Session resets but confirmation never sent (bot shows "typing...")
4. **After fix**: Confirmation "✨ Session reset!" is delivered immediately

## Code Path Comparison

| Path | Agent running? | Dispatch | Response mechanism | Broken? |
|------|----------------|----------|-------------------|---------|
| A | No | `_process_message_background` | Normal send | ✅ Works |
| B | Yes | `_dispatch_active_session_command` | Send after cancel | ❌ Race condition |
| B (fixed) | Yes | `_dispatch_active_session_command` | Send before cancel | ✅ Fixed |
