### PR TITLE
Feat/api server compress command

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -965,7 +965,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return str(e)
             if not sanitized:
                 return "Title must have printable characters."
-            db.set_session_title(session_id, sanitized)
+            try:
+                db.set_session_title(session_id, sanitized)
+            except ValueError as e:
+                return f"⚠️  {e}"
             return f"Title set: {sanitized}"
 
         title = db.get_session_title(session_id)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -61,6 +61,19 @@ CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
+# Slash commands supported over the API server (subset of gateway commands).
+# Commands NOT in this set fall through to the LLM as normal user messages.
+_API_SERVER_SLASH_COMMANDS: frozenset[str] = frozenset({
+    "help",
+    "new",
+    "reset",
+    "title",
+    "status",
+    "usage",
+    "retry",
+    "undo",
+})
+
 
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
@@ -857,6 +870,262 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         })
 
+    # ------------------------------------------------------------------
+    # Slash command dispatch (API server subset)
+    # ------------------------------------------------------------------
+
+    async def _try_slash_command(
+        self, user_message: str, session_id: str, body: dict
+    ) -> Optional[dict]:
+        """Try to handle *user_message* as a slash command.
+
+        Returns:
+            ``{"handled": True, "response": str}`` — return as chat completion
+            ``{"handled": True, "rewrite_message": str}`` — replace message, fall through to agent
+            ``None`` — not a slash command, normal processing
+        """
+        if not isinstance(user_message, str) or not user_message.startswith("/"):
+            return None
+
+        from gateway.platforms.base import MessageEvent
+
+        # Reuse the same parser the gateway uses — /title my session
+        # tokenizes identically over SMS-via-API as it does over Telegram.
+        event = MessageEvent(text=user_message)
+        command = event.get_command()
+        if not command:
+            return None  # "/ " or "/path/to/file" — not a command
+
+        args = event.get_command_args().strip()
+
+        # Only intercept commands we explicitly support.  Telegram-style
+        # commands (/personality, /voice, /model, …) fall through to the
+        # LLM as normal user messages.
+        if command not in _API_SERVER_SLASH_COMMANDS:
+            return None
+
+        if command in ("help",):
+            return {"handled": True, "response": self._slash_help()}
+
+        if command in ("new", "reset"):
+            return {"handled": True, "response": self._slash_reset(session_id)}
+
+        if command == "title":
+            return {"handled": True, "response": self._slash_title(session_id, args)}
+
+        if command == "status":
+            return {"handled": True, "response": self._slash_status(session_id, body)}
+
+        if command == "usage":
+            return {"handled": True, "response": self._slash_usage(session_id)}
+
+        if command == "undo":
+            return {"handled": True, "response": self._slash_undo(session_id)}
+
+        if command == "retry":
+            recovered = self._slash_retry(session_id)
+            if recovered is None:
+                return {"handled": True, "response": "No previous message to retry."}
+            return {"handled": True, "rewrite_message": recovered}
+
+        return None  # Shouldn't reach here, but be safe
+
+    # -- individual command handlers -------------------------------------
+
+    def _slash_help(self) -> str:
+        """Return a plain-text list of API-server-supported slash commands."""
+        return (
+            "Available commands: "
+            "/new (reset session), "
+            "/title <name> (set session title), "
+            "/status (session info), "
+            "/usage (token counts), "
+            "/retry (rerun last message), "
+            "/undo (remove last exchange), "
+            "/help (this list)"
+        )
+
+    def _slash_reset(self, session_id: str) -> str:
+        """Clear all messages for *session_id*."""
+        db = self._ensure_session_db()
+        if db is not None:
+            db.clear_messages(session_id)
+        return "Session reset. Starting fresh."
+
+    def _slash_title(self, session_id: str, args: str) -> str:
+        """Set or show the session title."""
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        if args:
+            try:
+                sanitized = db.sanitize_title(args)
+            except ValueError as e:
+                return str(e)
+            if not sanitized:
+                return "Title must have printable characters."
+            db.set_session_title(session_id, sanitized)
+            return f"Title set: {sanitized}"
+
+        title = db.get_session_title(session_id)
+        if title:
+            return f"Title: {title}"
+        return "No title set. Usage: /title My Session Name"
+
+    def _slash_status(self, session_id: str, body: dict) -> str:
+        """Return a single-line session summary: messages, tokens, model, age."""
+        db = self._ensure_session_db()
+        model = body.get("model", self._model_name) if body else self._model_name
+
+        msg_count = db.message_count(session_id) if db else 0
+        parts = [f"{msg_count} msgs"]
+
+        if db is not None:
+            session = db.get_session(session_id)
+            if session:
+                inp = session.get("input_tokens", 0) or 0
+                out = session.get("output_tokens", 0) or 0
+                total = inp + out
+                if total:
+                    if total >= 1000:
+                        parts.append(f"{total / 1000:.0f}k tokens")
+                    else:
+                        parts.append(f"{total} tokens")
+                started = session.get("started_at")
+                if started:
+                    age_s = time.time() - started
+                    if age_s < 3600:
+                        parts.append(f"{max(1, age_s / 60):.0f}m old")
+                    elif age_s < 86400:
+                        parts.append(f"{age_s / 3600:.0f}h old")
+                    else:
+                        parts.append(f"{age_s / 86400:.0f}d old")
+
+        parts.append(model)
+        return f"session: {', '.join(parts)}"
+
+    def _slash_usage(self, session_id: str) -> str:
+        """Return token counts for the session."""
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        session = db.get_session(session_id)
+        if not session:
+            return "Session not found."
+
+        inp = session.get("input_tokens", 0) or 0
+        out = session.get("output_tokens", 0) or 0
+        total = inp + out
+        return f"{inp:,} in / {out:,} out / {total:,} total tokens"
+
+    def _slash_undo(self, session_id: str) -> str:
+        """Remove the last user/assistant exchange, transactionally."""
+        db = self._ensure_session_db()
+        if db is None:
+            return "Session database not available."
+
+        messages = db.get_messages(session_id)
+        if not messages:
+            return "Nothing to undo."
+
+        # Find the last user message index
+        last_user_idx = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+
+        if last_user_idx is None:
+            return "Nothing to undo."
+
+        removed_msg = messages[last_user_idx].get("content", "") or ""
+        removed_count = len(messages) - last_user_idx
+        old_count = len(messages)
+        new_count = last_user_idx
+
+        # Delete the tail rows in a single transaction
+        ids_to_delete = [messages[j]["id"] for j in range(last_user_idx, len(messages))]
+        placeholders = ",".join("?" for _ in ids_to_delete)
+
+        def _do(conn):
+            conn.execute(
+                f"DELETE FROM messages WHERE id IN ({placeholders})",
+                ids_to_delete,
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ? WHERE id = ?",
+                (new_count, session_id),
+            )
+
+        db._execute_write(_do)
+
+        logger.info(
+            "Rebuilt session %s: %d → %d messages (/undo)",
+            session_id, old_count, new_count,
+        )
+
+        preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
+        return f'Removed last {removed_count} message(s): "{preview}"'
+
+    def _slash_retry(self, session_id: str) -> Optional[str]:
+        """Return the last user message for re-processing, or None.
+
+        Truncates history so the retry doesn't duplicate context.
+        Caller is responsible for passing the returned message through
+        the normal agent run path.
+        """
+        db = self._ensure_session_db()
+        if db is None:
+            return None
+
+        messages = db.get_messages(session_id)
+        if not messages:
+            return None
+
+        # Find the last user message
+        last_user_idx = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+
+        if last_user_idx is None:
+            return None
+
+        last_user_content = messages[last_user_idx].get("content", "") or ""
+        if not last_user_content:
+            return None
+
+        old_count = len(messages)
+        new_count = last_user_idx  # keep everything BEFORE the last user msg
+
+        # Delete the tail (last user msg + everything after) in one transaction
+        ids_to_delete = [
+            messages[j]["id"] for j in range(last_user_idx, len(messages))
+        ]
+        placeholders = ",".join("?" for _ in ids_to_delete)
+
+        def _do(conn):
+            conn.execute(
+                f"DELETE FROM messages WHERE id IN ({placeholders})",
+                ids_to_delete,
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ? WHERE id = ?",
+                (new_count, session_id),
+            )
+
+        db._execute_write(_do)
+
+        logger.info(
+            "Rebuilt session %s: %d → %d messages (/retry)",
+            session_id, old_count, new_count,
+        )
+
+        return last_user_content
+
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
@@ -961,6 +1230,52 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
             session_id = _derive_chat_session_id(system_prompt, first_user)
             # history already set from request body above
