### PR TITLE
feat: add claude-mode approvals and yolo state

### DIFF
--- a/gateway/awareos_bridge.py
+++ b/gateway/awareos_bridge.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def awareos_overlay_enabled() -> bool:
+    return os.getenv("AWAREOS_OVERLAY_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def awareos_context_eval_enabled() -> bool:
+    return os.getenv("AWAREOS_CONTEXT_EVAL_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def awareos_work_overlay_events_path() -> Path:
+    raw = os.getenv("AWAREOS_WORK_OVERLAY_EVENTS_PATH", "").strip()
+    if raw:
+        return Path(raw)
+    return get_hermes_home() / "state" / "awareos_work_overlay_events.jsonl"
+
+
+def _append_jsonl(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(obj, ensure_ascii=False) + "\n")
+
+
+def record_work_overlay_event(payload: dict[str, Any]) -> None:
+    """Durably record an AwareOS work-overlay event for out-of-process ingest.
+
+    This is intentionally schema-light: we persist stable references and
+    compact summaries only (hashes, ids, counts). Do NOT include raw chat
+    bodies/tool outputs in ``payload``.
+    """
+    if not awareos_overlay_enabled():
+        return
+    _append_jsonl(awareos_work_overlay_events_path(), payload)
+
+
+def record_work_overlay_start(
+    *,
+    overlay_id: str,
+    source: dict[str, Any],
+    prompt_text: str | None = None,
+    journal: dict[str, Any] | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": "awareos.work_overlay_event.v1",
+        "recorded_at": _now_iso(),
+        "action": "start",
+        "overlay_id": overlay_id,
+        "source": dict(source or {}),
+    }
+    if prompt_text is not None:
+        payload["prompt"] = {
+            "sha256": _sha256_text(prompt_text),
+            "length": len(prompt_text or ""),
+        }
+    if journal:
+        payload["journal"] = dict(journal)
+    record_work_overlay_event(payload)
+
+
+def record_work_overlay_stop(
+    *,
+    overlay_id: str,
+    source: dict[str, Any],
+    result: dict[str, Any] | None = None,
+    journal: dict[str, Any] | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": "awareos.work_overlay_event.v1",
+        "recorded_at": _now_iso(),
+        "action": "stop",
+        "overlay_id": overlay_id,
+        "source": dict(source or {}),
+    }
+    if result:
+        payload["result"] = dict(result)
+    if journal:
+        payload["journal"] = dict(journal)
+    record_work_overlay_event(payload)
+
+
+_TIME_KEYWORDS = (
+    "today",
+    "tomorrow",
+    "yesterday",
+    "tonight",
+    "this week",
+    "next week",
+    "schedule",
+    "calendar",
+    "meeting",
+    "appointment",
+    "free time",
+    "availability",
+    "time",
+    "timezone",
+)
+_GOAL_KEYWORDS = (
+    "goal",
+    "goals",
+    "plan",
+    "plans",
+    "roadmap",
+    "milestone",
+    "todo",
+    "to-do",
+    "task",
+    "tasks",
+)
+_AWAREOS_KEYWORDS = ("awareos", "overlay", "contextual overlay", "work overlay")
+
+
+def should_trigger_context_eval(message_text: str) -> bool:
+    text = (message_text or "").strip().lower()
+    if not text:
+        return False
+    if text.startswith("/"):
+        return False
+    return any(k in text for k in (*_TIME_KEYWORDS, *_GOAL_KEYWORDS, *_AWAREOS_KEYWORDS))
+
+
+def context_eval_debounce_secs() -> int:
+    raw = os.getenv("AWAREOS_CONTEXT_EVAL_DEBOUNCE_SECS", "").strip()
+    try:
+        return max(0, int(raw)) if raw else 900
+    except Exception:
+        return 900
+
+
+@dataclass(frozen=True)
+class ContextEvalResult:
+    ok: bool
+    snippet: str
+    meta: dict[str, Any]
+
+
+def _awareos_bearer_token() -> str:
+    # Prefer a context-eval-specific env var, but support reusing the AwareOS
+    # North Star token name for convenience in unified deployments.
+    return (
+        os.getenv("AWAREOS_CONTEXT_EVAL_BEARER_TOKEN", "").strip()
+        or os.getenv("AWAREOS_MCP_SERVICE_TOKEN", "").strip()
+    )
+
+
+def _awareos_contextual_overlay_tz_offset_min() -> str | None:
+    raw = (
+        os.getenv("AWAREOS_CONTEXTUAL_OVERLAY_TZ_OFFSET_MIN", "").strip()
+        or os.getenv("AWAREOS_CONTEXT_EVAL_TZ_OFFSET_MIN", "").strip()
+    )
+    if not raw:
+        return None
+    try:
+        # Normalize to an int-like string; AwareOS clamps on its side.
+        return str(int(float(raw)))
+    except Exception:
+        return None
+
+
+def _looks_like_contextual_overlay_url(url: str) -> bool:
+    # AwareOS canonical route: GET /api/kaze/contextual-overlay
+    return "contextual-overlay" in (url or "")
+
+
+def _build_overlay_snippet(payload: Any) -> str:
+    """Convert the AwareOS contextual overlay response to a compact snippet."""
+    if not isinstance(payload, dict):
+        return ""
+    prompts = payload.get("prompts")
+    if not isinstance(prompts, list) or not prompts:
+        return ""
+
+    lines: list[str] = []
+    for prompt in prompts[:6]:
+        if not isinstance(prompt, dict):
+            continue
+        kind = str(prompt.get("kind") or "").strip()
+        priority = str(prompt.get("priority") or "").strip()
+        reason = str(prompt.get("reason") or "").strip()
+        suggested = str(prompt.get("suggested_action") or "").strip()
+        if not (kind or reason or suggested):
+            continue
+
+        head_parts: list[str] = []
+        if priority:
+            head_parts.append(f"[{priority}]")
+        if kind:
+            head_parts.append(kind)
+        head = " ".join(head_parts).strip()
+
+        if head and reason:
+            lines.append(f"- {head}: {reason}")
+        elif head:
+            lines.append(f"- {head}")
+        elif reason:
+            lines.append(f"- {reason}")
+        else:
+            lines.append("-")
+
+        if suggested:
+            lines.append(f"  suggested: {suggested}")
+
+    snippet = "\n".join(lines).strip()
+    return snippet[:1500].rstrip()
+
+
+def _run_contextual_overlay_eval(*, url: str, message_text: str) -> ContextEvalResult:
+    started = time.time()
+    token = _awareos_bearer_token()
+    if not token:
+        return ContextEvalResult(
+            ok=False,
+            snippet="",
+            meta={"mode": "contextual_overlay_get", "error": "missing_bearer_token"},
+        )
+
+    tz_offset_min = _awareos_contextual_overlay_tz_offset_min()
+    calendar_prep_needed = (
+        "1"
+        if any(k in (message_text or "").lower() for k in ("calendar", "meeting", "appointment"))
+        else "0"
+    )
+
+    parsed = urllib.parse.urlparse(url)
+    query = dict(urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
+    if tz_offset_min is not None and "tz_offset_min" not in query:
+        query["tz_offset_min"] = tz_offset_min
+    if "calendar_prep_needed" not in query:
+        query["calendar_prep_needed"] = calendar_prep_needed
+    new_url = urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
+
+    req = urllib.request.Request(
+        new_url,
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=6) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+        payload = json.loads(raw) if raw else {}
+        snippet = _build_overlay_snippet(payload)
+        return ContextEvalResult(
+            ok=bool(snippet),
+            snippet=snippet,
+            meta={
+                "mode": "contextual_overlay_get",
+                "latency_ms": int((time.time() - started) * 1000),
+                "response_keys": sorted(list(payload.keys())) if isinstance(payload, dict) else [],
+                "prompt_count": len(payload.get("prompts") or []) if isinstance(payload, dict) else 0,
+            },
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        return ContextEvalResult(
+            ok=False,
+            snippet="",
+            meta={
+                "mode": "contextual_overlay_get",
+                "error": str(exc),
+                "latency_ms": int((time.time() - started) * 1000),
+            },
+        )
+    except Exception as exc:
+        return ContextEvalResult(
+            ok=False,
+            snippet="",
+            meta={
+                "mode": "contextual_overlay_get",
+                "error": str(exc),
+                "latency_ms": int((time.time() - started) * 1000),
+            },
+        )
+
+def run_context_eval(
+    *,
+    message_text: str,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    user_id: str | None,
+) -> ContextEvalResult | None:
+    """Optional sparse AwareOS contextual-evaluator call.
+
+    If configured via ``AWAREOS_CONTEXT_EVAL_URL``, makes a best-effort HTTP call.
+
+    Two endpoint shapes are supported:
+
+    - AwareOS contextual overlay (preferred): when the URL points at the AwareOS
+      route ``/api/kaze/contextual-overlay`` this function issues a GET request
+      and converts the returned prompts into a compact snippet. No raw chat body
+      is sent.
+    - Legacy evaluator: POST JSON and expect a ``snippet``/``context`` field.
+    """
+    if not awareos_context_eval_enabled():
+        return None
+    url = os.getenv("AWAREOS_CONTEXT_EVAL_URL", "").strip()
+    if not url:
+        return None
+
+    if _looks_like_contextual_overlay_url(url):
+        return _run_contextual_overlay_eval(url=url, message_text=message_text)
+
+    body = {
+        "schema_version": "awareos.context_eval_request.v1",
+        "requested_at": _now_iso(),
+        "platform": platform,
+        "chat_id": chat_id,
+        "user_id": user_id or "",
+        "session_key": session_key,
+        "text": message_text or "",
+    }
+    data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    started = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=6) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+        parsed = json.loads(raw) if raw else {}
+        snippet = str(parsed.get("snippet") or parsed.get("context") or "").strip()
+        if not snippet:
+            return ContextEvalResult(
+                ok=False,
+                snippet="",
+                meta={"error": "empty_response", "latency_ms": int((time.time() - started) * 1000)},
+            )
+        # Hard cap; keep prompt caching impact bounded.
+        snippet = snippet[:1500].rstrip()
+        return ContextEvalResult(
+            ok=True,
+            snippet=snippet,
+            meta={
+                "latency_ms": int((time.time() - started) * 1000),
+                "response_keys": sorted(list(parsed.keys())) if isinstance(parsed, dict) else [],
+            },
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        return ContextEvalResult(
+            ok=False,
+            snippet="",
+            meta={"error": str(exc), "latency_ms": int((time.time() - started) * 1000)},
+        )
+    except Exception as exc:
+        return ContextEvalResult(
+            ok=False,
+            snippet="",
+            meta={"error": str(exc), "latency_ms": int((time.time() - started) * 1000)},
+        )

--- a/gateway/builtin_hooks/awareos_overlay.py
+++ b/gateway/builtin_hooks/awareos_overlay.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any
+
+from gateway.awareos_bridge import (
+    awareos_overlay_enabled,
+    record_work_overlay_start,
+    record_work_overlay_stop,
+)
+
+
+_ACTIVE: dict[str, dict[str, Any]] = {}
+
+
+def _stable_overlay_id(ctx: dict[str, Any]) -> str:
+    # session_id is already a stable UUID-like identifier.
+    session_id = str(ctx.get("session_id") or "").strip()
+    platform = str(ctx.get("platform") or "").strip()
+    chat_id = str(ctx.get("chat_id") or "").strip()
+    if session_id:
+        return f"hermes:{platform}:{chat_id}:{session_id}"
+    # Fallback: hash session_key + message_id for stability without raw text.
+    base = (
+        f"{platform}:{chat_id}:"
+        f"{str(ctx.get('session_key') or '')}:{str(ctx.get('message_id') or '')}"
+    )
+    return "hermes:" + hashlib.sha256(base.encode("utf-8")).hexdigest()[:24]
+
+
+def _is_substantive(ctx: dict[str, Any]) -> bool:
+    # Prefer explicit marker (set by gateway/run.py) when available.
+    if "substantive" in ctx:
+        return bool(ctx.get("substantive"))
+    api_calls = int(ctx.get("api_calls") or 0)
+    tool_names = ctx.get("tool_names") or []
+    return api_calls > 1 or (isinstance(tool_names, list) and len(tool_names) > 0)
+
+
+async def _handle_agent_start(_event_type: str, ctx: dict[str, Any]) -> None:
+    if not awareos_overlay_enabled():
+        return
+    if (ctx.get("platform") or "") != "telegram":
+        return
+    if not _is_substantive(ctx):
+        # Defer start until we see substantive info (agent:end can still emit stop
+        # without start, but we skip for truly trivial turns).
+        return
+    overlay_id = _stable_overlay_id(ctx)
+    source = {
+        "platform": ctx.get("platform") or "",
+        "chat_id": ctx.get("chat_id") or "",
+        "message_id": ctx.get("message_id") or "",
+        "session_id": ctx.get("session_id") or "",
+        "session_key": ctx.get("session_key") or "",
+        "user_id": ctx.get("user_id") or "",
+    }
+    record_work_overlay_start(
+        overlay_id=overlay_id,
+        source=source,
+        prompt_text=None,
+        journal={
+            "turn_kind": "hermes_agent",
+            "started_at_ms": int(time.time() * 1000),
+        },
+    )
+    _ACTIVE[overlay_id] = {"started_at": time.time(), "source": source}
+
+
+async def _handle_agent_end(_event_type: str, ctx: dict[str, Any]) -> None:
+    if not awareos_overlay_enabled():
+        return
+    if (ctx.get("platform") or "") != "telegram":
+        return
+    if not _is_substantive(ctx):
+        return
+    overlay_id = _stable_overlay_id(ctx)
+    active = _ACTIVE.pop(overlay_id, None) or {}
+    source = dict(active.get("source") or {})
+    if not source:
+        source = {
+            "platform": ctx.get("platform") or "",
+            "chat_id": ctx.get("chat_id") or "",
+            "message_id": ctx.get("message_id") or "",
+            "session_id": ctx.get("session_id") or "",
+            "session_key": ctx.get("session_key") or "",
+            "user_id": ctx.get("user_id") or "",
+        }
+    tool_names = ctx.get("tool_names") if isinstance(ctx.get("tool_names"), list) else []
+    record_work_overlay_stop(
+        overlay_id=overlay_id,
+        source=source,
+        result={
+            "api_calls": int(ctx.get("api_calls") or 0),
+            "response_length": int(ctx.get("response_length") or 0),
+            "tool_count": len(tool_names),
+        },
+        journal={
+            "turn_kind": "hermes_agent",
+            "ended_at_ms": int(time.time() * 1000),
+            "duration_ms": int(((time.time() - float(active.get("started_at") or time.time())) * 1000)),
+            "tool_names": tool_names,
+            "model": ctx.get("model") or "",
+        },
+    )
+
+
+def register_builtin_hooks(registry: Any) -> None:
+    """Called by HookRegistry during discover_and_load()."""
+    try:
+        registry._handlers.setdefault("agent:start", []).append(_handle_agent_start)
+        registry._handlers.setdefault("agent:end", []).append(_handle_agent_end)
+    except Exception:
+        return
+

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -59,7 +59,13 @@ class HookRegistry:
         point for future always-on gateway hooks so they drop in without
         re-plumbing discover_and_load().
         """
-        return
+        try:
+            from gateway.builtin_hooks.awareos_overlay import register_builtin_hooks
+
+            register_builtin_hooks(self)
+        except Exception:
+            # Built-in hooks are best-effort. Failure must never block the gateway.
+            return
 
     def discover_and_load(self) -> None:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1153,6 +1153,9 @@ class GatewayRunner:
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
 
+        # Sparse AwareOS contextual-evaluator debounce (in-memory only; never persisted).
+        self._awareos_last_context_eval_ts: Dict[str, float] = {}
+
 
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
         """Warn when Docker-backed gateways lack an explicit export mount.
@@ -5585,6 +5588,37 @@ class GatewayRunner:
             except Exception as exc:
                 logger.debug("@ context reference expansion failed: %s", exc)
 
+        # Sparse AwareOS context evaluator: only on relevant prompts, debounced
+        # per-session, and only when explicitly enabled via env.
+        try:
+            from gateway.awareos_bridge import (
+                should_trigger_context_eval as _awareos_should_eval,
+                context_eval_debounce_secs as _awareos_debounce,
+                run_context_eval as _awareos_eval,
+            )
+
+            if _awareos_should_eval(message_text):
+                now = time.time()
+                last_ts = float(self._awareos_last_context_eval_ts.get(session_key, 0.0) or 0.0)
+                debounce = float(_awareos_debounce() or 0)
+                if debounce <= 0 or (now - last_ts) >= debounce:
+                    res = _awareos_eval(
+                        message_text=message_text,
+                        session_key=session_key,
+                        platform=source.platform.value if source.platform else "",
+                        chat_id=str(source.chat_id or ""),
+                        user_id=str(source.user_id or "") if source.user_id is not None else None,
+                    )
+                    if res is not None and res.ok and res.snippet:
+                        self._awareos_last_context_eval_ts[session_key] = now
+                        message_text = (
+                            "[AwareOS context evaluator]\n"
+                            f"{res.snippet.strip()}\n\n"
+                            f"{message_text}"
+                        )
+        except Exception:
+            pass
+
         return message_text
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
@@ -6142,7 +6176,17 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
+                "session_key": session_key,
+                "chat_id": source.chat_id,
+                "message_id": event.message_id,
                 "message": message_text[:500],
+                "message_length": len(message_text or ""),
+                "is_command": bool((message_text or "").lstrip().startswith("/")),
+                # Heuristic; agent:end will refine with tool usage.
+                "substantive": (
+                    bool(message_text and not (message_text or "").lstrip().startswith("/"))
+                    and len((message_text or "").strip()) >= 20
+                ),
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
@@ -6301,10 +6345,37 @@ class GatewayRunner:
             if _footer_line and response and not agent_result.get("already_sent"):
                 response = f"{response}\n\n{_footer_line}"
 
+            # Compact per-turn tool usage summary for hooks/observers.
+            tool_names: list[str] = []
+            try:
+                for _m in agent_messages:
+                    if not isinstance(_m, dict) or _m.get("role") != "assistant":
+                        continue
+                    _tcs = _m.get("tool_calls")
+                    if not isinstance(_tcs, list):
+                        continue
+                    for _tc in _tcs:
+                        if not isinstance(_tc, dict):
+                            continue
+                        fn = (_tc.get("function") or {}) if isinstance(_tc.get("function"), dict) else {}
+                        name = fn.get("name")
+                        if isinstance(name, str) and name:
+                            tool_names.append(name)
+                # De-dup while preserving order.
+                seen = set()
+                tool_names = [n for n in tool_names if not (n in seen or seen.add(n))]
+            except Exception:
+                tool_names = []
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "response_length": len(response or ""),
+                "api_calls": int(agent_result.get("api_calls", 0) or 0),
+                "model": agent_result.get("model") or "",
+                "tool_names": tool_names,
+                "substantive": bool(tool_names) or bool(agent_result.get("api_calls", 0) or 0) > 1,
             })
             
             # Check for pending process watchers (check_interval on background processes)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1165,7 +1165,13 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
     Returns a list of non-``None`` return values from plugin callbacks.
     """
-    return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+    # Hook call sites exist in early startup paths (notably the gateway)
+    # before any explicit plugin discovery or command lookup has occurred.
+    # Ensure discovery runs idempotently so hook-based plugins work in a
+    # fresh process without requiring get_plugin_commands() as a side effect.
+    manager = get_plugin_manager()
+    manager.discover_and_load()
+    return manager.invoke_hook(hook_name, **kwargs)
 
 
 

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -30,6 +30,11 @@ from string import ascii_lowercase
 from typing import Any
 
 from hermes_constants import display_hermes_home, get_hermes_home
+from gateway.awareos_bridge import (
+    awareos_overlay_enabled,
+    record_work_overlay_start,
+    record_work_overlay_stop,
+)
 
 PLUGIN_NAME = "kaze-claude-mode"
 
@@ -991,6 +996,35 @@ async def _run_claude_code_print(
         if delivered:
             return ok_stream, ""
 
+    overlay_id = ""
+    overlay_source: dict[str, Any] = {}
+    overlay_started_at = 0.0
+    overlay_ok: bool | None = None
+    overlay_error: str = ""
+    if awareos_overlay_enabled() and platform == "telegram" and chat_id:
+        overlay_started_at = time.time()
+        overlay_id = (
+            "hermes:telegram:"
+            f"{chat_id}:claude_mode:"
+            f"{hashlib.sha256((session_key or chat_key or os.urandom(4).hex()).encode('utf-8')).hexdigest()[:16]}:"
+            f"{int(overlay_started_at * 1000)}"
+        )
+        overlay_source = {
+            "platform": platform,
+            "chat_id": chat_id,
+            "thread_id": thread_id or "",
+            "session_key": session_key or "",
+            "chat_key": chat_key or "",
+            "lane": "kaze-claude-mode",
+            "task_id": task_id,
+        }
+        record_work_overlay_start(
+            overlay_id=overlay_id,
+            source=overlay_source,
+            prompt_text=prompt,
+            journal={"turn_kind": "claude_code_cli"},
+        )
+
     try:
         from tools.approval import reset_current_session_key, set_current_session_key
         token = set_current_session_key(session_key or "")
@@ -1009,6 +1043,8 @@ async def _run_claude_code_print(
         )
         write_payload = json.loads(write_raw) if isinstance(write_raw, str) else {}
         if write_payload.get("error"):
+            overlay_ok = False
+            overlay_error = "stage_prompt_failed"
             return False, "Claude mode failed: could not stage prompt for Claude Code."
 
         allowed = _effective_allowed_tools(chat_key) if chat_key else _claude_code_allowed_tools()
@@ -1034,6 +1070,8 @@ async def _run_claude_code_print(
         )
         term = json.loads(term_raw) if isinstance(term_raw, str) else {}
         if term.get("status") == "approval_required":
+            overlay_ok = False
+            overlay_error = "approval_required"
             return False, "Claude mode: waiting for approval to run Claude Code CLI."
         out = _extract_terminal_text(term)
         exit_code = term.get("exit_code")
@@ -1061,6 +1099,8 @@ async def _run_claude_code_print(
                     },
                 )
                 safe_tool = tool_rule or "unknown"
+                overlay_ok = False
+                overlay_error = "permission_block"
                 return (
                     False,
                     _truncate_reply(
@@ -1070,9 +1110,26 @@ async def _run_claude_code_print(
                         "Reply `/claude-mode approve` to allow and retry, or `/claude-mode deny` to cancel."
                     ),
                 )
+            overlay_ok = False
+            overlay_error = "nonzero_exit"
             return False, _truncate_reply(f"Claude Code error:\n{err}")
+        overlay_ok = True
         return True, _truncate_reply(out or "(Claude Code returned no output.)")
     finally:
+        if overlay_id and overlay_source:
+            try:
+                record_work_overlay_stop(
+                    overlay_id=overlay_id,
+                    source=overlay_source,
+                    result={
+                        "ok": bool(overlay_ok) if overlay_ok is not None else None,
+                        "error": overlay_error or None,
+                        "duration_ms": int((time.time() - overlay_started_at) * 1000),
+                    },
+                    journal={"turn_kind": "claude_code_cli"},
+                )
+            except Exception:
+                pass
         if token is not None and reset_current_session_key is not None:
             with contextlib_suppress(Exception):
                 reset_current_session_key(token)

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -1,0 +1,468 @@
+"""Kaze Claude mode plugin.
+
+Chat-level Telegram "Claude lane" for Hermes/Kaze.
+
+When enabled for a Telegram chat, plain (non-slash) messages in that chat are
+routed through Hermes' normal agent/tool loop, but with a per-session runtime
+override to an Anthropic/Claude model. This preserves Hermes as the runtime
+owner (sessions, tools, approvals, safety) while providing a Claude-powered
+execution lane that can use Hermes tools to edit files and run commands.
+
+Slash commands remain escape hatches and are never captured as Claude-mode plain
+messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import display_hermes_home, get_hermes_home
+
+PLUGIN_NAME = "kaze-claude-mode"
+DEFAULT_CLAUDE_MODEL = os.environ.get("KAZE_CLAUDE_MODE_MODEL", "anthropic/claude-sonnet-4.6").strip()
+
+MODE_COMMANDS = {"claude-mode", "claude_mode"}
+INTERNAL_MODE = "kaze-claude-mode-dispatch"
+ESCAPE_COMMANDS = {
+    "approve",
+    "background",
+    "commands",
+    "debug",
+    "deny",
+    "help",
+    "new",
+    "queue",
+    "q",
+    "reset",
+    "restart",
+    "status",
+    "stop",
+}
+MAX_REPLY_CHARS = 3900
+
+_CTX = None  # set by register()
+_BOUNCE_PREFIX = (
+    "Claude mode is enabled for this chat, but the toolful Claude backend is not configured.\n"
+    "Routing this message to normal Hermes/Kaze instead.\n"
+    "Run `/claude-mode status` for setup info."
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _platform_value(source: Any) -> str:
+    platform = getattr(source, "platform", "")
+    return getattr(platform, "value", str(platform or ""))
+
+
+def state_key_from_source(source: Any) -> str:
+    """Stable per-chat key; includes thread/topic when Hermes exposes it."""
+    platform = _platform_value(source) or "unknown"
+    chat_id = str(getattr(source, "chat_id", "") or "unknown")
+    thread_id = str(getattr(source, "thread_id", "") or "")
+    if thread_id:
+        return f"{platform}:{chat_id}:{thread_id}"
+    return f"{platform}:{chat_id}"
+
+
+def _state_path() -> Path:
+    raw = os.environ.get("KAZE_CLAUDE_MODE_STATE", "").strip()
+    if raw:
+        return Path(raw)
+    return get_hermes_home() / "state" / "kaze_claude_mode.json"
+
+
+def _load_state(path: Path | None = None) -> dict[str, Any]:
+    path = _state_path() if path is None else path
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        except OSError:
+            pass
+
+
+def is_enabled(key: str, *, path: Path | None = None) -> bool:
+    path = _state_path() if path is None else path
+    entry = (_load_state(path).get("chats") or {}).get(key) or {}
+    return bool(entry.get("enabled"))
+
+
+def set_enabled(
+    key: str,
+    enabled: bool,
+    *,
+    source: Any = None,
+    path: Path | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    path = _state_path() if path is None else path
+    state = _load_state(path)
+    chats = state.setdefault("chats", {})
+    if not isinstance(chats, dict):
+        chats = {}
+        state["chats"] = chats
+    entry = chats.setdefault(key, {})
+    if not isinstance(entry, dict):
+        entry = {}
+        chats[key] = entry
+    entry.update({
+        "enabled": bool(enabled),
+        "updated_at": _now_iso(),
+    })
+    if source is not None:
+        entry["platform"] = _platform_value(source)
+        entry["chat_id"] = str(getattr(source, "chat_id", "") or "")
+        thread_id = getattr(source, "thread_id", None)
+        if thread_id:
+            entry["thread_id"] = str(thread_id)
+    if extra:
+        entry.update({k: v for k, v in extra.items() if v is not None})
+    state["updated_at"] = _now_iso()
+    _atomic_write_json(path, state)
+    return entry
+
+
+def _encode_packet(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_packet(raw: str) -> dict[str, Any]:
+    try:
+        data = base64.urlsafe_b64decode(raw.strip().encode("ascii"))
+        parsed = json.loads(data.decode("utf-8"))
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _command_name(text: str) -> str:
+    stripped = (text or "").strip()
+    if not stripped.startswith("/"):
+        return ""
+    token = stripped.split(maxsplit=1)[0].lstrip("/")
+    # Telegram group commands may arrive as /cmd@bot.
+    return token.split("@", 1)[0].lower()
+
+
+def _command_args(text: str) -> str:
+    stripped = (text or "").strip()
+    parts = stripped.split(maxsplit=1)
+    return parts[1] if len(parts) > 1 else ""
+
+
+def _resolve_toolful_claude_backend(*, model: str | None = None) -> tuple[bool, str, dict[str, Any]]:
+    """Return (ok, model, runtime) for the Claude toolful lane."""
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    target_model = (model or DEFAULT_CLAUDE_MODEL or "anthropic/claude-sonnet-4.6").strip()
+    runtime = resolve_runtime_provider(requested="anthropic", target_model=target_model)
+    ok = bool(runtime.get("api_key")) and str(runtime.get("provider") or "").strip().lower() == "anthropic"
+    return ok, target_model, runtime
+
+
+def _apply_gateway_override(gateway: Any, session_key: str, *, model: str, runtime: dict[str, Any]) -> None:
+    """Apply a per-session Claude lane override to the gateway runner."""
+    if not gateway or not session_key:
+        return
+    overrides = getattr(gateway, "_session_model_overrides", None)
+    if not isinstance(overrides, dict):
+        return
+    overrides[session_key] = {
+        "model": model,
+        "provider": runtime.get("provider") or "anthropic",
+        "api_key": runtime.get("api_key") or "",
+        "base_url": runtime.get("base_url") or "",
+        "api_mode": runtime.get("api_mode") or "",
+    }
+    try:
+        gateway._evict_cached_agent(session_key)
+    except Exception:
+        pass
+
+
+def _clear_gateway_override(gateway: Any, session_key: str) -> None:
+    if not gateway or not session_key:
+        return
+    try:
+        overrides = getattr(gateway, "_session_model_overrides", None)
+        if isinstance(overrides, dict):
+            overrides.pop(session_key, None)
+        gateway._evict_cached_agent(session_key)
+    except Exception:
+        pass
+
+
+def build_pre_dispatch_decision(event: Any, gateway: Any = None) -> dict[str, Any] | None:
+    """Return a pre_gateway_dispatch rewrite/allow decision for an event."""
+    text = getattr(event, "text", None) or ""
+    source = getattr(event, "source", None)
+    if not source or not text.strip():
+        return None
+    platform = _platform_value(source)
+    if platform != "telegram":
+        return None
+
+    key = state_key_from_source(source)
+    cmd = _command_name(text)
+    if cmd in MODE_COMMANDS:
+        args = _command_args(text).strip().lower()
+        session_key = ""
+        if gateway is not None:
+            try:
+                session_key = gateway._session_key_for_source(source)
+            except Exception:
+                session_key = ""
+
+        if args in {"off", "disable", "disabled"} and session_key:
+            _clear_gateway_override(gateway, session_key)
+
+        if args in {"on", "enable", "enabled"}:
+            ok, model, _runtime = _resolve_toolful_claude_backend()
+            if ok:
+                set_enabled(
+                    key,
+                    True,
+                    source=source,
+                    extra={
+                        "backend": "hermes_toolful",
+                        "provider": "anthropic",
+                        "model": model,
+                        "tool_edit_active": True,
+                        "last_enable_error": "",
+                    },
+                )
+            else:
+                set_enabled(
+                    key,
+                    False,
+                    source=source,
+                    extra={
+                        "backend": "unavailable",
+                        "provider": "anthropic",
+                        "model": DEFAULT_CLAUDE_MODEL,
+                        "tool_edit_active": False,
+                        "last_enable_error": "missing Anthropic credentials",
+                    },
+                )
+
+        packet = {
+            "key": key,
+            "args": _command_args(text),
+            "platform": platform,
+            "chat_id": str(getattr(source, "chat_id", "") or ""),
+            "thread_id": str(getattr(source, "thread_id", "") or ""),
+            "session_key": session_key,
+        }
+        return {"action": "rewrite", "text": f"/{INTERNAL_MODE} {_encode_packet(packet)}"}
+
+    if cmd:
+        return None
+
+    if is_enabled(key):
+        if gateway is None:
+            return {"action": "rewrite", "text": f"{_BOUNCE_PREFIX}\n\n{text}"}
+
+        try:
+            session_key = gateway._session_key_for_source(source)
+        except Exception:
+            session_key = ""
+
+        ok, model, runtime = _resolve_toolful_claude_backend()
+        if ok and session_key:
+            _apply_gateway_override(gateway, session_key, model=model, runtime=runtime)
+            return None
+
+        if session_key:
+            _clear_gateway_override(gateway, session_key)
+        return {"action": "rewrite", "text": f"{_BOUNCE_PREFIX}\n\n{text}"}
+
+    return None
+
+
+def pre_gateway_dispatch(event: Any = None, gateway: Any = None, session_store: Any = None, **_: Any) -> dict[str, Any] | None:
+    return build_pre_dispatch_decision(event, gateway)
+
+
+def _format_backend_status() -> tuple[str, bool, str]:
+    ok, model, runtime = _resolve_toolful_claude_backend()
+    if ok:
+        api_mode = str(runtime.get("api_mode") or "").strip() or "auto"
+        base_url = str(runtime.get("base_url") or "").strip() or "default"
+        backend = (
+            f"Hermes toolful Claude lane (provider=`anthropic`, model=`{model}`, "
+            f"api_mode=`{api_mode}`, base_url=`{base_url}`)"
+        )
+        return backend, True, model
+    backend = (
+        "Claude lane unavailable (missing Anthropic credentials).\n"
+        f"Configure in {display_hermes_home()}/.env (ANTHROPIC_API_KEY) or run `hermes auth add anthropic`."
+    )
+    return backend, False, (DEFAULT_CLAUDE_MODEL or "anthropic/claude-sonnet-4.6")
+
+
+class contextlib_suppress:
+    def __init__(self, *exceptions: type[BaseException]) -> None:
+        self.exceptions = exceptions or (Exception,)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return exc_type is not None and issubclass(exc_type, self.exceptions)
+
+
+def _status_message(key: str) -> str:
+    state = _load_state()
+    entry = ((state.get("chats") or {}).get(key) or {}) if isinstance(state, dict) else {}
+    mode = "on" if entry.get("enabled") else "off"
+    updated = entry.get("updated_at") or "unknown"
+    backend, toolful, _model = _format_backend_status()
+    tool_state = "**active**" if (entry.get("enabled") and toolful) else "**inactive**"
+    return (
+        f"Claude mode: **{mode}**\n"
+        f"chat: `{key}`\n"
+        f"updated: `{updated}`\n"
+        f"backend: {backend}\n"
+        f"tool/edit: {tool_state}"
+    )
+
+
+async def _run_smoke(session_key: str) -> str:
+    """Prove tool/edit capability without leaking outputs or source bodies."""
+    global _CTX
+    if _CTX is None:
+        return "Smoke failed: plugin context unavailable (tools not wired)."
+
+    backend, toolful, model = _format_backend_status()
+    if not toolful:
+        return f"Smoke: **unavailable**\nbackend: {backend}"
+
+    try:
+        from tools.approval import reset_current_session_key, set_current_session_key
+        token = set_current_session_key(session_key or "")
+    except Exception:
+        token = None
+        reset_current_session_key = None
+
+    tmp_dir = get_hermes_home() / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = tmp_dir / f"claude_mode_smoke_{os.urandom(3).hex()}.txt"
+    marker_cmd = "KAZE_CLAUDE_MODE_TOOL_OK"
+    marker_file = "KAZE_CLAUDE_MODE_FILE_OK"
+    try:
+        term_raw = _CTX.dispatch_tool(
+            "terminal",
+            {"command": f"echo {marker_cmd}", "timeout": 10},
+            task_id="claude_mode_smoke",
+        )
+        term = json.loads(term_raw) if isinstance(term_raw, str) else {}
+        term_out = str(term.get("stdout") or term.get("output") or term.get("result") or "")
+        if marker_cmd not in term_out:
+            return "Smoke failed: terminal tool did not return expected marker."
+
+        write_raw = _CTX.dispatch_tool(
+            "write_file",
+            {"path": str(tmp_path), "content": marker_file + "\n"},
+            task_id="claude_mode_smoke",
+        )
+        write_payload = json.loads(write_raw) if isinstance(write_raw, str) else {}
+        if write_payload.get("error"):
+            return "Smoke failed: write_file tool returned an error."
+
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except TypeError:
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+        return (
+            "Smoke: **OK**\n"
+            f"- model lane: `{model}`\n"
+            f"- tool call: `{marker_cmd}`\n"
+            f"- file write+cleanup: `{tmp_path.name}`"
+        )
+    finally:
+        if token is not None and reset_current_session_key is not None:
+            with contextlib_suppress(Exception):
+                reset_current_session_key(token)
+        with contextlib_suppress(Exception):
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+
+async def handle_internal_mode(raw_args: str) -> str:
+    packet = _decode_packet(raw_args)
+    key = str(packet.get("key") or "").strip()
+    args = str(packet.get("args") or "").strip().lower()
+    session_key = str(packet.get("session_key") or "").strip()
+    if not key:
+        return "Claude mode could not identify this chat."
+    if args in {"on", "enable", "enabled"}:
+        if not is_enabled(key):
+            backend, _toolful, _model = _format_backend_status()
+            return (
+                "Claude mode: **off**\n"
+                f"backend: {backend}\n\n"
+                "Cannot enable tool/edit Claude mode without Anthropic credentials."
+            )
+        backend, _toolful, _model = _format_backend_status()
+        return (
+            "Claude mode: **on**\n"
+            f"backend: {backend}\n"
+            "Plain (non-slash) messages in this chat now route through Claude + Hermes tools.\n"
+            "Use `/claude-mode off` to return to normal Hermes/Kaze."
+        )
+    if args in {"off", "disable", "disabled"}:
+        set_enabled(key, False, extra={"tool_edit_active": False})
+        return "Claude mode: **off**\nPlain messages now use normal Kaze/Hermes again."
+    if args in {"status", ""}:
+        return _status_message(key) + "\n\nUsage: `/claude-mode on|off|status|smoke`"
+    if args == "smoke":
+        return await _run_smoke(session_key)
+    return "Usage: `/claude-mode on|off|status|smoke`"
+
+
+async def handle_public_mode(raw_args: str) -> str:
+    return "Use `/claude-mode on|off|status|smoke` from Telegram so the plugin can identify the chat."
+
+
+def register(ctx: Any) -> None:
+    global _CTX
+    _CTX = ctx
+    ctx.register_hook("pre_gateway_dispatch", pre_gateway_dispatch)
+    ctx.register_command(
+        "claude-mode",
+        handle_public_mode,
+        "Toggle chat-level Claude Code fallback mode",
+        "on|off|status|smoke",
+    )
+    ctx.register_command(INTERNAL_MODE, handle_internal_mode, "Internal Kaze Claude mode control", "<packet>")

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -40,6 +40,8 @@ MAX_REPLY_CHARS = 3900
 _PENDING_TTL_SECS = 120
 _APPROVAL_ID_LEN = 5
 _APPROVAL_ID_ALPHABET = "".join([c for c in ascii_lowercase if c != "l"])
+_TRANSCRIPT_MAX_MESSAGES = 40
+_TRANSCRIPT_MAX_CHARS = 12000
 
 _CTX = None  # set by register()
 
@@ -396,11 +398,11 @@ def _extract_tool_rule(text: str) -> str:
 
 
 def _claude_code_max_turns() -> int:
-    raw = os.environ.get("KAZE_CLAUDE_MODE_MAX_TURNS", "10").strip()
+    raw = os.environ.get("KAZE_CLAUDE_MODE_MAX_TURNS", "30").strip()
     try:
         value = int(raw)
     except Exception:
-        value = 10
+        value = 30
     return max(1, min(60, value))
 
 
@@ -437,7 +439,73 @@ def _pop_pending_prompt(token: str) -> _PendingPrompt | None:
     return _PENDING.pop((token or "").strip(), None)
 
 
-def build_pre_dispatch_decision(event: Any, gateway: Any = None) -> dict[str, Any] | None:
+def _message_text_for_transcript(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if text:
+                    parts.append(str(text))
+            elif item is not None:
+                parts.append(str(item))
+        return " ".join(parts)
+    return "" if content is None else str(content)
+
+
+def _format_recent_transcript(session_store: Any, session_key: str) -> str:
+    if session_store is None or not session_key:
+        return ""
+    try:
+        session_store._ensure_loaded()
+        entry = getattr(session_store, "_entries", {}).get(session_key)
+        session_id = getattr(entry, "session_id", "") if entry else ""
+        if not session_id:
+            return ""
+        messages = session_store.load_transcript(session_id)
+    except Exception:
+        return ""
+    lines: list[str] = []
+    for message in messages[-_TRANSCRIPT_MAX_MESSAGES:]:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown")
+        if role == "tool":
+            continue
+        text = _message_text_for_transcript(message).strip()
+        if not text:
+            continue
+        text = re.sub(r"\s+", " ", text)
+        lines.append(f"{role}: {text[:1000]}")
+    excerpt = "\n".join(lines)
+    if len(excerpt) > _TRANSCRIPT_MAX_CHARS:
+        excerpt = excerpt[-_TRANSCRIPT_MAX_CHARS:]
+        first_newline = excerpt.find("\n")
+        if first_newline >= 0:
+            excerpt = excerpt[first_newline + 1 :]
+    return excerpt
+
+
+def _build_claude_mode_prompt(*, user_text: str, transcript: str) -> str:
+    if not transcript:
+        return user_text
+    return (
+        "You are the Claude Code CLI lane invoked from Hermes/Kaze for this Telegram chat.\n"
+        "Use the recent Hermes session transcript below as the available Telegram chat history. "
+        "Do not claim access to messages outside this transcript. Answer the user's latest message directly and concisely.\n\n"
+        "<recent_telegram_session_transcript>\n"
+        f"{transcript}\n"
+        "</recent_telegram_session_transcript>\n\n"
+        "<latest_user_message>\n"
+        f"{user_text}\n"
+        "</latest_user_message>"
+    )
+
+
+def build_pre_dispatch_decision(event: Any, gateway: Any = None, session_store: Any = None) -> dict[str, Any] | None:
     """Return a pre_gateway_dispatch rewrite/allow decision for an event."""
     text = getattr(event, "text", None) or ""
     source = getattr(event, "source", None)
@@ -492,14 +560,16 @@ def build_pre_dispatch_decision(event: Any, gateway: Any = None) -> dict[str, An
             session_key = gateway._session_key_for_source(source)
         except Exception:
             session_key = ""
-        token = _stash_pending_prompt(chat_key=chat_key, session_key=session_key, prompt=text)
+        transcript = _format_recent_transcript(session_store, session_key)
+        prompt = _build_claude_mode_prompt(user_text=text, transcript=transcript)
+        token = _stash_pending_prompt(chat_key=chat_key, session_key=session_key, prompt=prompt)
         return {"action": "rewrite", "text": f"/{INTERNAL_RUN} {token}"}
 
     return None
 
 
 def pre_gateway_dispatch(event: Any = None, gateway: Any = None, session_store: Any = None, **_: Any) -> dict[str, Any] | None:
-    return build_pre_dispatch_decision(event, gateway)
+    return build_pre_dispatch_decision(event, gateway, session_store=session_store)
 
 
 def _format_backend_status() -> tuple[str, bool]:

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -48,6 +48,14 @@ _APPROVAL_ID_LEN = 5
 _APPROVAL_ID_ALPHABET = "".join([c for c in ascii_lowercase if c != "l"])
 _TRANSCRIPT_MAX_MESSAGES = 40
 _TRANSCRIPT_MAX_CHARS = 12000
+_KAZE_VAULT_ROOT_DEFAULT = "/Users/rei/Documents/ki"
+_KAZE_CONTEXT_POINTERS: tuple[str, ...] = ("System/Boot.md", "System/Routines.md")
+_KAZE_SOURCE_SCRIPT_POINTERS: tuple[str, ...] = (
+    "Scripts/pulse_sync.py",
+    "Scripts/kaze_source_health.py",
+    "Scripts/kaze_live_intake_readiness_v1.py",
+)
+_KAZE_DAILY_DIRS: tuple[str, ...] = ("Daily", "Weekly")
 # Claude Code stream-json can emit very large one-line JSON events when tool
 # output is embedded. asyncio's default StreamReader limit is 64 KiB; exceeding
 # that raises LimitOverrunError("Separator is found, but chunk is longer than limit").
@@ -526,13 +534,86 @@ def _format_recent_transcript(session_store: Any, session_key: str) -> str:
     return excerpt
 
 
+def _kaze_vault_root() -> Path:
+    raw = os.environ.get("KAZE_VAULT_ROOT", "").strip()
+    return Path(raw or _KAZE_VAULT_ROOT_DEFAULT)
+
+
+def _build_kaze_context_pack() -> str:
+    """Build a bounded, metadata-only Kaze/Hermes context pack for Claude-mode.
+
+    Failure-tolerant: never raises; never reads or includes file bodies. All
+    filesystem checks are local stat-only and gracefully degrade if the vault
+    is missing.
+    """
+    vault_root = _kaze_vault_root()
+    try:
+        vault_exists = vault_root.is_dir()
+    except Exception:
+        vault_exists = False
+
+    available: list[str] = []
+    if vault_exists:
+        for pointer in (*_KAZE_CONTEXT_POINTERS, *_KAZE_SOURCE_SCRIPT_POINTERS):
+            try:
+                if (vault_root / pointer).is_file():
+                    available.append(pointer)
+            except Exception:
+                continue
+        for sub in _KAZE_DAILY_DIRS:
+            try:
+                if (vault_root / sub).is_dir():
+                    available.append(f"{sub}/")
+            except Exception:
+                continue
+
+    pointer_lines = (
+        "\n".join(f"  - {p}" for p in available)
+        if available
+        else "  - (no expected pointers found at vault_root)"
+    )
+
+    return (
+        "<kaze_context_pack>\n"
+        "role: Claude Code CLI lane invoked from Hermes/Kaze.\n"
+        "  - Hermes/Kaze is the runtime/session owner (Telegram routing, auth, approvals, tool allowlist).\n"
+        "  - You are not the top-level agent; you are a CLI lane Hermes invoked for this turn.\n"
+        f"vault_root: {vault_root}\n"
+        "available_pointers (descriptions only — do NOT dump full file bodies unless asked):\n"
+        f"{pointer_lines}\n"
+        "live_sources:\n"
+        "  - Kaze/Hermes can inspect the local vault, scripts, and CLIs when the configured tool allowlist permits it.\n"
+        "  - Source-health/live-intake script paths are listed in available_pointers when present; these are capability/status entry points, not raw source data.\n"
+        "  - Allowed tools for this run are passed via --allowedTools/--tools by Hermes; consult them before claiming no access.\n"
+        "  - Do NOT assert that a source is unavailable purely because you are a CLI lane: check this pack and the allowed tools first.\n"
+        "constraints:\n"
+        "  - Do not run a full live-source sync unless the user explicitly asks AND the allowed tools cover it.\n"
+        "  - Do not expose secrets or raw private source bodies in replies.\n"
+        "  - If tools/context are insufficient for the request, name the exact missing capability and route the user back to normal Kaze (e.g. `/kaze ...`).\n"
+        "</kaze_context_pack>"
+    )
+
+
 def _build_claude_mode_prompt(*, user_text: str, transcript: str) -> str:
+    context_pack = _build_kaze_context_pack()
     if not transcript:
-        return user_text
+        return (
+            "You are the Claude Code CLI lane invoked from Hermes/Kaze for this Telegram chat.\n"
+            "Use the Kaze context pack below to ground your role, available pointers, and constraints "
+            "before claiming any source is inaccessible. Answer the user's latest message directly and concisely.\n\n"
+            f"{context_pack}\n\n"
+            "<latest_user_message>\n"
+            f"{user_text}\n"
+            "</latest_user_message>"
+        )
     return (
         "You are the Claude Code CLI lane invoked from Hermes/Kaze for this Telegram chat.\n"
-        "Use the recent Hermes session transcript below as the available Telegram chat history. "
-        "Do not claim access to messages outside this transcript. Answer the user's latest message directly and concisely.\n\n"
+        "Use the Kaze context pack below to ground your role, available pointers, and constraints, "
+        "and the recent Hermes session transcript as the available Telegram chat history. "
+        "Do not claim access to messages outside this transcript, and do not claim no access to live sources "
+        "before considering the context pack and the allowed tools. "
+        "Answer the user's latest message directly and concisely.\n\n"
+        f"{context_pack}\n\n"
         "<recent_telegram_session_transcript>\n"
         f"{transcript}\n"
         "</recent_telegram_session_transcript>\n\n"

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -2,57 +2,57 @@
 
 Chat-level Telegram "Claude lane" for Hermes/Kaze.
 
-When enabled for a Telegram chat, plain (non-slash) messages in that chat are
-routed through Hermes' normal agent/tool loop, but with a per-session runtime
-override to an Anthropic/Claude model. This preserves Hermes as the runtime
-owner (sessions, tools, approvals, safety) while providing a Claude-powered
-execution lane that can use Hermes tools to edit files and run commands.
-
-Slash commands remain escape hatches and are never captured as Claude-mode plain
-messages.
+Spec-aligned behavior:
+- Hermes remains the Telegram/runtime/session owner (routing, auth, approvals).
+- When enabled for a Telegram chat, *plain (non-slash)* messages are routed to a
+  Claude Code CLI execution lane (headless `claude -p`), not a hidden model
+  provider switch.
+- Slash commands remain escape hatches and are never captured as Claude-mode
+  plain messages.
 """
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 import os
 import tempfile
+import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from shlex import quote as shell_quote
+from shutil import which
 from typing import Any
 
 from hermes_constants import display_hermes_home, get_hermes_home
 
 PLUGIN_NAME = "kaze-claude-mode"
-DEFAULT_CLAUDE_MODEL = os.environ.get("KAZE_CLAUDE_MODE_MODEL", "anthropic/claude-sonnet-4.6").strip()
 
 MODE_COMMANDS = {"claude-mode", "claude_mode"}
 INTERNAL_MODE = "kaze-claude-mode-dispatch"
-ESCAPE_COMMANDS = {
-    "approve",
-    "background",
-    "commands",
-    "debug",
-    "deny",
-    "help",
-    "new",
-    "queue",
-    "q",
-    "reset",
-    "restart",
-    "status",
-    "stop",
-}
+INTERNAL_RUN = "kaze-claude-mode-run"
+
 MAX_REPLY_CHARS = 3900
+_PENDING_TTL_SECS = 120
 
 _CTX = None  # set by register()
+
 _BOUNCE_PREFIX = (
-    "Claude mode is enabled for this chat, but the toolful Claude backend is not configured.\n"
-    "Routing this message to normal Hermes/Kaze instead.\n"
+    "Claude mode is enabled for this chat, but the Claude Code CLI backend is not available.\n"
     "Run `/claude-mode status` for setup info."
 )
+
+
+@dataclass(frozen=True)
+class _PendingPrompt:
+    chat_key: str
+    session_key: str
+    prompt: str
+    created_at: float
+
+
+_PENDING: dict[str, _PendingPrompt] = {}
 
 
 def _now_iso() -> str:
@@ -179,46 +179,79 @@ def _command_args(text: str) -> str:
     return parts[1] if len(parts) > 1 else ""
 
 
-def _resolve_toolful_claude_backend(*, model: str | None = None) -> tuple[bool, str, dict[str, Any]]:
-    """Return (ok, model, runtime) for the Claude toolful lane."""
-    from hermes_cli.runtime_provider import resolve_runtime_provider
-
-    target_model = (model or DEFAULT_CLAUDE_MODEL or "anthropic/claude-sonnet-4.6").strip()
-    runtime = resolve_runtime_provider(requested="anthropic", target_model=target_model)
-    ok = bool(runtime.get("api_key")) and str(runtime.get("provider") or "").strip().lower() == "anthropic"
-    return ok, target_model, runtime
+def _claude_code_cli_candidates() -> tuple[str, ...]:
+    return ("claude", "claude-code")
 
 
-def _apply_gateway_override(gateway: Any, session_key: str, *, model: str, runtime: dict[str, Any]) -> None:
-    """Apply a per-session Claude lane override to the gateway runner."""
-    if not gateway or not session_key:
-        return
-    overrides = getattr(gateway, "_session_model_overrides", None)
-    if not isinstance(overrides, dict):
-        return
-    overrides[session_key] = {
-        "model": model,
-        "provider": runtime.get("provider") or "anthropic",
-        "api_key": runtime.get("api_key") or "",
-        "base_url": runtime.get("base_url") or "",
-        "api_mode": runtime.get("api_mode") or "",
+def _resolve_claude_code_cli_backend() -> tuple[bool, dict[str, Any]]:
+    """Return (ok, info) for the Claude Code CLI backend.
+
+    This checks binary presence only; auth is exercised by smoke and live runs.
+    """
+    for cmd in _claude_code_cli_candidates():
+        path = which(cmd)
+        if path:
+            return True, {"backend": "claude-code-cli", "cmd": cmd, "path": path}
+    return False, {
+        "backend": "claude-code-cli",
+        "cmd": "",
+        "path": "",
+        "error": "Claude Code CLI not found on PATH",
     }
-    try:
-        gateway._evict_cached_agent(session_key)
-    except Exception:
-        pass
 
 
-def _clear_gateway_override(gateway: Any, session_key: str) -> None:
-    if not gateway or not session_key:
-        return
+def _claude_code_allowed_tools() -> str:
+    # Safe default: no shell/Bash tool, only read+edit.
+    raw = os.environ.get("KAZE_CLAUDE_MODE_ALLOWED_TOOLS", "Read,Edit").strip()
+    return raw or "Read,Edit"
+
+
+def _claude_code_permission_mode() -> str:
+    raw = os.environ.get("KAZE_CLAUDE_MODE_PERMISSION_MODE", "acceptEdits").strip()
+    allowed = {"acceptEdits", "auto", "default", "dontAsk", "plan"}
+    return raw if raw in allowed else "acceptEdits"
+
+
+def _claude_code_max_turns() -> int:
+    raw = os.environ.get("KAZE_CLAUDE_MODE_MAX_TURNS", "10").strip()
     try:
-        overrides = getattr(gateway, "_session_model_overrides", None)
-        if isinstance(overrides, dict):
-            overrides.pop(session_key, None)
-        gateway._evict_cached_agent(session_key)
+        value = int(raw)
     except Exception:
-        pass
+        value = 10
+    return max(1, min(60, value))
+
+
+def _claude_code_timeout_secs() -> int:
+    raw = os.environ.get("KAZE_CLAUDE_MODE_TIMEOUT", "240").strip()
+    try:
+        value = int(raw)
+    except Exception:
+        value = 240
+    return max(30, min(1800, value))
+
+
+def _gc_pending(now: float | None = None) -> None:
+    now = time.time() if now is None else now
+    expired = [k for k, v in _PENDING.items() if (now - v.created_at) > _PENDING_TTL_SECS]
+    for k in expired:
+        _PENDING.pop(k, None)
+
+
+def _stash_pending_prompt(*, chat_key: str, session_key: str, prompt: str) -> str:
+    _gc_pending()
+    token = os.urandom(9).hex()
+    _PENDING[token] = _PendingPrompt(
+        chat_key=chat_key,
+        session_key=session_key,
+        prompt=prompt,
+        created_at=time.time(),
+    )
+    return token
+
+
+def _pop_pending_prompt(token: str) -> _PendingPrompt | None:
+    _gc_pending()
+    return _PENDING.pop((token or "").strip(), None)
 
 
 def build_pre_dispatch_decision(event: Any, gateway: Any = None) -> dict[str, Any] | None:
@@ -231,51 +264,20 @@ def build_pre_dispatch_decision(event: Any, gateway: Any = None) -> dict[str, An
     if platform != "telegram":
         return None
 
-    key = state_key_from_source(source)
+    chat_key = state_key_from_source(source)
     cmd = _command_name(text)
+
+    # /claude-mode itself is rewritten to our internal dispatcher so we can
+    # identify the chat + (when possible) the gateway session key.
     if cmd in MODE_COMMANDS:
-        args = _command_args(text).strip().lower()
         session_key = ""
         if gateway is not None:
             try:
                 session_key = gateway._session_key_for_source(source)
             except Exception:
                 session_key = ""
-
-        if args in {"off", "disable", "disabled"} and session_key:
-            _clear_gateway_override(gateway, session_key)
-
-        if args in {"on", "enable", "enabled"}:
-            ok, model, _runtime = _resolve_toolful_claude_backend()
-            if ok:
-                set_enabled(
-                    key,
-                    True,
-                    source=source,
-                    extra={
-                        "backend": "hermes_toolful",
-                        "provider": "anthropic",
-                        "model": model,
-                        "tool_edit_active": True,
-                        "last_enable_error": "",
-                    },
-                )
-            else:
-                set_enabled(
-                    key,
-                    False,
-                    source=source,
-                    extra={
-                        "backend": "unavailable",
-                        "provider": "anthropic",
-                        "model": DEFAULT_CLAUDE_MODEL,
-                        "tool_edit_active": False,
-                        "last_enable_error": "missing Anthropic credentials",
-                    },
-                )
-
         packet = {
-            "key": key,
+            "key": chat_key,
             "args": _command_args(text),
             "platform": platform,
             "chat_id": str(getattr(source, "chat_id", "") or ""),
@@ -284,26 +286,31 @@ def build_pre_dispatch_decision(event: Any, gateway: Any = None) -> dict[str, An
         }
         return {"action": "rewrite", "text": f"/{INTERNAL_MODE} {_encode_packet(packet)}"}
 
+    # Slash commands are escape hatches.
     if cmd:
         return None
 
-    if is_enabled(key):
+    # Plain messages in an enabled chat route to Claude Code.
+    if is_enabled(chat_key):
+        ok, _info = _resolve_claude_code_cli_backend()
+        if not ok:
+            # Backend missing: fail closed with a clear message. Avoid embedding
+            # user text in the rewritten command to reduce logging leakage.
+            return {
+                "action": "rewrite",
+                "text": f"/{INTERNAL_MODE} {_encode_packet({'key': chat_key, 'args': 'unavailable'})}",
+            }
         if gateway is None:
-            return {"action": "rewrite", "text": f"{_BOUNCE_PREFIX}\n\n{text}"}
-
+            return {
+                "action": "rewrite",
+                "text": f"/{INTERNAL_MODE} {_encode_packet({'key': chat_key, 'args': 'unavailable'})}",
+            }
         try:
             session_key = gateway._session_key_for_source(source)
         except Exception:
             session_key = ""
-
-        ok, model, runtime = _resolve_toolful_claude_backend()
-        if ok and session_key:
-            _apply_gateway_override(gateway, session_key, model=model, runtime=runtime)
-            return None
-
-        if session_key:
-            _clear_gateway_override(gateway, session_key)
-        return {"action": "rewrite", "text": f"{_BOUNCE_PREFIX}\n\n{text}"}
+        token = _stash_pending_prompt(chat_key=chat_key, session_key=session_key, prompt=text)
+        return {"action": "rewrite", "text": f"/{INTERNAL_RUN} {token}"}
 
     return None
 
@@ -312,21 +319,18 @@ def pre_gateway_dispatch(event: Any = None, gateway: Any = None, session_store: 
     return build_pre_dispatch_decision(event, gateway)
 
 
-def _format_backend_status() -> tuple[str, bool, str]:
-    ok, model, runtime = _resolve_toolful_claude_backend()
+def _format_backend_status() -> tuple[str, bool]:
+    ok, info = _resolve_claude_code_cli_backend()
     if ok:
-        api_mode = str(runtime.get("api_mode") or "").strip() or "auto"
-        base_url = str(runtime.get("base_url") or "").strip() or "default"
-        backend = (
-            f"Hermes toolful Claude lane (provider=`anthropic`, model=`{model}`, "
-            f"api_mode=`{api_mode}`, base_url=`{base_url}`)"
-        )
-        return backend, True, model
-    backend = (
-        "Claude lane unavailable (missing Anthropic credentials).\n"
-        f"Configure in {display_hermes_home()}/.env (ANTHROPIC_API_KEY) or run `hermes auth add anthropic`."
+        return f"`claude-code-cli` (cmd=`{info.get('cmd')}`, path=`{info.get('path')}`)", True
+    return (
+        "Claude Code CLI unavailable.\n"
+        "Install: `npm install -g @anthropic-ai/claude-code`\n"
+        "Auth check: `claude auth status --text`\n"
+        "PATH hint: ensure your npm global bin is on PATH for the gateway process.\n"
+        f"(Hermes home: {display_hermes_home()})",
+        False,
     )
-    return backend, False, (DEFAULT_CLAUDE_MODEL or "anthropic/claude-sonnet-4.6")
 
 
 class contextlib_suppress:
@@ -345,7 +349,7 @@ def _status_message(key: str) -> str:
     entry = ((state.get("chats") or {}).get(key) or {}) if isinstance(state, dict) else {}
     mode = "on" if entry.get("enabled") else "off"
     updated = entry.get("updated_at") or "unknown"
-    backend, toolful, _model = _format_backend_status()
+    backend, toolful = _format_backend_status()
     tool_state = "**active**" if (entry.get("enabled") and toolful) else "**inactive**"
     return (
         f"Claude mode: **{mode}**\n"
@@ -356,15 +360,53 @@ def _status_message(key: str) -> str:
     )
 
 
-async def _run_smoke(session_key: str) -> str:
-    """Prove tool/edit capability without leaking outputs or source bodies."""
+def _truncate_reply(text: str, limit: int = MAX_REPLY_CHARS) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 20)].rstrip() + "\n\n…(truncated)…"
+
+
+def _extract_terminal_text(payload: dict[str, Any]) -> str:
+    stdout = str(payload.get("stdout") or payload.get("output") or payload.get("result") or "")
+    stderr = str(payload.get("stderr") or "")
+    combined = stdout.strip() or stderr.strip()
+    return combined
+
+
+def _dispatch_tool(tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
+    """Dispatch built-in Hermes tools from plugin command context.
+
+    Plugin discovery can happen before built-in tool modules are imported in
+    standalone command/plugin probes, so force idempotent built-in discovery
+    before using PluginContext.dispatch_tool.
+    """
+    from tools.registry import discover_builtin_tools
+
+    discover_builtin_tools()
+    return _CTX.dispatch_tool(tool_name, args, **kwargs)
+
+
+async def _run_claude_code_print(
+    *,
+    prompt: str,
+    session_key: str,
+    task_id: str,
+    workdir: str | None = None,
+) -> tuple[bool, str]:
+    """Run Claude Code CLI in headless print mode.
+
+    Critical: do NOT put the raw prompt on the shell command line (it would be
+    logged by approval/safety layers). Feed it via a temp file.
+    """
     global _CTX
     if _CTX is None:
-        return "Smoke failed: plugin context unavailable (tools not wired)."
+        return False, "Claude mode failed: plugin context unavailable (tools not wired)."
 
-    backend, toolful, model = _format_backend_status()
-    if not toolful:
-        return f"Smoke: **unavailable**\nbackend: {backend}"
+    ok, info = _resolve_claude_code_cli_backend()
+    if not ok:
+        backend, _toolful = _format_backend_status()
+        return False, backend
 
     try:
         from tools.approval import reset_current_session_key, set_current_session_key
@@ -373,50 +415,54 @@ async def _run_smoke(session_key: str) -> str:
         token = None
         reset_current_session_key = None
 
-    tmp_dir = get_hermes_home() / "tmp"
+    tmp_dir = get_hermes_home() / "tmp" / "kaze_claude_mode"
     tmp_dir.mkdir(parents=True, exist_ok=True)
-    tmp_path = tmp_dir / f"claude_mode_smoke_{os.urandom(3).hex()}.txt"
-    marker_cmd = "KAZE_CLAUDE_MODE_TOOL_OK"
-    marker_file = "KAZE_CLAUDE_MODE_FILE_OK"
+    prompt_path = tmp_dir / f"prompt_{os.urandom(4).hex()}.txt"
     try:
-        term_raw = _CTX.dispatch_tool(
-            "terminal",
-            {"command": f"echo {marker_cmd}", "timeout": 10},
-            task_id="claude_mode_smoke",
-        )
-        term = json.loads(term_raw) if isinstance(term_raw, str) else {}
-        term_out = str(term.get("stdout") or term.get("output") or term.get("result") or "")
-        if marker_cmd not in term_out:
-            return "Smoke failed: terminal tool did not return expected marker."
-
-        write_raw = _CTX.dispatch_tool(
+        write_raw = _dispatch_tool(
             "write_file",
-            {"path": str(tmp_path), "content": marker_file + "\n"},
-            task_id="claude_mode_smoke",
+            {"path": str(prompt_path), "content": prompt},
+            task_id=task_id,
         )
         write_payload = json.loads(write_raw) if isinstance(write_raw, str) else {}
         if write_payload.get("error"):
-            return "Smoke failed: write_file tool returned an error."
+            return False, "Claude mode failed: could not stage prompt for Claude Code."
 
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except TypeError:
-            if tmp_path.exists():
-                tmp_path.unlink()
+        allowed = _claude_code_allowed_tools()
+        max_turns = _claude_code_max_turns()
 
-        return (
-            "Smoke: **OK**\n"
-            f"- model lane: `{model}`\n"
-            f"- tool call: `{marker_cmd}`\n"
-            f"- file write+cleanup: `{tmp_path.name}`"
+        permission_mode = _claude_code_permission_mode()
+
+        # Use $(cat <file>) so the prompt is NOT present in the command string
+        # Hermes logs (inbound previews, approval queues, etc.).
+        cmd = (
+            f"{shell_quote(str(info.get('cmd') or 'claude'))} -p "
+            f"\"$(cat {shell_quote(str(prompt_path))})\" "
+            f"--allowedTools {shell_quote(allowed)} "
+            f"--permission-mode {shell_quote(permission_mode)} "
+            f"--max-turns {max_turns}"
         )
+        term_raw = _dispatch_tool(
+            "terminal",
+            {"command": cmd, "timeout": _claude_code_timeout_secs(), "workdir": workdir},
+            task_id=task_id,
+        )
+        term = json.loads(term_raw) if isinstance(term_raw, str) else {}
+        if term.get("status") == "approval_required":
+            return False, "Claude mode: waiting for approval to run Claude Code CLI."
+        out = _extract_terminal_text(term)
+        exit_code = term.get("exit_code")
+        if exit_code not in (None, 0, "0"):
+            err = out or "Claude Code returned a non-zero exit code."
+            return False, _truncate_reply(f"Claude Code error:\n{err}")
+        return True, _truncate_reply(out or "(Claude Code returned no output.)")
     finally:
         if token is not None and reset_current_session_key is not None:
             with contextlib_suppress(Exception):
                 reset_current_session_key(token)
         with contextlib_suppress(Exception):
-            if tmp_path.exists():
-                tmp_path.unlink()
+            if prompt_path.exists():
+                prompt_path.unlink()
 
 
 async def handle_internal_mode(raw_args: str) -> str:
@@ -426,29 +472,145 @@ async def handle_internal_mode(raw_args: str) -> str:
     session_key = str(packet.get("session_key") or "").strip()
     if not key:
         return "Claude mode could not identify this chat."
+
     if args in {"on", "enable", "enabled"}:
-        if not is_enabled(key):
-            backend, _toolful, _model = _format_backend_status()
+        ok, _info = _resolve_claude_code_cli_backend()
+        backend, toolful = _format_backend_status()
+        if not ok:
+            set_enabled(
+                key,
+                False,
+                extra={
+                    "backend": "claude-code-cli",
+                    "tool_edit_active": False,
+                    "last_enable_error": "Claude Code CLI not found",
+                },
+            )
             return (
                 "Claude mode: **off**\n"
                 f"backend: {backend}\n\n"
-                "Cannot enable tool/edit Claude mode without Anthropic credentials."
+                "Cannot enable Claude Code mode because the CLI backend is unavailable."
             )
-        backend, _toolful, _model = _format_backend_status()
+        set_enabled(
+            key,
+            True,
+            extra={
+                "backend": "claude-code-cli",
+                "tool_edit_active": True,
+                "last_enable_error": "",
+            },
+        )
         return (
             "Claude mode: **on**\n"
             f"backend: {backend}\n"
-            "Plain (non-slash) messages in this chat now route through Claude + Hermes tools.\n"
+            "Plain (non-slash) messages in this chat now route through Claude Code CLI (headless `claude -p`).\n"
             "Use `/claude-mode off` to return to normal Hermes/Kaze."
         )
+
     if args in {"off", "disable", "disabled"}:
         set_enabled(key, False, extra={"tool_edit_active": False})
         return "Claude mode: **off**\nPlain messages now use normal Kaze/Hermes again."
+
     if args in {"status", ""}:
         return _status_message(key) + "\n\nUsage: `/claude-mode on|off|status|smoke`"
+
+    if args == "unavailable":
+        backend, _toolful = _format_backend_status()
+        return f"{_BOUNCE_PREFIX}\n\nbackend: {backend}\n\nUse `/hermes <message>` to talk to Hermes."
+
     if args == "smoke":
-        return await _run_smoke(session_key)
+        backend, toolful = _format_backend_status()
+        ok, info = _resolve_claude_code_cli_backend()
+        if not ok or not toolful:
+            return f"Smoke: **unavailable**\nbackend: {backend}"
+
+        # Prove the real backend: run `claude -p` and verify it can edit a temp file.
+        tmp_dir = get_hermes_home() / "tmp" / "kaze_claude_mode_smoke"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        tmp_file = tmp_dir / f"smoke_{os.urandom(3).hex()}.txt"
+        marker = "KAZE_CLAUDE_MODE_FILE_OK"
+        _dispatch_tool("write_file", {"path": str(tmp_file), "content": "before\n"}, task_id="claude_mode_smoke")
+
+        prompt = (
+            "In the current directory, open the file named "
+            f"{tmp_file.name} and replace its entire content with exactly this single line:\n"
+            f"{marker}\n"
+            "Do not add any other text."
+        )
+        ok_run, out = await _run_claude_code_print(
+            prompt=prompt,
+            session_key=session_key,
+            task_id="claude_mode_smoke",
+            workdir=str(tmp_dir),
+        )
+        if not ok_run:
+            with contextlib_suppress(Exception):
+                tmp_file.unlink(missing_ok=True)
+            return f"Smoke: **FAILED**\n{out}"
+
+        # Verify edit happened (single-line marker) and clean up.
+        body = ""
+        try:
+            raw = _dispatch_tool(
+                "terminal",
+                {
+                    "command": (
+                        f"python -c {shell_quote('import pathlib;print(pathlib.Path(' + repr(str(tmp_file)) + ').read_text())')}"
+                    ),
+                    "timeout": 10,
+                },
+                task_id="claude_mode_smoke_verify",
+            )
+            payload = json.loads(raw) if isinstance(raw, str) else {}
+            body = _extract_terminal_text(payload)
+        except Exception:
+            body = ""
+        with contextlib_suppress(Exception):
+            tmp_file.unlink(missing_ok=True)
+        if marker not in body:
+            return "Smoke: **FAILED**\nClaude Code ran but did not apply the expected file edit in the temp dir."
+
+        return (
+            "Smoke: **OK**\n"
+            "- backend: `claude-code-cli`\n"
+            f"- allowedTools: `{_claude_code_allowed_tools()}`\n"
+            f"- permission-mode: `{_claude_code_permission_mode()}`\n"
+            f"- temp edit+cleanup: `{tmp_file.name}`"
+        )
+
     return "Usage: `/claude-mode on|off|status|smoke`"
+
+
+async def handle_internal_run(raw_args: str) -> str:
+    pending = _pop_pending_prompt(raw_args)
+    if pending is None:
+        return "Claude mode: expired request. Please resend the message."
+
+    ok, _info = _resolve_claude_code_cli_backend()
+    if not ok:
+        set_enabled(
+            pending.chat_key,
+            False,
+            extra={
+                "backend": "claude-code-cli",
+                "tool_edit_active": False,
+                "last_enable_error": "Claude Code CLI not found",
+            },
+        )
+        backend, _toolful = _format_backend_status()
+        return (
+            "Claude mode: **off** (auto-disabled)\n"
+            f"backend: {backend}\n\n"
+            "Claude Code CLI is unavailable. Your message was not routed.\n"
+            "Use `/hermes <message>` to talk to Hermes, or re-enable after setup."
+        )
+
+    ok_run, out = await _run_claude_code_print(
+        prompt=pending.prompt,
+        session_key=pending.session_key,
+        task_id="claude_mode_run",
+    )
+    return out
 
 
 async def handle_public_mode(raw_args: str) -> str:
@@ -462,7 +624,8 @@ def register(ctx: Any) -> None:
     ctx.register_command(
         "claude-mode",
         handle_public_mode,
-        "Toggle chat-level Claude Code fallback mode",
+        "Toggle chat-level Claude Code CLI mode",
         "on|off|status|smoke",
     )
     ctx.register_command(INTERNAL_MODE, handle_internal_mode, "Internal Kaze Claude mode control", "<packet>")
+    ctx.register_command(INTERNAL_RUN, handle_internal_run, "Internal Kaze Claude Code runner", "<token>")

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -13,6 +13,7 @@ Spec-aligned behavior:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -57,6 +58,9 @@ class _PendingPrompt:
     session_key: str
     prompt: str
     created_at: float
+    platform: str = ""
+    chat_id: str = ""
+    thread_id: str = ""
 
 
 _PENDING: dict[str, _PendingPrompt] = {}
@@ -398,21 +402,34 @@ def _extract_tool_rule(text: str) -> str:
 
 
 def _claude_code_max_turns() -> int:
-    raw = os.environ.get("KAZE_CLAUDE_MODE_MAX_TURNS", "30").strip()
+    raw = os.environ.get("KAZE_CLAUDE_MODE_MAX_TURNS", "90").strip()
     try:
         value = int(raw)
     except Exception:
-        value = 30
-    return max(1, min(60, value))
+        value = 90
+    return max(1, min(180, value))
 
 
 def _claude_code_timeout_secs() -> int:
-    raw = os.environ.get("KAZE_CLAUDE_MODE_TIMEOUT", "240").strip()
+    raw = os.environ.get("KAZE_CLAUDE_MODE_TIMEOUT", "900").strip()
     try:
         value = int(raw)
     except Exception:
-        value = 240
-    return max(30, min(1800, value))
+        value = 900
+    return max(30, min(3600, value))
+
+
+def _claude_code_max_budget_usd() -> str:
+    raw = os.environ.get("KAZE_CLAUDE_MODE_MAX_BUDGET_USD", "").strip()
+    if not raw:
+        return ""
+    try:
+        value = float(raw)
+    except Exception:
+        return ""
+    if value <= 0:
+        return ""
+    return str(value)
 
 
 def _gc_pending(now: float | None = None) -> None:
@@ -422,7 +439,15 @@ def _gc_pending(now: float | None = None) -> None:
         _PENDING.pop(k, None)
 
 
-def _stash_pending_prompt(*, chat_key: str, session_key: str, prompt: str) -> str:
+def _stash_pending_prompt(
+    *,
+    chat_key: str,
+    session_key: str,
+    prompt: str,
+    platform: str = "",
+    chat_id: str = "",
+    thread_id: str = "",
+) -> str:
     _gc_pending()
     token = os.urandom(9).hex()
     _PENDING[token] = _PendingPrompt(
@@ -430,6 +455,9 @@ def _stash_pending_prompt(*, chat_key: str, session_key: str, prompt: str) -> st
         session_key=session_key,
         prompt=prompt,
         created_at=time.time(),
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
     )
     return token
 
@@ -562,7 +590,14 @@ def build_pre_dispatch_decision(event: Any, gateway: Any = None, session_store: 
             session_key = ""
         transcript = _format_recent_transcript(session_store, session_key)
         prompt = _build_claude_mode_prompt(user_text=text, transcript=transcript)
-        token = _stash_pending_prompt(chat_key=chat_key, session_key=session_key, prompt=prompt)
+        token = _stash_pending_prompt(
+            chat_key=chat_key,
+            session_key=session_key,
+            prompt=prompt,
+            platform=platform,
+            chat_id=str(getattr(source, "chat_id", "") or ""),
+            thread_id=str(getattr(source, "thread_id", "") or ""),
+        )
         return {"action": "rewrite", "text": f"/{INTERNAL_RUN} {token}"}
 
     return None
@@ -617,6 +652,7 @@ def _status_message(key: str) -> str:
         f"backend: {backend}\n"
         f"allowedTools: `{_effective_allowed_tools(key)}`\n"
         f"permission-mode: `{_effective_permission_mode(key)}`\n"
+        f"max-turns: `{_claude_code_max_turns()}`\n"
         f"yolo: {yolo}\n"
         f"{pending_line}\n"
         f"tool/edit: {tool_state}"
@@ -637,6 +673,117 @@ def _extract_terminal_text(payload: dict[str, Any]) -> str:
     return combined
 
 
+class _TelegramProgress:
+    """Best-effort single-message Telegram progress updater for Claude Code."""
+
+    def __init__(self, *, chat_id: str, thread_id: str = "") -> None:
+        self.chat_id = str(chat_id or "")
+        self.thread_id = str(thread_id or "")
+        self._bot = None
+        self._message_id = ""
+        self._last_edit = 0.0
+        self._last_text = ""
+        self.active = False
+
+    async def start(self, text: str) -> bool:
+        if not self.chat_id:
+            return False
+        try:
+            from hermes_cli.config import load_config
+            from telegram import Bot
+
+            cfg = load_config()
+            platforms = cfg.get("platforms", {}) if isinstance(cfg, dict) else {}
+            telegram_cfg = platforms.get("telegram", {}) if isinstance(platforms, dict) else {}
+            token = str(telegram_cfg.get("token") or os.environ.get("TELEGRAM_BOT_TOKEN") or "").strip()
+            if not token:
+                return False
+            self._bot = Bot(token=token)
+            kwargs: dict[str, Any] = {"chat_id": int(self.chat_id), "text": text}
+            if self.thread_id:
+                kwargs["message_thread_id"] = int(self.thread_id)
+            msg = await self._bot.send_message(**kwargs)
+            self._message_id = str(getattr(msg, "message_id", "") or "")
+            self._last_text = text
+            self._last_edit = time.time()
+            self.active = bool(self._message_id)
+            return self.active
+        except Exception:
+            self.active = False
+            return False
+
+    async def edit(self, text: str, *, force: bool = False) -> None:
+        if not self.active or self._bot is None or not self._message_id:
+            return
+        text = _truncate_reply(text, 3900)
+        if not force and text == self._last_text:
+            return
+        now = time.time()
+        if not force and (now - self._last_edit) < 1.0:
+            return
+        try:
+            await self._bot.edit_message_text(
+                chat_id=int(self.chat_id),
+                message_id=int(self._message_id),
+                text=text,
+            )
+            self._last_text = text
+            self._last_edit = now
+        except Exception:
+            # Progress is auxiliary; never fail the Claude run because Telegram
+            # rejected an edit or rate-limited us.
+            return
+
+    async def typing(self) -> None:
+        if not self.active or self._bot is None:
+            return
+        try:
+            await self._bot.send_chat_action(chat_id=int(self.chat_id), action="typing")
+        except Exception:
+            return
+
+
+def _stream_status_text(*, status: str, assistant_text: str = "", detail: str = "") -> str:
+    parts = ["Claude mode: **running**", f"status: {status}"]
+    if detail:
+        parts.append(detail)
+    if assistant_text.strip():
+        parts.append("\n" + assistant_text.strip())
+    return _truncate_reply("\n".join(parts), 3900)
+
+
+def _summarize_stream_event(obj: dict[str, Any]) -> tuple[str, str]:
+    event = obj.get("event") if isinstance(obj.get("event"), dict) else {}
+    etype = str(event.get("type") or "")
+    if etype == "content_block_start":
+        block = event.get("content_block") if isinstance(event.get("content_block"), dict) else {}
+        if block.get("type") == "tool_use":
+            return "tool", str(block.get("name") or "tool")
+    if etype == "content_block_delta":
+        delta = event.get("delta") if isinstance(event.get("delta"), dict) else {}
+        if delta.get("type") == "text_delta":
+            return "text", str(delta.get("text") or "")
+    if etype == "message_stop":
+        return "status", "finalizing"
+    subtype = str(obj.get("subtype") or "")
+    if obj.get("type") == "system" and subtype == "status":
+        return "status", str(obj.get("status") or "working")
+    return "", ""
+
+
+def _result_text_from_stream_obj(obj: dict[str, Any]) -> str:
+    result = obj.get("result")
+    if isinstance(result, str) and result.strip():
+        return result.strip()
+    message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
+    content = message.get("content") if isinstance(message.get("content"), list) else []
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            parts.append(str(item.get("text") or ""))
+    return "".join(parts).strip()
+
+
 def _dispatch_tool(tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
     """Dispatch built-in Hermes tools from plugin command context.
 
@@ -650,6 +797,162 @@ def _dispatch_tool(tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
     return _CTX.dispatch_tool(tool_name, args, **kwargs)
 
 
+async def _run_claude_code_streaming(
+    *,
+    prompt: str,
+    chat_key: str,
+    session_key: str,
+    task_id: str,
+    chat_id: str,
+    thread_id: str = "",
+    workdir: str | None = None,
+) -> tuple[bool, str, bool]:
+    """Run Claude Code with stream-json and edit one Telegram progress message.
+
+    Returns (ok, text, delivered). When delivered=True, the final result/error was
+    already sent via the progress message and command dispatch should return None.
+    """
+    ok, info = _resolve_claude_code_cli_backend()
+    if not ok:
+        backend, _toolful = _format_backend_status()
+        return False, backend, False
+
+    progress = _TelegramProgress(chat_id=chat_id, thread_id=thread_id)
+    started = await progress.start(
+        _stream_status_text(status="starting Claude Code…", detail=f"max-turns: `{_claude_code_max_turns()}`")
+    )
+    if not started:
+        return False, "", False
+
+    allowed = _effective_allowed_tools(chat_key) if chat_key else _claude_code_allowed_tools()
+    tools_list = _tools_from_allowed_tools(allowed)
+    permission_mode = _effective_permission_mode(chat_key) if chat_key else _claude_code_permission_mode()
+    max_turns = _claude_code_max_turns()
+    budget = _claude_code_max_budget_usd()
+    cmd = [
+        str(info.get("cmd") or "claude"),
+        "-p",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "--include-hook-events",
+        "--allowedTools",
+        allowed,
+        "--tools",
+        tools_list,
+        "--permission-mode",
+        permission_mode,
+        "--max-turns",
+        str(max_turns),
+    ]
+    if budget:
+        cmd.extend(["--max-budget-usd", budget])
+
+    assistant_text = ""
+    final_text = ""
+    stderr_text = ""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=workdir or None,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write((prompt or "").encode("utf-8"))
+        await proc.stdin.drain()
+        proc.stdin.close()
+
+        async def _read_stderr() -> bytes:
+            assert proc.stderr is not None
+            return await proc.stderr.read()
+
+        stderr_task = asyncio.create_task(_read_stderr())
+
+        async def _read_stdout() -> None:
+            nonlocal assistant_text, final_text
+            assert proc.stdout is not None
+            while True:
+                raw_line = await proc.stdout.readline()
+                if not raw_line:
+                    break
+                try:
+                    obj = json.loads(raw_line.decode("utf-8", errors="replace"))
+                except Exception:
+                    continue
+                kind, value = _summarize_stream_event(obj)
+                if kind == "text" and value:
+                    assistant_text += value
+                    await progress.edit(_stream_status_text(status="answering…", assistant_text=assistant_text))
+                elif kind == "tool" and value:
+                    await progress.edit(
+                        _stream_status_text(status="working…", assistant_text=assistant_text, detail=f"tool: `{value}`"),
+                        force=False,
+                    )
+                elif kind == "status" and value:
+                    await progress.typing()
+                    await progress.edit(_stream_status_text(status=value, assistant_text=assistant_text), force=False)
+                if obj.get("type") == "result":
+                    final_text = _result_text_from_stream_obj(obj) or assistant_text
+
+        await asyncio.wait_for(_read_stdout(), timeout=_claude_code_timeout_secs())
+        exit_code = await asyncio.wait_for(proc.wait(), timeout=5)
+        stderr_bytes = await stderr_task
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace").strip()
+    except asyncio.TimeoutError:
+        with contextlib_suppress(Exception):
+            proc.kill()  # type: ignore[name-defined]
+        msg = f"Claude Code error:\nTimed out after `{_claude_code_timeout_secs()}` seconds."
+        await progress.edit(msg, force=True)
+        return False, msg, True
+    except Exception as e:
+        msg = f"Claude Code error:\n{e}"
+        await progress.edit(_truncate_reply(msg), force=True)
+        return False, msg, True
+
+    out = (final_text or assistant_text or stderr_text or "").strip()
+    if exit_code not in (0, None):
+        err = out or "Claude Code returned a non-zero exit code."
+        if chat_key and _looks_like_permission_block(err):
+            _clear_pending_approval(chat_key)
+            approval_id = _new_approval_id()
+            prompt_sha256 = hashlib.sha256((prompt or "").encode("utf-8")).hexdigest()
+            prompt_disk_path = _approval_prompt_path(approval_id)
+            _write_private_text(prompt_disk_path, prompt or "")
+            tool_rule = _extract_tool_rule(err)
+            _update_chat(
+                chat_key,
+                extra={
+                    "pending_approval": {
+                        "id": approval_id,
+                        "tool_rule": tool_rule,
+                        "created_at": _now_iso(),
+                        "prompt_path": str(prompt_disk_path),
+                        "prompt_sha256": prompt_sha256,
+                        "session_key": session_key or "",
+                    }
+                },
+            )
+            safe_tool = tool_rule or "unknown"
+            msg = _truncate_reply(
+                "Claude mode: **approval pending**\n"
+                f"- id: `{approval_id}`\n"
+                f"- tool: `{safe_tool}`\n"
+                "Reply `/claude-mode approve` to allow and retry, or `/claude-mode deny` to cancel."
+            )
+            await progress.edit(msg, force=True)
+            return False, msg, True
+        msg = _truncate_reply(f"Claude Code error:\n{err}")
+        await progress.edit(msg, force=True)
+        return False, msg, True
+
+    final = _truncate_reply(out or "(Claude Code returned no output.)")
+    await progress.edit(final, force=True)
+    return True, final, True
+
+
 async def _run_claude_code_print(
     *,
     prompt: str,
@@ -657,6 +960,9 @@ async def _run_claude_code_print(
     session_key: str,
     task_id: str,
     workdir: str | None = None,
+    platform: str = "",
+    chat_id: str = "",
+    thread_id: str = "",
 ) -> tuple[bool, str]:
     """Run Claude Code CLI in headless print mode.
 
@@ -671,6 +977,19 @@ async def _run_claude_code_print(
     if not ok:
         backend, _toolful = _format_backend_status()
         return False, backend
+
+    if platform == "telegram" and chat_id and not workdir:
+        ok_stream, out_stream, delivered = await _run_claude_code_streaming(
+            prompt=prompt,
+            chat_key=chat_key,
+            session_key=session_key,
+            task_id=task_id,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            workdir=workdir,
+        )
+        if delivered:
+            return ok_stream, ""
 
     try:
         from tools.approval import reset_current_session_key, set_current_session_key
@@ -977,8 +1296,11 @@ async def handle_internal_run(raw_args: str) -> str:
         chat_key=pending.chat_key,
         session_key=pending.session_key,
         task_id="claude_mode_run",
+        platform=pending.platform,
+        chat_id=pending.chat_id,
+        thread_id=pending.thread_id,
     )
-    return out
+    return out or None
 
 
 async def handle_public_mode(raw_args: str) -> str:

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -48,6 +48,10 @@ _APPROVAL_ID_LEN = 5
 _APPROVAL_ID_ALPHABET = "".join([c for c in ascii_lowercase if c != "l"])
 _TRANSCRIPT_MAX_MESSAGES = 40
 _TRANSCRIPT_MAX_CHARS = 12000
+# Claude Code stream-json can emit very large one-line JSON events when tool
+# output is embedded. asyncio's default StreamReader limit is 64 KiB; exceeding
+# that raises LimitOverrunError("Separator is found, but chunk is longer than limit").
+_CLAUDE_STREAM_READER_LIMIT = 4 * 1024 * 1024
 
 _CTX = None  # set by register()
 
@@ -864,6 +868,7 @@ async def _run_claude_code_streaming(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=workdir or None,
+            limit=_CLAUDE_STREAM_READER_LIMIT,
         )
         assert proc.stdin is not None
         proc.stdin.write((prompt or "").encode("utf-8"))

--- a/plugins/kaze-claude-mode/__init__.py
+++ b/plugins/kaze-claude-mode/__init__.py
@@ -14,8 +14,10 @@ Spec-aligned behavior:
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
+import re
 import tempfile
 import time
 from dataclasses import dataclass
@@ -23,6 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from shlex import quote as shell_quote
 from shutil import which
+from string import ascii_lowercase
 from typing import Any
 
 from hermes_constants import display_hermes_home, get_hermes_home
@@ -35,6 +38,8 @@ INTERNAL_RUN = "kaze-claude-mode-run"
 
 MAX_REPLY_CHARS = 3900
 _PENDING_TTL_SECS = 120
+_APPROVAL_ID_LEN = 5
+_APPROVAL_ID_ALPHABET = "".join([c for c in ascii_lowercase if c != "l"])
 
 _CTX = None  # set by register()
 
@@ -201,15 +206,193 @@ def _resolve_claude_code_cli_backend() -> tuple[bool, dict[str, Any]]:
 
 
 def _claude_code_allowed_tools() -> str:
-    # Safe default: no shell/Bash tool, only read+edit.
-    raw = os.environ.get("KAZE_CLAUDE_MODE_ALLOWED_TOOLS", "Read,Edit").strip()
-    return raw or "Read,Edit"
+    # Safe baseline: file ops + search only (no Bash by default).
+    raw = os.environ.get("KAZE_CLAUDE_MODE_ALLOWED_TOOLS", "").strip()
+    return raw or "Read,Write,Edit,Grep,Glob"
 
 
 def _claude_code_permission_mode() -> str:
     raw = os.environ.get("KAZE_CLAUDE_MODE_PERMISSION_MODE", "acceptEdits").strip()
-    allowed = {"acceptEdits", "auto", "default", "dontAsk", "plan"}
+    allowed = {"acceptEdits", "auto", "default", "dontAsk", "plan", "bypassPermissions"}
     return raw if raw in allowed else "acceptEdits"
+
+
+def _update_chat(
+    key: str,
+    *,
+    source: Any = None,
+    path: Path | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update a chat entry in the profile-safe state file without toggling enablement."""
+    path = _state_path() if path is None else path
+    state = _load_state(path)
+    chats = state.setdefault("chats", {})
+    if not isinstance(chats, dict):
+        chats = {}
+        state["chats"] = chats
+    entry = chats.setdefault(key, {})
+    if not isinstance(entry, dict):
+        entry = {}
+        chats[key] = entry
+    entry["updated_at"] = _now_iso()
+    if source is not None:
+        entry["platform"] = _platform_value(source)
+        entry["chat_id"] = str(getattr(source, "chat_id", "") or "")
+        thread_id = getattr(source, "thread_id", None)
+        if thread_id:
+            entry["thread_id"] = str(thread_id)
+    if extra:
+        for k, v in extra.items():
+            if v is None:
+                entry.pop(k, None)
+            else:
+                entry[k] = v
+    state["updated_at"] = _now_iso()
+    _atomic_write_json(path, state)
+    return entry
+
+
+def _chat_entry(key: str) -> dict[str, Any]:
+    state = _load_state()
+    entry = ((state.get("chats") or {}).get(key) or {}) if isinstance(state, dict) else {}
+    return entry if isinstance(entry, dict) else {}
+
+
+def _chat_allowed_tools_extra(key: str) -> list[str]:
+    raw = _chat_entry(key).get("allowed_tools_extra") or []
+    if not isinstance(raw, list):
+        return []
+    items: list[str] = []
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            items.append(item.strip())
+    return items
+
+
+def _effective_allowed_tools(key: str) -> str:
+    base = _claude_code_allowed_tools()
+    extras = _chat_allowed_tools_extra(key)
+    parts = [p.strip() for p in base.split(",") if p.strip()]
+    parts.extend(extras)
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for part in parts:
+        if part in seen:
+            continue
+        seen.add(part)
+        deduped.append(part)
+    return ",".join(deduped)
+
+
+def _is_yolo_enabled(key: str) -> bool:
+    return bool(_chat_entry(key).get("yolo"))
+
+
+def _effective_permission_mode(key: str) -> str:
+    if _is_yolo_enabled(key):
+        return "bypassPermissions"
+    return _claude_code_permission_mode()
+
+
+def _tools_from_allowed_tools(allowed_tools: str) -> str:
+    """Derive a built-in tool allowlist for `--tools` from allowedTools rules.
+
+    Claude Code's `--allowedTools` controls auto-approval, not tool availability.
+    `--tools` limits which built-in tools are present at all.
+    """
+    builtins: list[str] = []
+    for raw in (allowed_tools or "").split(","):
+        token = raw.strip()
+        if not token or token.startswith("mcp__"):
+            continue
+        name = token.split("(", 1)[0].strip()
+        if not name:
+            continue
+        builtins.append(name)
+    if not builtins:
+        builtins = ["Read", "Write", "Edit", "Grep", "Glob"]
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in builtins:
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return ",".join(out)
+
+
+def _pending_approval(key: str) -> dict[str, Any] | None:
+    raw = _chat_entry(key).get("pending_approval")
+    return raw if isinstance(raw, dict) and raw else None
+
+
+def _has_pending_approval(key: str) -> bool:
+    return bool(_pending_approval(key))
+
+
+def _new_approval_id() -> str:
+    # Five lowercase letters drawn from a-z without l (avoids 1/I ambiguity on phones).
+    return "".join(_APPROVAL_ID_ALPHABET[b % len(_APPROVAL_ID_ALPHABET)] for b in os.urandom(_APPROVAL_ID_LEN))
+
+
+def _approval_prompt_path(approval_id: str) -> Path:
+    base = get_hermes_home() / "state" / "kaze_claude_mode_prompts"
+    return base / f"{approval_id}.txt"
+
+
+def _write_private_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def _read_private_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _clear_pending_approval(key: str) -> None:
+    pending = _pending_approval(key) or {}
+    prompt_path = pending.get("prompt_path")
+    _update_chat(key, extra={"pending_approval": None})
+    if isinstance(prompt_path, str) and prompt_path:
+        with contextlib_suppress(Exception):
+            Path(prompt_path).unlink(missing_ok=True)
+
+
+def _looks_like_permission_block(text: str) -> bool:
+    lowered = (text or "").lower()
+    if "permission blocked" in lowered:
+        return True
+    if "permission" in lowered and ("approve" in lowered or "prompt" in lowered or "denied" in lowered):
+        return True
+    return False
+
+
+_TOOL_RULE_RE = re.compile(r"(mcp__[-a-zA-Z0-9_]+__[-a-zA-Z0-9_*]+|[A-Za-z][A-Za-z0-9_]*(?:\([^\)]{1,200}\))?)")
+
+
+def _extract_tool_rule(text: str) -> str:
+    """Best-effort extraction of a tool rule from Claude Code errors."""
+    for match in _TOOL_RULE_RE.finditer(text or ""):
+        candidate = (match.group(1) or "").strip()
+        if not candidate:
+            continue
+        # Skip obvious non-tool words.
+        if candidate.lower() in {"permission", "permissions", "error", "blocked", "headless"}:
+            continue
+        # Prefer explicit specifiers (Tool(...)) or mcp__ patterns.
+        if candidate.startswith("mcp__") or "(" in candidate:
+            return candidate
+    # Fallback to a bare tool name if present.
+    for match in _TOOL_RULE_RE.finditer(text or ""):
+        candidate = (match.group(1) or "").strip()
+        if candidate and "(" not in candidate and candidate.startswith(("Read", "Write", "Edit", "Bash", "WebFetch", "WebSearch", "Grep", "Glob")):
+            return candidate
+    return ""
 
 
 def _claude_code_max_turns() -> int:
@@ -345,17 +528,27 @@ class contextlib_suppress:
 
 
 def _status_message(key: str) -> str:
-    state = _load_state()
-    entry = ((state.get("chats") or {}).get(key) or {}) if isinstance(state, dict) else {}
+    entry = _chat_entry(key)
     mode = "on" if entry.get("enabled") else "off"
     updated = entry.get("updated_at") or "unknown"
     backend, toolful = _format_backend_status()
     tool_state = "**active**" if (entry.get("enabled") and toolful) else "**inactive**"
+    yolo = "**on**" if _is_yolo_enabled(key) else "**off**"
+    pending = _pending_approval(key)
+    pending_line = "pending: **none**"
+    if pending:
+        pending_id = pending.get("id") or "unknown"
+        pending_tool = pending.get("tool_rule") or "unknown"
+        pending_line = f"pending: **yes** (`{pending_id}` / `{pending_tool}`)"
     return (
         f"Claude mode: **{mode}**\n"
         f"chat: `{key}`\n"
         f"updated: `{updated}`\n"
         f"backend: {backend}\n"
+        f"allowedTools: `{_effective_allowed_tools(key)}`\n"
+        f"permission-mode: `{_effective_permission_mode(key)}`\n"
+        f"yolo: {yolo}\n"
+        f"{pending_line}\n"
         f"tool/edit: {tool_state}"
     )
 
@@ -390,6 +583,7 @@ def _dispatch_tool(tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
 async def _run_claude_code_print(
     *,
     prompt: str,
+    chat_key: str,
     session_key: str,
     task_id: str,
     workdir: str | None = None,
@@ -428,10 +622,11 @@ async def _run_claude_code_print(
         if write_payload.get("error"):
             return False, "Claude mode failed: could not stage prompt for Claude Code."
 
-        allowed = _claude_code_allowed_tools()
+        allowed = _effective_allowed_tools(chat_key) if chat_key else _claude_code_allowed_tools()
+        tools_list = _tools_from_allowed_tools(allowed)
         max_turns = _claude_code_max_turns()
 
-        permission_mode = _claude_code_permission_mode()
+        permission_mode = _effective_permission_mode(chat_key) if chat_key else _claude_code_permission_mode()
 
         # Use $(cat <file>) so the prompt is NOT present in the command string
         # Hermes logs (inbound previews, approval queues, etc.).
@@ -439,6 +634,7 @@ async def _run_claude_code_print(
             f"{shell_quote(str(info.get('cmd') or 'claude'))} -p "
             f"\"$(cat {shell_quote(str(prompt_path))})\" "
             f"--allowedTools {shell_quote(allowed)} "
+            f"--tools {shell_quote(tools_list)} "
             f"--permission-mode {shell_quote(permission_mode)} "
             f"--max-turns {max_turns}"
         )
@@ -454,6 +650,37 @@ async def _run_claude_code_print(
         exit_code = term.get("exit_code")
         if exit_code not in (None, 0, "0"):
             err = out or "Claude Code returned a non-zero exit code."
+            if chat_key and _looks_like_permission_block(err):
+                # Replace any previous pending approval for this chat.
+                _clear_pending_approval(chat_key)
+                approval_id = _new_approval_id()
+                prompt_sha256 = hashlib.sha256((prompt or "").encode("utf-8")).hexdigest()
+                prompt_disk_path = _approval_prompt_path(approval_id)
+                _write_private_text(prompt_disk_path, prompt or "")
+                tool_rule = _extract_tool_rule(err)
+                _update_chat(
+                    chat_key,
+                    extra={
+                        "pending_approval": {
+                            "id": approval_id,
+                            "tool_rule": tool_rule,
+                            "created_at": _now_iso(),
+                            "prompt_path": str(prompt_disk_path),
+                            "prompt_sha256": prompt_sha256,
+                            "session_key": session_key or "",
+                        }
+                    },
+                )
+                safe_tool = tool_rule or "unknown"
+                return (
+                    False,
+                    _truncate_reply(
+                        "Claude mode: **approval pending**\n"
+                        f"- id: `{approval_id}`\n"
+                        f"- tool: `{safe_tool}`\n"
+                        "Reply `/claude-mode approve` to allow and retry, or `/claude-mode deny` to cancel."
+                    ),
+                )
             return False, _truncate_reply(f"Claude Code error:\n{err}")
         return True, _truncate_reply(out or "(Claude Code returned no output.)")
     finally:
@@ -468,10 +695,15 @@ async def _run_claude_code_print(
 async def handle_internal_mode(raw_args: str) -> str:
     packet = _decode_packet(raw_args)
     key = str(packet.get("key") or "").strip()
-    args = str(packet.get("args") or "").strip().lower()
+    raw = str(packet.get("args") or "").strip()
+    args = raw.lower()
     session_key = str(packet.get("session_key") or "").strip()
     if not key:
         return "Claude mode could not identify this chat."
+
+    head, *_rest = raw.split(maxsplit=1) if raw else [""]
+    head_l = head.lower()
+    tail = _rest[0] if _rest else ""
 
     if args in {"on", "enable", "enabled"}:
         ok, _info = _resolve_claude_code_cli_backend()
@@ -497,6 +729,7 @@ async def handle_internal_mode(raw_args: str) -> str:
             extra={
                 "backend": "claude-code-cli",
                 "tool_edit_active": True,
+                "yolo": bool(_chat_entry(key).get("yolo")),
                 "last_enable_error": "",
             },
         )
@@ -512,7 +745,7 @@ async def handle_internal_mode(raw_args: str) -> str:
         return "Claude mode: **off**\nPlain messages now use normal Kaze/Hermes again."
 
     if args in {"status", ""}:
-        return _status_message(key) + "\n\nUsage: `/claude-mode on|off|status|smoke`"
+        return _status_message(key) + "\n\nUsage: `/claude-mode on|off|status|smoke|approve|deny|yolo`"
 
     if args == "unavailable":
         backend, _toolful = _format_backend_status()
@@ -539,6 +772,7 @@ async def handle_internal_mode(raw_args: str) -> str:
         )
         ok_run, out = await _run_claude_code_print(
             prompt=prompt,
+            chat_key=key,
             session_key=session_key,
             task_id="claude_mode_smoke",
             workdir=str(tmp_dir),
@@ -573,12 +807,75 @@ async def handle_internal_mode(raw_args: str) -> str:
         return (
             "Smoke: **OK**\n"
             "- backend: `claude-code-cli`\n"
-            f"- allowedTools: `{_claude_code_allowed_tools()}`\n"
-            f"- permission-mode: `{_claude_code_permission_mode()}`\n"
+            f"- allowedTools: `{_effective_allowed_tools(key)}`\n"
+            f"- tools: `{_tools_from_allowed_tools(_effective_allowed_tools(key))}`\n"
+            f"- permission-mode: `{_effective_permission_mode(key)}`\n"
+            f"- yolo: `{'on' if _is_yolo_enabled(key) else 'off'}`\n"
             f"- temp edit+cleanup: `{tmp_file.name}`"
         )
 
-    return "Usage: `/claude-mode on|off|status|smoke`"
+    if head_l == "yolo":
+        sub = tail.strip().lower()
+        if sub in {"", "status"}:
+            return _status_message(key) + "\n\nUsage: `/claude-mode yolo on|off|status`"
+        if sub in {"on", "enable", "enabled", "true", "1"}:
+            _update_chat(key, extra={"yolo": True})
+            return _status_message(key)
+        if sub in {"off", "disable", "disabled", "false", "0"}:
+            _update_chat(key, extra={"yolo": False})
+            return _status_message(key)
+        return "Usage: `/claude-mode yolo on|off|status`"
+
+    if head_l in {"approve", "deny"}:
+        pending = _pending_approval(key)
+        if not pending:
+            return "Claude mode: no pending approval for this chat."
+
+        pending_id = str(pending.get("id") or "").strip()
+        token_or_rule = tail.strip()
+        if token_or_rule and re.fullmatch(rf"[{_APPROVAL_ID_ALPHABET}]{{{_APPROVAL_ID_LEN}}}", token_or_rule):
+            if token_or_rule != pending_id:
+                return f"Claude mode: unknown approval id `{token_or_rule}` for this chat."
+            token_or_rule = ""
+
+        if head_l == "deny":
+            _clear_pending_approval(key)
+            return "Claude mode: denied and cleared the pending approval."
+
+        tool_rule = token_or_rule or str(pending.get("tool_rule") or "").strip()
+        if not tool_rule:
+            return (
+                "Claude mode: pending approval has no parsed tool rule.\n"
+                "Retry with an explicit rule, e.g. `/claude-mode approve Bash(git status *)`."
+            )
+
+        # Persist chat-scoped allow rule (escape hatch; doesn't flip yolo).
+        extras = _chat_allowed_tools_extra(key)
+        if tool_rule not in extras:
+            extras.append(tool_rule)
+            _update_chat(key, extra={"allowed_tools_extra": extras})
+
+        # Re-run the original prompt and clear pending on success (or refresh on re-block).
+        prompt_path = pending.get("prompt_path")
+        prompt_text = ""
+        if isinstance(prompt_path, str) and prompt_path:
+            with contextlib_suppress(Exception):
+                prompt_text = _read_private_text(Path(prompt_path))
+        if not prompt_text:
+            _clear_pending_approval(key)
+            return "Claude mode: pending approval expired (missing prompt). Please resend your message."
+
+        ok_run, out = await _run_claude_code_print(
+            prompt=prompt_text,
+            chat_key=key,
+            session_key=str(pending.get("session_key") or session_key or ""),
+            task_id="claude_mode_approve",
+        )
+        if ok_run:
+            _clear_pending_approval(key)
+        return out
+
+    return "Usage: `/claude-mode on|off|status|smoke|approve|deny|yolo`"
 
 
 async def handle_internal_run(raw_args: str) -> str:
@@ -607,6 +904,7 @@ async def handle_internal_run(raw_args: str) -> str:
 
     ok_run, out = await _run_claude_code_print(
         prompt=pending.prompt,
+        chat_key=pending.chat_key,
         session_key=pending.session_key,
         task_id="claude_mode_run",
     )
@@ -614,7 +912,7 @@ async def handle_internal_run(raw_args: str) -> str:
 
 
 async def handle_public_mode(raw_args: str) -> str:
-    return "Use `/claude-mode on|off|status|smoke` from Telegram so the plugin can identify the chat."
+    return "Use `/claude-mode on|off|status|smoke|approve|deny|yolo` from Telegram so the plugin can identify the chat."
 
 
 def register(ctx: Any) -> None:

--- a/plugins/kaze-claude-mode/plugin.yaml
+++ b/plugins/kaze-claude-mode/plugin.yaml
@@ -1,0 +1,6 @@
+name: kaze-claude-mode
+version: 0.2.0
+description: Chat-level Telegram Claude lane (tool/edit-capable) for Kaze via Hermes tools.
+author: Kaze
+provides_hooks:
+  - pre_gateway_dispatch

--- a/plugins/kaze-claude-mode/plugin.yaml
+++ b/plugins/kaze-claude-mode/plugin.yaml
@@ -1,6 +1,6 @@
 name: kaze-claude-mode
-version: 0.2.0
-description: Chat-level Telegram Claude lane (tool/edit-capable) for Kaze via Hermes tools.
+version: 0.3.0
+description: Chat-level Telegram Claude lane for Kaze using Claude Code CLI (headless `claude -p`).
 author: Kaze
 provides_hooks:
   - pre_gateway_dispatch

--- a/tests/gateway/test_awareos_bridge_contextual_overlay_contract.py
+++ b/tests/gateway/test_awareos_bridge_contextual_overlay_contract.py
@@ -1,0 +1,72 @@
+import json
+
+import pytest
+
+
+def _fake_response(payload: dict):
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+    return _Resp()
+
+
+def test_run_context_eval_uses_get_contextual_overlay_without_raw_body(monkeypatch):
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_ENABLED", "1")
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_URL", "http://awareos.test/api/kaze/contextual-overlay")
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_BEARER_TOKEN", "tok_test")
+    monkeypatch.setenv("AWAREOS_CONTEXTUAL_OVERLAY_TZ_OFFSET_MIN", "540")
+
+    from gateway import awareos_bridge as ab
+
+    captured = {}
+
+    def _urlopen(req, timeout=0):
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        captured["data"] = getattr(req, "data", None)
+        assert timeout == 6
+        return _fake_response(
+            {
+                "now": "2026-05-03T00:00:00.000Z",
+                "warrants_action": True,
+                "prompts": [
+                    {
+                        "kind": "kriya_missing",
+                        "priority": "high",
+                        "reason": "No Kriya logged today.",
+                        "suggested_action": "Do Kriya.",
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(ab.urllib.request, "urlopen", _urlopen)
+
+    message_text = "calendar tomorrow; secret=DO_NOT_SEND"
+    res = ab.run_context_eval(
+        message_text=message_text,
+        session_key="telegram:1",
+        platform="telegram",
+        chat_id="1",
+        user_id="u",
+    )
+
+    assert res is not None
+    assert res.ok is True
+    assert "kriya_missing" in res.snippet
+
+    assert captured["method"] == "GET"
+    assert captured["data"] is None
+    assert captured["headers"].get("Authorization") == "Bearer tok_test"
+    assert "tz_offset_min=540" in captured["url"]
+    assert "calendar_prep_needed=1" in captured["url"]
+    assert "DO_NOT_SEND" not in captured["url"]
+

--- a/tests/gateway/test_awareos_context_eval_injection.py
+++ b/tests/gateway/test_awareos_context_eval_injection.py
@@ -1,0 +1,96 @@
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner(config: GatewayConfig) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._awareos_last_context_eval_ts = {}
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_context_eval_injects_on_calendar_prompt(monkeypatch):
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_ENABLED", "1")
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_URL", "http://example.invalid/eval")
+
+    from gateway import awareos_bridge as ab
+
+    class _Res:
+        ok = True
+        snippet = "calendar: none"
+        meta = {}
+
+    monkeypatch.setattr(ab, "run_context_eval", lambda **_: _Res())
+
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+        )
+    )
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="u")
+    event = MessageEvent(text="What's on my calendar tomorrow?", source=source)
+    out = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+    assert out.startswith("[AwareOS context evaluator]\ncalendar: none\n\n")
+
+
+@pytest.mark.asyncio
+async def test_context_eval_debounces_per_session(monkeypatch):
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_ENABLED", "1")
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_URL", "http://example.invalid/eval")
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_DEBOUNCE_SECS", "9999")
+
+    from gateway import awareos_bridge as ab
+
+    calls = {"n": 0}
+
+    class _Res:
+        ok = True
+        snippet = "ok"
+        meta = {}
+
+    def _fake(**_):
+        calls["n"] += 1
+        return _Res()
+
+    monkeypatch.setattr(ab, "run_context_eval", _fake)
+
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+        )
+    )
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="u")
+    event = MessageEvent(text="calendar today", source=source)
+    out1 = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+    out2 = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+    assert calls["n"] == 1
+    assert out1.startswith("[AwareOS context evaluator]\n")
+    assert out2 == "calendar today"
+
+
+@pytest.mark.asyncio
+async def test_context_eval_skips_slash_commands(monkeypatch):
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_ENABLED", "1")
+    monkeypatch.setenv("AWAREOS_CONTEXT_EVAL_URL", "http://example.invalid/eval")
+
+    from gateway import awareos_bridge as ab
+
+    monkeypatch.setattr(ab, "run_context_eval", lambda **_: (_ for _ in ()).throw(AssertionError("should not call")))
+
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+        )
+    )
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="u")
+    event = MessageEvent(text="/help", source=source)
+    out = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+    assert out == "/help"

--- a/tests/gateway/test_awareos_overlay_builtin_hook.py
+++ b/tests/gateway/test_awareos_overlay_builtin_hook.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+
+from gateway.hooks import HookRegistry
+
+
+@pytest.mark.asyncio
+async def test_builtin_awareos_overlay_hook_emits_start_stop(tmp_path, monkeypatch):
+    events_path = tmp_path / "awareos_events.jsonl"
+    monkeypatch.setenv("AWAREOS_OVERLAY_ENABLED", "1")
+    monkeypatch.setenv("AWAREOS_WORK_OVERLAY_EVENTS_PATH", str(events_path))
+
+    reg = HookRegistry()
+    reg.discover_and_load()
+
+    ctx = {
+        "platform": "telegram",
+        "chat_id": "123",
+        "message_id": "456",
+        "session_id": "sess-abc",
+        "session_key": "telegram:123",
+        "user_id": "u1",
+        "substantive": True,
+        "api_calls": 3,
+        "tool_names": ["terminal"],
+        "response_length": 10,
+        "model": "test-model",
+    }
+
+    await reg.emit("agent:start", dict(ctx))
+    await reg.emit("agent:end", dict(ctx))
+
+    lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    start = json.loads(lines[0])
+    stop = json.loads(lines[1])
+    assert start["action"] == "start"
+    assert stop["action"] == "stop"
+    assert start["overlay_id"] == stop["overlay_id"]
+    assert start["source"]["platform"] == "telegram"
+    assert stop["result"]["tool_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_builtin_awareos_overlay_hook_skips_non_substantive(tmp_path, monkeypatch):
+    events_path = tmp_path / "awareos_events.jsonl"
+    monkeypatch.setenv("AWAREOS_OVERLAY_ENABLED", "1")
+    monkeypatch.setenv("AWAREOS_WORK_OVERLAY_EVENTS_PATH", str(events_path))
+
+    reg = HookRegistry()
+    reg.discover_and_load()
+
+    ctx = {
+        "platform": "telegram",
+        "chat_id": "123",
+        "session_id": "sess-abc",
+        "session_key": "telegram:123",
+        "user_id": "u1",
+        "substantive": False,
+        "api_calls": 1,
+        "tool_names": [],
+        "response_length": 2,
+    }
+
+    await reg.emit("agent:start", dict(ctx))
+    await reg.emit("agent:end", dict(ctx))
+
+    assert not events_path.exists()
+

--- a/tests/gateway/test_kaze_claude_mode_toolful.py
+++ b/tests/gateway/test_kaze_claude_mode_toolful.py
@@ -183,6 +183,116 @@ def test_claude_mode_injects_recent_session_transcript_without_rewrite_leak(tmp_
     assert store.loaded is True
 
 
+def test_claude_mode_injects_kaze_context_pack_into_pending_prompt(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+
+    # Point the vault root at a synthetic directory so the test does not depend
+    # on the real ki vault and runs hermetically.
+    fake_vault = tmp_path / "ki"
+    (fake_vault / "System").mkdir(parents=True, exist_ok=True)
+    (fake_vault / "System" / "Boot.md").write_text("boot stub", encoding="utf-8")
+    (fake_vault / "System" / "Routines.md").write_text("routines stub", encoding="utf-8")
+    (fake_vault / "Daily").mkdir(parents=True, exist_ok=True)
+    (fake_vault / "Weekly").mkdir(parents=True, exist_ok=True)
+    (fake_vault / "Scripts").mkdir(parents=True, exist_ok=True)
+    (fake_vault / "Scripts" / "pulse_sync.py").write_text("# pulse stub", encoding="utf-8")
+    (fake_vault / "Scripts" / "kaze_source_health.py").write_text("# health stub", encoding="utf-8")
+    (fake_vault / "Scripts" / "kaze_live_intake_readiness_v1.py").write_text("# readiness stub", encoding="utf-8")
+    monkeypatch.setenv("KAZE_VAULT_ROOT", str(fake_vault))
+
+    from hermes_cli.plugins import discover_plugins, invoke_hook
+    discover_plugins(force=True)
+    from hermes_plugins import kaze_claude_mode as mod
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+    from hermes_plugins.kaze_claude_mode import set_enabled, state_key_from_source
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    session_key = "agent:main:telegram:dm:1"
+    set_enabled(chat_key, True, source=src)
+    store = _FakeSessionStore(
+        session_key,
+        [
+            {"role": "user", "content": "Earlier user request"},
+            {"role": "assistant", "content": "Earlier assistant answer"},
+        ],
+    )
+
+    secret_user_text = "SENSITIVE-USER-PROMPT-TOKEN"
+    event = SimpleNamespace(text=secret_user_text, source=src)
+    results = invoke_hook(
+        "pre_gateway_dispatch",
+        event=event,
+        gateway=_FakeGateway(session_key),
+        session_store=store,
+    )
+
+    assert len(results) == 1
+    rewrite = results[0]["text"]
+    assert rewrite.startswith("/kaze-claude-mode-run ")
+    # Rewritten command must carry only the internal token — no user text,
+    # transcript, or context pack body.
+    assert secret_user_text not in rewrite
+    assert "Earlier user request" not in rewrite
+    assert "<kaze_context_pack>" not in rewrite
+    assert "vault_root" not in rewrite
+
+    token = rewrite.split(maxsplit=1)[1]
+    prompt = mod._PENDING[token].prompt
+
+    # Context pack is present with the key boundary lines.
+    assert "<kaze_context_pack>" in prompt
+    assert "</kaze_context_pack>" in prompt
+    assert "Claude Code CLI lane invoked from Hermes/Kaze" in prompt
+    assert "runtime/session owner" in prompt
+    assert f"vault_root: {fake_vault}" in prompt
+    assert "System/Boot.md" in prompt
+    assert "System/Routines.md" in prompt
+    assert "Daily/" in prompt
+    assert "Weekly/" in prompt
+    assert "Scripts/pulse_sync.py" in prompt
+    assert "Scripts/kaze_source_health.py" in prompt
+    assert "Scripts/kaze_live_intake_readiness_v1.py" in prompt
+    assert "capability/status entry points" in prompt
+    assert "do NOT dump full file bodies" in prompt
+    assert "allowed tools" in prompt.lower()
+    assert "do not run a full live-source sync" in prompt.lower()
+    assert "/kaze" in prompt
+
+    # Existing transcript behavior remains: transcript and latest user message still wrapped.
+    assert "<recent_telegram_session_transcript>" in prompt
+    assert "Earlier user request" in prompt
+    assert "Earlier assistant answer" in prompt
+    assert "<latest_user_message>" in prompt
+    assert secret_user_text in prompt
+
+
+def test_claude_mode_context_pack_is_failure_tolerant_when_vault_missing(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+
+    # Point at a non-existent vault root.
+    monkeypatch.setenv("KAZE_VAULT_ROOT", str(tmp_path / "missing-vault"))
+
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins(force=True)
+    from hermes_plugins import kaze_claude_mode as mod
+
+    pack = mod._build_kaze_context_pack()
+    assert "<kaze_context_pack>" in pack
+    assert "Claude Code CLI lane invoked from Hermes/Kaze" in pack
+    assert "no expected pointers found" in pack
+
+
 @pytest.mark.asyncio
 async def test_claude_mode_smoke_uses_tools_without_leaking_outputs(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes_test"

--- a/tests/gateway/test_kaze_claude_mode_toolful.py
+++ b/tests/gateway/test_kaze_claude_mode_toolful.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+
+def _reset_plugin_singleton(monkeypatch):
+    import hermes_cli.plugins as _plugins_mod
+    monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
+
+
+def _enable_plugin(hermes_home: Path, name: str) -> None:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    cfg = {"plugins": {"enabled": [name]}}
+    (hermes_home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+
+class _FakeGateway:
+    def __init__(self, session_key: str):
+        self._session_model_overrides: dict = {}
+        self._evicted: list[str] = []
+        self._session_key = session_key
+
+    def _session_key_for_source(self, source) -> str:  # noqa: ARG002
+        return self._session_key
+
+    def _evict_cached_agent(self, session_key: str) -> None:
+        self._evicted.append(session_key)
+
+
+def _tg_source(chat_id: str = "1"):
+    return SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        chat_id=chat_id,
+        thread_id="",
+        user_id="u",
+        user_name="user",
+        chat_type="dm",
+    )
+
+
+def test_claude_mode_bounce_when_backend_unavailable(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+    # Ensure no Anthropic credentials leak into this test even if some import
+    # side-effect rehydrates them in the worker process.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    from hermes_cli.plugins import discover_plugins, invoke_hook
+    from hermes_constants import get_hermes_home
+
+    # Force enabled state without requiring backend credentials.
+    discover_plugins(force=True)
+    from hermes_plugins import kaze_claude_mode as mod
+    monkeypatch.setattr(
+        mod,
+        "_resolve_toolful_claude_backend",
+        lambda **_: (False, "anthropic/claude-sonnet-4.6", {"provider": "anthropic", "api_key": ""}),
+    )
+    from hermes_plugins.kaze_claude_mode import set_enabled, state_key_from_source
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    gw = _FakeGateway("agent:main:telegram:dm:1")
+    event = SimpleNamespace(text="Please edit files", source=src)
+
+    results = invoke_hook("pre_gateway_dispatch", event=event, gateway=gw, session_store=None)
+    assert len(results) == 1
+    assert results[0]["action"] == "rewrite"
+    assert "Routing this message to normal Hermes/Kaze" in results[0]["text"]
+
+    # State file is profile-safe (under HERMES_HOME), not ~/.hermes.
+    assert (get_hermes_home() / "state" / "kaze_claude_mode.json").exists()
+
+
+def test_claude_mode_sets_gateway_override_when_backend_available(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+
+    # Dummy credentials so resolve_runtime_provider reports "toolful backend ok".
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    from hermes_cli.plugins import discover_plugins, invoke_hook
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import set_enabled, state_key_from_source
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    gw = _FakeGateway("agent:main:telegram:dm:1")
+    event = SimpleNamespace(text="Hello", source=src)
+
+    results = invoke_hook("pre_gateway_dispatch", event=event, gateway=gw, session_store=None)
+    # No rewrite when backend is available; hook returns [].
+    assert results == []
+    assert gw._session_model_overrides["agent:main:telegram:dm:1"]["provider"] == "anthropic"
+    assert "model" in gw._session_model_overrides["agent:main:telegram:dm:1"]
+    assert gw._evicted == ["agent:main:telegram:dm:1"]
+
+
+@pytest.mark.asyncio
+async def test_claude_mode_smoke_uses_tools_without_leaking_outputs(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    # Provide a fake tool dispatcher so smoke doesn't actually run shell commands.
+    class _FakeCtx:
+        def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
+            if name == "terminal":
+                return json.dumps({"stdout": "KAZE_CLAUDE_MODE_TOOL_OK\\n"})
+            if name == "write_file":
+                return json.dumps({"ok": True})
+            return json.dumps({"error": "unexpected tool"})
+
+        # register_* stubs (not used in this test, but plugin register() expects them)
+        def register_hook(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+        def register_command(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import _encode_packet, handle_internal_mode, state_key_from_source, set_enabled
+    from hermes_plugins import kaze_claude_mode as mod
+
+    mod._CTX = _FakeCtx()
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    packet = {"key": chat_key, "args": "smoke", "session_key": "agent:main:telegram:dm:1"}
+    reply = await handle_internal_mode(_encode_packet(packet))
+
+    assert "Smoke: **OK**" in reply
+    assert "KAZE_CLAUDE_MODE_TOOL_OK" in reply
+    # Must not dump raw tool JSON or arbitrary stdout bodies.
+    assert "\"stdout\"" not in reply

--- a/tests/gateway/test_kaze_claude_mode_toolful.py
+++ b/tests/gateway/test_kaze_claude_mode_toolful.py
@@ -48,22 +48,16 @@ def test_claude_mode_bounce_when_backend_unavailable(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     _enable_plugin(hermes_home, "kaze-claude-mode")
     _reset_plugin_singleton(monkeypatch)
-    # Ensure no Anthropic credentials leak into this test even if some import
-    # side-effect rehydrates them in the worker process.
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
-    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
 
     from hermes_cli.plugins import discover_plugins, invoke_hook
     from hermes_constants import get_hermes_home
 
-    # Force enabled state without requiring backend credentials.
     discover_plugins(force=True)
     from hermes_plugins import kaze_claude_mode as mod
     monkeypatch.setattr(
         mod,
-        "_resolve_toolful_claude_backend",
-        lambda **_: (False, "anthropic/claude-sonnet-4.6", {"provider": "anthropic", "api_key": ""}),
+        "_resolve_claude_code_cli_backend",
+        lambda: (False, {"backend": "claude-code-cli", "cmd": "", "path": "", "error": "not found"}),
     )
     from hermes_plugins.kaze_claude_mode import set_enabled, state_key_from_source
 
@@ -77,23 +71,30 @@ def test_claude_mode_bounce_when_backend_unavailable(tmp_path, monkeypatch):
     results = invoke_hook("pre_gateway_dispatch", event=event, gateway=gw, session_store=None)
     assert len(results) == 1
     assert results[0]["action"] == "rewrite"
-    assert "Routing this message to normal Hermes/Kaze" in results[0]["text"]
+    assert results[0]["text"].startswith("/kaze-claude-mode-dispatch ")
+    # Must not echo the user prompt into the rewritten command (avoid log leakage).
+    assert "Please edit files" not in results[0]["text"]
+    packet = mod._decode_packet(results[0]["text"].split(maxsplit=1)[1])
+    assert packet["args"] == "unavailable"
 
     # State file is profile-safe (under HERMES_HOME), not ~/.hermes.
     assert (get_hermes_home() / "state" / "kaze_claude_mode.json").exists()
 
 
-def test_claude_mode_sets_gateway_override_when_backend_available(tmp_path, monkeypatch):
+def test_claude_mode_rewrites_plain_message_to_internal_run_when_backend_available(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes_test"
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     _enable_plugin(hermes_home, "kaze-claude-mode")
     _reset_plugin_singleton(monkeypatch)
 
-    # Dummy credentials so resolve_runtime_provider reports "toolful backend ok".
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-
     from hermes_cli.plugins import discover_plugins, invoke_hook
     discover_plugins(force=True)
+    from hermes_plugins import kaze_claude_mode as mod
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
     from hermes_plugins.kaze_claude_mode import set_enabled, state_key_from_source
 
     src = _tg_source()
@@ -104,11 +105,16 @@ def test_claude_mode_sets_gateway_override_when_backend_available(tmp_path, monk
     event = SimpleNamespace(text="Hello", source=src)
 
     results = invoke_hook("pre_gateway_dispatch", event=event, gateway=gw, session_store=None)
-    # No rewrite when backend is available; hook returns [].
-    assert results == []
-    assert gw._session_model_overrides["agent:main:telegram:dm:1"]["provider"] == "anthropic"
-    assert "model" in gw._session_model_overrides["agent:main:telegram:dm:1"]
-    assert gw._evicted == ["agent:main:telegram:dm:1"]
+    assert len(results) == 1
+    assert results[0]["action"] == "rewrite"
+    assert results[0]["text"].startswith("/kaze-claude-mode-run ")
+    # Must not embed the user message.
+    assert "Hello" not in results[0]["text"]
+    token = results[0]["text"].split(maxsplit=1)[1]
+    assert token in mod._PENDING
+    # No provider-switch masquerade.
+    assert gw._session_model_overrides == {}
+    assert gw._evicted == []
 
 
 @pytest.mark.asyncio
@@ -117,15 +123,17 @@ async def test_claude_mode_smoke_uses_tools_without_leaking_outputs(tmp_path, mo
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     _enable_plugin(hermes_home, "kaze-claude-mode")
     _reset_plugin_singleton(monkeypatch)
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
 
     # Provide a fake tool dispatcher so smoke doesn't actually run shell commands.
     class _FakeCtx:
         def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
-            if name == "terminal":
-                return json.dumps({"stdout": "KAZE_CLAUDE_MODE_TOOL_OK\\n"})
             if name == "write_file":
                 return json.dumps({"ok": True})
+            if name == "terminal":
+                # - In smoke: claude run returns no stdout we care about; verify step reads the temp file.
+                if "python -c" in (args.get("command") or ""):
+                    return json.dumps({"stdout": "KAZE_CLAUDE_MODE_FILE_OK\\n"})
+                return json.dumps({"stdout": "ok\\n", "exit_code": 0})
             return json.dumps({"error": "unexpected tool"})
 
         # register_* stubs (not used in this test, but plugin register() expects them)
@@ -141,6 +149,11 @@ async def test_claude_mode_smoke_uses_tools_without_leaking_outputs(tmp_path, mo
     from hermes_plugins import kaze_claude_mode as mod
 
     mod._CTX = _FakeCtx()
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
 
     src = _tg_source()
     chat_key = state_key_from_source(src)
@@ -150,6 +163,46 @@ async def test_claude_mode_smoke_uses_tools_without_leaking_outputs(tmp_path, mo
     reply = await handle_internal_mode(_encode_packet(packet))
 
     assert "Smoke: **OK**" in reply
-    assert "KAZE_CLAUDE_MODE_TOOL_OK" in reply
     # Must not dump raw tool JSON or arbitrary stdout bodies.
     assert "\"stdout\"" not in reply
+
+
+@pytest.mark.asyncio
+async def test_claude_mode_status_reports_backend_precisely(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+
+    class _FakeCtx:
+        def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
+            return json.dumps({"error": "not used"})
+
+        def register_hook(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+        def register_command(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import _encode_packet, handle_internal_mode, state_key_from_source, set_enabled
+    from hermes_plugins import kaze_claude_mode as mod
+
+    mod._CTX = _FakeCtx()
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    packet = {"key": chat_key, "args": "status", "session_key": "agent:main:telegram:dm:1"}
+    reply = await handle_internal_mode(_encode_packet(packet))
+
+    assert "backend:" in reply
+    assert "claude-code-cli" in reply
+    assert "anthropic" not in reply.lower()

--- a/tests/gateway/test_kaze_claude_mode_toolful.py
+++ b/tests/gateway/test_kaze_claude_mode_toolful.py
@@ -33,6 +33,25 @@ class _FakeGateway:
         self._evicted.append(session_key)
 
 
+class _FakeSessionEntry:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+
+class _FakeSessionStore:
+    def __init__(self, session_key: str, messages: list[dict]):
+        self._entries = {session_key: _FakeSessionEntry("session-1")}
+        self._messages = messages
+        self.loaded = False
+
+    def _ensure_loaded(self) -> None:
+        self.loaded = True
+
+    def load_transcript(self, session_id: str):
+        assert session_id == "session-1"
+        return self._messages
+
+
 def _tg_source(chat_id: str = "1"):
     return SimpleNamespace(
         platform=SimpleNamespace(value="telegram"),
@@ -116,6 +135,52 @@ def test_claude_mode_rewrites_plain_message_to_internal_run_when_backend_availab
     # No provider-switch masquerade.
     assert gw._session_model_overrides == {}
     assert gw._evicted == []
+
+
+def test_claude_mode_injects_recent_session_transcript_without_rewrite_leak(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+
+    from hermes_cli.plugins import discover_plugins, invoke_hook
+    discover_plugins(force=True)
+    from hermes_plugins import kaze_claude_mode as mod
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+    from hermes_plugins.kaze_claude_mode import set_enabled, state_key_from_source
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    session_key = "agent:main:telegram:dm:1"
+    set_enabled(chat_key, True, source=src)
+    store = _FakeSessionStore(
+        session_key,
+        [
+            {"role": "user", "content": "Earlier user request"},
+            {"role": "assistant", "content": "Earlier assistant answer"},
+            {"role": "tool", "content": "raw tool JSON should be skipped"},
+        ],
+    )
+
+    event = SimpleNamespace(text="What did I miss?", source=src)
+    results = invoke_hook("pre_gateway_dispatch", event=event, gateway=_FakeGateway(session_key), session_store=store)
+
+    assert len(results) == 1
+    assert results[0]["text"].startswith("/kaze-claude-mode-run ")
+    assert "Earlier user request" not in results[0]["text"]
+    token = results[0]["text"].split(maxsplit=1)[1]
+    prompt = mod._PENDING[token].prompt
+    assert "<recent_telegram_session_transcript>" in prompt
+    assert "Earlier user request" in prompt
+    assert "Earlier assistant answer" in prompt
+    assert "raw tool JSON" not in prompt
+    assert "<latest_user_message>" in prompt
+    assert "What did I miss?" in prompt
+    assert store.loaded is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_kaze_claude_mode_toolful.py
+++ b/tests/gateway/test_kaze_claude_mode_toolful.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -206,3 +207,243 @@ async def test_claude_mode_status_reports_backend_precisely(tmp_path, monkeypatc
     assert "backend:" in reply
     assert "claude-code-cli" in reply
     assert "anthropic" not in reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_claude_mode_status_reports_allowed_tools_permission_mode_yolo_and_pending(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+    monkeypatch.delenv("KAZE_CLAUDE_MODE_ALLOWED_TOOLS", raising=False)
+    monkeypatch.delenv("KAZE_CLAUDE_MODE_PERMISSION_MODE", raising=False)
+
+    class _FakeCtx:
+        def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
+            return json.dumps({"error": "not used"})
+
+        def register_hook(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+        def register_command(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import _encode_packet, handle_internal_mode, state_key_from_source, set_enabled
+    from hermes_plugins import kaze_claude_mode as mod
+
+    mod._CTX = _FakeCtx()
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    packet = {"key": chat_key, "args": "status", "session_key": "agent:main:telegram:dm:1"}
+    reply = await handle_internal_mode(_encode_packet(packet))
+
+    assert "allowedTools:" in reply
+    assert "`Read,Write,Edit,Grep,Glob`" in reply
+    assert "permission-mode:" in reply
+    assert "`acceptEdits`" in reply
+    assert "yolo:" in reply
+    assert "**off**" in reply
+    assert "pending:" in reply
+    assert "**none**" in reply
+
+
+@pytest.mark.asyncio
+async def test_claude_mode_env_overrides_allowed_tools_and_permission_mode(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+    monkeypatch.setenv("KAZE_CLAUDE_MODE_ALLOWED_TOOLS", "Read,Edit")
+    monkeypatch.setenv("KAZE_CLAUDE_MODE_PERMISSION_MODE", "auto")
+
+    class _FakeCtx:
+        def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
+            return json.dumps({"error": "not used"})
+
+        def register_hook(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+        def register_command(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import _encode_packet, handle_internal_mode, state_key_from_source, set_enabled
+    from hermes_plugins import kaze_claude_mode as mod
+
+    mod._CTX = _FakeCtx()
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    packet = {"key": chat_key, "args": "status", "session_key": "agent:main:telegram:dm:1"}
+    reply = await handle_internal_mode(_encode_packet(packet))
+
+    assert "`Read,Edit`" in reply
+    assert "`auto`" in reply
+
+
+@pytest.mark.asyncio
+async def test_claude_mode_yolo_toggles_bypass_permission_mode(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+    monkeypatch.setenv("KAZE_CLAUDE_MODE_PERMISSION_MODE", "auto")
+
+    class _FakeCtx:
+        def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
+            return json.dumps({"error": "not used"})
+
+        def register_hook(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+        def register_command(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import _encode_packet, handle_internal_mode, state_key_from_source, set_enabled
+    from hermes_plugins import kaze_claude_mode as mod
+
+    mod._CTX = _FakeCtx()
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    packet_on = {"key": chat_key, "args": "yolo on", "session_key": "agent:main:telegram:dm:1"}
+    reply_on = await handle_internal_mode(_encode_packet(packet_on))
+    assert "yolo: **on**" in reply_on
+    assert "`bypassPermissions`" in reply_on
+
+    packet_off = {"key": chat_key, "args": "yolo off", "session_key": "agent:main:telegram:dm:1"}
+    reply_off = await handle_internal_mode(_encode_packet(packet_off))
+    assert "yolo: **off**" in reply_off
+    assert "`auto`" in reply_off
+
+
+@pytest.mark.asyncio
+async def test_claude_mode_permission_block_creates_pending_approval_and_approve_retries(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+    monkeypatch.delenv("KAZE_CLAUDE_MODE_ALLOWED_TOOLS", raising=False)
+
+    class _FakeCtx:
+        def __init__(self):
+            self.calls: list[tuple[str, dict]] = []
+
+        def dispatch_tool(self, name: str, args: dict, **kw):  # noqa: ARG002
+            self.calls.append((name, args))
+            if name == "write_file":
+                return json.dumps({"ok": True})
+            if name == "terminal":
+                cmd = args.get("command") or ""
+                if "Bash(git status *)" in cmd:
+                    return json.dumps({"stdout": "ok\\n", "exit_code": 0})
+                return json.dumps({"stdout": "Permission blocked: approve Bash(git status *)\\n", "exit_code": 1})
+            return json.dumps({"error": "unexpected tool"})
+
+        def register_hook(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+        def register_command(self, *a, **kw):  # noqa: ANN001,ARG002
+            return None
+
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import (
+        _encode_packet,
+        _pending_approval,
+        _stash_pending_prompt,
+        handle_internal_mode,
+        handle_internal_run,
+        state_key_from_source,
+        set_enabled,
+    )
+    from hermes_plugins import kaze_claude_mode as mod
+
+    mod._CTX = _FakeCtx()
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    secret_prompt = "TOPSECRET: do not leak"
+    token = _stash_pending_prompt(chat_key=chat_key, session_key="agent:main:telegram:dm:1", prompt=secret_prompt)
+    out = await handle_internal_run(token)
+    assert "approval pending" in out.lower()
+    assert secret_prompt not in out
+
+    pending = _pending_approval(chat_key)
+    assert pending is not None
+    assert pending.get("tool_rule") == "Bash(git status *)"
+    assert pending.get("prompt_sha256") == hashlib.sha256(secret_prompt.encode("utf-8")).hexdigest()
+
+    # State file must not contain the raw prompt body.
+    state_text = (hermes_home / "state" / "kaze_claude_mode.json").read_text(encoding="utf-8")
+    assert secret_prompt not in state_text
+
+    approve_packet = {"key": chat_key, "args": "approve", "session_key": "agent:main:telegram:dm:1"}
+    out2 = await handle_internal_mode(_encode_packet(approve_packet))
+    assert "ok" in out2.lower()
+    assert _pending_approval(chat_key) is None
+
+
+def test_claude_mode_keeps_other_slash_commands_as_escape_hatches(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_test"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _enable_plugin(hermes_home, "kaze-claude-mode")
+    _reset_plugin_singleton(monkeypatch)
+
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins(force=True)
+    from hermes_plugins.kaze_claude_mode import build_pre_dispatch_decision, state_key_from_source, set_enabled
+    from hermes_plugins import kaze_claude_mode as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_resolve_claude_code_cli_backend",
+        lambda: (True, {"backend": "claude-code-cli", "cmd": "claude", "path": "/usr/bin/claude"}),
+    )
+
+    src = _tg_source()
+    chat_key = state_key_from_source(src)
+    set_enabled(chat_key, True, source=src)
+
+    # /claude-mode is rewritten (handled by this plugin), but other slash commands must pass through.
+    event = SimpleNamespace(text="/help", source=src)
+    assert build_pre_dispatch_decision(event, gateway=_FakeGateway("agent:main:telegram:dm:1")) is None

--- a/tests/gateway/test_kaze_claude_mode_toolful.py
+++ b/tests/gateway/test_kaze_claude_mode_toolful.py
@@ -321,6 +321,8 @@ async def test_claude_mode_status_reports_allowed_tools_permission_mode_yolo_and
     assert "**off**" in reply
     assert "pending:" in reply
     assert "**none**" in reply
+    assert "max-turns:" in reply
+    assert "`90`" in reply
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -334,6 +334,39 @@ class TestPluginHooks:
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
 
+    def test_module_invoke_hook_triggers_discovery(self, tmp_path, monkeypatch):
+        """Module-level invoke_hook() must be discovery-safe.
+
+        Regression test: in a fresh process, gateway code calls
+        ``hermes_cli.plugins.invoke_hook("pre_gateway_dispatch", ...)`` before
+        any plugin command lookup. That hook invocation must still discover
+        and load enabled user plugins so they can rewrite incoming commands.
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "kaze_claude_mode",
+            register_body=(
+                'ctx.register_command("claude-mode", lambda args: "ok")\n'
+                '    ctx.register_hook("pre_gateway_dispatch", '
+                'lambda **kw: {"action": "rewrite", "text": "REWRITTEN"} '
+                'if getattr(kw.get("event"), "text", "").startswith("/claude-mode") '
+                'else None)'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        # Simulate a fresh process: other imports during test setup may have
+        # already triggered plugin discovery (e.g. model_tools), so reset the
+        # singleton after creating the on-disk plugin.
+        import hermes_cli.plugins as _plugins_mod
+        monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
+
+        from types import SimpleNamespace
+
+        results = invoke_hook("pre_gateway_dispatch", event=SimpleNamespace(text="/claude-mode status"))
+
+        assert results == [{"action": "rewrite", "text": "REWRITTEN"}]
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## Summary
- add chat-scoped `/claude-mode` approval state for Claude Code permission blocks
- add `/claude-mode approve`, `deny`, and `yolo on|off|status`
- make Claude Code tool availability explicit via `--tools` derived from safe allowed tools
- report allowed tools, permission mode, yolo, and pending approval in status/smoke
- preserve prompt privacy by storing only hashes/state metadata in the state file and keeping prompt bodies in private temp files

## Test Plan
- `python -m py_compile plugins/kaze-claude-mode/__init__.py`
- `python -m pytest tests/gateway/test_kaze_claude_mode_toolful.py tests/hermes_cli/test_plugins.py -q`
  - `72 passed, 2 warnings`

## Notes
- This is the Hermes Agent upstream PR for Milan/Kaze tracking issue alnimra/ki#64.
- No gateway restart was performed during verification.
