### PR TITLE
fix(delegate): read delegation config from disk first to avoid stale cache

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2320,13 +2320,19 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from persistent config, falling back to CLI_CONFIG.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Reads the persistent config first so that ``hermes config set delegation.*``
+    changes take effect immediately in a running process.  Falls back to the
+    runtime cache (cli.py CLI_CONFIG) only when the disk read fails.
     """
+    try:
+        from hermes_cli.config import load_config
+
+        full = load_config()
+        return full.get("delegation", {})
+    except Exception:
+        pass
     try:
         from cli import CLI_CONFIG
 
@@ -2335,13 +2341,7 @@ def _load_config() -> dict:
             return cfg
     except Exception:
         pass
-    try:
-        from hermes_cli.config import load_config
-
-        full = load_config()
-        return full.get("delegation", {})
-    except Exception:
-        return {}
+    return {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #18946

`_load_config()` in `tools/delegate_tool.py` checked the runtime cache (`cli.CLI_CONFIG`) first and never fell back to disk when the cache existed. This meant `hermes config set delegation.model <X>` wrote to disk correctly but the running process continued using the old value silently.

## Changes

Reverse the priority in `_load_config()`: always read from the persistent config file first, falling back to `CLI_CONFIG` only when the disk read fails. This makes `delegation.*` changes take effect immediately without requiring a process restart.

## Test plan

```bash
# Start hermes, then from another shell:
hermes config set delegation.model some-other-model
# delegate_task should now use the new model without restart
```