### PR TITLE
fix: exclude hidden and archive dirs from _find_skill rglob

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -283,11 +283,13 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import EXCLUDED_SKILL_DIRS, get_all_skills_dirs
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
+            if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+                continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None


### PR DESCRIPTION
## Summary

`_find_skill()` in `tools/skill_manager_tool.py` uses a bare `rglob("SKILL.md")` across skill directories without filtering out hidden or archive paths. This means skill mutations can accidentally match entries inside `.git/`, `.github/`, `.hub/`, or `.archive/` directories.

Every other skill-scanning function in the codebase (`tools/skills_tool.py`, `agent/skill_utils.py`) already applies `EXCLUDED_SKILL_DIRS` filtering. This PR adds the same guard to `_find_skill`.

## Changes

- Import `EXCLUDED_SKILL_DIRS` alongside `get_all_skills_dirs` in `_find_skill()`
- Add a path-parts exclusion check in the rglob loop, matching the pattern used in `tools/skills_tool.py:576`

## Testing

- All 85 tests in `tests/tools/test_skill_manager_tool.py` pass
- All 36 tests in `tests/agent/test_skill_commands.py` pass
- `py_compile` and `ruff check` clean (no new warnings)

Closes #18900
