### PR TITLE
fix(kanban): anchor board to default Hermes root, not active profile

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1,8 +1,13 @@
 """SQLite-backed Kanban board for multi-profile collaboration.
 
-The board lives at ``$HERMES_HOME/kanban.db`` (profile-agnostic on purpose:
-multiple profiles on the same machine all see the same board, which IS the
-coordination primitive).
+The board lives at the *default* Hermes root (``~/.hermes/kanban.db`` in
+standard installs, ``$HERMES_HOME/kanban.db`` in Docker / custom roots) —
+profile-agnostic on purpose: multiple profiles on the same machine all see
+the same board, which IS the coordination primitive.  The path is resolved
+via ``get_default_hermes_root()``, NOT ``get_hermes_home()``, so that a
+worker running under ``hermes -p <name>`` (HERMES_HOME pointed at
+``profiles/<name>``) still reaches the shared host-level board instead of a
+private per-profile DB.  See issue #18442.
 
 Schema is intentionally small: tasks, task_links, task_comments,
 task_events.  The ``workspace_kind`` field decouples coordination from git
@@ -62,15 +67,26 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban.db"
+    """Return the path to the shared host-level ``kanban.db``.
+
+    Resolved against the *default* Hermes root rather than the active
+    profile's HERMES_HOME, so that a worker spawned under
+    ``hermes -p <name>`` reaches the same board as the dispatcher and the
+    other profiles on the host.  See issue #18442.
+    """
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "kanban.db"
 
 
 def workspaces_root() -> Path:
-    """Return the directory under which ``scratch`` workspaces are created."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban" / "workspaces"
+    """Return the directory under which ``scratch`` workspaces are created.
+
+    Anchored at the default Hermes root for the same reason as
+    :func:`kanban_db_path` -- workspace paths are absolute and shared across
+    profiles, so they must not be created under a profile-private root.
+    """
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "kanban" / "workspaces"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`kanban_db_path()` and `workspaces_root()` resolve via `get_hermes_home()`, which under `hermes -p <name>` points at `profiles/<name>/`. As a result, each profile silently writes to its own private `kanban.db`, contradicting both the module docstring (*"profile-agnostic on purpose: multiple profiles on the same machine all see the same board"*) and the user-facing docs (*"shared across all your Hermes profiles"*).

In practice the dispatcher claims work in DB A, spawns a worker via `hermes -p <assignee>`, and the worker's kanban tools — which call `kb.connect()` → `kanban_db_path()` — look in DB B and report the task missing. Because `connect()` auto-runs `init_db`, an empty `profiles/<name>/kanban.db` is created on the spot, and the bug silently re-establishes itself.

## Fix

Both helpers now resolve via `get_default_hermes_root()`, which already handles all three layouts correctly:

- standard install: `~/.hermes/`
- Docker / custom root (`HERMES_HOME=/opt/data`): `/opt/data/`
- profile mode (`HERMES_HOME=~/.hermes/profiles/<name>`): `~/.hermes/`

No new env var, no new public API. The helper exists for exactly this case (see `hermes_constants.py:71-107`).

## Notes

- Module docstring updated to describe the resolution rule and link the issue.
- Existing per-profile `kanban.db` files (created before the fix) become orphans. Hand-merging the rare populated case is the user's call — empty profile DBs (the common outcome of stumbling into this bug recently) can just be deleted.
- Worker logs at `_default_spawn` (`get_hermes_home() / "kanban" / "logs"`) intentionally left per-profile — that's a separate observability call, not part of this bug.

## Test plan

- [x] Reproduced: task created at root board, assigned to a profile worker. Dispatcher spawns successfully but the worker's `kanban_show` / `kanban_complete` return "task not found" because the worker process resolves to the profile-private DB.
- [x] After patch: same flow completes normally; both `kanban.db` and scratch workspaces land at the root.
- [x] No regression for default-profile, Docker, or custom-root users — `get_default_hermes_root()` covers all three cases.

Fixes #18442.