### PR TITLE
feat(gateway): add optional IMAP IDLE receive mode for email

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -11,6 +11,7 @@ Environment variables:
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
     EMAIL_ADDRESS       — Email address for the agent
     EMAIL_PASSWORD      — Email password or app-specific password
+    EMAIL_RECEIVE_MODE  — Receive mode: poll, idle, or auto (default: poll)
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
 """
@@ -21,8 +22,11 @@ import imaplib
 import logging
 import os
 import re
+import select
+import socket
 import smtplib
 import ssl
+import time
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -61,6 +65,14 @@ _AUTOMATED_HEADERS = {
 
 # Gmail-safe max length per email body
 MAX_MESSAGE_LENGTH = 50_000
+
+# RFC 2177 recommends terminating IDLE at least every 29 minutes.
+_IDLE_RECONNECT_SECONDS = 25 * 60
+_IDLE_READ_TIMEOUT_SECONDS = 5
+_IDLE_EVENT = "event"
+_IDLE_BACKOFF = "backoff"
+_IDLE_RECONNECT = "reconnect"
+_VALID_RECEIVE_MODES = {"poll", "idle", "auto"}
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
@@ -232,6 +244,13 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._receive_mode = os.getenv("EMAIL_RECEIVE_MODE", "poll").strip().lower()
+        if self._receive_mode not in _VALID_RECEIVE_MODES:
+            logger.warning(
+                "[Email] Invalid EMAIL_RECEIVE_MODE=%r; falling back to polling",
+                self._receive_mode,
+            )
+            self._receive_mode = "poll"
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -244,6 +263,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
+        self._idle_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
@@ -271,11 +291,13 @@ class EmailAdapter(BasePlatformAdapter):
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
     async def connect(self) -> bool:
-        """Connect to the IMAP server and start polling for new messages."""
+        """Connect to the IMAP server and start receiving new messages."""
+        imap_supports_idle = False
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
+            imap_supports_idle = self._imap_supports_idle(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
@@ -302,21 +324,57 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         self._running = True
-        self._poll_task = asyncio.create_task(self._poll_loop())
-        print(f"[Email] Connected as {self._address}")
+        receive_mode = self._resolve_receive_mode(imap_supports_idle)
+        if receive_mode == "idle":
+            self._idle_task = asyncio.create_task(self._idle_loop())
+            logger.info("[Email] Receiving messages with IMAP IDLE.")
+        else:
+            self._poll_task = asyncio.create_task(self._poll_loop())
+            logger.info("[Email] Receiving messages with polling every %d seconds.", self._poll_interval)
+        print(f"[Email] Connected as {self._address} (receive_mode: {receive_mode})")
         return True
 
     async def disconnect(self) -> None:
-        """Stop polling and disconnect."""
+        """Stop receiving and disconnect."""
         self._running = False
-        if self._poll_task:
-            self._poll_task.cancel()
+        for task_attr in ("_poll_task", "_idle_task"):
+            task = getattr(self, task_attr)
+            if not task:
+                continue
+            task.cancel()
             try:
-                await self._poll_task
+                await task
             except asyncio.CancelledError:
                 pass
-            self._poll_task = None
+            setattr(self, task_attr, None)
         logger.info("[Email] Disconnected.")
+
+    def _resolve_receive_mode(self, imap_supports_idle: bool) -> str:
+        """Resolve configured receive mode after server capability probing."""
+        if self._receive_mode == "poll":
+            return "poll"
+        if imap_supports_idle:
+            return "idle"
+        if self._receive_mode == "idle":
+            logger.warning("[Email] IMAP server does not advertise IDLE; falling back to polling.")
+        else:
+            logger.info("[Email] IMAP server does not advertise IDLE; using polling.")
+        return "poll"
+
+    def _imap_supports_idle(self, imap: imaplib.IMAP4_SSL) -> bool:
+        """Return True when the connected IMAP server advertises IDLE."""
+        try:
+            status, data = imap.capability()
+        except Exception as e:
+            logger.debug("[Email] IMAP capability check failed: %s", e)
+            return False
+        if str(status).upper() != "OK" or not data:
+            return False
+        capabilities = b" ".join(
+            item if isinstance(item, bytes) else str(item).encode("ascii", errors="ignore")
+            for item in data
+        ).upper().split()
+        return b"IDLE" in capabilities
 
     async def _poll_loop(self) -> None:
         """Poll IMAP for new messages at regular intervals."""
@@ -328,6 +386,98 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("[Email] Poll error: %s", e)
             await asyncio.sleep(self._poll_interval)
+
+    async def _idle_loop(self) -> None:
+        """Wait for IMAP IDLE notifications, then reuse the normal inbox check."""
+        while self._running:
+            try:
+                await self._check_inbox()
+                idle_result = await asyncio.to_thread(self._idle_wait_once)
+                if idle_result == _IDLE_EVENT and self._running:
+                    await self._check_inbox()
+                elif idle_result == _IDLE_BACKOFF and self._running:
+                    await asyncio.sleep(self._poll_interval)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("[Email] IDLE error: %s", e)
+                await asyncio.sleep(self._poll_interval)
+
+    def _idle_wait_once(self) -> str:
+        """Block in IMAP IDLE until a mailbox event or periodic reconnect.
+
+        Returns:
+            "event" when the server sent an untagged mailbox update,
+            "backoff" when IDLE is unavailable or rejected, and
+            "reconnect" when the wait ended normally or the connection closed.
+        """
+        imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+        idling = False
+        try:
+            imap.login(self._address, self._password)
+            if not self._imap_supports_idle(imap):
+                logger.warning("[Email] IMAP server stopped advertising IDLE; falling back to polling wait.")
+                return _IDLE_BACKOFF
+            imap.select("INBOX")
+            tag = imap._new_tag()
+            if isinstance(tag, str):
+                tag_bytes = tag.encode("ascii")
+            else:
+                tag_bytes = tag
+            imap.send(tag_bytes + b" IDLE\r\n")
+
+            continuation = imap.readline()
+            if not continuation.startswith(b"+"):
+                logger.warning("[Email] IMAP IDLE was not accepted by server: %r", continuation)
+                return _IDLE_BACKOFF
+
+            idling = True
+            deadline = time.monotonic() + _IDLE_RECONNECT_SECONDS
+            sock = getattr(imap, "sock", None)
+
+            while self._running and time.monotonic() < deadline:
+                try:
+                    # Do not block forever in readline(); waiting with select()
+                    # lets disconnect() stop promptly without putting imaplib's
+                    # buffered reader into a bad state after socket timeouts.
+                    if sock is not None:
+                        readable, _, _ = select.select([sock], [], [], _IDLE_READ_TIMEOUT_SECONDS)
+                        if not readable:
+                            continue
+                    line = imap.readline()
+                except (TimeoutError, socket.timeout):
+                    return _IDLE_RECONNECT
+                if not line:
+                    return _IDLE_RECONNECT
+                upper = line.upper()
+                if b"EXISTS" in upper or b"RECENT" in upper or b"EXPUNGE" in upper:
+                    return _IDLE_EVENT
+            return _IDLE_RECONNECT
+        finally:
+            if idling:
+                try:
+                    imap.send(b"DONE\r\n")
+                    self._drain_idle_completion(imap)
+                except Exception:
+                    pass
+            try:
+                imap.logout()
+            except Exception:
+                pass
+
+    def _set_imap_socket_timeout(self, imap: imaplib.IMAP4_SSL, timeout: int) -> None:
+        """Set the underlying IMAP socket timeout when available."""
+        sock = getattr(imap, "sock", None)
+        if sock is not None:
+            sock.settimeout(timeout)
+
+    def _drain_idle_completion(self, imap: imaplib.IMAP4_SSL) -> None:
+        """Read the tagged completion response after sending DONE."""
+        self._set_imap_socket_timeout(imap, _IDLE_READ_TIMEOUT_SECONDS)
+        try:
+            imap.readline()
+        except (TimeoutError, socket.timeout):
+            pass
 
     async def _check_inbox(self) -> None:
         """Check INBOX for unseen messages and dispatch them."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -767,6 +767,124 @@ class TestConnectDisconnect(unittest.TestCase):
             if adapter._poll_task:
                 adapter._poll_task.cancel()
 
