### PR TITLE
fix(tui): move /q alias from quit to queue

### DIFF
--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -82,7 +82,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
-    aliases: ['exit', 'q'],
+    aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
     run: (_arg, ctx) => ctx.session.die()
@@ -466,6 +466,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['q'],
     help: 'inspect or enqueue a message',
     name: 'queue',
     run: (arg, ctx) => {


### PR DESCRIPTION
## Summary

This PR fixes the TUI (`hermes --tui`) frontend where the `/q` alias was incorrectly attached to the `quit` command instead of the `queue` command. It is a **single-file, two-line fix** in `ui-tui/src/app/slash/commands/core.ts`.

## Problem

Typing `/q <prompt>` in the TUI immediately exits the application because the `quit` command definition includes `q` in its alias list (`aliases: ['exit', 'q']`). The `queue` command has no aliases, so `q` is not recognized as a shorthand for queue at all.

This contradicts the canonical definition in the central `COMMAND_REGISTRY` (`hermes_cli/commands.py`) and the documentation (`website/docs/reference/slash-commands.md`), both of which list `q` exclusively as an alias for `queue`.

## Changes Made

| File | Before | After |
|---|---|---|
| `ui-tui/src/app/slash/commands/core.ts` (`quit`) | `aliases: ['exit', 'q']` | `aliases: ['exit']` |
| `ui-tui/src/app/slash/commands/core.ts` (`queue`) | *(no aliases)* | `aliases: ['q']` |

No changes are needed in Python, gateway, CLI, or documentation — the central registry and docs are already correct.

## How to Test

1. Start `hermes --tui`
2. Type `/q hello` and press Enter
3. ✅ The session should enqueue the message and stay alive
4. Type `/queue` — it should report the queued message count
5. Type `/quit` or `/exit` — it should exit normally

## Test Results

- **Python tests** (`tests/tui_gateway/test_protocol.py`): 65 passed (including existing `queue` dispatch tests)
- **TUI tests** (`vitest run`):
  - `slashParity.test.ts`: 2 passed
  - `createSlashHandler.test.ts`: 44 passed (slash command registration + routing)
- **TypeScript type-check** (`tsc --noEmit`): ✅ clean

Remaining `vitest` failures (`terminalSetup`, `wheelAccel`, etc.) are pre-existing (missing `hermes-ink` build bundle + SSH short-circuit) and unrelated to this change.

## Scope & Compatibility

- **Only affects** the TUI frontend (`ui-tui/`)
- **Does not change** CLI, gateway, Python backend, or any other surface behavior
- **Non-breaking** — users of `/quit`, `/exit`, `/queue`, and `/q` via non-TUI surfaces already work correctly

## Checklist

- [x] Read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Searched existing PRs — no duplicate found
- [x] PR contains **only** the fix (no unrelated commits)
- [x] Ran `pytest tests/tui_gateway/test_protocol.py` — all passed
- [x] Ran `vitest` for slash-command tests — all passed
- [x] Ran `tsc --noEmit` — clean type check
- [x] Manually tested on Fedora 41: `/q` queues, `/quit` exits
- [x] No documentation or config changes required

## Related Issue

Fixes #18927
