### PR TITLE
fix(gateway): strip MEDIA tags before chained /queue follow-up

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13251,6 +13251,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except OSError:
                     pass
 
+    async def _send_queued_followup_first_response(
+        self,
+        adapter,
+        source,
+        response: str,
+        metadata,
+        session_key,
+    ) -> None:
+        """Deliver the agent's first response before draining a queued
+        follow-up, stripping ``MEDIA:`` tags so chained ``/queue`` items
+        don't drop their attachments (#18539).
+
+        Without this, the queue-drain path called ``adapter.send(raw_text)``
+        directly — the per-item ``MEDIA:/path`` markers leaked through as
+        plain text and only the last queue item's files reached the
+        platform. Mirrors the normal ``_process_message_background`` path:
+        ``extract_media`` first, send the cleaned text, then upload each
+        file via ``send_voice`` (when flagged voice) or ``send_document``.
+        """
+        media_files, cleaned_text = adapter.extract_media(response)
+        await adapter.send(
+            source.chat_id,
+            cleaned_text,
+            metadata=metadata,
+        )
+        for media_path, is_voice in media_files or []:
+            try:
+                if is_voice and hasattr(adapter, "send_voice"):
+                    await adapter.send_voice(
+                        chat_id=source.chat_id,
+                        audio_path=media_path,
+                        metadata=metadata,
+                    )
+                else:
+                    await adapter.send_document(
+                        chat_id=source.chat_id,
+                        file_path=media_path,
+                        metadata=metadata,
+                    )
+            except Exception as media_err:
+                logger.warning(
+                    "Queued follow-up for session %s: failed to deliver MEDIA file %s: %s",
+                    session_key or "?", media_path, media_err,
+                )
+
     async def _deliver_media_from_response(
         self,
         response: str,
@@ -19980,10 +20025,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
+                            await self._send_queued_followup_first_response(
+                                adapter,
+                                source,
                                 first_response,
                                 metadata=_status_thread_metadata,
+                                session_key=session_key,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)

--- a/tests/gateway/test_queue_followup_media.py
+++ b/tests/gateway/test_queue_followup_media.py
@@ -1,0 +1,183 @@
+"""Regression tests for /queue FIFO MEDIA delivery (#18539).
+
+Before the fix, the queue-drain path in ``GatewayRunner._run_agent`` sent
+the first response with ``adapter.send(raw_text)`` directly. Per-item
+``MEDIA:/path`` markers leaked through as plain text and only the LAST
+queue item's media file reached the platform — preceding items had their
+attachments silently dropped (the file existed on disk but never
+uploaded).
+
+These tests target ``_send_queued_followup_first_response`` — the helper
+the queue-drain path now delegates to — and assert that:
+
+1. ``extract_media`` is called before ``send``.
+2. The cleaned (MEDIA-tag-free) text is what reaches ``adapter.send``.
+3. Each extracted file is uploaded via ``send_document`` or ``send_voice``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+def _stub_runner() -> GatewayRunner:
+    """A bare GatewayRunner just for invoking instance methods in tests.
+
+    ``object.__new__`` skips ``__init__`` so we don't need to stand up the
+    full gateway config / adapter set. The methods under test here only
+    touch their explicit arguments.
+    """
+    return object.__new__(GatewayRunner)
+
+
+def _stub_source():
+    return SimpleNamespace(chat_id="chat-1", platform="telegram", thread_id=None)
+
+
+@pytest.mark.asyncio
+async def test_extract_media_runs_before_send():
+    """The cleaned text — not the raw MEDIA-tagged response — must reach
+    ``adapter.send``. Otherwise users see literal ``MEDIA:/path`` lines
+    instead of the upload."""
+    runner = _stub_runner()
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_document = AsyncMock()
+    adapter.send_voice = AsyncMock()
+    adapter.extract_media = MagicMock(
+        return_value=([("/tmp/report.pdf", False)], "Here is the report.")
+    )
+
+    await runner._send_queued_followup_first_response(
+        adapter,
+        _stub_source(),
+        "Here is the report.\nMEDIA:/tmp/report.pdf",
+        metadata=None,
+        session_key="sess-1",
+    )
+
+    adapter.extract_media.assert_called_once_with(
+        "Here is the report.\nMEDIA:/tmp/report.pdf"
+    )
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "Here is the report.",
+        metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_documents_are_uploaded_via_send_document():
+    runner = _stub_runner()
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_document = AsyncMock()
+    adapter.send_voice = AsyncMock()
+    adapter.extract_media = MagicMock(
+        return_value=(
+            [
+                ("/tmp/a.pdf", False),
+                ("/tmp/b.csv", False),
+            ],
+            "Two files attached.",
+        )
+    )
+
+    await runner._send_queued_followup_first_response(
+        adapter,
+        _stub_source(),
+        "raw response with media tags",
+        metadata={"thread_id": "42"},
+        session_key="sess-1",
+    )
+
+    assert adapter.send_document.await_count == 2
+    adapter.send_document.assert_any_await(
+        chat_id="chat-1", file_path="/tmp/a.pdf", metadata={"thread_id": "42"}
+    )
+    adapter.send_document.assert_any_await(
+        chat_id="chat-1", file_path="/tmp/b.csv", metadata={"thread_id": "42"}
+    )
+    adapter.send_voice.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_voice_flagged_files_route_to_send_voice():
+    runner = _stub_runner()
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_document = AsyncMock()
+    adapter.send_voice = AsyncMock()
+    adapter.extract_media = MagicMock(
+        return_value=([("/tmp/note.ogg", True)], "Voice note attached.")
+    )
+
+    await runner._send_queued_followup_first_response(
+        adapter,
+        _stub_source(),
+        "Voice note attached. MEDIA:/tmp/note.ogg",
+        metadata=None,
+        session_key="sess-1",
+    )
+
+    adapter.send_voice.assert_awaited_once_with(
+        chat_id="chat-1", audio_path="/tmp/note.ogg", metadata=None
+    )
+    adapter.send_document.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_individual_file_failure_does_not_block_remaining_uploads():
+    """If one media upload raises, remaining files must still attempt
+    upload — losing one attachment is better than losing all."""
+    runner = _stub_runner()
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_document = AsyncMock(side_effect=[RuntimeError("S3 down"), None])
+    adapter.send_voice = AsyncMock()
+    adapter.extract_media = MagicMock(
+        return_value=(
+            [
+                ("/tmp/broken.pdf", False),
+                ("/tmp/ok.pdf", False),
+            ],
+            "Two files.",
+        )
+    )
+
+    await runner._send_queued_followup_first_response(
+        adapter,
+        _stub_source(),
+        "raw",
+        metadata=None,
+        session_key="sess-1",
+    )
+
+    assert adapter.send_document.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_media_just_sends_text():
+    """Responses with no MEDIA tags should behave exactly like the
+    pre-fix path: a single send() call, no document uploads."""
+    runner = _stub_runner()
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_document = AsyncMock()
+    adapter.send_voice = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], "Plain text response."))
+
+    await runner._send_queued_followup_first_response(
+        adapter,
+        _stub_source(),
+        "Plain text response.",
+        metadata=None,
+        session_key="sess-1",
+    )
+
+    adapter.send.assert_awaited_once()
+    adapter.send_document.assert_not_called()
+    adapter.send_voice.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Multiple `/queue` items chained in one session via the FIFO queue lost attachments on every item except the last. The queue-drain path in `_run_agent` called `adapter.send(first_response)` with the raw, `MEDIA:/path`-tagged response — so per-item file markers leaked through as plain text, the file existed on disk, but the upload never happened. The normal `_process_message_background` path runs `adapter.extract_media` before `adapter.send`; the queue path missed that gate.

Extract the queue-drain delivery into `_send_queued_followup_first_response` and run the same `extract_media` → `send(cleaned_text)` → `send_document` / `send_voice` per file pipeline as the normal path. `is_voice`-flagged files route through `send_voice` when the adapter exposes one, falling back to `send_document` so unsupported adapters still deliver instead of crashing. Per-file upload errors are logged but don't block remaining files — losing one attachment beats losing all.

## Related Issue

Fixes #18539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — replace the inline raw-send block in `_run_agent`'s queue-drain branch with a call to a new helper.
- `gateway/run.py` — new `_send_queued_followup_first_response()` method that mirrors the normal path's extract → send → upload-files pipeline.
- `tests/gateway/test_queue_followup_media.py` — new file, 5 tests: extract-before-send ordering, multi-document dispatch, voice routing, per-file failure containment, no-MEDIA preserves pre-fix behaviour.

## How to Test

1. In one session, run `/queue` twice with messages that produce MEDIA attachments (e.g. ask the agent for a chart and a PDF).
2. Before this PR: only the last item's attachment uploaded; the first appeared as raw `MEDIA:/path` text.
3. After: both attachments upload, both texts arrive cleanly.
4. `pytest tests/gateway/test_queue_consumption.py tests/gateway/test_queue_followup_media.py -q` → 16/16 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/gateway/test_queue_consumption.py tests/gateway/test_queue_followup_media.py -q
16 passed
```
