### PR TITLE
feat: show Codex token windows in status bar

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -61,8 +61,15 @@ class RateLimitState:
     requests_hour: RateLimitBucket = field(default_factory=RateLimitBucket)
     tokens_min: RateLimitBucket = field(default_factory=RateLimitBucket)
     tokens_hour: RateLimitBucket = field(default_factory=RateLimitBucket)
+    tokens_5h: RateLimitBucket = field(default_factory=RateLimitBucket)
+    tokens_week: RateLimitBucket = field(default_factory=RateLimitBucket)
     captured_at: float = 0.0  # when the headers were captured
     provider: str = ""
+    plan_type: str = ""
+    active_limit: str = ""
+    credits_balance: str = ""
+    credits_has_credits: Optional[bool] = None
+    credits_unlimited: Optional[bool] = None
 
     @property
     def has_data(self) -> bool:
@@ -101,12 +108,39 @@ def parse_rate_limit_headers(
     # capitalises headers (HTTP header names are case-insensitive per RFC 7230).
     lowered = {k.lower(): v for k, v in headers.items()}
 
-    # Quick check: at least one rate limit header must exist
-    has_any = any(k.startswith("x-ratelimit-") for k in lowered)
+    # Quick check: at least one supported rate limit header must exist.
+    has_any = any(k.startswith(("x-ratelimit-", "x-codex-")) for k in lowered)
     if not has_any:
         return None
 
     now = time.time()
+
+    def _bool_header(name: str) -> Optional[bool]:
+        value = lowered.get(name)
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        if text in {"1", "true", "yes", "y", "on"}:
+            return True
+        if text in {"0", "false", "no", "n", "off"}:
+            return False
+        return None
+
+    def _codex_percent_bucket(prefix: str) -> RateLimitBucket:
+        pct = _safe_float(lowered.get(f"x-codex-{prefix}-used-percent"), default=-1.0)
+        if pct < 0:
+            return RateLimitBucket(captured_at=now)
+        pct = max(0.0, min(100.0, pct))
+        used = round(pct)
+        return RateLimitBucket(
+            limit=100,
+            remaining=max(0, 100 - used),
+            reset_seconds=_safe_float(lowered.get(f"x-codex-{prefix}-reset-after-seconds")),
+            captured_at=now,
+        )
+
+    codex_5h = _codex_percent_bucket("primary")
+    codex_week = _codex_percent_bucket("secondary")
 
     def _bucket(resource: str, suffix: str = "") -> RateLimitBucket:
         # e.g. resource="requests", suffix="" -> per-minute
@@ -119,13 +153,34 @@ def parse_rate_limit_headers(
             captured_at=now,
         )
 
+    def _bucket_any(resource: str, suffixes: tuple[str, ...]) -> RateLimitBucket:
+        """Return the first populated bucket for providers with variant suffixes."""
+        for suffix in suffixes:
+            bucket = _bucket(resource, suffix)
+            if bucket.limit > 0 or bucket.remaining > 0 or bucket.reset_seconds > 0:
+                return bucket
+        return RateLimitBucket(captured_at=now)
+
+    ratelimit_5h = _bucket_any("tokens", ("-5h", "-5hr", "-5hrs"))
+    ratelimit_week = _bucket_any("tokens", ("-1w", "-week", "-weekly", "-7d"))
+
     return RateLimitState(
         requests_min=_bucket("requests"),
         requests_hour=_bucket("requests", "-1h"),
         tokens_min=_bucket("tokens"),
         tokens_hour=_bucket("tokens", "-1h"),
+        # Codex plan limits arrive as percent-only x-codex-primary/secondary
+        # headers.  Fall back to x-ratelimit aliases for OpenAI-compatible
+        # providers that expose explicit 5h/week token buckets.
+        tokens_5h=codex_5h if codex_5h.limit > 0 else ratelimit_5h,
+        tokens_week=codex_week if codex_week.limit > 0 else ratelimit_week,
         captured_at=now,
         provider=provider,
+        plan_type=str(lowered.get("x-codex-plan-type") or ""),
+        active_limit=str(lowered.get("x-codex-active-limit") or ""),
+        credits_balance=str(lowered.get("x-codex-credits-balance") or ""),
+        credits_has_credits=_bool_header("x-codex-credits-has-credits"),
+        credits_unlimited=_bool_header("x-codex-credits-unlimited"),
     )
 
 
@@ -194,15 +249,44 @@ def format_rate_limit_display(state: RateLimitState) -> str:
 
     provider_label = state.provider.title() if state.provider else "Provider"
 
-    lines = [
-        f"{provider_label} Rate Limits (captured {freshness}):",
-        "",
+    lines = [f"{provider_label} Rate Limits (captured {freshness}):"]
+    meta_lines = []
+    if state.plan_type or state.active_limit:
+        plan = state.plan_type or "unknown"
+        if state.active_limit:
+            plan = f"{plan} / {state.active_limit}"
+        meta_lines.append(f"Plan: {plan}")
+    if state.credits_unlimited is not None or state.credits_has_credits is not None or state.credits_balance:
+        if state.credits_unlimited:
+            credits = "unlimited"
+        elif state.credits_has_credits is False:
+            credits = "none"
+        elif state.credits_balance:
+            credits = state.credits_balance
+        elif state.credits_has_credits:
+            credits = "available"
+        else:
+            credits = "unknown"
+        meta_lines.append(f"Credits: {credits}")
+
+    if meta_lines:
+        lines.extend(meta_lines)
+    lines.append("")
+    lines.extend([
         _bucket_line("Requests/min", state.requests_min),
         _bucket_line("Requests/hr", state.requests_hour),
         "",
         _bucket_line("Tokens/min", state.tokens_min),
         _bucket_line("Tokens/hr", state.tokens_hour),
-    ]
+    ])
+    long_token_lines = []
+    if state.tokens_5h.limit > 0:
+        long_token_lines.append(_bucket_line("Tokens/5h", state.tokens_5h))
+    if state.tokens_week.limit > 0:
+        long_token_lines.append(_bucket_line("Tokens/week", state.tokens_week))
+    if long_token_lines:
+        lines.append("")
+        lines.extend(long_token_lines)
 
     # Add warnings if any bucket is getting hot
     warnings = []
@@ -211,6 +295,8 @@ def format_rate_limit_display(state: RateLimitState) -> str:
         ("requests/hr", state.requests_hour),
         ("tokens/min", state.tokens_min),
         ("tokens/hr", state.tokens_hour),
+        ("tokens/5h", state.tokens_5h),
+        ("tokens/week", state.tokens_week),
     ]:
         if bucket.limit > 0 and bucket.usage_pct >= 80:
             reset = _fmt_seconds(bucket.remaining_seconds_now)
