### PR TITLE
fix(tui): respect voice.record_key config instead of hardcoded Ctrl+B

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5120,8 +5120,15 @@ def _(rid, params: dict) -> dict:
         # Mirror CLI's _show_voice_status: include STT/TTS provider
         # availability so the user can tell at a glance *why* voice mode
         # isn't working ("STT provider: MISSING ..." is the common case).
+        # ``record_key`` mirrors the configured ``voice.record_key`` so the
+        # TUI can both bind it (frontend ``isVoiceToggleKey``) and display
+        # it in /voice status — previously the TUI hardcoded Ctrl+B and
+        # ignored the config (#18994).
         payload: dict = {
             "enabled": _voice_mode_enabled(),
+            "record_key": str(
+                (_load_cfg().get("voice") or {}).get("record_key") or "ctrl+b"
+            ),
             "tts": _voice_tts_enabled(),
         }
         try:
@@ -5158,7 +5165,16 @@ def _(rid, params: dict) -> dict:
             except Exception as e:
                 logger.warning("voice: stop_continuous failed during toggle off: %s", e)
 
-        return _ok(rid, {"enabled": enabled, "tts": _voice_tts_enabled()})
+        return _ok(
+            rid,
+            {
+                "enabled": enabled,
+                "record_key": str(
+                    (_load_cfg().get("voice") or {}).get("record_key") or "ctrl+b"
+                ),
+                "tts": _voice_tts_enabled(),
+            },
+        )
 
     if action == "tts":
         if not _voice_mode_enabled():

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -90,13 +90,10 @@ describe('isVoiceToggleKey', () => {
 })
 
 describe('parseVoiceRecordKey (#18994)', () => {
-  it('falls back to Ctrl+B for empty / malformed input', async () => {
+  it('falls back to Ctrl+B for empty input', async () => {
     const { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } = await importPlatform('linux')
 
     expect(parseVoiceRecordKey('')).toEqual(DEFAULT_VOICE_RECORD_KEY)
-    // Multi-character chunks are unsupported (CLI binds single keys), so a
-    // typo like "ctrl+space" falls back to the doc default.
-    expect(parseVoiceRecordKey('ctrl+space')).toEqual(DEFAULT_VOICE_RECORD_KEY)
   })
 
   it('parses ctrl+<letter> bindings', async () => {
@@ -116,6 +113,37 @@ describe('parseVoiceRecordKey (#18994)', () => {
     expect(parseVoiceRecordKey('super+b').mod).toBe('super')
     expect(parseVoiceRecordKey('win+b').mod).toBe('super')
   })
+
+  it('parses named keys (space, enter, tab, escape, backspace, delete)', async () => {
+    const { parseVoiceRecordKey } = await importPlatform('linux')
+
+    // Every named token from the CLI's prompt_toolkit ``c-<name>`` set is
+    // accepted with both the canonical name and its common alias.
+    expect(parseVoiceRecordKey('ctrl+space')).toEqual({
+      ch: 'space',
+      mod: 'ctrl',
+      named: 'space',
+      raw: 'ctrl+space'
+    })
+    expect(parseVoiceRecordKey('alt+enter').named).toBe('enter')
+    expect(parseVoiceRecordKey('alt+return').named).toBe('enter') // ``return`` ↔ ``enter``
+    expect(parseVoiceRecordKey('ctrl+tab').named).toBe('tab')
+    expect(parseVoiceRecordKey('ctrl+escape').named).toBe('escape')
+    expect(parseVoiceRecordKey('ctrl+esc').named).toBe('escape') // ``esc`` alias
+    expect(parseVoiceRecordKey('ctrl+backspace').named).toBe('backspace')
+    expect(parseVoiceRecordKey('ctrl+delete').named).toBe('delete')
+    expect(parseVoiceRecordKey('ctrl+del').named).toBe('delete') // ``del`` alias
+  })
+
+  it('falls back to Ctrl+B for unrecognised multi-character tokens', async () => {
+    const { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } = await importPlatform('linux')
+
+    // Typos / unsupported names (``ctrl+spcae``, ``ctrl+f5``, …) fall back
+    // to the documented Ctrl+B default rather than silently disabling the
+    // binding.
+    expect(parseVoiceRecordKey('ctrl+spcae')).toEqual(DEFAULT_VOICE_RECORD_KEY)
+    expect(parseVoiceRecordKey('ctrl+f5')).toEqual(DEFAULT_VOICE_RECORD_KEY)
+  })
 })
 
 describe('formatVoiceRecordKey (#18994)', () => {
@@ -126,6 +154,14 @@ describe('formatVoiceRecordKey (#18994)', () => {
     expect(formatVoiceRecordKey(parseVoiceRecordKey('ctrl+o'))).toBe('Ctrl+O')
     expect(formatVoiceRecordKey(parseVoiceRecordKey('alt+r'))).toBe('Alt+R')
     expect(formatVoiceRecordKey(parseVoiceRecordKey('cmd+b'))).toBe('Cmd+B')
+  })
+
+  it('renders named keys in title case (Ctrl+Space, Ctrl+Enter)', async () => {
+    const { formatVoiceRecordKey, parseVoiceRecordKey } = await importPlatform('linux')
+
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('ctrl+space'))).toBe('Ctrl+Space')
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('alt+enter'))).toBe('Alt+Enter')
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('ctrl+esc'))).toBe('Ctrl+Escape')
   })
 })
 
