### PR TITLE
fix(memory): guard hindsight_client import to prevent gateway crash when package missing

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -503,6 +503,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 return available
             if mode == "local_external":
                 return True
+            # Cloud mode — verify the client package is importable
+            try:
+                importlib.import_module("hindsight_client")
+            except ImportError:
+                logger.warning("hindsight-client not installed — Hindsight memory unavailable")
+                return False
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")
@@ -805,7 +811,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
             else:
-                from hindsight_client import Hindsight
+                try:
+                    from hindsight_client import Hindsight
+                except ImportError:
+                    raise RuntimeError(
+                        "hindsight-client is required for cloud mode. "
+                        "Install it with: pip install hindsight-client"
+                    )
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:


### PR DESCRIPTION
## Fix: Guard hindsight_client import to prevent gateway crash

Closes #18876

### Problem

When `memory.provider` is set to `hindsight` but the `hindsight-client` package is not installed, the Hermes gateway crashes with an unhelpful `ImportError` and enters an infinite Docker restart loop. No error message explains why.

The root cause: `plugins/memory/hindsight/__init__.py` does `from hindsight_client import Hindsight` at line 808 without any fallback. In cloud mode, `is_available()` only checks for config keys (API key/URL) — it doesn't verify the package is importable. So `is_available()` returns `True`, the gateway attempts to use Hindsight memory, and `_get_client()` crashes.

### Fix

Two changes in `plugins/memory/hindsight/__init__.py`:

1. **`is_available()` now checks importability for cloud mode**: Added `importlib.import_module("hindsight_client")` check — returns `False` with a warning log if the package is missing, so the gateway skips Hindsight gracefully.

2. **`_get_client()` wraps the import in try/except**: If `hindsight_client` isn't installed, raises a clear `RuntimeError("hindsight-client is required for cloud mode. Install it with: pip install hindsight-client")` instead of a bare `ImportError`.

### Testing

- Verified that `is_available()` returns `False` when `hindsight_client` is not importable
- Verified that `_get_client()` raises a descriptive `RuntimeError` instead of crashing
- Local mode already had this guard via `_check_local_runtime()`