### PR TITLE
feat(cli): launch background agents while busy

### DIFF
--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -51,6 +51,13 @@ def busy_input_hint_gateway(mode: str) -> str:
             "Send `/busy interrupt` or `/busy queue` to change this, or "
             "`/busy status` to check. This notice won't appear again."
         )
+    if mode == "background":
+        return (
+            "💡 First-time tip — I started your message in a separate background agent "
+            "instead of interrupting the current task. Send `/busy queue` to process "
+            "follow-ups in the same session later, `/busy steer` to inject context "
+            "mid-run, or `/busy status` to check. This notice won't appear again."
+        )
     return (
         "💡 First-time tip — I just interrupted my current task to answer you. "
         "Send `/busy queue` to queue follow-ups for after the current task instead, "
@@ -72,6 +79,12 @@ def busy_input_hint_cli(mode: str) -> str:
             "(tip) Your message was steered into the current run; it arrives "
             "after the next tool call. Use /busy interrupt or /busy queue to "
             "change this. This tip only shows once."
+        )
+    if mode == "background":
+        return (
+            "(tip) Your message started in a separate background agent. "
+            "Use /busy queue for same-session next-turn handling, or /busy steer "
+            "to inject mid-run. This tip only shows once."
         )
     return (
         "(tip) Your message interrupted the current run. "

--- a/cli.py
+++ b/cli.py
@@ -4527,6 +4527,20 @@ class HermesCLI:
         provider = getattr(self, "provider", None) or "unknown"
         model = getattr(self, "model", None) or "(unknown)"
         is_running = bool(getattr(self, "_agent_running", False))
+        busy_mode = getattr(self, "busy_input_mode", "interrupt")
+        try:
+            queued_inputs = int(getattr(getattr(self, "_pending_input", None), "qsize", lambda: 0)())
+        except Exception:
+            queued_inputs = 0
+        try:
+            from tools.process_registry import process_registry
+
+            processes = process_registry.list_sessions()
+            running_processes = sum(1 for p in processes if p.get("status") == "running")
+            finished_processes = sum(1 for p in processes if p.get("status") != "running")
+        except Exception:
+            running_processes = 0
+            finished_processes = 0
 
         lines = [
             "Hermes CLI Status",
@@ -4542,6 +4556,9 @@ class HermesCLI:
             f"Last Activity: {updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"Tokens: {total_tokens:,}",
             f"Agent Running: {'Yes' if is_running else 'No'}",
+            f"Busy Input Mode: {busy_mode}",
+            f"Queued Inputs: {queued_inputs}",
+            f"Background Processes: {running_processes} running, {finished_processes} recent",
         ])
         self._console_print("\n".join(lines), highlight=False, markup=False)
     

--- a/cli.py
+++ b/cli.py
@@ -2017,13 +2017,16 @@ class HermesCLI:
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         # busy_input_mode: "interrupt" (Enter interrupts current run),
-        # "queue" (Enter queues for next turn), or "steer" (Enter injects
-        # mid-run via /steer, arriving after the next tool call).
+        # "queue" (Enter queues for next turn), "steer" (Enter injects
+        # mid-run via /steer, arriving after the next tool call), or
+        # "background" (Enter starts a separate background agent).
         _bim = str(CLI_CONFIG["display"].get("busy_input_mode", "interrupt")).strip().lower()
         if _bim == "queue":
             self.busy_input_mode = "queue"
         elif _bim == "steer":
             self.busy_input_mode = "steer"
+        elif _bim == "background":
+            self.busy_input_mode = "background"
         else:
             self.busy_input_mode = "interrupt"
 
@@ -7418,6 +7421,7 @@ class HermesCLI:
             /busy status        Show current busy input mode
             /busy queue         Queue input for the next turn instead of interrupting
             /busy steer         Inject Enter mid-run via /steer (after next tool call)