+
+        # ── slash command interception ──────────────────────────────────
+        slash_result = await self._try_slash_command(
+            user_message, session_id, body
+        )
+        if slash_result is not None:
+            if slash_result.get("rewrite_message"):
+                # /retry — replace message and fall through to normal agent run.
+                # The command already truncated history so the retry doesn't
+                # duplicate context.  Reload history from DB to pick up the
+                # truncated state (history was loaded before our truncation).
+                user_message = slash_result["rewrite_message"]
+                db = self._ensure_session_db()
+                if db is not None:
+                    try:
+                        history = db.get_messages_as_conversation(session_id)
+                    except Exception:
+                        pass
+            else:
+                # Simple command response — return immediately, no LLM call.
+                response_text = slash_result.get("response", "")
+                return web.json_response(
+                    {
+                        "id": f"chatcmpl-{uuid.uuid4().hex[:29]}",
+                        "object": "chat.completion",
+                        "created": int(time.time()),
+                        "model": body.get("model", self._model_name),
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": response_text,
+                                },
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 0,
+                            "completion_tokens": 0,
+                            "total_tokens": 0,
+                        },
+                    },
+                    headers={"X-Hermes-Session-Id": session_id},
+                )
+        # ─────────────────────────────────────────────────────────────────
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2619,6 +2619,29 @@ class TestSlashCommandInterception:
             assert data["usage"]["total_tokens"] == 0
 
     @pytest.mark.asyncio