+    def test_connect_defaults_to_polling(self):
+        """Email adapter should keep polling as the default receive mode."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1 IDLE"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            self.assertIsNotNone(adapter._poll_task)
+            self.assertIsNone(adapter._idle_task)
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+
+    def test_connect_idle_mode_starts_idle_task_when_supported(self):
+        """EMAIL_RECEIVE_MODE=idle should start IDLE when capability is advertised."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_RECEIVE_MODE": "idle",
+        }):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+        mock_imap.capability.return_value = ("OK", [b"imap4rev1 idle"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            self.assertIsNotNone(adapter._idle_task)
+            self.assertIsNone(adapter._poll_task)
+            adapter._running = False
+            if adapter._idle_task:
+                adapter._idle_task.cancel()
+
+    def test_connect_auto_mode_uses_idle_when_supported(self):
+        """EMAIL_RECEIVE_MODE=auto should use IDLE when available."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_RECEIVE_MODE": "auto",
+        }):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1", b"IDLE"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            self.assertIsNotNone(adapter._idle_task)
+            self.assertIsNone(adapter._poll_task)
+            adapter._running = False
+            if adapter._idle_task:
+                adapter._idle_task.cancel()
+
+    def test_connect_auto_mode_falls_back_to_polling_without_idle(self):
+        """EMAIL_RECEIVE_MODE=auto should poll when IDLE is not advertised."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_RECEIVE_MODE": "auto",
+        }):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            self.assertIsNotNone(adapter._poll_task)
+            self.assertIsNone(adapter._idle_task)
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+
     def test_connect_imap_failure(self):
         """IMAP connection failure returns False."""
         import asyncio
