### PR TITLE
fix(cron): inherit configured provider at run time

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -913,6 +913,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        configured_provider = None
+        configured_base_url = None
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -928,6 +930,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
                         model = _model_cfg.get("default", model)
+                if isinstance(_model_cfg, dict):
+                    configured_provider = _model_cfg.get("provider")
+                    configured_base_url = _model_cfg.get("base_url")
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
@@ -974,11 +979,16 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         from hermes_cli.auth import AuthError
         try:
+            job_provider = job.get("provider")
+            env_provider = os.getenv("HERMES_INFERENCE_PROVIDER")
             runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                "requested": job_provider or env_provider or configured_provider,
             }
-            if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
+            explicit_base_url = job.get("base_url")
+            if explicit_base_url is None and not job_provider and not env_provider:
+                explicit_base_url = configured_base_url
+            if explicit_base_url:
+                runtime_kwargs["explicit_base_url"] = explicit_base_url
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except AuthError as auth_exc:
             # Primary provider auth failed — try fallback chain before giving up.

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -99,7 +99,7 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
-        lambda requested=None: {
+        lambda requested=None, **kwargs: {
             "provider": "openai-codex",
             "api_mode": "codex_responses",
             "base_url": "https://chatgpt.com/backend-api/codex",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -819,6 +819,130 @@ class TestRunJobSessionPersistence:
             ),
         ]
 
+    def test_run_job_uses_configured_model_provider_when_job_provider_unset(self, tmp_path, monkeypatch):
+        job = {
+            "id": "config-provider-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-5.5\n"
+            "  provider: openai-codex\n"
+            "  base_url: https://chatgpt.com/backend-api/codex\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://chatgpt.com/backend-api/codex",
+                     "provider": "openai-codex",
+                     "api_mode": "codex_responses",
+                 },
+             ) as resolve_runtime_provider, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        resolve_runtime_provider.assert_called_once()
+        assert resolve_runtime_provider.call_args.kwargs["requested"] == "openai-codex"
+        assert resolve_runtime_provider.call_args.kwargs["explicit_base_url"] == "https://chatgpt.com/backend-api/codex"
+
+    def test_run_job_env_provider_does_not_inherit_config_base_url(self, tmp_path, monkeypatch):
+        job = {
+            "id": "env-provider-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-5.5\n"
+            "  provider: openai-codex\n"
+            "  base_url: https://chatgpt.com/backend-api/codex\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "anthropic")
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://api.anthropic.com",
+                     "provider": "anthropic",
+                     "api_mode": "anthropic",
+                 },
+             ) as resolve_runtime_provider, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert resolve_runtime_provider.call_args.kwargs["requested"] == "anthropic"
+        assert "explicit_base_url" not in resolve_runtime_provider.call_args.kwargs
+
+    def test_run_job_job_provider_does_not_inherit_config_base_url(self, tmp_path, monkeypatch):
+        job = {
+            "id": "job-provider-job",
+            "name": "test",
+            "prompt": "hello",
+            "provider": "openrouter",
+        }
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-5.5\n"
+            "  provider: openai-codex\n"
+            "  base_url: https://chatgpt.com/backend-api/codex\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://openrouter.ai/api/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ) as resolve_runtime_provider, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert resolve_runtime_provider.call_args.kwargs["requested"] == "openrouter"
+        assert "explicit_base_url" not in resolve_runtime_provider.call_args.kwargs
+
     def test_run_job_passes_enabled_toolsets_to_agent(self, tmp_path):
         job = {
             "id": "toolset-job",


### PR DESCRIPTION
## Summary

Cron jobs now inherit the configured runtime provider from `config.yaml` at execution time when the job itself and `HERMES_INFERENCE_PROVIDER` do not specify a provider.

This complements #13337: that PR handles provider inheritance when cron jobs are created, while this change covers scheduler execution for existing jobs or jobs without persisted provider fields.

## Details

- Read `model.provider` and `model.base_url` from `config.yaml` during `run_job`.
- Preserve precedence: job provider > `HERMES_INFERENCE_PROVIDER` > configured provider.
- Avoid leaking the configured `base_url` when a job-level or environment provider override is active.
- Keep the existing AuthError fallback-provider path intact.

## Validation

- `uv run --extra dev pytest tests/cron/test_scheduler.py tests/cron/test_codex_execution_paths.py -n 0`
- Result: `108 passed`