+    async def test_title_duplicate_returns_warning_not_500(self, adapter):
+        """/title returns a ⚠️ warning (not 500) when set_session_title raises ValueError."""
+        app = _create_app(adapter)
+
+        mock_db = MagicMock()
+        mock_db.sanitize_title = lambda t: t.strip() if t else None
+        mock_db.set_session_title = MagicMock(side_effect=ValueError("A session with this title already exists"))
+        mock_db.get_session_title = MagicMock(return_value=None)
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/title My Duped Title"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "⚠️" in content
+            assert "already exists" in content
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
     async def test_retry_triggers_agent_rerun(self, auth_adapter):
         """/retry rewrites the message and reruns the agent."""
         mock_result = {"final_response": "Fresh answer!", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2491,3 +2491,200 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+# ---------------------------------------------------------------------------
+# Slash command interception
+# ---------------------------------------------------------------------------
+
+
+class TestSlashCommandInterception:
+    """Slash commands are intercepted before the LLM call."""
+
+    @pytest.mark.asyncio
+    async def test_help_command_returns_formatted_list(self, adapter):
+        """/help returns the command list without hitting the LLM."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/help"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            content = data["choices"][0]["message"]["content"]
+            assert "/new" in content
+            assert "/help" in content
+            assert "/status" in content
+            # Must be a slash response, not an LLM response — no tokens consumed
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_new_reset_clears_session(self, adapter):
+        """/new and /reset both clear the session and return confirmation."""
+        for cmd in ("/new", "/reset"):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": cmd}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert "Session reset" in data["choices"][0]["message"]["content"]
+                assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_non_slash_message_passes_through_to_llm(self, adapter):
+        """A non-slash message is NOT intercepted — it reaches the agent."""
+        mock_result = {"final_response": "Hello, human!", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 50, "output_tokens": 20, "total_tokens": 70}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Hello"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            # The agent ran and produced a response
+            assert data["choices"][0]["message"]["content"] == "Hello, human!"
+            assert data["usage"]["total_tokens"] == 70
+            mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_slash_command_passes_through_to_llm(self, adapter):
+        """/xyz123 (not in supported set) falls through to the LLM."""
+        mock_result = {"final_response": "I don't know that command", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/xyz123"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            # The agent ran (not intercepted)
+            assert data["choices"][0]["message"]["content"] == "I don't know that command"
+            mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_malformed_slash_not_treated_as_command(self, adapter):
+        """/path/to/file (contains extra slashes) is not parsed as a command."""
+        mock_result = {"final_response": "That looks like a path", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/path/to/file"}]},
+                )
+            assert resp.status == 200
+            # Falls through to LLM — not treated as a command
+            mock_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_title_set_and_show(self, adapter):
+        """/title sets the session title via SessionDB."""
+        app = _create_app(adapter)
+        session_id = "test-title-session-002"
+
+        # Mock SessionDB to store/retrieve title
+        mock_db = MagicMock()
+        mock_db.sanitize_title = lambda t: t.strip() if t else None
+        mock_db.set_session_title = MagicMock(return_value=True)
+        mock_db.get_session_title = MagicMock(return_value=None)
+        adapter._session_db = mock_db
+
+        async with TestClient(TestServer(app)) as cli:
+            # Set title
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/title hello world"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "hello world" in data["choices"][0]["message"]["content"]
+            mock_db.set_session_title.assert_called_once()
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_triggers_agent_rerun(self, auth_adapter):
+        """/retry rewrites the message and reruns the agent."""
+        mock_result = {"final_response": "Fresh answer!", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 100, "output_tokens": 30, "total_tokens": 130}
+
+        app = _create_app(auth_adapter)
+        session_id = "test-retry-session-004"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_slash_retry", return_value="recovered question"), \
+                 patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": session_id, "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/retry"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["choices"][0]["message"]["content"] == "Fresh answer!"
+                assert data["usage"]["total_tokens"] == 130
+                # Verify agent was called with the recovered message
+                mock_run.assert_awaited_once()
+                call_kwargs = mock_run.call_args.kwargs
+                assert call_kwargs["user_message"] == "recovered question"
+
+    @pytest.mark.asyncio
+    async def test_undo_removes_last_exchange(self, adapter):
+        """/undo returns a confirmation message."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_slash_undo", return_value="Removed 2 message(s): \"test\""):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/undo"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                content = data["choices"][0]["message"]["content"]
+                assert "Removed" in content or "Undid" in content
+                assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_with_no_history_returns_error(self, adapter):
+        """/retry with no prior messages returns a helpful message."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/retry"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "No previous message" in data["choices"][0]["message"]["content"]
+            assert data["usage"]["total_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_undo_with_no_history_returns_error(self, adapter):
+        """/undo with nothing to undo returns a helpful message."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "/undo"}]},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "Nothing to undo" in data["choices"][0]["message"]["content"]
+            assert data["usage"]["total_tokens"] == 0


