### PR TITLE
fix(cli): propagate fallback_providers to AIAgent in oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -284,6 +284,10 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
+    # Load fallback provider chain from config.yaml so oneshot mode can
+    # survive 429 rate-limits on the primary provider (parity with gateway).
+    fallback_model = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -294,6 +298,7 @@ def _run_agent(
         quiet_mode=True,
         platform="cli",
         credential_pool=runtime.get("credential_pool"),
+        fallback_model=fallback_model,
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction


### PR DESCRIPTION
## Summary

Fixes #18961 — `--oneshot` CLI mode now respects the configured `fallback_providers` chain from `config.yaml`, bringing it to parity with gateway mode.

## Problem

When the primary provider returns HTTP 429 (rate-limit) in `--oneshot` mode, the agent hard-fails instead of falling back to the next provider in the `fallback_providers` chain. Gateway mode already handles this correctly by passing `fallback_model=self._fallback_model` to the `AIAgent()` constructor.

## Root Cause

`hermes_cli/oneshot.py` loads `cfg = load_config()` but never extracts `fallback_providers` / `fallback_model` from it, and the `AIAgent(...)` call at line 287 is missing the `fallback_model=` parameter entirely.

## Fix

Two-line change:
1. Extract fallback config from the already-loaded `cfg`: `fallback_model = cfg.get("fallback_providers") or cfg.get("fallback_model") or None`
2. Pass it to `AIAgent(...)`: `fallback_model=fallback_model`

`AIAgent.__init__` already normalizes both the list (`fallback_providers`) and legacy dict (`fallback_model`) formats into a fallback chain, so this works with either config style.

## Testing

- Manual: configure a `fallback_providers` chain in `config.yaml`, then run `hermes --oneshot` while the primary provider is rate-limited → previously hard-failed, now falls back.
- `AIAgent.__init__` signature already accepts `fallback_model` parameter (line 954 in `run_agent.py`), so no downstream changes needed.

## Files Changed

- `hermes_cli/oneshot.py`: Added fallback config extraction + parameter passthrough (5 lines)
