### PR TITLE
fix(gateway): resume sessions after crash/restart instead of blanket suspend

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2755,7 +2755,7 @@ class GatewayRunner:
             try:
                 suspended = self.session_store.suspend_recently_active()
                 if suspended:
-                    logger.info("Suspended %d in-flight session(s) from previous run", suspended)
+                    logger.info("Marked %d in-flight session(s) as resumable from previous run", suspended)
             except Exception as e:
                 logger.warning("Session suspension on startup failed: %s", e)
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1086,19 +1086,22 @@ class SessionStore:
         return len(removed_keys)
 
     def suspend_recently_active(self, max_age_seconds: int = 120) -> int:
-        """Mark recently-active sessions as suspended.
+        """Mark recently-active sessions as resumable after an unexpected exit.
 
-        Called on gateway startup to prevent sessions that were likely
-        in-flight when the gateway last exited from being blindly resumed
-        (#7536).  Only suspends sessions updated within *max_age_seconds*
-        to avoid resetting long-idle sessions that are harmless to resume.
-        Returns the number of sessions that were suspended.
+        Called on gateway startup after a crash or fast restart to preserve
+        in-flight sessions instead of destroying their conversation history
+        (#7536).  Only marks sessions updated within *max_age_seconds* to
+        avoid touching long-idle sessions.  Sets ``resume_pending=True`` so
+        the next incoming message on the same session_key auto-resumes from
+        the existing transcript.
 
-        Entries flagged ``resume_pending=True`` are skipped — those were
-        marked intentionally by the drain-timeout path as recoverable.
-        Terminal escalation for genuinely stuck ``resume_pending`` sessions
-        is handled by the existing ``.restart_failure_counts`` stuck-loop
-        counter, which runs after this method on startup.
+        Entries already flagged ``resume_pending=True`` are skipped.  Entries
+        explicitly ``suspended=True`` (from /stop or stuck-loop escalation)
+        are also skipped.  Terminal escalation for genuinely stuck sessions
+        is still handled by the existing ``.restart_failure_counts`` counter
+        (threshold 3), which runs after this method and sets ``suspended=True``.
+
+        Returns the number of sessions marked resumable.
         """
         from datetime import timedelta
 
@@ -1110,7 +1113,9 @@ class SessionStore:
                 if entry.resume_pending:
                     continue
                 if not entry.suspended and entry.updated_at >= cutoff:
-                    entry.suspended = True
+                    entry.resume_pending = True
+                    entry.resume_reason = "restart_interrupted"
+                    entry.last_resume_marked_at = _now()
                     count += 1
             if count:
                 self._save()


### PR DESCRIPTION
# Fix: `suspend_recently_active()` blanket-suspends sessions, destroying conversation context across restarts

## Problem

On gateway startup, `suspend_recently_active()` marks **all sessions updated in the last 120 seconds** as `suspended=True`. When the user next messages the agent, `get_or_create_session()` sees `suspended=True` and **forces a brand-new session**, wiping the conversation history.

This is intended to prevent "blindly resuming" stuck in-flight sessions (#7536), but it also destroys healthy sessions that were simply interrupted by a **fast restart** or **crash**.

### Evidence

Multiple sessions created on the same day (May 2) with empty history, showing repeated session resets instead of resumption:
- `20260502_014024_90599d48.jsonl`
- `20260502_145832_67f819.jsonl`
- `20260502_165213_8c9ba3.jsonl`
- `20260502_170141_6180e883.jsonl`

Each restart logs: `Suspended 1 in-flight session(s) from previous run`

## Root Cause

In `gateway/session.py`, `get_or_create_session()` checks:<br>
```python
if entry.suspended:
    reset_reason = "suspended"           # ← hard wipe, always wins
elif entry.resume_pending:
    return entry                         # ← preserves transcript
```

`suspend_recently_active()` unconditionally sets `suspended=True` on startup, so the safe `resume_pending` path is never reached.

Meanwhile, `mark_resume_pending()` — the *actual* resume mechanism — only runs inside `stop()` when the drain times out. Graceful restarts and crashes never trigger it.

The existing stuck-loop counter (`_suspend_stuck_loop_sessions()`) already provides terminal escalation for genuinely stuck sessions (threshold: 3 consecutive restarts). The blanket `suspend_recently_active()` is redundant safety that destroys user experience.

## Fix

Change `suspend_recently_active()` to set **`resume_pending=True`** (with reason `"restart_interrupted"`) instead of `suspended=True`.

This means:
- `get_or_create_session()` will return the **existing entry**, preserving `session_id` and transcript
- The next successful turn clears `resume_pending` normally
- If a session keeps appearing across **3+ restarts**, the stuck-loop counter escalates to `suspended=True`, giving the user a clean slate

## Code Change

`gateway/session.py`: `suspend_recently_active()` now sets `resume_pending=True` + `resume_reason="restart_interrupted"` instead of `suspended=True`.

`gateway/run.py`: Startup log message updated from "Suspended" to "Marked...as resumable" for clarity.

## Why this is safe

| Protection | Before | After |
|------------|--------|-------|
| Graceful restart (clean_shutdown marker) | skip suspend | unchanged |
| Stuck-loop (3+ restarts while active) | `suspended=True` | unchanged |
| Crash / fast restart | `suspended=True` → **wipe** | `resume_pending=True` → **resume** |

The stuck-loop counter (`restart_failure_counts`) in `.restart_failure_counts` is **incremented at shutdown** and **checked at startup** by `_suspend_stuck_loop_sessions()`, which still sets `suspended=True`. This is the proper terminal escalation, not the blanket startup suspend.

`clear_resume_pending()` is called after every successful turn, so the flag does not persist.

## Testing

1. Start gateway, send messages to build history
2. Kill gateway with SIGKILL (simulate crash)
3. Restart gateway
4. Send next message → expect **same session_id**, transcript preserved
5. Repeat 3 more times → expect stuck-loop escalation to `suspended=True` → new session

## Related

- #7536 — stuck-loop detection
- Commit d1ce90893 — `fix(gateway): shutdown + restart hygiene`
- `gateway/run.py` lines 2745–2770, `gateway/session.py` lines 1080–1110
