### PR TITLE
feat(cli): add --stream flag to chat -Q for live response feedback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -244,6 +244,38 @@ def _parse_service_tier_config(raw: str) -> str | None:
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
 
+
+def _make_quiet_stream_callbacks():
+    """Build the stdout/stderr callbacks used by `chat -Q --stream`.
+
+    Split off `main()` so it can be exercised by unit tests. The contract:
+    assistant text deltas go to stdout (so wrappers that capture stdout get
+    the answer with no extra framing); tool lifecycle markers go to stderr
+    (kept distinct from the answer payload, mirroring the existing
+    `session_id: ...` line that already lands on stderr).
+    """
+    def stream_delta(text: str) -> None:
+        sys.stdout.write(text)
+        sys.stdout.flush()
+
+    def tool_progress(event_type, name=None, preview=None, args=None,
+                      **kwargs):
+        # Only surface lifecycle events; ignore "_thinking" / "subagent.*"
+        # noise so quiet-mode stderr stays compact and grep-friendly.
+        if event_type == "tool.started" and name:
+            sys.stderr.write(f"[tool] {name} started\n")
+            sys.stderr.flush()
+        elif event_type == "tool.completed" and name:
+            dur = kwargs.get("duration")
+            err = kwargs.get("is_error")
+            suffix = f" ({dur:.1f}s)" if isinstance(dur, (int, float)) else ""
+            tag = "failed" if err else "completed"
+            sys.stderr.write(f"[tool] {name} {tag}{suffix}\n")
+            sys.stderr.flush()
+
+    return stream_delta, tool_progress
+
+
 def load_cli_config() -> Dict[str, Any]:
     """
     Load CLI configuration from config files.
@@ -11772,6 +11804,7 @@ def main(
     max_turns: int = None,
     verbose: bool = False,
     quiet: bool = False,
+    stream: bool = False,
     compact: bool = False,
     list_tools: bool = False,
     list_toolsets: bool = False,
@@ -11997,11 +12030,23 @@ def main(
                 ):
                     cli.agent.quiet_mode = True
                     cli.agent.suppress_status_output = True
-                    # Suppress streaming display callbacks so stdout stays
-                    # machine-readable (no styled "Hermes" box, no tool-gen
-                    # status lines).  The response is printed once below.
-                    cli.agent.stream_delta_callback = None
-                    cli.agent.tool_gen_callback = None
+                    if stream:
+                        # Opt-in live feedback for long turns (e.g. running
+                        # inside a remote sandbox). The agent already streams
+                        # internally via _fire_stream_delta; we just route
+                        # the deltas to stdout and tool lifecycle to stderr.
+                        # tool_gen_callback stays off to avoid duplicate
+                        # "preparing <tool>" noise alongside [tool] markers.
+                        delta_cb, progress_cb = _make_quiet_stream_callbacks()
+                        cli.agent.stream_delta_callback = delta_cb
+                        cli.agent.tool_progress_callback = progress_cb
+                        cli.agent.tool_gen_callback = None
+                    else:
+                        # Suppress streaming display callbacks so stdout stays
+                        # machine-readable (no styled "Hermes" box, no tool-gen
+                        # status lines).  The response is printed once below.
+                        cli.agent.stream_delta_callback = None
+                        cli.agent.tool_gen_callback = None
                     result = cli.agent.run_conversation(
                         user_message=effective_query,
                         conversation_history=cli.conversation_history,
@@ -12016,7 +12061,14 @@ def main(
                     ):
                         cli.session_id = cli.agent.session_id
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                    if response:
+                    if stream:
+                        # stdout already received the full text via deltas;
+                        # avoid duplicating it. Emit a trailing newline so
+                        # piped consumers see a line-terminated payload and
+                        # the stderr session line below starts cleanly.
+                        sys.stdout.write("\n")
+                        sys.stdout.flush()
+                    elif response:
                         print(response)
                     # Session ID goes to stderr so piped stdout is clean.
                     print(f"\nsession_id: {cli.session_id}", file=sys.stderr)

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -274,6 +274,11 @@ def build_top_level_parser():
         help="Quiet mode for programmatic use: suppress banner, spinner, and tool previews. Only output the final response and session info.",
     )
     chat_parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Stream the response on stdout (and tool-progress markers on stderr) while the agent works. Only meaningful with -Q/--quiet; ignored in interactive mode.",
+    )
+    chat_parser.add_argument(
         "--resume",
         "-r",
         metavar="SESSION_ID",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1320,6 +1320,7 @@ def cmd_chat(args):
         "skills": getattr(args, "skills", None),
         "verbose": args.verbose,
         "quiet": getattr(args, "quiet", False),
+        "stream": getattr(args, "stream", False),
         "query": args.query,
         "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),

--- a/tests/cli/test_quiet_stream_callbacks.py
+++ b/tests/cli/test_quiet_stream_callbacks.py
@@ -1,0 +1,120 @@
+"""Tests for the `chat -Q --stream` callback factory.
+
+The `--stream` flag opts into live feedback in non-interactive quiet mode
+(e.g. when the agent is running inside a remote sandbox and the user wants
+to see progress instead of staring at a frozen terminal). The factory in
+``cli._make_quiet_stream_callbacks`` produces the two callbacks that wire
+into ``AIAgent.stream_delta_callback`` and ``AIAgent.tool_progress_callback``.
+
+We test the factory directly — the surrounding ``main()`` call site is too
+entangled to unit-test in isolation, but the contract that matters
+(stdout = answer text, stderr = lifecycle markers, formatting stable) lives
+in the factory.
+"""
+
+import pytest
+
+from cli import _make_quiet_stream_callbacks
+
+
+class TestStreamDeltaCallback:
+    def test_writes_text_verbatim_to_stdout(self, capsys):
+        delta_cb, _ = _make_quiet_stream_callbacks()
+
+        delta_cb("Hello, ")
+        delta_cb("world")
+        delta_cb("!")
+
+        # Concatenation is the load-bearing contract: wrappers that capture
+        # stdout must reconstruct the full response by simple concatenation.
+        out, err = capsys.readouterr()
+        assert out == "Hello, world!"
+        assert err == ""
+
+    def test_empty_delta_is_safe(self, capsys):
+        delta_cb, _ = _make_quiet_stream_callbacks()
+
+        delta_cb("")  # streaming providers occasionally emit empty deltas
+
+        out, _ = capsys.readouterr()
+        assert out == ""
+
+
+class TestToolProgressCallback:
+    def test_started_event_emits_to_stderr(self, capsys):
+        _, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb("tool.started", "terminal", "ls -la", {"cmd": "ls -la"})
+
+        out, err = capsys.readouterr()
+        assert err == "[tool] terminal started\n"
+        assert out == ""  # never on stdout
+
+    def test_completed_event_includes_duration(self, capsys):
+        _, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb("tool.completed", "terminal", duration=1.234, is_error=False)
+
+        _, err = capsys.readouterr()
+        assert err == "[tool] terminal completed (1.2s)\n"
+
+    def test_completed_event_marks_failure(self, capsys):
+        _, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb("tool.completed", "web_search", duration=0.5, is_error=True)
+
+        _, err = capsys.readouterr()
+        assert err == "[tool] web_search failed (0.5s)\n"
+
+    def test_completed_without_duration_omits_suffix(self, capsys):
+        _, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb("tool.completed", "memory")  # no kwargs
+
+        _, err = capsys.readouterr()
+        assert err == "[tool] memory completed\n"
+
+    @pytest.mark.parametrize(
+        "event_type",
+        ["_thinking", "reasoning.available", "subagent.started", "tool.progress"],
+    )
+    def test_unknown_or_internal_events_are_ignored(self, capsys, event_type):
+        # Quiet-mode stderr stays compact; only lifecycle start/complete
+        # events should surface. Anything else (subagent chatter, internal
+        # thinking signals) must be dropped.
+        _, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb(event_type, "anything", "preview", {"args": True})
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err == ""
+
+    def test_started_event_without_name_is_ignored(self, capsys):
+        # Defensive: if the agent ever fires tool.started with name=None,
+        # we shouldn't emit a malformed "[tool]  started" line.
+        _, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb("tool.started", None)
+
+        _, err = capsys.readouterr()
+        assert err == ""
+
+
+class TestStdoutStderrSeparation:
+    """The headline contract: piped stdout must contain ONLY the answer."""
+
+    def test_mixed_events_keep_streams_separate(self, capsys):
+        delta_cb, progress_cb = _make_quiet_stream_callbacks()
+
+        progress_cb("tool.started", "terminal")
+        delta_cb("The answer is ")
+        progress_cb("tool.completed", "terminal", duration=0.8)
+        delta_cb("42.")
+
+        out, err = capsys.readouterr()
+        assert out == "The answer is 42."
+        assert err == (
+            "[tool] terminal started\n"
+            "[tool] terminal completed (0.8s)\n"
+        )


### PR DESCRIPTION
## Summary

- Adds an opt-in `--stream` flag to `hermes chat` (effective alongside `-Q/--quiet`) that wires the agent's existing internal streaming into stdout. Default behavior is unchanged.
- Tool lifecycle markers (`[tool] X started`, `[tool] X completed (1.2s)` / `failed (...)`) stream to stderr — preserving the existing contract that piped stdout contains only the assistant's answer (and the trailing `session_id:` line stays on stderr).
- Reuses the agent-side machinery already in place (`stream_delta_callback`, `tool_progress_callback`, `_fire_stream_delta` at `run_agent.py:6540`). No changes to the agent core, providers, or message format.

## Motivation

Running `hermes chat -Q --provider openrouter -m <model> -q '...'` inside a remote sandbox (Daytona, ssh, container) currently buffers the entire turn and prints once at the end. On long multi-tool turns this looks like a frozen process. The agent already streams from OpenAI-compatible / Anthropic / Bedrock / Codex providers — the `-Q` branch in `cli.py` was simply pinning `stream_delta_callback = None` to keep stdout machine-readable. This PR offers users an opt-in path to live feedback without breaking that contract for existing automation wrappers.

## Behavior contract

| Mode | stdout | stderr |
|---|---|---|
| `-Q` (unchanged) | full final response, trailing `\n` | `\nsession_id: ...` |
| `-Q --stream` (new) | response chunks as they arrive, terminated by `\n` | `[tool] X started`, `[tool] X completed (1.2s)`, finally `\nsession_id: ...` |

Concatenated stdout bytes are identical between modes for the same turn (modulo chunk boundaries).

## Implementation

- `hermes_cli/_parser.py` — adds `--stream` to the `chat` subparser.
- `hermes_cli/main.py` — threads `args.stream` through `cmd_chat()` kwargs.
- `cli.py` — adds `stream: bool = False` to `main()`, conditionally installs callbacks in the `-Q` branch via a small extracted helper `_make_quiet_stream_callbacks()`. Helper is at module scope to keep the call site readable and to allow direct unit testing.
- `tests/cli/test_quiet_stream_callbacks.py` — 12 unit tests covering the factory's contract: stdout/stderr separation, duration formatting, failure tagging, defensive handling of missing names, and ignoring non-lifecycle events (`_thinking`, `subagent.*`, `tool.progress`, `reasoning.available`).

## Test plan

- [x] Unit tests pass — `pytest tests/cli/test_quiet_stream_callbacks.py -v` (12/12 green)
- [x] Manual smoke: `hermes chat -Q --provider openrouter -m openai/gpt-4o-mini -q 'reply with hello world'` produces byte-identical stdout/stderr to before (no `--stream`).
- [x] Manual smoke: `hermes chat -Q --stream --provider openrouter -m openai/gpt-4o-mini -q 'count from 1 to 20 with a comment per number'` streams numbers incrementally on stdout.
- [x] Pipe isolation: with `--stream`, `... 2>/dev/null | tee out.txt` → `out.txt` contains only the assistant's response.
- [x] Multi-tool turn: `[tool] X started` / `[tool] X completed (...)` markers appear on stderr in real time during tool calls.
- [x] Resume continues to work: `hermes chat -Q --stream -r <session_id> ...`.

## Out of scope (deliberately)

- Reasoning streaming (`reasoning_callback`) — easy follow-up behind a `--stream-reasoning` flag if desired; skipped to keep stdout strictly "the answer."
- Structured NDJSON / SSE output — appropriate when wrapping in a UI; for the human-watching-a-CLI case the line-streaming format is sufficient.
- Gateway platforms (Telegram/Slack/Discord/...) — separate, larger workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)