### PR TITLE
fix(vision): remove kimi-coding from _PROVIDERS_WITHOUT_VISION deny-list

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -247,17 +247,13 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 # Providers whose endpoint does not accept image input, even though the
 # provider's broader ecosystem has vision models available elsewhere.  When
 # `auxiliary.vision.provider: auto` sees one of these as the main provider,
-# it must skip straight to the aggregator chain instead of returning a client
-# that will 404 on every vision request.
+# Providers whose main endpoint does not accept image input and must be
+# skipped on the vision auto-detect path, falling through to the aggregator
+# chain instead of returning a client that will 404 on every vision request.
 #
-# kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
-# api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
-# describe as having no image_in capability. Vision lives on the separate
-# Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
-_PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
-    "kimi-coding",
-    "kimi-coding-cn",
-})
+# kimi-coding / kimi-coding-cn were removed in #18990 because Kimi Coding
+# now supports vision upstream.
+_PROVIDERS_WITHOUT_VISION: frozenset = frozenset()
 
 # OpenRouter app attribution headers
 _OR_HEADERS = {
@@ -2631,19 +2627,6 @@ def resolve_vision_provider_client(
                         main_provider, default_model or resolved_model or main_model,
                     )
                     return _finalize(main_provider, sync_client, default_model)
-            elif main_provider in _PROVIDERS_WITHOUT_VISION:
-                # Kimi Coding Plan's /coding endpoint (Anthropic Messages wire)
-                # does not accept image input — Kimi's own docs say "Current
-                # model does not support image input, switch to a model with
-                # image_in capability" and vision lives on the separate Kimi
-                # Platform (api.moonshot.ai). Skip the main provider and fall
-                # through to the aggregator chain instead of returning a
-                # client that will 404 on every vision request (#17076).
-                logger.debug(
-                    "Vision auto-detect: skipping main provider %s (no "
-                    "vision support) — falling through to aggregator chain",
-                    main_provider,
-                )
             else:
                 rpc_client, rpc_model = resolve_provider_client(
                     main_provider, vision_model,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1652,83 +1652,16 @@ class TestCodexAdapterReasoningTranslation:
 
 
 
-class TestVisionAutoSkipsKimiCoding:
-    """_resolve_auto vision branch skips providers that have no vision on
-    their main endpoint (e.g. Kimi Coding Plan /coding) and falls through
-    to the aggregator chain instead of handing back a client that will 404
-    on every request (#17076).
+class TestVisionAutoKimiCoding:
+    """kimi-coding no longer needs to be skipped on vision auto-detect
+    because it now supports vision upstream (#18990).  The explicit-override
+    path still works, and the skip set should be empty.
     """
 
-    def test_kimi_coding_skipped_falls_through_to_openrouter(self, monkeypatch):
-        """kimi-coding as main + vision auto → OpenRouter (not kimi)."""
-        fake_or_client = MagicMock(name="openrouter_client")
-
-        monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding",
-        )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_model", lambda: "kimi-code",
-        )
-        # Guard: if the skip doesn't fire, _resolve_strict_vision_backend
-        # and resolve_provider_client both would try kimi-coding — detect
-        # either via the main-provider call and fail loud.
-        rpc_mock = MagicMock(side_effect=AssertionError(
-            "resolve_provider_client should NOT be called for kimi-coding "
-            "on the vision auto path"))
-        monkeypatch.setattr(
-            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
-        )
-
-        def fake_strict(provider, model=None):
-            if provider == "openrouter":
-                return fake_or_client, "google/gemini-3-flash-preview"
-            if provider == "nous":
-                return None, None
-            raise AssertionError(
-                f"strict vision backend should not be called for {provider!r} "
-                "when main provider is kimi-coding"
-            )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._resolve_strict_vision_backend",
-            fake_strict,
-        )
-
-        provider, client, model = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
-        assert model == "google/gemini-3-flash-preview"
-
-    def test_kimi_coding_cn_skipped_too(self, monkeypatch):
-        """Same skip applies to the CN variant."""
-        fake_or_client = MagicMock(name="openrouter_client")
-
-        monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding-cn",
-        )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_model", lambda: "kimi-code",
-        )
-        rpc_mock = MagicMock(side_effect=AssertionError(
-            "resolve_provider_client should NOT be called for kimi-coding-cn"))
-        monkeypatch.setattr(
-            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
-        )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._resolve_strict_vision_backend",
-            lambda p, m=None: (fake_or_client, "gemini")
-            if p == "openrouter"
-            else (None, None),
-        )
-
-        provider, client, _ = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
-
     def test_explicit_override_to_kimi_coding_still_honored(self, monkeypatch):
-        """When a user *explicitly* requests kimi-coding for vision (e.g.
-        they know what they're doing, or are running a future build that
-        adds image_in capability to Kimi Code), the explicit path still
-        routes to kimi-coding — only the auto branch applies the skip.
+        """When a user *explicitly* requests kimi-coding for vision, the
+        explicit path routes to kimi-coding — there is no skip list entry
+        that would block it anymore.
         """
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_provider", lambda: "openrouter",
@@ -1746,13 +1679,10 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_kimi_client
         gcc_mock.assert_called_once()
 
-    def test_skip_set_covers_exactly_known_entries(self):
-        """Guard against accidental widening of the skip list."""
+    def test_skip_set_is_empty(self):
+        """All known providers now support vision — the skip list should be empty."""
         from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
-        assert _PROVIDERS_WITHOUT_VISION == frozenset({
-            "kimi-coding",
-            "kimi-coding-cn",
-        })
+        assert _PROVIDERS_WITHOUT_VISION == frozenset()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes `kimi-coding` and `kimi-coding-cn` from `_PROVIDERS_WITHOUT_VISION` since Kimi Coding now supports vision upstream.

Closes #18990

## Problem

PR #17451 added `kimi-coding` and `kimi-coding-cn` to `_PROVIDERS_WITHOUT_VISION` because Kimi Coding's vision endpoint was unreliable at the time. Kimi has since added proper vision support — the Messages API (`/v1/messages`) with `content` blocks containing `type: "image"` and `image_url` (Anthropic wire format) works correctly.

This deny-list entry now blocks legitimate vision requests for Kimi Coding users: `resolve_vision_provider_client()` hits the guard, skips `kimi-coding`, falls through to unavailable aggregators, and returns `None`.

## Changes

1. **`agent/auxiliary_client.py`**: Emptied `_PROVIDERS_WITHOUT_VISION` frozenset (was `{"kimi-coding", "kimi-coding-cn"}`, now `frozenset()`). Removed the `elif main_provider in _PROVIDERS_WITHOUT_VISION:` branch (13 lines) from `resolve_vision_provider_client()` — dead code now that the set is empty. Updated comment block to reference #18990.

2. **`tests/agent/test_auxiliary_client.py`**: Updated test class names, removed two tests that verified kimi-coding was skipped (no longer applicable), kept the explicit-override test, updated skip-set assertion to verify `frozenset()`.

## Verification

- No other references to kimi-coding vision blocking exist in the codebase
- The `else` branch in `resolve_vision_provider_client()` now handles kimi-coding normally — calling `resolve_provider_client()` which works correctly for vision-capable providers