### PR TITLE
fix(cron): treat non-dict origin as missing instead of crashing tick

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -123,9 +123,19 @@ _LOCK_FILE = _LOCK_DIR / ".tick.lock"
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
-    """Extract origin info from a job, preserving any extra routing metadata."""
+    """Extract origin info from a job, preserving any extra routing metadata.
+
+    Treats non-dict origins (free-form provenance strings, ints, lists from
+    migration scripts or hand-edited jobs.json) as missing instead of
+    crashing with ``AttributeError`` on ``origin.get(...)``. Without this
+    guard, a job tagged with e.g. ``"combined-digest-replaces-x-and-y"``
+    crashed every fire attempt with
+    ``'str' object has no attribute 'get'`` — ``mark_job_run`` recorded the
+    failure, but the next tick re-loaded the same poisoned origin and
+    crashed identically until the field was patched manually (#18722).
+    """
     origin = job.get("origin")
-    if not origin:
+    if not isinstance(origin, dict):
         return None
     platform = origin.get("platform")
     chat_id = origin.get("chat_id")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -46,6 +46,29 @@ class TestResolveOrigin:
         job = {"origin": {}}
         assert _resolve_origin(job) is None
 
+    @pytest.mark.parametrize(
+        "non_dict_origin",
+        [
+            "combined-digest-replaces-x-and-y-20260503",
+            123,
+            ["telegram", "12345"],
+            ("platform", "chat_id"),
+            42.0,
+        ],
+    )
+    def test_non_dict_origin_returns_none_instead_of_crashing(self, non_dict_origin):
+        """Non-dict origins (provenance strings from hand-edited or migrated
+        jobs.json) must be treated as missing instead of crashing the
+        scheduler tick on ``origin.get('platform')`` with
+        ``'str' object has no attribute 'get'`` (#18722).
+
+        Before this guard a job in this state crashed every fire attempt
+        forever; ``mark_job_run`` recorded the error but the next tick
+        re-loaded the poisoned origin and crashed identically.
+        """
+        job = {"origin": non_dict_origin}
+        assert _resolve_origin(job) is None
+
 
 class TestResolveDeliveryTarget:
     def test_origin_delivery_preserves_thread_id(self):


### PR DESCRIPTION
## What does this PR do?

`_resolve_origin` called `origin.get('platform')` on whatever `job.get('origin')` returned. The leading `if not origin: return None` short-circuited the falsy cases (None, empty dict, "") but a non-empty string passed that guard and crashed with `AttributeError: 'str' object has no attribute 'get'` on every fire attempt. Observed in the wild after a migration script tagged jobs with free-form provenance strings (e.g. `"combined-digest-replaces-x-and-y-20260503"`).

`mark_job_run` did record `last_status: error, last_error: "'str' object has no attribute 'get'"` once, but the next tick re-loaded the same poisoned origin and crashed identically. The job stayed enabled and accumulated cascading errors until `origin` was patched manually.

Replace the falsy guard with `isinstance(origin, dict)`. Non-dict origins (string, int, list, tuple, float — anything that survived a hand-edit, JSON-script write, or migration) are now treated the same as a missing origin: the job continues with `deliver` falling back through its normal home-channel path instead of crashing the scheduler loop.

**Scope:** the non-dict-`origin` crash sub-bug from #18722. The `next_run_at: null` recurring-job recovery (the second sub-bug) is independently addressed by the in-flight #18825, which extends the never-silently-disable defense from #16265 to `get_due_jobs()`. Either one can land first.

## Related Issue

Fixes #18722 (non-dict origin crash; recurring-job recovery covered by #18825)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `_resolve_origin` guards `isinstance(origin, dict)` before `.get()` calls; updated docstring with the production trigger pattern.
- `tests/cron/test_scheduler.py` — `TestResolveOrigin.test_non_dict_origin_returns_none_instead_of_crashing` parametrises over the non-dict shapes (str, int, list, tuple, float).

## How to Test

1. Edit \`~/.hermes/cron/jobs.json\` and set a job's `origin` to a string like `"my-migration-tag"`.
2. Restart the gateway / wait for the cron tick.
3. Before this PR: every fire crashes with `AttributeError`; after: job runs with default delivery routing.
4. \`pytest tests/cron/test_scheduler.py::TestResolveOrigin -q\` → 10/10 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs (note: #18825 covers the sibling sub-bug; explicitly out of scope here)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and the touched suite passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A