### PR TITLE
fix(skills): exclude hidden dirs from skill search, guard cyclic symlinks, handle non-dict quick_commands

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -441,9 +441,26 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
     Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+
+    Symlinks are followed (``followlinks=True``) so that external skill
+    directories linked into the skills tree are discovered.  A seen-inode
+    set guards against infinite loops caused by cyclic symlinks -- if a
+    directory's ``(st_dev, st_ino)`` pair has already been visited the
+    subtree is skipped rather than traversed again.  Fixes #18809.
     """
     matches = []
+    seen_inodes: set[tuple[int, int]] = set()
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
+        try:
+            st = os.stat(root)
+            inode_key = (st.st_dev, st.st_ino)
+        except OSError:
+            dirs[:] = []
+            continue
+        if inode_key in seen_inodes:
+            dirs[:] = []  # cycle detected -- prune this subtree
+            continue
+        seen_inodes.add(inode_key)
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
         if filename in files:
             matches.append(Path(root) / filename)

--- a/cli.py
+++ b/cli.py
@@ -6581,6 +6581,12 @@ class HermesCLI:
             quick_commands = self.config.get("quick_commands", {})
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
+                if not isinstance(qcmd, dict):
+                    # Gracefully handle misconfigured quick_commands entries
+                    # where the value is a plain string or other non-dict type
+                    # instead of crashing with AttributeError.  Fixes #18816.
+                    self._console_print(f"[bold red]Quick command '{base_cmd}' is misconfigured -- expected a dict, got {type(qcmd).__name__}. Check your config.[/]")
+                    return True
                 if qcmd.get("type") == "exec":
                     import subprocess
                     exec_cmd = qcmd.get("command", "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5215,6 +5215,11 @@ class GatewayRunner:
                 quick_commands = {}
             if command in quick_commands:
                 qcmd = quick_commands[command]
+                if not isinstance(qcmd, dict):
+                    # Gracefully handle misconfigured quick_commands entries
+                    # where the value is a plain string or other non-dict type
+                    # instead of crashing with AttributeError.  Fixes #18816.
+                    return f"Quick command '/{command}' is misconfigured -- expected a dict, got {type(qcmd).__name__}. Check your gateway config."
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:

--- a/tests/test_skill_rglob_and_quick_commands.py
+++ b/tests/test_skill_rglob_and_quick_commands.py
@@ -1,0 +1,139 @@
+"""Tests for three bug fixes:
+
+  #18900 -- _find_skill rglob leaks into .archive, .git, .github, .hub
+  #18809 -- os.walk(followlinks=True) infinite-loop on cyclic symlinks
+  #18816 -- quick_commands with non-dict values crashes slash command dispatch
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_skill_tree(base: Path, structure: dict):
+    for name, value in structure.items():
+        d = base / name
+        d.mkdir(parents=True, exist_ok=True)
+        if value is True:
+            (d / "SKILL.md").write_text(f"# {name}\n")
+        elif isinstance(value, dict):
+            _make_skill_tree(d, value)
+
+
+class TestIterSkillIndexFilesExclusion:
+    def _run(self, tree: dict) -> list[str]:
+        from agent.skill_utils import iter_skill_index_files
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_skill_tree(root, tree)
+            return [p.parent.name for p in iter_skill_index_files(root, "SKILL.md")]
+
+    def test_normal_skill_discovered(self):
+        assert "my-skill" in self._run({"my-skill": True})
+
+    def test_git_dir_excluded(self):
+        names = self._run({".git": {"hooks": True}, "real-skill": True})
+        assert "hooks" not in names
+        assert "real-skill" in names
+
+    def test_github_dir_excluded(self):
+        names = self._run({".github": {"workflows": True}, "real-skill": True})
+        assert "workflows" not in names
+        assert "real-skill" in names
+
+    def test_hub_dir_excluded(self):
+        names = self._run({".hub": {"cached": True}, "real-skill": True})
+        assert "cached" not in names
+        assert "real-skill" in names
+
+    def test_archive_dir_excluded(self):
+        names = self._run({".archive": {"old-skill": True}, "real-skill": True})
+        assert "old-skill" not in names
+        assert "real-skill" in names
+
+    def test_multiple_excluded_dirs_with_real_skills(self):
+        tree = {".git": {"internal": True}, ".archive": {"retired": True}, "skill-a": True, "skill-b": True}
+        names = self._run(tree)
+        assert sorted(names) == ["skill-a", "skill-b"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevated privileges on Windows")
+class TestIterSkillIndexFilesCyclicSymlinks:
+    def test_cyclic_symlink_does_not_loop(self):
+        from agent.skill_utils import iter_skill_index_files
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = root / "my-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# my-skill\n")
+            (root / "loop").symlink_to(root)
+            results = list(iter_skill_index_files(root, "SKILL.md"))
+            assert "my-skill" in [p.parent.name for p in results]
+
+    def test_non_cyclic_symlink_still_followed(self):
+        from agent.skill_utils import iter_skill_index_files
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ext = Path(tmp) / "external"
+            ext.mkdir()
+            skill_dir = ext / "ext-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# ext-skill\n")
+            (root / "ext-link").symlink_to(ext)
+            results = list(iter_skill_index_files(root, "SKILL.md"))
+            assert "ext-skill" in [p.parent.name for p in results]
+
+
+class TestQuickCommandsNonDictGateway:
+    def test_string_value_returns_error_message(self):
+        qcmd = "hello world"
+        command = "greet"
+        if not isinstance(qcmd, dict):
+            result = f"Quick command '/{command}' is misconfigured -- expected a dict, got {type(qcmd).__name__}. Check your gateway config."
+        else:
+            result = qcmd.get("type")
+        assert "misconfigured" in result
+        assert "str" in result
+
+    def test_int_value_returns_error_message(self):
+        qcmd = 42
+        command = "count"
+        if not isinstance(qcmd, dict):
+            result = f"Quick command '/{command}' is misconfigured -- expected a dict, got {type(qcmd).__name__}. Check your gateway config."
+        else:
+            result = qcmd.get("type")
+        assert "misconfigured" in result
+        assert "int" in result
+
+    def test_none_value_returns_error_message(self):
+        qcmd = None
+        command = "empty"
+        if not isinstance(qcmd, dict):
+            result = f"Quick command '/{command}' is misconfigured -- expected a dict, got {type(qcmd).__name__}. Check your gateway config."
+        else:
+            result = qcmd.get("type")
+        assert "misconfigured" in result
+
+    def test_valid_dict_exec_command_still_works(self):
+        qcmd = {"type": "exec", "command": "echo ok"}
+        assert isinstance(qcmd, dict)
+        assert qcmd.get("type") == "exec"
+
+    def test_valid_dict_alias_command_still_works(self):
+        qcmd = {"type": "alias", "target": "/help"}
+        assert isinstance(qcmd, dict)
+        assert qcmd.get("type") == "alias"
+
+    def test_list_value_returns_error_message(self):
+        qcmd = ["a", "b"]
+        command = "tags"
+        if not isinstance(qcmd, dict):
+            result = f"Quick command '/{command}' is misconfigured -- expected a dict, got {type(qcmd).__name__}. Check your gateway config."
+        else:
+            result = qcmd.get("type")
+        assert "misconfigured" in result
+        assert "list" in result

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -282,12 +282,17 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
+
+    Uses ``iter_skill_index_files`` instead of a bare ``rglob`` so that
+    hidden/internal directories (``.git``, ``.github``, ``.hub``,
+    ``.archive``) are excluded and cyclic symlinks do not cause an
+    infinite loop.  Fixes #18900 and #18809.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None


### PR DESCRIPTION
Fixes #18900, #18809, #18816

**#18900 -- _find_skill rglob leaks into .archive, .git, .github, .hub**
Replace bare rglob in _find_skill with iter_skill_index_files which already excludes those dirs.

**#18809 -- os.walk(followlinks=True) infinite-loop on cyclic symlinks**
Add seen-inode tracking to iter_skill_index_files. If a directory inode pair has already been visited the subtree is pruned. Non-cyclic symlinks are still followed.

**#18816 -- quick_commands with non-dict values crashes slash command dispatch**
Add isinstance(qcmd, dict) guard in both gateway/run.py and cli.py before calling .get(). Misconfigured entries return a clear error message instead of crashing with AttributeError.

14 new tests in tests/test_skill_rglob_and_quick_commands.py, all passing.