### PR TITLE
feat(tools): add TinyFish web search and extract backend

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1025,7 +1025,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 22,
+    "_config_version": 23,
 }
 
 # =============================================================================
@@ -1041,6 +1041,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    23: ["TINYFISH_API_KEY"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1526,6 +1527,14 @@ OPTIONAL_ENV_VARS = {
         "url": "https://github.com/jo-inc/camofox-browser",
         "tools": ["browser_navigate", "browser_click"],
         "password": False,
+        "category": "tool",
+    },
+    "TINYFISH_API_KEY": {
+        "description": "TinyFish API key for web search and content extraction",
+        "prompt": "TinyFish API key",
+        "url": "https://agent.tinyfish.ai/api-keys",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
         "category": "tool",
     },
     "FAL_KEY": {
@@ -3762,6 +3771,7 @@ def show_config():
         ("TAVILY_API_KEY", "Tavily"),
         ("BROWSERBASE_API_KEY", "Browserbase"),
         ("BROWSER_USE_API_KEY", "Browser Use"),
+        ("TINYFISH_API_KEY", "TinyFish"),
         ("FAL_KEY", "FAL"),
     ]
     
@@ -3943,6 +3953,7 @@ def set_config_value(key: str, value: str):
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
         'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
+        'TINYFISH_API_KEY',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1025,7 +1025,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 22,
 }
 
 # =============================================================================
@@ -1041,7 +1041,6 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
-    23: ["TINYFISH_API_KEY"],
 }
 
 # Required environment variables with metadata for migration prompts.

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -379,7 +379,7 @@ def _print_setup_summary(config: dict, hermes_home):
             label = f"Web Search & Extract ({subscription_features.web.current_provider})"
         tool_status.append((label, True, None))
     else:
