### PR TITLE
fix(kanban): profile discovery ignores HERMES_HOME in custom-root deployments

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2661,7 +2661,8 @@ def list_profiles_on_disk() -> list[str]:
     ``config.yaml`` — a bare dir without config isn't a real profile.
     """
     try:
-        home = Path.home() / ".hermes" / "profiles"
+        from hermes_constants import get_default_hermes_root
+        home = get_default_hermes_root() / "profiles"
     except Exception:
         return []
     if not home.is_dir():

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -902,15 +902,30 @@ def test_list_profiles_on_disk(tmp_path, monkeypatch):
     """list_profiles_on_disk returns directories under ~/.hermes/profiles/
     that contain a config.yaml."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
     profiles = tmp_path / ".hermes" / "profiles"
     profiles.mkdir(parents=True)
-    (profiles / "researcher").mkdir()
-    (profiles / "researcher" / "config.yaml").write_text("model: {}\n")
-    (profiles / "writer").mkdir()
-    (profiles / "writer" / "config.yaml").write_text("model: {}\n")
+    for name in ("researcher", "writer"):
+        d = profiles / name
+        d.mkdir()
+        (d / "config.yaml").write_text("model: {}\n")
     (profiles / "empty_dir").mkdir()
     # A stray file; should be ignored.
     (profiles / "stray.txt").write_text("noise")
+
+    names = kb.list_profiles_on_disk()
+    assert names == ["researcher", "writer"]
+
+
+def test_list_profiles_on_disk_custom_root(tmp_path, monkeypatch):
+    """list_profiles_on_disk respects a custom HERMES_HOME root."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    profiles = tmp_path / "profiles"
+    profiles.mkdir(parents=True)
+    for name in ("researcher", "writer"):
+        d = profiles / name
+        d.mkdir()
+        (d / "config.yaml").write_text("model: {}\n")
 
     names = kb.list_profiles_on_disk()
     assert names == ["researcher", "writer"]


### PR DESCRIPTION
## What does this PR do?

`list_profiles_on_disk()` in `kanban_db.py` hardcodes `Path.home() / ".hermes" / "profiles"`,
so `hermes kanban init` always reports "No profiles found" on custom-root deployments
(e.g. Docker with `HERMES_HOME=/opt/data`), even when valid profiles exist under
`$HERMES_HOME/profiles/`.

This PR switches `list_profiles_on_disk()` to use `get_default_hermes_root()`,
making profile discovery consistent with how `kanban_db_path()` and `workspaces_root()`
were fixed in #18985.


## Related Issue

Fixes #19017 
Related to #18442, #18985

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: replace `Path.home() / ".hermes" / "profiles"` with
  `get_default_hermes_root() / "profiles"` in `list_profiles_on_disk()`
- `tests/hermes_cli/test_kanban_core_functionality.py`: add
  `monkeypatch.delenv("HERMES_HOME", raising=False)` to existing test, and add
  new `test_list_profiles_on_disk_custom_root` to cover custom HERMES_HOME case
## How to Test

1. Create a fresh directory with a profile under a custom root:

   mkdir hermes-test && cd hermes-test
   mkdir -p data/profiles/my-agent
   echo "model: {}" > data/profiles/my-agent/config.yaml

2. Run kanban init with Docker:

   docker run --rm \
     -e HERMES_HOME=/data \
     -v $(pwd)/data:/data \
     nousresearch/hermes-agent \
     hermes kanban init

3. Expected output includes:

   Discovered 1 profile(s) on disk; any of these can be an --assignee:
     my-agent

   Before this fix, the output was:
   "No profiles found under ~/.hermes/profiles."

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping
 
All N/A