@@ -234,6 +320,19 @@ def format_rate_limit_compact(state: RateLimitState) -> str:
     th = state.tokens_hour
 
     parts = []
+    meta = []
+    if state.plan_type:
+        meta.append(f"plan {state.plan_type}")
+    if state.active_limit:
+        meta.append(f"limit {state.active_limit}")
+    if state.credits_unlimited:
+        meta.append("credits unlimited")
+    elif state.credits_has_credits is False:
+        meta.append("credits none")
+    elif state.credits_balance:
+        meta.append(f"credits {state.credits_balance}")
+    if meta:
+        parts.append(", ".join(meta))
     if rm.limit > 0:
         parts.append(f"RPM: {rm.remaining}/{rm.limit}")
     if rh.limit > 0:
@@ -242,5 +341,11 @@ def format_rate_limit_compact(state: RateLimitState) -> str:
         parts.append(f"TPM: {_fmt_count(tm.remaining)}/{_fmt_count(tm.limit)}")
     if th.limit > 0:
         parts.append(f"TPH: {_fmt_count(th.remaining)}/{_fmt_count(th.limit)} (resets {_fmt_seconds(th.remaining_seconds_now)})")
+    if state.tokens_5h.limit > 0:
+        t5 = state.tokens_5h
+        parts.append(f"T5H: {_fmt_count(t5.remaining)}/{_fmt_count(t5.limit)} (resets {_fmt_seconds(t5.remaining_seconds_now)})")
+    if state.tokens_week.limit > 0:
+        tw = state.tokens_week
+        parts.append(f"TW: {_fmt_count(tw.remaining)}/{_fmt_count(tw.limit)} (resets {_fmt_seconds(tw.remaining_seconds_now)})")
 
     return " | ".join(parts)

