### PR TITLE
fix(gateway): fallback missing post-stream media

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8346,6 +8346,26 @@ class GatewayRunner:
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
 
+            async def _send_missing_attachment_notice(path: str) -> None:
+                logger.warning(
+                    "[%s] Skipping missing post-stream media attachment: %s",
+                    adapter.name,
+                    path,
+                )
+                display_name = Path(path).name or path
+                try:
+                    await adapter.send(
+                        chat_id=event.source.chat_id,
+                        content=f"Media attachment unavailable: `{display_name}`",
+                        metadata=_thread_meta,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[%s] Failed to send missing post-stream media fallback: %s",
+                        adapter.name,
+                        e,
+                    )
+
             from gateway.platforms.base import should_send_media_as_audio
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
@@ -8356,6 +8376,9 @@ class GatewayRunner:
             image_paths: list = []
             non_image_media: list = []
             for media_path, is_voice in media_files:
+                if not Path(media_path).is_file():
+                    await _send_missing_attachment_notice(media_path)
+                    continue
                 ext = Path(media_path).suffix.lower()
                 if ext in _IMAGE_EXTS and not is_voice:
                     image_paths.append(media_path)
@@ -8364,6 +8387,9 @@ class GatewayRunner:
 
             non_image_local: list = []
             for file_path in local_files:
+                if not Path(file_path).is_file():
+                    await _send_missing_attachment_notice(file_path)
+                    continue
                 if Path(file_path).suffix.lower() in _IMAGE_EXTS:
                     image_paths.append(file_path)
                 else:

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _event():
+    return MessageEvent(
+        text="done",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="dm",
+            thread_id="1777.1",
+        ),
+        message_id="m1",
+    )
+
+
+def _adapter(*, media_files=None, local_files=None):
+    return SimpleNamespace(
+        name="test",
+        extract_media=lambda response: (media_files or [], response),
+        extract_images=lambda response: ([], response),
+        extract_local_files=lambda response: (local_files or [], response),
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
+        send_multiple_images=AsyncMock(
+            return_value=SendResult(success=True, message_id="images")
+        ),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_missing_media_tag_uses_text_fallback_without_file_send():
+    adapter = _adapter(media_files=[("/missing/screenshot.png", False)])
+
+    await GatewayRunner._deliver_media_from_response(
+        object(),
+        "Here is the screenshot MEDIA:/missing/screenshot.png",
+        _event(),
+        adapter,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        chat_id="C123",
+        content="Media attachment unavailable: `screenshot.png`",
+        metadata={"thread_id": "1777.1"},
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_missing_local_file_uses_text_fallback_without_file_send():
+    adapter = _adapter(local_files=["/missing/report.pdf"])
+
+    await GatewayRunner._deliver_media_from_response(
+        object(),
+        "Created /missing/report.pdf",
+        _event(),
+        adapter,
+    )
+
+    adapter.send.assert_awaited_once_with(
+        chat_id="C123",
+        content="Media attachment unavailable: `report.pdf`",
+        metadata={"thread_id": "1777.1"},
+    )
+    adapter.send_document.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -107,8 +107,10 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
 
 
 @pytest.mark.asyncio
-async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sender():
+async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sender(tmp_path):
     event = _event(thread_id="topic-1")
+    media_path = tmp_path / "speech.flac"
+    media_path.write_bytes(b"flac")
     adapter = SimpleNamespace(
         name="test",
         extract_media=BasePlatformAdapter.extract_media,
@@ -122,22 +124,24 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
 
     await GatewayRunner._deliver_media_from_response(
         object(),
-        "MEDIA:/tmp/speech.flac",
+        f"MEDIA:{media_path}",
         event,
         adapter,
     )
 
     adapter.send_document.assert_awaited_once_with(
         chat_id="chat-1",
-        file_path="/tmp/speech.flac",
+        file_path=str(media_path),
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_voice.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_document_sender():
+async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_document_sender(tmp_path):
     event = _event(thread_id="topic-1")
+    media_path = tmp_path / "speech.ogg"
+    media_path.write_bytes(b"ogg")
     adapter = SimpleNamespace(
         name="test",
         extract_media=BasePlatformAdapter.extract_media,
@@ -151,24 +155,26 @@ async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_doc
 
     await GatewayRunner._deliver_media_from_response(
         object(),
-        "MEDIA:/tmp/speech.ogg",
+        f"MEDIA:{media_path}",
         event,
         adapter,
     )
 
     adapter.send_document.assert_awaited_once_with(
         chat_id="chat-1",
-        file_path="/tmp/speech.ogg",
+        file_path=str(media_path),
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_voice.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender():
+async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender(tmp_path):
     """MP3 audio on Telegram must go through send_voice (which routes to
     sendAudio internally); Telegram accepts MP3 for the audio player."""
     event = _event(thread_id="topic-1")
+    media_path = tmp_path / "speech.mp3"
+    media_path.write_bytes(b"mp3")
     adapter = SimpleNamespace(
         name="test",
         extract_media=BasePlatformAdapter.extract_media,
@@ -182,14 +188,14 @@ async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender(
 
     await GatewayRunner._deliver_media_from_response(
         object(),
-        "MEDIA:/tmp/speech.mp3",
+        f"MEDIA:{media_path}",
         event,
         adapter,
     )
 
     adapter.send_voice.assert_awaited_once_with(
         chat_id="chat-1",
-        audio_path="/tmp/speech.mp3",
+        audio_path=str(media_path),
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_document.assert_not_awaited()


### PR DESCRIPTION
## Summary

When a streamed response contains a `MEDIA:` attachment path that no longer exists, the gateway now sends a user-visible text fallback instead of trying to hand the missing file to the platform adapter.

This is intentionally narrow: it does not change streamed reply routing, and it does not replace the media disposition logging work in #5034.

## Details

- Check post-stream `MEDIA:` paths before image batching or file delivery.
- Send a text notice naming the missing file in the original thread.
- Skip native file/image/audio/video senders for missing attachments.
- Update existing TTS media routing tests to create real temporary files, so those tests continue to assert routing rather than missing-file fallback behavior.

## Validation

- `uv run --extra dev pytest tests/gateway/test_post_stream_media_delivery.py tests/gateway/test_tts_media_routing.py tests/gateway/test_send_multiple_images.py -n 0`
- Result: `27 passed`
