### PR TITLE
feat: add smart model routing

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,209 @@
+"""Conservative per-turn smart model routing.
+
+This module is intentionally pure/small: it decides whether a user turn is
+safe to route to a configured cheaper model and, when requested, resolves the
+runtime for that model through the existing provider-resolution stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Callable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class SmartRouteDecision:
+    """Decision returned by :func:`decide_smart_route`."""
+
+    should_route: bool
+    reason: str
+    model_config: dict[str, Any]
+
+
+_CODE_OR_CONTEXT_MARKERS = (
+    "```",
+    "`",
+    "@file",
+    "@diff",
+    "@code",
+    "@repo",
+    "@image",
+    "@photo",
+    "MEDIA:",
+    "<image",
+    "![",
+)
+
+_WORK_INTENT_PATTERNS = [
+    # English
+    r"\b(debug|fix|repair|implement|code|refactor|test|pytest|mypy|lint|build|deploy|docker|kubernetes|terraform|ssh|git|commit|pull request|pr|review|audit|research|search|browse|scrape|download|upload|install|configure|schedule|cron|database|sql|migration|delete|remove|drop|truncate|send|email|post|publish)\b",
+    # Russian stems/verbs. Keep broad and conservative: false negatives are
+    # cheap; false positives could send real work to a weak model.
+    r"\b(почин\w*|исправ\w*|рефактор\w*|код\w*|тест\w*|запусти\w*|собери\w*|задепло\w*|депло\w*|проверь\w*|найди\w*|исслед\w*|скача\w*|загру\w*|установ\w*|настро\w*|удали\w*|отправ\w*|опубли\w*|коммит\w*|пулл\w*|реквест\w*|аудит\w*)\b",
+]
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _routing_config(config: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    cfg = _as_mapping(config)
+    routing = cfg.get("smart_model_routing")
+    return _as_mapping(routing)
+
+
+def _cheap_model_config(routing: Mapping[str, Any]) -> dict[str, Any]:
+    raw = routing.get("cheap_model") or routing.get("model")
+    if isinstance(raw, str):
+        return {"model": raw}
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    # Also accept flat keys for quick hand-edits:
+    # smart_model_routing: {provider: openai-codex, model: gpt-...}
+    if routing.get("model") or routing.get("provider"):
+        return {
+            "model": routing.get("model") or "",
+            "provider": routing.get("provider") or "",
+            "base_url": routing.get("base_url") or "",
+            "api_key": routing.get("api_key") or "",
+        }
+    return {}
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"[\wА-Яа-яЁё]+", text, flags=re.UNICODE))
+
+
+def _history_has_context(history: Sequence[Mapping[str, Any]] | None) -> bool:
+    if not history:
+        return False
+    return any(bool(_as_mapping(item).get("content")) for item in history)
+
+
+def decide_smart_route(
+    user_message: str,
+    config: Mapping[str, Any] | None,
+    *,
+    history: Sequence[Mapping[str, Any]] | None = None,
+) -> SmartRouteDecision:
+    """Decide whether ``user_message`` may use the cheap route.
+
+    The classifier is deliberately conservative and deterministic.  It routes
+    only short standalone plain-text turns with no obvious need for tools,
+    repository context, current web facts, code edits, or external side effects.
+    """
+
+    routing = _routing_config(config)
+    if not bool(routing.get("enabled", False)):
+        return SmartRouteDecision(False, "disabled", {})
+
+    model_cfg = _cheap_model_config(routing)
+    if not str(model_cfg.get("model") or "").strip():
+        return SmartRouteDecision(False, "missing_cheap_model", {})
+
+    message = str(user_message or "").strip()
+    if not message:
+        return SmartRouteDecision(False, "empty_message", model_cfg)
+
+    require_empty_history = bool(routing.get("require_empty_history", True))
+    if require_empty_history and _history_has_context(history):
+        return SmartRouteDecision(False, "has_history", model_cfg)
+
+    if message.startswith("/"):
+        return SmartRouteDecision(False, "slash_command", model_cfg)
+
+    for marker in _CODE_OR_CONTEXT_MARKERS:
+        if marker.lower() in message.lower():
+            return SmartRouteDecision(False, "context_marker", model_cfg)
+
+    try:
+        max_chars = int(routing.get("max_simple_chars", 400))
+    except (TypeError, ValueError):
+        max_chars = 400
+    try:
+        max_words = int(routing.get("max_simple_words", 80))
+    except (TypeError, ValueError):
+        max_words = 80
+
+    if len(message) > max_chars:
+        return SmartRouteDecision(False, "too_long_chars", model_cfg)
+    if _word_count(message) > max_words:
+        return SmartRouteDecision(False, "too_many_words", model_cfg)
+
+    lowered = message.lower()
+    for pattern in _WORK_INTENT_PATTERNS:
+        if re.search(pattern, lowered, flags=re.IGNORECASE | re.UNICODE):
+            return SmartRouteDecision(False, "work_intent", model_cfg)
+
+    return SmartRouteDecision(True, "simple_turn", model_cfg)
+
+
+def _clean_runtime(runtime: Mapping[str, Any] | None) -> dict[str, Any]:
+    runtime = _as_mapping(runtime)
+    return {
+        "api_key": runtime.get("api_key"),
+        "base_url": runtime.get("base_url"),
+        "provider": runtime.get("provider"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+        "credential_pool": runtime.get("credential_pool"),
+    }
+
+
+def resolve_smart_model_route(
+    *,
+    primary_model: str,
+    primary_runtime: Mapping[str, Any],
+    user_message: str,
+    config: Mapping[str, Any] | None,
+    history: Sequence[Mapping[str, Any]] | None = None,
+    runtime_resolver: Callable[..., Mapping[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Return a cheap turn route or ``None`` when primary route should be used."""
+
+    decision = decide_smart_route(user_message, config, history=history)
+    if not decision.should_route:
+        return None
+
+    cheap_cfg = decision.model_config
+    cheap_model = str(cheap_cfg.get("model") or "").strip()
+    if not cheap_model:
+        return None
+
+    resolver = runtime_resolver
+    if resolver is None:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        resolver = resolve_runtime_provider
+
+    requested = str(cheap_cfg.get("provider") or "").strip() or None
+    explicit_base_url = str(cheap_cfg.get("base_url") or "").strip() or None
+    explicit_api_key = str(cheap_cfg.get("api_key") or "").strip() or None
+
+    try:
+        resolved_runtime = resolver(
+            requested=requested,
+            explicit_base_url=explicit_base_url,
+            explicit_api_key=explicit_api_key,
+            target_model=cheap_model,
+        )
+    except Exception:
+        return None
+
+    runtime = _clean_runtime(resolved_runtime)
+    # Some provider resolvers expose requested_provider/source rather than a
+    # final provider.  Keep the final provider explicit for route signatures.
+    if not runtime.get("provider"):
+        runtime["provider"] = requested or _as_mapping(primary_runtime).get("provider")
+    if runtime.get("base_url") is None and explicit_base_url:
+        runtime["base_url"] = explicit_base_url
+
+    return {
+        "model": cheap_model,
+        "runtime": runtime,
+        "reason": decision.reason,
+        "primary_model": primary_model,
+    }