@@ -804,6 +922,21 @@ class TestConnectDisconnect(unittest.TestCase):
 
         self.assertFalse(adapter._running)
         self.assertIsNone(adapter._poll_task)
+
+    def test_disconnect_cancels_idle(self):
+        """disconnect() should cancel the IDLE task."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._running = True
+
+        async def _exercise_disconnect():
+            adapter._idle_task = asyncio.create_task(asyncio.sleep(100))
+            await adapter.disconnect()
+
+        asyncio.run(_exercise_disconnect())
+
+        self.assertFalse(adapter._running)
+        self.assertIsNone(adapter._idle_task)
 
 
 class TestFetchNewMessages(unittest.TestCase):
@@ -947,6 +1080,139 @@ class TestPollLoop(unittest.TestCase):
 
         self.assertEqual(len(dispatched), 1)
         self.assertEqual(dispatched[0]["subject"], "Inbox Test")
+
+
+class TestIdleLoop(unittest.TestCase):
+    """Test optional IMAP IDLE receive mode."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_POLL_INTERVAL": "1",
+            "EMAIL_RECEIVE_MODE": "idle",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_capability_check_is_case_insensitive(self):
+        """IDLE capability detection should ignore case."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.capability.return_value = ("OK", [b"imap4rev1 idle"])
+
+        self.assertTrue(adapter._imap_supports_idle(mock_imap))
+
+    def test_capability_check_returns_false_without_idle(self):
+        """Missing IDLE capability should be treated as unsupported."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1 STARTTLS"])
+
+        self.assertFalse(adapter._imap_supports_idle(mock_imap))
+
+    def test_idle_loop_checks_inbox_after_event(self):
+        """IDLE events should trigger the normal inbox check path."""
+        import asyncio
+        adapter = self._make_adapter()
+        calls = []
+
+        async def mock_check_inbox():
+            calls.append("check")
+            if len(calls) >= 2:
+                adapter._running = False
+
+        adapter._check_inbox = mock_check_inbox
+        adapter._idle_wait_once = MagicMock(return_value="event")
+        adapter._running = True
+
+        asyncio.run(adapter._idle_loop())
+
+        self.assertEqual(calls, ["check", "check"])
+        adapter._idle_wait_once.assert_called_once()
+
+    def test_idle_loop_backs_off_after_rejected_idle(self):
+        """Rejected IDLE should back off in the async loop after IMAP cleanup."""
+        import asyncio
+        adapter = self._make_adapter()
+        calls = []
+
+        async def mock_check_inbox():
+            calls.append("check")
+
+        async def mock_sleep(seconds):
+            calls.append(f"sleep:{seconds}")
+            adapter._running = False
+
+        adapter._check_inbox = mock_check_inbox
+        adapter._idle_wait_once = MagicMock(return_value="backoff")
+        adapter._running = True
+
+        with patch("asyncio.sleep", side_effect=mock_sleep):
+            asyncio.run(adapter._idle_loop())
+
+        self.assertEqual(calls, ["check", "sleep:1"])
+        adapter._idle_wait_once.assert_called_once()
+
+    def test_idle_loop_handles_idle_errors(self):
+        """IDLE loop errors should be caught without leaving the loop broken."""
+        import asyncio
+        adapter = self._make_adapter()
+        calls = []
+
+        async def mock_check_inbox():
+            calls.append("check")
+            adapter._running = False
+
+        adapter._check_inbox = mock_check_inbox
+        adapter._idle_wait_once = MagicMock(side_effect=Exception("idle failed"))
+        adapter._running = True
+
+        asyncio.run(adapter._idle_loop())
+
+        self.assertEqual(calls, ["check"])
+
+    def test_idle_wait_sends_done_after_mailbox_event(self):
+        """_idle_wait_once should enter IDLE and leave it with DONE."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.sock = None
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1 IDLE"])
+        mock_imap._new_tag.return_value = b"A001"
+        mock_imap.readline.side_effect = [
+            b"+ idling\r\n",
+            b"* 2 EXISTS\r\n",
+            b"A001 OK IDLE terminated\r\n",
+        ]
+        adapter._running = True
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            result = adapter._idle_wait_once()
+
+        self.assertEqual(result, "event")
+        mock_imap.send.assert_any_call(b"A001 IDLE\r\n")
+        mock_imap.send.assert_any_call(b"DONE\r\n")
+        mock_imap.logout.assert_called_once()
+
+    def test_idle_wait_returns_backoff_when_idle_rejected(self):
+        """Rejected IDLE should return backoff after logging out."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1 IDLE"])
+        mock_imap._new_tag.return_value = b"A001"
+        mock_imap.readline.return_value = b"A001 NO IDLE not accepted\r\n"
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("time.sleep") as mock_sleep:
+            result = adapter._idle_wait_once()
+
+        self.assertEqual(result, "backoff")
+        mock_sleep.assert_not_called()
+        mock_imap.logout.assert_called_once()
 
 
 class TestSendEmailStandalone(unittest.TestCase):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -313,6 +313,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_HOME_ADDRESS` | Default recipient for proactive email delivery |
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |
 | `EMAIL_POLL_INTERVAL` | Email polling interval in seconds |
+| `EMAIL_RECEIVE_MODE` | Email receive mode: `poll`, `idle`, or `auto` |
 | `EMAIL_ALLOW_ALL_USERS` | Allow all inbound email senders |
 | `DINGTALK_CLIENT_ID` | DingTalk bot AppKey from developer portal ([open.dingtalk.com](https://open.dingtalk.com)) |
 | `DINGTALK_CLIENT_SECRET` | DingTalk bot AppSecret from developer portal |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -71,6 +71,7 @@ EMAIL_ALLOWED_USERS=your@email.com,colleague@work.com
 EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
+EMAIL_RECEIVE_MODE=poll                # poll, idle, or auto (default: poll)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
 ```
 
