### PR TITLE
test(credential_pool): align with .env-first seed precedence

### DIFF
--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -106,10 +106,22 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert active_sources == set()
         assert entries == []
 
-    def test_os_environ_still_wins_over_dotenv(self, isolated_hermes_home, monkeypatch):
-        """get_env_value checks os.environ first — verify seeding picks that up."""
-        _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="sk-dotenv-stale")
-        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-fresh-xyz")
+    def test_dotenv_wins_over_os_environ(self, isolated_hermes_home, monkeypatch):
+        """
+        ``_seed_from_env`` deliberately prefers ``~/.hermes/.env`` over
+        ``os.environ`` (commit 2ef1ad280, fixes #18254). Stale env vars
+        inherited from parent shells (Codex CLI, test scripts, ...) must
+        not shadow deliberate edits to the .env file — otherwise
+        ``auth.json`` caches an outdated key and the user hits silent 401s
+        until they manually clear the cache.
+
+        Note: this is the **opposite** precedence from
+        :func:`hermes_cli.config.get_env_value` (which is os.environ-first).
+        ``_seed_from_env`` uses its own ``_get_env_prefer_dotenv`` helper
+        on purpose; if that ever flips back, this test catches it.
+        """
+        _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="sk-dotenv-authoritative")
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-stale-from-parent-shell")
 
         from agent.credential_pool import _seed_from_env
         entries = []
@@ -118,7 +130,7 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert changed is True
         seeded = [e for e in entries if e.source == "env:DEEPSEEK_API_KEY"]
         assert len(seeded) == 1
-        assert seeded[0].access_token == "sk-env-fresh-xyz"
+        assert seeded[0].access_token == "sk-dotenv-authoritative"
 
 
 class TestAuthResolvesFromDotEnv:


### PR DESCRIPTION
## Summary

Fixes one `Tests` failure observed on `main` (and therefore propagating to every open PR):

```
FAILED tests/tools/test_credential_pool_env_fallback.py::TestCredentialPoolSeedsFromDotEnv::test_os_environ_still_wins_over_dotenv
  AssertionError: assert 'sk-dotenv-stale' == 'sk-env-fresh-xyz'
```

Reference run: [25250051126](https://github.com/NousResearch/hermes-agent/actions/runs/25250051126) on `5d3be898a`.

## Root cause

The test docstring says:

> `get_env_value` checks `os.environ` first — verify seeding picks that up.

…which **was** true for `_seed_from_env` until commit [2ef1ad280](https://github.com/NousResearch/hermes-agent/commit/2ef1ad280) ("fix: prefer ~/.hermes/.env over os.environ when seeding credential pool", fixes #18254). That commit introduced a private `_get_env_prefer_dotenv` helper and **deliberately flipped** the precedence:

```python
# Prefer ~/.hermes/.env over os.environ — the user's config file is the
# authoritative source for Hermes credentials. Stale env vars from parent
# processes (Codex CLI, test scripts, etc.) should not override deliberate
# changes to the .env file.
def _get_env_prefer_dotenv(key: str) -> str:
    env_file = load_env()
    val = env_file.get(key) or os.environ.get(key) or ""
    return val.strip()
```

The fix was correct (#18254 reported real users hitting silent 401s with stale `auth.json` caches), but the unit test was never updated to match.

## Fix

Rename + rewrite the test to assert the **current**, deliberate behaviour: `.env` wins over `os.environ`, with a docstring explaining *why* (stale shell env vars from parent processes shadowing deliberate `.env` edits, leading to cached 401s in `auth.json`).

The cousin `Auth*` tests below already exercise `os.environ`-first semantics for `_resolve_api_key_provider_secret` (which still uses `get_env_value`), so the two precedence policies are both pinned now.

## Validation

```
$ pytest tests/tools/test_credential_pool_env_fallback.py -q
9 passed in 1.59s
```

## Refs

- #18254 — bug report that motivated the precedence flip
- 2ef1ad280 — the precedence flip commit
- #18757 — cousin: `os.getenv` → `get_env_value` fix on `auth.py` base_url path

## Scope

- ✅ No production code change (test-only)
- ✅ All 9 tests in the file pass
- ✅ Test name + docstring now accurately describe the contract

## Out of scope

The other ~10 main-CI failures — separate focused PRs (#18972, #18974, #18977, #18979 already up).
