### PR TITLE
fix(tui): scale transcript prompt gutter for compound prompt symbols

### DIFF
--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -106,6 +106,16 @@ describe('input metrics helpers', () => {
     expect(composerPromptWidth('Ψ >')).toBe(4)
   })
 
+  it('scales for compound prompt symbols (transcript gutter parity)', () => {
+    // messageLine.tsx reuses composerPromptWidth() so the saved transcript
+    // gutter accommodates the same wider prompt glyphs the composer does.
+    // Without this, compound branding glyphs were clipped against the old
+    // hardcoded width=3 and the message body visually attached to the
+    // glyph (#18996).
+    expect(composerPromptWidth('❯❯')).toBe(3)
+    expect(composerPromptWidth('❯❯❯')).toBe(4)
+  })
+
   it('reserves gutters on wide panes without starving narrow composer width', () => {
     expect(stableComposerColumns(100, 3)).toBe(93)
     expect(stableComposerColumns(100, 5)).toBe(91)


### PR DESCRIPTION
## What does this PR do?

`MessageLine` reserved a hard-coded `width={3}` for the role glyph gutter and rendered `{glyph}{' '}` inside it. For any skin whose `branding.prompt_symbol` rendered wider than two cells (compound prompts like `❯❯`, multi-codepoint branding glyphs, `Ψ >`), the trailing separator space was clipped and the message body visually attached to the prompt:

    ❯Okay        instead of        ❯ Okay

The composer side already shares one width formula: `composerPromptWidth()` in `lib/inputMetrics.ts` (`stringWidth(promptText) + COMPOSER_PROMPT_GAP_WIDTH`). This PR reuses that formula for the transcript gutter so the live composer and the saved transcript stay aligned for any prompt symbol width. The downstream content box is widened by the same formula so wider gutters don't squeeze the body.

## Related Issue

Fixes #18996

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/messageLine.tsx` — import `composerPromptWidth`; compute `gutterWidth = composerPromptWidth(glyph)` and use it for the `<NoSelect width={...}>` and the adjacent content `<Box width={...}>`.
- `ui-tui/src/__tests__/textInputWrap.test.ts` — extends the existing `composerPromptWidth` suite with the compound-prompt regression cases (`❯❯` → 3, `❯❯❯` → 4) the hardcoded gutter could no longer accommodate.

## How to Test

1. `cp ~/.hermes/skins/default.yaml ~/.hermes/skins/wide.yaml`
2. Edit `wide.yaml` so `branding.prompt_symbol: '❯❯'`
3. `hermes --tui --skin wide`, send a message.
4. Confirm sent message renders as `❯❯ Okay` (with a visible space), not `❯❯Okay`.
5. `cd ui-tui && npm test -- src/__tests__/textInputWrap.test.ts` → 18/18 pass.
6. `npm run type-check` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
cd ui-tui && npm test -- src/__tests__/textInputWrap.test.ts
# 18/18 pass
npm run type-check
# clean
```
