### PR TITLE
fix: resolve agent log errors across TTS, vision, HA adapter, and CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9662,13 +9662,17 @@ class HermesCLI:
 
         symbol = (symbol or "❯ ").rstrip() + " "
 
-        # Prepend profile name when not default
+        # Prepend profile name when not default.
+        # Catch BaseException (not just Exception) because a KeyboardInterrupt
+        # from the signal handler can arrive mid-pathlib comparison inside
+        # get_active_profile_name(), and this code runs on the prompt_toolkit
+        # rendering thread where an unhandled KI crashes the TUI layout.
         try:
             from hermes_cli.profiles import get_active_profile_name
             profile = get_active_profile_name()
             if profile not in ("default", "custom"):
                 symbol = f"{profile} {symbol}"
-        except Exception:
+        except BaseException:
             pass
         stripped = symbol.rstrip()
         if not stripped:

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -61,6 +61,9 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
     # Reconnection backoff schedule (seconds)
     _BACKOFF_STEPS = [5, 10, 30, 60]
+    # After this many consecutive failures, reduce log level to DEBUG
+    # to avoid flooding the log when HA is simply not on the network.
+    _LOG_QUIET_AFTER = 3
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.HOMEASSISTANT)
@@ -71,6 +74,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._rest_session: Optional["aiohttp.ClientSession"] = None
         self._listen_task: Optional[asyncio.Task] = None
         self._msg_id: int = 0
+        self._consecutive_failures: int = 0
 
         # Configuration from extra
         extra = config.extra or {}
@@ -130,10 +134,13 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             # Start background listener
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._running = True
+            self._consecutive_failures = 0
             logger.info("[%s] Connected to %s", self.name, self._hass_url)
             return True
 
         except Exception as e:
+            # Ensure no session leaks on connection failure
+            await self._cleanup_ws()
             logger.error("[%s] Failed to connect: %s", self.name, e)
             return False
 
@@ -145,7 +152,13 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30)
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        try:
+            self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        except Exception:
+            # Connection failed (DNS, refused, timeout) — close the session
+            # we just created so it doesn't leak.
+            await self._cleanup_ws()
+            raise
 
         # Step 1: Receive auth_required
         msg = await self._ws.receive_json()
@@ -231,7 +244,16 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
             # Reconnect with backoff
             delay = self._BACKOFF_STEPS[min(backoff_idx, len(self._BACKOFF_STEPS) - 1)]
-            logger.info("[%s] Reconnecting in %ds...", self.name, delay)
+            self._consecutive_failures += 1
+            quiet = self._consecutive_failures > self._LOG_QUIET_AFTER
+            log = logger.debug if quiet else logger.info
+            log("[%s] Reconnecting in %ds... (attempt %d)", self.name, delay, self._consecutive_failures)
+            if quiet and self._consecutive_failures == self._LOG_QUIET_AFTER + 1:
+                logger.warning(
+                    "[%s] %d consecutive connection failures — suppressing "
+                    "further reconnect logs to DEBUG level",
+                    self.name, self._consecutive_failures,
+                )
             await asyncio.sleep(delay)
             backoff_idx += 1
 
@@ -240,9 +262,11 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                 success = await self._ws_connect()
                 if success:
                     backoff_idx = 0  # Reset on successful reconnect
+                    self._consecutive_failures = 0
                     logger.info("[%s] Reconnected", self.name)
             except Exception as e:
-                logger.warning("[%s] Reconnection failed: %s", self.name, e)
+                log_fn = logger.debug if self._consecutive_failures > self._LOG_QUIET_AFTER else logger.warning
+                log_fn("[%s] Reconnection failed: %s", self.name, e)
 
     async def _read_events(self) -> None:
         """Read events from WebSocket until disconnected."""

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1140,13 +1140,37 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     }
 
     endpoint = f"{base_url}/models/{model}:generateContent"
