### PR TITLE
feat: add Codex quota usage indicator

### DIFF
--- a/agent/codex_quota.py
+++ b/agent/codex_quota.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+
+USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+
+
+@dataclass(frozen=True)
+class CodexQuotaWindow:
+    key: str
+    label: str
+    used_percent: float
+    elapsed_percent: float
+    limit_window_seconds: Optional[int] = None
+    reset_at: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class CodexQuotaResult:
+    ok: bool
+    fetched_at: datetime
+    plan_type: Optional[str] = None
+    windows: tuple[CodexQuotaWindow, ...] = ()
+    error: Optional[str] = None
+    status_code: Optional[int] = None
+    payload: Optional[dict[str, Any]] = None
+
+
+class CodexQuotaError(RuntimeError):
+    def __init__(self, message: str, *, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp_percent(value: Any) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        numeric = 0.0
+    return max(0.0, min(100.0, numeric))
+
+
+def parse_reset_at(value: Any) -> Optional[datetime]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric <= 0:
+            return None
+        if numeric > 1_000_000_000_000:
+            numeric /= 1000.0
+        return datetime.fromtimestamp(numeric, tz=timezone.utc)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return parse_reset_at(float(text))
+        except ValueError:
+            pass
+        try:
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            dt = datetime.fromisoformat(text)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def compute_elapsed_percent(
+    *,
+    used_percent: float,
+    limit_window_seconds: Any,
+    reset_at: Optional[datetime],
+    now: Optional[datetime] = None,
+) -> float:
+    try:
+        window_seconds = int(limit_window_seconds)
+    except (TypeError, ValueError):
+        window_seconds = 0
+    if window_seconds <= 0 or reset_at is None:
+        return _clamp_percent(used_percent)
+    current = now or _now()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    remaining = max(0.0, (reset_at - current).total_seconds())
+    elapsed = ((window_seconds - remaining) / window_seconds) * 100.0
+    return _clamp_percent(elapsed)
+
+
+def classify_quota_usage(usage_percent: float, elapsed_percent: float) -> str:
+    usage = _clamp_percent(usage_percent)
+    elapsed = _clamp_percent(elapsed_percent)
+    if usage >= 90:
+        return "error"
+    if usage >= 75:
+        return "warning"
+    if usage >= elapsed + 10:
+        return "warning"
+    if usage >= 50:
+        return "accent"
+    return "success"
+
+
+def _bar_cells(usage_percent: float, elapsed_percent: float, width: int) -> tuple[int, int]:
+    width = max(1, int(width))
+    filled_end = round((_clamp_percent(usage_percent) / 100.0) * width)
+    cursor_pos = round((_clamp_percent(elapsed_percent) / 100.0) * (width - 1))
+    return max(0, min(width, filled_end)), max(0, min(width - 1, cursor_pos))
+
+
+def render_quota_bar_text(
+    usage_percent: float,
+    elapsed_percent: float,
+    *,
+    width: int = 16,
+    fill: str = "━",
+    track: str = "━",
+    cursor: str = "|",
+) -> str:
+    filled_end, cursor_pos = _bar_cells(usage_percent, elapsed_percent, width)
+    cells: list[str] = []
+    for index in range(max(1, int(width))):
+        if index == cursor_pos:
+            cells.append(cursor)
+        elif index < filled_end:
+            cells.append(fill)
+        else:
+            cells.append(track)
+    return "".join(cells)
+
+
+def render_quota_bar_fragments(
+    usage_percent: float,
+    elapsed_percent: float,
+    *,
+    width: int = 16,
+) -> list[tuple[str, str]]:
+    usage_style = classify_quota_usage(usage_percent, elapsed_percent)
+    style_map = {
+        "error": "class:status-bar-critical",
+        "warning": "class:status-bar-bad",
+        "accent": "class:status-bar-warn",
+        "success": "class:status-bar-good",
+    }
+    fill_style = style_map[usage_style]
+    filled_end, cursor_pos = _bar_cells(usage_percent, elapsed_percent, width)
+    fragments: list[tuple[str, str]] = []
+    for index in range(max(1, int(width))):
+        if index == cursor_pos:
+            fragments.append(("class:status-bar-strong", "|"))
+        elif index < filled_end:
+            fragments.append((fill_style, "━"))
+        else:
+            fragments.append(("class:status-bar-dim", "━"))
+    return fragments
+
+
+def format_remaining(reset_at: Optional[datetime], *, now: Optional[datetime] = None) -> str:
+    if reset_at is None:
+        return "unknown"
+    current = now or _now()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    seconds = int((reset_at - current).total_seconds())
+    if seconds <= 0:
+        return "now"
+    minutes = max(1, seconds // 60)
+    if minutes >= 24 * 60:
+        days = minutes // (24 * 60)
+        hours = (minutes % (24 * 60)) // 60
+        return f"{days}d{hours}h"
+    if minutes >= 60:
+        hours = minutes // 60
+        mins = minutes % 60
+        return f"{hours}h{mins}m"
+    return f"{minutes}m"
+
+
+def _clock_no_leading_zero(dt: datetime) -> str:
+    text = dt.strftime("%I:%M%p").lower()
+    return text[1:] if text.startswith("0") else text
+
+
+def format_reset_clock(reset_at: Optional[datetime], *, now: Optional[datetime] = None) -> str:
+    if reset_at is None:
+        return "unknown"
+    current = now or _now()
+    local_reset = reset_at.astimezone()
+    local_now = current.astimezone()
+    clock = _clock_no_leading_zero(local_reset)
+    if local_reset.date() == local_now.date():
+        return clock
+    return f"{local_reset.day} {local_reset.strftime('%b')} {clock}"
+
+
+def format_window_metadata(
+    window: CodexQuotaWindow,
+    *,
+    now: Optional[datetime] = None,
+    compact: bool = False,
+) -> str:
+    used = round(_clamp_percent(window.used_percent))
+    sep = "·" if compact else " · "
+    return f"{used}%{sep}{format_remaining(window.reset_at, now=now)}→{format_reset_clock(window.reset_at, now=now)}"
+
+
+def parse_codex_quota_payload(payload: dict[str, Any], *, now: Optional[datetime] = None) -> CodexQuotaResult:
+    rate_limit = payload.get("rate_limit") if isinstance(payload, dict) else None
+    if not isinstance(rate_limit, dict):
+        rate_limit = {}
+    windows: list[CodexQuotaWindow] = []
+    for key, label in (("primary_window", "Primary"), ("secondary_window", "Secondary")):
+        raw = rate_limit.get(key)
+        if not isinstance(raw, dict) or raw.get("used_percent") is None:
+            continue
+        used = _clamp_percent(raw.get("used_percent"))
+        reset_at = parse_reset_at(raw.get("reset_at"))
+        limit_window_seconds = raw.get("limit_window_seconds")
+        elapsed = compute_elapsed_percent(
+            used_percent=used,
+            limit_window_seconds=limit_window_seconds,
+            reset_at=reset_at,
+            now=now,
+        )
+        try:
+            window_seconds = int(limit_window_seconds) if limit_window_seconds is not None else None
+        except (TypeError, ValueError):
+            window_seconds = None
+        windows.append(
+            CodexQuotaWindow(
+                key=key,
+                label=label,
+                used_percent=used,
+                elapsed_percent=elapsed,
+                limit_window_seconds=window_seconds,
+                reset_at=reset_at,
+            )
+        )
+    return CodexQuotaResult(
+        ok=True,
+        fetched_at=now or _now(),
+        plan_type=str(payload.get("plan_type") or "").strip() or None,
+        windows=tuple(windows),
+        payload=payload,
+    )
+
+
+def _codex_usage_headers(api_key: str, account_id: Optional[str]) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": "codex-cli",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    return headers
+
+
+def _resolve_codex_quota_credentials() -> tuple[str, Optional[str]]:
+    """Return (access_token, account_id) from Codex auth, including credential pools."""
+    try:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        api_key = str(creds.get("api_key") or "").strip()
+        if api_key:
+            token_data = _read_codex_tokens()
+            tokens = token_data.get("tokens") if isinstance(token_data, dict) else None
+            account_id = None
+            if isinstance(tokens, dict):
+                account_id = str(tokens.get("account_id") or "").strip() or None
+            return api_key, account_id
+    except Exception:
+        pass
+
+    try:
+        from agent.credential_pool import load_pool
+
+        entry = load_pool("openai-codex").select()
+        if entry and entry.runtime_api_key:
+            return str(entry.runtime_api_key).strip(), None
+    except Exception:
+        pass
+    return "", None
+
+
+def fetch_codex_quota(*, timeout: float = 8.0) -> CodexQuotaResult:
+    fetched_at = _now()
+    api_key, account_id = _resolve_codex_quota_credentials()
+    if not api_key:
+        return CodexQuotaResult(ok=False, fetched_at=fetched_at, error="no codex auth")
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(USAGE_URL, headers=_codex_usage_headers(api_key, account_id))
+        if response.status_code in (401, 403):
+            return CodexQuotaResult(ok=False, fetched_at=fetched_at, error="codex auth expired", status_code=response.status_code)
+        if response.status_code >= 400:
+            return CodexQuotaResult(ok=False, fetched_at=fetched_at, error=f"codex quota: http {response.status_code}", status_code=response.status_code)
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return CodexQuotaResult(ok=False, fetched_at=fetched_at, error="codex quota: malformed response")
+        return parse_codex_quota_payload(payload or {}, now=fetched_at)
+    except httpx.TimeoutException:
+        return CodexQuotaResult(ok=False, fetched_at=fetched_at, error="codex quota: timeout")
+    except httpx.HTTPError as exc:
+        return CodexQuotaResult(ok=False, fetched_at=fetched_at, error=f"codex quota: {exc.__class__.__name__}")
+    except ValueError:
+        return CodexQuotaResult(ok=False, fetched_at=fetched_at, error="codex quota: malformed response")
+
+
+def format_codex_quota_compact(result: Optional[CodexQuotaResult], *, width: int = 12) -> str:
+    if result is None:
+        return "codex quota --"
+    if not result.ok:
+        return result.error or "codex quota unavailable"
+    if not result.windows:
+        return "codex quota unavailable"
+    parts = ["codex"]
+    for window in result.windows:
+        parts.append(render_quota_bar_text(window.used_percent, window.elapsed_percent, width=width))
+        parts.append(f"{round(window.used_percent)}%")
+    return " ".join(parts)
+
+
+def format_codex_quota_full(result: Optional[CodexQuotaResult], *, width: int = 16) -> str:
+    if result is None:
+        return "codex quota unavailable"
+    if not result.ok:
+        return result.error or "codex quota unavailable"
+    if not result.windows:
+        return "codex quota unavailable"
+    title = "Codex quota"
+    if result.plan_type:
+        title += f" ({result.plan_type})"
+    lines = [title]
+    for window in result.windows:
+        bar = render_quota_bar_text(window.used_percent, window.elapsed_percent, width=width)
+        lines.append(f"  {window.label:<9} {bar} {format_window_metadata(window)}")
+    return "\n".join(lines)

--- a/cli.py
+++ b/cli.py
@@ -2037,6 +2037,12 @@ class HermesCLI:
         if self.final_response_markdown not in {"render", "strip", "raw"}:
             self.final_response_markdown = "strip"
 
+        self.codex_quota_display = str(
+            CLI_CONFIG["display"].get("codex_quota", "minimal")
+        ).strip().lower() or "minimal"
+        if self.codex_quota_display not in {"minimal", "detailed"}:
+            self.codex_quota_display = "minimal"
+
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
         self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
 
@@ -2290,6 +2296,10 @@ class HermesCLI:
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        self._codex_quota_snapshot = None
+        self._codex_quota_last_refresh = 0.0
+        self._codex_quota_refreshing = False
+        self._codex_quota_lock = threading.Lock()
 
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
@@ -2353,6 +2363,44 @@ class HermesCLI:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
+
+    def _is_codex_provider_active(self) -> bool:
+        agent = getattr(self, "agent", None)
+        provider = (getattr(agent, "provider", None) or getattr(self, "provider", None) or "").lower()
+        base_url = (getattr(agent, "base_url", None) or getattr(self, "base_url", None) or "").lower()
+        return provider == "openai-codex" or "chatgpt.com/backend-api/codex" in base_url
+
+    def _maybe_refresh_codex_quota(self, *, force: bool = False) -> None:
+        if not self._is_codex_provider_active():
+            return
+        now = time.monotonic()
+        with self._codex_quota_lock:
+            if self._codex_quota_refreshing:
+                return
+            if not force and self._codex_quota_last_refresh and (now - self._codex_quota_last_refresh) < 30.0:
+                return
+            self._codex_quota_refreshing = True
+            self._codex_quota_last_refresh = now
+
+        def _worker() -> None:
+            try:
+                from agent.codex_quota import fetch_codex_quota
+                snapshot = fetch_codex_quota(timeout=8.0)
+                with self._codex_quota_lock:
+                    self._codex_quota_snapshot = snapshot
+            except Exception:
+                pass
+            finally:
+                with self._codex_quota_lock:
+                    self._codex_quota_refreshing = False
+                self._invalidate(min_interval=0.0)
+
+        threading.Thread(target=_worker, name="codex-quota-refresh", daemon=True).start()
+
+    def _get_codex_quota_snapshot(self):
+        self._maybe_refresh_codex_quota()
+        with self._codex_quota_lock:
+            return self._codex_quota_snapshot
 
     @staticmethod
     def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
@@ -2658,6 +2706,45 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    quota_snapshot = self._get_codex_quota_snapshot() if self._is_codex_provider_active() else None
+                    if quota_snapshot is not None:
+                        try:
+                            from agent.codex_quota import format_window_metadata, render_quota_bar_fragments
+                            if quota_snapshot.ok and quota_snapshot.windows:
+                                detailed_quota = getattr(self, "codex_quota_display", "minimal") == "detailed"
+                                frags.append(("class:status-bar-dim", " │ codex "))
+                                if detailed_quota:
+                                    bar_width = 10 if width >= 140 else 8
+                                    for idx, window in enumerate(quota_snapshot.windows[:2]):
+                                        if idx:
+                                            frags.append(("class:status-bar-dim", "  "))
+                                        frags.extend(render_quota_bar_fragments(
+                                            window.used_percent,
+                                            window.elapsed_percent,
+                                            width=bar_width,
+                                        ))
+                                        frags.append(("class:status-bar-dim", " "))
+                                        frags.append((
+                                            self._status_bar_context_style(round(window.used_percent)),
+                                            format_window_metadata(window, compact=True),
+                                        ))
+                                else:
+                                    for idx, window in enumerate(quota_snapshot.windows[:2]):
+                                        if idx:
+                                            frags.append(("class:status-bar-dim", " "))
+                                        frags.extend(render_quota_bar_fragments(
+                                            window.used_percent,
+                                            window.elapsed_percent,
+                                            width=8,
+                                        ))
+                                        frags.append(("class:status-bar-dim", " "))
+                                        frags.append((self._status_bar_context_style(round(window.used_percent)), f"{round(window.used_percent)}%"))
+                            elif quota_snapshot.error:
+                                frags.append(("class:status-bar-dim", f" │ {quota_snapshot.error}"))
+                        except Exception:
+                            pass
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
@@ -2666,7 +2753,7 @@ class HermesCLI:
                         (bar_style, percent_label),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
-                    ]
+                    ])
                     # Position 7: per-prompt elapsed timer (live or frozen)
                     prompt_elapsed = snapshot.get("prompt_elapsed")
                     if prompt_elapsed:
