### PR TITLE
fix(memory): clean up failed plugin submodules from sys.modules

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -253,12 +253,21 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
                         sub_spec.loader.exec_module(sub_mod)
                     except Exception as e:
                         logger.debug("Failed to load submodule %s: %s", full_sub_name, e)
+                        # Remove partially loaded submodule from sys.modules so it
+                        # doesn't poison future import attempts.
+                        sys.modules.pop(full_sub_name, None)
 
         try:
             spec.loader.exec_module(mod)
         except Exception as e:
             logger.debug("Failed to exec_module %s: %s", module_name, e)
+            # Clean up the main module AND any pre-loaded submodules from
+            # sys.modules so that a future load attempt starts fresh.
             sys.modules.pop(module_name, None)
+            for _sub in provider_dir.glob("*.py"):
+                if _sub.name == "__init__.py":
+                    continue
+                sys.modules.pop(f"{module_name}.{_sub.stem}", None)
             return None
 
     # Try register(ctx) pattern first (how our plugins are written)


### PR DESCRIPTION
## Problem

When a memory provider plugin fails to load during initialization, partially loaded submodules remain in `sys.modules`. This poisons all subsequent import attempts for that provider, causing it to be silently unavailable until the host process is restarted.

### Root cause

`_load_provider_from_dir()` pre-loads all `.py` files in the plugin directory as submodules and registers them in `sys.modules` **before** executing them:

```python
sys.modules[full_sub_name] = sub_mod  # registered immediately
try:
    sub_spec.loader.exec_module(sub_mod)  # may fail
except Exception:
    pass  # submodule stays in sys.modules in broken state
```

If a submodule fails to load, it remains in `sys.modules` as a broken placeholder. When the main module (`__init__.py`) later tries `from .failed_submodule import ...`, it receives the broken module object and fails.

When `exec_module` for the main module fails, only the main module was removed from `sys.modules`:

```python
sys.modules.pop(module_name, None)  # main module removed
return None  # but pre-loaded submodules remain!
```

### Impact

- Affects **all** memory providers with multiple Python files (hindsight, honcho, mem0, etc.)
- Once triggered, the provider becomes permanently unavailable for the lifetime of the process
- Silent failure — only a `logger.debug()` message, no warning or error

## Fix

1. **Remove failed submodules immediately** — when a submodule fails to load, pop it from `sys.modules`
2. **Clean up all pre-loaded submodules on main module failure** — when `exec_module` fails, iterate over all `.py` files in the plugin directory and remove any that were pre-registered

## Testing

Verified that:
- Provider loads correctly when all submodules are healthy
- After a failed load, subsequent load attempts start fresh (no sys.modules pollution)
- No change to successful load behavior