### PR TITLE
fix(hindsight): read retain_every_n_turns from banks.hermes config

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1042,7 +1042,8 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
-        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
+        banks_retain_every_n = banks.get("retain_every_n_turns", 1) if isinstance(banks, dict) else 1
+        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", banks_retain_every_n)))
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
         # Recall controls

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -238,6 +238,41 @@ class TestConfig:
         assert p._recall_max_input_chars == 500
         assert p._bank_mission == "Test agent mission"
 
+    # --- PR #18938: banks.hermes.retain_every_n_turns fallback ---
+
+    def test_retain_every_n_turns_read_from_banks_hermes(self, provider_with_config):
+        """When only banks.hermes.retain_every_n_turns is set, it must be used.
+
+        Regression guard for #18938: before the fix the nested value was ignored
+        and the provider silently fell back to the default of 1.
+        """
+        p = provider_with_config(
+            banks={"hermes": {"bankId": "test-bank", "retain_every_n_turns": 10}},
+        )
+        assert p._retain_every_n_turns == 10
+
+    def test_retain_every_n_turns_top_level_overrides_banks_hermes(self, provider_with_config):
+        """Top-level retain_every_n_turns must take precedence over banks.hermes."""
+        p = provider_with_config(
+            retain_every_n_turns=5,
+            banks={"hermes": {"bankId": "test-bank", "retain_every_n_turns": 10}},
+        )
+        assert p._retain_every_n_turns == 5
+
+    def test_retain_every_n_turns_banks_hermes_overrides_default(self, provider_with_config):
+        """banks.hermes value must win over the hardcoded default of 1 (no top-level set)."""
+        p = provider_with_config(
+            banks={"hermes": {"bankId": "test-bank", "retain_every_n_turns": 7}},
+        )
+        assert p._retain_every_n_turns == 7
+
+    def test_retain_every_n_turns_default_when_neither_set(self, provider_with_config):
+        """With neither top-level nor banks.hermes set, the default of 1 applies."""
+        p = provider_with_config(
+            banks={"hermes": {"bankId": "test-bank"}},
+        )
+        assert p._retain_every_n_turns == 1
+
     def test_config_from_env_fallback(self, tmp_path, monkeypatch):
         """When no config file exists, falls back to env vars."""
         monkeypatch.setattr(


### PR DESCRIPTION
When `retain_every_n_turns` is set inside the `banks.hermes` block of `~/.hermes/hindsight/config.json`, the plugin ignored it and always used the default value of 1 (retain every turn). This happened because the code only checked the top-level config.

This change makes the lookup consistent with `budget`, which already reads from `banks.hermes` as a fallback. Now `retain_every_n_turns` is checked in priority order: top-level config, then banks.hermes, then default of 1.

**Before:**
```python
self._retain_every_n_turns = max(1, int(self._config.get(retain_every_n_turns, 1)))
```

**After:**
```python
banks_retain_every_n = banks.get("retain_every_n_turns", 1) if isinstance(banks, dict) else 1
self._retain_every_n_turns = max(1, int(self._config.get(retain_every_n_turns, banks_retain_every_n)))
```

**Config file location that now works:**
```json
{
  "mode": "local_external",
  "api_url": "http://localhost:8888",
  "banks": {
    "hermes": {
      "bankId": "shared-brain",
      "budget": "mid",
      "retain_every_n_turns": 10
    }
  }
}
```