### PR TITLE
test(update): teach restart-mocks about the post-update survivor sweep

### DIFF
--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -415,7 +415,13 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        # ``find_gateway_pids`` is invoked twice: once to enumerate manual
+         # PIDs to restart, then again ~3s later by the post-restart survivor
+         # sweep (#17648). Return the live PID first, then an empty list to
+         # simulate the process actually exiting after the graceful restart
+         # — otherwise the sweep would SIGKILL pid 12345 even though graceful
+         # drain succeeded, and ``kill.assert_not_called()`` would fire.
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
              patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
              patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
@@ -453,7 +459,11 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        # See note in ``test_update_restarts_profile_manual_gateways``: the
+        # post-restart survivor sweep (#17648) re-queries ``find_gateway_pids``
+        # ~3s after the restart attempt. Return ``[]`` on the second call so
+        # the SIGTERM fallback isn't escalated to SIGKILL by the sweep.
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
              patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
              patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=False) as graceful, \
@@ -872,15 +882,25 @@ class TestServicePidExclusion:
             launchctl_loaded=True,
         )
 
+        # Survivor sweep (#17648) re-queries ``find_gateway_pids`` after
+         # SIGTERM. ``os.kill`` is mocked, so the PID never "dies" — track
+         # the killed-via-SIGTERM PIDs ourselves and exclude them on later
+         # calls to simulate the OS reaping the process. Without this the
+         # sweep escalates with SIGKILL and ``manual_kills == 2`` instead of 1.
+        _killed_pids: set[int] = set()
+
         def fake_find(exclude_pids=None, all_profiles=False):
-            _exclude = exclude_pids or set()
+            _exclude = (exclude_pids or set()) | _killed_pids
             return [p for p in [SERVICE_PID, MANUAL_PID] if p not in _exclude]
+
+        def fake_kill(pid, _sig):
+            _killed_pids.add(pid)
 
         with patch.object(
             gateway_cli, "_get_service_pids", return_value={SERVICE_PID}
         ), patch.object(
             gateway_cli, "find_gateway_pids", side_effect=fake_find,
-        ), patch("os.kill") as mock_kill:
+        ), patch("os.kill", side_effect=fake_kill) as mock_kill:
             cmd_update(mock_args)
 
         captured = capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fixes three CI failures observed on `main`:

```
FAILED tests/hermes_cli/test_update_gateway_restart.py
  ::TestCmdUpdateLaunchdRestart::test_update_restarts_profile_manual_gateways
    AssertionError: Expected 'kill' to not have been called. Called 1 times.
    Calls: [call(12345, <Signals.SIGKILL: 9>)].

FAILED tests/hermes_cli/test_update_gateway_restart.py
  ::TestCmdUpdateLaunchdRestart::test_update_profile_manual_gateway_falls_back_to_sigterm
    AssertionError: Expected 'kill' to have been called once. Called 2 times.
    Calls: [call(12345, SIGTERM), call(12345, SIGKILL)].

FAILED tests/hermes_cli/test_update_gateway_restart.py
  ::TestServicePidExclusion::test_update_kills_manual_pid_but_not_service_pid
    assert 2 == 1
      manual_kills = [call(42999, SIGTERM), call(42999, SIGKILL)]
```

Reference run: [25250051126](https://github.com/NousResearch/hermes-agent/actions/runs/25250051126) on `5d3be898a`.

## Root cause

Issue #17648 added a **post-update SIGTERM-survivor sweep** to `cmd_update`. ~3s after issuing graceful restart / SIGTERM, the code re-queries `find_gateway_pids` and SIGKILLs anything still alive — the right fix for stuck-drain gateways in production:

```python
# hermes_cli/main.py:7553
# --- Post-restart survivor sweep -----------------------------
# Issue #17648: some gateways ignore SIGTERM (stuck drain, blocked I/O, ...)
_time.sleep(3.0)
_surviving = find_gateway_pids(exclude_pids=_service_pids_after, all_profiles=True)
_stuck = [pid for pid in _surviving if pid in killed_pids]
if _stuck:
    print(f"  ⚠ {len(_stuck)} gateway process(es) ignored SIGTERM — force-killing")
    for pid in _stuck:
        os.kill(pid, _signal.SIGKILL)
```

But the three unit tests assumed `find_gateway_pids` would keep returning the same PIDs forever (`return_value=[12345]`). With `os.kill` mocked, the simulated PID never actually exits → the sweep finds it again → SIGKILL escalation → assertion fires.

The production code is correct; the tests just need to model OS behaviour properly.

## Fix

**Two profile-manual restart tests:** use `side_effect=[[12345], []]` so the first `find_gateway_pids` call returns the live PID and the second (the sweep) returns nothing, as if the OS had reaped the process.

**Service-PID-exclusion test:** track which PIDs got killed in a closure set, and exclude them on subsequent `fake_find` calls. Give `os.kill` a `side_effect` that records the kill instead of swallowing it silently. Now the sweep doesn't re-find the manual PID, no SIGKILL escalation, `manual_kills == 1`.

## Validation

```
$ pytest tests/hermes_cli/test_update_gateway_restart.py -q
43 passed in 4.13s
```

## Scope

- ✅ No production code change (test-only)
- ✅ All 43 tests in the file pass
- ✅ The survivor-sweep contract from #17648 is preserved

## Refs

- #17648 — post-update survivor sweep that the tests didn't model

## Out of scope

The other ~5 main-CI failures — separate focused PRs.
