### PR TITLE
test(gateway/teams): patch TypingActivityInput on the loaded adapter module

### DIFF
--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -405,7 +405,21 @@ class TestTeamsSend:
         mock_app.send = AsyncMock()
         adapter._app = mock_app
 
-        await adapter.send_typing("conv-id")
+        # ``TypingActivityInput`` is conditionally imported from the
+        # ``microsoft_teams`` SDK — when the SDK isn't installed (e.g. CI
+        # without the Teams extra), it resolves to ``None`` and the
+        # underlying ``send_typing`` call raises ``TypeError`` and is
+        # silently swallowed by the adapter's broad ``except``. Patch in
+        # a stand-in so the test exercises the call path it intends to.
+        # The adapter is loaded under a mangled module name by
+        # ``load_plugin_adapter`` (see top of file), so patch by
+        # attribute on that module rather than dotted import path.
+        with patch.object(
+            _teams_mod, "TypingActivityInput",
+            new=MagicMock(return_value=MagicMock()),
+        ):
+            await adapter.send_typing("conv-id")
+
         mock_app.send.assert_awaited_once()
         call_args = mock_app.send.call_args
         assert call_args[0][0] == "conv-id"


### PR DESCRIPTION
## Summary

Fixes one `Tests` failure observed on `main` (and therefore propagating to every open PR):

```
FAILED tests/gateway/test_teams.py::TestTeamsSend::test_send_typing
  AssertionError: Expected send to have been awaited once. Awaited 0 times.
```

Reference run: [25250051126](https://github.com/NousResearch/hermes-agent/actions/runs/25250051126) on `5d3be898a`.

## Root cause

`TypingActivityInput` is **conditionally imported** from the `microsoft_teams` SDK in `plugins/platforms/teams/adapter.py`:

```python
try:
    from microsoft_teams.api.activities.typing import TypingActivityInput
    ...
    TEAMS_SDK_AVAILABLE = True
except ImportError:
    TEAMS_SDK_AVAILABLE = False
    TypingActivityInput = None  # type: ignore[assignment,misc]
```

The Teams SDK isn't a tracked extra in `pyproject.toml` (no `[teams]` extra, not in `[messaging]` either), so on a CI worker doing `uv pip install -e ".[all,dev]"` the SDK is absent → `TypingActivityInput is None`.

`send_typing` then does:

```python
async def send_typing(self, chat_id, metadata=None):
    if not self._app: return
    try:
        await self._app.send(chat_id, TypingActivityInput())  # ← TypeError
    except Exception:
        pass  # swallowed
```

…which raises `TypeError: 'NoneType' object is not callable`, gets silently swallowed by the broad `except`, and `mock_app.send` never awaits.

## Why my first attempt didn't work

I initially tried `patch("plugins.platforms.teams.adapter.TypingActivityInput", ...)`, but the test loads the adapter via:

```python
_teams_mod = load_plugin_adapter("teams")  # mangled name 'plugin_adapter_teams'
```

…which gives the test a *different* module instance than `plugins.platforms.teams.adapter`. Patching the dotted path patches the wrong module.

## Fix

`patch.object(_teams_mod, "TypingActivityInput", ...)` — patch the actual loaded module the test is exercising:

```python
with patch.object(
    _teams_mod, "TypingActivityInput",
    new=MagicMock(return_value=MagicMock()),
):
    await adapter.send_typing("conv-id")
```

## Validation

```
$ pytest tests/gateway/test_teams.py -q
34 passed in 1.79s
```

## Scope

- ✅ No production code change (test-only fix)
- ✅ All 34 Teams tests pass
- ✅ Behavioural assertions intact (`send` awaited once, with the right `chat_id`)

## Out of scope

The other ~11 main-CI failures — separate focused PRs (#18972, #18974, #18977 already up).
