### PR TITLE
feat: configure MoA provider routing

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -664,7 +664,7 @@ platform_toolsets:
 #   image_gen    - image_generate  (requires FAL_KEY)
 #   skills       - skills_list, skill_view
 #   skills_hub   - skill_hub (search/install/manage from online registries — user-driven only)
-#   moa          - mixture_of_agents  (requires OPENROUTER_API_KEY)
+#   moa          - mixture_of_agents  (configure providers under `moa:`)
 #   todo         - todo (in-memory task planning, no deps)
 #   tts          - text_to_speech  (Edge TTS free, or ELEVENLABS/OPENAI/MINIMAX/MISTRAL key)
 #   cronjob      - cronjob (create/list/update/pause/resume/run/remove scheduled tasks)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -664,6 +664,30 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Mixture-of-Agents tool: per-model provider routing and reasoning effort.
+    # Absent/empty moa block inherits these defaults; omitted provider fields
+    # default to "openrouter". Routing multiple reference models through Codex
+    # multiplies consumption against the Codex plan's daily cap.
+    "moa": {
+        "enabled": True,
+        "reference_models": [
+            {"model": "anthropic/claude-opus-4.7", "provider": "openrouter", "reasoning": "xhigh"},
+            {"model": "google/gemini-3.1-pro-preview", "provider": "openrouter", "reasoning": "xhigh"},
+            {"model": "openai/gpt-5.5-pro", "provider": "openrouter", "reasoning": "xhigh"},
+            {"model": "qwen/qwen3.6-plus", "provider": "openrouter", "reasoning": "xhigh"},
+        ],
+        "aggregator_model": {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "reasoning": "xhigh",
+        },
+        "reference_temperature": 0.6,
+        "aggregator_temperature": 0.4,
+        # min_successful_references: defaults to min(2, len(reference_models))
+        # when omitted so a single silent reference failure doesn't pass.
+    },
+
+
     # Auxiliary model config — provider:model for each side task.
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
@@ -1315,7 +1339,7 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "OPENROUTER_API_KEY": {
-        "description": "OpenRouter API key (for vision, web scraping helpers, and MoA)",
+        "description": "OpenRouter API key (for vision, web scraping helpers, and OpenRouter-routed MoA entries)",
         "prompt": "OpenRouter API key",
         "url": "https://openrouter.ai/keys",
         "password": True,
@@ -3968,6 +3992,26 @@ _COMMENTED_SECTIONS = """
 # fallback_model:
 #   provider: openrouter
 #   model: anthropic/claude-sonnet-4
+#
+# ── Mixture of Agents ────────────────────────────────────────────────
+# Per-model roster for the MoA tool.  Each entry accepts `model`,
+# `provider`, and optional `reasoning` (Hermes reasoning effort or `none`).
+# Warning: routing multiple reference models through `openai-codex`
+# multiplies consumption against the Codex plan's daily cap.
+#
+# moa:
+#   enabled: true
+#   reference_models:
+#     - {model: anthropic/claude-opus-4.7,   provider: openrouter, reasoning: xhigh}
+#     - {model: google/gemini-3.1-pro-preview, provider: openrouter, reasoning: xhigh}
+#     - {model: openai/gpt-5.5-pro,          provider: openrouter, reasoning: xhigh}
+#     - {model: qwen/qwen3.6-plus,           provider: openrouter, reasoning: xhigh}
+#   aggregator_model:
+#     model: anthropic/claude-opus-4.7
+#     provider: openrouter
+#     reasoning: xhigh
+#   reference_temperature: 0.6
+#   aggregator_temperature: 0.4
 """
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -367,11 +367,18 @@ def _print_setup_summary(config: dict, hermes_home):
     else:
         tool_status.append(("Vision (image analysis)", False, "run 'hermes setup' to configure"))
 
-    # Mixture of Agents — requires OpenRouter specifically (calls multiple models)
-    if get_env_value("OPENROUTER_API_KEY"):
-        tool_status.append(("Mixture of Agents", True, None))
-    else:
-        tool_status.append(("Mixture of Agents", False, "OPENROUTER_API_KEY"))
+    # Mixture of Agents — availability depends on the configured roster.
+    try:
+        from tools.mixture_of_agents_tool import get_moa_preflight_status
+
+        moa_available, moa_hint = get_moa_preflight_status()
+    except Exception:
+        moa_available, moa_hint = False, "configured MoA provider credentials"
+    tool_status.append((
+        "Mixture of Agents",
+        moa_available,
+        None if moa_available else (moa_hint or "configured MoA provider credentials"),
+    ))
 
     # Web tools (Exa, Parallel, Firecrawl, or Tavily)
     if subscription_features.web.managed_by_nous:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -57,7 +57,7 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
-    ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
+    ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents (edit roster/providers/reasoning under `moa:` in config.yaml)"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
@@ -462,10 +462,9 @@ TOOL_CATEGORIES = {
 }
 
 # Simple env-var requirements for toolsets NOT in TOOL_CATEGORIES.
-# Used as a fallback for tools like vision/moa that just need an API key.
+# Used as a fallback for tools that still have a single fixed API-key backend.
 TOOLSET_ENV_REQUIREMENTS = {
     "vision":     [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
-    "moa":        [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
 }
 
 
@@ -1051,6 +1050,15 @@ def _toolset_has_keys(ts_key: str, config: dict = None) -> bool:
         except Exception:
             return False
 
+    if ts_key == "moa":
+        try:
+            from tools.mixture_of_agents_tool import get_moa_preflight_status
+
+            available, _hint = get_moa_preflight_status()
+            return available
+        except Exception:
+            return False
+
     if ts_key in {"web", "image_gen", "tts", "browser"}:
         features = get_nous_subscription_features(config)
         feature = features.features.get(ts_key)
@@ -1196,7 +1204,7 @@ def _configure_toolset(ts_key: str, config: dict):
     if cat:
         _configure_tool_category(ts_key, cat, config)
     else:
-        # Simple fallback for vision, moa, etc.
+        # Simple fallback for vision and other fixed-key toolsets.
         _configure_simple_requirements(ts_key)
 
 

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -454,6 +454,52 @@ def test_setup_summary_marks_anthropic_auth_as_vision_available(tmp_path, monkey
     assert "missing run 'hermes setup' to configure" not in output
 
 
+def test_setup_summary_marks_codex_only_moa_as_available_without_openrouter(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    monkeypatch.setattr("agent.auxiliary_client._read_codex_access_token", lambda: "codex-token")
+
+    config = load_config()
+    config["moa"] = {
+        "enabled": True,
+        "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+        "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+    }
+    save_config(config)
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Mixture of Agents" in output
+    assert "missing OPENROUTER_API_KEY" not in output
+    assert "missing credentials for openai-codex" not in output
+
+
+def test_setup_summary_reports_configured_moa_provider_not_openrouter(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    monkeypatch.setattr("agent.auxiliary_client._read_codex_access_token", lambda: "")
+
+    config = load_config()
+    config["moa"] = {
+        "enabled": True,
+        "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+        "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+    }
+    save_config(config)
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Mixture of Agents" in output
+    assert "missing credentials for openai-codex" in output
+    assert "missing OPENROUTER_API_KEY" not in output
+
+
 def test_setup_summary_shows_camofox_when_browser_feature_is_camofox(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -269,6 +269,22 @@ def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     assert _toolset_has_keys("vision") is True
 
 
+def test_toolset_has_keys_for_moa_uses_config_aware_preflight(monkeypatch):
+    import tools.mixture_of_agents_tool as moa
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(moa, "get_moa_preflight_status", lambda: (True, None))
+
+    assert _toolset_has_keys("moa") is True
+
+    monkeypatch.setattr(
+        moa,
+        "get_moa_preflight_status",
+        lambda: (False, "credentials for openai-codex"),
+    )
+    assert _toolset_has_keys("moa") is False
+
+
 def test_save_platform_tools_preserves_mcp_server_names():
     """Ensure MCP server names are preserved when saving platform tools.
 

--- a/tests/tools/test_mixture_of_agents_tool.py
+++ b/tests/tools/test_mixture_of_agents_tool.py
@@ -33,12 +33,21 @@ async def test_reference_model_retry_warnings_avoid_exc_info_until_terminal_fail
     warn = MagicMock()
     err = MagicMock()
 
-    monkeypatch.setattr(moa, "_get_openrouter_client", lambda: fake_client)
+    monkeypatch.setattr(
+        moa,
+        "resolve_provider_client",
+        lambda *a, **k: (fake_client, "openai/gpt-5.4-pro"),
+    )
     monkeypatch.setattr(moa.logger, "warning", warn)
     monkeypatch.setattr(moa.logger, "error", err)
 
+    entry = {
+        "model": "openai/gpt-5.4-pro",
+        "provider": "openrouter",
+        "reasoning_config": None,
+    }
     model, message, success = await moa._run_reference_model_safe(
-        "openai/gpt-5.4-pro", "hello", max_retries=2
+        entry, "hello", max_retries=2
     )
 
     assert model == "openai/gpt-5.4-pro"

--- a/tests/tools/test_mixture_of_agents_tool_provider_routing.py
+++ b/tests/tools/test_mixture_of_agents_tool_provider_routing.py
@@ -1,0 +1,897 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+import hermes_cli.models as models_mod
+from hermes_cli.config import DEFAULT_CONFIG, get_config_path
+from hermes_cli.model_normalize import normalize_model_for_provider
+from hermes_constants import VALID_REASONING_EFFORTS
+
+import tools.mixture_of_agents_tool as moa
+
+
+VALID_PROVIDER_IDS = [
+    "openrouter",
+    "nous",
+    "openai-codex",
+    "lmstudio",
+    "google-gemini-cli",
+    "copilot",
+    "copilot-acp",
+    "gemini",
+    "huggingface",
+    "zai",
+    "kimi-coding",
+    "kimi-coding-cn",
+    "minimax",
+    "minimax-cn",
+    "kilocode",
+    "anthropic",
+    "alibaba",
+    "qwen-oauth",
+    "xiaomi",
+    "tencent-tokenhub",
+    "opencode-zen",
+    "opencode-go",
+    "ai-gateway",
+    "deepseek",
+    "arcee",
+    "xai",
+    "nvidia",
+    "ollama-cloud",
+    "bedrock",
+    "custom",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_moa_state():
+    moa._codex_warning_seen.clear()
+    moa._reasoning_skip_warning_seen.clear()
+
+
+@pytest.fixture(autouse=True)
+def _stable_provider_registry(monkeypatch):
+    monkeypatch.setattr(
+        models_mod,
+        "list_available_providers",
+        lambda: [{"id": provider_id} for provider_id in VALID_PROVIDER_IDS],
+    )
+
+
+def _write_config(data: dict):
+    config_path = get_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+@pytest.fixture
+def fake_catalogs(monkeypatch):
+    catalogs = {
+        "openrouter": [
+            "anthropic/claude-opus-4.7",
+            "google/gemini-3.1-pro-preview",
+            "openai/gpt-5.5-pro",
+            "qwen/qwen3.6-plus",
+            "qwen/qwen3.5-plus-02-15",
+        ],
+        "anthropic": ["claude-opus-4-6"],
+        "openai-codex": ["gpt-5.4"],
+        "copilot": ["gpt-5.4", "gpt-4.1"],
+        "copilot-acp": ["gpt-5.4"],
+        "nous": ["minimax/minimax-m2.5"],
+        "ai-gateway": ["anthropic/claude-opus-4.7"],
+        "lmstudio": ["local-reasoner"],
+        "tencent-tokenhub": ["hy3-preview"],
+        "custom": [],
+    }
+
+    def _provider_model_ids(provider, *, force_refresh=False):
+        return list(catalogs.get(provider, []))
+
+    monkeypatch.setattr(models_mod, "provider_model_ids", _provider_model_ids)
+    return catalogs
+
+
+@pytest.mark.parametrize("reasoning_value", [None, "", "   "])
+def test_load_moa_config_absent_or_blank_reasoning_uses_defaults(fake_catalogs, reasoning_value):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "anthropic/claude-opus-4.7",
+                        "reasoning": reasoning_value,
+                    }
+                ],
+                "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["enabled"] is True
+    assert loaded["reference_models"][0]["provider"] == "openrouter"
+    assert loaded["reference_models"][0]["reasoning_config"] is None
+    assert loaded["aggregator_model"]["provider"] == "openrouter"
+    assert loaded["aggregator_model"]["reasoning_config"] is None
+    assert loaded["min_successful_references"] == 1
+
+
+def test_load_moa_config_defaults_when_block_absent(fake_catalogs):
+    _write_config({"model": "anthropic/claude-opus-4.7"})
+
+    loaded = moa._load_moa_config()
+
+    assert [entry["model"] for entry in loaded["reference_models"]] == moa.REFERENCE_MODELS
+    assert all(entry["provider"] == "openrouter" for entry in loaded["reference_models"])
+    assert all(entry["reasoning_config"] == {"enabled": True, "effort": "xhigh"} for entry in loaded["reference_models"])
+    assert loaded["aggregator_model"]["model"] == moa.AGGREGATOR_MODEL
+    assert loaded["aggregator_model"]["provider"] == "openrouter"
+    assert loaded["aggregator_model"]["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+    assert loaded["reference_temperature"] == moa.REFERENCE_TEMPERATURE
+    assert loaded["aggregator_temperature"] == moa.AGGREGATOR_TEMPERATURE
+    assert loaded["min_successful_references"] == 2
+
+
+def test_load_moa_config_accepts_explicit_enabled_true(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "enabled": True,
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["enabled"] is True
+
+
+def test_load_moa_config_rejects_non_bool_enabled(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "enabled": "yes",
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="moa.enabled"):
+        moa._load_moa_config()
+
+
+def test_load_moa_config_accepts_string_shorthand(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["gpt-5.4"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["model"] == "gpt-5.4"
+    assert loaded["reference_models"][0]["provider"] == "openrouter"
+    assert loaded["reference_models"][0]["reasoning_config"] is None
+    assert loaded["aggregator_model"]["model"] == "anthropic/claude-opus-4.7"
+    assert loaded["aggregator_model"]["provider"] == "openrouter"
+
+
+def test_load_moa_config_preserves_dict_entries(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "gpt-5.4",
+                        "provider": "openai-codex",
+                        "reasoning": "high",
+                    }
+                ],
+                "aggregator_model": {
+                    "model": "claude-opus-4-6",
+                    "provider": "anthropic",
+                    "reasoning": "none",
+                },
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0] == {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "reasoning_config": {"enabled": True, "effort": "high"},
+    }
+    assert loaded["aggregator_model"] == {
+        "model": "claude-opus-4-6",
+        "provider": "anthropic",
+        "reasoning_config": {"enabled": False},
+    }
+
+
+def test_load_moa_config_normalizes_provider_aliases(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "hy3-preview", "provider": "tokenhub"}],
+                "aggregator_model": {"model": "local-reasoner", "provider": "lm-studio"},
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["provider"] == "tencent-tokenhub"
+    assert loaded["aggregator_model"]["provider"] == "lmstudio"
+
+
+def test_load_moa_config_accepts_named_custom_provider_slug(fake_catalogs):
+    _write_config(
+        {
+            "custom_providers": [
+                {
+                    "name": "internal",
+                    "base_url": "http://localhost:1234/v1",
+                    "api_key": "test",
+                }
+            ],
+            "moa": {
+                "reference_models": [{"model": "my-model", "provider": "custom:internal"}],
+                "aggregator_model": {"model": "my-model", "provider": "custom:internal"},
+            },
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["provider"] == "custom:internal"
+    assert loaded["aggregator_model"]["provider"] == "custom:internal"
+
+
+def test_load_moa_config_rejects_unknown_provider(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {"model": "anthropic/claude-opus-4.7", "provider": "totally-made-up"}
+                ],
+                "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="unknown provider"):
+        moa._load_moa_config()
+
+
+@pytest.mark.parametrize("reasoning", ["extreme", "max"])
+def test_load_moa_config_rejects_invalid_reasoning(fake_catalogs, reasoning):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {"model": "anthropic/claude-opus-4.7", "reasoning": reasoning}
+                ],
+                "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+            }
+        }
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        moa._load_moa_config()
+
+    message = str(exc_info.value)
+    for effort in (*VALID_REASONING_EFFORTS, "none"):
+        assert effort in message
+    assert "max" not in message.replace(repr(reasoning), "")
+
+
+@pytest.mark.parametrize("reasoning", VALID_REASONING_EFFORTS)
+def test_load_moa_config_accepts_every_valid_reasoning_effort(fake_catalogs, reasoning):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "anthropic/claude-opus-4.7",
+                        "reasoning": reasoning,
+                    }
+                ],
+                "aggregator_model": {
+                    "model": "anthropic/claude-opus-4.7",
+                    "reasoning": "none",
+                },
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["reasoning_config"] == {
+        "enabled": True,
+        "effort": reasoning,
+    }
+    assert loaded["aggregator_model"]["reasoning_config"] == {"enabled": False}
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_match"),
+    [
+        (
+            {
+                "moa": {
+                    "reference_models": [],
+                    "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+                }
+            },
+            "reference_models",
+        ),
+        (
+            {
+                "moa": {
+                    "reference_models": ["anthropic/claude-opus-4.7"],
+                    "aggregator_model": None,
+                }
+            },
+            "aggregator_model",
+        ),
+        (
+            {
+                "moa": {
+                    "reference_models": ["anthropic/claude-opus-4.7"],
+                    "aggregator_model": {},
+                }
+            },
+            "aggregator_model",
+        ),
+        (
+            {
+                "moa": {
+                    "reference_models": [{}],
+                    "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+                }
+            },
+            "reference_models",
+        ),
+    ],
+)
+def test_load_moa_config_rejects_invalid_shapes(fake_catalogs, config, expected_match):
+    _write_config(config)
+
+    with pytest.raises(ValueError, match=expected_match):
+        moa._load_moa_config()
+
+
+def test_load_moa_config_surfaces_raw_moa_read_failure(fake_catalogs, monkeypatch):
+    _write_config({"model": "anthropic/claude-opus-4.7"})
+    monkeypatch.setattr(
+        moa,
+        "_read_raw_moa_subtree",
+        lambda: (_ for _ in ()).throw(
+            ValueError("unable to read raw moa config for validation: boom")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="unable to read raw moa config"):
+        moa._load_moa_config()
+
+
+def test_normalize_entry_surfaces_provider_normalization_errors(monkeypatch):
+    def _boom(provider):
+        raise RuntimeError(f"bad provider alias: {provider}")
+
+    monkeypatch.setattr(models_mod, "normalize_provider", _boom)
+
+    with pytest.raises(RuntimeError, match="bad provider alias"):
+        moa._normalize_entry(
+            {"model": "m", "provider": "lm-studio"},
+            idx=0,
+            is_aggregator=False,
+        )
+
+
+def test_load_moa_config_surfaces_custom_provider_helper_errors(
+    fake_catalogs,
+    monkeypatch,
+):
+    import hermes_cli.config as config_mod
+
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+
+    def _boom(config):
+        raise RuntimeError("bad custom provider config")
+
+    monkeypatch.setattr(config_mod, "get_compatible_custom_providers", _boom)
+
+    with pytest.raises(RuntimeError, match="bad custom provider config"):
+        moa._load_moa_config()
+
+
+@pytest.mark.parametrize(
+    ("roster", "explicit", "expected"),
+    [
+        (["a", "b", "c"], None, 2),
+        (["a"], None, 1),
+        (["a", "b", "c"], 1, 1),
+    ],
+)
+def test_min_successful_references_default_and_override(fake_catalogs, roster, explicit, expected):
+    config = {
+        "moa": {
+            "reference_models": roster,
+            "aggregator_model": "anthropic/claude-opus-4.7",
+        }
+    }
+    if explicit is not None:
+        config["moa"]["min_successful_references"] = explicit
+    _write_config(config)
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["min_successful_references"] == expected
+
+
+@pytest.mark.parametrize("value", [0, 3, 1.5, True])
+def test_min_successful_references_out_of_range(fake_catalogs, value):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7", "gpt-5.4"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+                "min_successful_references": value,
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="min_successful_references"):
+        moa._load_moa_config()
+
+
+@pytest.mark.asyncio
+async def test_per_call_reference_override_honors_explicit_quorum(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7", "openai/gpt-5.5-pro"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+                "min_successful_references": 2,
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(
+        await moa.mixture_of_agents_tool("solve this", reference_models=["solo"])
+    )
+
+    assert result["success"] is False
+    assert "pinned to 2" in result["error"]
+
+
+def test_model_catalog_mismatch_warns_but_does_not_raise(monkeypatch):
+    monkeypatch.setattr(
+        models_mod,
+        "provider_model_ids",
+        lambda provider, *, force_refresh=False: ["gpt-5.4"],
+    )
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "not-in-catalog", "provider": "openai-codex"}],
+                "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+            }
+        }
+    )
+
+    with patch.object(moa.logger, "warning") as warn:
+        loaded = moa._load_moa_config(emit_warnings=True)
+
+    assert loaded["reference_models"][0]["model"] == "not-in-catalog"
+    warn.assert_any_call(
+        "MoA: model %r not in %s catalog — may fail at call time",
+        "not-in-catalog",
+        "openai-codex",
+    )
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_short_circuits_fail_closed(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "enabled": False,
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result == {
+        "success": False,
+        "response": "",
+        "models_used": {"reference_models": [], "aggregator_model": ""},
+        "error": "MoA disabled via moa.enabled=false",
+    }
+    assert moa.check_moa_requirements() is False
+
+
+def test_check_moa_requirements_is_config_aware(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+                "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_provider_has_credentials",
+        lambda provider, model=None: provider == "openai-codex",
+    )
+
+    assert moa.check_moa_requirements() is True
+
+
+def test_check_moa_requirements_reports_missing_provider(fake_catalogs, monkeypatch, caplog):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+    monkeypatch.setattr(moa, "_provider_has_credentials", lambda provider, model=None: False)
+
+    available, hint = moa.get_moa_preflight_status()
+
+    assert available is False
+    assert hint == "credentials for openrouter"
+    assert "openrouter" in caplog.text.lower()
+
+
+def test_custom_provider_slug_does_not_bypass_preflight(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "custom_providers": [
+                {
+                    "name": "internal",
+                    "base_url": "http://localhost:1234/v1",
+                    "api_key": "test",
+                }
+            ],
+            "moa": {
+                "reference_models": [{"model": "my-model", "provider": "custom:internal"}],
+                "aggregator_model": {"model": "my-model", "provider": "custom:internal"},
+            },
+        }
+    )
+    monkeypatch.setattr(moa, "resolve_provider_client", lambda *args, **kwargs: (None, "my-model"))
+
+    available, hint = moa.get_moa_preflight_status()
+
+    assert available is False
+    assert hint == "credentials for custom:internal"
+
+
+def test_preflight_uses_resolver_and_closes_clients(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+                "aggregator_model": {"model": "claude-opus-4-6", "provider": "anthropic"},
+            }
+        }
+    )
+    client = SimpleNamespace(close=MagicMock())
+    calls = []
+
+    def _resolve(provider, model=None, async_mode=False):
+        calls.append((provider, model, async_mode))
+        return client, model
+
+    monkeypatch.setattr(moa, "resolve_provider_client", _resolve)
+
+    available, hint = moa.get_moa_preflight_status()
+
+    assert available is True
+    assert hint is None
+    assert calls == [
+        ("openai-codex", "gpt-5.4", False),
+        ("anthropic", "claude-opus-4-6", False),
+    ]
+    assert client.close.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_supports_sync_create():
+    calls = []
+
+    def _create(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+
+    response = await moa._create_chat_completion(client, model="m", messages=[])
+
+    assert response.choices[0].message.content == "ok"
+    assert calls == [{"model": "m", "messages": []}]
+
+
+def test_build_api_params_omits_extra_body_without_reasoning():
+    params = moa._build_api_params(
+        "openrouter",
+        "anthropic/claude-opus-4.7",
+        [{"role": "user", "content": "hi"}],
+        None,
+        0.6,
+    )
+
+    assert "extra_body" not in params
+
+
+def test_build_api_params_forwards_reasoning_for_pr1_supported_providers():
+    reasoning_config = {"enabled": True, "effort": "high"}
+
+    for provider in ("openrouter", "nous", "ai-gateway", "openai-codex"):
+        params = moa._build_api_params(
+            provider,
+            "model",
+            [{"role": "user", "content": "hi"}],
+            reasoning_config,
+            0.6,
+        )
+        assert params["extra_body"] == {"reasoning": reasoning_config}
+
+
+def test_build_api_params_skips_reasoning_for_unsupported_provider_once():
+    reasoning_config = {"enabled": True, "effort": "high"}
+
+    with patch.object(moa.logger, "warning") as warn:
+        first = moa._build_api_params(
+            "anthropic",
+            "claude-opus-4-6",
+            [{"role": "user", "content": "hi"}],
+            reasoning_config,
+            0.6,
+        )
+        second = moa._build_api_params(
+            "anthropic",
+            "claude-opus-4-6",
+            [{"role": "user", "content": "again"}],
+            reasoning_config,
+            0.6,
+        )
+
+    assert "extra_body" not in first
+    assert "extra_body" not in second
+    warn.assert_called_once()
+    assert "not forwarded in PR1" in warn.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_reference_model_forwards_default_max_tokens_and_reasoning(monkeypatch):
+    calls = []
+
+    async def _create(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+    monkeypatch.setattr(
+        moa,
+        "resolve_provider_client",
+        lambda *args, **kwargs: (fake_client, "anthropic/claude-opus-4.7"),
+    )
+    monkeypatch.setattr(
+        moa,
+        "extract_content_or_reasoning",
+        lambda response: response.choices[0].message.content,
+    )
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "reasoning_config": {"enabled": True, "effort": "xhigh"},
+        },
+        "hello",
+        max_retries=1,
+    )
+
+    assert (model_name, content, success) == (
+        "anthropic/claude-opus-4.7",
+        "ok",
+        True,
+    )
+    assert calls[0]["max_tokens"] == 32000
+    assert calls[0]["extra_body"] == {
+        "reasoning": {"enabled": True, "effort": "xhigh"}
+    }
+    assert calls[0]["temperature"] == moa.REFERENCE_TEMPERATURE
+
+
+@pytest.mark.asyncio
+async def test_reference_model_init_failure_is_reported_as_model_failure(fake_catalogs, monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("bad provider state")
+
+    monkeypatch.setattr(moa, "resolve_provider_client", _boom)
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "openai-codex", "reasoning_config": None},
+        "hello",
+        max_retries=1,
+    )
+
+    assert model_name == "gpt-5.4"
+    assert success is False
+    assert "could not be initialized" in content
+
+
+@pytest.mark.asyncio
+async def test_run_reference_model_safe_supports_copilot_acp(fake_catalogs):
+    from agent.copilot_acp_client import CopilotACPClient
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="ok",
+                    reasoning=None,
+                    reasoning_content=None,
+                    reasoning_details=None,
+                )
+            )
+        ]
+    )
+
+    with (
+        patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.4"),
+        patch.object(CopilotACPClient, "_create_chat_completion", return_value=fake_response) as mock_create,
+        patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "copilot-acp",
+                "api_key": "copilot-acp",
+                "base_url": "acp://copilot",
+                "command": "/usr/bin/copilot",
+                "args": ["--acp", "--stdio"],
+            },
+        ),
+    ):
+        model_name, content, success = await moa._run_reference_model_safe(
+            {"model": "gpt-5.4", "provider": "copilot-acp", "reasoning_config": None},
+            "hello",
+            max_retries=1,
+        )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    mock_create.assert_called_once()
+
+
+def _static_provider_catalog(provider: str) -> list[str]:
+    provider = models_mod.normalize_provider(provider)
+    if provider == "openrouter":
+        return [model_id for model_id, _ in models_mod.OPENROUTER_MODELS]
+    return list(models_mod._PROVIDER_MODELS.get(provider, []))
+
+
+def test_default_config_moa_entries_exist_in_provider_catalogs():
+    default_moa = DEFAULT_CONFIG["moa"]
+    entries = list(default_moa["reference_models"]) + [default_moa["aggregator_model"]]
+
+    for entry in entries:
+        normalized_model = normalize_model_for_provider(entry["model"], entry["provider"])
+        assert normalized_model in _static_provider_catalog(entry["provider"])
+
+
+def test_module_constant_fallbacks_exist_in_openrouter_catalog():
+    openrouter_catalog = _static_provider_catalog("openrouter")
+    for model in moa.REFERENCE_MODELS + [moa.AGGREGATOR_MODEL]:
+        normalized_model = normalize_model_for_provider(model, "openrouter")
+        assert normalized_model in openrouter_catalog
+
+
+def test_debug_parameters_capture_provider_and_reasoning(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "anthropic/claude-opus-4.7",
+                        "provider": "openrouter",
+                        "reasoning": "high",
+                    },
+                    {"model": "gpt-5.4", "provider": "openai-codex"},
+                ],
+                "aggregator_model": {
+                    "model": "anthropic/claude-opus-4.7",
+                    "provider": "ai-gateway",
+                    "reasoning": "none",
+                },
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    ref0 = loaded["reference_models"][0]
+    ref1 = loaded["reference_models"][1]
+    agg = loaded["aggregator_model"]
+
+    assert ref0["provider"] == "openrouter"
+    assert ref0["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert ref1["provider"] == "openai-codex"
+    assert ref1["reasoning_config"] is None
+    assert agg["provider"] == "ai-gateway"
+    assert agg["reasoning_config"] == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_mixture_of_agents_uses_adaptive_quorum(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7", "openai/gpt-5.5-pro"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_run_reference_model_safe",
+        AsyncMock(side_effect=[
+            ("anthropic/claude-opus-4.7", "ok", True),
+            ("openai/gpt-5.5-pro", "failed", False),
+        ]),
+    )
+    monkeypatch.setattr(moa, "_run_aggregator_model", AsyncMock(return_value="final"))
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result["success"] is False
+    assert "Need at least 2 successful responses" in result["error"]

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -1,288 +1,652 @@
 #!/usr/bin/env python3
-"""
-Mixture-of-Agents Tool Module
+"""Mixture-of-Agents Tool Module.
 
-This module implements the Mixture-of-Agents (MoA) methodology that leverages
-the collective strengths of multiple LLMs through a layered architecture to
-achieve state-of-the-art performance on complex reasoning tasks.
-
-Based on the research paper: "Mixture-of-Agents Enhances Large Language Model Capabilities"
-by Junlin Wang et al. (arXiv:2406.04692v1)
-
-Key Features:
-- Multi-layer LLM collaboration for enhanced reasoning
-- Parallel processing of reference models for efficiency
-- Intelligent aggregation and synthesis of diverse responses
-- Specialized for extremely difficult problems requiring intense reasoning
-- Optimized for coding, mathematics, and complex analytical tasks
-
-Available Tool:
-- mixture_of_agents_tool: Process complex queries using multiple frontier models
-
-Architecture:
-1. Reference models generate diverse initial responses in parallel
-2. Aggregator model synthesizes responses into a high-quality output
-3. Multiple layers can be used for iterative refinement (future enhancement)
-
-Models Used (via OpenRouter):
-- Reference Models: claude-opus-4.6, gemini-3-pro-preview, gpt-5.4-pro, deepseek-v3.2
-- Aggregator Model: claude-opus-4.6 (highest capability for synthesis)
-
-Configuration:
-    To customize the MoA setup, modify the configuration constants at the top of this file:
-    - REFERENCE_MODELS: List of models for generating diverse initial responses
-    - AGGREGATOR_MODEL: Model used to synthesize the final response
-    - REFERENCE_TEMPERATURE/AGGREGATOR_TEMPERATURE: Sampling temperatures
-    - MIN_SUCCESSFUL_REFERENCES: Minimum successful models needed to proceed
-
-Usage:
-    from mixture_of_agents_tool import mixture_of_agents_tool
-    import asyncio
-    
-    # Process a complex query
-    result = await mixture_of_agents_tool(
-        user_prompt="Solve this complex mathematical proof..."
-    )
+Runs a hard prompt through multiple frontier LLMs in parallel (layer 1:
+reference models), then synthesizes their responses with an aggregator
+model (layer 2).  Per-model provider routing and reasoning effort are
+configured via ``config.yaml`` under the ``moa`` key; see
+``hermes_cli.config.DEFAULT_CONFIG`` for the default shape.  The module
+constants below are fallback defaults used only when the ``moa`` block
+is absent or incomplete.
 """
 
-import json
-import logging
-import os
 import asyncio
 import datetime
-from typing import Dict, Any, List, Optional
-from tools.openrouter_client import get_async_client as _get_openrouter_client, check_api_key as check_openrouter_api_key
-from agent.auxiliary_client import extract_content_or_reasoning
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.auxiliary_client import (
+    extract_content_or_reasoning,
+    resolve_provider_client,
+)
 from tools.debug_helpers import DebugSession
+from tools.openrouter_client import check_api_key as check_openrouter_api_key
 
 logger = logging.getLogger(__name__)
 
-# Configuration for MoA processing
-# Reference models - these generate diverse initial responses in parallel.
-# Keep this list aligned with current top-tier OpenRouter frontier options.
+# Fallback defaults — used only when the `moa` config block is absent or
+# incomplete.  Mirrors DEFAULT_CONFIG["moa"] so upstream rotations flow in
+# cleanly via merge.  Configure via config.yaml; don't edit here.
 REFERENCE_MODELS = [
-    "anthropic/claude-opus-4.6",
-    "google/gemini-2.5-pro",
-    "openai/gpt-5.4-pro",
-    "deepseek/deepseek-v3.2",
+    "anthropic/claude-opus-4.7",
+    "google/gemini-3.1-pro-preview",
+    "openai/gpt-5.5-pro",
+    "qwen/qwen3.6-plus",
 ]
+AGGREGATOR_MODEL = "anthropic/claude-opus-4.7"
+REFERENCE_TEMPERATURE = 0.6
+AGGREGATOR_TEMPERATURE = 0.4
+MIN_SUCCESSFUL_REFERENCES = 2
 
-# Aggregator model - synthesizes reference responses into final output.
-# Prefer the strongest synthesis model in the current OpenRouter lineup.
-AGGREGATOR_MODEL = "anthropic/claude-opus-4.6"
-
-# Temperature settings optimized for MoA performance
-REFERENCE_TEMPERATURE = 0.6  # Balanced creativity for diverse perspectives
-AGGREGATOR_TEMPERATURE = 0.4  # Focused synthesis for consistency
-
-# Failure handling configuration
-MIN_SUCCESSFUL_REFERENCES = 1  # Minimum successful reference models needed to proceed
-
-# System prompt for the aggregator model (from the research paper)
-AGGREGATOR_SYSTEM_PROMPT = """You have been provided with a set of responses from various open-source models to the latest user query. Your task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.
+AGGREGATOR_SYSTEM_PROMPT = """You have been provided with a set of responses from various frontier models to the latest user query. Your task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.
 
 Responses from models:"""
 
 _debug = DebugSession("moa_tools", env_var="MOA_TOOLS_DEBUG")
 
 
-def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
+# One-shot Codex plan-consumption warnings.  Re-fires when the set of
+# Codex-routed slots changes (e.g. profile switch flips the aggregator).
+_codex_warning_seen: set = set()
+_reasoning_skip_warning_seen: set[Tuple[str, str]] = set()
+
+# PR1 only forwards reasoning through providers that accept
+# OpenAI-compatible ``extra_body.reasoning`` or already translate it in
+# Hermes' auxiliary adapter. Provider-specific kwargs land in PR2.
+_REASONING_EXTRA_BODY_PROVIDERS = frozenset({
+    "openrouter",
+    "nous",
+    "ai-gateway",
+    "openai-codex",
+})
+
+
+def _effort_label(entry: Dict[str, Any]) -> str:
+    """Return the raw reasoning label for logs / debug output."""
+    rc = entry.get("reasoning_config")
+    if rc is None:
+        return "default"
+    if rc.get("enabled") is False:
+        return "none"
+    return rc.get("effort") or "default"
+
+
+# ---------------------------------------------------------------------------
+# Config loading + validation
+# ---------------------------------------------------------------------------
+def _normalize_entry(entry: Any, idx: Optional[int], is_aggregator: bool) -> Dict[str, Any]:
+    """Expand string shorthand / validate dict shape.  Returns {model, provider, _raw_reasoning}."""
+    if is_aggregator:
+        where = "moa.aggregator_model"
+    else:
+        where = f"moa.reference_models[{idx}]"
+
+    if isinstance(entry, str):
+        model = entry.strip()
+        if not model:
+            raise ValueError(f"{where} must specify a non-empty model")
+        return {"model": model, "provider": "openrouter", "_raw_reasoning": None}
+
+    if not isinstance(entry, dict):
+        raise ValueError(f"{where} must be a string or a dict")
+
+    model = entry.get("model")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError(f"{where} must specify a 'model' field")
+    model = model.strip()
+
+    provider = entry.get("provider") or "openrouter"
+    if not isinstance(provider, str):
+        raise ValueError(f"{where}.provider must be a string")
+    try:
+        from hermes_cli.models import normalize_provider
+    except ImportError:
+        provider = provider.strip().lower()
+    else:
+        provider = normalize_provider(provider)
+
+    raw_reasoning = entry.get("reasoning")
+    return {
+        "model": model,
+        "provider": provider,
+        "_raw_reasoning": raw_reasoning,
+    }
+
+
+def _read_raw_moa_subtree() -> Dict[str, Any]:
+    """Re-read the YAML config for pre-merge empty-dict override detection.
+
+    ``_deep_merge`` recurses into dict-typed fields and preserves the default
+    when the override is ``{}``, so ``aggregator_model: {}`` is invisible
+    against the merged dict.  We load the raw file to catch that typo.
     """
-    Construct the final system prompt for the aggregator including all model responses.
-    
+    import yaml
+    from hermes_cli.config import get_config_path
+
+    path = get_config_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(
+            f"unable to read raw moa config for validation: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        return {}
+    return data.get("moa") or {}
+
+
+def _load_moa_config(emit_warnings: bool = False) -> Dict[str, Any]:
+    """Load and validate the ``moa`` config block.
+
     Args:
-        system_prompt (str): Base system prompt for aggregation
-        responses (List[str]): List of responses from reference models
-        
+        emit_warnings: When True, emit operational-guidance logs (Codex
+            plan-consumption warnings, catalog-drift soft warnings).
+            Suppressed during preflight and startup.
+
     Returns:
-        str: Complete system prompt with enumerated responses
+        Dict with keys: enabled, reference_models, aggregator_model,
+        reference_temperature, aggregator_temperature,
+        min_successful_references.  Reference/aggregator entries carry
+        {model, provider, reasoning_config}.
+
+    Raises:
+        ValueError: On shape errors, unknown providers, invalid reasoning
+        strings, out-of-range min_successful_references, or empty rosters.
+        Raised even when ``enabled`` is False so toggling back on is safe.
     """
-    response_text = "\n".join([f"{i+1}. {response}" for i, response in enumerate(responses)])
+    from hermes_cli.config import load_config
+    from hermes_cli.models import list_available_providers, provider_model_ids
+    from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+
+    config = load_config()
+    moa_value = config.get("moa", {})
+    if moa_value is None:
+        moa = {}
+    elif not isinstance(moa_value, dict):
+        raise ValueError("moa must be a mapping")
+    else:
+        moa = moa_value
+    raw_moa = _read_raw_moa_subtree()
+    raw_moa_dict = raw_moa if isinstance(raw_moa, dict) else {}
+
+    # Kill switch
+    enabled_val = moa.get("enabled", True)
+    if not isinstance(enabled_val, bool):
+        raise ValueError("moa.enabled must be a boolean")
+    enabled = enabled_val
+
+    # Pre-merge empty-dict detection (raw YAML re-read; see _read_raw_moa_subtree)
+    if raw_moa_dict:
+        raw_agg = raw_moa_dict.get("aggregator_model")
+        if isinstance(raw_agg, dict) and raw_agg == {}:
+            raise ValueError("moa.aggregator_model must specify a 'model' field")
+        raw_refs = raw_moa_dict.get("reference_models")
+        if isinstance(raw_refs, list):
+            for i, item in enumerate(raw_refs):
+                if isinstance(item, dict) and item == {}:
+                    raise ValueError(
+                        f"moa.reference_models[{i}] must specify a 'model' field"
+                    )
+
+    # Reference models
+    missing = object()
+    if "reference_models" in raw_moa_dict:
+        ref_raw = raw_moa_dict["reference_models"]
+    elif "reference_models" in moa:
+        ref_raw = moa["reference_models"]
+    else:
+        ref_raw = missing
+
+    if ref_raw is not missing:
+        if ref_raw is None:
+            raise ValueError("moa.reference_models must be a non-empty list")
+        if not isinstance(ref_raw, list) or len(ref_raw) == 0:
+            raise ValueError("moa.reference_models must be a non-empty list")
+        ref_entries = [
+            _normalize_entry(e, idx=i, is_aggregator=False)
+            for i, e in enumerate(ref_raw)
+        ]
+    else:
+        ref_entries = [
+            {"model": m, "provider": "openrouter", "_raw_reasoning": None}
+            for m in REFERENCE_MODELS
+        ]
+
+    # Aggregator
+    if "aggregator_model" in raw_moa_dict:
+        agg_raw = raw_moa_dict["aggregator_model"]
+    elif "aggregator_model" in moa:
+        agg_raw = moa["aggregator_model"]
+    else:
+        agg_raw = missing
+
+    if agg_raw is not missing:
+        if agg_raw is None:
+            raise ValueError("moa.aggregator_model must specify a 'model' field")
+        agg_entry = _normalize_entry(agg_raw, idx=None, is_aggregator=True)
+    else:
+        agg_entry = {
+            "model": AGGREGATOR_MODEL,
+            "provider": "openrouter",
+            "_raw_reasoning": None,
+        }
+
+    # Valid provider ids (from the canonical list + named custom providers)
+    valid_providers = {p["id"] for p in list_available_providers()}
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        from hermes_cli.providers import custom_provider_slug
+    except ImportError:
+        custom_provider_slugs = set()
+    else:
+        custom_provider_slugs = {
+            custom_provider_slug(str(entry.get("name") or ""))
+            for entry in get_compatible_custom_providers(config)
+            if isinstance(entry, dict) and str(entry.get("name") or "").strip()
+        }
+
+    for e in ref_entries + [agg_entry]:
+        prov = e["provider"]
+        if prov in custom_provider_slugs:
+            continue
+        if prov not in valid_providers:
+            raise ValueError(
+                f"moa: unknown provider {prov!r}; "
+                f"valid ids: {sorted(valid_providers | custom_provider_slugs)}"
+            )
+
+    # Reasoning per entry (accepts unset/null/'' as "use provider default")
+    valid_reasoning_values = (*VALID_REASONING_EFFORTS, "none")
+    for e in ref_entries + [agg_entry]:
+        raw = e.pop("_raw_reasoning", None)
+        if raw is None:
+            e["reasoning_config"] = None
+            continue
+        if isinstance(raw, str) and raw.strip() == "":
+            e["reasoning_config"] = None
+            continue
+        if not isinstance(raw, str):
+            raise ValueError(
+                f"moa: reasoning must be a string; valid: "
+                f"{list(valid_reasoning_values)}"
+            )
+        normalized_raw = raw.strip().lower()
+        if normalized_raw not in valid_reasoning_values:
+            raise ValueError(
+                f"moa: invalid reasoning {raw!r}; valid: "
+                f"{list(valid_reasoning_values)}"
+            )
+        parsed = parse_reasoning_effort(raw)
+        if parsed is None:
+            raise ValueError(
+                f"moa: invalid reasoning {raw!r}; valid: "
+                f"{list(valid_reasoning_values)}"
+            )
+        e["reasoning_config"] = parsed
+
+    # Temperatures
+    ref_temp = moa.get("reference_temperature", REFERENCE_TEMPERATURE)
+    agg_temp = moa.get("aggregator_temperature", AGGREGATOR_TEMPERATURE)
+
+    # min_successful_references (adaptive default)
+    if "min_successful_references" in moa:
+        msr = moa["min_successful_references"]
+        if isinstance(msr, bool) or not isinstance(msr, int):
+            raise ValueError("moa.min_successful_references must be an integer")
+        if msr < 1 or msr > len(ref_entries):
+            raise ValueError(
+                f"moa.min_successful_references must be between 1 and "
+                f"{len(ref_entries)} (got {msr})"
+            )
+    else:
+        msr = min(2, len(ref_entries))
+
+    # Soft catalog-drift warning (emit_warnings gates this; no raise)
+    if emit_warnings:
+        for e in ref_entries + [agg_entry]:
+            try:
+                catalog = provider_model_ids(e["provider"])
+            except Exception:
+                catalog = []
+            if catalog and e["model"] not in catalog:
+                logger.warning(
+                    "MoA: model %r not in %s catalog — may fail at call time",
+                    e["model"], e["provider"],
+                )
+
+    # Codex plan warning
+    codex_slots = [
+        e["model"] for e in ref_entries
+        if e["provider"] == "openai-codex"
+    ]
+    aggregator_is_codex = agg_entry["provider"] == "openai-codex"
+    if aggregator_is_codex:
+        codex_slots.append(agg_entry["model"])
+    if emit_warnings and codex_slots:
+        key = (frozenset(codex_slots), aggregator_is_codex)
+        if key not in _codex_warning_seen:
+            _codex_warning_seen.add(key)
+            msg_parts = [
+                "MoA: %d slot(s) routed through "
+                "openai-codex; each invocation consumes a Codex plan request"
+                % len(codex_slots)
+            ]
+            if aggregator_is_codex:
+                msg_parts.append(
+                    "aggregator is Codex-routed — aggregator failure fails "
+                    "the whole MoA call"
+                )
+            logger.warning("; ".join(msg_parts))
+
+    return {
+        "enabled": enabled,
+        "reference_models": ref_entries,
+        "aggregator_model": agg_entry,
+        "reference_temperature": ref_temp,
+        "aggregator_temperature": agg_temp,
+        "min_successful_references": msr,
+        "min_successful_references_explicit": "min_successful_references" in moa,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model runners
+# ---------------------------------------------------------------------------
+def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
+    response_text = "\n".join(
+        f"{i+1}. {response}" for i, response in enumerate(responses)
+    )
     return f"{system_prompt}\n\n{response_text}"
 
 
+async def _create_chat_completion(client, **kwargs):
+    """Create a chat completion with async and sync client compatibility."""
+    import inspect
+
+    create = client.chat.completions.create
+    if inspect.iscoroutinefunction(create):
+        return await create(**kwargs)
+    return await asyncio.to_thread(create, **kwargs)
+
+
+def _build_api_params(
+    provider: str,
+    resolved_model: str,
+    messages: List[Dict[str, Any]],
+    reasoning_config: Optional[dict],
+    temperature: float,
+    max_tokens: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Assemble the minimal PR1 chat.completions kwargs."""
+    params: Dict[str, Any] = {
+        "model": resolved_model,
+        "messages": messages,
+        "temperature": temperature,
+    }
+    if reasoning_config is not None:
+        if provider in _REASONING_EXTRA_BODY_PROVIDERS:
+            params["extra_body"] = {"reasoning": reasoning_config}
+        else:
+            warning_key = (provider, resolved_model)
+            if warning_key not in _reasoning_skip_warning_seen:
+                _reasoning_skip_warning_seen.add(warning_key)
+                logger.warning(
+                    "MoA: reasoning for provider %r is not forwarded in PR1; "
+                    "omit moa.*.reasoning for this provider or rely on "
+                    "provider defaults until provider-specific routing lands",
+                    provider,
+                )
+    if max_tokens is not None:
+        params["max_tokens"] = max_tokens
+    return params
+
+
 async def _run_reference_model_safe(
-    model: str,
+    model_entry: Dict[str, Any],
     user_prompt: str,
     temperature: float = REFERENCE_TEMPERATURE,
     max_tokens: int = 32000,
-    max_retries: int = 6
-) -> tuple[str, str, bool]:
-    """
-    Run a single reference model with retry logic and graceful failure handling.
-    
-    Args:
-        model (str): Model identifier to use
-        user_prompt (str): The user's query
-        temperature (float): Sampling temperature for response generation
-        max_tokens (int): Maximum tokens in response
-        max_retries (int): Maximum number of retry attempts
-        
-    Returns:
-        tuple[str, str, bool]: (model_name, response_content_or_error, success_flag)
-    """
-    for attempt in range(max_retries):
+    max_retries: int = 6,
+) -> Tuple[str, str, bool]:
+    """Call a single reference model with retry handling."""
+    model = model_entry["model"]
+    provider = model_entry["provider"]
+    reasoning_config = model_entry.get("reasoning_config")
+
+    try:
+        client, resolved_model = resolve_provider_client(
+            provider, model=model, async_mode=True
+        )
+    except Exception as exc:  # noqa: BLE001 — init failure is per-model, not fatal
+        err = f"{model} could not be initialized: {exc}"
+        logger.error("%s", err, exc_info=True)
+        return model, err, False
+    if client is None:
+        err = f"{model}: no credentials configured for provider {provider!r}"
+        logger.error("%s", err)
+        return model, err, False
+
+    messages = [{"role": "user", "content": user_prompt}]
+    logger.info(
+        "MoA reference %s via %s (resolved=%s, reasoning=%s)",
+        model, provider, resolved_model, _effort_label(model_entry),
+    )
+
+    attempt = 0
+    while attempt < max_retries:
         try:
-            logger.info("Querying %s (attempt %s/%s)", model, attempt + 1, max_retries)
-            
-            # Build parameters for the API call
-            api_params = {
-                "model": model,
-                "messages": [{"role": "user", "content": user_prompt}],
-                "max_tokens": max_tokens,
-                "extra_body": {
-                    "reasoning": {
-                        "enabled": True,
-                        "effort": "xhigh"
-                    }
-                }
-            }
-            
-            # GPT models (especially gpt-4o-mini) don't support custom temperature values
-            # Only include temperature for non-GPT models
-            if not model.lower().startswith('gpt-'):
-                api_params["temperature"] = temperature
-            
-            response = await _get_openrouter_client().chat.completions.create(**api_params)
-            
+            api_params = _build_api_params(
+                provider,
+                resolved_model,
+                messages,
+                reasoning_config,
+                temperature,
+                max_tokens=max_tokens,
+            )
+            response = await _create_chat_completion(client, **api_params)
+
             content = extract_content_or_reasoning(response)
             if not content:
-                # Reasoning-only response — let the retry loop handle it
-                logger.warning("%s returned empty content (attempt %s/%s), retrying", model, attempt + 1, max_retries)
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(min(2 ** (attempt + 1), 60))
-                    continue
+                logger.warning(
+                    "%s returned empty content (attempt %s/%s), retrying",
+                    model, attempt + 1, max_retries,
+                )
+                attempt += 1
+                if attempt < max_retries:
+                    await asyncio.sleep(min(2 ** attempt, 60))
+                continue
             logger.info("%s responded (%s characters)", model, len(content))
             return model, content, True
-            
-        except Exception as e:
+
+        except Exception as e:  # noqa: BLE001
             error_str = str(e)
-            # Keep retry-path logging concise; full tracebacks are reserved for
-            # terminal failure paths so long-running MoA retries don't flood logs.
             if "invalid" in error_str.lower():
                 logger.warning("%s invalid request error (attempt %s): %s", model, attempt + 1, error_str)
             elif "rate" in error_str.lower() or "limit" in error_str.lower():
                 logger.warning("%s rate limit error (attempt %s): %s", model, attempt + 1, error_str)
             else:
-                logger.warning("%s unknown error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s error (attempt %s): %s", model, attempt + 1, error_str)
 
-            if attempt < max_retries - 1:
-                # Exponential backoff for rate limiting: 2s, 4s, 8s, 16s, 32s, 60s
-                sleep_time = min(2 ** (attempt + 1), 60)
-                logger.info("Retrying in %ss...", sleep_time)
+            attempt += 1
+            if attempt < max_retries:
+                sleep_time = min(2 ** attempt, 60)
+                logger.info("Retrying %s in %ss...", model, sleep_time)
                 await asyncio.sleep(sleep_time)
             else:
-                error_msg = f"{model} failed after {max_retries} attempts: {error_str}"
-                logger.error("%s", error_msg, exc_info=True)
-                return model, error_msg, False
+                err = f"{model} failed after {max_retries} attempts: {error_str}"
+                logger.error("%s", err, exc_info=True)
+                return model, err, False
+
+    return model, f"{model} exhausted retries", False
 
 
 async def _run_aggregator_model(
+    agg_entry: Dict[str, Any],
     system_prompt: str,
     user_prompt: str,
     temperature: float = AGGREGATOR_TEMPERATURE,
-    max_tokens: int = None
+    max_tokens: Optional[int] = None,
+    max_retries: int = 3,
 ) -> str:
-    """
-    Run the aggregator model to synthesize the final response.
-    
-    Args:
-        system_prompt (str): System prompt with all reference responses
-        user_prompt (str): Original user query
-        temperature (float): Focused temperature for consistent aggregation
-        max_tokens (int): Maximum tokens in final response
-        
-    Returns:
-        str: Synthesized final response
-    """
-    logger.info("Running aggregator model: %s", AGGREGATOR_MODEL)
+    """Call the aggregator with retry handling."""
+    model = agg_entry["model"]
+    provider = agg_entry["provider"]
+    reasoning_config = agg_entry.get("reasoning_config")
 
-    # Build parameters for the API call
-    api_params = {
-        "model": AGGREGATOR_MODEL,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt}
-        ],
-        "max_tokens": max_tokens,
-        "extra_body": {
-            "reasoning": {
-                "enabled": True,
-                "effort": "xhigh"
-            }
+    client, resolved_model = resolve_provider_client(
+        provider, model=model, async_mode=True
+    )
+    if client is None:
+        raise ValueError(
+            f"MoA aggregator: no credentials configured for provider {provider!r}"
+        )
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+    logger.info(
+        "MoA aggregator %s via %s (resolved=%s, reasoning=%s)",
+        model, provider, resolved_model, _effort_label(agg_entry),
+    )
+
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries):
+        try:
+            api_params = _build_api_params(
+                provider,
+                resolved_model,
+                messages,
+                reasoning_config,
+                temperature,
+                max_tokens=max_tokens,
+            )
+            response = await _create_chat_completion(client, **api_params)
+            content = extract_content_or_reasoning(response)
+            if not content and attempt < max_retries - 1:
+                logger.warning("Aggregator returned empty content, retrying")
+                continue
+            logger.info("Aggregation complete (%s characters)", len(content) if content else 0)
+            return content or ""
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            logger.warning("Aggregator error (attempt %s): %s", attempt + 1, e)
+            if attempt < max_retries - 1:
+                await asyncio.sleep(min(2 ** (attempt + 1), 30))
+
+    raise RuntimeError(f"MoA aggregator failed after {max_retries} attempts: {last_error}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def _override_entries_from_strings(
+    reference_models: Optional[List[str]],
+    aggregator_model: Optional[str],
+    cfg: Dict[str, Any],
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Apply optional string-only per-invocation overrides (OpenRouter-only)."""
+    ref_entries = cfg["reference_models"]
+    agg_entry = cfg["aggregator_model"]
+    if reference_models is not None:
+        ref_entries = [
+            {"model": m.strip(), "provider": "openrouter", "reasoning_config": None}
+            for m in reference_models
+            if isinstance(m, str) and m.strip()
+        ]
+    if aggregator_model is not None:
+        agg_entry = {
+            "model": aggregator_model.strip(),
+            "provider": "openrouter",
+            "reasoning_config": None,
         }
-    }
+    return ref_entries, agg_entry
 
-    # GPT models (especially gpt-4o-mini) don't support custom temperature values
-    # Only include temperature for non-GPT models
-    if not AGGREGATOR_MODEL.lower().startswith('gpt-'):
-        api_params["temperature"] = temperature
 
-    response = await _get_openrouter_client().chat.completions.create(**api_params)
+def _effective_min_successful_references(
+    cfg: Dict[str, Any],
+    ref_entries: List[Dict[str, Any]],
+) -> int:
+    """Return the effective quorum after per-call roster overrides."""
+    if not ref_entries:
+        raise ValueError("MoA requires at least one reference model")
 
-    content = extract_content_or_reasoning(response)
-
-    # Retry once on empty content (reasoning-only response)
-    if not content:
-        logger.warning("Aggregator returned empty content, retrying once")
-        response = await _get_openrouter_client().chat.completions.create(**api_params)
-        content = extract_content_or_reasoning(response)
-
-    logger.info("Aggregation complete (%s characters)", len(content))
-    return content
+    configured = cfg["min_successful_references"]
+    if cfg.get("min_successful_references_explicit"):
+        if configured > len(ref_entries):
+            raise ValueError(
+                "MoA per-call overrides reduced the reference roster to "
+                f"{len(ref_entries)} model(s), but "
+                f"moa.min_successful_references is pinned to {configured}. "
+                "Lower the config quorum or remove the override."
+            )
+        return configured
+    return min(2, len(ref_entries))
 
 
 async def mixture_of_agents_tool(
     user_prompt: str,
     reference_models: Optional[List[str]] = None,
-    aggregator_model: Optional[str] = None
+    aggregator_model: Optional[str] = None,
 ) -> str:
-    """
-    Process a complex query using the Mixture-of-Agents methodology.
-    
-    This tool leverages multiple frontier language models to collaboratively solve
-    extremely difficult problems requiring intense reasoning. It's particularly
-    effective for:
-    - Complex mathematical proofs and calculations
-    - Advanced coding problems and algorithm design
-    - Multi-step analytical reasoning tasks
-    - Problems requiring diverse domain expertise
-    - Tasks where single models show limitations
-    
-    The MoA approach uses a fixed 2-layer architecture:
-    1. Layer 1: Multiple reference models generate diverse responses in parallel (temp=0.6)
-    2. Layer 2: Aggregator model synthesizes the best elements into final response (temp=0.4)
-    
-    Args:
-        user_prompt (str): The complex query or problem to solve
-        reference_models (Optional[List[str]]): Custom reference models to use
-        aggregator_model (Optional[str]): Custom aggregator model to use
-    
-    Returns:
-        str: JSON string containing the MoA results with the following structure:
-             {
-                 "success": bool,
-                 "response": str,
-                 "models_used": {
-                     "reference_models": List[str],
-                     "aggregator_model": str
-                 },
-                 "processing_time": float
-             }
-    
-    Raises:
-        Exception: If MoA processing fails or API key is not set
+    """Run a prompt through multiple frontier LLMs and synthesize the responses.
+
+    Configuration is loaded from ``config.yaml`` (the ``moa`` block) on every
+    invocation so profile switches take effect without a restart.  Per-model
+    provider routing and reasoning effort live in config; ``reference_models``
+    and ``aggregator_model`` parameters are OpenRouter-only string overrides
+    retained for backward compatibility.
     """
     start_time = datetime.datetime.now()
-    
-    debug_call_data = {
+
+    try:
+        cfg = _load_moa_config(emit_warnings=True)
+    except ValueError as exc:
+        error_msg = f"MoA config error: {exc}"
+        logger.error("%s", error_msg)
+        return json.dumps({
+            "success": False,
+            "response": "",
+            "models_used": {"reference_models": [], "aggregator_model": ""},
+            "error": error_msg,
+        }, indent=2, ensure_ascii=False)
+
+    # Kill switch: fail-closed.  Callers branching on ``success`` route to
+    # their normal error path; ``error`` string is distinct from real failures.
+    if not cfg["enabled"]:
+        logger.info("MoA disabled via config; short-circuiting without calling any model")
+        return json.dumps({
+            "success": False,
+            "response": "",
+            "models_used": {"reference_models": [], "aggregator_model": ""},
+            "error": "MoA disabled via moa.enabled=false",
+        }, indent=2, ensure_ascii=False)
+
+    ref_entries, agg_entry = _override_entries_from_strings(
+        reference_models, aggregator_model, cfg,
+    )
+    ref_temp = cfg["reference_temperature"]
+    agg_temp = cfg["aggregator_temperature"]
+
+    debug_call_data: Dict[str, Any] = {
         "parameters": {
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
-            "reference_models": reference_models or REFERENCE_MODELS,
-            "aggregator_model": aggregator_model or AGGREGATOR_MODEL,
-            "reference_temperature": REFERENCE_TEMPERATURE,
-            "aggregator_temperature": AGGREGATOR_TEMPERATURE,
-            "min_successful_references": MIN_SUCCESSFUL_REFERENCES
+            "reference_models": [
+                {"model": e["model"], "provider": e["provider"], "reasoning": _effort_label(e)}
+                for e in ref_entries
+            ],
+            "aggregator_model": {
+                "model": agg_entry["model"],
+                "provider": agg_entry["provider"],
+                "reasoning": _effort_label(agg_entry),
+            },
+            "reference_temperature": ref_temp,
+            "aggregator_temperature": agg_temp,
+            "min_successful_references": None,
         },
         "error": None,
         "success": False,
@@ -291,140 +655,174 @@ async def mixture_of_agents_tool(
         "failed_models": [],
         "final_response_length": 0,
         "processing_time_seconds": 0,
-        "models_used": {}
+        "models_used": {},
     }
-    
+
     try:
+        msr = _effective_min_successful_references(cfg, ref_entries)
+        debug_call_data["parameters"]["min_successful_references"] = msr
+
         logger.info("Starting Mixture-of-Agents processing...")
         logger.info("Query: %s", user_prompt[:100])
-        
-        # Validate API key availability
-        if not os.getenv("OPENROUTER_API_KEY"):
-            raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        
-        # Use provided models or defaults
-        ref_models = reference_models or REFERENCE_MODELS
-        agg_model = aggregator_model or AGGREGATOR_MODEL
-        
-        logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_models))
-        
-        # Layer 1: Generate diverse responses from reference models (with failure handling)
+        logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_entries))
+
+        # Layer 1: parallel fanout
         logger.info("Layer 1: Generating reference responses...")
         model_results = await asyncio.gather(*[
-            _run_reference_model_safe(model, user_prompt, REFERENCE_TEMPERATURE)
-            for model in ref_models
+            _run_reference_model_safe(entry, user_prompt, ref_temp)
+            for entry in ref_entries
         ])
-        
-        # Separate successful and failed responses
-        successful_responses = []
-        failed_models = []
-        
+
+        successful_responses: List[str] = []
+        failed_models: List[str] = []
         for model_name, content, success in model_results:
             if success:
                 successful_responses.append(content)
             else:
                 failed_models.append(model_name)
-        
+
         successful_count = len(successful_responses)
         failed_count = len(failed_models)
-        
         logger.info("Reference model results: %s successful, %s failed", successful_count, failed_count)
-        
         if failed_models:
-            logger.warning("Failed models: %s", ', '.join(failed_models))
-        
-        # Check if we have enough successful responses to proceed
-        if successful_count < MIN_SUCCESSFUL_REFERENCES:
-            raise ValueError(f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). Need at least {MIN_SUCCESSFUL_REFERENCES} successful responses.")
-        
+            logger.warning("Failed models: %s", ", ".join(failed_models))
+
+        if successful_count < msr:
+            raise ValueError(
+                f"Insufficient successful reference models "
+                f"({successful_count}/{len(ref_entries)}). "
+                f"Need at least {msr} successful responses."
+            )
+
         debug_call_data["reference_responses_count"] = successful_count
         debug_call_data["failed_models_count"] = failed_count
         debug_call_data["failed_models"] = failed_models
-        
-        # Layer 2: Aggregate responses using the aggregator model
+
+        # Layer 2: aggregation
         logger.info("Layer 2: Synthesizing final response...")
         aggregator_system_prompt = _construct_aggregator_prompt(
-            AGGREGATOR_SYSTEM_PROMPT, 
-            successful_responses
+            AGGREGATOR_SYSTEM_PROMPT, successful_responses,
         )
-        
         final_response = await _run_aggregator_model(
-            aggregator_system_prompt,
-            user_prompt,
-            AGGREGATOR_TEMPERATURE
+            agg_entry, aggregator_system_prompt, user_prompt, agg_temp,
         )
-        
-        # Calculate processing time
+
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
         logger.info("MoA processing completed in %.2f seconds", processing_time)
-        
-        # Prepare successful response (only final aggregated result, minimal fields)
+
         result = {
             "success": True,
             "response": final_response,
             "models_used": {
-                "reference_models": ref_models,
-                "aggregator_model": agg_model
-            }
+                "reference_models": [e["model"] for e in ref_entries],
+                "aggregator_model": agg_entry["model"],
+            },
         }
-        
+
         debug_call_data["success"] = True
         debug_call_data["final_response_length"] = len(final_response)
         debug_call_data["processing_time_seconds"] = processing_time
         debug_call_data["models_used"] = result["models_used"]
-        
-        # Log debug information
+
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
         return json.dumps(result, indent=2, ensure_ascii=False)
-        
-    except Exception as e:
+
+    except Exception as e:  # noqa: BLE001
         error_msg = f"Error in MoA processing: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
-        
-        # Calculate processing time even for errors
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
-        # Prepare error response (minimal fields)
+
         result = {
             "success": False,
             "response": "MoA processing failed. Please try again or use a single model for this query.",
             "models_used": {
-                "reference_models": reference_models or REFERENCE_MODELS,
-                "aggregator_model": aggregator_model or AGGREGATOR_MODEL
+                "reference_models": [e["model"] for e in ref_entries],
+                "aggregator_model": agg_entry["model"],
             },
-            "error": error_msg
+            "error": error_msg,
         }
-        
         debug_call_data["error"] = error_msg
         debug_call_data["processing_time_seconds"] = processing_time
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
         return json.dumps(result, indent=2, ensure_ascii=False)
 
 
-def check_moa_requirements() -> bool:
-    """
-    Check if all requirements for MoA tools are met.
-    
-    Returns:
-        bool: True if requirements are met, False otherwise
-    """
-    return check_openrouter_api_key()
+# ---------------------------------------------------------------------------
+# Preflight / introspection
+# ---------------------------------------------------------------------------
+def _provider_has_credentials(provider: str, model: Optional[str] = None) -> bool:
+    """Return True when the runtime provider resolver can create a client."""
+    try:
+        client, _ = resolve_provider_client(
+            provider,
+            model=model,
+            async_mode=False,
+        )
+    except Exception:
+        return False
+    if client is None:
+        return False
+    try:
+        close_fn = getattr(client, "close", None)
+        if callable(close_fn):
+            close_fn()
+    except Exception:
+        pass
+    return True
 
+
+def get_moa_preflight_status() -> Tuple[bool, Optional[str]]:
+    """Return (available, hint) for setup/preflight surfaces.
+
+    The hint is phrased to fit setup output like ``(missing <hint>)``.
+    """
+    try:
+        cfg = _load_moa_config(emit_warnings=False)
+    except ValueError as exc:
+        logger.error("MoA config invalid: %s", exc)
+        return False, "valid MoA config"
+
+    if not cfg["enabled"]:
+        # Hide from preflight-gated menus when the kill switch is flipped.
+        return False, "enabled MoA config"
+
+    entries = list(cfg["reference_models"]) + [cfg["aggregator_model"]]
+    missing = sorted({
+        entry["provider"]
+        for entry in entries
+        if not _provider_has_credentials(entry["provider"], model=entry["model"])
+    })
+    if missing:
+        logger.error(
+            "MoA: missing credentials for provider(s): %s",
+            ", ".join(missing),
+        )
+        return False, f"credentials for {', '.join(missing)}"
+    return True, None
+
+
+def check_moa_requirements() -> bool:
+    """Preflight: return True iff all configured providers have credentials."""
+    available, _ = get_moa_preflight_status()
+    return available
+
+
+def get_available_models() -> List[str]:
+    """Return the module-constant fallback reference models.
+
+    Reflects fallback defaults, not the resolved roster.
+    """
+    return list(REFERENCE_MODELS)
 
 
 def get_moa_configuration() -> Dict[str, Any]:
-    """
-    Get the current MoA configuration settings.
-    
-    Returns:
-        Dict[str, Any]: Dictionary containing all configuration parameters
+    """Return module-constant fallback configuration.
+
+    Reflects fallback defaults, not the resolved roster from config.yaml.
     """
     return {
         "reference_models": REFERENCE_MODELS,
@@ -433,90 +831,45 @@ def get_moa_configuration() -> Dict[str, Any]:
         "aggregator_temperature": AGGREGATOR_TEMPERATURE,
         "min_successful_references": MIN_SUCCESSFUL_REFERENCES,
         "total_reference_models": len(REFERENCE_MODELS),
-        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} models can fail"
+        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} models can fail",
     }
 
 
 if __name__ == "__main__":
-    """
-    Simple test/demo when run directly
-    """
     print("🤖 Mixture-of-Agents Tool Module")
     print("=" * 50)
-    
-    # Check if API key is available
+
     api_available = check_openrouter_api_key()
-    
     if not api_available:
-        print("❌ OPENROUTER_API_KEY environment variable not set")
-        print("Please set your API key: export OPENROUTER_API_KEY='your-key-here'")
-        print("Get API key at: https://openrouter.ai/")
-        exit(1)
+        print("⚠️  OPENROUTER_API_KEY not set — OpenRouter-routed entries will fail")
     else:
         print("✅ OpenRouter API key found")
-    
+
     print("🛠️  MoA tools ready for use!")
-    
-    # Show current configuration
     config = get_moa_configuration()
-    print("\n⚙️  Current Configuration:")
+    print("\n⚙️  Fallback constants (config.yaml overrides these):")
     print(f"  🤖 Reference models ({len(config['reference_models'])}): {', '.join(config['reference_models'])}")
     print(f"  🧠 Aggregator model: {config['aggregator_model']}")
     print(f"  🌡️  Reference temperature: {config['reference_temperature']}")
     print(f"  🌡️  Aggregator temperature: {config['aggregator_temperature']}")
     print(f"  🛡️  Failure tolerance: {config['failure_tolerance']}")
     print(f"  📊 Minimum successful models: {config['min_successful_references']}")
-    
-    # Show debug mode status
+
     if _debug.active:
         print(f"\n🐛 Debug mode ENABLED - Session ID: {_debug.session_id}")
         print(f"   Debug logs will be saved to: ./logs/moa_tools_debug_{_debug.session_id}.json")
     else:
         print("\n🐛 Debug mode disabled (set MOA_TOOLS_DEBUG=true to enable)")
-    
-    print("\nBasic usage:")
-    print("  from mixture_of_agents_tool import mixture_of_agents_tool")
-    print("  import asyncio")
-    print("")
-    print("  async def main():")
-    print("      result = await mixture_of_agents_tool(")
-    print("          user_prompt='Solve this complex mathematical proof...'")
-    print("      )")
-    print("      print(result)")
-    print("  asyncio.run(main())")
-    
-    print("\nBest use cases:")
-    print("  - Complex mathematical proofs and calculations")
-    print("  - Advanced coding problems and algorithm design")
-    print("  - Multi-step analytical reasoning tasks")
-    print("  - Problems requiring diverse domain expertise")
-    print("  - Tasks where single models show limitations")
-    
-    print("\nPerformance characteristics:")
-    print("  - Higher latency due to multiple model calls")
-    print("  - Significantly improved quality for complex tasks")
-    print("  - Parallel processing for efficiency")
-    print(f"  - Optimized temperatures: {REFERENCE_TEMPERATURE} for reference models, {AGGREGATOR_TEMPERATURE} for aggregation")
-    print("  - Token-efficient: only returns final aggregated response")
-    print("  - Resilient: continues with partial model failures")
-    print("  - Configurable: easy to modify models and settings at top of file")
-    print("  - State-of-the-art results on challenging benchmarks")
-    
-    print("\nDebug mode:")
-    print("  # Enable debug logging")
-    print("  export MOA_TOOLS_DEBUG=true")
-    print("  # Debug logs capture all MoA processing steps and metrics")
-    print("  # Logs saved to: ./logs/moa_tools_debug_UUID.json")
 
 
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
-from tools.registry import registry
+from tools.registry import registry  # noqa: E402
 
 MOA_SCHEMA = {
     "name": "mixture_of_agents",
-    "description": "Route a hard problem through multiple frontier LLMs collaboratively. Makes 5 API calls (4 reference models + 1 aggregator) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives.",
+    "description": "Route a hard problem through multiple frontier LLMs collaboratively. Fans out to a user-configured roster of reference models in parallel, then synthesizes their answers with an aggregator model (N reference calls + 1 aggregator call; roster size, providers, and per-entry reasoning are set under `moa:` in config.yaml). Use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -535,7 +888,7 @@ registry.register(
     schema=MOA_SCHEMA,
     handler=lambda args, **kw: mixture_of_agents_tool(user_prompt=args.get("user_prompt", "")),
     check_fn=check_moa_requirements,
-    requires_env=["OPENROUTER_API_KEY"],
+    requires_env=[],
     is_async=True,
     emoji="🧠",
 )

--- a/website/docs/reference/mixture-of-agents.md
+++ b/website/docs/reference/mixture-of-agents.md
@@ -1,0 +1,124 @@
+---
+title: Mixture of Agents (MoA)
+---
+
+Mixture of Agents (MoA) runs several reference models in parallel, then sends their responses to a separate aggregator model that synthesizes the final answer.
+
+Use it for genuinely hard prompts where diversity helps: multi-step reasoning, architecture tradeoffs, difficult debugging, complex coding tasks, or synthesis across viewpoints.
+
+Configuration lives under `moa:` in `config.yaml`.
+
+## Shipped default config
+
+```yaml
+moa:
+  enabled: true
+  reference_models:
+    - model: "anthropic/claude-opus-4.7"
+      provider: "openrouter"
+      reasoning: "xhigh"
+    - model: "google/gemini-3.1-pro-preview"
+      provider: "openrouter"
+      reasoning: "xhigh"
+    - model: "openai/gpt-5.5-pro"
+      provider: "openrouter"
+      reasoning: "xhigh"
+    - model: "qwen/qwen3.6-plus"
+      provider: "openrouter"
+      reasoning: "xhigh"
+  aggregator_model:
+    model: "anthropic/claude-opus-4.7"
+    provider: "openrouter"
+    reasoning: "xhigh"
+  reference_temperature: 0.6
+  aggregator_temperature: 0.4
+```
+
+This is the fallback roster Hermes ships with when your `moa:` block is absent.
+`min_successful_references` is omitted by default and resolves to `2` for this
+four-model roster.
+
+Notes:
+
+- `enabled: false` disables the tool without deleting the roster.
+- String shorthand is allowed for convenience:
+
+```yaml
+moa:
+  reference_models:
+    - "anthropic/claude-opus-4.7"
+  aggregator_model: "anthropic/claude-opus-4.7"
+```
+
+Those shorthand entries default to `provider: openrouter`.
+
+## Provider routing
+
+Each entry chooses its own provider.
+
+That lets you mix:
+
+- OpenRouter for breadth and reliability
+- OpenAI Codex for GPT-5 via a Codex subscription
+- Anthropic direct for native Claude routing
+- Other configured providers supported by Hermes
+
+Preflight is roster-aware: Hermes checks the providers actually referenced by
+your MoA config. A Codex-only roster does not require `OPENROUTER_API_KEY`,
+while a mixed roster needs credentials for every provider it touches.
+
+If a provider/model pairing is not in the known provider catalog, Hermes logs a warning but does not block the call. This is intentional: catalogs can lag behind newly released model slugs.
+
+## Reasoning per model
+
+Each entry may optionally set `reasoning`.
+
+Accepted values are the standard Hermes reasoning-effort values plus `none`.
+`max` is not accepted for MoA entries.
+
+Behavior:
+
+- omitted / `null` / `""` => do not send any reasoning parameter; use the provider default
+- `none` => send an explicit reasoning-disabled config when supported
+- invalid value => load-time config error
+
+In this PR1 implementation, MoA forwards reasoning only for providers with a
+safe OpenAI-compatible path: `openrouter`, `nous`, `ai-gateway`, and
+`openai-codex`. For other providers, MoA logs once and omits the reasoning
+override so the provider default applies. Deeper provider-specific request
+kwargs are intentionally out of scope for this config-routing release.
+
+:::note Silent-accept providers
+OpenRouter proxies to many backends that silently accept and drop `extra_body.reasoning` without error; if a reasoning setting seems inert, cross-check against provider-side logs or billing.
+:::
+
+## Operational notes
+
+- The aggregator is the final answer. If the aggregator fails, the whole MoA call fails.
+- `min_successful_references` is validated against the roster size.
+- When the key is omitted, Hermes uses an adaptive default: `2` for multi-model rosters, `1` for single-model rosters.
+
+## `/model` and `/reasoning_effort` do not cascade into MoA
+
+MoA has its own roster and per-entry reasoning configuration.
+
+Important:
+
+- `/model` changes the main agent model, not the MoA reference roster or aggregator
+- `/reasoning_effort` changes the main agent loop, not the `moa.*.reasoning` entries
+
+If you want MoA to track your main model or reasoning preferences, update both places.
+
+## Codex warning
+
+Routing one or more MoA slots through `openai-codex` can burn through a Codex plan quickly.
+
+Because MoA fans out in parallel, routing multiple reference models through Codex multiplies consumption against the plan's daily cap.
+
+If the aggregator itself is Codex-routed and fails, the whole MoA tool fails.
+
+## Related docs
+
+- [Tools Reference](./tools-reference.md)
+- [Toolsets Reference](./toolsets-reference.md)
+- [Providers](../integrations/providers.md)

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -125,7 +125,7 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `mixture_of_agents` | Route a hard problem through multiple frontier LLMs collaboratively. Makes 5 API calls (4 reference models + 1 aggregator) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced alg… | OPENROUTER_API_KEY |
+| `mixture_of_agents` | Route a hard problem through multiple frontier LLMs collaboratively. Roster, providers, and per-model reasoning effort are configured under `moa:` in `config.yaml` — see [Mixture of Agents](../user-guide/features/mixture-of-agents.md). | Credentials for each configured provider |
 
 ## `rl` toolset
 

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -1,0 +1,72 @@
+---
+title: Mixture of Agents
+description: Run a hard prompt through multiple frontier LLMs in parallel, then synthesize the responses with an aggregator.
+sidebar_label: Mixture of Agents
+sidebar_position: 16
+---
+
+# Mixture of Agents
+
+The **Mixture of Agents** (MoA) tool runs your prompt through several frontier models in parallel (the *reference* layer), then feeds the collected answers to a single aggregator model that synthesizes a final response. It is most useful for hard one-shot questions where you want to trade latency and token spend for higher answer quality.
+
+MoA is part of the `moa` toolset. It is OFF by default; enable it from the setup checklist or by adding `moa` under `enabled_toolsets` in `config.yaml`.
+
+## Configuring the roster
+
+MoA is configured entirely from `~/.hermes/config.yaml` under the `moa:` key. The module constants inside `tools/mixture_of_agents_tool.py` are fallbacks; do not edit them.
+
+```yaml
+moa:
+  enabled: true
+  reference_models:
+    - {model: anthropic/claude-opus-4.7,       provider: openrouter, reasoning: xhigh}
+    - {model: google/gemini-3.1-pro-preview,   provider: openrouter, reasoning: xhigh}
+    - {model: openai/gpt-5.5-pro,              provider: openrouter, reasoning: xhigh}
+    - {model: qwen/qwen3.6-plus,               provider: openrouter, reasoning: xhigh}
+  aggregator_model:
+    model: anthropic/claude-opus-4.7
+    provider: openrouter
+    reasoning: xhigh
+  reference_temperature: 0.6
+  aggregator_temperature: 0.4
+  min_successful_references: 2
+```
+
+Every entry in `reference_models` and `aggregator_model` accepts:
+
+- `model` — the provider-native model slug.
+- `provider` — any provider accepted by the main agent's router (`openrouter`, `openai-codex`, `nous`, `anthropic`, `copilot`, `ai-gateway`, `custom`, …). Defaults to `openrouter` if omitted.
+- `reasoning` *(optional)* — a standard Hermes reasoning effort or `none`. Omit the key (or set `null` / `""`) to send no MoA-specific reasoning override.
+
+In PR1, reasoning overrides are forwarded only for `openrouter`, `nous`,
+`ai-gateway`, and `openai-codex`. For other providers, MoA logs once and omits
+the override so the provider default applies; provider-specific request kwargs
+are deferred to PR2.
+
+A bare string is accepted as shorthand for `{model: <string>, provider: openrouter}`.
+
+### Kill switch
+
+Set `moa.enabled: false` to disable the tool without touching `enabled_toolsets`. Preflight will refuse to run, and calls to the tool return a structured failure (`error: "MoA disabled via moa.enabled=false"`). Invalid config under a disabled block still raises at load time — errors are not deferred.
+
+### `min_successful_references`
+
+Defaults to `min(2, len(reference_models))` so a typical 3–4 model roster tolerates one reference failure. Set it explicitly to override. Values outside `[1, len(reference_models)]` fail validation.
+
+## Interaction with `/model` and `/reasoning_effort`
+
+MoA keeps its own roster — **`/model` does not cascade into MoA**. Switching the main agent's model has no effect on the reference or aggregator models used by the tool.
+
+Similarly, **`/reasoning_effort` only affects the main agent loop**. MoA entries each carry their own `reasoning` field, and the tool does not read the session-level reasoning effort. If you want MoA to track a change, update both `/reasoning_effort` *and* the relevant `reasoning:` fields under `moa:`.
+
+## Provider cost warning
+
+Routing multiple reference models through `openai-codex` multiplies consumption against the Codex plan's daily cap. The tool logs a one-time warning per Codex-routed config shape; take it seriously if you're on a metered plan.
+
+## Credentials
+
+`check_moa_requirements` is config-aware: it asks Hermes' provider resolver to create a client for every `provider` in your roster (including the aggregator). An all-Codex roster with Codex credentials will pass even when `OPENROUTER_API_KEY` is unset. A mixed roster needs credentials for every provider it touches.
+
+## Debug mode
+
+Set `MOA_TOOLS_DEBUG=true` in your environment to dump per-call metadata (provider, resolved model, reasoning kwargs, reference successes/failures, final response length) to the Hermes debug directory.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -95,6 +95,7 @@ const sidebars: SidebarsConfig = {
           label: 'Advanced',
           items: [
             'user-guide/features/rl-training',
+            'user-guide/features/mixture-of-agents',
             'user-guide/features/spotify',
           ],
         },
@@ -234,6 +235,7 @@ const sidebars: SidebarsConfig = {
         'reference/environment-variables',
         'reference/tools-reference',
         'reference/toolsets-reference',
+        'reference/mixture-of-agents',
         'reference/mcp-config-reference',
         'reference/model-catalog',
         'reference/skills-catalog',


### PR DESCRIPTION
## Rationale
MoA currently assumes a fixed OpenRouter-only roster and a fixed OpenRouter credential requirement. That makes the tool hard to use for users who already route models through Codex, Nous, AI Gateway, Anthropic, or named custom providers, and it causes setup/tool configuration surfaces to report MoA unavailable even when the configured roster has valid non-OpenRouter credentials. The smallest maintainable fix is to make MoA read a typed `moa:` config block and route each slot through the existing provider resolver instead of adding a parallel auth path or provider-specific configuration surface.

## Implementation
- Adds `DEFAULT_CONFIG["moa"]` with a provider-aware reference roster, aggregator, temperatures, reasoning settings, kill switch, and adaptive `min_successful_references` semantics.
- Extends `tools/mixture_of_agents_tool.py` to normalize string/dict entries, validate providers and named custom-provider slugs, route reference and aggregator calls through `resolve_provider_client`, and preserve legacy string overrides as OpenRouter-only overrides.
- Makes MoA preflight config-aware in setup and tool configuration flows, so OpenRouter is required only when the configured roster uses OpenRouter.
- Uses standard Hermes reasoning constants for validation. PR1 forwards reasoning only through safe OpenAI-compatible paths (`openrouter`, `nous`, `ai-gateway`, `openai-codex`) and logs once when omitting reasoning for providers whose provider-specific kwargs are deferred to PR2.
- Documents the new `moa:` config surface in the user guide/reference docs and updates tool references/sidebar entries.

## Tests
- `scripts/run_tests.sh tests/tools/test_mixture_of_agents_tool_provider_routing.py -q`
- `scripts/run_tests.sh tests/tools/test_mixture_of_agents_tool_provider_routing.py tests/tools/test_mixture_of_agents_tool.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_setup_model_provider.py -q`
- `uv run ruff check tools/mixture_of_agents_tool.py tests/tools/test_mixture_of_agents_tool_provider_routing.py`
- `git diff --check`

## Risks and follow-ups
- MoA fan-out can multiply provider usage and Codex plan consumption; the tool logs Codex roster warnings and the docs call this out.
- Provider/model catalog mismatches remain soft warnings so newly released model slugs are not blocked by stale catalogs.
- PR2 should add provider-specific reasoning kwargs for Anthropic, custom OpenAI-compatible endpoints, Copilot, Kimi/Tencent/LM Studio-style providers, plus any sticky unsupported-parameter fallback behavior.