### PR TITLE
fix(cli): dependency install hint when check command exits nonzero

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -133,13 +133,15 @@ def _install_dependencies(provider_name: str) -> None:
         install_cmd = dep.get("install", "")
         if check_cmd:
             try:
-                subprocess.run(
+                result = subprocess.run(
                     check_cmd, shell=True, capture_output=True, timeout=5
                 )
+                not_installed = result.returncode != 0
             except Exception:
-                if install_cmd:
-                    print(f"\n  ⚠ '{dep_name}' not found. Install with:")
-                    print(f"    {install_cmd}")
+                not_installed = True
+            if not_installed and install_cmd:
+                print(f"\n  ⚠ '{dep_name}' not found. Install with:")
+                print(f"    {install_cmd}")
 
 
 def _get_available_providers() -> list:


### PR DESCRIPTION
## Summary
`_install_dependencies` runs each provider's `check_cmd` via `subprocess.run` without `check=True` and without inspecting `returncode`. The install hint is only printed from the `except` branch, so it fires on timeouts or spawn failures but never on the normal case i.e. a check command that runs cleanly and exits nonzero to signal the dependency is missing.

In practice that means users setting up a memory provider whose backing CLI isn't installed see nothing: the check silently succeeds from Python's perspective, no hint is shown, and setup continues as if the dependency were present.

## Fix
Capture the result, treat any nonzero `returncode` (or an exception) as not-installed, and print the install hint in either case.

## Tests
Install hints now print in both cases (both timeouts and normal clean runs)