### PR TITLE
fix(kanban): enable kanban tools for profiles with kanban in toolsets config

### DIFF
--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -40,13 +40,28 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _check_kanban_mode() -> bool:
-    """Tools are available iff the current process has ``HERMES_KANBAN_TASK``
-    set in its env, which the dispatcher sets when spawning a worker.
+    """Tools are available when either:
 
-    Humans running ``hermes chat`` see zero kanban tools. Workers spawned
-    by the kanban dispatcher (gateway-embedded by default) see all seven.
+    1. The current process has ``HERMES_KANBAN_TASK`` set in its env, which
+       the dispatcher sets when spawning a worker — same as before.
+    2. The current profile has ``kanban`` in its ``toolsets`` config — this
+       allows orchestrator profiles to create and manage kanban tasks without
+       being dispatched workers.
+
+    Humans running ``hermes chat`` with no kanban toolset see zero kanban
+    tools. Workers spawned by the dispatcher see all seven. Orchestrator
+    profiles with ``toolsets: [kanban, ...]`` also see all seven.
     """
-    return bool(os.environ.get("HERMES_KANBAN_TASK"))
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    # Also enable when the current profile explicitly includes 'kanban'
+    # in its toolsets config. Uses load_config() which is mtime-cached,
+    # so this is cheap on repeated calls.
+    from hermes_cli.config import load_config
+    cfg = load_config()
+    if cfg and "kanban" in cfg.get("toolsets", []):
+        return True
+    return False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix

`_check_kanban_mode()` now also returns `True` when the current profile has `kanban` in its `toolsets` config, not just when `HERMES_KANBAN_TASK` is set in the environment.

## Problem

The `_check_kanban_mode()` gating function only checked `os.environ.get("HERMES_KANBAN_TASK")`, which is only set by the kanban dispatcher when spawning a worker process. This meant:

- Orchestrator profiles with `kanban` in their `toolsets` config saw **zero** kanban tools
- The agent would hallucinate task creation because SOUL.md instructs it to use kanban tools that don't exist in its schema
- Only dispatched workers (with the env var set) could use kanban tools

## Fix

Extended `_check_kanban_mode()` to also check `load_config()` for `"kanban"` in the current profile's `toolsets` list. Uses the same mtime-cached `load_config()` that other `check_fn` functions use, so this is cheap on repeated calls.

The existing env-var check is preserved as the first (faster) path, so there's no performance regression for dispatched workers.

## Testing

- Workers with `HERMES_KANBAN_TASK` set → still get all kanban tools (env var check runs first)
- Profiles with `toolsets: [kanban, ...]` → now get all kanban tools
- Profiles without `kanban` in toolsets and no env var → still see zero kanban tools

Fixes #18968