### PR TITLE
fix(kanban): make kanban_db_path and workspaces_root profile-agnostic (#19036)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -62,15 +62,24 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban.db"
+    """Return the path to ``kanban.db`` under the default HERMES_HOME.
+    
+    Profile-agnostic on purpose: multiple profiles on the same machine all
+    see the same board, which IS the coordination primitive for multi-agent
+    orchestrator → worker workflows.
+    """
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "kanban.db"
 
 
 def workspaces_root() -> Path:
-    """Return the directory under which ``scratch`` workspaces are created."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban" / "workspaces"
+    """Return the directory under which ``scratch`` workspaces are created.
+    
+    Profile-agnostic: all profiles share the same workspace root so that
+    orchestrator-created task directories are visible to worker profiles.
+    """
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "kanban" / "workspaces"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix: Kanban board is profile-agnostic, but `kanban_db_path()` and `workspaces_root()` were profile-aware

Closes #19036

### Problem

The module docstring in `kanban_db.py` states:

> The board lives at `$HERMES_HOME/kanban.db` (profile-agnostic on purpose: multiple profiles on the same machine all see the same board)

But `kanban_db_path()` used `get_hermes_home()`, which returns `~/.hermes/profiles/<profile>/` when a profile is active. This means:

1. Orchestrator (e.g., `techlead`) creates tasks in `~/.hermes/profiles/techlead/kanban.db`
2. Workers (e.g., `dev`, `devops`, `qa`) look in `~/.hermes/profiles/dev/kanban.db`
3. Workers can never find orchestrator-created tasks → crash loop

### Fix

Changed `kanban_db_path()` and `workspaces_root()` to use `get_default_hermes_root()` instead of `get_hermes_home()`. This ensures all profiles share the same `kanban.db` regardless of active profile — matching the documented intent.

Log paths (`log_dir`, `task_log_path`) intentionally still use `get_hermes_home()` since per-profile logs make sense.

### Companion PR

This extends the fix from #19030 which addressed `list_profiles_on_disk()`. Together, all path resolution in `kanban_db.py` is now consistent with the "profile-agnostic" design.

### Testing

- Verified `kanban_db_path()` and `workspaces_root()` return base `~/.hermes/` paths regardless of profile
- Verified log paths still correctly resolve to profile-specific directories
- Type checks pass