### PR TITLE
test(gateway): derive expected TimeoutStopSec from configured drain timeout

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -108,6 +108,14 @@ class TestSystemdServiceRefresh:
 
 
 class TestGeneratedSystemdUnits:
+    @staticmethod
+    def _expected_timeout_stop_sec() -> int:
+        """Mirror the formula in ``hermes_cli.gateway`` so this test stays
+        green when ``agent.restart_drain_timeout`` (and therefore the
+        derived TimeoutStopSec headroom) shifts in the shared defaults."""
+        drain = int(gateway_cli._get_restart_drain_timeout() or 0)
+        return max(60, drain) + 30
+
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=False)
 
@@ -115,10 +123,13 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        assert "TimeoutStopSec=90" in unit
+        # TimeoutStopSec must exceed the configured drain_timeout so systemd
+        # doesn't SIGKILL the cgroup before post-interrupt cleanup (tool
+        # subprocess kill, adapter disconnect) runs — issue #8202. Compute
+        # the expected value from the same helper the unit generator uses,
+        # so the assertion follows the configured default rather than
+        # hardcoding a stale value.
+        assert f"TimeoutStopSec={self._expected_timeout_stop_sec()}" in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
@@ -134,10 +145,11 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        assert "TimeoutStopSec=90" in unit
+        # TimeoutStopSec must exceed the configured drain_timeout so systemd
+        # doesn't SIGKILL the cgroup before post-interrupt cleanup (tool
+        # subprocess kill, adapter disconnect) runs — issue #8202. See
+        # ``_expected_timeout_stop_sec`` above for why this is computed.
+        assert f"TimeoutStopSec={self._expected_timeout_stop_sec()}" in unit
         assert "WantedBy=multi-user.target" in unit
 
 


### PR DESCRIPTION
## Summary

Fixes two `Tests` failures observed on `main` (and therefore propagating to every open PR):

```
FAILED tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits::test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout
FAILED tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits::test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout
```

Reference run: [25250051126](https://github.com/NousResearch/hermes-agent/actions/runs/25250051126) on `5d3be898a`.

## Root cause

`hermes_cli/gateway.py:1635` computes:

```python
_drain_timeout = int(_get_restart_drain_timeout() or 0)
restart_timeout = max(60, _drain_timeout) + 30
```

The default `agent.restart_drain_timeout` was bumped to **180s**, which makes the rendered systemd unit emit `TimeoutStopSec=210`. The two assertions in `TestGeneratedSystemdUnits` were still pinned to `TimeoutStopSec=90` (formerly correct when the default was 60s), so they fail on every CI run.

## Fix

Compute the expected value from the same helper the unit generator uses:

```python
@staticmethod
def _expected_timeout_stop_sec() -> int:
    drain = int(gateway_cli._get_restart_drain_timeout() or 0)
    return max(60, drain) + 30
```

…then assert `f"TimeoutStopSec={self._expected_timeout_stop_sec()}" in unit`. The assertion now tracks the configured default rather than hardcoding a literal.

## Validation

```
$ pytest tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits -q
3 passed in 1.82s
```

## Scope

- ✅ No production code change (test-only fix)
- ✅ Both `system=True` and `system=False` units re-validated
- ✅ Issue #8202's invariant ("TimeoutStopSec must exceed drain_timeout") is still asserted, just expressed correctly

## Out of scope

The other ~13 main-CI failures (gateway-restart `kill` semantics, dotenv vs `os.environ`, Dockerfile pid1, etc.) — happy to send those as separate focused PRs.
