### PR TITLE
fix: allow kanban tools for orchestrator profiles with kanban toolset

### DIFF
--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -40,13 +40,31 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _check_kanban_mode() -> bool:
-    """Tools are available iff the current process has ``HERMES_KANBAN_TASK``
-    set in its env, which the dispatcher sets when spawning a worker.
+    """Tools are available when:
 
-    Humans running ``hermes chat`` see zero kanban tools. Workers spawned
-    by the kanban dispatcher (gateway-embedded by default) see all seven.
+    1. ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), OR
+    2. The current profile has ``kanban`` in its toolsets config
+       (orchestrator profiles like techlead that route work via Kanban).
+
+    Humans running ``hermes chat`` without the kanban toolset see zero
+    kanban tools. Workers spawned by the kanban dispatcher (gateway-
+    embedded by default) and orchestrator profiles with the kanban
+    toolset enabled see all seven.
     """
-    return bool(os.environ.get("HERMES_KANBAN_TASK"))
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+
+    # Check if the current profile has the kanban toolset enabled.
+    # Uses load_config() which has mtime-based caching, so this adds
+    # negligible overhead. The check_fn results are further TTL-cached
+    # (~30s) by the tool registry.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        toolsets = cfg.get("toolsets", [])
+        return "kanban" in toolsets
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `_check_kanban_mode()` gating function in `tools/kanban_tools.py` only returns `True` when `HERMES_KANBAN_TASK` is set in the environment. This env var is only set by the kanban dispatcher when spawning a worker process.

**Orchestrator profiles (like a techlead that routes work via Kanban) never see the kanban tools**, even when they have `kanban` explicitly listed in their `toolsets` config.

### Impact

- Orchestrator profiles cannot create, link, or manage Kanban tasks via tool calls
- The orchestrator hallucinates task creation because its SOUL.md instructs it to use kanban tools that do not exist in its schema
- Workers spawned by the dispatcher work fine (they get `HERMES_KANBAN_TASK` set)

### Fix

Modified `_check_kanban_mode()` to also return `True` when the current profile has `kanban` in its `toolsets` config.

Uses `load_config()` from `hermes_cli.config` which has **mtime-based caching**, so this adds negligible overhead. The `check_fn` results are further TTL-cached (~30s) by the tool registry.

This allows orchestrator profiles to use `kanban_create`, `kanban_link`, etc. to route work, while workers continue to use the full kanban toolset via the dispatcher env var.

### Testing

Tested in a real multi-agent setup with 4 profiles (techlead, dev, devops, qa). Before the fix, the techlead orchestrator could not see any kanban tools and hallucinated task creation. After the fix, it correctly sees and uses `kanban_create`, `kanban_link`, etc.

Fixes #18968