### PR DESCRIPTION
**Depends on #17178** — adds `_try_slash_command()` dispatcher and `_API_SERVER_SLASH_COMMANDS` frozenset that this PR extends. Diff against main will collapse to just `_slash_compress()` and tests once #17178 merges.

## Problem

The `/compress` slash command — which manually triggers conversation context compression via the auxiliary LLM — works in the CLI (`cli.py`) and all gateway platforms (Telegram, Discord, Slack, etc.) but is not available on the API server. Bridges and Open WebUI users who hit long-context limits have no way to compact their session without starting a `/new` session.

## Fix

Add a `_slash_compress()` handler to `APIServerAdapter` that mirrors the existing gateway implementation (`gateway/run.py:_handle_compress_command`).

**What happens:**
- The handler creates a `ContextCompressor` with the resolved main model credentials (same path `_create_agent` uses)
- Calls `compressor.compress(messages, focus_topic=...)` — a single one-shot LLM call through `agent/auxiliary_client.py` (no multi-turn agent loop)
- Rotates the session: ends the old session, creates a new child with `parent_session_id`, propagates the title with auto-numbering
- Returns human-readable feedback via `summarize_manual_compression()`
- Communicates the new `session_id` via the `X-Hermes-Session-Id` response header so bridges can persist the rotation

**Why this is not new architectural ground:**
- The gateway's `/compress` handler has shipped since v0.4.0 and makes the same `ContextCompressor → call_llm` call chain
- `ContextCompressor` is a standalone class — it takes messages + credentials, returns compressed messages. No agent loop needed.

## Scope

- `gateway/platforms/api_server.py`:
  - `_slash_compress()` async handler (~160 lines)
  - `"compress"` added to `_API_SERVER_SLASH_COMMANDS` frozenset
  - Dispatch case in `_try_slash_command()` with `new_session_id` support
  - `_slash_help()` updated to include `/compress [focus]`
  - Slash response header uses `new_session_id` when present (backward-compatible)
- `tests/gateway/test_api_server_compress.py`: 8 integration tests

Deliberately excluded:
- Gateway-side changes (already shipped)
- Session-override consumption in bridges (separate consumer responsibility)

## Tests

8 integration tests in `tests/gateway/test_api_server_compress.py`:

```
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_insufficient_messages PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_session_db_unavailable PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_nothing_to_compress PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_successful_rotates_session PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_propagates_title PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_focus_topic_passed_to_compressor PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_handles_llm_failure PASSED
tests/gateway/test_api_server_compress.py::TestSlashCompressHTTP::test_compress_response_header_has_new_session_id PASSED
```

Tests use `aiohttp.test_utils.TestClient` + mocked `ContextCompressor` (same pattern as `test_api_server_multimodal.py`).

## Validation

- [x] Compress tests pass: `python -m pytest tests/gateway/test_api_server_compress.py -v -o "addopts="`
- [x] Adjacent tests pass alongside: `python -m pytest tests/gateway/test_api_server_compress.py tests/gateway/test_api_server_multimodal.py -v -o "addopts="` — 31 passed
- [x] Full gateway suite: `python -m pytest tests/gateway/ -o "addopts=" -q` — 4063 passed, 0 failures

## No regressions

- [x] 4063 passed, 0 failures in 4:46 (198 pre-existing warnings, all in slack/sms tests)


