### PR TITLE
fix(feishu): wrap pipe tables in code fences so columns survive

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -159,6 +159,15 @@ _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+# Markdown table detection — Feishu's post `md` tag does NOT support pipe
+# table syntax, so contiguous table blocks must be wrapped in a code fence
+# (which the post payload renders as monospace) to keep the columns
+# visible. Without this, tables silently disappear from outgoing messages
+# (#18756).
+_MARKDOWN_TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$")
+_MARKDOWN_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?\s*$"
+)
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
@@ -558,6 +567,73 @@ def _build_markdown_post_payload(content: str) -> str:
     )
 
 
+def _wrap_markdown_tables_in_fences(content: str) -> str:
+    r"""Wrap contiguous Markdown pipe-table blocks in code fences.
+
+    Feishu's post ``md`` tag does NOT support Markdown table syntax — table
+    rows are silently dropped on outbound. Wrapping each detected table
+    block in a triple-backtick fence routes it through the existing
+    code-block handling in ``_build_markdown_post_rows``, which renders
+    monospace text inside its own row. The columns stay visible (#18756).
+
+    A table is detected as: a row matching ``_MARKDOWN_TABLE_ROW_RE``
+    immediately followed by a separator row (``|---|---|...``) followed by
+    zero or more additional table rows. Lines inside an existing fenced
+    code block are left untouched.
+    """
+    if "|" not in content:
+        return content
+
+    lines = content.splitlines()
+    out: List[str] = []
+    in_code_block = False
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        # Toggle fence-state so we don't double-wrap tables that already
+        # live inside a user-authored code fence.
+        if not in_code_block and _MARKDOWN_FENCE_OPEN_RE.match(stripped):
+            out.append(line)
+            in_code_block = True
+            i += 1
+            continue
+        if in_code_block and _MARKDOWN_FENCE_CLOSE_RE.match(stripped):
+            out.append(line)
+            in_code_block = False
+            i += 1
+            continue
+        if in_code_block:
+            out.append(line)
+            i += 1
+            continue
+
+        # Detect: header row → separator row → 0+ data rows.
+        if (
+            _MARKDOWN_TABLE_ROW_RE.match(line)
+            and i + 1 < n
+            and _MARKDOWN_TABLE_SEPARATOR_RE.match(lines[i + 1].strip())
+        ):
+            table_block: List[str] = [line, lines[i + 1]]
+            j = i + 2
+            while j < n and _MARKDOWN_TABLE_ROW_RE.match(lines[j]):
+                table_block.append(lines[j])
+                j += 1
+            out.append("```")
+            out.extend(table_block)
+            out.append("```")
+            i = j
+            continue
+
+        out.append(line)
+        i += 1
+
+    return "\n".join(out)
+
+
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     """Build Feishu post rows while isolating fenced code blocks.
 
@@ -565,9 +641,14 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     appears inside one large markdown element. Split the reply at real fence
     lines so prose before/after the code block remains visible while code stays
     in a dedicated row.
+
+    Markdown pipe tables are also rewritten into fenced code blocks before
+    splitting, because Feishu's ``md`` renderer does not support pipe-table
+    syntax and would silently drop the table (#18756).
     """
     if not content:
         return [[{"tag": "md", "text": ""}]]
+    content = _wrap_markdown_tables_in_fences(content)
     if "```" not in content:
         return [[{"tag": "md", "text": content}]]
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2706,6 +2706,96 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_wraps_pipe_table_in_code_fence(self):
+        """Pipe tables are silently dropped by Feishu's md tag, so wrap each
+        contiguous table block in a code fence so the columns survive (#18756).
+        """
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = (
+            "Comparison results:\n"
+            "| Model | Tokens | Latency |\n"
+            "|-------|--------|---------|\n"
+            "| A     | 1024   | 800ms   |\n"
+            "| B     | 2048   | 1500ms  |\n"
+            "Conclusion: A wins."
+        )
+        payload = json.loads(adapter._build_post_payload(content))
+
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [{"tag": "md", "text": "Comparison results:"}],
+                [
+                    {
+                        "tag": "md",
+                        "text": (
+                            "```\n"
+                            "| Model | Tokens | Latency |\n"
+                            "|-------|--------|---------|\n"
+                            "| A     | 1024   | 800ms   |\n"
+                            "| B     | 2048   | 1500ms  |\n"
+                            "```"
+                        ),
+                    }
+                ],
+                [{"tag": "md", "text": "Conclusion: A wins."}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_leaves_table_inside_existing_code_block_untouched(self):
+        """A pipe table that is already inside a user-authored code fence
+        must NOT be double-wrapped (#18756)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = (
+            "Sample:\n"
+            "```\n"
+            "| a | b |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+            "```\n"
+            "Done."
+        )
+        payload = json.loads(adapter._build_post_payload(content))
+
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [{"tag": "md", "text": "Sample:"}],
+                [
+                    {
+                        "tag": "md",
+                        "text": "```\n| a | b |\n|---|---|\n| 1 | 2 |\n```",
+                    }
+                ],
+                [{"tag": "md", "text": "Done."}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_ignores_pipes_without_separator_row(self):
+        """A line with pipe characters but NO separator row underneath is not
+        a Markdown table — leave it as inline markdown so single-line uses
+        of pipes (e.g. union types ``Foo | Bar``) are not falsely wrapped."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "Type signature: ``f(x: int | str) -> bool``."
+        payload = json.loads(adapter._build_post_payload(content))
+
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [[{"tag": "md", "text": content}]],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_falls_back_to_text_when_post_payload_is_rejected(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

Feishu's post `md` tag does NOT support Markdown table syntax. When `_build_markdown_post_rows` passed a pipe-table block straight through, Feishu's renderer silently dropped the table — the user saw nothing where the comparison/results table should have appeared. The post-payload fallback to plain text didn't preserve column structure either.

Add a `_wrap_markdown_tables_in_fences` pre-pass that detects contiguous pipe-table blocks (header row → `|---|---|...` separator → zero or more data rows) and wraps each in a triple-backtick fence. The existing fence handling in `_build_markdown_post_rows` then routes the wrapped block into its own row as monospace text, keeping every column visible.

Tables already inside a user-authored code fence are left untouched (the open/close fence state-machine skips the table-detection branch). Single-line pipe usage like type signatures (`int | str`) is not a table candidate because the separator-row check is required.

## Related Issue

Fixes #18756

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py` — new `_MARKDOWN_TABLE_ROW_RE` and `_MARKDOWN_TABLE_SEPARATOR_RE`; new `_wrap_markdown_tables_in_fences()` helper invoked at top of `_build_markdown_post_rows`.
- `tests/gateway/test_feishu.py` — three new tests: `test_build_post_payload_wraps_pipe_table_in_code_fence`, `test_build_post_payload_leaves_table_inside_existing_code_block_untouched`, `test_build_post_payload_ignores_pipes_without_separator_row`.

## How to Test

1. From the Feishu gateway, send a message that contains a Markdown pipe table.
2. Before this PR: the table is missing in Feishu. After: it appears inside a monospace code block with all columns intact.
3. `pytest tests/gateway/test_feishu.py -k "post_payload or fenced or table" -q` → 11/11 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (gateway-side text rendering)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/gateway/test_feishu.py -k "post_payload or fenced or table" -q
11 passed
```