--- a/cli.py
+++ b/cli.py
@@ -282,6 +282,18 @@ def load_cli_config() -> Dict[str, Any]:
             "base_url": "",
             "provider": "auto",
         },
+        "smart_model_routing": {
+            "enabled": False,
+            "cheap_model": {
+                "provider": "",
+                "model": "",
+                "base_url": "",
+                "api_key": "",
+            },
+            "max_simple_chars": 400,
+            "max_simple_words": 80,
+            "require_empty_history": True,
+        },
         "terminal": {
             "env_type": "local",
             "cwd": ".",  # "." is resolved to os.getcwd() at runtime
@@ -3451,12 +3463,13 @@ class HermesCLI:
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.
 
-        Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
-        Processing / Anthropic fast mode, attach `request_overrides` so the
-        API call is marked accordingly.
+        Uses the session's primary model/provider unless smart model routing is
+        enabled and the current standalone message is safe for the configured
+        cheap model. `/fast` service-tier overrides are then computed against
+        the effective model for this turn.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from agent.smart_model_routing import resolve_smart_model_route
 
         runtime = {
             "api_key": self.api_key,
@@ -3467,17 +3480,39 @@ class HermesCLI:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        effective_model = self.model
+        effective_runtime = runtime
+        route_reason = "primary"
+
+        smart_route = None
+        # A CLI --model argument is an explicit session pin; keep it on the
+        # selected model.  Otherwise allow the deterministic router to choose a
+        # cheap model for simple standalone turns.
+        if getattr(self, "_model_is_default", True):
+            smart_route = resolve_smart_model_route(
+                primary_model=self.model,
+                primary_runtime=runtime,
+                user_message=user_message,
+                history=getattr(self, "conversation_history", None),
+                config=CLI_CONFIG,
+            )
+        if smart_route:
+            effective_model = smart_route["model"]
+            effective_runtime = smart_route["runtime"]
+            route_reason = f"smart:{smart_route.get('reason') or 'simple_turn'}"
+
         route = {
-            "model": self.model,
-            "runtime": runtime,
+            "model": effective_model,
+            "runtime": effective_runtime,
             "signature": (
-                self.model,
-                runtime["provider"],
-                runtime["base_url"],
-                runtime["api_mode"],
-                runtime["command"],
-                tuple(runtime["args"]),
+                effective_model,
+                effective_runtime["provider"],
+                effective_runtime["base_url"],
+                effective_runtime["api_mode"],
+                effective_runtime["command"],
+                tuple(effective_runtime["args"]),
             ),
+            "route_reason": route_reason,
         }
 
         service_tier = getattr(self, "service_tier", None)

--- a/docs/plans/2026-05-02-smart-model-routing.md
+++ b/docs/plans/2026-05-02-smart-model-routing.md
@@ -1,0 +1,47 @@
+# Smart model routing for simple turns
+
+## Goal
+
+Route obviously simple, low-risk user turns to a configured cheap model while preserving the existing primary model for coding, tool-heavy, contextual, multimodal, and long-running work.
+
+## Architecture
+
+- Add a small shared routing module under `agent/` with pure functions:
+  - classify whether a user message is safe to route cheaply;
+  - build an alternate route from `smart_model_routing.cheap_model`;
+  - resolve provider credentials through `hermes_cli.runtime_provider.resolve_runtime_provider`.
+- Call the helper from both CLI and gateway `_resolve_turn_agent_config()` so Telegram/Discord/etc. and terminal behavior match.
+- Keep `/fast` service-tier request overrides independent from model routing.
+- Keep the agent cache safe by including the routed model/provider/base_url/api_mode in the existing route signatures.
+
+## Initial policy
+
+Route to cheap model only when all are true:
+
+- `smart_model_routing.enabled` is true;
+- a cheap model is configured;
+- current turn is plain text;
+- no prior conversation history unless explicitly disabled via config;
+- message is short (`max_simple_chars`, `max_simple_words`);
+- message is not a slash command, not an `@file`/`@diff` context reference, not a code block, not an image/media indicator;
+- message does not contain obvious coding/deploy/research/tooling verbs or dangerous-operation terms.
+
+## Non-goals
+
+- No LLM classifier in the first slice: it would spend tokens to save tokens.
+- No mid-agent switching after tool results.
+- No routing for cron/API-server/Feishu-comment special paths in this first slice unless they already share gateway `_resolve_turn_agent_config()`.
+
+## Tasks
+
+1. Add RED tests for classification and cheap route resolution.
+2. Add helper implementation.
+3. Wire CLI and gateway wrappers, passing history where available.
+4. Document config keys.
+5. Validate targeted tests and a lightweight integration smoke.
+
+## Validation
+
+- `python -m pytest tests/agent/test_smart_model_routing.py -q`
+- targeted CLI/gateway tests if added
+- `python -m pytest tests/hermes_cli/test_config_validation.py tests/gateway/test_session_model_override_routing.py -q` when routing code touches those paths

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27,7 +27,7 @@ import tempfile
 import threading
 import time
 from collections import OrderedDict
-from contextvars import copy_context
+from contextvars import copy_context, ContextVar
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List, Union
@@ -541,6 +541,10 @@ from gateway.whatsapp_identity import (
 
 
 logger = logging.getLogger(__name__)
+_SMART_MODEL_ROUTE_CONTEXT: ContextVar[dict | None] = ContextVar(
+    "smart_model_route_context",
+    default=None,
+)
 
 
 # Sentinel placed into _running_agents immediately when a session starts
@@ -1485,15 +1489,25 @@ class GatewayRunner:
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        *,
+        history: Optional[list[dict]] = None,
+        user_config: Optional[dict] = None,
+        allow_smart_model_routing: bool = True,
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
-        Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        Uses the session's primary model/provider unless smart model routing is
+        enabled and the current standalone message is safe for the configured
+        cheap model. `/fast` request overrides are computed against the
+        effective model for this turn.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from agent.smart_model_routing import resolve_smart_model_route
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -1504,17 +1518,50 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
+        effective_model = model
+        effective_runtime = runtime
+        route_reason = "primary"
+
+        route_context = _SMART_MODEL_ROUTE_CONTEXT.get() or getattr(
+            self,
+            "_smart_model_route_context",
+            {},
+        ) or {}
+        if history is None:
+            history = route_context.get("history")
+        if user_config is None:
+            user_config = route_context.get("user_config")
+        if route_context.get("disable"):
+            allow_smart_model_routing = False
+
+        if allow_smart_model_routing:
+            try:
+                smart_route = resolve_smart_model_route(
+                    primary_model=model,
+                    primary_runtime=runtime,
+                    user_message=user_message,
+                    history=history,
+                    config=user_config if user_config is not None else _load_gateway_config(),
+                )
+            except Exception:
+                smart_route = None
+            if smart_route:
+                effective_model = smart_route["model"]
+                effective_runtime = smart_route["runtime"]
+                route_reason = f"smart:{smart_route.get('reason') or 'simple_turn'}"
+
         route = {
-            "model": model,
-            "runtime": runtime,
+            "model": effective_model,
+            "runtime": effective_runtime,
             "signature": (
-                model,
-                runtime["provider"],
-                runtime["base_url"],
-                runtime["api_mode"],
-                runtime["command"],
-                tuple(runtime["args"]),
+                effective_model,
+                effective_runtime["provider"],
+                effective_runtime["base_url"],
+                effective_runtime["api_mode"],
+                effective_runtime["command"],
+                tuple(effective_runtime["args"]),
             ),
+            "route_reason": route_reason,
         }
 
         service_tier = getattr(self, "_service_tier", None)
@@ -8552,7 +8599,21 @@ class GatewayRunner:
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            try:
+                _bg_session_key = self._session_key_for_source(source)
+            except Exception:
+                _bg_session_key = None
+            _smart_context_token = _SMART_MODEL_ROUTE_CONTEXT.set({
+                "history": [],
+                "user_config": user_config,
+                "disable": bool(
+                    _bg_session_key and self._session_model_overrides.get(_bg_session_key)
+                ),
+            })
+            try:
+                turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            finally:
+                _SMART_MODEL_ROUTE_CONTEXT.reset(_smart_context_token)
 
             def run_sync():
                 agent = AIAgent(
@@ -12368,7 +12429,17 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            _smart_context_token = _SMART_MODEL_ROUTE_CONTEXT.set({
+                "history": history,
+                "user_config": user_config,
+                "disable": bool(
+                    session_key and self._session_model_overrides.get(session_key)
+                ),
+            })
+            try:
+                turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            finally:
+                _SMART_MODEL_ROUTE_CONTEXT.reset(_smart_context_token)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -387,6 +387,18 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "smart_model_routing": {
+        "enabled": False,
+        "cheap_model": {
+            "provider": "",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+        },
+        "max_simple_chars": 400,
+        "max_simple_words": 80,
+        "require_empty_history": True,
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     "agent": {

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from agent.smart_model_routing import (
+    decide_smart_route,
+    resolve_smart_model_route,
+)
+
+
+BASE_CONFIG = {
+    "smart_model_routing": {
+        "enabled": True,
+        "max_simple_chars": 80,
+        "max_simple_words": 12,
+        "cheap_model": {
+            "provider": "openai-codex",
+            "model": "gpt-5.3-codex-spark",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    }
+}
+
+
+PRIMARY_RUNTIME = {
+    "api_key": "primary-key",
+    "base_url": "https://chatgpt.com/backend-api/codex",
+    "provider": "openai-codex",
+    "api_mode": "codex_responses",
+    "command": None,
+    "args": [],
+    "credential_pool": object(),
+}
+
+
+def test_decision_routes_short_plain_standalone_turn():
+    decision = decide_smart_route("сколько будет 2+2?", BASE_CONFIG, history=[])
+
+    assert decision.should_route is True
+    assert decision.model_config["model"] == "gpt-5.3-codex-spark"
+    assert decision.reason == "simple_turn"
+
+
+def test_decision_blocks_contextual_turns_by_default():
+    history = [{"role": "user", "content": "работаем над PR"}]
+
+    decision = decide_smart_route("ок", BASE_CONFIG, history=history)
+
+    assert decision.should_route is False
+    assert decision.reason == "has_history"
+
+
+def test_decision_allows_contextual_turns_when_configured():
+    cfg = {
+        **BASE_CONFIG,
+        "smart_model_routing": {
+            **BASE_CONFIG["smart_model_routing"],
+            "require_empty_history": False,
+        },
+    }
+
+    decision = decide_smart_route("ок", cfg, history=[{"role": "user", "content": "hi"}])
+
+    assert decision.should_route is True
+
+
+def test_decision_blocks_tool_or_work_intent_markers():
+    blocked_messages = [
+        "/status",
+        "посмотри @file:cli.py",
+        "```python\nprint(1)\n```",
+        "задеплой сервис",
+        "почини тесты",
+        "найди свежие новости",
+        "удали файл",
+    ]
+
+    for message in blocked_messages:
+        decision = decide_smart_route(message, BASE_CONFIG, history=[])
+        assert decision.should_route is False, message
+
+
+def test_decision_blocks_long_messages():
+    message = "это уже не короткий запрос " * 20
+
+    decision = decide_smart_route(message, BASE_CONFIG, history=[])
+
+    assert decision.should_route is False
+    assert decision.reason in {"too_long_chars", "too_many_words"}
+
+
+def test_resolve_smart_model_route_uses_configured_runtime():
+    calls = []
+
+    def fake_resolver(**kwargs):
+        calls.append(kwargs)
+        return {
+            "api_key": "cheap-key",
+            "base_url": kwargs.get("explicit_base_url"),
+            "provider": kwargs.get("requested"),
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": [],
+        }
+
+    route = resolve_smart_model_route(
+        primary_model="gpt-5.5",
+        primary_runtime=PRIMARY_RUNTIME,
+        user_message="ок",
+        history=[],
+        config=BASE_CONFIG,
+        runtime_resolver=fake_resolver,
+    )
+
+    assert route is not None
+    assert route["model"] == "gpt-5.3-codex-spark"
+    assert route["runtime"] == {
+        "api_key": "cheap-key",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+    assert route["reason"] == "simple_turn"
+    assert calls == [
+        {
+            "requested": "openai-codex",
+            "explicit_base_url": "https://chatgpt.com/backend-api/codex",
+            "explicit_api_key": None,
+            "target_model": "gpt-5.3-codex-spark",
+        }
+    ]
+
+
+def test_resolve_smart_model_route_returns_none_when_disabled_or_unresolved():
+    disabled = {
+        **BASE_CONFIG,
+        "smart_model_routing": {
+            **BASE_CONFIG["smart_model_routing"],
+            "enabled": False,
+        },
+    }
+
+    assert resolve_smart_model_route(
+        primary_model="gpt-5.5",
+        primary_runtime=PRIMARY_RUNTIME,
+        user_message="ок",
+        history=[],
+        config=disabled,
+        runtime_resolver=lambda **_: PRIMARY_RUNTIME,
+    ) is None
+
+    assert resolve_smart_model_route(
+        primary_model="gpt-5.5",
+        primary_runtime=PRIMARY_RUNTIME,
+        user_message="ок",
+        history=[],
+        config=BASE_CONFIG,
+        runtime_resolver=lambda **_: (_ for _ in ()).throw(RuntimeError("auth")),
+    ) is None

--- a/tests/agent/test_smart_model_routing_wiring.py
+++ b/tests/agent/test_smart_model_routing_wiring.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _runtime(provider="primary"):
+    return {
+        "api_key": f"{provider}-key",
+        "base_url": f"https://{provider}.example/v1",
+        "provider": provider,
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+
+def test_cli_turn_config_uses_smart_route_for_default_model(monkeypatch):
+    import cli
+    from cli import HermesCLI
+
+    calls = []
+
+    def fake_route(**kwargs):
+        calls.append(kwargs)
+        return {
+            "model": "cheap-model",
+            "runtime": _runtime("cheap"),
+            "reason": "simple_turn",
+        }
+
+    monkeypatch.setattr("agent.smart_model_routing.resolve_smart_model_route", fake_route)
+    monkeypatch.setattr(cli, "CLI_CONFIG", {"smart_model_routing": {"enabled": True}})
+
+    shell = SimpleNamespace(
+        api_key="primary-key",
+        base_url="https://primary.example/v1",
+        provider="primary",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        model="primary-model",
+        _model_is_default=True,
+        conversation_history=[],
+        service_tier=None,
+    )
+
+    route = HermesCLI._resolve_turn_agent_config(shell, "ок")
+
+    assert route["model"] == "cheap-model"
+    assert route["runtime"]["provider"] == "cheap"
+    assert route["signature"][:4] == (
+        "cheap-model",
+        "cheap",
+        "https://cheap.example/v1",
+        "codex_responses",
+    )
+    assert route["route_reason"] == "smart:simple_turn"
+    assert calls[0]["history"] == []
+
+
+def test_cli_turn_config_preserves_explicit_model_pin(monkeypatch):
+    from cli import HermesCLI
+
+    def fake_route(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("smart routing must not run for explicit model pins")
+
+    monkeypatch.setattr("agent.smart_model_routing.resolve_smart_model_route", fake_route)
+
+    shell = SimpleNamespace(
+        api_key="primary-key",
+        base_url="https://primary.example/v1",
+        provider="primary",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        model="pinned-model",
+        _model_is_default=False,
+        conversation_history=[],
+        service_tier=None,
+    )
+
+    route = HermesCLI._resolve_turn_agent_config(shell, "ок")
+
+    assert route["model"] == "pinned-model"
+    assert route["route_reason"] == "primary"
+
+
+def test_gateway_turn_config_uses_route_context(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    calls = []
+
+    def fake_route(**kwargs):
+        calls.append(kwargs)
+        return {
+            "model": "cheap-model",
+            "runtime": _runtime("cheap"),
+            "reason": "simple_turn",
+        }
+
+    monkeypatch.setattr("agent.smart_model_routing.resolve_smart_model_route", fake_route)
+
+    runner = SimpleNamespace(
+        _service_tier=None,
+        _smart_model_route_context={
+            "history": [],
+            "user_config": {"smart_model_routing": {"enabled": True}},
+            "disable": False,
+        },
+    )
+
+    route = GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "ок",
+        "primary-model",
+        _runtime("primary"),
+    )
+
+    assert route["model"] == "cheap-model"
+    assert route["runtime"]["provider"] == "cheap"
+    assert route["route_reason"] == "smart:simple_turn"
+    assert calls[0]["history"] == []
+    assert calls[0]["config"] == {"smart_model_routing": {"enabled": True}}
+
+
+def test_gateway_turn_config_preserves_session_override_context(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    def fake_route(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("smart routing must not run when disabled by session override")
+
+    monkeypatch.setattr("agent.smart_model_routing.resolve_smart_model_route", fake_route)
+
+    runner = SimpleNamespace(
+        _service_tier=None,
+        _smart_model_route_context={"disable": True},
+    )
+
+    route = GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "ок",
+        "session-model",
+        _runtime("session-provider"),
+    )
+
+    assert route["model"] == "session-model"
+    assert route["runtime"]["provider"] == "session-provider"
+    assert route["route_reason"] == "primary"

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -118,6 +118,22 @@ auxiliary:
 
 `provider: auto` with `model: ''` tells Hermes to use the main model for that task.
 
+**Smart model routing (optional):**
+```yaml
+smart_model_routing:
+  enabled: true
+  cheap_model:
+    provider: openai-codex
+    model: gpt-5.3-codex-spark
+    base_url: https://chatgpt.com/backend-api/codex
+    api_key: ''        # optional; usually leave blank and use provider auth
+  max_simple_chars: 400
+  max_simple_words: 80
+  require_empty_history: true
+```
+
+When enabled, Hermes keeps your main model as the default but routes very short standalone plain-text turns to `cheap_model`. It deliberately refuses slash commands, code blocks, file/context references, long prompts, messages with prior chat history, and obvious coding/deploy/search/delete/send/publish work. `/model` session overrides and explicit CLI `--model` pins stay on the selected model.
+
 ## When does it take effect?
 
 - **CLI** (`hermes chat`): next `hermes chat` invocation.


### PR DESCRIPTION
## Summary

- Add deterministic `smart_model_routing` support for short standalone turns.
- Route eligible simple turns to a configured cheap model while preserving primary model/runtime for normal work.
- Wire the router into CLI and gateway turn config, including cache-safe route signatures and `/fast` request override compatibility.
- Document the config schema and add focused tests.

## Behavior

Smart routing is off by default. When enabled, Hermes only routes to the cheap model when the current turn is plain text, short, standalone, and lacks obvious command/code/tool/work markers. It refuses slash commands, code blocks, file/context references, long messages, contextual history by default, and coding/deploy/search/delete/send/publish-style tasks.

Explicit CLI `--model` pins and gateway session `/model` overrides stay on the selected model.

## Test Plan

- [x] `python -m pytest tests/agent/test_smart_model_routing.py tests/agent/test_smart_model_routing_wiring.py tests/cron/test_codex_execution_paths.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_drift.py -q`
- [x] `python -m py_compile agent/smart_model_routing.py cli.py gateway/run.py hermes_cli/config.py`

## Config example

```yaml
smart_model_routing:
  enabled: true
  cheap_model:
    provider: openai-codex
    model: gpt-5.3-codex-spark
    base_url: https://chatgpt.com/backend-api/codex
    api_key: ''
  max_simple_chars: 400
  max_simple_words: 80
  require_empty_history: true
```