@@ -5870,6 +5957,26 @@ class HermesCLI:
             self._console_print(f"    {header:40s}  {bar}  {pct_str}")
         self._console_print()
 
+    def _handle_codex_quota_command(self, cmd_original: str) -> None:
+        """Show OpenAI Codex quota usage for the current OAuth account."""
+        try:
+            from agent.codex_quota import fetch_codex_quota, format_codex_quota_full
+        except ImportError as exc:
+            self._console_print(f"  [red]Codex quota module unavailable: {exc}[/]")
+            return
+        result = fetch_codex_quota(timeout=8.0)
+        with self._codex_quota_lock:
+            self._codex_quota_snapshot = result
+            self._codex_quota_last_refresh = time.monotonic()
+        rendered = format_codex_quota_full(result)
+        if result.ok:
+            self._console_print()
+            for line in rendered.splitlines():
+                self._console_print(f"  {line}")
+            self._console_print()
+        else:
+            self._console_print(f"  [yellow]{rendered}[/]")
+
     def _handle_personality_command(self, cmd: str):
         """Handle the /personality command to set predefined personalities."""
         parts = cmd.split(maxsplit=1)
@@ -6429,6 +6536,8 @@ class HermesCLI:
             self._handle_model_switch(cmd_original)
         elif canonical == "gquota":
             self._handle_gquota_command(cmd_original)
