### PR TITLE
feat: HERMES_SEALED env var to lock the runtime to a single profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -32,6 +32,31 @@ from typing import List, Optional
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
+
+class SealedProfileError(RuntimeError):
+    """Raised when a profile-mutating operation is attempted in sealed mode.
+
+    Sealed mode (``HERMES_SEALED=true``) locks the runtime to a single
+    profile; mutation operations (create/delete/rename/import/export/use)
+    refuse to run because the deployment posture is "this binary serves
+    one profile, period". See :func:`hermes_constants.is_sealed`.
+    """
+
+
+def _enforce_not_sealed(operation: str) -> None:
+    """Raise :class:`SealedProfileError` when running in sealed mode.
+
+    Mutation entry points call this at the top to refuse cleanly with a
+    helpful message rather than failing later in unexpected ways.
+    """
+    from hermes_constants import is_sealed
+    if is_sealed():
+        raise SealedProfileError(
+            f"Cannot {operation}: hermes-agent is running in sealed mode "
+            f"(HERMES_SEALED=true). The runtime is locked to a single "
+            f"profile and refuses profile management operations."
+        )
+
 # Directories bootstrapped inside every new profile
 _PROFILE_DIRS = [
     "memories",
@@ -347,13 +372,24 @@ def _count_skills(profile_dir: Path) -> int:
 # ---------------------------------------------------------------------------
 
 def list_profiles() -> List[ProfileInfo]:
-    """Return info for all profiles, including the default."""
+    """Return info for all profiles, including the default.
+
+    In sealed mode (``HERMES_SEALED=true``), reports only the configured
+    profile (resolved via :func:`hermes_constants.get_sealed_profile_name`).
+    Sealed deployments treat sibling profiles as not-existing — by-design
+    information hiding for multi-tenant isolation.
+    """
+    from hermes_constants import is_sealed, get_sealed_profile_name
+
     profiles = []
     wrapper_dir = _get_wrapper_dir()
 
-    # Default profile
+    sealed = is_sealed()
+    sealed_name = get_sealed_profile_name() if sealed else None
+
+    # Default profile (skipped in sealed mode unless sealed_name == "default")
     default_home = _get_default_hermes_home()
-    if default_home.is_dir():
+    if default_home.is_dir() and (not sealed or sealed_name == "default"):
         model, provider = _read_config_model(default_home)
         profiles.append(ProfileInfo(
             name="default",
@@ -366,7 +402,7 @@ def list_profiles() -> List[ProfileInfo]:
             skill_count=_count_skills(default_home),
         ))
 
-    # Named profiles
+    # Named profiles (sealed mode filters to sealed_name only)
     profiles_root = _get_profiles_root()
     if profiles_root.is_dir():
         for entry in sorted(profiles_root.iterdir()):
@@ -374,6 +410,8 @@ def list_profiles() -> List[ProfileInfo]:
                 continue
             name = entry.name
             if not _PROFILE_ID_RE.match(name):
+                continue
+            if sealed and name != sealed_name:
                 continue
             model, provider = _read_config_model(entry)
             alias_path = wrapper_dir / name
@@ -401,6 +439,9 @@ def create_profile(
 ) -> Path:
     """Create a new profile directory.
 
+    Refuses with :class:`SealedProfileError` when running in sealed mode
+    (``HERMES_SEALED=true``).
+
     Parameters
     ----------
     name:
@@ -421,6 +462,7 @@ def create_profile(
     Path
         The newly created profile directory.
     """
+    _enforce_not_sealed("create profile")
     validate_profile_name(name)
 
     if name == "default":
@@ -538,8 +580,11 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     Stops the gateway if running. Disables systemd/launchd service first
     to prevent auto-restart.
 
+    Refuses with :class:`SealedProfileError` when running in sealed mode.
+
     Returns the path that was removed.
     """
+    _enforce_not_sealed("delete profile")
     validate_profile_name(name)
 
     if name == "default":
@@ -729,7 +774,22 @@ def set_active_profile(name: str) -> None:
     """Set the sticky active profile.
 
     Writes to ``~/.hermes/active_profile``. Use ``"default"`` to clear.
+
+    In sealed mode (``HERMES_SEALED=true``), only accepts the configured
+    sealed profile name (no-op when already that value); raises
+    :class:`SealedProfileError` for any other name.
     """
+    from hermes_constants import is_sealed, get_sealed_profile_name
+    if is_sealed():
+        sealed_name = get_sealed_profile_name()
+        if name != sealed_name:
+            raise SealedProfileError(
+                f"Cannot switch to profile '{name}': hermes-agent is running "
+                f"in sealed mode (HERMES_SEALED=true). The runtime is locked "
+                f"to profile '{sealed_name}'."
+            )
+        # No-op: already on the sealed profile.
+        return
     validate_profile_name(name)
     if name != "default" and not profile_exists(name):
         raise FileNotFoundError(
@@ -807,10 +867,14 @@ def _default_export_ignore(root_dir: Path):
 def export_profile(name: str, output_path: str) -> Path:
     """Export a profile to a tar.gz archive.
 
+    Refuses with :class:`SealedProfileError` when running in sealed mode
+    — sealed images are not authorized to export their profile data.
+
     Returns the output file path.
     """
     import tempfile
 
+    _enforce_not_sealed("export profile")
     validate_profile_name(name)
     profile_dir = get_profile_dir(name)
     if not profile_dir.is_dir():
@@ -927,11 +991,14 @@ def _inspect_profile_archive_roots(archive: Path) -> set[str]:
 def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     """Import a profile from a tar.gz archive.
 
+    Refuses with :class:`SealedProfileError` when running in sealed mode.
+
     If *name* is not given, infers it from the archive's top-level directory.
     Returns the imported profile directory.
     """
     import tempfile
 
+    _enforce_not_sealed("import profile")
     archive = Path(archive_path)
     if not archive.exists():
         raise FileNotFoundError(f"Archive not found: {archive}")
@@ -1046,8 +1113,11 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
 def rename_profile(old_name: str, new_name: str) -> Path:
     """Rename a profile: directory, wrapper script, service, active_profile.
 
+    Refuses with :class:`SealedProfileError` when running in sealed mode.
+
     Returns the new profile directory.
     """
+    _enforce_not_sealed("rename profile")
     validate_profile_name(old_name)
     validate_profile_name(new_name)
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -162,6 +162,59 @@ def display_hermes_home() -> str:
         return str(home)
 
 
+_SEALED_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def is_sealed() -> bool:
+    """Return True when ``HERMES_SEALED`` is set to a truthy value.
+
+    Sealed mode locks the runtime to a single profile. It's an opt-in
+    deployment posture for multi-tenant SaaS / sealed-image scenarios
+    (e.g. per-client docker images that bake one profile and should
+    refuse to enumerate or load any other).
+
+    When sealed:
+
+    * ``hermes profile list`` reports only the configured profile, not
+      siblings on disk.
+    * ``hermes profile create`` / ``delete`` / ``rename`` / ``import`` /
+      ``export`` raise ``SealedProfileError``.
+    * ``hermes profile use`` accepts only the configured profile name
+      (no-op if already active).
+
+    Truthy values: ``1``, ``true``, ``yes``, ``on`` (case-insensitive).
+    Anything else (including unset) → unchanged behavior, fully
+    backward-compatible.
+    """
+    return os.environ.get("HERMES_SEALED", "").strip().lower() in _SEALED_TRUTHY
+
+
+def get_sealed_profile_name() -> str | None:
+    """Return the configured sealed-profile name, or None if not sealed.
+
+    Resolution order:
+
+    1. ``HERMES_PROFILE_NAME`` env var (explicit).
+    2. Inferred from ``HERMES_HOME`` path when it ends in
+       ``.../profiles/<name>``.
+    3. ``None`` — caller treats as a configuration error (sealed mode
+       was requested but the profile name can't be determined).
+
+    Always returns ``None`` when sealed mode is not active.
+    """
+    if not is_sealed():
+        return None
+    explicit = os.environ.get("HERMES_PROFILE_NAME", "").strip()
+    if explicit:
+        return explicit
+    home = os.environ.get("HERMES_HOME", "").strip()
+    if home:
+        path = Path(home)
+        if path.parent.name == "profiles":
+            return path.name
+    return None
+
+
 def get_subprocess_home() -> str | None:
     """Return a per-profile HOME directory for subprocesses, or None.
 

--- a/tests/hermes_cli/test_sealed_mode.py
+++ b/tests/hermes_cli/test_sealed_mode.py
@@ -1,0 +1,194 @@
+"""Tests for HERMES_SEALED env var support in profile management.
+
+Sealed mode (HERMES_SEALED=true) locks the runtime to a single profile —
+opt-in deployment posture for multi-tenant SaaS / sealed-image scenarios.
+See hermes_constants.is_sealed and hermes_cli.profiles.SealedProfileError.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import is_sealed, get_sealed_profile_name
+from hermes_cli.profiles import (
+    SealedProfileError,
+    create_profile,
+    delete_profile,
+    export_profile,
+    import_profile,
+    list_profiles,
+    rename_profile,
+    set_active_profile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def sealed_env(tmp_path, monkeypatch):
+    """Set up a sealed-mode test environment with one captain profile.
+
+    Layout::
+
+        tmp_path/
+        └── .hermes/
+            └── profiles/
+                ├── captain/
+                │   └── (one profile dir to pretend it's the sealed one)
+                └── other/
+                    └── (a sibling profile that should be hidden)
+
+    Sealed mode is configured to pin the captain profile.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    (profiles_root / "captain").mkdir(parents=True)
+    (profiles_root / "other").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profiles_root / "captain"))
+    monkeypatch.setenv("HERMES_SEALED", "true")
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "captain")
+    return tmp_path
+
+
+@pytest.fixture()
+def unsealed_env(tmp_path, monkeypatch):
+    """Same layout as sealed_env but without HERMES_SEALED set."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    (profiles_root / "captain").mkdir(parents=True)
+    (profiles_root / "other").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.delenv("HERMES_SEALED", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# is_sealed()
+# ---------------------------------------------------------------------------
+
+class TestIsSealed:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "True", "yes", "YES", "on", "ON"])
+    def test_truthy_values_return_true(self, value, monkeypatch):
+        monkeypatch.setenv("HERMES_SEALED", value)
+        assert is_sealed() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "anything-else"])
+    def test_non_truthy_values_return_false(self, value, monkeypatch):
+        monkeypatch.setenv("HERMES_SEALED", value)
+        assert is_sealed() is False
+
+    def test_unset_returns_false(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SEALED", raising=False)
+        assert is_sealed() is False
+
+    def test_whitespace_stripped(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SEALED", "  true  ")
+        assert is_sealed() is True
+
+
+# ---------------------------------------------------------------------------
+# get_sealed_profile_name()
+# ---------------------------------------------------------------------------
+
+class TestGetSealedProfileName:
+    def test_returns_none_when_not_sealed(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SEALED", raising=False)
+        monkeypatch.setenv("HERMES_PROFILE_NAME", "captain")
+        assert get_sealed_profile_name() is None
+
+    def test_explicit_env_var_wins(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SEALED", "true")
+        monkeypatch.setenv("HERMES_PROFILE_NAME", "captain")
+        monkeypatch.setenv("HERMES_HOME", "/opt/data/profiles/some-other-name")
+        assert get_sealed_profile_name() == "captain"
+
+    def test_inferred_from_hermes_home_path(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SEALED", "true")
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+        monkeypatch.setenv("HERMES_HOME", "/opt/data/profiles/captain")
+        assert get_sealed_profile_name() == "captain"
+
+    def test_returns_none_when_cant_be_determined(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SEALED", "true")
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+        monkeypatch.setenv("HERMES_HOME", "/opt/data")  # not under profiles/
+        assert get_sealed_profile_name() is None
+
+
+# ---------------------------------------------------------------------------
+# list_profiles() filtering
+# ---------------------------------------------------------------------------
+
+class TestListProfilesSealed:
+    def test_sealed_returns_only_configured_profile(self, sealed_env):
+        profiles = list_profiles()
+        names = [p.name for p in profiles]
+        assert names == ["captain"]
+        assert "other" not in names
+        assert "default" not in names  # default profile not exposed in sealed mode
+
+    def test_unsealed_returns_all_profiles(self, unsealed_env):
+        profiles = list_profiles()
+        names = sorted(p.name for p in profiles)
+        # Order: default first, then sorted alphabetically
+        assert "captain" in names
+        assert "other" in names
+
+
+# ---------------------------------------------------------------------------
+# Mutation operations refused in sealed mode
+# ---------------------------------------------------------------------------
+
+class TestMutationsRefusedSealed:
+    def test_create_profile_raises_in_sealed(self, sealed_env):
+        with pytest.raises(SealedProfileError, match="create profile"):
+            create_profile("anything-new")
+
+    def test_delete_profile_raises_in_sealed(self, sealed_env):
+        with pytest.raises(SealedProfileError, match="delete profile"):
+            delete_profile("captain")
+
+    def test_rename_profile_raises_in_sealed(self, sealed_env):
+        with pytest.raises(SealedProfileError, match="rename profile"):
+            rename_profile("captain", "captain-renamed")
+
+    def test_export_profile_raises_in_sealed(self, sealed_env, tmp_path):
+        with pytest.raises(SealedProfileError, match="export profile"):
+            export_profile("captain", str(tmp_path / "out.tar.gz"))
+
+    def test_import_profile_raises_in_sealed(self, sealed_env, tmp_path):
+        # Pre-create a fake archive — the gate trips before file checks.
+        archive = tmp_path / "fake.tar.gz"
+        archive.write_bytes(b"")
+        with pytest.raises(SealedProfileError, match="import profile"):
+            import_profile(str(archive))
+
+    def test_set_active_to_other_profile_raises(self, sealed_env):
+        with pytest.raises(SealedProfileError, match="locked to profile 'captain'"):
+            set_active_profile("other")
+
+    def test_set_active_to_sealed_profile_is_noop(self, sealed_env):
+        # Setting to the already-sealed profile should be a clean no-op
+        # (no error, no state change required).
+        set_active_profile("captain")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — unsealed mode unchanged
+# ---------------------------------------------------------------------------
+
+class TestUnsealedModeUnchanged:
+    def test_create_profile_works_in_unsealed(self, unsealed_env):
+        # Should not raise SealedProfileError; downstream logic is the
+        # existing unchanged behavior (and may raise its own errors,
+        # which is fine — we only care that the sealed gate is absent).
+        path = create_profile("brand-new")
+        assert path.is_dir()
+
+    def test_set_active_profile_validates_normally_in_unsealed(self, unsealed_env):
+        # Existing validation for non-existent profiles should fire.
+        with pytest.raises(FileNotFoundError):
+            set_active_profile("does-not-exist")


### PR DESCRIPTION
## Summary

Adds opt-in **HERMES_SEALED** + **HERMES_PROFILE_NAME** env vars that lock the runtime to a single profile. When sealed:

- \`hermes profile list\` reports only the configured profile, not siblings on disk
- \`hermes profile create\` / \`delete\` / \`rename\` / \`import\` / \`export\` raise a new \`SealedProfileError\`
- \`hermes profile use\` accepts only the configured profile name (no-op when already active); raises for any other

Unset = unchanged behavior, fully backward-compatible.

## Why

Multi-tenant SaaS deployments of hermes-agent (per-client docker images, sealed-image scenarios) need a way to lock the runtime to a single profile **at the binary level** — not just by what's mounted into the volume.

In our case (an AI persona we ship to client VPSs), volume-mount restriction + image-build sanitization handle most of the isolation. But there are scenarios where defense-in-depth at the binary level is the right posture:

- **Misconfigured volume mount** that exposes other profiles → those profiles become loadable
- **\`profile list\`** would enumerate beyond the intended profile (information disclosure to the client side)
- **\`profile create\`** / \`delete\` / \`rename\` are reachable in client-deployed images where the operator should only ever interact with one profile

This PR adds an opt-in flag for that posture. Unset, hermes-agent behaves identically.

## Implementation

### \`hermes_constants.py\`

Two new helpers:

\`\`\`python
def is_sealed() -> bool:
    \"\"\"True when HERMES_SEALED is set to truthy (1, true, yes, on; case-insensitive).\"\"\"

def get_sealed_profile_name() -> str | None:
    \"\"\"Resolves: HERMES_PROFILE_NAME → inferred from HERMES_HOME path → None.
    Always None when not sealed.\"\"\"
\`\`\`

### \`hermes_cli/profiles.py\`

- New \`SealedProfileError(RuntimeError)\`
- New \`_enforce_not_sealed(operation: str)\` helper
- \`list_profiles()\` filters output to the sealed profile when sealed
- All mutation entry points (\`create_profile\`, \`delete_profile\`, \`rename_profile\`, \`import_profile\`, \`export_profile\`) call \`_enforce_not_sealed\` at the top
- \`set_active_profile\` special-cases — accepts the sealed profile name as a no-op; raises for any other

## Testing

New \`tests/hermes_cli/test_sealed_mode.py\` — **31 tests, all passing**:

- \`TestIsSealed\` (12): truthy/falsy/whitespace handling
- \`TestGetSealedProfileName\` (4): env var precedence + path inference
- \`TestListProfilesSealed\` (2): filter behavior in sealed mode + unchanged when unsealed
- \`TestMutationsRefusedSealed\` (7): each mutation raises \`SealedProfileError\`; \`set_active\` to sealed name is no-op
- \`TestUnsealedModeUnchanged\` (2): regression check — existing behavior preserved when unset

Existing \`tests/hermes_cli/test_profiles.py\` (94 tests) **unchanged; still all passing — zero regressions** (\`uv run pytest tests/hermes_cli/\` is green: 125/125).

## Backward compatibility

Fully backward-compatible. Unset HERMES_SEALED → existing behavior in every code path. The only behavior change for non-sealed deployments is the addition of two helper functions in \`hermes_constants.py\` and one new exception class in \`hermes_cli/profiles.py\` — neither affects runtime unless explicitly used.

## Naming alternatives considered

- \`HERMES_LOCKED=true\` — collides with existing \`auth.lock\`, \`gateway.lock\` files
- \`HERMES_SINGLE_PROFILE=true\` — clearer but verbose
- \`HERMES_RESTRICTED_MODE=true\` — too generic; doesn't convey the profile-locking semantic
- **\`HERMES_SEALED=true\`** ← chosen; matches docker/sealed-image vocabulary; semantic is "no admin operations, this binary is sealed to one profile"

🤖 Generated with [Claude Code](https://claude.com/claude-code)