-        tool_status.append(("Web Search & Extract", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL, or TAVILY_API_KEY"))
+        tool_status.append(("Web Search & Extract", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL, TAVILY_API_KEY, or TINYFISH_API_KEY"))
 
     # Browser tools (local Chromium, Camofox, Browserbase, Browser Use, or Firecrawl)
     browser_provider = subscription_features.browser.current_provider

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -280,6 +280,14 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "TinyFish",
+                "tag": "Fast search and extract with stealth proxies",
+                "web_backend": "tinyfish",
+                "env_vars": [
+                    {"key": "TINYFISH_API_KEY", "prompt": "TinyFish API key", "url": "https://agent.tinyfish.ai/api-keys"},
+                ],
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "badge": "free · self-hosted",
                 "tag": "Run your own Firecrawl instance (Docker)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "exa-py>=2.9.0,<3",
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",
+  "tinyfish>=0.2.5,<1",
   "fal-client>=0.13.1,<1",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts>=7.2.7,<8",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -527,6 +527,7 @@ AUTHOR_MAP = {
     "chenzeshi@live.com": "chen1749144759",
     "mor.aleksandr@yahoo.com": "MorAlekss",
     "ash@users.noreply.github.com": "ash",
+    "simantak@mac.local": "simantak-dabhade",
 }
 
 

--- a/tests/tools/test_web_tools_tinyfish.py
+++ b/tests/tools/test_web_tools_tinyfish.py
@@ -1,0 +1,258 @@
+"""Tests for TinyFish web backend integration.
+
+Coverage:
+  _get_tinyfish_client() — API key handling, base URL override, singleton caching.
+  _tinyfish_search() — search response normalization.
+  _tinyfish_extract() — extract response normalization, error entries.
+  web_search_tool / web_extract_tool — TinyFish dispatch paths.
+"""
+
+import json
+import os
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ─── _get_tinyfish_client ───────────────────────────────────────────────────
+
+class TestTinyFishClient:
+    """Test suite for TinyFish client initialization."""
+
+    def setup_method(self):
+        import tools.web_tools
+        tools.web_tools._tinyfish_client = None
+        os.environ.pop("TINYFISH_API_KEY", None)
+        os.environ.pop("TINYFISH_API_URL", None)
+
+    def teardown_method(self):
+        import tools.web_tools
+        tools.web_tools._tinyfish_client = None
+        os.environ.pop("TINYFISH_API_KEY", None)
+        os.environ.pop("TINYFISH_API_URL", None)
+
+    def test_raises_without_api_key(self):
+        """No TINYFISH_API_KEY → ValueError with guidance."""
+        with patch("tools.web_tools.TinyFish", create=True):
+            from tools.web_tools import _get_tinyfish_client
+            with pytest.raises(ValueError, match="TINYFISH_API_KEY"):
+                _get_tinyfish_client()
+
+    def test_creates_client_with_api_key(self):
+        """TINYFISH_API_KEY set → client created."""
+        mock_cls = MagicMock()
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test-key"}):
+            with patch("tinyfish.TinyFish", mock_cls):
+                from tools.web_tools import _get_tinyfish_client
+                client = _get_tinyfish_client()
+                mock_cls.assert_called_once_with(api_key="tf-test-key")
+                assert client is mock_cls.return_value
+
+    def test_base_url_override(self):
+        """TINYFISH_API_URL overrides default base URL."""
+        mock_cls = MagicMock()
+        with patch.dict(os.environ, {
+            "TINYFISH_API_KEY": "tf-test-key",
+            "TINYFISH_API_URL": "https://staging.tinyfish.ai/",
+        }):
+            with patch("tinyfish.TinyFish", mock_cls):
+                from tools.web_tools import _get_tinyfish_client
+                _get_tinyfish_client()
+                mock_cls.assert_called_once_with(
+                    api_key="tf-test-key",
+                    base_url="https://staging.tinyfish.ai",
+                )
+
+    def test_singleton_caching(self):
+        """Repeated calls return the same client instance."""
+        mock_cls = MagicMock()
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test-key"}):
+            with patch("tinyfish.TinyFish", mock_cls):
+                from tools.web_tools import _get_tinyfish_client
+                first = _get_tinyfish_client()
+                second = _get_tinyfish_client()
+                assert first is second
+                assert mock_cls.call_count == 1
+
+
+# ─── _tinyfish_search ───────────────────────────────────────────────────────
+
+class TestTinyFishSearch:
+    """Test search result normalization."""
+
+    def setup_method(self):
+        import tools.web_tools
+        tools.web_tools._tinyfish_client = None
+
+    def teardown_method(self):
+        import tools.web_tools
+        tools.web_tools._tinyfish_client = None
+
+    def test_basic_normalization(self):
+        mock_result_1 = MagicMock(title="Python Docs", url="https://docs.python.org", snippet="Official docs", position=1)
+        mock_result_2 = MagicMock(title="Tutorial", url="https://example.com", snippet="A tutorial", position=2)
+        mock_response = MagicMock(results=[mock_result_1, mock_result_2])
+        mock_client = MagicMock()
+        mock_client.search.query.return_value = mock_response
+
+        with patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _tinyfish_search
+            result = _tinyfish_search("python docs", limit=10)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "Python Docs"
+        assert web[0]["url"] == "https://docs.python.org"
+        assert web[0]["description"] == "Official docs"
+        assert web[0]["position"] == 1
+        assert web[1]["position"] == 2
+
+    def test_empty_results(self):
+        mock_response = MagicMock(results=[])
+        mock_client = MagicMock()
+        mock_client.search.query.return_value = mock_response
+
+        with patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _tinyfish_search
+            result = _tinyfish_search("nothing")
+
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_respects_limit(self):
+        mock_results = [MagicMock(title=f"R{i}", url=f"https://r{i}.com", snippet=f"s{i}", position=i+1) for i in range(10)]
+        mock_response = MagicMock(results=mock_results)
+        mock_client = MagicMock()
+        mock_client.search.query.return_value = mock_response
+
+        with patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _tinyfish_search
+            result = _tinyfish_search("test", limit=3)
+
+        assert len(result["data"]["web"]) == 3
+
+    def test_interrupted_returns_error(self):
+        with patch("tools.interrupt.is_interrupted", return_value=True):
+            from tools.web_tools import _tinyfish_search
+            result = _tinyfish_search("test")
+            assert result["success"] is False
+
+
+# ─── _tinyfish_extract ──────────────────────────────────────────────────────
+
+class TestTinyFishExtract:
+    """Test extract response normalization."""
+
+    def setup_method(self):
+        import tools.web_tools
+        tools.web_tools._tinyfish_client = None
+
+    def teardown_method(self):
+        import tools.web_tools
+        tools.web_tools._tinyfish_client = None
+
+    def test_basic_extraction(self):
+        mock_result = MagicMock(text="Page content here", final_url="https://example.com", url="https://example.com", title="Example")
+        mock_response = MagicMock(results=[mock_result], errors=[])
+        mock_client = MagicMock()
+        mock_client.fetch.get_contents.return_value = mock_response
+
+        with patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _tinyfish_extract
+            results = _tinyfish_extract(["https://example.com"])
+
+        assert len(results) == 1
+        assert results[0]["url"] == "https://example.com"
+        assert results[0]["title"] == "Example"
+        assert results[0]["content"] == "Page content here"
+        assert results[0]["raw_content"] == "Page content here"
+        assert results[0]["metadata"]["sourceURL"] == "https://example.com"
+
+    def test_error_entries_included(self):
+        mock_error = MagicMock(url="https://fail.com", error="timeout")
+        mock_response = MagicMock(results=[], errors=[mock_error])
+        mock_client = MagicMock()
+        mock_client.fetch.get_contents.return_value = mock_response
+
+        with patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _tinyfish_extract
+            results = _tinyfish_extract(["https://fail.com"])
+
+        assert len(results) == 1
+        assert results[0]["url"] == "https://fail.com"
+        assert results[0]["error"] == "timeout"
+        assert results[0]["content"] == ""
+
+    def test_mixed_success_and_error(self):
+        mock_ok = MagicMock(text="Good content", final_url="https://ok.com", url="https://ok.com", title="OK")
+        mock_fail = MagicMock(url="https://bad.com", error="403 Forbidden")
+        mock_response = MagicMock(results=[mock_ok], errors=[mock_fail])
+        mock_client = MagicMock()
+        mock_client.fetch.get_contents.return_value = mock_response
+
+        with patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _tinyfish_extract
+            results = _tinyfish_extract(["https://ok.com", "https://bad.com"])
+
+        assert len(results) == 2
+        assert results[0]["content"] == "Good content"
+        assert results[1]["error"] == "403 Forbidden"
+
+    def test_interrupted_returns_error_per_url(self):
+        with patch("tools.interrupt.is_interrupted", return_value=True):
+            from tools.web_tools import _tinyfish_extract
+            results = _tinyfish_extract(["https://a.com", "https://b.com"])
+            assert len(results) == 2
+            assert all(r["error"] == "Interrupted" for r in results)
+
+
+# ─── web_search_tool (TinyFish dispatch) ────────────────────────────────────
+
+class TestWebSearchTinyFish:
+    """Test web_search_tool dispatch to TinyFish."""
+
+    def test_search_dispatches_to_tinyfish(self):
+        mock_result = MagicMock(title="Result", url="https://r.com", snippet="desc", position=1)
+        mock_response = MagicMock(results=[mock_result])
+        mock_client = MagicMock()
+        mock_client.search.query.return_value = mock_response
+
+        with patch("tools.web_tools._get_backend", return_value="tinyfish"), \
+             patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            result = json.loads(web_search_tool("test query", limit=5))
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+            assert result["data"]["web"][0]["title"] == "Result"
+
+
+# ─── web_extract_tool (TinyFish dispatch) ───────────────────────────────────
+
+class TestWebExtractTinyFish:
+    """Test web_extract_tool dispatch to TinyFish."""
+
+    def test_extract_dispatches_to_tinyfish(self):
+        mock_result = MagicMock(text="Extracted content", final_url="https://example.com", url="https://example.com", title="Page")
+        mock_response = MagicMock(results=[mock_result], errors=[])
+        mock_client = MagicMock()
+        mock_client.fetch.get_contents.return_value = mock_response
+
+        with patch("tools.web_tools._get_backend", return_value="tinyfish"), \
+             patch("tools.web_tools._get_tinyfish_client", return_value=mock_client), \
+             patch("tools.web_tools.process_content_with_llm", return_value=None), \
+             patch("tools.web_tools.is_safe_url", return_value=True):
+            from tools.web_tools import web_extract_tool
+            result = json.loads(asyncio.get_event_loop().run_until_complete(
+                web_extract_tool(["https://example.com"], use_llm_processing=False)
+            ))
+            assert "results" in result
+            assert len(result["results"]) == 1
+            assert result["results"][0]["url"] == "https://example.com"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -17,6 +17,7 @@ Backend compatibility:
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
 - Tavily: https://tavily.com (search, extract, crawl)
+- TinyFish: https://tinyfish.ai (search, extract)
 
 LLM Processing:
 - Uses OpenRouter API with Gemini 3 Flash Preview for intelligent content extraction
@@ -88,7 +89,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "tinyfish"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -99,6 +100,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("tinyfish", _has_env("TINYFISH_API_KEY")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -117,6 +119,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "tinyfish":
+        return _has_env("TINYFISH_API_KEY")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -189,6 +193,7 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "TINYFISH_API_KEY",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -956,6 +961,94 @@ def _exa_extract(urls: List[str]) -> List[Dict[str, Any]]:
     return results
 
 
+# ─── TinyFish Client ───────────────────────────────────────────────────────
+
+_tinyfish_client = None
+
+
+def _get_tinyfish_client():
+    """Get or create the TinyFish client (lazy initialization)."""
+    from tinyfish import TinyFish
+    global _tinyfish_client
+    if _tinyfish_client is None:
+        api_key = os.getenv("TINYFISH_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TINYFISH_API_KEY environment variable not set. "
+                "Get your API key at https://agent.tinyfish.ai/api-keys"
+            )
+        kwargs: Dict[str, Any] = {"api_key": api_key}
+        base_url = os.getenv("TINYFISH_API_URL")
+        if base_url:
+            kwargs["base_url"] = base_url.rstrip("/")
+        _tinyfish_client = TinyFish(**kwargs)
+    return _tinyfish_client
+
+
+# ─── TinyFish Search & Extract Helpers ──────────────────────────────────────
+
+def _tinyfish_search(query: str, limit: int = 10) -> dict:
+    """Search using the TinyFish SDK and return results as a dict."""
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    logger.info("TinyFish search: '%s' (limit=%d)", query, limit)
+    response = _get_tinyfish_client().search.query(query)
+
+    web_results = []
+    for i, result in enumerate(response.results or []):
+        if i >= limit:
+            break
+        web_results.append({
+            "title": result.title or "",
+            "url": result.url or "",
+            "description": result.snippet or "",
+            "position": result.position,
+        })
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _tinyfish_extract(urls: List[str]) -> List[Dict[str, Any]]:
+    """Extract content from URLs using the TinyFish SDK.
+
+    Returns a list of result dicts matching the structure expected by the
+    LLM post-processing pipeline (url, title, content, metadata).
+    """
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+    logger.info("TinyFish extract: %d URL(s)", len(urls))
+    response = _get_tinyfish_client().fetch.get_contents(urls, format="markdown")
+
+    results = []
+    for result in response.results or []:
+        content = result.text or ""
+        url = result.final_url or result.url or ""
+        title = result.title or ""
+        results.append({
+            "url": url,
+            "title": title,
+            "content": content,
+            "raw_content": content,
+            "metadata": {"sourceURL": url, "title": title},
+        })
+
+    for fail in response.errors or []:
+        results.append({
+            "url": fail.url or "",
+            "title": "",
+            "content": "",
+            "raw_content": "",
+            "error": fail.error or "extraction failed",
+            "metadata": {"sourceURL": fail.url or ""},
+        })
+
+    return results
+
+
 # ─── Parallel Search & Extract Helpers ────────────────────────────────────────
 
 def _parallel_search(query: str, limit: int = 5) -> dict:
@@ -1095,6 +1188,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
         if backend == "exa":
             response_data = _exa_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "tinyfish":
+            response_data = _tinyfish_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
@@ -1252,6 +1354,8 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "tinyfish":
+                results = _tinyfish_extract(safe_urls)
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1922,9 +2026,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "tinyfish"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "tinyfish"))
 
 
 def check_auxiliary_model() -> bool:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -2075,7 +2075,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, TINYFISH_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -22,7 +22,7 @@ Hermes supports multiple AI inference providers out of the box. Use `hermes mode
 
 ## Web Search Backends
 
-The `web_search` and `web_extract` tools support four backend providers, configured via `config.yaml` or `hermes tools`:
+The `web_search` and `web_extract` tools support five backend providers, configured via `config.yaml` or `hermes tools`:
 
 | Backend | Env Var | Search | Extract | Crawl |
 |---------|---------|--------|---------|-------|
@@ -30,12 +30,13 @@ The `web_search` and `web_extract` tools support four backend providers, configu
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
+| **TinyFish** | `TINYFISH_API_KEY` | ✔ | ✔ | — |
 
 Quick setup example:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | parallel | tavily | exa | tinyfish
 ```
 
 If `web.backend` is not set, the backend is auto-detected from whichever API key is available. Self-hosted Firecrawl is also supported via `FIRECRAWL_API_URL`.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1108,6 +1108,7 @@ You can switch between providers at any time with `hermes model` — no restart 
 | Feature | Provider | Env Variable |
 |---------|----------|--------------|
 | Web scraping | [Firecrawl](https://firecrawl.dev/) | `FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL` |
+| Web search & extraction | [TinyFish](https://tinyfish.ai/) | `TINYFISH_API_KEY` |
 | Browser automation | [Browserbase](https://browserbase.com/) | `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID` |
 | Image generation | [FAL](https://fal.ai/) | `FAL_KEY` |
 | Premium TTS voices | [ElevenLabs](https://elevenlabs.io/) | `ELEVENLABS_API_KEY` |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -107,6 +107,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `FIRECRAWL_API_URL` | Custom Firecrawl API endpoint for self-hosted instances (optional) |
 | `TAVILY_API_KEY` | Tavily API key for AI-native web search, extract, and crawl ([app.tavily.com](https://app.tavily.com/home)) |
 | `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |
+| `TINYFISH_API_KEY` | Web search and content extraction ([tinyfish.ai](https://tinyfish.ai/)) |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -172,8 +172,8 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `web_search` | Search the web for information on any topic. Returns up to 5 relevant results with titles, URLs, and descriptions. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY |
-| `web_extract` | Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY |
+| `web_search` | Search the web for information on any topic. Returns up to 5 relevant results with titles, URLs, and descriptions. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY or TINYFISH_API_KEY |
+| `web_extract` | Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY or TINYFISH_API_KEY |
 
 ## `tts` toolset
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1215,11 +1215,11 @@ Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, 
 
 ## Web Search Backends
 
-The `web_search`, `web_extract`, and `web_crawl` tools support four backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+The `web_search`, `web_extract`, and `web_crawl` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | parallel | tavily | exa | tinyfish
 ```
 
 | Backend | Env Var | Search | Extract | Crawl |
@@ -1228,8 +1228,9 @@ web:
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
+| **TinyFish** | `TINYFISH_API_KEY` | ✔ | ✔ | — |
 
-**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. If only `TINYFISH_API_KEY` is set, TinyFish is used. Otherwise Firecrawl is the default.
 
 **Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=false` on the server to disable auth).
 

--- a/website/docs/user-guide/features/tool-gateway.md
+++ b/website/docs/user-guide/features/tool-gateway.md
@@ -17,7 +17,7 @@ The **Tool Gateway** lets paid [Nous Portal](https://portal.nousresearch.com) su
 
 | Tool | What It Does | Direct Alternative |
 |------|--------------|--------------------|
-| **Web search & extract** | Search the web and extract page content via Firecrawl | `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY` |
+| **Web search & extract** | Search the web and extract page content via Firecrawl | `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `TINYFISH_API_KEY` |
 | **Image generation** | Generate images via FAL (8 models: FLUX 2 Klein/Pro, GPT-Image, Nano Banana Pro, Ideogram, Recraft V4 Pro, Qwen, Z-Image) | `FAL_KEY` |
 | **Text-to-speech** | Convert text to speech via OpenAI TTS | `VOICE_TOOLS_OPENAI_KEY`, `ELEVENLABS_API_KEY` |
 | **Browser automation** | Control cloud browsers via Browser Use | `BROWSER_USE_API_KEY`, `BROWSERBASE_API_KEY` |

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -113,7 +113,7 @@ Config changes take effect on the next agent session or gateway restart. The web
 Manage the `.env` file where API keys and credentials are stored. Keys are grouped by category:
 
 - **LLM Providers** — OpenRouter, Anthropic, OpenAI, DeepSeek, etc.
-- **Tool API Keys** — Browserbase, Firecrawl, Tavily, ElevenLabs, etc.
+- **Tool API Keys** — Browserbase, Firecrawl, Tavily, TinyFish, ElevenLabs, etc.
 - **Messaging Platforms** — Telegram, Discord, Slack bot tokens, etc.
 - **Agent Settings** — non-secret env vars like `API_SERVER_ENABLED`
 


### PR DESCRIPTION
## Summary

- Adds [TinyFish](https://tinyfish.ai) as a new web search and content extraction backend in `tools/web_tools.py`, following the same pattern as Exa, Parallel, Tavily, and Firecrawl
- Registers `TINYFISH_API_KEY` in the CLI config system and `hermes tools` setup wizard
- Adds the [`tinyfish`](https://pypi.org/project/tinyfish/) Python SDK as a project dependency

This is independent of #6329 (TinyFish cloud browser provider). Both PRs register `TINYFISH_API_KEY` — whichever merges second does a trivial config merge to combine the `tools` lists.

## Changes

| File | What |
|------|------|
| `tools/web_tools.py` | Backend detection, SDK client singleton, `_tinyfish_search()` / `_tinyfish_extract()` helpers, dispatch in `web_search_tool()` and `web_extract_tool()`, availability checks |
| `hermes_cli/config.py` | `TINYFISH_API_KEY` in `OPTIONAL_ENV_VARS`, config version bump, `show_config` / `set_config_value` |
| `hermes_cli/tools_config.py` | TinyFish entry in the Web Search & Scraping provider picker |
| `pyproject.toml` | `tinyfish>=0.2.5,<1` dependency |

## Setup

```bash
# Add to ~/.hermes/.env
TINYFISH_API_KEY=your_key_here
```

Get your API key at [agent.tinyfish.ai/api-keys](https://agent.tinyfish.ai/api-keys). Then select TinyFish as your web backend:

```bash
hermes setup tools
# → Web Search & Scraping → TinyFish
```

## Implementation notes

- **SDK-based** — uses the `tinyfish` Python SDK (`client.search.query()`, `client.fetch.get_contents()`) rather than raw HTTP, matching the pattern used by Exa and Parallel
- **Lowest fallback priority** — TinyFish is last in the auto-detection chain (after Firecrawl, Parallel, Tavily, Exa). Users select it explicitly via `hermes tools` or by setting only `TINYFISH_API_KEY`
- **Search + Extract only** — crawl is not supported (TinyFish does not offer a crawl API). The `web_crawl_tool` falls through to Firecrawl as before

## Test plan

- [ ] `hermes setup tools` → TinyFish appears in Web Search & Scraping provider list with tagline "Fast search and extract with stealth proxies"
- [ ] Selecting TinyFish sets `web.backend: tinyfish` in `~/.hermes/config.yaml`
- [ ] `TINYFISH_API_KEY` set → `check_web_api_key()` returns `True`; unset → `False`
- [ ] `web_search("python async tutorial")` returns normalized results with titles, URLs, descriptions
- [ ] `web_extract(["https://example.com"])` returns markdown content
- [ ] Fallback: only `TINYFISH_API_KEY` set, no config → auto-selects TinyFish
- [ ] Existing Exa / Parallel / Tavily / Firecrawl paths unaffected
- [ ] `hermes show config` displays TinyFish API key status