### PR TITLE
fix(doctor): use get_env_value for API keys and base URLs instead of os.getenv

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -995,7 +995,8 @@ def run_doctor(args):
     print()
     print(color("◆ API Connectivity", Colors.CYAN, Colors.BOLD))
     
-    openrouter_key = os.getenv("OPENROUTER_API_KEY")
+    from hermes_cli.config import get_env_value as _get_env_value
+    openrouter_key = _get_env_value("OPENROUTER_API_KEY") or os.getenv("OPENROUTER_API_KEY")
     if openrouter_key:
         print("  Checking OpenRouter API...", end="", flush=True)
         try:
@@ -1108,7 +1109,7 @@ def run_doctor(args):
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
         _key = ""
         for _ev in _env_vars:
-            _key = os.getenv(_ev, "")
+            _key = _get_env_value(_ev) or os.getenv(_ev, "")
             if _key:
                 break
         if _key:
@@ -1120,7 +1121,7 @@ def run_doctor(args):
             print(f"  Checking {_pname} API...", end="", flush=True)
             try:
                 import httpx
-                _base = os.getenv(_base_env, "") if _base_env else ""
+                _base = (_get_env_value(_base_env) or os.getenv(_base_env, "")) if _base_env else ""
                 # Auto-detect Kimi Code keys (sk-kimi-) → api.kimi.com/coding/v1
                 # (OpenAI-compat surface, which exposes /models for health check).
                 if not _base and _key.startswith("sk-kimi-"):


### PR DESCRIPTION
## Problem

`hermes_cli/doctor.py` uses `os.getenv()` to read API keys and base URL env vars, which only reads from `os.environ`. Values stored in `~/.hermes/.env` (the standard location for API keys) are silently missed.

This causes:
- **API key blindspot**: doctor reports keys as "not configured" when they exist only in `~/.hermes/.env`
- **Base URL fallback**: providers with custom `BASE_URL` in `.env` (like `DASHSCOPE_BASE_URL`) fall back to wrong registry defaults, causing false "invalid key" reports

Same pattern as #18757 (fixed in auth.py) — `os.getenv()` vs `get_env_value()` inconsistency.

## Fix

Replace `os.getenv()` with `get_env_value()` (with `os.getenv()` fallback) at 3 call sites:

1. **Line 998**: `openrouter_key = os.getenv("OPENROUTER_API_KEY")` → `_get_env_value("OPENROUTER_API_KEY") or os.getenv("OPENROUTER_API_KEY")`
2. **Line 1111**: `_key = os.getenv(_ev, "")` in provider loop → `_get_env_value(_ev) or os.getenv(_ev, "")`
3. **Line 1123**: `_base = os.getenv(_base_env, "")` for base URL → `_get_env_value(_base_env) or os.getenv(_base_env, "")`

The fallback to `os.getenv()` ensures values injected directly into the process environment (e.g., Docker, CI) still work.

## Related

- #18757 — same fix applied to `auth.py` 
- Skill docs note this as a known standing issue: `doctor.py line 1122 (_base = os.getenv(_base_env, ""))  still uses os.getenv`