### PR TITLE
fix(tui): remap /q alias from quit to queue (#18927)

### DIFF
--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -82,7 +82,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
-    aliases: ['exit', 'q'],
+    aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
     run: (_arg, ctx) => ctx.session.die()
@@ -466,6 +466,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['q'],
     help: 'inspect or enqueue a message',
     name: 'queue',
     run: (arg, ctx) => {


### PR DESCRIPTION
## Problem

Fixes #18927: In the TUI, `/q` is incorrectly mapped to the `quit` command instead of `queue`. Typing `/q hello` unexpectedly exits the application instead of enqueueing the message.

This is inconsistent with every other slash-command surface (CLI, gateway, documentation) where `/q` maps to `queue`.

## Fix

In `ui-tui/src/app/slash/commands/core.ts`:

1. Remove `'q'` from the `quit` command aliases (line 85): `['exit', 'q']` → `['exit']`
2. Add `aliases: ['q']` to the `queue` command definition (line 468)

This brings the TUI into alignment with the central `COMMAND_REGISTRY` and all other surfaces.

## Testing

- Manual verification: the TypeScript changes are minimal and directly address the alias mapping
- No other command surfaces affected — this is TUI-frontend only

## References

| Surface | `quit` aliases | `queue` aliases |
|---|---|---|
| Central registry (`commands.py`) | `exit` | `q` |
| CLI (`cli.py`) | `exit` | `q` |
| Gateway (`gateway/run.py`) | `exit` | `q` |
| Documentation | `exit` | `q` |
| **TUI (before this fix)** | **`exit`, `q` (wrong)** | **none (wrong)** |
| **TUI (after this fix)** | `exit` ✅ | `q` ✅ |