+            /busy background    Start a separate background agent on Enter
             /busy interrupt     Interrupt the current run on Enter (default)
         """
         parts = cmd.strip().split(maxsplit=1)
@@ -7427,16 +7431,18 @@ class HermesCLI:
                 _behavior = "queues for next turn"
             elif self.busy_input_mode == "steer":
                 _behavior = "steers into current run (after next tool call)"
+            elif self.busy_input_mode == "background":
+                _behavior = "starts a separate background agent"
             else:
                 _behavior = "interrupts current run"
             _cprint(f"  {_DIM}Enter while busy: {_behavior}{_RST}")
-            _cprint(f"  {_DIM}Usage: /busy [queue|steer|interrupt|status]{_RST}")
+            _cprint(f"  {_DIM}Usage: /busy [queue|steer|background|interrupt|status]{_RST}")
             return
 
         arg = parts[1].strip().lower()
-        if arg not in {"queue", "interrupt", "steer"}:
+        if arg not in {"queue", "interrupt", "steer", "background"}:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Usage: /busy [queue|steer|interrupt|status]{_RST}")
+            _cprint(f"  {_DIM}Usage: /busy [queue|steer|background|interrupt|status]{_RST}")
             return
 
         self.busy_input_mode = arg
@@ -7445,6 +7451,8 @@ class HermesCLI:
                 behavior = "Enter will queue follow-up input while Hermes is busy."
             elif arg == "steer":
                 behavior = "Enter will steer your message into the current run (after the next tool call)."
+            elif arg == "background":
+                behavior = "Enter will launch follow-up input in a separate background agent while the current run continues."
             else:
                 behavior = "Enter will interrupt the current run while Hermes is busy."
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (saved to config){_RST}")
@@ -10126,6 +10134,13 @@ class HermesCLI:
                         self._pending_input.put(payload)
                         preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
                         _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
+                    elif _effective_mode == "background":
+                        if images or not text:
+                            self._pending_input.put(payload)
+                            preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
+                            _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
+                        else:
+                            self._handle_background_command(f"/background {text}")
                     elif _effective_mode == "interrupt":
                         self._interrupt_queue.put(payload)
                         # Debug: log to file when message enters interrupt queue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1922,6 +1922,8 @@ class GatewayRunner:
             return "queue"
         if mode == "steer":
             return "steer"
+        if mode == "background":
+            return "background"
         return "interrupt"
 
     @staticmethod
@@ -2102,15 +2104,33 @@ class GatewayRunner:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
 
+        background_task_id = None
+        if effective_mode == "background":
+            background_prompt = (event.text or "").strip()
+            if background_prompt:
+                background_task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+                _task = asyncio.create_task(
+                    self._run_background_task(background_prompt, event.source, background_task_id)
+                )
+                self._background_tasks.add(_task)
+                _task.add_done_callback(self._background_tasks.discard)
+            else:
+                # Attachments or empty follow-ups cannot be represented as a
+                # standalone background prompt yet; preserve them for the next
+                # foreground turn instead of dropping them.
+                effective_mode = "queue"
+
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
         # successful steer — the text already landed inside the run and
-        # must NOT also be replayed as a next-turn user message.
-        if not steered:
+        # must NOT also be replayed as a next-turn user message.  Also skip
+        # for background mode: a separate agent owns that prompt now.
+        if not steered and effective_mode != "background":
             merge_pending_message_event(adapter._pending_messages, session_key, event)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
+        is_background_mode = effective_mode == "background"
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
@@ -2165,6 +2185,12 @@ class GatewayRunner:
                 f"⏩ Steered into current run{status_detail}. "
                 f"Your message arrives after the next tool call."
             )
+        elif is_background_mode:
+            task_detail = f" Task ID: {background_task_id}." if background_task_id else ""
+            message = (
+                f"🔄 Started a separate background agent{status_detail}.{task_detail} "
+                f"I'll keep the current task running and send the background result here when it finishes."
+            )
         elif is_queue_mode:
             message = (
                 f"⏳ Queued for the next turn{status_detail}. "
@@ -2191,6 +2217,8 @@ class GatewayRunner:
             if not is_seen(_user_cfg, BUSY_INPUT_FLAG):
                 if is_steer_mode:
                     _hint_mode = "steer"
+                elif is_background_mode:
+                    _hint_mode = "background"
                 elif is_queue_mode:
                     _hint_mode = "queue"
                 else:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -141,8 +141,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
-               cli_only=True, args_hint="[queue|steer|interrupt|status]",
-               subcommands=("queue", "steer", "interrupt", "status")),
+               cli_only=True, args_hint="[queue|steer|background|interrupt|status]",
+               subcommands=("queue", "steer", "background", "interrupt", "status")),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -756,7 +756,7 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "interrupt",  # interrupt | queue | steer | background
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.
         # Mirrors `hermes -c` muscle memory.  Default off so existing

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -293,7 +293,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.busy_input_mode": {
         "type": "select",
         "description": "Input behavior while agent is running",
-        "options": ["interrupt", "queue", "steer"],
+        "options": ["interrupt", "queue", "steer", "background"],
     },
     "memory.provider": {
         "type": "select",

--- a/tests/cli/test_busy_input_mode_command.py
+++ b/tests/cli/test_busy_input_mode_command.py
@@ -94,6 +94,20 @@ class TestHandleBusyCommand(unittest.TestCase):
         # The usage line should also advertise the steer option
         self.assertIn("steer", printed)
 
+    def test_background_argument_sets_background_mode_and_saves(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("interrupt")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_busy_command(stub, "/busy background")
+
+        self.assertEqual(stub.busy_input_mode, "background")
+        mock_save.assert_called_once_with("display.busy_input_mode", "background")
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("background", printed.lower())
+
     def test_invalid_argument_prints_usage(self):
         cli_mod = _import_cli()
         stub = self._make_cli()
@@ -119,5 +133,5 @@ class TestBusyCommandRegistry(unittest.TestCase):
         from hermes_cli.commands import COMMAND_REGISTRY
 
         busy = next(c for c in COMMAND_REGISTRY if c.name == "busy")
-        assert busy.args_hint == "[queue|steer|interrupt|status]"
+        assert busy.args_hint == "[queue|steer|background|interrupt|status]"
         assert busy.category == "Configuration"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -105,6 +105,10 @@ class TestBusyInputMode:
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
         assert cli.busy_input_mode == "queue"
 
+    def test_busy_input_mode_background_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "background"}})
+        assert cli.busy_input_mode == "background"
+
     def test_unknown_busy_input_mode_falls_back_to_interrupt(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "bogus"}})
         assert cli.busy_input_mode == "interrupt"

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -16,6 +16,8 @@ def _make_cli():
     cli_obj.conversation_history = []
     cli_obj.session_id = "session-123"
     cli_obj._pending_input = MagicMock()
+    cli_obj._pending_input.qsize.return_value = 2
+    cli_obj.busy_input_mode = "background"
     cli_obj._status_bar_visible = True
     cli_obj.model = "openai/gpt-5.4"
     cli_obj.provider = "openai"
@@ -70,7 +72,10 @@ def test_show_session_status_prints_gateway_style_summary():
         "started_at": 1775791440,
     }
 
-    with patch("cli.display_hermes_home", return_value="~/.hermes"):
+    with patch("cli.display_hermes_home", return_value="~/.hermes"), patch(
+        "tools.process_registry.process_registry.list_sessions",
+        return_value=[{"status": "running"}, {"status": "finished"}],
+    ):
         cli_obj._show_session_status()
 
     printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
@@ -81,6 +86,9 @@ def test_show_session_status_prints_gateway_style_summary():
     assert "Model: openai/gpt-5.4 (openai)" in printed
     assert "Tokens: 321" in printed
     assert "Agent Running: No" in printed
+    assert "Busy Input Mode: background" in printed
+    assert "Queued Inputs: 2" in printed
+    assert "Background Processes: 1 running, 1 recent" in printed
     _, kwargs = cli_obj.console.print.call_args
     assert kwargs.get("highlight") is False
     assert kwargs.get("markup") is False

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -65,6 +65,7 @@ def _make_runner():
     runner._pending_messages = {}
     runner._busy_ack_ts = {}
     runner._draining = False
+    runner._background_tasks = set()
     runner.adapters = {}
     runner.config = MagicMock()
     runner.session_store = None
@@ -270,6 +271,52 @@ class TestBusySessionAck:
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_background_mode_starts_background_agent_without_interrupt_or_queue(self):
+        """busy_input_mode='background' launches a separate agent for follow-ups."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "background"
+        adapter = _make_adapter()
+
+        event = _make_event(text="please audit the docs separately")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        created = []
+
+        class _FakeTask:
+            def add_done_callback(self, cb):
+                self._cb = cb
+
+        def _fake_create_task(coro):
+            coro.close()
+            task = _FakeTask()
+            created.append(task)
+            return task
+
+        async def _fake_run_background_task(*_args, **_kwargs):
+            return None
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge, \
+             patch("gateway.run.asyncio.create_task", side_effect=_fake_create_task) as mock_create, \
+             patch.object(runner, "_run_background_task", side_effect=_fake_run_background_task) as mock_run_bg:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_not_called()
+        mock_create.assert_called_once()
+        mock_run_bg.assert_called_once()
+        assert runner._background_tasks
+
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "separate background agent" in content
+        assert "Task ID: bg_" in content
+        assert "Interrupting" not in content
 
     @pytest.mark.asyncio
     async def test_debounce_suppresses_rapid_acks(self):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -95,11 +95,19 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     )
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_input_mode: background\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "background"
+
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "interrupt")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
 
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "steer")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "background")
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "background"
 
     # Unknown values fall through to the safe default
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -998,11 +998,11 @@ def test_config_busy_get_and_set(monkeypatch):
         {
             "id": "2",
             "method": "config.set",
-            "params": {"key": "busy", "value": "interrupt"},
+            "params": {"key": "busy", "value": "background"},
         }
     )