--- a/cli.py
+++ b/cli.py
@@ -2272,6 +2272,36 @@ class HermesCLI:
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
+    def _status_bar_limit_style(self, bucket: Any) -> str:
+        pct = getattr(bucket, "usage_pct", 0.0) if bucket else 0.0
+        return self._status_bar_context_style(round(pct))
+
+    def _build_limit_bar(self, bucket: Any, width: int = 5) -> str:
+        pct = getattr(bucket, "usage_pct", 0.0) if bucket else 0.0
+        safe_percent = max(0.0, min(100.0, pct))
+        filled = round((safe_percent / 100.0) * width)
+        return f"[{'█' * filled}{'░' * max(0, width - filled)}]"
+
+    @staticmethod
+    def _format_limit_percent(bucket: Any) -> str:
+        if not bucket or getattr(bucket, "limit", 0) <= 0:
+            return "--"
+        return f"{round(getattr(bucket, 'usage_pct', 0.0))}%"
+
+    def _status_bar_rate_limit_parts(self, snapshot: Dict[str, Any], *, visual: bool = False) -> list[str]:
+        """Return compact 5h/week token quota labels for the status bar."""
+        parts: list[str] = []
+        for key, label in (("rate_limit_tokens_5h", "5h"), ("rate_limit_tokens_week", "W")):
+            bucket = snapshot.get(key)
+            if not bucket or getattr(bucket, "limit", 0) <= 0:
+                continue
+            pct = self._format_limit_percent(bucket)
+            if visual:
+                parts.append(f"{label}{self._build_limit_bar(bucket, width=4)}{pct}")
+            else:
+                parts.append(f"{label} {pct}")
+        return parts
+
     @staticmethod
     def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
         """Format per-prompt elapsed time for the status bar.
@@ -2345,6 +2375,8 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "rate_limit_tokens_5h": None,
+            "rate_limit_tokens_week": None,
         }
 
         if not agent:
@@ -2358,6 +2390,14 @@ class HermesCLI:
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+        try:
+            get_rl_state = getattr(agent, "get_rate_limit_state", None)
+            rl_state = get_rl_state() if callable(get_rl_state) else None
+            if rl_state and getattr(rl_state, "has_data", False):
+                snapshot["rate_limit_tokens_5h"] = getattr(rl_state, "tokens_5h", None)
+                snapshot["rate_limit_tokens_week"] = getattr(rl_state, "tokens_week", None)
+        except Exception:
+            pass
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -2522,6 +2562,9 @@ class HermesCLI:
                 context_label = "ctx --"
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            limit_parts = self._status_bar_rate_limit_parts(snapshot, visual=width >= 110)
+            if width >= 100 and limit_parts:
+                parts.append(" ".join(limit_parts))
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -2582,9 +2625,23 @@ class HermesCLI:
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
+                    ]
+                    if width >= 100:
+                        for key, label in (("rate_limit_tokens_5h", "5h"), ("rate_limit_tokens_week", "W")):
+                            bucket = snapshot.get(key)
+                            if not bucket or getattr(bucket, "limit", 0) <= 0:
+                                continue
+                            limit_style = self._status_bar_limit_style(bucket)
+                            frags.extend([
+                                ("class:status-bar-dim", " │ "),
+                                ("class:status-bar-dim", f"{label}"),
+                                (limit_style, self._build_limit_bar(bucket, width=4)),
+                                (limit_style, self._format_limit_percent(bucket)),
+                            ])
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
-                    ]
+                    ])
                     # Position 7: per-prompt elapsed timer (live or frozen)
                     prompt_elapsed = snapshot.get("prompt_elapsed")
                     if prompt_elapsed:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5583,6 +5583,7 @@ class AIAgent:
             collected_output_items: list = []
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
+                    self._capture_rate_limits(getattr(stream, "response", None) or getattr(stream, "_response", None))
                     for event in stream:
                         self._touch_activity("receiving stream response")
                         if self._interrupt_requested:
@@ -5697,6 +5698,7 @@ class AIAgent:
         fallback_kwargs["stream"] = True
         fallback_kwargs = self._get_transport().preflight_kwargs(fallback_kwargs, allow_stream=True)
         stream_or_response = active_client.responses.create(**fallback_kwargs)
+        self._capture_rate_limits(getattr(stream_or_response, "response", None) or getattr(stream_or_response, "_response", None))
 
         # Compatibility shim for mocks or providers that still return a concrete response.
         if hasattr(stream_or_response, "output"):
@@ -6529,9 +6531,10 @@ class AIAgent:
             stream = request_client_holder["client"].chat.completions.create(**stream_kwargs)
 
             # Capture rate limit headers from the initial HTTP response.
-            # The OpenAI SDK Stream object exposes the underlying httpx
-            # response via .response before any chunks are consumed.
-            self._capture_rate_limits(getattr(stream, "response", None))
+            # The OpenAI SDK Stream object usually exposes the underlying
+            # httpx response via .response, but Codex Responses streams have
+            # also exposed it only via the private ._response attribute.
+            self._capture_rate_limits(getattr(stream, "response", None) or getattr(stream, "_response", None))
 
             content_parts: list = []
             tool_calls_acc: dict = {}

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -53,6 +53,63 @@ class TestParseHeaders:
         assert state.tokens_hour.remaining == 335999000
         assert state.tokens_hour.reset_seconds == 3490.0
 
+    def test_parses_long_codex_token_windows(self):
+        headers = {
+            "x-ratelimit-limit-tokens-5h": "1000000",
+            "x-ratelimit-remaining-tokens-5h": "750000",
+            "x-ratelimit-reset-tokens-5h": "14400",
+            "x-ratelimit-limit-tokens-1w": "10000000",
+            "x-ratelimit-remaining-tokens-1w": "2500000",
+            "x-ratelimit-reset-tokens-1w": "259200",
+        }
+        state = parse_rate_limit_headers(headers, provider="openai-codex")
+
+        assert state is not None
+        assert state.tokens_5h.limit == 1_000_000
+        assert state.tokens_5h.remaining == 750_000
+        assert state.tokens_week.limit == 10_000_000
+        assert state.tokens_week.remaining == 2_500_000
+
+    def test_parses_codex_plan_limit_headers(self):
+        headers = {
+            "x-codex-active-limit": "premium",
+            "x-codex-plan-type": "plus",
+            "x-codex-credits-balance": "0",
+            "x-codex-credits-has-credits": "false",
+            "x-codex-credits-unlimited": "false",
+            "x-codex-primary-used-percent": "40.2",
+            "x-codex-primary-window-minutes": "300",
+            "x-codex-primary-reset-after-seconds": "5900",
+            "x-codex-secondary-used-percent": "21",
+            "x-codex-secondary-window-minutes": "10080",
+            "x-codex-secondary-reset-after-seconds": "521340",
+        }
+        state = parse_rate_limit_headers(headers, provider="openai-codex")
+
+        assert state is not None
+        assert state.plan_type == "plus"
+        assert state.active_limit == "premium"
+        assert state.credits_has_credits is False
+        assert state.credits_unlimited is False
+        assert state.tokens_5h.limit == 100
+        assert state.tokens_5h.remaining == 60
+        assert round(state.tokens_5h.usage_pct) == 40
+        assert state.tokens_5h.reset_seconds == 5900
+        assert state.tokens_week.limit == 100
+        assert state.tokens_week.remaining == 79
+        assert round(state.tokens_week.usage_pct) == 21
+
+    def test_parses_weekly_aliases(self):
+        headers = {
+            "x-ratelimit-limit-tokens-weekly": "9000000",
+            "x-ratelimit-remaining-tokens-weekly": "4500000",
+        }
+        state = parse_rate_limit_headers(headers)
+
+        assert state is not None
+        assert state.tokens_week.limit == 9_000_000
+        assert state.tokens_week.remaining == 4_500_000
+
     def test_no_headers(self):
         state = parse_rate_limit_headers({})
         assert state is None
@@ -159,6 +216,42 @@ class TestFormatting:
         assert "Tokens/min" in result
         assert "Tokens/hr" in result
         assert "resets in" in result
+
+    def test_format_display_includes_long_token_windows_when_present(self):
+        state = parse_rate_limit_headers(
+            {
+                **NOUS_HEADERS,
+                "x-ratelimit-limit-tokens-5h": "1000000",
+                "x-ratelimit-remaining-tokens-5h": "500000",
+                "x-ratelimit-limit-tokens-1w": "10000000",
+                "x-ratelimit-remaining-tokens-1w": "9000000",
+            }
+        )
+        result = format_rate_limit_display(state)
+
+        assert "Tokens/5h" in result
+        assert "Tokens/week" in result
+
+    def test_format_display_includes_codex_plan_metadata(self):
+        state = parse_rate_limit_headers(
+            {
+                "x-codex-active-limit": "premium",
+                "x-codex-plan-type": "plus",
+                "x-codex-credits-has-credits": "false",
+                "x-codex-primary-used-percent": "40",
+                "x-codex-secondary-used-percent": "21",
+            },
+            provider="openai-codex",
+        )
+        result = format_rate_limit_display(state)
+        compact = format_rate_limit_compact(state)
+
+        assert "Plan: plus / premium" in result
+        assert "Credits: none" in result
+        assert "Tokens/5h" in result
+        assert "Tokens/week" in result
+        assert "plan plus" in compact
+        assert "T5H:" in compact
 
     def test_format_display_warning_on_high_usage(self):
         headers = {

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -28,6 +28,7 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    rate_limit_state=None,
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
@@ -41,7 +42,7 @@ def _attach_agent(
         session_completion_tokens=completion_tokens,
         session_total_tokens=total_tokens,
         session_api_calls=api_calls,
-        get_rate_limit_state=lambda: None,
+        get_rate_limit_state=lambda: rate_limit_state,
         context_compressor=SimpleNamespace(
             last_prompt_tokens=context_tokens,
             context_length=context_length,
@@ -79,6 +80,30 @@ class TestCLIStatusBar:
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_build_status_bar_text_shows_5h_and_week_token_limits(self):
+        rate_limit_state = SimpleNamespace(
+            has_data=True,
+            tokens_5h=SimpleNamespace(limit=1_000_000, remaining=600_000, usage_pct=40.0),
+            tokens_week=SimpleNamespace(limit=10_000_000, remaining=2_000_000, usage_pct=80.0),
+        )
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            rate_limit_state=rate_limit_state,
+        )
+
+        text = cli_obj._build_status_bar_text(width=140)
+
+        assert "5h[" in text
+        assert "40%" in text
+        assert "W[" in text
+        assert "80%" in text
 
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()


### PR DESCRIPTION
## Summary\n- parse OpenAI Codex x-codex plan-limit headers for 5h and weekly windows\n- surface 5h/W visual bars in the CLI status bar when quota headers are available\n- capture Responses stream headers from both response and _response\n\n## Tests\n- python -m pytest tests/gateway/test_usage_command.py tests/agent/test_rate_limit_tracker.py tests/cli/test_cli_status_bar.py -o 'addopts=' -q\n- python -m py_compile agent/rate_limit_tracker.py cli.py run_agent.py