+        elif canonical == "codex-quota":
+            self._handle_codex_quota_command(cmd_original)
 
         elif canonical == "personality":
             # Use original case (handler lowercases the personality name itself)
@@ -11544,6 +11653,7 @@ class HermesCLI:
                         self._tool_start_time = 0.0
                         self._pending_tool_info.clear()
                         self._last_scrollback_tool = ""
+                        self._maybe_refresh_codex_quota(force=True)
 
                         app.invalidate()  # Refresh status line
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -114,6 +114,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("provider",), args_hint="[model] [--provider name] [--global]"),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
+    CommandDef("codex-quota", "Show OpenAI Codex quota usage and reset windows", "Info",
+               cli_only=True, aliases=("quota",)),
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -768,6 +768,7 @@ DEFAULT_CONFIG = {
         "final_response_markdown": "strip",  # render | strip | raw
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
+        "codex_quota": "minimal", # Codex quota status bar: minimal | detailed
         "skin": "default",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/tests/test_codex_quota.py
+++ b/tests/test_codex_quota.py
@@ -1,0 +1,161 @@
+from datetime import datetime, timedelta, timezone
+
+from agent.codex_quota import (
+    CodexQuotaResult,
+    CodexQuotaWindow,
+    classify_quota_usage,
+    compute_elapsed_percent,
+    fetch_codex_quota,
+    format_codex_quota_full,
+    format_remaining,
+    format_window_metadata,
+    parse_codex_quota_payload,
+    render_quota_bar_text,
+)
+
+
+class _Response:
+    def __init__(self, payload=None, status_code=200):
+        self._payload = payload if payload is not None else {}
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        self.calls.append((url, headers or {}))
+        return self.response
+
+
+def test_compute_elapsed_percent_from_reset_window():
+    now = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+    reset_at = now + timedelta(hours=2)
+    assert compute_elapsed_percent(
+        used_percent=22,
+        limit_window_seconds=5 * 3600,
+        reset_at=reset_at,
+        now=now,
+    ) == 60.0
+
+
+def test_compute_elapsed_percent_falls_back_to_usage_when_timing_missing():
+    assert compute_elapsed_percent(used_percent=37, limit_window_seconds=None, reset_at=None) == 37
+
+
+def test_render_quota_bar_cursor_and_fill_are_separate():
+    # 25% usage over a 10-cell bar fills 2 cells; 50% elapsed puts cursor at index 4.
+    assert render_quota_bar_text(25, 50, width=10) == "━━━━|━━━━━"
+
+
+def test_classify_quota_usage_thresholds_and_over_pace():
+    assert classify_quota_usage(91, 90) == "error"
+    assert classify_quota_usage(75, 80) == "warning"
+    assert classify_quota_usage(61, 40) == "warning"
+    assert classify_quota_usage(55, 50) == "accent"
+    assert classify_quota_usage(30, 40) == "success"
+
+
+def test_remaining_time_formatting():
+    now = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+    assert format_remaining(now - timedelta(seconds=1), now=now) == "now"
+    assert format_remaining(now + timedelta(minutes=42), now=now) == "42m"
+    assert format_remaining(now + timedelta(hours=3, minutes=13), now=now) == "3h13m"
+    assert format_remaining(now + timedelta(days=2, hours=6), now=now) == "2d6h"
+
+
+def test_format_window_metadata_compact_removes_statusbar_waste():
+    now = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+    window = CodexQuotaWindow(
+        key="primary_window",
+        label="Primary",
+        used_percent=2.0,
+        elapsed_percent=7,
+        reset_at=now + timedelta(hours=4, minutes=39),
+    )
+    assert format_window_metadata(window, now=now) == "2% · 4h39m→2:39pm"
+    assert format_window_metadata(window, now=now, compact=True) == "2%·4h39m→2:39pm"
+
+
+def test_parse_codex_quota_payload_handles_primary_secondary_and_elapsed():
+    now = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+    result = parse_codex_quota_payload(
+        {
+            "plan_type": "team",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 22.4,
+                    "limit_window_seconds": 18000,
+                    "reset_at": int((now + timedelta(hours=3, minutes=13)).timestamp()),
+                },
+                "secondary_window": {
+                    "used_percent": 46.8,
+                    "limit_window_seconds": 604800,
+                    "reset_at": int((now + timedelta(days=2, hours=6)).timestamp()),
+                },
+            },
+        },
+        now=now,
+    )
+    assert result.ok
+    assert result.plan_type == "team"
+    assert [w.key for w in result.windows] == ["primary_window", "secondary_window"]
+    assert round(result.windows[0].used_percent) == 22
+    assert result.windows[0].elapsed_percent > 0
+
+
+def test_format_codex_quota_full_reports_missing_windows():
+    result = CodexQuotaResult(ok=True, fetched_at=datetime.now(timezone.utc), windows=())
+    assert format_codex_quota_full(result) == "codex quota unavailable"
+
+
+def test_fetch_codex_quota_auth_expired(monkeypatch):
+    monkeypatch.setattr(
+        "agent.codex_quota.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {"api_key": "token"},
+    )
+    monkeypatch.setattr("agent.codex_quota._read_codex_tokens", lambda: {"tokens": {}})
+    monkeypatch.setattr("agent.codex_quota.httpx.Client", lambda timeout=8.0: _Client(_Response(status_code=403)))
+
+    result = fetch_codex_quota()
+
+    assert not result.ok
+    assert result.error == "codex auth expired"
+    assert result.status_code == 403
+
+
+def test_fetch_codex_quota_missing_credentials(monkeypatch):
+    def _raise(**kwargs):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr("agent.codex_quota.resolve_codex_runtime_credentials", _raise)
+
+    result = fetch_codex_quota()
+
+    assert not result.ok
+    assert result.error == "no codex auth"
+
+
+def test_fetch_codex_quota_malformed_response(monkeypatch):
+    monkeypatch.setattr(
+        "agent.codex_quota.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {"api_key": "token"},
+    )
+    monkeypatch.setattr("agent.codex_quota._read_codex_tokens", lambda: {"tokens": {}})
+    monkeypatch.setattr("agent.codex_quota.httpx.Client", lambda timeout=8.0: _Client(_Response(payload=[])))
+
+    result = fetch_codex_quota()
+
+    assert not result.ok
+    assert result.error == "codex quota: malformed response"


