### PR TITLE
fix(cli): preserve cmd_key when clamping skill command names

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -514,8 +514,9 @@ def _clamp_command_names(
     If all 10 digit slots are taken the entry is silently dropped.
     """
     used: set[str] = set(reserved)
-    result: list[tuple[str, str]] = []
-    for name, desc in entries:
+    result: list[tuple] = []
+    for entry in entries:
+        name, desc, *extra = entry
         if len(name) > _CMD_NAME_LIMIT:
             candidate = name[:_CMD_NAME_LIMIT]
             if candidate in used:
@@ -531,7 +532,7 @@ def _clamp_command_names(
         if name in used:
             continue
         used.add(name)
-        result.append((name, desc))
+        result.append((name, desc, *extra))
     return result
 
 
@@ -651,17 +652,15 @@ def _collect_gateway_skill_entries(
     except Exception:
         pass
 
-    # Clamp names; _clamp_command_names works on (name, desc) pairs so we
-    # need to zip/unzip.
-    skill_pairs = [(n, d) for n, d, _ in skill_triples]
-    key_by_pair = {(n, d): k for n, d, k in skill_triples}
-    skill_pairs = _clamp_command_names(skill_pairs, reserved_names)
+    # Clamp names; cmd_key is passed through as extra payload so it survives
+    # any clamp-induced renames.
+    skill_triples = _clamp_command_names(skill_triples, reserved_names)
 
     # Skills fill remaining slots — only tier that gets trimmed
     remaining = max(0, max_slots - len(all_entries))
-    hidden_count = max(0, len(skill_pairs) - remaining)
-    for n, d in skill_pairs[:remaining]:
-        all_entries.append((n, d, key_by_pair.get((n, d), "")))
+    hidden_count = max(0, len(skill_triples) - remaining)
+    for n, d, k in skill_triples[:remaining]:
+        all_entries.append((n, d, k))
 
     return all_entries[:max_slots], hidden_count
 


### PR DESCRIPTION
## Summary
In `_collect_gateway_skill_entries`, skill entries were unzipped into `(name, desc)` pairs before being passed through `_clamp_command_names`, with `cmd_key` stashed in a separate key_by_pair dict keyed by the original tuple. When a skill name exceeds the 32-char Discord limit, `_clamp_command_names` truncates it and appends a digit, so the post-clamp `(name, desc)` no longer matches the original key. The lookup falls back to `""`, and Discord ends up with a slash command whose dispatch key is empty. When you click it, nothing happens.

## Fix
The fix generalizes `_clamp_command_names` to pass arbitrary extra tuple elements through unchanged, so `cmd_key` rides along with each entry and survives any rename.

## Tests
Both normal skills and long skills (over 32-char) have normal behavior now.