### PR TITLE
fix: preserve credential pool through /model session override

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5475,27 +5475,15 @@ class HermesCLI:
 
         if self.agent is not None:
             try:
-                # Resolve credential pool for the target provider so the
-                # agent can rotate keys on 429/402 after a /model switch.
-                _pool = None
-                _prov = result.target_provider
-                if _prov.startswith("custom:"):
-                    try:
-                        from agent.credential_pool import load_pool
-                        _p = load_pool(_prov)
-                        if _p and _p.has_credentials():
-                            _pool = _p
-                    except Exception:
-                        pass
-                if _pool is not None:
-                    self._credential_pool = _pool
+                if result.credential_pool is not None:
+                    self._credential_pool = result.credential_pool
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    credential_pool=_pool,
+                    credential_pool=result.credential_pool,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -5714,27 +5702,15 @@ class HermesCLI:
         # Apply to running agent (in-place swap)
         if self.agent is not None:
             try:
-                # Resolve credential pool for the target provider so the
-                # agent can rotate keys on 429/402 after a /model switch.
-                _pool = None
-                _prov = result.target_provider
-                if _prov.startswith("custom:"):
-                    try:
-                        from agent.credential_pool import load_pool
-                        _p = load_pool(_prov)
-                        if _p and _p.has_credentials():
-                            _pool = _p
-                    except Exception:
-                        pass
-                if _pool is not None:
-                    self._credential_pool = _pool
+                if result.credential_pool is not None:
+                    self._credential_pool = result.credential_pool
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    credential_pool=_pool,
+                    credential_pool=result.credential_pool,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")

--- a/cli.py
+++ b/cli.py
@@ -5475,12 +5475,27 @@ class HermesCLI:
 
         if self.agent is not None:
             try:
+                # Resolve credential pool for the target provider so the
+                # agent can rotate keys on 429/402 after a /model switch.
+                _pool = None
+                _prov = result.target_provider
+                if _prov.startswith("custom:"):
+                    try:
+                        from agent.credential_pool import load_pool
+                        _p = load_pool(_prov)
+                        if _p and _p.has_credentials():
+                            _pool = _p
+                    except Exception:
+                        pass
+                if _pool is not None:
+                    self._credential_pool = _pool
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    credential_pool=_pool,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -5699,12 +5714,27 @@ class HermesCLI:
         # Apply to running agent (in-place swap)
         if self.agent is not None:
             try:
+                # Resolve credential pool for the target provider so the
+                # agent can rotate keys on 429/402 after a /model switch.
+                _pool = None
+                _prov = result.target_provider
+                if _prov.startswith("custom:"):
+                    try:
+                        from agent.credential_pool import load_pool
+                        _p = load_pool(_prov)
+                        if _p and _p.has_credentials():
+                            _pool = _p
+                    except Exception:
+                        pass
+                if _pool is not None:
+                    self._credential_pool = _pool
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    credential_pool=_pool,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1441,7 +1441,23 @@ class GatewayRunner:
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
             }
+            # Carry credential_pool from override if stored (new behavior)
+            if override.get("credential_pool") is not None:
+                override_runtime["credential_pool"] = override["credential_pool"]
             if override_runtime.get("api_key"):
