### PR TITLE
fix(approval): require exact smart approval verdicts

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -42,6 +42,33 @@ class TestSmartApproval:
         assert mock_call.call_args.kwargs["temperature"] == 0
         assert mock_call.call_args.kwargs["max_tokens"] == 16
 
+    def test_smart_approval_accepts_exact_deny(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="DENY"))]
+        )
+        with mock_patch("agent.auxiliary_client.call_llm", return_value=response):
+            result = _smart_approve("rm -rf /tmp/demo", "recursive delete")
+
+        assert result == "deny"
+
+    def test_smart_approval_does_not_accept_disapprove_substring(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="DISAPPROVE"))]
+        )
+        with mock_patch("agent.auxiliary_client.call_llm", return_value=response):
+            result = _smart_approve("rm -rf /tmp/demo", "recursive delete")
+
+        assert result == "escalate"
+
+    def test_smart_approval_does_not_accept_embedded_approve_phrase(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="DO NOT APPROVE"))]
+        )
+        with mock_patch("agent.auxiliary_client.call_llm", return_value=response):
+            result = _smart_approve("rm -rf /tmp/demo", "recursive delete")
+
+        assert result == "escalate"
+
 
 class TestDetectDangerousRm:
     def test_rm_rf_detected(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -761,10 +761,12 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()
+        token_match = re.match(r"([A-Z]+)\b", answer)
+        verdict = token_match.group(1) if token_match else ""
 
-        if "APPROVE" in answer:
+        if verdict == "APPROVE":
             return "approve"
-        elif "DENY" in answer:
+        elif verdict == "DENY":
             return "deny"
         else:
             return "escalate"


### PR DESCRIPTION
## Summary

- parse smart-approval LLM responses using an exact leading verdict token instead of substring matching
- prevent negative responses like `DISAPPROVE` and `DO NOT APPROVE` from being misclassified as `APPROVE`
- add regression coverage for exact `DENY` and negative approval phrasing

## Problem

`_smart_approve()` previously checked for `"APPROVE"` and `"DENY"` using substring matching. That allowed responses containing the word `APPROVE` inside a negative phrase to be treated as an approval. For example, `DISAPPROVE` could incorrectly return `approve`.

## Fix

Normalize the model response, extract the leading uppercase token, and only accept exact `APPROVE` or `DENY` verdicts. Any other response falls back to `escalate`.

## Tests

- `uv run pytest tests/tools/test_approval.py -k SmartApproval`

Passed:
- `4 passed in 7.83s`
