### PR TITLE
fix(compression): use extract_content_or_reasoning for thinking models

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -24,7 +24,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 from agent.context_engine import ContextEngine
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -868,7 +868,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
+            content = extract_content_or_reasoning(response)
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""


### PR DESCRIPTION
## Summary

Fixes #19003

Context compressor ignores the `reasoning` field when extracting summary content from the auxiliary LLM response. When using thinking/reasoning models (DeepSeek v4, GLM-5.1, Qwen 3.5, etc.) via Ollama 0.22+, these models return their output in the `reasoning` field with `content` as an empty string — especially when `max_tokens` is constrained (which compression does). The compressor gets an empty summary and falls back to a static context marker, losing the entire compaction.

## Bug

`agent/context_compressor.py` line 871:
```python
content = response.choices[0].message.content  # BUG: ignores reasoning field
```

When a thinking model returns `content=""` and `reasoning="..."`, this line produces an empty string. The compressor then falls back to: `"Summary generation failed — inserting static fallback context marker"`

In our deployment, 3 of 25 compression events (12%) produced fallback markers.

## Fix

Replace raw `.message.content` access with the existing `extract_content_or_reasoning()` helper from `auxiliary_client.py`, which checks `content` first, then falls back to `reasoning`, `reasoning_content`, and `reasoning_details`.

```python
from agent.auxiliary_client import call_llm, extract_content_or_reasoning
# ...
content = extract_content_or_reasoning(response)
```

The `extract_content_or_reasoning()` function already exists and is used by the main agent loop — this just applies the same reasoning-field handling to the compression path.

## Testing

- Tested with Ollama 0.22.1+ and `deepseek-v4-flash:cloud` as compression auxiliary
- Before fix: `content=""`, `reasoning` held the actual summary → fallback marker inserted
- After fix: `extract_content_or_reasoning()` returns the reasoning content → proper summary

## Impact

- One-line change + one import addition
- No behavior change for models that return content normally (the common path)
- Fixes 12% compression failure rate with thinking models