@@ -87,7 +88,7 @@ sudo hermes gateway install --system   # Linux only: boot-time system service
 On startup, the adapter:
 1. Tests IMAP and SMTP connections
 2. Marks all existing inbox messages as "seen" (only processes new emails)
-3. Starts polling for new messages
+3. Starts receiving new messages with the configured receive mode
 
 ---
 
@@ -95,7 +96,7 @@ On startup, the adapter:
 
 ### Receiving Messages
 
-The adapter polls the IMAP inbox for UNSEEN messages at a configurable interval (default: 15 seconds). For each new email:
+By default, the adapter polls the IMAP inbox for UNSEEN messages at a configurable interval (default: 15 seconds). For each new email:
 
 - **Subject line** is included as context (e.g., `[Subject: Deploy to production]`)
 - **Reply emails** (subject starting with `Re:`) skip the subject prefix — the thread context is already established
@@ -105,6 +106,24 @@ The adapter polls the IMAP inbox for UNSEEN messages at a configurable interval 
 - **HTML-only emails** have tags stripped for plain text extraction
 - **Self-messages** are filtered out to prevent reply loops
 - **Automated/noreply senders** are silently ignored — `noreply@`, `mailer-daemon@`, `bounce@`, `no-reply@`, and emails with `Auto-Submitted`, `Precedence: bulk`, or `List-Unsubscribe` headers