### PR DESCRIPTION
## Summary
- add a shared Codex quota usage fetcher for ChatGPT's wham usage endpoint
- add `/codex-quota` with `/quota` alias for primary and secondary quota windows
- show Codex quota pace bars in the CLI status bar for openai-codex sessions
- add configurable status-bar detail levels via `display.codex_quota`

## Configuration

The status-bar indicator defaults to the compact/minimal view:

```yaml
display:
  codex_quota: minimal
```

Available values:

- `minimal` — default. Shows compact quota pace bars plus used percentages.
- `detailed` — shows quota pace bars plus reset countdown/clock metadata, e.g. `2%·4h39m→1:49pm`.

Switch with:

```bash
hermes config set display.codex_quota detailed
hermes config set display.codex_quota minimal
```

The slash command output remains detailed regardless of this setting:

```bash
/codex-quota
/quota
```

## Minimal preview
![Minimal Codex quota indicator preview](https://github.com/user-attachments/assets/cc7b3085-0264-4783-90fe-901e9f17fb47)

## Detailed preview
![Detailed Codex quota indicator preview](https://github.com/user-attachments/assets/90928977-b925-4a9e-858c-83808b088e86)

## Test Plan
- venv/bin/python -m pytest tests/test_codex_quota.py tests/hermes_cli/test_commands.py tests/cli/test_cli_status_bar.py tests/hermes_cli/test_config.py -q -o 'addopts='
