### PR TITLE
fix(gateway,cron): persist Telegram forum topic on /sethome

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -27,7 +27,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -135,16 +135,55 @@ def _resolve_origin(job: dict) -> Optional[dict]:
 
 
 def _get_home_target_chat_id(platform_name: str) -> str:
-    """Return the configured home target chat/room ID for a delivery platform."""
+    """Return the configured home target chat/room ID for a delivery platform.
+
+    Strips an optional ``:thread_id`` suffix so callers that only need the
+    chat id keep working unchanged. Use ``_get_home_target(platform_name)``
+    for callers that also need the persisted thread / topic id (#18934).
+    """
+    chat_id, _ = _get_home_target(platform_name)
+    return chat_id
+
+
+def _get_home_target(platform_name: str) -> Tuple[str, Optional[str]]:
+    """Return the configured home target as ``(chat_id, thread_id_or_None)``.
+
+    The home-channel env var (``TELEGRAM_HOME_CHANNEL`` etc.) is persisted
+    by ``/sethome`` as either ``chat_id`` or ``chat_id:thread_id`` when the
+    command is run inside a forum topic / thread (#18934). Earlier
+    behaviour stored only ``chat_id`` and lost the topic, sending cron
+    reports to the parent chat instead of the configured topic.
+
+    Falls back to the legacy env-var name for backwards compatibility.
+    """
     env_var = _HOME_TARGET_ENV_VARS.get(platform_name.lower())
     if not env_var:
-        return ""
+        return "", None
     value = os.getenv(env_var, "")
     if not value:
         legacy = _LEGACY_HOME_TARGET_ENV_VARS.get(env_var)
         if legacy:
             value = os.getenv(legacy, "")
-    return value
+    if not value:
+        return "", None
+
+    # Parse ``chat_id:thread_id`` via the platform-aware ref parser so the
+    # same ``-1003984902686:1`` shape used by ``deliver: telegram:<...>``
+    # is accepted here. ``_parse_target_ref`` returns ``is_explicit=True``
+    # only when the platform's regex actually matched the topic form;
+    # otherwise we treat the whole value as the chat id.
+    try:
+        from tools.send_message_tool import _parse_target_ref
+
+        parsed_chat_id, parsed_thread_id, is_explicit = _parse_target_ref(
+            platform_name.lower(), value
+        )
+        if is_explicit:
+            return (parsed_chat_id or value, parsed_thread_id)
+    except Exception:
+        pass
+
+    return value, None
 
 
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
@@ -165,7 +204,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
         for platform_name in _HOME_TARGET_ENV_VARS:
-            chat_id = _get_home_target_chat_id(platform_name)
+            chat_id, thread_id = _get_home_target(platform_name)
             if chat_id:
                 logger.info(
                     "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
@@ -175,7 +214,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 return {
                     "platform": platform_name,
                     "chat_id": chat_id,
-                    "thread_id": None,
+                    "thread_id": thread_id,
                 }
         return None
 
@@ -222,14 +261,14 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if platform_name.lower() not in _KNOWN_DELIVERY_PLATFORMS:
         return None
-    chat_id = _get_home_target_chat_id(platform_name)
+    chat_id, thread_id = _get_home_target(platform_name)
     if not chat_id:
         return None
 
     return {
         "platform": platform_name,
         "chat_id": chat_id,
-        "thread_id": None,
+        "thread_id": thread_id,
     }
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7963,18 +7963,27 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
+        thread_id = source.thread_id
 
         env_key = _home_target_env_var(platform_name)
+
+        # Encode the home target as ``chat_id:thread_id`` when /sethome is run
+        # inside a Telegram forum topic / Discord thread / Feishu sub-thread,
+        # otherwise just ``chat_id``. Cron delivery's home-channel resolver
+        # parses both shapes via ``_parse_target_ref`` so reports land in the
+        # exact topic instead of the parent chat (#18934).
+        env_value = f"{chat_id}:{thread_id}" if thread_id else str(chat_id)
+        thread_suffix = f" (topic {thread_id})" if thread_id else ""
 
         # Save to .env so it persists across restarts
         try:
             from hermes_cli.config import save_env_value
-            save_env_value(env_key, str(chat_id))
+            save_env_value(env_key, env_value)
         except Exception as e:
             return f"Failed to save home channel: {e}"
 
         return (
-            f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
+            f"✅ Home channel set to **{chat_name}** (ID: {chat_id}{thread_suffix}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."
         )
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -145,6 +145,73 @@ class TestResolveDeliveryTarget:
             "thread_id": "17",
         }
 
