### PR TITLE
fix(kanban): use get_default_hermes_root() for profile discovery

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2655,20 +2655,23 @@ def read_worker_log(
 def list_profiles_on_disk() -> list[str]:
     """Return the set of named profiles discovered on disk.
 
-    Reads ``~/.hermes/profiles/`` directly so this module has no import
-    dependency on ``hermes_cli.profiles`` (which pulls in a large chunk
-    of the CLI startup path). Only returns directories that contain a
+    Reads the profiles directory under ``HERMES_HOME`` (respecting
+    ``HERMES_HOME`` env overrides and profile-aware root) so this module
+    works correctly in custom-root deployments (e.g. Docker with
+    ``HERMES_HOME=/data``). Only returns directories that contain a
     ``config.yaml`` — a bare dir without config isn't a real profile.
     """
     try:
-        home = Path.home() / ".hermes" / "profiles"
+        from hermes_constants import get_default_hermes_root
+        profiles_dir = get_default_hermes_root() / "profiles"
     except Exception:
-        return []
-    if not home.is_dir():
+        # Fallback for environments where hermes_constants is unavailable
+        profiles_dir = Path.home() / ".hermes" / "profiles"
+    if not profiles_dir.is_dir():
         return []
     names: list[str] = []
     try:
-        for entry in sorted(home.iterdir()):
+        for entry in sorted(profiles_dir.iterdir()):
             if not entry.is_dir():
                 continue
             if (entry / "config.yaml").is_file():


### PR DESCRIPTION
## Fix: kanban init profile discovery hardcodes `~/.hermes/profiles`

### Problem

`list_profiles_on_disk()` in `kanban_db.py` hardcoded `Path.home() / ".hermes" / "profiles"`, so `hermes kanban init` always reported "No profiles found" on custom-root deployments (e.g., `HERMES_HOME=/data` in Docker).

This is inconsistent with `kanban_db_path()` and `workspaces_root()`, which were already fixed to use `get_hermes_home()` in #18985.

### Solution

Replace the hardcoded path with `get_default_hermes_root() / "profiles"`, consistent with how `kanban_db_path()` and `workspaces_root()` already resolve paths. Falls back to `Path.home() / ".hermes" / "profiles"` if `hermes_constants` is unavailable.

### Testing

- Custom-root deployments (`HERMES_HOME` override) will now correctly discover profiles under the custom root
- Default deployments (no `HERMES_HOME` override) behave identically since `get_default_hermes_root()` returns `Path.home() / ".hermes"` in that case
- The fallback path matches the old behavior exactly

Fixes #19017