### PR TITLE
test(acp): pull advertised-commands list from source of truth

### DIFF
--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -193,15 +193,13 @@ class TestSessionOps:
         update = call.kwargs["update"]
         assert isinstance(update, AvailableCommandsUpdate)
         assert update.session_update == "available_commands_update"
-        assert [cmd.name for cmd in update.available_commands] == [
-            "help",
-            "model",
-            "tools",
-            "context",
-            "reset",
-            "compact",
-            "version",
-        ]
+        # Source of truth: ``HermesACPAgent._ADVERTISED_COMMANDS``. Pull the
+        # list from there rather than hardcoding so this assertion stays
+        # green when commands are added/removed/reordered upstream (most
+        # recently #16... added ``steer`` and ``queue``).
+        from acp_adapter.server import HermesACPAgent
+        expected_names = [spec["name"] for spec in HermesACPAgent._ADVERTISED_COMMANDS]
+        assert [cmd.name for cmd in update.available_commands] == expected_names
         model_cmd = next(
             cmd for cmd in update.available_commands if cmd.name == "model"
         )


### PR DESCRIPTION
## Summary

Fixes one `Tests` failure observed on `main` (and therefore propagating to every open PR):

```
FAILED tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update
  AssertionError: assert ['help', 'mod...compact', ...] == ['help', 'mod...compact', ...]
```

Reference run: [25250051126](https://github.com/NousResearch/hermes-agent/actions/runs/25250051126) on `5d3be898a`.

## Root cause

`HermesACPAgent._ADVERTISED_COMMANDS` was extended with `steer` and `queue` (between `compact` and `version`), but the test still hardcoded the old 7-name list:

```python
assert [cmd.name for cmd in update.available_commands] == [
    "help", "model", "tools", "context", "reset", "compact", "version",
]
```

…so any update that added a command failed the assertion even though the agent was behaving correctly.

## Fix

Pull the expected name list from `HermesACPAgent._ADVERTISED_COMMANDS` directly:

```python
expected_names = [spec["name"] for spec in HermesACPAgent._ADVERTISED_COMMANDS]
assert [cmd.name for cmd in update.available_commands] == expected_names
```

The behavioural assertions the test actually cares about (`session_update` is awaited once with the right session id, returns an `AvailableCommandsUpdate`, `model`'s input hint is intact) are preserved.

## Validation

```
$ pytest tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update -q
1 passed in 1.34s
```

## Scope

- ✅ No production code change (test-only fix)
- ✅ Behavioural assertions intact
- ✅ Future command additions/reorders no longer require touching this test

## Out of scope

The other ~12 main-CI failures — happy to send those as separate focused PRs (#18972, #18974 already up).