+    def test_telegram_home_channel_preserves_thread_id_from_env(self, monkeypatch):
+        """When ``/sethome`` is run inside a Telegram forum topic the saved
+        env value is ``chat_id:thread_id``; cron delivery to ``telegram``
+        must hand the topic id back instead of dropping it (#18934).
+        """
+        for fallback_env in (
+            "TELEGRAM_HOME_CHANNEL",
+            "DISCORD_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(fallback_env, raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1003984902686:17")
+
+        assert _resolve_delivery_target({"deliver": "telegram"}) == {
+            "platform": "telegram",
+            "chat_id": "-1003984902686",
+            "thread_id": "17",
+        }
+
+    def test_telegram_home_channel_without_thread_id_remains_thread_none(self, monkeypatch):
+        """A pre-#18934 env value (``chat_id`` only, no ``:thread_id``) must
+        keep working — cron delivery returns ``thread_id: None`` rather than
+        crashing on the missing colon.
+        """
+        for fallback_env in (
+            "TELEGRAM_HOME_CHANNEL",
+            "DISCORD_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(fallback_env, raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1003984902686")
+
+        assert _resolve_delivery_target({"deliver": "telegram"}) == {
+            "platform": "telegram",
+            "chat_id": "-1003984902686",
+            "thread_id": None,
+        }
+
+    def test_telegram_origin_fallback_to_home_preserves_thread_id(self, monkeypatch):
+        """``deliver: origin`` with no origin falls back to a configured
+        home channel; the home channel's persisted topic id must survive
+        that fallback (#18934).
+        """
+        for fallback_env in (
+            "TELEGRAM_HOME_CHANNEL",
+            "DISCORD_HOME_CHANNEL",
+            "MATRIX_HOME_ROOM",
+            "MATRIX_HOME_CHANNEL",
+            "SLACK_HOME_CHANNEL",
+            "SIGNAL_HOME_CHANNEL",
+            "MATTERMOST_HOME_CHANNEL",
+            "SMS_HOME_CHANNEL",
+            "EMAIL_HOME_ADDRESS",
+            "DINGTALK_HOME_CHANNEL",
+            "BLUEBUBBLES_HOME_CHANNEL",
+            "FEISHU_HOME_CHANNEL",
+            "WECOM_HOME_CHANNEL",
+            "WEIXIN_HOME_CHANNEL",
+            "QQ_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(fallback_env, raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1003984902686:42")
+
+        assert _resolve_delivery_target({"deliver": "origin"}) == {
+            "platform": "telegram",
+            "chat_id": "-1003984902686",
+            "thread_id": "42",
+        }
+
     def test_explicit_telegram_chat_id_without_thread_id(self):
         """deliver: 'telegram:chat_id' sets thread_id to None."""
         job = {


### PR DESCRIPTION
## What does this PR do?

`/sethome` saved the bare `chat_id` to `TELEGRAM_HOME_CHANNEL` (and sibling `*_HOME_CHANNEL` env vars) and dropped the forum topic / thread id when run inside a Telegram forum topic. Cron reports configured for `deliver: telegram` landed in the parent chat instead of the configured topic, with no log signal and a successful-looking `/sethome` confirmation message.

The cron delivery code already supported `chat_id:thread_id` shape via `deliver: telegram:<chat_id>:<thread_id>` (parsed by `tools.send_message_tool._parse_target_ref`). This PR makes the home channel use the same encoding so the topic survives the env-var round trip.

Pre-#18934 env values without `:thread_id` continue to resolve as `thread_id: None` — no migration needed.

**Scope:** the `/sethome` topic-persistence sub-bug from #18934. The `cron deliver=telegram prefers origin over home` sub-bug is intentionally out of scope and could ship as a follow-up.

## Related Issue

Fixes #18934 (sethome topic persistence; deliver origin-vs-home priority deferred)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `_handle_set_home_command` writes `f"{chat_id}:{thread_id}"` when `source.thread_id` is non-empty; confirmation message surfaces the topic id.
- `cron/scheduler.py` — new `_get_home_target(platform_name)` returns `(chat_id, thread_id)` after parsing via `_parse_target_ref`. `_get_home_target_chat_id` wraps it for back-compat string callers. Both home-channel branches in `_resolve_single_delivery_target` (deliver=origin fallback, bare deliver=<platform>) hand the parsed thread id back.
- `tests/cron/test_scheduler.py` — three new tests covering `chat_id:thread_id`, plain `chat_id` back-compat, and origin-fallback topic preservation.

## How to Test

1. In a Telegram forum topic, run \`/sethome\`. Check `~/.hermes/.env`: `TELEGRAM_HOME_CHANNEL=<chat_id>:<thread_id>`. Confirmation message shows the topic id.
2. Schedule a cron job with `deliver: telegram` from another chat.
3. Before this PR: report lands in the parent chat. After: it lands in the configured topic.
4. Existing pre-#18934 `TELEGRAM_HOME_CHANNEL=<chat_id>` values keep working.
5. \`pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q\` → 30/30 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and the touched suite passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (env var format is internal; the Telegram-topic shape was already documented for `deliver:` keys)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var change only)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (gateway-side, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A