@@ -146,6 +182,35 @@ describe('isVoiceToggleKey honours configured record key (#18994)', () => {
     expect(isVoiceToggleKey({ alt: true, ctrl: false, meta: false, super: false }, 'r', altR)).toBe(true)
     expect(isVoiceToggleKey({ ctrl: false, meta: true, super: false }, 'r', altR)).toBe(true)
     expect(isVoiceToggleKey({ ctrl: false, meta: false, super: false }, 'r', altR)).toBe(false)
+  })
+
+  it('binds named keys via ink event flags (space → ch === " ", enter → key.return, …)', async () => {
+    const { isVoiceToggleKey, parseVoiceRecordKey } = await importPlatform('linux')
+
+    const ctrlSpace = parseVoiceRecordKey('ctrl+space')
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, ' ', ctrlSpace)).toBe(true)
+    // Single-char ``b`` must NOT match a ``space``-configured binding.
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'b', ctrlSpace)).toBe(false)
+    // Space without the configured modifier must not fire either.
+    expect(isVoiceToggleKey({ ctrl: false, meta: false, super: false }, ' ', ctrlSpace)).toBe(false)
+
+    const ctrlEnter = parseVoiceRecordKey('ctrl+enter')
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, return: true, super: false }, '', ctrlEnter)).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, return: false, super: false }, '', ctrlEnter)).toBe(false)
+
+    const altTab = parseVoiceRecordKey('alt+tab')
+    expect(isVoiceToggleKey({ alt: true, ctrl: false, meta: false, super: false, tab: true }, '', altTab)).toBe(true)
+    expect(isVoiceToggleKey({ alt: false, ctrl: false, meta: false, super: false, tab: true }, '', altTab)).toBe(false)
+
+    const ctrlEscape = parseVoiceRecordKey('ctrl+escape')
+    expect(isVoiceToggleKey({ ctrl: true, escape: true, meta: false, super: false }, '', ctrlEscape)).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: true, escape: false, meta: false, super: false }, '', ctrlEscape)).toBe(false)
+
+    const ctrlBackspace = parseVoiceRecordKey('ctrl+backspace')
+    expect(isVoiceToggleKey({ backspace: true, ctrl: true, meta: false, super: false }, '', ctrlBackspace)).toBe(true)
+
+    const ctrlDelete = parseVoiceRecordKey('ctrl+delete')
+    expect(isVoiceToggleKey({ ctrl: true, delete: true, meta: false, super: false }, '', ctrlDelete)).toBe(true)
   })
 
   it('omitted configured key falls back to ctrl+b (back-compat)', async () => {

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -89,6 +89,74 @@ describe('isVoiceToggleKey', () => {
   })
 })
 
