### PR TITLE
Add RSI platform runtime envelope plugin

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -187,6 +187,7 @@ class PluginManifest:
     requires_env: List[Union[str, Dict[str, Any]]] = field(default_factory=list)
     provides_tools: List[str] = field(default_factory=list)
     provides_hooks: List[str] = field(default_factory=list)
+    capabilities: Dict[str, Any] = field(default_factory=dict)
     source: str = ""        # "user", "project", or "entrypoint"
     path: Optional[str] = None
     # Plugin kind — see plugins.py module docstring for semantics.
@@ -897,6 +898,7 @@ class PluginManager:
                 requires_env=data.get("requires_env", []),
                 provides_tools=data.get("provides_tools", []),
                 provides_hooks=data.get("provides_hooks", []),
+                capabilities=data.get("capabilities", {}) if isinstance(data.get("capabilities"), dict) else {},
                 source=source,
                 path=str(plugin_dir),
                 kind=kind,
@@ -1108,6 +1110,7 @@ class PluginManager:
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
                     "commands": len(loaded.commands_registered),
+                    "capabilities": dict(loaded.manifest.capabilities or {}),
                     "error": loaded.error,
                 }
             )

--- a/plugins/rsi_platform_runtime/__init__.py
+++ b/plugins/rsi_platform_runtime/__init__.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import time
+from typing import Any
+
+
+PLUGIN_NAME = "rsi_platform_runtime"
+PLUGIN_VERSION = "0.1.0"
+CONTRACT_VERSION = "execution-envelope/v1"
+CAPABILITIES = {
+    "execution_scoped_context_supported": True,
+    "execution_envelope_v1_producer": True,
+    "atomic_envelope_writer": True,
+}
+
+_STATE_BY_EXECUTION: dict[str, dict[str, Any]] = {}
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\b(bearer)\s+([A-Za-z0-9._~+/=-]{8,})"),
+    re.compile(r"\b(xox[baprs]-[A-Za-z0-9-]{8,})\b"),
+    re.compile(r"\b(sk-[A-Za-z0-9_-]{8,})\b"),
+    re.compile(r"(?i)(token|secret|password|api[_-]?key)(['\"\s:=]+)([^\s'\",}\]]{4,})"),
+)
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _json_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _parse_json_maybe(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return value
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return value
+    try:
+        return json.loads(text)
+    except Exception:
+        return value
+
+
+def _redact_text(value: str) -> str:
+    out = value
+    for pattern in _SECRET_PATTERNS:
+        if pattern.pattern.startswith("(?i)\\b(bearer)"):
+            out = pattern.sub(lambda match: f"{match.group(1)} [redacted]", out)
+        elif "token|secret|password" in pattern.pattern:
+            out = pattern.sub(lambda match: f"{match.group(1)}{match.group(2)}[redacted]", out)
+        else:
+            out = pattern.sub("[redacted]", out)
+    return out
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if any(fragment in key_text.lower() for fragment in ("token", "secret", "password", "api_key", "apikey")):
+                redacted[key_text] = "[redacted]"
+            else:
+                redacted[key_text] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _runtime_path(env_name: str) -> Path:
+    raw = os.getenv(env_name, "").strip()
+    if not raw:
+        raise RuntimeError(f"{env_name} is required for RSI native workflow execution.")
+    return Path(raw).expanduser().resolve()
+
+
+def _runtime_ids() -> dict[str, str]:
+    ids = {
+        "execution_id": os.getenv("RSI_EXECUTION_ID", "").strip(),
+        "operation_id": os.getenv("RSI_OPERATION_ID", "").strip(),
+        "trace_id": os.getenv("RSI_TRACE_ID", "").strip(),
+        "workflow_id": os.getenv("RSI_WORKFLOW_ID", "").strip(),
+    }
+    missing = [key for key, value in ids.items() if not value]
+    if missing:
+        raise RuntimeError("Missing RSI runtime identifier(s): " + ", ".join(missing))
+    return ids
+
+
+def _load_context() -> dict[str, Any]:
+    context_path = _runtime_path("RSI_RUNTIME_CONTEXT_PATH")
+    if not context_path.exists():
+        raise RuntimeError(f"RSI runtime context not found at {context_path}.")
+    parsed = json.loads(context_path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"RSI runtime context at {context_path} must be a JSON object.")
+    ids = _runtime_ids()
+    for key, expected in ids.items():
+        actual = str(parsed.get(key, "") or "").strip()
+        if actual != expected:
+            raise RuntimeError(f"RSI runtime context {key} mismatch: expected {expected!r}, got {actual!r}.")
+    return parsed
+
+
+def _fsync_parent(path: Path) -> None:
+    try:
+        flags = getattr(os, "O_DIRECTORY", 0) | os.O_RDONLY
+        fd = os.open(str(path.parent), flags)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.parent / f"{path.name}.{os.getpid()}.{time.time_ns()}.tmp"
+    try:
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump(_redact(payload), handle, ensure_ascii=True, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        _fsync_parent(path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _state() -> dict[str, Any]:
+    ids = _runtime_ids()
+    execution_id = ids["execution_id"]
+    state = _STATE_BY_EXECUTION.setdefault(
+        execution_id,
+        {
+            **ids,
+            "created_at": _now_iso(),
+            "ledger_events": [],
+            "artifacts": [],
+            "deliveries": [],
+        },
+    )
+    if "context" not in state:
+        state["context"] = _load_context()
+    return state
+
+
+def _tool_call_event(tool_name: str, args: dict[str, Any], result: Any, tool_call_id: str, duration_ms: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "tool_name": tool_name,
+        "tool_call_id": tool_call_id,
+        "args": args,
+        "result": result,
+    }
+    try:
+        payload["duration_ms"] = int(duration_ms)
+    except Exception:
+        pass
+    return {
+        "event_id": hashlib.sha256(f"{tool_call_id}:{tool_name}:{time.time_ns()}".encode("utf-8")).hexdigest()[:24],
+        "kind": "tool.call.completed",
+        "phase_id": "main",
+        "status": "completed",
+        "sequence": 0,
+        "idempotency_key": tool_call_id or "",
+        "recorded_at": _now_iso(),
+        "payload": payload,
+    }
+
+
+def _delivery_from_tool_result(tool_name: str, args: dict[str, Any], result: Any, tool_call_id: str) -> dict[str, Any] | None:
+    if not (tool_name == "send_message" or tool_name.endswith(".send_message")):
+        return None
+    parsed = _parse_json_maybe(result)
+    if not isinstance(parsed, dict) or not parsed.get("success"):
+        return None
+    platform = _string(parsed.get("platform")) or _string(args.get("target")).split(":", 1)[0]
+    chat_id = _string(parsed.get("chat_id"))
+    thread_id = _string(parsed.get("thread_id"))
+    provider_ref = _string(parsed.get("message_id"))
+    delivery: dict[str, Any] = {
+        "send_status": "posted",
+        "channel_id": chat_id,
+        "thread_ts": thread_id,
+        "body": _string(args.get("message")),
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "provider_ref": provider_ref,
+        "message_link": _string(parsed.get("message_link")),
+    }
+    if platform:
+        delivery["platform"] = platform
+    if parsed.get("idempotency_key"):
+        delivery["idempotency_key"] = _string(parsed.get("idempotency_key"))
+    return delivery
+
+
+def _artifact_from_tool_result(tool_name: str, result: Any) -> dict[str, Any] | None:
+    parsed = _parse_json_maybe(result)
+    if not isinstance(parsed, dict):
+        return None
+    output = _json_object(parsed.get("output"))
+    path = _string(output.get("path")) or _string(parsed.get("path"))
+    if not path:
+        return None
+    if not any(fragment in tool_name for fragment in ("write_file", "artifact")):
+        return None
+    return {
+        "kind": "file",
+        "workspace_path": path,
+        "file_ref": path,
+        "share_status": "not_shared",
+    }
+
+
+def post_tool_call(tool_name: str = "", args: dict[str, Any] | None = None, result: Any = None, tool_call_id: str = "", duration_ms: Any = None, **_kwargs) -> None:
+    state = _state()
+    safe_args = args if isinstance(args, dict) else {}
+    parsed_result = _parse_json_maybe(result)
+    event = _tool_call_event(tool_name, safe_args, parsed_result, tool_call_id, duration_ms)
+    event["sequence"] = len(state["ledger_events"]) + 1
+    state["ledger_events"].append(event)
+    delivery = _delivery_from_tool_result(tool_name, safe_args, parsed_result, tool_call_id)
+    if delivery:
+        state["deliveries"].append(delivery)
+    artifact = _artifact_from_tool_result(tool_name, parsed_result)
+    if artifact:
+        state["artifacts"].append(artifact)
+
+
+def _phase_runs(state: dict[str, Any], completion: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "phase_id": "main",
+            "phase_type": "workflow",
+            "status": "completed" if completion.get("ok") else "failed",
+            "completion_verdict": completion.get("completion_verdict", ""),
+            "termination_reason": completion.get("termination_reason", ""),
+        }
+    ]
+
+
+def _write_envelope(final_response: str) -> None:
+    state = _state()
+    envelope_path = _runtime_path("RSI_RUNTIME_ENVELOPE_PATH")
+    completion = {
+        "ok": True,
+        "completion_verdict": "complete",
+        "termination_reason": "normal_completion",
+        "partial": False,
+        "max_iterations_reached": False,
+    }
+    envelope = {
+        "contract_version": CONTRACT_VERSION,
+        "producer": PLUGIN_NAME,
+        "producer_version": PLUGIN_VERSION,
+        "created_at": _now_iso(),
+        "facts_source": [
+            "rsi_platform_runtime.post_tool_call",
+            "rsi_platform_runtime.post_llm_call",
+        ],
+        "execution_id": state["execution_id"],
+        "operation_id": state["operation_id"],
+        "trace_id": state["trace_id"],
+        "workflow_id": state["workflow_id"],
+        "session_id": _string(state.get("context", {}).get("hermes_session_id")),
+        "phase_runs": _phase_runs(state, completion),
+        "ledger_events": list(state["ledger_events"]),
+        "artifacts": list(state["artifacts"]),
+        "deliveries": list(state["deliveries"]),
+        "completion": completion,
+        "final_response": str(final_response or ""),
+    }
+    _atomic_write_json(envelope_path, envelope)
+
+
+def post_llm_call(assistant_response: str = "", **_kwargs) -> None:
+    _write_envelope(assistant_response)
+
+
+def on_session_end(completed: bool = False, **_kwargs) -> None:
+    if not completed:
+        return
+    envelope_path_raw = os.getenv("RSI_RUNTIME_ENVELOPE_PATH", "").strip()
+    if envelope_path_raw and not Path(envelope_path_raw).expanduser().exists():
+        _write_envelope("")
+
+
+def _capabilities_handler(_args=None, **_kwargs) -> str:
+    return json.dumps(
+        {
+            "plugin": PLUGIN_NAME,
+            "version": PLUGIN_VERSION,
+            "capabilities": CAPABILITIES,
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+    )
+
+
+def register(ctx) -> None:
+    ctx.register_hook("post_tool_call", post_tool_call)
+    ctx.register_hook("post_llm_call", post_llm_call)
+    ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_tool(
+        name="rsi_platform_runtime_capabilities",
+        toolset="rsi-platform-runtime",
+        schema={
+            "name": "rsi_platform_runtime_capabilities",
+            "description": "Report RSI platform runtime plugin static capabilities.",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+        handler=_capabilities_handler,
+        description="Report RSI platform runtime plugin static capabilities.",
+    )

--- a/plugins/rsi_platform_runtime/plugin.yaml
+++ b/plugins/rsi_platform_runtime/plugin.yaml
@@ -1,0 +1,11 @@
+name: rsi_platform_runtime
+version: "0.1.0"
+description: "RSI strict native workflow runtime envelope and delivery facts"
+provides_hooks:
+  - post_tool_call
+  - post_llm_call
+  - on_session_end
+capabilities:
+  execution_scoped_context_supported: true
+  execution_envelope_v1_producer: true
+  atomic_envelope_writer: true

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -670,6 +670,29 @@ class TestPluginManagerList:
             assert "tools" in p
             assert "hooks" in p
 
+    def test_list_includes_static_capabilities(self, tmp_path, monkeypatch):
+        """list_plugins() exposes static plugin capability metadata."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "rsi_platform_runtime",
+            manifest_extra={
+                "capabilities": {
+                    "execution_scoped_context_supported": True,
+                    "execution_envelope_v1_producer": True,
+                }
+            },
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        listing = mgr.list_plugins()
+        plugin = next(p for p in listing if p["name"] == "rsi_platform_runtime")
+        assert plugin["capabilities"]["execution_scoped_context_supported"] is True
+        assert plugin["capabilities"]["execution_envelope_v1_producer"] is True
+
 
 
 class TestPreLlmCallTargetRouting:

--- a/tests/plugins/test_rsi_platform_runtime.py
+++ b/tests/plugins/test_rsi_platform_runtime.py
@@ -1,0 +1,88 @@
+"""Tests for the RSI native workflow runtime plugin."""
+
+import json
+
+import pytest
+
+from plugins import rsi_platform_runtime as runtime
+
+
+def _write_context(path, *, execution_id="hexec-1"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "execution_id": execution_id,
+                "operation_id": "op-1",
+                "trace_id": "trace-1",
+                "workflow_id": "wf-1",
+                "hermes_session_id": "rsi-prod-conversation-1",
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _install_runtime_env(monkeypatch, context_path, envelope_path, *, execution_id="hexec-1"):
+    monkeypatch.setenv("RSI_RUNTIME_CONTEXT_PATH", str(context_path))
+    monkeypatch.setenv("RSI_RUNTIME_ENVELOPE_PATH", str(envelope_path))
+    monkeypatch.setenv("RSI_EXECUTION_ID", execution_id)
+    monkeypatch.setenv("RSI_OPERATION_ID", "op-1")
+    monkeypatch.setenv("RSI_TRACE_ID", "trace-1")
+    monkeypatch.setenv("RSI_WORKFLOW_ID", "wf-1")
+
+
+def test_platform_runtime_writes_execution_scoped_redacted_envelope(tmp_path, monkeypatch):
+    context_path = tmp_path / "rsi_runtime" / "context" / "executions" / "hexec-1.json"
+    envelope_path = tmp_path / "rsi_runtime" / "envelopes" / "hexec-1.json"
+    _write_context(context_path)
+    _install_runtime_env(monkeypatch, context_path, envelope_path)
+    runtime._STATE_BY_EXECUTION.clear()
+
+    runtime.post_tool_call(
+        tool_name="send_message",
+        args={"message": "Final reply", "api_key": "should-not-leak"},
+        result=json.dumps(
+            {
+                "success": True,
+                "platform": "slack",
+                "chat_id": "C123456789",
+                "thread_id": "171000001.000100",
+                "message_id": "171000001.000200",
+                "message_link": "https://slack.example/messages/171000001.000200",
+                "idempotency_key": "idem-send-1",
+            },
+            sort_keys=True,
+        ),
+        tool_call_id="call-send-1",
+        duration_ms=12,
+    )
+    runtime.post_llm_call("Final reply with sk-secret-openrouter")
+
+    envelope = json.loads(envelope_path.read_text(encoding="utf-8"))
+    assert envelope["contract_version"] == "execution-envelope/v1"
+    assert envelope["producer"] == "rsi_platform_runtime"
+    assert envelope["execution_id"] == "hexec-1"
+    assert envelope["operation_id"] == "op-1"
+    assert envelope["trace_id"] == "trace-1"
+    assert envelope["workflow_id"] == "wf-1"
+    assert envelope["final_response"] == "Final reply with [redacted]"
+    assert envelope["ledger_events"][0]["kind"] == "tool.call.completed"
+    assert envelope["ledger_events"][0]["payload"]["args"]["api_key"] == "[redacted]"
+    assert envelope["deliveries"][0]["send_status"] == "posted"
+    assert envelope["deliveries"][0]["idempotency_key"] == "idem-send-1"
+    assert not list(envelope_path.parent.glob("*.tmp"))
+
+
+def test_platform_runtime_rejects_mismatched_execution_context(tmp_path, monkeypatch):
+    context_path = tmp_path / "rsi_runtime" / "context" / "executions" / "hexec-1.json"
+    envelope_path = tmp_path / "rsi_runtime" / "envelopes" / "hexec-1.json"
+    _write_context(context_path, execution_id="hexec-other")
+    _install_runtime_env(monkeypatch, context_path, envelope_path)
+    runtime._STATE_BY_EXECUTION.clear()
+
+    with pytest.raises(RuntimeError, match="execution_id mismatch"):
+        runtime.post_llm_call("Final reply")
+
+    assert not envelope_path.exists()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -213,6 +213,73 @@ class TestSendMessageTool:
             user_id="user-123",
         )
 
+    def test_inferred_session_target_uses_persistent_idempotency_receipt(self, tmp_path):
+        config = SimpleNamespace(
+            platforms={Platform.SLACK: SimpleNamespace(enabled=True, token="xoxb-test", extra={})},
+            get_home_channel=lambda _platform: None,
+        )
+        send_mock = AsyncMock(
+            return_value={
+                "success": True,
+                "platform": "slack",
+                "chat_id": "C123456789",
+                "thread_id": "171000001.000100",
+                "message_id": "171000001.000200",
+                "message_link": "https://slack.example/messages/171000001.000200",
+            }
+        )
+
+        def get_session_env(name, default=""):
+            return {
+                "HERMES_SESSION_PLATFORM": "slack",
+                "HERMES_SESSION_CHAT_ID": "C123456789",
+                "HERMES_SESSION_THREAD_ID": "171000001.000100",
+                "HERMES_SESSION_USER_ID": "U123",
+            }.get(name, default)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "RSI_EXECUTION_ID": "hexec-1"}, clear=False), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("gateway.session_context.get_session_env", side_effect=get_session_env), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            first = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "message": "hello",
+                    },
+                    tool_call_id="call-send-1",
+                )
+            )
+            second = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "message": "hello",
+                    },
+                    tool_call_id="call-send-1",
+                )
+            )
+
+        assert first["success"] is True
+        assert first["target_source"] == "session"
+        assert first["idempotency_key"] == "rsi:hexec-1:call-send-1"
+        assert second["success"] is True
+        assert second["deduped"] is True
+        assert second["message_id"] == "171000001.000200"
+        send_mock.assert_awaited_once_with(
+            Platform.SLACK,
+            config.platforms[Platform.SLACK],
+            "C123456789",
+            "hello",
+            thread_id="171000001.000100",
+            media_files=[],
+        )
+        receipt_files = list((tmp_path / "rsi_runtime" / "deliveries").glob("*.json"))
+        assert len(receipt_files) == 1
+
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()
         leaked = "very-secret-query-token-123456"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -6,6 +6,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -151,7 +152,7 @@ def send_message_tool(args, **kw):
     if action == "list":
         return _handle_list()
 
-    return _handle_send(args)
+    return _handle_send(args, **kw)
 
 
 def _handle_list():
@@ -163,23 +164,36 @@ def _handle_list():
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
 
 
-def _handle_send(args):
+def _handle_send(args, **kw):
     """Send a message to a platform target."""
-    target = args.get("target", "")
+    target = str(args.get("target", "") or "").strip()
     message = args.get("message", "")
-    if not target or not message:
-        return tool_error("Both 'target' and 'message' are required when action='send'")
+    if not message:
+        return tool_error("'message' is required when action='send'")
 
-    parts = target.split(":", 1)
-    platform_name = parts[0].strip().lower()
-    target_ref = parts[1].strip() if len(parts) > 1 else None
-    chat_id = None
-    thread_id = None
-
-    if target_ref:
-        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+    inferred_target = None
+    target_source = "explicit"
+    if not target:
+        inferred_target = _get_session_delivery_target()
+        if not inferred_target:
+            return tool_error("'target' is required when no session delivery target is bound")
+        platform_name = inferred_target["platform"]
+        target_ref = inferred_target["chat_id"]
+        chat_id = inferred_target["chat_id"]
+        thread_id = inferred_target.get("thread_id")
+        is_explicit = True
+        target_source = "session"
     else:
-        is_explicit = False
+        parts = target.split(":", 1)
+        platform_name = parts[0].strip().lower()
+        target_ref = parts[1].strip() if len(parts) > 1 else None
+        chat_id = None
+        thread_id = None
+
+        if target_ref:
+            chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+        else:
+            is_explicit = False
 
     # Resolve human-friendly channel names to numeric IDs
     if target_ref and not is_explicit:
@@ -255,12 +269,19 @@ def _handle_send(args):
         if home:
             chat_id = home.chat_id
             used_home_channel = True
+            target_source = "home_channel"
         else:
             return json.dumps({
                 "error": f"No home channel set for {platform_name} to determine where to send the message. "
                 f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
                 f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
             })
+
+    idempotency_key = _delivery_idempotency_key(args, kw, platform_name, chat_id, thread_id, message)
+    stored_receipt = _load_delivery_receipt(idempotency_key)
+    if stored_receipt:
+        stored_receipt["deduped"] = True
+        return json.dumps(stored_receipt)
 
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:
@@ -302,6 +323,14 @@ def _handle_send(args):
 
         if isinstance(result, dict) and "error" in result:
             result["error"] = _sanitize_error_text(result["error"])
+        if isinstance(result, dict) and result.get("success"):
+            result.setdefault("platform", platform_name)
+            result.setdefault("chat_id", chat_id)
+            if thread_id:
+                result.setdefault("thread_id", thread_id)
+            result["target_source"] = target_source
+            result["idempotency_key"] = idempotency_key
+            _store_delivery_receipt(idempotency_key, result)
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
@@ -367,6 +396,103 @@ def _describe_media_for_mirror(media_files):
             return "[Sent audio attachment]"
         return "[Sent document attachment]"
     return f"[Sent {len(media_files)} media attachments]"
+
+
+def _get_session_delivery_target():
+    """Return the active gateway session target for inferred native sends."""
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    if not platform or not chat_id:
+        return None
+    thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip() or None
+    return {
+        "platform": platform,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+    }
+
+
+def _delivery_receipts_dir() -> str:
+    hermes_home = os.getenv("HERMES_HOME", os.path.expanduser("~/.hermes")).strip() or os.path.expanduser("~/.hermes")
+    return os.path.join(os.path.expanduser(hermes_home), "rsi_runtime", "deliveries")
+
+
+def _delivery_receipt_path(idempotency_key: str) -> str:
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+    return os.path.join(_delivery_receipts_dir(), f"{digest}.json")
+
+
+def _delivery_idempotency_key(args, kw, platform_name: str, chat_id: str, thread_id: str | None, message: str) -> str:
+    explicit = str(args.get("idempotency_key") or kw.get("idempotency_key") or os.getenv("RSI_DELIVERY_IDEMPOTENCY_KEY", "") or "").strip()
+    if explicit:
+        return explicit
+    execution_id = os.getenv("RSI_EXECUTION_ID", "").strip()
+    tool_call_id = str(kw.get("tool_call_id") or args.get("tool_call_id") or "").strip()
+    if execution_id and tool_call_id:
+        return f"rsi:{execution_id}:{tool_call_id}"
+    material = json.dumps(
+        {
+            "execution_id": execution_id,
+            "platform": platform_name,
+            "chat_id": str(chat_id or ""),
+            "thread_id": str(thread_id or ""),
+            "message_sha256": hashlib.sha256(str(message or "").encode("utf-8")).hexdigest(),
+        },
+        sort_keys=True,
+    )
+    return "rsi:auto:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _load_delivery_receipt(idempotency_key: str):
+    if not idempotency_key:
+        return None
+    path = _delivery_receipt_path(idempotency_key)
+    try:
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as handle:
+            parsed = json.load(handle)
+    except Exception:
+        return None
+    if not isinstance(parsed, dict) or not parsed.get("success"):
+        return None
+    return parsed
+
+
+def _store_delivery_receipt(idempotency_key: str, receipt) -> None:
+    if not idempotency_key or not isinstance(receipt, dict):
+        return
+    path = _delivery_receipt_path(idempotency_key)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    temp_path = os.path.join(os.path.dirname(path), f"{os.path.basename(path)}.{os.getpid()}.{time.time_ns()}.tmp")
+    payload = dict(receipt)
+    payload["idempotency_key"] = idempotency_key
+    try:
+        with open(temp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=True, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        try:
+            dir_fd = os.open(os.path.dirname(path), getattr(os, "O_DIRECTORY", 0) | os.O_RDONLY)
+        except OSError:
+            dir_fd = None
+        if dir_fd is not None:
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+    except Exception:
+        try:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+        except Exception:
+            pass
 
 
 def _get_cron_auto_delivery_target():


### PR DESCRIPTION
## Summary
- add bundled `rsi_platform_runtime` plugin with static capabilities and execution-envelope production
- persist idempotent send_message receipts and support inferred session targets
- expose plugin manifest capabilities through plugin listing

## Companion PR
- Platform: https://github.com/piplabs/rsi-agent-platform/pull/209

## Tests
- `/Users/blake/hermes-agent/.venv/bin/pytest tests/tools/test_send_message_tool.py tests/hermes_cli/test_plugins.py tests/plugins/test_rsi_platform_runtime.py -q`
