### PR TITLE
fix(agent): detect Kimi runtime by model slug for aggregator routes

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -893,11 +893,19 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     )
     _is_nous = "nousresearch" in agent._base_url_lower
     _is_nvidia = "integrate.api.nvidia.com" in agent._base_url_lower
-    _is_kimi = (
-        base_url_host_matches(agent.base_url, "api.kimi.com")
-        or base_url_host_matches(agent.base_url, "moonshot.ai")
-        or base_url_host_matches(agent.base_url, "moonshot.cn")
-    )
+    # Use agent helper when available so aggregator routes serving Moonshot
+    # inference (synthetic.new, OpenRouter, Together, …) are also flagged
+    # via is_moonshot_model() slug detection (#18742). Falls back to direct
+    # host-only detection for older agent objects.
+    _is_kimi_fn = getattr(agent, "_is_kimi_runtime", None)
+    if callable(_is_kimi_fn):
+        _is_kimi = _is_kimi_fn()
+    else:
+        _is_kimi = (
+            base_url_host_matches(agent.base_url, "api.kimi.com")
+            or base_url_host_matches(agent.base_url, "moonshot.ai")
+            or base_url_host_matches(agent.base_url, "moonshot.cn")
+        )
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5495,6 +5495,30 @@ class AIAgent:
         self._thinking_pad_cache = (key, result)
         return result
 
+    def _is_kimi_runtime(self) -> bool:
+        """Return True when the runtime is serving Moonshot/Kimi inference.
+
+        Direct routes are caught by host match. Aggregator routes
+        (synthetic.new, OpenRouter, Together, …) keep the aggregator's base
+        URL but still serve Moonshot inference for Kimi slugs, so we also
+        match by model name via ``is_moonshot_model()``.
+
+        Distinct from ``_needs_kimi_tool_reasoning()``: that helper guards a
+        signature-replay quirk on the Anthropic-shaped Kimi/Moonshot routes
+        only and intentionally does NOT match aggregator slugs.  This helper
+        gates the chat_completions Kimi defaults (max_tokens floor,
+        reasoning_effort hint) which Kimi K2.x needs on every route or
+        thinking-mode burns the entire token budget on hidden reasoning and
+        emits an empty visible response (#18742).
+        """
+        from agent.moonshot_schema import is_moonshot_model
+        return (
+            base_url_host_matches(self.base_url, "api.kimi.com")
+            or base_url_host_matches(self.base_url, "moonshot.ai")
+            or base_url_host_matches(self.base_url, "moonshot.cn")
+            or is_moonshot_model(self.model)
+        )
+
     def _needs_kimi_tool_reasoning(self) -> bool:
         """Return True when the current provider is Kimi / Moonshot thinking mode.
 

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -647,3 +647,47 @@ class TestReasoningPrimaryToStrictFallback:
         api_msg: dict = {"role": "assistant", "tool_calls": [{"id": "a"}]}
         mistral._copy_reasoning_content_for_api(source, api_msg)
         assert "reasoning_content" not in api_msg
+
+
+class TestIsKimiRuntime:
+    """Coverage for ``_is_kimi_runtime()`` — gates the chat_completions Kimi
+    defaults (max_tokens floor, reasoning_effort hint) used in
+    ``_build_api_kwargs``.
+
+    Distinct from ``_needs_kimi_tool_reasoning()``: this one MUST match
+    aggregator-routed Kimi K2.x slugs (synthetic.new, OpenRouter, Together,
+    …) so thinking-mode K2.x doesn't burn the entire token budget on hidden
+    reasoning and emit an empty visible response (#18742).
+    """
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            # Direct host routes
+            ("custom", "kimi-k2.5", "https://api.kimi.com/v1"),
+            ("custom", "kimi-k2.5", "https://api.moonshot.ai/v1"),
+            ("custom", "kimi-k2.5", "https://api.moonshot.cn/v1"),
+            # Aggregator routes — host doesn't match but slug does
+            ("custom", "hf:moonshotai/Kimi-K2.5", "https://api.synthetic.new/v1"),
+            ("openrouter", "moonshotai/kimi-k2.5", "https://openrouter.ai/api/v1"),
+            ("custom", "nous/moonshotai/kimi-k2-thinking", "https://nousresearch.com/v1"),
+            ("custom", "kimi-k2-thinking", "https://together.xyz/v1"),
+        ],
+    )
+    def test_kimi_runtime_signals(self, provider: str, model: str, base_url: str) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        assert agent._is_kimi_runtime() is True
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("openai", "gpt-5.4", "https://api.openai.com/v1"),
+            ("anthropic", "claude-sonnet-4.6", "https://api.anthropic.com/v1"),
+            ("custom", "deepseek-v4-flash", "https://api.deepseek.com/v1"),
+            ("custom", "qwen2.5-72b", "https://api.qwen.ai/v1"),
+            ("custom", "", ""),
+        ],
+    )
+    def test_non_kimi_runtimes(self, provider: str, model: str, base_url: str) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        assert agent._is_kimi_runtime() is False


### PR DESCRIPTION
## What does this PR do?

`AIAgent._build_api_kwargs` flagged Kimi runtime by base-URL only (`api.kimi.com`, `moonshot.ai`, `moonshot.cn`). Aggregator routes (synthetic.new, OpenRouter, Together, …) keep the aggregator's base URL but still serve Moonshot inference for `hf:moonshotai/Kimi-K2.x`, `moonshotai/kimi-k2.x`, `nous/moonshotai/kimi-k2-thinking` slugs, so the Kimi-specific `max_tokens` floor and `reasoning_effort` hint were silently skipped. Kimi K2.x in thinking mode then burned the entire token budget on hidden reasoning and emitted an empty visible response, surfacing as repeated `finish_reason='length'` warnings and final `Agent completed but produced empty response` from cron.

Extract the inline check into `_is_kimi_runtime()` (mirrors the existing `_needs_kimi_tool_reasoning()` helper next door) and add `is_moonshot_model(self.model)` as a fourth match. The slug helper already exists in `agent/moonshot_schema.py` and is unit-tested for all known aggregator prefixes — this just wires it into the runtime detection that gates Kimi defaults.

`_needs_kimi_tool_reasoning()` is intentionally NOT widened: it guards a signature-replay quirk on the Anthropic-shaped Kimi/Moonshot routes only, and its existing aggregator-host=False test (`test_non_kimi_provider`) is preserved.

## Related Issue

Fixes #18742

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py` — import `is_moonshot_model`; replace inline `_is_kimi = (...)` with call to new `_is_kimi_runtime()` helper; add the helper itself parallel to `_needs_kimi_tool_reasoning()` with a docstring spelling out why the two helpers have different aggregator semantics.
- `tests/run_agent/test_deepseek_reasoning_content_echo.py` — new `TestIsKimiRuntime` class parametrised over direct hosts AND aggregator routes (synthetic.new, OpenRouter, Nous, Together) plus negative cases (OpenAI, Anthropic, DeepSeek, Qwen, empty).

## How to Test

1. Configure `model.default: hf:moonshotai/Kimi-K2.5` with a synthetic.new (or OpenRouter / Together) credential pointing at the aggregator's base URL.
2. Send a long prompt with multiple tool calls.
3. Before this PR: repeated `Response truncated (finish_reason='length')` warnings → empty final response. After: visible content returns.
4. `pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -q` → 48/48 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -q
48/48 pass
```