+describe('parseVoiceRecordKey (#18994)', () => {
+  it('falls back to Ctrl+B for empty / malformed input', async () => {
+    const { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } = await importPlatform('linux')
+
+    expect(parseVoiceRecordKey('')).toEqual(DEFAULT_VOICE_RECORD_KEY)
+    // Multi-character chunks are unsupported (CLI binds single keys), so a
+    // typo like "ctrl+space" falls back to the doc default.
+    expect(parseVoiceRecordKey('ctrl+space')).toEqual(DEFAULT_VOICE_RECORD_KEY)
+  })
+
+  it('parses ctrl+<letter> bindings', async () => {
+    const { parseVoiceRecordKey } = await importPlatform('linux')
+
+    expect(parseVoiceRecordKey('ctrl+o')).toEqual({ ch: 'o', mod: 'ctrl', raw: 'ctrl+o' })
+    expect(parseVoiceRecordKey('Ctrl+R')).toEqual({ ch: 'r', mod: 'ctrl', raw: 'ctrl+r' })
+  })
+
+  it('parses alt/cmd/super aliases', async () => {
+    const { parseVoiceRecordKey } = await importPlatform('linux')
+
+    expect(parseVoiceRecordKey('alt+b').mod).toBe('alt')
+    expect(parseVoiceRecordKey('option+b').mod).toBe('alt')
+    expect(parseVoiceRecordKey('cmd+b').mod).toBe('meta')
+    expect(parseVoiceRecordKey('command+b').mod).toBe('meta')
+    expect(parseVoiceRecordKey('super+b').mod).toBe('super')
+    expect(parseVoiceRecordKey('win+b').mod).toBe('super')
+  })
+})
+
+describe('formatVoiceRecordKey (#18994)', () => {
+  it('renders as the user expects in /voice status', async () => {
+    const { formatVoiceRecordKey, parseVoiceRecordKey } = await importPlatform('linux')
+
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('ctrl+b'))).toBe('Ctrl+B')
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('ctrl+o'))).toBe('Ctrl+O')
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('alt+r'))).toBe('Alt+R')
+    expect(formatVoiceRecordKey(parseVoiceRecordKey('cmd+b'))).toBe('Cmd+B')
+  })
+})
+
+describe('isVoiceToggleKey honours configured record key (#18994)', () => {
+  it('binds the configured letter, not hardcoded b', async () => {
+    const { isVoiceToggleKey, parseVoiceRecordKey } = await importPlatform('linux')
+    const ctrlO = parseVoiceRecordKey('ctrl+o')
+
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'o', ctrlO)).toBe(true)
+    // The old hardcoded 'b' must NOT match when the user configured 'o'.
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'b', ctrlO)).toBe(false)
+  })
+
+  it('alt+<letter> binding matches alt OR meta (terminal-protocol parity)', async () => {
+    const { isVoiceToggleKey, parseVoiceRecordKey } = await importPlatform('linux')
+    const altR = parseVoiceRecordKey('alt+r')
+
+    expect(isVoiceToggleKey({ alt: true, ctrl: false, meta: false, super: false }, 'r', altR)).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: false, meta: true, super: false }, 'r', altR)).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: false, meta: false, super: false }, 'r', altR)).toBe(false)
+  })
+
+  it('omitted configured key falls back to ctrl+b (back-compat)', async () => {
+    const { isVoiceToggleKey } = await importPlatform('linux')
+
+    // No third arg → DEFAULT_VOICE_RECORD_KEY → Ctrl+B behaviour.
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'b')).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'o')).toBe(false)
+  })
+})
+
 describe('isMacActionFallback', () => {
   it('routes raw Ctrl+K and Ctrl+W to readline kill-to-end / delete-word on macOS', async () => {
     const { isMacActionFallback } = await importPlatform('darwin')

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -4,6 +4,7 @@ import type { MutableRefObject, ReactNode, RefObject, SetStateAction } from 'rea
 import type { PasteEvent } from '../components/textInput.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ImageAttachResponse } from '../gatewayTypes.js'
+import type { ParsedVoiceRecordKey } from '../lib/platform.js'
 import type { RpcResult } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 import type {
@@ -210,6 +211,7 @@ export interface InputHandlerContext {
   }
   voice: {
     enabled: boolean
+    recordKey: ParsedVoiceRecordKey
     recording: boolean
     setProcessing: StateSetter<boolean>
     setRecording: StateSetter<boolean>

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -10,6 +10,7 @@ import type {
   SessionUsageResponse,
   VoiceToggleResponse
 } from '../../../gatewayTypes.js'
+import { formatVoiceRecordKey, parseVoiceRecordKey } from '../../../lib/platform.js'
 import { fmtK } from '../../../lib/text.js'
 import type { PanelSection } from '../../../types.js'
 import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
@@ -221,6 +222,12 @@ export const sessionCommands: SlashCommand[] = [
         ctx.guarded<VoiceToggleResponse>(r => {
           ctx.voice.setVoiceEnabled(!!r.enabled)
 
+          // Render the configured record key (config.yaml ``voice.record_key``)
+          // instead of hardcoded "Ctrl+B" — the gateway response carries the
+          // current value so /voice status and /voice on stay in sync with
+          // both the CLI and the TUI's actual binding (#18994).
+          const recordKeyLabel = formatVoiceRecordKey(parseVoiceRecordKey(r.record_key ?? 'ctrl+b'))
+
           // Match CLI's _show_voice_status / _enable_voice_mode /
           // _toggle_voice_tts output shape so users don't have to learn
           // two vocabularies.
@@ -230,11 +237,11 @@ export const sessionCommands: SlashCommand[] = [
             ctx.transcript.sys('Voice Mode Status')
             ctx.transcript.sys(`  Mode:       ${mode}`)
             ctx.transcript.sys(`  TTS:        ${tts}`)
-            ctx.transcript.sys('  Record key: Ctrl+B')
+            ctx.transcript.sys(`  Record key: ${recordKeyLabel}`)
 
             // CLI's "Requirements:" block — surfaces STT/audio setup issues
             // so the user sees "STT provider: MISSING ..." instead of
-            // silently failing on every Ctrl+B press.
+            // silently failing on every record-key press.
             if (r.details) {
               ctx.transcript.sys('')
               ctx.transcript.sys('  Requirements:')
@@ -259,7 +266,7 @@ export const sessionCommands: SlashCommand[] = [
           if (r.enabled) {
             const tts = r.tts ? ' (TTS enabled)' : ''
             ctx.transcript.sys(`Voice mode enabled${tts}`)
-            ctx.transcript.sys('  Ctrl+B to start/stop recording')
+            ctx.transcript.sys(`  ${recordKeyLabel} to start/stop recording`)
             ctx.transcript.sys('  /voice tts  to toggle speech output')
             ctx.transcript.sys('  /voice off  to disable voice mode')
           } else {

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -7,6 +7,11 @@ import type {
   ConfigMtimeResponse,
   ReloadMcpResponse
 } from '../gatewayTypes.js'
+import {
+  DEFAULT_VOICE_RECORD_KEY,
+  parseVoiceRecordKey,
+  type ParsedVoiceRecordKey
+} from '../lib/platform.js'
 import { asRpcResult } from '../lib/rpc.js'
 
 import {
@@ -89,10 +94,23 @@ const quietRpc = async <T extends Record<string, any> = Record<string, any>>(
   }
 }
 
-export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolean) => void) => {
+const _voiceRecordKeyFromConfig = (cfg: ConfigFullResponse | null): ParsedVoiceRecordKey => {
+  const raw = cfg?.config?.voice?.record_key
+
+  return raw ? parseVoiceRecordKey(raw) : DEFAULT_VOICE_RECORD_KEY
+}
+
+export const applyDisplay = (
+  cfg: ConfigFullResponse | null,
+  setBell: (v: boolean) => void,
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
+) => {
   const d = cfg?.config?.display ?? {}
 
   setBell(!!d.bell_on_complete)
+  if (setVoiceRecordKey) {
+    setVoiceRecordKey(_voiceRecordKeyFromConfig(cfg))
+  }
   patchUiState({
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
@@ -109,7 +127,13 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
   })
 }
 
-export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid }: UseConfigSyncOptions) {
+export function useConfigSync({
+  gw,
+  setBellOnComplete,
+  setVoiceEnabled,
+  setVoiceRecordKey,
+  sid
+}: UseConfigSyncOptions) {
   const mtimeRef = useRef(0)
 
   useEffect(() => {
@@ -125,8 +149,10 @@ export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid }: U
     quietRpc<ConfigMtimeResponse>(gw, 'config.get', { key: 'mtime' }).then(r => {
       mtimeRef.current = Number(r?.mtime ?? 0)
     })
-    quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r => applyDisplay(r, setBellOnComplete))
-  }, [gw, setBellOnComplete, setVoiceEnabled, sid])
+    quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r =>
+      applyDisplay(r, setBellOnComplete, setVoiceRecordKey)
+    )
+  }, [gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid])
 
   useEffect(() => {
     if (!sid) {
@@ -154,17 +180,20 @@ export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid }: U
         quietRpc<ReloadMcpResponse>(gw, 'reload.mcp', { session_id: sid, confirm: true }).then(
           r => r && turnController.pushActivity('MCP reloaded after config change')
         )
-        quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r => applyDisplay(r, setBellOnComplete))
+        quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r =>
+          applyDisplay(r, setBellOnComplete, setVoiceRecordKey)
+        )
       })
     }, MTIME_POLL_MS)
 
     return () => clearInterval(id)
-  }, [gw, setBellOnComplete, sid])
+  }, [gw, setBellOnComplete, setVoiceRecordKey, sid])
 }
 
 export interface UseConfigSyncOptions {
   gw: GatewayClient
   setBellOnComplete: (v: boolean) => void
   setVoiceEnabled: (v: boolean) => void
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
   sid: null | string
 }

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -439,7 +439,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return
     }
 
