### PR TITLE
fix(tools): allow orchestrator profiles to see kanban tools via toolsets config

### DIFF
--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -40,13 +40,29 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _check_kanban_mode() -> bool:
-    """Tools are available iff the current process has ``HERMES_KANBAN_TASK``
-    set in its env, which the dispatcher sets when spawning a worker.
+    """Tools are available when the current process has ``HERMES_KANBAN_TASK``
+    set (kanban worker) OR when the active profile has ``kanban`` in its
+    toolsets config (orchestrator profiles that route via kanban).
 
-    Humans running ``hermes chat`` see zero kanban tools. Workers spawned
-    by the kanban dispatcher (gateway-embedded by default) see all seven.
+    Workers spawned by the kanban dispatcher always pass via the env var.
+    Orchestrator profiles that list ``kanban`` in their ``toolsets`` config
+    need this second path because the dispatcher never sets the env var
+    for them — they create/link tasks, not execute them. (issue #18968)
     """
-    return bool(os.environ.get("HERMES_KANBAN_TASK"))
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    # Check if kanban is in the current profile's toolsets config.
+    # This allows orchestrator profiles to use kanban_create/kanban_link
+    # even when they're not kanban workers.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        toolsets = cfg.get("toolsets") or []
+        if "kanban" in toolsets:
+            return True
+    except Exception:
+        pass
+    return False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends `_check_kanban_mode()` in `tools/kanban_tools.py` to also return `True` when the active profile has `kanban` in its `toolsets` config — not only when `HERMES_KANBAN_TASK` env var is set.

## Problem

Orchestrator profiles (e.g., a techlead that routes work via Kanban) cannot see any kanban tools (`kanban_create`, `kanban_link`, etc.) even when they have `kanban` explicitly listed in their `toolsets` config. This is because `_check_kanban_mode()` only checks for the `HERMES_KANBAN_TASK` env var, which is only set by the kanban dispatcher when spawning a **worker** process.

The orchestrator then hallucinates task creation because its SOUL.md instructs it to use kanban tools that don't exist in its schema.

## Fix

Add a second path to `_check_kanban_mode()` that checks the current config for `kanban` in `toolsets`. Uses the existing `load_config()` which has mtime-based caching, so this adds negligible overhead. The check_fn results are further TTL-cached (~30s) by the tools registry.

Workers continue to work via the `HERMES_KANBAN_TASK` env var (no change). Orchestrators now get visibility via their `toolsets` config.

Fixes #18968

## Testing

- Existing kanban worker behavior unchanged (env var path still checked first)
- Orchestrator profiles with `kanban` in `toolsets` now see all 7 kanban tools
- Profiles without `kanban` in `toolsets` continue to see zero kanban tools
