### PR TITLE
fix(model): avoid Bedrock credential probe in provider picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1057,6 +1057,45 @@ def list_authenticated_providers(
         if normed:
             _builtin_endpoints.add(normed)
 
+    def _has_fast_aws_sdk_signal() -> bool:
+        """Return True when explicit AWS auth config is present.
+
+        This intentionally avoids botocore's full credential chain. Provider
+        picker/model-switch discovery can run for non-Bedrock providers, and
+        botocore may otherwise probe EC2 IMDS (169.254.169.254) on local
+        machines before returning no credentials.
+        """
+        if os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip():
+            return True
+        if (
+            os.environ.get("AWS_ACCESS_KEY_ID", "").strip()
+            and os.environ.get("AWS_SECRET_ACCESS_KEY", "").strip()
+        ):
+            return True
+        return any(
+            os.environ.get(name, "").strip()
+            for name in (
+                "AWS_PROFILE",
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "AWS_WEB_IDENTITY_TOKEN_FILE",
+            )
+        )
+
+    def _has_aws_sdk_creds_for_listing(slug: str) -> bool:
+        """Credential check for AWS SDK providers in non-runtime discovery."""
+        slug_norm = str(slug or "").strip().lower()
+        current_norm = str(current_provider or "").strip().lower()
+        if _has_fast_aws_sdk_signal():
+            return True
+        if slug_norm != current_norm:
+            return False
+        try:
+            from agent.bedrock_adapter import has_aws_credentials
+            return bool(has_aws_credentials())
+        except Exception:
+            return False
+
     data = fetch_models_dev()
 
     # Build curated model lists keyed by hermes provider ID
@@ -1184,7 +1223,9 @@ def list_authenticated_providers(
 
         # Check if credentials exist
         has_creds = False
-        if overlay.extra_env_vars:
+        if overlay.auth_type == "aws_sdk":
+            has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
+        elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
@@ -1324,11 +1365,7 @@ def list_authenticated_providers(
         # credentials come from the boto3 credential chain (env vars,
         # ~/.aws/credentials, instance roles, etc.)
         if not _cp_has_creds and _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
-            try:
-                from agent.bedrock_adapter import has_aws_credentials
-                _cp_has_creds = has_aws_credentials()
-            except Exception:
-                pass
+            _cp_has_creds = _has_aws_sdk_creds_for_listing(_cp.slug)
 
         if not _cp_has_creds:
             continue

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -203,6 +203,30 @@ class TestListAuthenticatedProvidersBedrock:
         bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
         assert bedrock is None, "bedrock should NOT appear when AWS credentials are absent"
 
+    def test_non_bedrock_picker_does_not_probe_full_aws_chain(self, monkeypatch):
+        """Non-Bedrock provider discovery must not touch boto3's full credential chain."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_WEB_IDENTITY_TOKEN_FILE", raising=False)
+        monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", raising=False)
+        monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", raising=False)
+
+        calls = {"has_aws_credentials": 0}
+
+        def _has_aws_credentials():
+            calls["has_aws_credentials"] += 1
+            return False
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", side_effect=_has_aws_credentials):
+            providers = list_authenticated_providers(current_provider="openrouter", max_models=0)
+
+        assert calls["has_aws_credentials"] == 0
+        assert all(p["slug"] != "bedrock" for p in providers)
+
     def test_bedrock_falls_back_to_curated_when_discovery_fails(self, monkeypatch):
         """When discover_bedrock_models() raises, fall back to curated list without crashing."""
         from hermes_cli.model_switch import list_authenticated_providers


### PR DESCRIPTION
## What does this PR do?

Fixes a provider-picker slowdown where non-Bedrock /model and provider discovery paths could call Bedrock credential detection, causing botocore to probe EC2 instance metadata at 169.254.169.254 on local machines before returning no credentials.

The provider picker now treats Bedrock as available from fast explicit AWS signals such as AWS_PROFILE, AWS_ACCESS_KEY_ID plus AWS_SECRET_ACCESS_KEY, AWS_BEARER_TOKEN_BEDROCK, container credentials, or web identity. It only falls back to the full boto3 credential chain when Bedrock is the active provider, where implicit instance or task credentials are expected.

## Related Issue

N/A. Found while investigating a local /model minimax/minimax-m2.5:free --provider openrouter switch that was delayed by unrelated Bedrock IMDS timeouts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- hermes_cli/model_switch.py: add a fast AWS SDK credential signal check for provider listing and avoid botocore credential-chain probing for unrelated providers.
- tests/hermes_cli/test_bedrock_model_picker.py: add regression coverage proving OpenRouter provider listing does not call has_aws_credentials() when no explicit AWS auth signal is present.

## How to Test

1. Run pytest -n 4 tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_model_switch_custom_providers.py.
2. Run git diff --check -- hermes_cli/model_switch.py tests/hermes_cli/test_bedrock_model_picker.py.
3. Run scripts/run_tests.sh for the full non-integration suite with the repo-standard -n 4 worker count.

## Checklist

### Code

- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run pytest tests/ -q and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: WSL Ubuntu on Windows

### Documentation and Housekeeping

- [x] Documentation update N/A
- [x] cli-config.yaml.example update N/A
- [x] CONTRIBUTING.md or AGENTS.md update N/A
- [x] Cross-platform impact considered: avoids local IMDS timeout behavior on non-cloud machines while preserving Bedrock active-provider behavior
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Before the fix, non-Bedrock provider listing could emit botocore timeout traces for http://169.254.169.254/latest/api/token and http://169.254.169.254/latest/meta-data/iam/security-credentials/.

Targeted verification:

```bash
pytest -n 4 tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_model_switch_custom_providers.py
# 38 passed

git diff --check -- hermes_cli/model_switch.py tests/hermes_cli/test_bedrock_model_picker.py
# no output
```

Full suite verification:

```bash
scripts/run_tests.sh
# 28 failed, 19093 passed, 51 skipped, 219 warnings in 421.72s (0:07:01)
```

The full-suite failures are outside this PRs touched files. Failure list from the run:

```text
FAILED tests/acp/test_server.py::TestSessionOps::test_send_available_commands_update
FAILED tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once
FAILED tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_intermediate_send_stays_streaming
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_done_fires_only_when_reply_to_is_set
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_fires_done
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_false_tracks_sibling
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_next_send_auto_closes_sibling_streaming_cards
FAILED tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured
FAILED tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none
FAILED tests/agent/test_auxiliary_client.py::TestGetTextAuxiliaryClient::test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api
FAILED tests/gateway/test_teams.py::TestTeamsSend::test_send_typing
FAILED tests/gateway/test_api_server.py::TestAdapterInit::test_default_config
FAILED tests/hermes_cli/test_backup.py::TestProfileRestoration::test_import_creates_profile_wrappers
FAILED tests/hermes_cli/test_backup.py::TestPreUpdateBackup::test_rotation_keeps_only_n
FAILED tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_refreshes_repo_and_tui_node_dependencies
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_restarts_profile_manual_gateways
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_profile_manual_gateway_falls_back_to_sigterm
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestServicePidExclusion::test_update_kills_manual_pid_but_not_service_pid
FAILED tests/plugins/test_kanban_dashboard_plugin.py::test_ws_events_rejects_when_token_required
FAILED tests/test_tui_gateway_server.py::test_session_create_drops_pending_title_on_valueerror
FAILED tests/run_agent/test_concurrent_interrupt.py::test_concurrent_interrupt_cancels_pending
FAILED tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_installs_tui_dependencies
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_materializes_local_tui_ink_package
FAILED tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears
FAILED tests/tools/test_credential_pool_env_fallback.py::TestCredentialPoolSeedsFromDotEnv::test_os_environ_still_wins_over_dotenv
```