-    if (isVoiceToggleKey(key, ch)) {
+    if (isVoiceToggleKey(key, ch, voice.recordKey)) {
       return voiceRecordToggle()
     }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -17,7 +17,7 @@ import type {
 import { useGitBranch } from '../hooks/useGitBranch.js'
 import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { appendTranscriptMessage } from '../lib/messages.js'
-import { isMac } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
@@ -103,6 +103,7 @@ export function useMainApp(gw: GatewayClient) {
   const [voiceEnabled, setVoiceEnabled] = useState(false)
   const [voiceRecording, setVoiceRecording] = useState(false)
   const [voiceProcessing, setVoiceProcessing] = useState(false)
+  const [voiceRecordKey, setVoiceRecordKey] = useState<ParsedVoiceRecordKey>(DEFAULT_VOICE_RECORD_KEY)
   const [sessionStartedAt, setSessionStartedAt] = useState(() => Date.now())
   const [turnStartedAt, setTurnStartedAt] = useState<null | number>(null)
   const [goodVibesTick, setGoodVibesTick] = useState(0)
@@ -384,7 +385,7 @@ export function useMainApp(gw: GatewayClient) {
     }
   }, [ui.busy])
 
-  useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid: ui.sid })
+  useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
   const model = ui.info?.model?.replace(/^.*\//, '') ?? ''
@@ -529,6 +530,7 @@ export function useMainApp(gw: GatewayClient) {
     terminal: { hasSelection, scrollRef, scrollWithSelection, selection, stdout },
     voice: {
       enabled: voiceEnabled,
+      recordKey: voiceRecordKey,
       recording: voiceRecording,
       setProcessing: setVoiceProcessing,
       setRecording: setVoiceRecording,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -75,8 +75,12 @@ export interface ConfigDisplayConfig {
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
 }
 
+export interface ConfigVoiceConfig {
+  record_key?: string
+}
+
 export interface ConfigFullResponse {
-  config?: { display?: ConfigDisplayConfig }
+  config?: { display?: ConfigDisplayConfig; voice?: ConfigVoiceConfig }
 }
 
 export interface ConfigMtimeResponse {
@@ -279,6 +283,7 @@ export interface VoiceToggleResponse {
   available?: boolean
   details?: string
   enabled?: boolean
+  record_key?: string
   stt_available?: boolean
   tts?: boolean
 }

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -51,13 +51,117 @@ export const isCopyShortcut = (
     (isMac && key.ctrl && (key.meta || key.super === true)))
 
 /**
- * Voice recording toggle key (Ctrl+B).
+ * Voice recording toggle key — configurable via ``voice.record_key`` in
+ * ``config.yaml`` (default ``ctrl+b``).
  *
- * Documented as "Ctrl+B" everywhere: tips.py, config.yaml's voice.record_key
- * default, and the Python CLI prompt_toolkit handler. We accept raw Ctrl+B on
- * every platform so the TUI matches those docs. On macOS we additionally
- * accept Cmd+B (the platform action modifier) so existing macOS muscle memory
- * keeps working.
+ * Documented in tips.py, the Python CLI prompt_toolkit handler, and the
+ * config.yaml default. The TUI honours the same config knob (#18994);
+ * when ``voice.record_key`` is e.g. ``ctrl+o`` the TUI binds Ctrl+O.
+ *
+ * On macOS we additionally accept the platform action modifier (Cmd) for
+ * the configured letter so existing macOS muscle memory keeps working
+ * alongside the documented Ctrl+<letter> shortcut.
  */
-export const isVoiceToggleKey = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string): boolean =>
-  (key.ctrl || isActionMod(key)) && ch.toLowerCase() === 'b'
+export type VoiceRecordKeyMod = 'alt' | 'ctrl' | 'meta' | 'super'
+
+export interface ParsedVoiceRecordKey {
+  ch: string
+  mod: VoiceRecordKeyMod
+  raw: string
+}
+
+export const DEFAULT_VOICE_RECORD_KEY: ParsedVoiceRecordKey = {
+  ch: 'b',
+  mod: 'ctrl',
+  raw: 'ctrl+b'
+}
+
+const _MOD_ALIASES: Record<string, VoiceRecordKeyMod> = {
+  alt: 'alt',
+  cmd: 'meta',
+  command: 'meta',
+  control: 'ctrl',
+  ctrl: 'ctrl',
+  meta: 'meta',
+  option: 'alt',
+  opt: 'alt',
+  super: 'super',
+  win: 'super',
+  windows: 'super'
+}
+
+/**
+ * Parse a config-string voice record key like ``ctrl+b`` / ``alt+r`` /
+ * ``cmd+space`` into ``{mod, ch}``. Falls back to the documented Ctrl+B
+ * default for empty / malformed input so a typo never silently disables
+ * the shortcut.
+ */
+export const parseVoiceRecordKey = (raw: string): ParsedVoiceRecordKey => {
+  const lower = (raw ?? '').trim().toLowerCase()
+
+  if (!lower) {
+    return DEFAULT_VOICE_RECORD_KEY
+  }
+
+  const parts = lower.split('+').map(p => p.trim()).filter(Boolean)
+
+  if (!parts.length) {
+    return DEFAULT_VOICE_RECORD_KEY
+  }
+
+  const ch = parts[parts.length - 1]
+  const modCandidates = parts.slice(0, -1)
+
+  let mod: VoiceRecordKeyMod = 'ctrl'
+
+  for (const cand of modCandidates) {
+    const norm = _MOD_ALIASES[cand]
+
+    if (norm) {
+      mod = norm
+      break
+    }
+  }
+
+  // Reject multi-character chunks (e.g. "ctrl+space" → ch="space" — we
+  // only support single-character bindings, matching the Python side's
+  // prompt_toolkit binding shape).
+  if (ch.length !== 1) {
+    return DEFAULT_VOICE_RECORD_KEY
+  }
+
+  return { ch, mod, raw: lower }
+}
+
+/** Render a parsed key back as ``Ctrl+B`` for status text. */
+export const formatVoiceRecordKey = (parsed: ParsedVoiceRecordKey): string => {
+  const modLabel = parsed.mod === 'meta' ? 'Cmd' : parsed.mod[0].toUpperCase() + parsed.mod.slice(1)
+
+  return `${modLabel}+${parsed.ch.toUpperCase()}`
+}
+
+export const isVoiceToggleKey = (
+  key: { alt?: boolean; ctrl: boolean; meta: boolean; super?: boolean },
+  ch: string,
+  configured: ParsedVoiceRecordKey = DEFAULT_VOICE_RECORD_KEY
+): boolean => {
+  if (ch.toLowerCase() !== configured.ch) {
+    return false
+  }
+
+  switch (configured.mod) {
+    case 'alt':
+      // Most terminals surface Alt as either ``alt`` or ``meta``; accept
+      // both so the binding works across xterm-style and kitty-style
+      // protocols.
+      return key.alt === true || key.meta
+    case 'ctrl':
+      // Doc default — also accept the platform action modifier so macOS
+      // Cmd+<letter> muscle memory keeps working alongside Ctrl+<letter>.
+      return key.ctrl || isActionMod(key)
+    case 'meta':
+      return key.meta || key.super === true
+    case 'super':
+      return key.super === true
+  }
+}

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -64,9 +64,18 @@ export const isCopyShortcut = (
  */
 export type VoiceRecordKeyMod = 'alt' | 'ctrl' | 'meta' | 'super'
 
+/** Named (multi-character) keys we support, matching the CLI's
+ * prompt_toolkit binding shape (``c-space``, ``c-enter``, etc.) so a
+ * config value like ``ctrl+space`` binds in both runtimes. */
+export type VoiceRecordKeyNamed = 'backspace' | 'delete' | 'enter' | 'escape' | 'space' | 'tab'
+
 export interface ParsedVoiceRecordKey {
+  /** Single character (``'b'``, ``'o'``) when ``named`` is undefined,
+   * otherwise the named-key token (``'space'``, ``'enter'``…). Kept as
+   * one field for back-compat with the v1 ``{ ch, mod, raw }`` shape. */
   ch: string
   mod: VoiceRecordKeyMod
+  named?: VoiceRecordKeyNamed
   raw: string
 }
 
@@ -90,10 +99,72 @@ const _MOD_ALIASES: Record<string, VoiceRecordKeyMod> = {
   windows: 'super'
 }
 
+/** Map config-string named tokens to the canonical name used at match time.
+ *
+ * Aliases mirror what prompt_toolkit accepts (``return`` ↔ ``enter``,
+ * ``esc`` ↔ ``escape``) so a config that round-trips through the CLI also
+ * binds in the TUI. */
+const _NAMED_KEY_ALIASES: Record<string, VoiceRecordKeyNamed> = {
+  backspace: 'backspace',
+  bs: 'backspace',
+  del: 'delete',
+  delete: 'delete',
+  enter: 'enter',
+  esc: 'escape',
+  escape: 'escape',
+  ret: 'enter',
+  return: 'enter',
+  space: 'space',
+  spc: 'space',
+  tab: 'tab'
+}
+
+interface RuntimeKeyEvent {
+  alt?: boolean
+  backspace?: boolean
+  ctrl: boolean
+  delete?: boolean
+  escape?: boolean
+  meta: boolean
+  return?: boolean
+  super?: boolean
+  tab?: boolean
+}
+
+/** Match an ink ``key`` event against a parsed named key. The ink runtime
+ * sets one boolean per named key; ``space`` is a printable char so it
+ * arrives as ``ch === ' '`` rather than a dedicated ``key.space`` flag. */
+const _matchesNamedKey = (
+  named: VoiceRecordKeyNamed,
+  key: RuntimeKeyEvent,
+  ch: string
+): boolean => {
+  switch (named) {
+    case 'backspace':
+      return key.backspace === true
+    case 'delete':
+      return key.delete === true
+    case 'enter':
+      return key.return === true
+    case 'escape':
+      return key.escape === true
+    case 'space':
+      return ch === ' '
+    case 'tab':
+      return key.tab === true
+  }
+}
+
 /**
  * Parse a config-string voice record key like ``ctrl+b`` / ``alt+r`` /
- * ``cmd+space`` into ``{mod, ch}``. Falls back to the documented Ctrl+B
- * default for empty / malformed input so a typo never silently disables
+ * ``ctrl+space`` into ``{mod, ch, named?}``. Accepts single characters
+ * AND the named tokens declared in ``_NAMED_KEY_ALIASES`` (``space``,
+ * ``enter``/``return``, ``tab``, ``escape``/``esc``, ``backspace``,
+ * ``delete``) — matching the keys prompt_toolkit accepts on the CLI
+ * side via the ``c-<name>`` rewrite in ``cli.py``.
+ *
+ * Falls back to the documented Ctrl+B default for empty input or for
+ * unrecognised multi-character tokens so a typo never silently disables
  * the shortcut.
  */
 export const parseVoiceRecordKey = (raw: string): ParsedVoiceRecordKey => {
@@ -109,7 +180,7 @@ export const parseVoiceRecordKey = (raw: string): ParsedVoiceRecordKey => {
     return DEFAULT_VOICE_RECORD_KEY
   }
 
-  const ch = parts[parts.length - 1]
+  const last = parts[parts.length - 1]
   const modCandidates = parts.slice(0, -1)
 
   let mod: VoiceRecordKeyMod = 'ctrl'
@@ -123,29 +194,46 @@ export const parseVoiceRecordKey = (raw: string): ParsedVoiceRecordKey => {
     }
   }
 
-  // Reject multi-character chunks (e.g. "ctrl+space" → ch="space" — we
-  // only support single-character bindings, matching the Python side's
-  // prompt_toolkit binding shape).
-  if (ch.length !== 1) {
-    return DEFAULT_VOICE_RECORD_KEY
+  if (last.length === 1) {
+    return { ch: last, mod, raw: lower }
   }
 
-  return { ch, mod, raw: lower }
+  const named = _NAMED_KEY_ALIASES[last]
+
+  if (named) {
+    return { ch: named, mod, named, raw: lower }
+  }
+
+  // Unknown multi-character token (e.g. typo'd ``ctrl+spcae``) — fall back
+  // to the doc default rather than silently disabling the binding.
+  return DEFAULT_VOICE_RECORD_KEY
 }
 
-/** Render a parsed key back as ``Ctrl+B`` for status text. */
+/** Render a parsed key back as ``Ctrl+B`` / ``Ctrl+Space`` for status text. */
 export const formatVoiceRecordKey = (parsed: ParsedVoiceRecordKey): string => {
   const modLabel = parsed.mod === 'meta' ? 'Cmd' : parsed.mod[0].toUpperCase() + parsed.mod.slice(1)
+  // Named tokens render in title case (Ctrl+Space, Ctrl+Enter); single
+  // chars render upper-case to match the existing Ctrl+B convention.
+  const keyLabel = parsed.named
+    ? parsed.named[0].toUpperCase() + parsed.named.slice(1)
+    : parsed.ch.toUpperCase()
 
-  return `${modLabel}+${parsed.ch.toUpperCase()}`
+  return `${modLabel}+${keyLabel}`
 }
 
 export const isVoiceToggleKey = (
-  key: { alt?: boolean; ctrl: boolean; meta: boolean; super?: boolean },
+  key: RuntimeKeyEvent,
   ch: string,
   configured: ParsedVoiceRecordKey = DEFAULT_VOICE_RECORD_KEY
 ): boolean => {
-  if (ch.toLowerCase() !== configured.ch) {
+  // Match the configured key first (single-char compare or named-key
+  // event-property check). Bail out before evaluating modifier shape
+  // so the wrong key never reaches the modifier guard.
+  if (configured.named) {
+    if (!_matchesNamedKey(configured.named, key, ch)) {
+      return false
+    }
+  } else if (ch.toLowerCase() !== configured.ch) {
     return false
   }
 


### PR DESCRIPTION
## What does this PR do?

Classic CLI loaded `voice.record_key` from config.yaml and bound the prompt-toolkit handler dynamically (`cli.py` rewrites `ctrl+x` → `c-x`, `ctrl+space` → `c-space`, etc.). The new TUI hardcoded `Ctrl+B` everywhere — `isVoiceToggleKey` (input handler), `/voice status` ("Record key: Ctrl+B"), and `/voice on` ("Ctrl+B to start/stop recording"). A user who set `voice.record_key: ctrl+o` (or any other key, including named keys like `ctrl+space`) saw the documented config silently ignored — only Ctrl+B worked, the displayed shortcut lied about it.

Wire the configured key end-to-end through the existing channels:

- **Backend**: `voice.toggle` action=status AND action=on/off responses now include `record_key`, sourced from `cfg.voice.record_key` (default `ctrl+b`).
- **Backend types**: `ConfigFullResponse.config.voice.record_key` and `VoiceToggleResponse.record_key`.
- **Frontend parser/formatter**: `parseVoiceRecordKey()` accepts single-character bindings (`ctrl+b`, `alt+r`) AND the named-key tokens that the CLI's prompt_toolkit binding accepts (`ctrl+space`, `ctrl+enter`/`return`, `ctrl+tab`, `ctrl+escape`/`esc`, `ctrl+backspace`/`bs`, `ctrl+delete`/`del`). Modifier aliases mirror common conventions (`option`, `cmd`, `command`, `win`, `windows`). Falls back to documented Ctrl+B for empty / unrecognised multi-character input so a typo never silently disables the shortcut. `formatVoiceRecordKey()` renders for status text in title case (`Ctrl+Space`, `Ctrl+Enter`).
- **Hydration**: startup `config.get full` already runs; extract `cfg.voice.record_key`, parse, push into a new `voiceRecordKey` state, forward to input handler ctx. Mtime-poll path also re-applies so a `config.yaml` hand-edit takes effect on the next tick (matches existing display-option behaviour).
- **Slash command**: `/voice status` and `/voice on` use `formatVoiceRecordKey` on the response's `record_key` instead of the hardcoded label.

`ParsedVoiceRecordKey` carries an optional `named` field; `ch` holds either a single character (back-compat) or the canonical named token. The runtime matcher dispatches on `named` before checking modifier shape — wrong key never reaches the modifier guard. Aliases collapse to one canonical name so `ctrl+esc` and `ctrl+escape` behave identically in both binding and display.

## Related Issue

Fixes #18994

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — `voice.toggle` status + on/off branches include `record_key` in response (sourced from `cfg.voice.record_key`).
- `ui-tui/src/lib/platform.ts` — new `parseVoiceRecordKey`, `formatVoiceRecordKey`, `DEFAULT_VOICE_RECORD_KEY`, `ParsedVoiceRecordKey`, `VoiceRecordKeyMod`, `VoiceRecordKeyNamed`. Internal `_NAMED_KEY_ALIASES` and `_matchesNamedKey` map config tokens to ink event-property checks. `isVoiceToggleKey` now takes a parsed `ParsedVoiceRecordKey`; default arg keeps existing call sites back-compat.
- `ui-tui/src/gatewayTypes.ts` — `ConfigVoiceConfig`, `ConfigFullResponse.config.voice`, `VoiceToggleResponse.record_key`.
- `ui-tui/src/app/useConfigSync.ts` — hydrate from `config.get full`; mtime poll also re-applies the parsed key.
- `ui-tui/src/app/useMainApp.ts` — `voiceRecordKey` state, pass through to `useConfigSync` and the input handler ctx.
- `ui-tui/src/app/interfaces.ts` — `InputHandlerContext.voice.recordKey`.
- `ui-tui/src/app/useInputHandlers.ts` — pass `voice.recordKey` into `isVoiceToggleKey`.
- `ui-tui/src/app/slash/commands/session.ts` — render configured key in `/voice status` and `/voice on`.
- `ui-tui/src/__tests__/platform.test.ts` — coverage for the parser (single-char + every supported named token + each alias variant + fall-back-to-Ctrl+B for empty/typo'd input), the formatter (single-char and named-key title-case rendering), and the runtime matcher (configured-letter binding, alt/meta terminal-protocol parity, named-key event-property dispatch including modifier-mismatch negatives, and back-compat default-arg behaviour).

## How to Test

### Letter binding (most common)
1. `voice: { record_key: ctrl+o }` in `~/.hermes/config.yaml`.
2. `hermes --tui` → `/voice status` → "Record key: Ctrl+O" (was: Ctrl+B).
3. `/voice on` → "Ctrl+O to start/stop recording".
4. Press Ctrl+O → recording toggles. Press Ctrl+B → no effect.

### Named-key binding
5. `voice: { record_key: ctrl+space }` in `~/.hermes/config.yaml`.
6. `hermes --tui` → `/voice status` → "Record key: Ctrl+Space".
7. Press Ctrl+Space → recording toggles. (Also try `ctrl+enter`, `ctrl+tab`, `ctrl+esc`, `ctrl+backspace`, `ctrl+delete` — and the aliases `return`, `escape`, `bs`, `del`.)

### Tests
8. `cd ui-tui && npm test` → 559/559 pass. `npm run type-check` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and the touched suites pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — config-side behaviour was already documented (`tips.py:322` already says "configurable via voice.record_key in config.yaml — not just Ctrl+B"); this PR closes the gap between docs and behaviour. No new docs needed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (uses existing `voice.record_key`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — checked: ink event flags (`key.return`, `key.tab`, `key.escape`, `key.backspace`, `key.delete`) are surfaced consistently across xterm-style and kitty-style terminals; the alt+meta dual-match in the modifier dispatch covers the protocol split. Ctrl/Cmd dual-accept on macOS preserves existing muscle memory.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A