### PR TITLE
fix(auth): allow profile credential pools to read base entries

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -42,7 +42,7 @@ import httpx
 import yaml
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_constants import OPENROUTER_BASE_URL, get_default_hermes_root
 from utils import atomic_replace, atomic_yaml_write, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -931,6 +931,30 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
+def _credential_pool_share_base_enabled() -> bool:
+    try:
+        config = read_raw_config()
+    except Exception:
+        return False
+    agent_cfg = config.get("agent") if isinstance(config, dict) else None
+    if not isinstance(agent_cfg, dict):
+        return False
+    return is_truthy_value(agent_cfg.get("credential_pool_share_base"))
+
+
+def _load_base_auth_store_for_pool_fallback() -> Optional[Dict[str, Any]]:
+    if not _credential_pool_share_base_enabled():
+        return None
+    try:
+        active_auth_path = _auth_file_path().resolve(strict=False)
+        base_auth_path = (get_default_hermes_root() / "auth.json").resolve(strict=False)
+    except Exception:
+        return None
+    if active_auth_path == base_auth_path:
+        return None
+    return _load_auth_store(base_auth_path)
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice."""
     auth_store = _load_auth_store()
@@ -940,7 +964,17 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     if provider_id is None:
         return dict(pool)
     provider_entries = pool.get(provider_id)
-    return list(provider_entries) if isinstance(provider_entries, list) else []
+    if isinstance(provider_entries, list) and provider_entries:
+        return list(provider_entries)
+
+    fallback_store = _load_base_auth_store_for_pool_fallback()
+    if fallback_store is not None:
+        fallback_pool = fallback_store.get("credential_pool")
+        if isinstance(fallback_pool, dict):
+            fallback_entries = fallback_pool.get(provider_id)
+            if isinstance(fallback_entries, list):
+                return list(fallback_entries)
+    return []
 
 
 def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Path:

--- a/tests/hermes_cli/test_credential_pool_base_fallback.py
+++ b/tests/hermes_cli/test_credential_pool_base_fallback.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _base_and_profile(tmp_path: Path) -> tuple[Path, Path]:
+    base_home = tmp_path / "hermes"
+    profile_home = base_home / "profiles" / "webui"
+    profile_home.mkdir(parents=True)
+    return base_home, profile_home
+
+
+def _auth_store(cred_id: str, token: str = "sk-or-test") -> dict:
+    label = cred_id.split("-", 1)[0]
+    return {
+        "version": 1,
+        "credential_pool": {
+            "openrouter": [
+                {
+                    "id": cred_id,
+                    "label": label,
+                    "source": "manual",
+                    "auth_type": "api_key",
+                    "access_token": token,
+                    "priority": 0,
+                }
+            ]
+        },
+    }
+
+
+def _empty_profile_store() -> dict:
+    return {"version": 1, "credential_pool": {"openrouter": []}}
+
+
+def _enable_base_sharing(profile_home: Path) -> None:
+    (profile_home / "config.yaml").write_text(
+        "agent:\n  credential_pool_share_base: true\n",
+        encoding="utf-8",
+    )
+
+
+def test_read_credential_pool_falls_back_to_base_profile_when_enabled(
+    tmp_path,
+    monkeypatch,
+):
+    base_home, profile_home = _base_and_profile(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_json(base_home / "auth.json", _auth_store("base-cred", "sk-or-base"))
+    _write_json(profile_home / "auth.json", _empty_profile_store())
+    _enable_base_sharing(profile_home)
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("openrouter")
+
+    assert [entry["id"] for entry in entries] == ["base-cred"]
+    profile_store = json.loads((profile_home / "auth.json").read_text(encoding="utf-8"))
+    assert profile_store["credential_pool"]["openrouter"] == []
+
+
+def test_read_credential_pool_does_not_fallback_without_flag(tmp_path, monkeypatch):
+    base_home, profile_home = _base_and_profile(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_json(base_home / "auth.json", _auth_store("base-cred", "sk-or-base"))
+    _write_json(profile_home / "auth.json", _empty_profile_store())
+
+    from hermes_cli.auth import read_credential_pool
+
+    assert read_credential_pool("openrouter") == []
+
+
+def test_read_credential_pool_prefers_profile_entries_when_enabled(
+    tmp_path,
+    monkeypatch,
+):
+    base_home, profile_home = _base_and_profile(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_json(base_home / "auth.json", _auth_store("base-cred", "sk-or-base"))
+    _write_json(
+        profile_home / "auth.json",
+        _auth_store("profile-cred", "sk-or-profile"),
+    )
+    _enable_base_sharing(profile_home)
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("openrouter")
+
+    assert [entry["id"] for entry in entries] == ["profile-cred"]
+
+
+def test_load_pool_uses_base_entries_without_copying_to_profile(tmp_path, monkeypatch):
+    base_home, profile_home = _base_and_profile(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    _write_json(base_home / "auth.json", _auth_store("base-cred", "sk-or-base"))
+    _write_json(profile_home / "auth.json", _empty_profile_store())
+    _enable_base_sharing(profile_home)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.id == "base-cred"
+    profile_store = json.loads((profile_home / "auth.json").read_text(encoding="utf-8"))
+    assert profile_store["credential_pool"]["openrouter"] == []


### PR DESCRIPTION
﻿## Summary
- add an opt-in `agent.credential_pool_share_base` gate for profile-scoped credential pools
- when a profile has no entries for a provider, read the base Hermes auth store for that provider without copying entries into the profile store
- keep profile-local entries authoritative when present

## Context
This implements pickup option A from https://github.com/nesquena/hermes-webui/issues/1452. In WebUI/profile mode, terminal-authenticated credentials can live in the base `~/.hermes/auth.json` while the WebUI runs under `~/.hermes/profiles/<name>/auth.json`, making the pool appear empty even though the base profile is authenticated.

## Tests
- `python -m pytest tests\\hermes_cli\\test_credential_pool_base_fallback.py -q -o addopts=""`
- `python -m pytest tests\\agent\\test_credential_pool.py -q -o addopts=""`

Note: this environment does not have `pytest-xdist`, so I disabled the repo default `-n auto` addopt for the targeted runs.
