### PR TITLE
fix(tools): prefer load_config() over stale CLI_CONFIG in delegate _load_config()

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2320,26 +2320,28 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from persistent config or runtime config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Prefers the persistent config (hermes_cli/config.py load_config()) which
+    has mtime-based cache invalidation, so changes made via ``hermes config
+    set`` take effect immediately without a process restart. Falls back to
+    the runtime config (cli.py CLI_CONFIG) if load_config() is unavailable.
     """
+    try:
+        from hermes_cli.config import load_config
+
+        full = load_config()
+        cfg = full.get("delegation", {})
+        if cfg:
+            return cfg
+    except Exception:
+        pass
     try:
         from cli import CLI_CONFIG
 
         cfg = CLI_CONFIG.get("delegation", {})
         if cfg:
             return cfg
-    except Exception:
-        pass
-    try:
-        from hermes_cli.config import load_config
-
-        full = load_config()
-        return full.get("delegation", {})
     except Exception:
         return {}
 


### PR DESCRIPTION
## Fix

Reverses the priority in `_load_config()` so that `load_config()` (which has mtime-based cache invalidation) is checked **before** the in-memory `CLI_CONFIG` dict.

## Problem

`hermes config set delegation.model X` writes to disk and reports success, but `_load_config()` in `delegate_tool.py` checks the in-memory `CLI_CONFIG` dict first. Since `CLI_CONFIG` was loaded once at process startup and never invalidated, the stale cached value wins — the new disk config is never read until the process restarts.

This affects CLI, gateway, and cron — any long-running process that calls `delegate_task()` after a config change via `hermes config set`.

## Root Cause

`_load_config()` prioritized `CLI_CONFIG` (stale in-memory dict) over `load_config()` (mtime-cached disk reads with automatic invalidation). The `load_config()` function in `hermes_cli/config.py` already handles cache invalidation correctly by checking `(mtime_ns, size)` on every call — it just was never reached because `CLI_CONFIG` was checked first.

## Fix Details

- Try `hermes_cli.config.load_config()` first (mtime-aware, always fresh)
- Fall back to `cli.CLI_CONFIG` only if `load_config()` fails
- Added `if cfg:` guard to the `CLI_CONFIG` path for consistency

## Testing

1. Start a gateway session with `delegation.model: google/gemini-2.5-flash`
2. From another shell: `hermes config set delegation.model google/gemini-3-flash-preview`
3. Call `delegate_task(...)` from the original session
4. **Before fix**: subagent uses `gemini-2.5-flash` (stale cache)
5. **After fix**: subagent uses `gemini-3-flash-preview` (fresh from disk)

Fixes #18946