+                # Credential pool fix: /model stores api_key but may lack
+                # credential_pool (ModelSwitchResult has no such field).
+                # When the provider is a pool name (e.g. "custom:mimo-sgp-friend"),
+                # resolve the pool here so the agent can rotate on 429/402.
+                _prov = override.get("provider", "")
+                if _prov.startswith("custom:") and "credential_pool" not in override_runtime:
+                    try:
+                        from agent.credential_pool import load_pool
+                        _pool = load_pool(_prov)
+                        if _pool and _pool.has_credentials():
+                            override_runtime["credential_pool"] = _pool
+                    except Exception:
+                        pass
                 logger.debug(
                     "Session model override (fast): session=%s config_model=%s -> override_model=%s provider=%s",
                     resolved_session_key or "", model, override_model,
@@ -7524,6 +7540,19 @@ class GatewayRunner:
             with _cache_lock:
                 cached_entry = _cache.get(session_key)
 
+        # Resolve credential pool for the target provider so the agent can
+        # rotate keys on 429/402 after a /model switch.
+        _resolved_pool = None
+        _prov = result.target_provider
+        if _prov.startswith("custom:"):
+            try:
+                from agent.credential_pool import load_pool
+                _p = load_pool(_prov)
+                if _p and _p.has_credentials():
+                    _resolved_pool = _p
+            except Exception:
+                pass
+
         if cached_entry and cached_entry[0] is not None:
             try:
                 cached_entry[0].switch_model(
@@ -7532,6 +7561,7 @@ class GatewayRunner:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    credential_pool=_resolved_pool,
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
@@ -7553,6 +7583,7 @@ class GatewayRunner:
             "api_key": result.api_key,
             "base_url": result.base_url,
             "api_mode": result.api_mode,
+            "credential_pool": _resolved_pool,
         }
 
         # Evict cached agent so the next turn creates a fresh agent from the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -959,7 +959,8 @@ class GatewayRunner:
     _restart_detached: bool = False
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
-    _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    # Values are mostly str but credential_pool is a CredentialPool instance.
+    _session_model_overrides: Dict[str, Dict[str, Any]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     # Stale-code self-check defaults (see _detect_stale_code()).  Class-level
     # so tests that construct GatewayRunner via ``object.__new__`` without
@@ -1058,7 +1059,7 @@ class GatewayRunner:
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
-        self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        self._session_model_overrides: Dict[str, Dict[str, Any]] = {}
         # Per-session reasoning effort overrides from /reasoning.
         # Key: session_key, Value: parsed reasoning config dict.
         self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
@@ -7540,19 +7541,6 @@ class GatewayRunner:
             with _cache_lock:
                 cached_entry = _cache.get(session_key)
 
-        # Resolve credential pool for the target provider so the agent can
-        # rotate keys on 429/402 after a /model switch.
-        _resolved_pool = None
-        _prov = result.target_provider
-        if _prov.startswith("custom:"):
-            try:
-                from agent.credential_pool import load_pool
-                _p = load_pool(_prov)
-                if _p and _p.has_credentials():
-                    _resolved_pool = _p
-            except Exception:
-                pass
-
         if cached_entry and cached_entry[0] is not None:
             try:
                 cached_entry[0].switch_model(
@@ -7561,7 +7549,7 @@ class GatewayRunner:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    credential_pool=_resolved_pool,
+                    credential_pool=result.credential_pool,
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
@@ -7583,7 +7571,7 @@ class GatewayRunner:
             "api_key": result.api_key,
             "base_url": result.base_url,
             "api_mode": result.api_mode,
-            "credential_pool": _resolved_pool,
+            "credential_pool": result.credential_pool,
         }
 
         # Evict cached agent so the next turn creates a fresh agent from the

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,10 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
+
+if TYPE_CHECKING:
+    from agent.credential_pool import CredentialPool
 
 from hermes_cli.providers import (
     custom_provider_slug,
@@ -246,6 +249,10 @@ class ModelSwitchResult:
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    # CredentialPool for the resolved target provider, when one was loaded.
+    # Callers must propagate this into runtime kwargs / session overrides so
+    # per-provider 429 rotation continues to work after a /model switch.
+    credential_pool: Optional["CredentialPool"] = None
 
 
 @dataclass
@@ -818,6 +825,7 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    _resolved_pool = None
 
     if provider_changed or explicit_provider:
         try:
@@ -828,6 +836,7 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            _resolved_pool = runtime.get("credential_pool")
         except Exception as e:
             return ModelSwitchResult(
                 success=False,
@@ -853,6 +862,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                _resolved_pool = runtime.get("credential_pool")
         except Exception:
             pass
 
@@ -978,6 +988,7 @@ def switch_model(
         capabilities=capabilities,
         model_info=model_info,
         is_global=is_global,
+        credential_pool=_resolved_pool,
     )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2278,7 +2278,7 @@ class AIAgent:
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode='', credential_pool=None):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -2324,6 +2324,15 @@ class AIAgent:
             self._transport_cache.clear()
         if api_key:
             self.api_key = api_key
+
+        # ── Swap credential pool if provided ──
+        # The /model pipeline resolves pools via load_pool() but the result
+        # was historically lost in the ModelSwitchResult → session-override
+        # chain.  Callers that resolve the pool themselves can now pass it
+        # through so the agent can rotate on 429/402 after a mid-session
+        # model switch.
+        if credential_pool is not None:
+            self._credential_pool = credential_pool
 
         # ── Build new client ──
         if api_mode == "anthropic_messages":


### PR DESCRIPTION
## Summary

Fix credential pool not being passed through after a `/model` session override, causing key rotation to silently fail on 429/402 errors.

**Root cause:** `ModelSwitchResult` had no `credential_pool` field. When `/model` resolved a pool-backed provider (e.g. `custom:mimo-sgp-friend`) via `resolve_runtime_provider()`, the pool object was returned in the runtime dict but silently dropped when building the result. The gateway's session override and CLI's in-place swap both received the incomplete set. The agent was created with `credential_pool=None`, making `_recover_with_credential_pool()` a no-op — it retried the same exhausted key 3 times instead of rotating.

**Impact:** Any user with a `custom:<name>` credential pool who switches providers via `/model` (CLI or gateway) loses pool rotation until the next full restart.

## Changes

**`hermes_cli/model_switch.py`** — `ModelSwitchResult` + `switch_model()`:
- Add `credential_pool` field to `ModelSwitchResult`
- Capture pool from `resolve_runtime_provider()` on both explicit-provider and same-provider re-resolve paths

**`gateway/run.py`** — `_handle_model_command()`:
- Propagate `result.credential_pool` into session overrides and in-place `agent.switch_model()`
- Update `_session_model_overrides` type hint to `Dict[str, Any]` for the `CredentialPool` instance

**`cli.py`** — `_apply_model_switch_result()` and `_handle_model_switch()`:
- Pass `result.credential_pool` to `agent.switch_model()` and update `self._credential_pool`

**`run_agent.py`** — `switch_model()`:
- Accept `credential_pool=None` parameter, update `self._credential_pool` when provided

## Relation to #16701

This PR adopts the approach from #16701 (briandevans) — adding `credential_pool` to `ModelSwitchResult` as the proper source-level fix — and extends it with **CLI path coverage** that #16701 missed:

- `cli.py:5476` (`_apply_model_switch_result`) — interactive picker path
- `cli.py:5700` (`_handle_model_switch`) — main `/model` command handler

Both call `agent.switch_model()` without passing the pool, so a CLI `/model` switch to a `custom:<name>` provider also loses rotation.

## Test Plan

- [x] Verified `load_pool('custom:mimo-sgp-friend')` returns a valid pool
- [x] Verified `resolve_runtime_provider()` returns `credential_pool` in runtime dict
- [x] Gateway restart + Telegram `/model` switch now rotates on 429
- [x] All 4 modified files compile cleanly
- [ ] CI passes (no behavioral change for non-pool providers)