+
+### Receive Modes
+
+The default receive mode is polling because it works with the widest range of IMAP providers. If your provider supports the IMAP `IDLE` command, you can opt in to reduce idle mailbox polling load:
+
+```bash
+EMAIL_RECEIVE_MODE=idle
+```
+
+Available modes:
+
+| Mode | Behavior |
+|------|----------|
+| `poll` | Check the inbox every `EMAIL_POLL_INTERVAL` seconds. This is the default and most compatible option. |
+| `idle` | Use IMAP IDLE when the server advertises support. If IDLE is not advertised, Hermes falls back to polling. |
+| `auto` | Use IMAP IDLE when available, otherwise use polling. |
+
+IDLE delivery latency depends on provider behavior and may not be faster than short-interval polling. Exchange and self-hosted IMAP servers that document reliable IDLE support are good candidates. Some consumer providers either delay IDLE notifications, do not support IDLE, or do not document it clearly; keep `poll` for those providers unless you have tested IDLE successfully.
 
 ### Sending Replies
 
@@ -156,7 +175,8 @@ Email access follows the same pattern as all other Hermes platforms:
 | **Messages not received** | Check `EMAIL_ALLOWED_USERS` includes the sender's email. Check spam folder — some providers flag automated replies. |
 | **"Authentication failed"** | For Gmail, you must use an App Password, not your regular password. Ensure 2FA is enabled first. |
 | **Duplicate replies** | Ensure only one gateway instance is running. Check `hermes gateway status`. |
-| **Slow response** | The default poll interval is 15 seconds. Reduce with `EMAIL_POLL_INTERVAL=5` for faster response (but more IMAP connections). |
+| **Slow response** | The default poll interval is 15 seconds. Reduce with `EMAIL_POLL_INTERVAL=5` for faster response (but more IMAP connections). IDLE can reduce polling load, but provider delivery latency varies. |
+| **IDLE falls back to polling** | The IMAP server did not advertise the `IDLE` capability. Keep polling enabled or check whether your provider supports IMAP IDLE. |
 | **Replies not threading** | The adapter uses In-Reply-To headers. Some email clients (especially web-based) may not thread correctly with automated messages. |
 
 ---
@@ -185,6 +205,7 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
 | `EMAIL_SMTP_PORT` | No | `587` | SMTP server port |
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
+| `EMAIL_RECEIVE_MODE` | No | `poll` | Receive mode: `poll`, `idle`, or `auto` |
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |


### PR DESCRIPTION
## What does this PR do?

Adds an optional IMAP IDLE receive mode for the email gateway.

The existing polling behavior remains the default. Users can opt in with `EMAIL_RECEIVE_MODE=idle`, or use `EMAIL_RECEIVE_MODE=auto` to select IDLE only when the IMAP server advertises the `IDLE` capability.

This is intended to reduce idle IMAP polling load for providers with reliable IDLE support. It is not intended to replace polling or guarantee lower latency, since IDLE delivery behavior varies by provider.

## Related Issue

Fixes #18541

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/email.py`: add `EMAIL_RECEIVE_MODE=poll|idle|auto`
- `gateway/platforms/email.py`: probe IMAP `CAPABILITY` for `IDLE`
- `gateway/platforms/email.py`: add optional IMAP IDLE receive loop
- `gateway/platforms/email.py`: keep polling as the default and fall back to polling checks when IDLE is unavailable
- `tests/gateway/test_email.py`: add tests for receive-mode selection, IDLE capability detection, IDLE event handling, and backoff behavior
- `website/docs/user-guide/messaging/email.md`: document email receive modes and provider caveats
- `website/docs/reference/environment-variables.md`: document `EMAIL_RECEIVE_MODE`

## How to Test

1. Run the targeted email gateway tests:

```bash
scripts/run_tests.sh tests/gateway/test_email.py
```

Result:

```text
66 passed, 4 warnings
```

2. Confirm that the default receive mode is still polling by leaving `EMAIL_RECEIVE_MODE` unset.

3. Optionally test IDLE with a compatible IMAP provider:

```bash
EMAIL_RECEIVE_MODE=idle hermes gateway
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, this adds an env var rather than a config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
