### PR TITLE
fix(web): add ignoreDeprecations for TS6 baseUrl deprecation

### DIFF
--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -18,6 +18,7 @@
 
     /* Path aliases */
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
TypeScript 6.0.3 marks `baseUrl` as deprecated with a hard error by default, causing the dashboard build to fail after the TS 6.0.3 update.

**Problem:** `hermes update` fails to build the web dashboard because TS 6.0.3 errors on `baseUrl` in tsconfig.app.json.

**Fix:** Add `ignoreDeprecations: '6.0'` to silence the error and allow the build to succeed. This is a temporary measure until path aliases can be migrated away from baseUrl/paths.

See https://aka.ms/ts6 for context.