### PR TITLE
fix(gateway): handle PermissionError on stale root-owned gateway.lock

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -22,6 +23,8 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Any, Optional
 from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
 
 if sys.platform == "win32":
     import msvcrt
@@ -355,7 +358,21 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if not resolved_lock_path.exists():
         return False
 
-    handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    try:
+        handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    except PermissionError:
+        # Lock file is owned by another user (e.g. root after entrypoint bypass).
+        # Self-heal: remove the stale file so subsequent checks work normally.
+        logger.warning(
+            "gateway.lock at %s not accessible (PermissionError); "
+            "removing stale lock file.",
+            resolved_lock_path,
+        )
+        try:
+            resolved_lock_path.unlink()
+        except OSError:
+            pass
+        return False
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)


### PR DESCRIPTION
## What does this PR do?

Fixes #18935: When the gateway container runs without `entrypoint.sh` (bypassing the `gosu` privilege drop), `gateway.lock` is created owned by `root:root`. After restoring the entrypoint and restarting, the dashboard (uid 10000) cannot open the lock file, causing `PermissionError` that propagates as HTTP 500 on `/api/status` and breaks the events feed.

The fix wraps the `open(resolved_lock_path, "a+")` call in `is_gateway_runtime_lock_active()` with a `PermissionError` handler. Since the hermes user owns the parent directory (`$HERMES_HOME`), it can `unlink()` the stale file. This is self-healing: the stale file is removed on first poll and subsequent checks work normally.

## Related Issue

Fixes #18935

Relates to #18936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill

## Changes Made

- `gateway/status.py`
  - Add module logger (`logger = logging.getLogger(__name__)`)
  - Catch `PermissionError` when opening `gateway.lock` in `is_gateway_runtime_lock_active()`
  - Attempt `resolved_lock_path.unlink()` on `PermissionError`, then return `False`

## How to Test

1. Start the gateway via Docker without `entrypoint.sh` (or `chown root:root gateway.lock` manually)
2. Restart the gateway with the normal entrypoint
3. Query `/api/status` — should return `200` with `runtime_active: true` instead of `500`
4. `gateway.lock` should be removed on the first poll and recreated on the next gateway start

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — or N/A (backend fix, no user-facing docs change)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [ ] I've considered cross-platform impact — N/A (Linux-only `os.kill` + `unlink` path)
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

N/A — backend fix only
