### PR TITLE
test(docker): align Dockerfile contract tests with simplified TUI flow

### DIFF
--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -106,8 +106,15 @@ def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
 
 
 def test_dockerfile_installs_tui_dependencies(dockerfile_text):
+    # The TUI workspace manifests must be present so ``npm install`` can
+    # resolve dependencies. The bundled ``hermes-ink`` workspace package is
+    # now COPIED into the image as a whole tree (not just its lockfile)
+    # because it's referenced as a ``file:`` workspace dependency from
+    # ``ui-tui/package.json`` — copying the tree avoids npm stopping at a
+    # bare ``package.json`` shell.
     assert "ui-tui/package.json" in dockerfile_text
-    assert "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
+    assert "ui-tui/package-lock.json" in dockerfile_text
+    assert "ui-tui/packages/hermes-ink/" in dockerfile_text
     assert any(
         "ui-tui" in step and "npm" in step and (" install" in step or " ci" in step)
         for step in _run_steps(dockerfile_text)
@@ -122,16 +129,17 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
 
 
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
-    assert any(
-        "ui-tui" in step
-        and "node_modules/@hermes/ink" in step
-        and "packages/hermes-ink" in step
-        and "rm -rf packages/hermes-ink/node_modules" in step
-        and "npm install --omit=dev" in step
-        and "--prefix node_modules/@hermes/ink" in step
-        and "rm -rf node_modules/@hermes/ink/node_modules/react" in step
-        and "await import('@hermes/ink')" in step
-        for step in _run_steps(dockerfile_text)
+    # ``hermes-ink`` is a bundled workspace package referenced from
+    # ``ui-tui/package.json`` via ``file:`` — not pulled from the npm
+    # registry. The contract this test pins is just that the image
+    # actually carries the package source so ``await import('@hermes/ink')``
+    # can resolve at runtime; the previous, much pickier assertion (manual
+    # ``rm -rf`` + ``npm install --omit=dev --prefix node_modules/@hermes/ink``)
+    # baked in implementation details of an older materialisation flow that
+    # was simplified once npm workspaces handled the resolution natively.
+    assert "ui-tui/packages/hermes-ink/" in dockerfile_text, (
+        "Dockerfile must COPY the bundled hermes-ink workspace package "
+        "so ``await import('@hermes/ink')`` resolves at runtime."
     )
 
 


### PR DESCRIPTION
## Summary

Fixes two `Tests` failures observed on `main` (and therefore propagating to every open PR):

```
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_installs_tui_dependencies
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_materializes_local_tui_ink_package
```

Reference run: [25250051126](https://github.com/NousResearch/hermes-agent/actions/runs/25250051126) on `5d3be898a`.

## Root cause

The Dockerfile dropped the manual `@hermes/ink` materialisation gymnastics in favour of letting npm workspaces resolve the bundled package naturally. Two contract tests still asserted the older flow.

`test_dockerfile_installs_tui_dependencies` required:

```python
assert "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
```

…but the lockfile is no longer `COPY`'d individually — the entire `ui-tui/packages/hermes-ink/` tree is `COPY`'d instead (the workspace reference from `ui-tui/package.json` is `file:` so npm needs the real source, not just a manifest stub).

`test_dockerfile_materializes_local_tui_ink_package` required a 7-clause conjunction matching very specific `rm -rf` / `npm install --omit=dev` / `--prefix node_modules/@hermes/ink` / `rm -rf .../react` invocations that were stripped out when the workspace resolution was simplified.

## Fix

Pin the **contract** the image has to satisfy (zombie reaping + bundled workspace package resolves) rather than the **exact shell incantations** the old flow used:

* TUI deps install: `ui-tui/package.json` + `ui-tui/package-lock.json` + `ui-tui/packages/hermes-ink/` tree are all `COPY`'d, and an `npm install`/`ci` step runs in `ui-tui`.
* Bundled hermes-ink: the workspace package source is `COPY`'d (so `await import('@hermes/ink')` resolves at runtime).

Keeps the spirit of #15012 (zombie reaping) / #16690 (bundled workspace materialisation) without locking the Dockerfile into one specific implementation flavour.

## Validation

```
$ pytest tests/tools/test_dockerfile_pid1_reaping.py -q
6 passed in 1.43s
```

## Scope

- ✅ No production code change (test-only)
- ✅ All 6 dockerfile contract tests pass
- ✅ The pid1/tini contract (the actual reason the file exists) is unchanged

## Out of scope

The other ~9 main-CI failures — separate focused PRs (#18972, #18974, #18977, #18979 already up; #18980 dotenv inbound; this one is the next).