-    response = requests.post(
-        endpoint,
-        params={"key": api_key},
-        headers={"Content-Type": "application/json"},
-        json=payload,
-        timeout=60,
-    )
+    timeout = float(gemini_config.get("timeout", 120))
+    max_retries = int(gemini_config.get("max_retries", 2))
+
+    last_error: Optional[Exception] = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.post(
+                endpoint,
+                params={"key": api_key},
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=timeout,
+            )
+            break  # success — exit retry loop
+        except requests.exceptions.ReadTimeout as exc:
+            last_error = exc
+            if attempt < max_retries:
+                wait = 2 ** attempt
+                logger.warning(
+                    "Gemini TTS timed out (attempt %d/%d), retrying in %ds...",
+                    attempt, max_retries, wait,
+                )
+                import time
+                time.sleep(wait)
+            else:
+                raise RuntimeError(
+                    f"Gemini TTS timed out after {max_retries} attempts "
+                    f"(timeout={timeout}s). Increase tts.gemini.timeout in "
+                    f"config.yaml or check your network connection."
+                ) from exc
+
     if response.status_code != 200:
         # Surface the API error message when present
         try:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -119,10 +119,27 @@ def _detect_image_mime_type(image_path: Path) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
+    # TIFF: little-endian (II) or big-endian (MM)
+    if header[:4] in (b"II\x2a\x00", b"MM\x00\x2a"):
+        return "image/tiff"
+    # ICO / CUR
+    if len(header) >= 4 and header[:4] in (b"\x00\x00\x01\x00", b"\x00\x00\x02\x00"):
+        return "image/x-icon"
+    # AVIF / HEIC (ISOBMFF: ftyp box)
+    if len(header) >= 12 and header[4:8] == b"ftyp":
+        brand = header[8:12]
+        if brand in (b"avif", b"avis"):
+            return "image/avif"
+        if brand in (b"heic", b"heix", b"mif1"):
+            return "image/heic"
     if image_path.suffix.lower() == ".svg":
         head = image_path.read_text(encoding="utf-8", errors="ignore")[:4096].lower()
         if "<svg" in head:
             return "image/svg+xml"
+    # Fallback: use file extension when magic bytes are unrecognised
+    ext_mime = _determine_mime_type(image_path)
+    if ext_mime != "image/jpeg" or image_path.suffix.lower() in (".jpg", ".jpeg"):
+        return ext_mime
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes four categories of recurring errors observed in agent.log:

### 1. Gemini TTS Read Timeout
```
TTS GENERATION FAILED (GEMINI): READ TIMED OUT. (READ TIMEOUT=60)
```
- Increased default timeout from 60s → 120s
- Added configurable retry with exponential backoff (`tts.gemini.timeout` / `tts.gemini.max_retries` in config.yaml)
- Actionable error message on final failure

### 2. Vision Tool False Image Rejection
```
ERROR ANALYZING IMAGE: ONLY REAL IMAGE FILES ARE SUPPORTED FOR VISION ANALYSIS
```
- Added magic-byte detection for TIFF, ICO/CUR, AVIF, and HEIC formats
- Added extension-based fallback when magic bytes are unrecognised, so valid images aren't rejected

### 3. Home Assistant aiohttp Session Leak + Log Spam
```
UNCLOSED CLIENT SESSION  (every ~5 min)
FAILED TO CONNECT: CANNOT CONNECT TO HOST HOMEASSISTANT.LOCAL:8123
```
- Fixed `ClientSession` leak in `_ws_connect()`: session is now closed if `ws_connect()` raises
- Added `_cleanup_ws()` in `connect()`'s exception handler as safety net
- After 3 consecutive failures, reconnect logs demote to DEBUG (one-time WARNING at transition); resets on successful reconnect

### 4. CLI KeyboardInterrupt Race Condition
```
KEYBOARDINTERRUPT during pathlib.__eq__ → OSError: [ERRNO 5] INPUT/OUTPUT ERROR
```
- Changed `except Exception` → `except BaseException` in `_get_tui_prompt_symbols` so a `KeyboardInterrupt` from the signal handler during `get_active_profile_name()` doesn't crash the TUI layout

## Test Results
- **250 tests passed** (TTS + vision suites)
- **113 tests passed** (Home Assistant adapter + tools)
- 0 failures

---
[Warp conversation](https://app.warp.dev/conversation/f781b7bb-d9c4-4643-a947-ffa247f1c860)

Co-Authored-By: Oz <oz-agent@warp.dev>