### PR TITLE
fix(cli): catch OSError in _resolve_attachment_path to prevent ENO36 on long command strings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1435,7 +1435,10 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
     except Exception:
         resolved = path
 
-    if not resolved.exists() or not resolved.is_file():
+    try:
+        if not resolved.exists() or not resolved.is_file():
+            return None
+    except OSError:
         return None
     return resolved
 


### PR DESCRIPTION
## Bug

`_detect_file_drop()` in `cli.py` treats any user input starting with `/` as a potential file path and calls `os.stat()` on it via `pathlib.Path.exists()`. When the input string exceeds 255 bytes (Linux `NAME_MAX`), `os.stat()` raises `OSError: [Errno 36] File name too long` before any command dispatch runs.

Any slash command whose argument string exceeds 255 bytes and starts with `/` crashes Hermes before dispatch.

## Fix

In `_resolve_attachment_path()`, wrap the `exists()` call in a try/except that catches `OSError` and returns `None`, allowing the code to continue to normal command dispatch:

```python
try:
    if not resolved.exists() or not resolved.is_file():
        return None
except OSError:
    return None
```

## Files changed

`hermes_cli/main.py`