### PR TITLE
fix(gateway): evict oldest signal echo timestamp in FIFO order

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -19,6 +19,7 @@ import os
 import random
 import time
 import uuid
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -216,7 +217,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Track recently sent message timestamps to prevent echo-back loops
         # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
-        self._recent_sent_timestamps: set = set()
+        self._recent_sent_timestamps: "OrderedDict[Any, None]" = OrderedDict()
         self._max_recent_timestamps = 50
         # Signal increasingly exposes ACI/PNI UUIDs as stable recipient IDs.
         # Keep a best-effort mapping so outbound sends can upgrade from a
@@ -440,7 +441,7 @@ class SignalAdapter(BasePlatformAdapter):
                     if dest == self._account_normalized:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
-                            self._recent_sent_timestamps.discard(sent_ts)
+                            self._recent_sent_timestamps.pop(sent_ts, None)
                             return
                         # Genuine user Note to Self — promote to dataMessage
                         is_note_to_self = True
@@ -962,9 +963,10 @@ class SignalAdapter(BasePlatformAdapter):
         """Record outbound message timestamp for echo-back filtering."""
         ts = rpc_result.get("timestamp") if isinstance(rpc_result, dict) else None
         if ts:
-            self._recent_sent_timestamps.add(ts)
+            self._recent_sent_timestamps[ts] = None
+            self._recent_sent_timestamps.move_to_end(ts)
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
-                self._recent_sent_timestamps.pop()
+                self._recent_sent_timestamps.popitem(last=False)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator.


### PR DESCRIPTION
## Summary
The Signal adapter tracked recently-sent timestamps in a plain `set` and called `set.pop()` once the buffer exceeded 50 entries (`gateway/platforms/signal.py:967`). `set.pop()` removes an arbitrary element, so it could evict a timestamp that had just been recorded, letting the next sync echo of that message slip past the dedupe check and re-enter the conversation as if it were user input.

## Fix
Switched `_recent_sent_timestamps` to an `OrderedDict` keyed by timestamp, recording new sends with `move_to_end` and trimming via `popitem(last=False)` so eviction is FIFO. The echo-match path now uses `pop(ts, None)` instead of `discard` to keep the same single-consume semantics.

## Tests
Verified manually by sending >50 Note-to-Self messages in quick succession and confirming none of the sync echoes were re-ingested as user messages; `pytest tests/ -v` still passes.
