### PR TITLE
fix(agent): forward reasoning_config to background review AIAgent fork

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3620,6 +3620,7 @@ class AIAgent:
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
                         enabled_toolsets=["memory", "skills"],
+                        reasoning_config=self.reasoning_config,
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -20,6 +22,7 @@ def _bare_agent() -> AIAgent:
     agent._memory_store = object()
     agent._memory_enabled = True
     agent._user_profile_enabled = False
+    agent.reasoning_config = None
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
@@ -189,4 +192,50 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     assert len(captured_bg_callback) == 1
     assert captured_bg_callback[0].startswith("💾 Self-improvement review:"), (
         captured_bg_callback[0]
+    )
+
+
+@pytest.mark.parametrize("reasoning_cfg", [
+    None,
+    {"enabled": True, "effort": "xhigh"},
+    {"enabled": False},
+])
+def test_background_review_inherits_reasoning_config(monkeypatch, reasoning_cfg):
+    """_spawn_background_review() must forward the parent's reasoning_config.
+
+    Without this, a session configured for xhigh reasoning effort spawns a
+    review agent that falls back to the transport default (medium), generating
+    unexpected medium-effort upstream requests (#18871).
+    """
+    captured: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["reasoning_config"] = kwargs.get("reasoning_config")
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent.reasoning_config = reasoning_cfg
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured["reasoning_config"] == reasoning_cfg, (
+        f"Expected reasoning_config={reasoning_cfg!r} to be forwarded to the "
+        f"review agent, got {captured['reasoning_config']!r}"
     )


### PR DESCRIPTION
## What does this PR do?

\`_spawn_background_review()\` in \`run_agent.py\` (line ~3611) inherits the parent session's \`provider\`, \`model\`, \`base_url\`, \`api_key\`, and \`api_mode\` when forking a review agent. \`reasoning_config\` was not forwarded.

On Codex Responses routes the missing field causes the forked review agent to fall back to the transport default (\`medium\` effort), so a session configured for \`agent.reasoning_effort: xhigh\` still generates medium-effort background review requests — wasting budget and ignoring the user's explicit preference.

One-line fix in \`_spawn_background_review()\` — passes \`reasoning_config=self.reasoning_config\`. When \`reasoning_config\` is \`None\` the behaviour is identical to before: harmless no-op for sessions without a reasoning override. Symmetric with the \`api_mode\`, \`base_url\`, and \`api_key\` fields that #16006 and #15884 already propagate on the same fork path.

## Related Issue
Fixes #18871

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made
- \`run_agent.py\`: add \`reasoning_config=self.reasoning_config\` to \`AIAgent(...)\` in \`_spawn_background_review()\` (+1 line)
- \`tests/run_agent/test_background_review.py\`: add \`reasoning_config = None\` to \`_bare_agent()\` helper; add \`test_background_review_inherits_reasoning_config\` parametrized over \`None\`, \`{"effort": "xhigh"}\`, and \`{"enabled": False}\` (+49 lines)

## How to Test
\`\`\`bash
python3.11 -m pytest tests/run_agent/test_background_review.py -v --override-ini="addopts="
\`\`\`

## Checklist
### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] Single logical change only
- [x] pytest passing
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A