### PR TITLE
fix(title): strip thinking blocks from auto-generated session titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,10 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        # Use extract_content_or_reasoning() so titles from thinking models
+        # (MiniMax-M2.7, DeepSeek-R1, Qwen-QwQ, …) drop their <think>/<reasoning>
+        # blocks instead of leaking them into the saved session title.
+        title = extract_content_or_reasoning(response).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -95,6 +95,41 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("nope")):
             assert generate_title("q", "a") is None
 
+    def test_strips_inline_thinking_blocks(self):
+        """Thinking models (MiniMax-M2.7, DeepSeek-R1, Qwen-QwQ) embed reasoning
+        in <think>/<reasoning> tags inside content. The title must drop those
+        blocks instead of saving them as the session title (#18529).
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "<think>The user is asking me to generate a title for a "
+            "conversation. Let me analyze the topic and pick something "
+            "concise.</think>Refactoring the Cron Scheduler"
+        )
+        mock_response.choices[0].message.reasoning = None
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.reasoning_details = None
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("how do I refactor cron", "Sure, first…")
+            assert title == "Refactoring the Cron Scheduler"
+
+    def test_falls_back_to_reasoning_field_when_content_empty(self):
+        """When content is empty but reasoning_content is populated (Moonshot,
+        Novita, etc.) the title must still come back instead of None (#18529).
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.reasoning = "Setting Up Postgres Replication"
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.reasoning_details = None
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("postgres replica setup", "Sure…")
+            assert title == "Setting Up Postgres Replication"
+
     def test_truncates_long_messages(self):
         """Long user/assistant messages should be truncated in the LLM request."""
         captured_kwargs = {}


### PR DESCRIPTION
## What does this PR do?

`agent/title_generator.py` read `response.choices[0].message.content` directly when building auto-generated session titles. Thinking models (MiniMax-M2.7, DeepSeek-R1, Qwen-QwQ, …) embed their reasoning inside `<think>`/`<reasoning>` blocks in the content field, or split the visible answer and reasoning across structured fields, so saved titles silently became `<tool_call>The user is asking me to generate a title for a conversation…` instead of an actual title.

Switch to `agent.auxiliary_client.extract_content_or_reasoning()` — the same helper the main agent loop already uses for these models. It strips inline think/reasoning blocks first and falls back to the structured `reasoning` / `reasoning_content` / `reasoning_details` fields when `content` is empty.

## Related Issue

Fixes #18529

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/title_generator.py:11` — import `extract_content_or_reasoning`.
- `agent/title_generator.py:64` — replace direct `message.content` read with `extract_content_or_reasoning(response).strip()`. Comment explains why.
- `tests/agent/test_title_generator.py` — two new tests: `test_strips_inline_thinking_blocks` (content with `<think>` tags collapses to the visible portion) and `test_falls_back_to_reasoning_field_when_content_empty` (empty content + populated `reasoning` field still yields a title).

## How to Test

1. Configure `auxiliary.title_generation` with a thinking model (MiniMax-M2.7, DeepSeek-R1, etc.).
2. Start a fresh session and send a message.
3. After the first response, confirm the auto-generated session title contains only the visible answer — no `<think>` / `<tool_call>` prefix.
4. `pytest tests/agent/test_title_generator.py -q` → 21/21 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_title_generator.py -q
21 passed
```
