### PR TITLE
feat(cli): add /reasoning reveal — post-hoc reasoning display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2200,6 +2200,9 @@ class HermesCLI:
         self._pending_edit_snapshots = {}
         self._last_input_mode_recovery = 0.0
         self._input_mode_recovery_notice_shown = False
+        # Post-hoc reasoning reveal — captured on every turn, even when
+        # show_reasoning is off.  /reasoning reveal prints this.
+        self._last_reasoning = ""
         
         # Configuration - priority: CLI args > env vars > config file
         # Model comes from: CLI arg or config.yaml (single source of truth).
@@ -7666,6 +7669,7 @@ class HermesCLI:
             /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
             /reasoning show|on      Show model thinking/reasoning in output
             /reasoning hide|off     Hide model thinking/reasoning from output
+            /reasoning reveal       Show reasoning from the last turn
         """
         parts = cmd.strip().split(maxsplit=1)
 
@@ -7681,7 +7685,7 @@ class HermesCLI:
             display_state = "on ✓" if self.show_reasoning else "off"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide|reveal>{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -7701,6 +7705,19 @@ class HermesCLI:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
             save_config_value("display.show_reasoning", False)
             _cprint(f"  {_ACCENT}✓ Reasoning display: OFF (saved){_RST}")
+            return
+        if arg == "reveal":
+            rtext = getattr(self, "_last_reasoning", "")
+            if not rtext:
+                _cprint(f"  {_DIM}(._.) No reasoning stored from the last turn.{_RST}")
+                return
+            w = shutil.get_terminal_size().columns
+            r_label = " Thinking "
+            r_fill = w - 2 - len(r_label)
+            _cprint(f"\n{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}")
+            for line in rtext.strip().splitlines():
+                _cprint(f"{_DIM}{line}{_RST}")
+            _cprint(f"{_DIM}└{'─' * (w - 2)}┘{_RST}")
             return
 
         # Effort level change
@@ -9830,6 +9847,18 @@ class HermesCLI:
                     else:
                         display_reasoning = reasoning.strip()
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
+
+            # Capture reasoning for post-hoc reveal (/reasoning reveal)
+            # even when show_reasoning is off or already shown live.
+            _reasoning_for_reveal = result.get("last_reasoning") if result else None
+            if _reasoning_for_reveal:
+                self._last_reasoning = _reasoning_for_reveal
+                if not self.show_reasoning:
+                    lines = _reasoning_for_reveal.count("\n") + 1
+                    chars = len(_reasoning_for_reveal)
+                    _cprint(f"  {_DIM}━━ Thinking: {lines} lines, {chars} chars — /reasoning reveal ━━{_RST}")
+            else:
+                self._last_reasoning = ""
 
             if response and not response_previewed:
                 # Use skin engine for label/color with fallback


### PR DESCRIPTION
## Summary

Adds `/reasoning reveal` — a slash command that displays the last turn's model reasoning in a dimmed terminal box, even when `show_reasoning` is off.

## Changes

**`cli.py`** (+30/-1):
- `self._last_reasoning = ""` — captures reasoning on every turn
- `/reasoning reveal` handler — renders captured reasoning in a styled dim box with `┌─ Thinking ───┐` / `└──────────────┘` borders
- Post-response capture — grabs `last_reasoning` from result dict; when `show_reasoning` is off, prints a subtle hint: `━━ Thinking: N lines, M chars — /reasoning reveal ━━`
- Updated usage text to include `reveal`

## Behavior

- **show_reasoning: true** — reasoning streams live as before, `/reasoning reveal` still works for replay
- **show_reasoning: false** — reasoning silently captured, subtle hint printed after each turn, `/reasoning reveal` displays it
- **No reasoning** (first turn, model without thinking) — shows `(._.) No reasoning stored from the last turn.`
- Reasoning always persisted in session DB regardless

Fixes the gap where reasoning was captured but had no post-hoc CLI access.