### PR TITLE
fix(docs): correct ACP command docs - remove misleading claude references

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2448,7 +2448,7 @@ DELEGATE_TASK_SCHEMA = {
                         },
                         "acp_command": {
                             "type": "string",
-                            "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
+                            "description": "Per-task ACP command override (e.g. 'copilot'). Overrides the top-level acp_command for this task only. Only ACP-compatible CLIs are supported.",
                         },
                         "acp_args": {
                             "type": "array",
@@ -2488,10 +2488,10 @@ DELEGATE_TASK_SCHEMA = {
             "acp_command": {
                 "type": "string",
                 "description": (
-                    "Override ACP command for child agents (e.g. 'claude', 'copilot'). "
+                    "Override ACP command for child agents (e.g. 'copilot'). "
                     "When set, children use ACP subprocess transport instead of inheriting "
-                    "the parent's transport. Enables spawning Claude Code (claude --acp --stdio) "
-                    "or other ACP-capable agents from any parent, including Discord/Telegram/CLI."
+                    "the parent's transport. Enables spawning ACP-capable CLIs (e.g. GitHub Copilot: "
+                    "copilot --acp --stdio) from any parent, including Discord/Telegram/CLI."
                 ),
             },
             "acp_args": {
@@ -2499,7 +2499,7 @@ DELEGATE_TASK_SCHEMA = {
                 "items": {"type": "string"},
                 "description": (
                     "Arguments for the ACP command (default: ['--acp', '--stdio']). "
-                    "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
+                    "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'gpt-4o']"
                 ),
             },
         },


### PR DESCRIPTION
## Summary

Fixes #19055

The `delegate_task` tool schema in `tools/delegate_tool.py` contained misleading references suggesting `claude --acp --stdio` works as an ACP transport. In reality, Claude Code CLI (v2.1.126+) does not support `--acp` or `--stdio` flags. The underlying implementation (`agent/copilot_acp_client.py`) is built for GitHub Copilot CLI (`copilot --acp --stdio`), not Claude Code.

## Changes

1. **Per-task `acp_command` description**: Changed example from `'claude'` to `'copilot'`, added note that only ACP-compatible CLIs are supported
2. **Top-level `acp_command` description**: Changed example from `'claude', 'copilot'` to `'copilot'`, replaced "Enables spawning Claude Code (claude --acp --stdio)" with "Enables spawning ACP-capable CLIs (e.g. GitHub Copilot: copilot --acp --stdio)"
3. **`acp_args` description example**: Changed model example from `'claude-opus-4-6'` to `'gpt-4o'` to avoid implying Claude works with ACP transport

## Test Plan

- [x] Python syntax validated (`compile()` check passes)
- [x] No functional code changes — only doc/description strings modified
- [x] `copilot --acp --stdio` is the correct invocation per `agent/copilot_acp_client.py`