-    assert set_resp["result"]["value"] == "interrupt"
-    assert ("display.busy_input_mode", "interrupt") in writes
+    assert set_resp["result"]["value"] == "background"
+    assert ("display.busy_input_mode", "background") in writes
 
 
 def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -267,7 +267,7 @@ def _load_busy_input_mode() -> str:
     if not isinstance(display, dict):
         display = {}
     raw = str(display.get("busy_input_mode", "") or "").strip().lower()
-    return raw if raw in {"queue", "steer", "interrupt"} else "interrupt"
+    return raw if raw in {"background", "queue", "steer", "interrupt"} else "interrupt"
 
 
 def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
@@ -3394,7 +3394,7 @@ def _(rid, params: dict) -> dict:
         raw = str(value or "").strip().lower()
         if raw in ("", "status"):
             return _ok(rid, {"key": key, "value": _load_busy_input_mode()})
-        if raw not in {"queue", "steer", "interrupt"}:
+        if raw not in {"background", "queue", "steer", "interrupt"}:
             return _err(rid, 4002, f"unknown busy mode: {value}")
         _write_config_key("display.busy_input_mode", raw)
         return _ok(rid, {"key": key, "value": raw})

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -253,6 +253,20 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('updates busy input mode immediately after /busy background succeeds', async () => {
+    patchUiState({ busyInputMode: 'queue' })
+    const rpc = vi.fn(() => Promise.resolve({ key: 'busy', value: 'background' }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/busy background')).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('config.set', { key: 'busy', value: 'background' })
+
+    await vi.waitFor(() => {
+      expect(getUiState().busyInputMode).toBe('background')
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('busy input mode: background')
+    })
+  })
+
   it('renders browser connect progress messages from the gateway', async () => {
     const rpc = vi.fn(() =>
       Promise.resolve({

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -406,7 +406,45 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
   })
 
-  it('lets exact catalog commands win over longer prefix matches', async () => {
+  it('renders /status locally instead of delegating to the slash worker', () => {
+    patchUiState({
+      bgTasks: new Set(['bg-1', 'bg-2']),
+      busy: true,
+      busyInputMode: 'background',
+      detailsMode: 'expanded',
+      info: {
+        cwd: '/repo',
+        mcp_servers: [
+          { connected: true, name: 'fetch', tools: 2, transport: 'stdio' },
+          { connected: false, name: 'example', tools: 0, transport: 'stdio' }
+        ],
+        model: 'anthropic/claude-sonnet-4.6',
+        skills: {},
+        tools: {},
+        version: '0.12.0'
+      },
+      sid: 'sid-status',
+      statusBar: 'bottom',
+      usage: { calls: 3, input: 1000, output: 250, total: 1250 }
+    })
+
+    const ctx = buildCtx({ composer: { ...buildComposer(), queueRef: { current: ['one queued prompt'] } } })
+
+    expect(createSlashHandler(ctx)('/status')).toBe(true)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).not.toHaveBeenCalledWith(expect.stringContaining('ambiguous command'))
+    expect(ctx.transcript.panel).toHaveBeenCalledWith(
+      'Hermes TUI Status',
+      expect.arrayContaining([
+        expect.objectContaining({ rows: expect.arrayContaining([['Session ID', 'sid-status']]), title: 'Session' }),
+        expect.objectContaining({ rows: expect.arrayContaining([['Queued prompts', '1']]), title: 'Work queue' }),
+        expect.objectContaining({ rows: expect.arrayContaining([['Total tokens', '1,250']]), title: 'Usage' }),
+        expect.objectContaining({ rows: expect.arrayContaining([['MCP servers', '1/2 connected']]), title: 'UI' })
+      ])
+    )
+  })
+
+  it('lets exact catalog /statusbar win over shorter prefix matches', () => {
     const ctx = buildCtx({
       local: {
         catalog: {
@@ -418,13 +456,9 @@ describe('createSlashHandler', () => {
       }
     })
 
-    expect(createSlashHandler(ctx)('/status')).toBe(true)
-    await vi.waitFor(() => {
-      expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
-        command: 'status',
-        session_id: null
-      })
-    })
+    expect(createSlashHandler(ctx)('/statusbar')).toBe(true)
+    expect(getUiState().statusBar).toBe('off')
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
     expect(ctx.transcript.sys).not.toHaveBeenCalledWith(expect.stringContaining('ambiguous command'))
   })
 

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -197,11 +197,13 @@ describe('normalizeBusyInputMode', () => {
   it('passes through the canonical CLI parity values', () => {
     expect(normalizeBusyInputMode('queue')).toBe('queue')
     expect(normalizeBusyInputMode('steer')).toBe('steer')
+    expect(normalizeBusyInputMode('background')).toBe('background')
     expect(normalizeBusyInputMode('interrupt')).toBe('interrupt')
   })
 
   it('trims and lowercases input', () => {
     expect(normalizeBusyInputMode(' Queue ')).toBe('queue')
+    expect(normalizeBusyInputMode('BACKGROUND')).toBe('background')
     expect(normalizeBusyInputMode('STEER')).toBe('steer')
   })
 
@@ -254,6 +256,9 @@ describe('applyDisplay → busy_input_mode', () => {
 
     applyDisplay({ config: { display: { busy_input_mode: 'steer' } } }, setBell)
     expect($uiState.get().busyInputMode).toBe('steer')
+
+    applyDisplay({ config: { display: { busy_input_mode: 'background' } } }, setBell)
+    expect($uiState.get().busyInputMode).toBe('background')
   })
 
   it('falls back to queue when value is missing or invalid (TUI-only default)', () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -27,7 +27,7 @@ export interface StateSetter<T> {
 
 export type StatusBarMode = 'bottom' | 'off' | 'top'
 
-export type BusyInputMode = 'interrupt' | 'queue' | 'steer'
+export type BusyInputMode = 'background' | 'interrupt' | 'queue' | 'steer'
 
 // Single source of truth for indicator style names.  Union type is
 // derived from this tuple so adding/removing a style only touches one

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -48,6 +48,10 @@ const DETAILS_USAGE =
 
 const DETAILS_SECTION_USAGE = 'usage: /details <section> [hidden|collapsed|expanded|reset]'
 
+const numberFormatter = new Intl.NumberFormat('en-US')
+const formatNumber = (value: number | undefined): string =>
+  typeof value === 'number' ? numberFormatter.format(value) : '0'
+
 export const coreCommands: SlashCommand[] = [
   {
     help: 'list commands + hotkeys',
@@ -78,6 +82,62 @@ export const coreCommands: SlashCommand[] = [
       )
 
       ctx.transcript.panel(ctx.ui.theme.brand.helpHeader, sections)
+    }
+  },
+
+  {
+    help: 'show local TUI/session status',
+    name: 'status',
+    run: (_arg, ctx) => {
+      const info = ctx.ui.info
+      const usage = ctx.ui.usage ?? info?.usage
+      const mcpServers = info?.mcp_servers ?? []
+      const connectedMcp = mcpServers.filter(server => server.connected).length
+      const queued = ctx.composer.queueRef.current.length
+      const backgroundTasks = ctx.ui.bgTasks.size
+      const model = info?.model ?? 'unknown'
+      const cwd = info?.cwd ?? 'unknown'
+
+      const sections: PanelSection[] = [
+        {
+          rows: [
+            ['Session ID', ctx.sid ?? ctx.ui.sid ?? '(none)'],
+            ['Model', model],
+            ['CWD', cwd],
+            ['Hermes', info?.version ? `v${info.version}` : 'unknown']
+          ],
+          title: 'Session'
+        },
+        {
+          rows: [
+            ['Agent busy', ctx.ui.busy ? 'yes' : 'no'],
+            ['Busy input mode', ctx.ui.busyInputMode],
+            ['Queued prompts', String(queued)],
+            ['Background tasks', String(backgroundTasks)]
+          ],
+          title: 'Work queue'
+        },
+        {
+          rows: [
+            ['API calls', formatNumber(usage?.calls)],
+            ['Input tokens', formatNumber(usage?.input)],
+            ['Output tokens', formatNumber(usage?.output)],
+            ['Total tokens', formatNumber(usage?.total)]
+          ],
+          title: 'Usage'
+        },
+        {
+          rows: [
+            ['Status bar', ctx.ui.statusBar],
+            ['Details mode', ctx.ui.detailsMode],
+            ['Streaming', ctx.ui.streaming ? 'on' : 'off'],
+            ['MCP servers', mcpServers.length ? `${connectedMcp}/${mcpServers.length} connected` : 'none']
+          ],
+          title: 'UI'
+        }
+      ]
+
+      ctx.transcript.panel('Hermes TUI Status', sections)
     }
   },
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../../gatewayTypes.js'
 import { fmtK } from '../../../lib/text.js'
 import type { PanelSection } from '../../../types.js'
-import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
+import { type BusyInputMode, DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
 import type { SlashCommand } from '../types.js'
@@ -420,14 +420,14 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
-    help: 'control busy enter mode [queue|steer|interrupt|status]',
+    help: 'control busy enter mode [queue|steer|background|interrupt|status]',
     name: 'busy',
     run: (arg, ctx) => {
       const mode = arg.trim().toLowerCase()
-      const valid = new Set(['', 'status', 'queue', 'steer', 'interrupt'])
+      const valid = new Set(['', 'status', 'queue', 'steer', 'background', 'interrupt'])
 
       if (!valid.has(mode)) {
-        return ctx.transcript.sys('usage: /busy [queue|steer|interrupt|status]')
+        return ctx.transcript.sys('usage: /busy [queue|steer|background|interrupt|status]')
       }
 
       if (!mode || mode === 'status') {
@@ -446,7 +446,8 @@ export const sessionCommands: SlashCommand[] = [
         .rpc<ConfigSetResponse>('config.set', { key: 'busy', value: mode })
         .then(
           ctx.guarded<ConfigSetResponse>(r => {
-            const next = r.value || mode
+            const next = (r.value || mode) as BusyInputMode
+            patchUiState({ busyInputMode: next })
             ctx.transcript.sys(`busy input mode: ${next}`)
           })
         )

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -29,7 +29,7 @@ const STATUSBAR_ALIAS: Record<string, StatusBarMode> = {
 export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
   raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'top') : 'top'
 
-const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
+const BUSY_MODES = new Set<BusyInputMode>(['background', 'interrupt', 'queue', 'steer'])
 
 // TUI defaults to `queue` even though the framework default
 // (`hermes_cli/config.py`) is `interrupt`.  Rationale: in a full-screen

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -5,6 +5,7 @@ import { attachedImageNotice } from '../domain/messages.js'
 import { looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
+  BackgroundStartResponse,
   InputDetectDropResponse,
   PromptSubmitResponse,
   SessionSteerResponse,
@@ -217,6 +218,8 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   // Honors `display.busy_input_mode` from config.yaml (CLI parity):
   //   - 'queue'     (legacy): append to queueRef; drains on busy → false
+  //   - 'background': launch the prompt in a separate background agent;
+  //                   falls back to queue when the gateway rejects it.
   //   - 'steer'     : inject into the current turn via session.steer; falls
   //                   back to queue when steer is rejected (no agent / no
   //                   tool window).
@@ -244,6 +247,33 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
       if (mode === 'queue') {
         return composerActions.enqueue(full)
+      }
+
+      if (mode === 'background' && live.sid) {
+        const launch = (text: string) => {
+          gw.request<BackgroundStartResponse>('prompt.background', { session_id: live.sid, text })
+            .then(raw => {
+              const r = asRpcResult<BackgroundStartResponse>(raw)
+
+              if (!r?.task_id) {
+                return fallback('background launch rejected — message queued for next turn')
+              }
+
+              patchUiState(state => ({ ...state, bgTasks: new Set(state.bgTasks).add(r.task_id!) }))
+              sys(`bg ${r.task_id} started`)
+            })
+            .catch(() => fallback('background launch failed — message queued for next turn'))
+        }
+
+        if (hasInterpolation(full)) {
+          patchUiState({ status: 'interpolating…' })
+
+          return interpolate(full, launch)
+        }
+
+        launch(full)
+
+        return
       }
 
       if (mode === 'steer' && live.sid) {


### PR DESCRIPTION
## Summary
- Add `/busy background` and `display.busy_input_mode=background`
- Launch busy-time text prompts in separate background agents instead of interrupting current work
- Support CLI, gateway, and TUI background busy handling, including onboarding hints, config schema, command registry updates, and immediate TUI state sync

## Test Plan
- `python -m py_compile cli.py gateway/run.py hermes_cli/config.py hermes_cli/web_server.py hermes_cli/commands.py agent/onboarding.py`
- `python -m pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_restart_drain.py tests/cli/test_busy_input_mode_command.py tests/cli/test_cli_init.py -q -o 'addopts='`
- `python3 -m pytest tests/test_tui_gateway_server.py::test_config_busy_get_and_set tests/gateway/test_restart_drain.py::test_load_busy_input_mode_prefers_env_then_config_then_default tests/cli/test_busy_input_mode_command.py tests/cli/test_cli_init.py::TestBusyInputMode::test_busy_input_mode_background_is_honored -q -o 'addopts='`
- `npm run type-check --prefix ui-tui`
- `npm run test --prefix ui-tui -- useConfigSync createSlashHandler`
- `npm run build --prefix ui-tui`
- `git diff --check`

## Notes
- `npm run lint --prefix ui-tui` still reports pre-existing unrelated lint errors in `src/lib/mathUnicode.ts`; changed files pass targeted ESLint with warnings only.
