### PR TITLE
fix(moa): align provider request kwargs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -215,6 +215,34 @@ def _fixed_temperature_for_model(
         return OMIT_TEMPERATURE
     return None
 
+
+def resolve_chat_temperature(
+    model: str,
+    base_url: Optional[str],
+    requested: Optional[float],
+) -> Optional[float]:
+    """Resolve the temperature to send for a chat-completions style request.
+
+    ``None`` means omit the request field and let the provider/server default
+    apply.  This public helper lets direct auxiliary callers share the same
+    strict-model handling as ``_build_call_kwargs`` without importing private
+    sentinel helpers.
+    """
+    temperature = requested
+    fixed_temperature = _fixed_temperature_for_model(model, base_url)
+    if fixed_temperature is OMIT_TEMPERATURE:
+        return None
+    if fixed_temperature is not None:
+        temperature = fixed_temperature
+
+    if temperature is not None:
+        from agent.anthropic_adapter import _forbids_sampling_params
+
+        if _forbids_sampling_params(model):
+            return None
+
+    return temperature
+
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
@@ -496,34 +524,33 @@ class _CodexCompletionsAdapter:
         # Note: the Codex endpoint (chatgpt.com/backend-api/codex) does NOT
         # support max_output_tokens or temperature — omit to avoid 400 errors.
 
-        # Translate extra_body.reasoning (chat.completions shape) into the
-        # Responses API's top-level reasoning + include fields.  Mirrors
-        # agent/transports/codex.py::build_kwargs() so auxiliary callers
-        # that configure reasoning via auxiliary.<task>.extra_body get the
-        # same behavior as the main agent's Codex transport.
-        extra_body = kwargs.get("extra_body") or {}
-        if isinstance(extra_body, dict):
-            reasoning_cfg = extra_body.get("reasoning")
-            if isinstance(reasoning_cfg, dict):
-                if reasoning_cfg.get("enabled") is False:
-                    # Reasoning explicitly disabled — do not set reasoning
-                    # or include.  The Codex backend still thinks by
-                    # default, but we honor the caller's intent where the
-                    # API allows it.
-                    pass
-                else:
-                    effort = reasoning_cfg.get("effort", "medium")
-                    # Codex backend rejects "minimal"; clamp to "low" to
-                    # match the main-agent Codex transport behavior.
-                    if effort == "minimal":
-                        effort = "low"
-                    resp_kwargs["reasoning"] = {
-                        "effort": effort,
-                        "summary": "auto",
-                    }
-                    resp_kwargs["include"] = ["reasoning.encrypted_content"]
+        reasoning_cfg = kwargs.get("reasoning_config")
+        if not isinstance(reasoning_cfg, dict):
+            # Translate extra_body.reasoning (chat.completions shape) into the
+            # Responses API's top-level reasoning + include fields.  Mirrors
+            # agent/transports/codex.py::build_kwargs() so auxiliary callers
+            # that configure reasoning via auxiliary.<task>.extra_body get the
+            # same behavior as the main agent's Codex transport.
+            extra_body = kwargs.get("extra_body") or {}
+            if isinstance(extra_body, dict):
+                reasoning_cfg = extra_body.get("reasoning")
 
-        # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
+        if isinstance(reasoning_cfg, dict):
+            if reasoning_cfg.get("enabled") is False:
+                # Reasoning explicitly disabled — do not set reasoning or
+                # include. The Codex backend still thinks by default, but we
+                # honor the caller's intent where the API allows it.
+                pass
+            else:
+                effort = str(reasoning_cfg.get("effort") or "medium").strip().lower()
+                # Codex backend rejects "minimal"; clamp to "low" to match
+                # the main-agent Codex transport behavior.
+                if effort == "minimal":
+                    effort = "low"
+                resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
+                resp_kwargs["include"] = ["reasoning.encrypted_content"]
+
+        # Tools support for auxiliary callers that pass function schemas
         tools = kwargs.get("tools")
         if tools:
             converted = []
@@ -738,14 +765,16 @@ class _AnthropicCompletionsAdapter:
             messages=messages,
             tools=tools,
             max_tokens=max_tokens,
-            reasoning_config=None,
+            reasoning_config=kwargs.get("reasoning_config"),
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
         )
         # Opus 4.7+ rejects any non-default temperature/top_p/top_k; only set
         # temperature for models that still accept it. build_anthropic_kwargs
         # additionally strips these keys as a safety net — keep both layers.
-        if temperature is not None:
+        # Also skip if build_anthropic_kwargs already set temperature (e.g. to 1
+        # when thinking is enabled on older models) so we don't clobber it.
+        if temperature is not None and "temperature" not in anthropic_kwargs:
             from agent.anthropic_adapter import _forbids_sampling_params
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
@@ -3206,20 +3235,7 @@ def _build_call_kwargs(
         "timeout": timeout,
     }
 
-    fixed_temperature = _fixed_temperature_for_model(model, base_url)
-    if fixed_temperature is OMIT_TEMPERATURE:
-        temperature = None  # strip — let server choose
-    elif fixed_temperature is not None:
-        temperature = fixed_temperature
-
-    # Opus 4.7+ rejects any non-default temperature/top_p/top_k — silently
-    # drop here so auxiliary callers that hardcode temperature (e.g. 0 on
-    # structured-JSON extraction) don't 400 the moment
-    # the aux model is flipped to 4.7.
-    if temperature is not None:
-        from agent.anthropic_adapter import _forbids_sampling_params
-        if _forbids_sampling_params(model):
-            temperature = None
+    temperature = resolve_chat_temperature(model, base_url, temperature)
 
     if temperature is not None:
         kwargs["temperature"] = temperature

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -664,7 +664,7 @@ platform_toolsets:
 #   image_gen    - image_generate  (requires FAL_KEY)
 #   skills       - skills_list, skill_view
 #   skills_hub   - skill_hub (search/install/manage from online registries — user-driven only)
-#   moa          - mixture_of_agents  (requires OPENROUTER_API_KEY)
+#   moa          - mixture_of_agents  (configure providers under `moa:`)
 #   todo         - todo (in-memory task planning, no deps)
 #   tts          - text_to_speech  (Edge TTS free, or ELEVENLABS/OPENAI/MINIMAX/MISTRAL key)
 #   cronjob      - cronjob (create/list/update/pause/resume/run/remove scheduled tasks)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -664,6 +664,29 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Mixture-of-Agents tool: per-model provider routing and reasoning effort.
+    # Absent/empty moa block inherits these defaults; omitted provider fields
+    # default to "openrouter". Routing multiple reference models through Codex
+    # multiplies consumption against the Codex plan's daily cap.
+    "moa": {
+        "enabled": True,
+        "reference_models": [
+            {"model": "anthropic/claude-opus-4.7", "provider": "openrouter", "reasoning": "xhigh"},
+            {"model": "google/gemini-2.5-pro", "provider": "openrouter", "reasoning": "xhigh"},
+            {"model": "openai/gpt-5.5-pro", "provider": "openrouter", "reasoning": "xhigh"},
+            {"model": "deepseek/deepseek-v3.2", "provider": "openrouter", "reasoning": "xhigh"},
+        ],
+        "aggregator_model": {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "reasoning": "xhigh",
+        },
+        "reference_temperature": 0.6,
+        "aggregator_temperature": 0.4,
+        # min_successful_references: defaults to min(2, len(reference_models))
+        # when omitted so a single silent reference failure doesn't pass.
+    },
+
     # Auxiliary model config — provider:model for each side task.
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
@@ -1315,7 +1338,7 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "OPENROUTER_API_KEY": {
-        "description": "OpenRouter API key (for vision, web scraping helpers, and MoA)",
+        "description": "OpenRouter API key (for vision, web scraping helpers, and OpenRouter-routed MoA entries)",
         "prompt": "OpenRouter API key",
         "url": "https://openrouter.ai/keys",
         "password": True,

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -367,11 +367,18 @@ def _print_setup_summary(config: dict, hermes_home):
     else:
         tool_status.append(("Vision (image analysis)", False, "run 'hermes setup' to configure"))
 
-    # Mixture of Agents — requires OpenRouter specifically (calls multiple models)
-    if get_env_value("OPENROUTER_API_KEY"):
-        tool_status.append(("Mixture of Agents", True, None))
-    else:
-        tool_status.append(("Mixture of Agents", False, "OPENROUTER_API_KEY"))
+    # Mixture of Agents — availability depends on the configured roster.
+    try:
+        from tools.mixture_of_agents_tool import get_moa_preflight_status
+
+        moa_available, moa_hint = get_moa_preflight_status()
+    except Exception:
+        moa_available, moa_hint = False, "configured MoA provider credentials"
+    tool_status.append((
+        "Mixture of Agents",
+        moa_available,
+        None if moa_available else (moa_hint or "configured MoA provider credentials"),
+    ))
 
     # Web tools (Exa, Parallel, Firecrawl, or Tavily)
     if subscription_features.web.managed_by_nous:

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -144,7 +144,7 @@ TIPS = [
     "The todo tool helps the agent track complex multi-step tasks during a session.",
     "session_search performs full-text search across ALL past conversations.",
     "The agent automatically saves preferences, corrections, and environment facts to memory.",
-    "mixture_of_agents routes hard problems through 4 frontier LLMs collaboratively.",
+    "mixture_of_agents routes hard problems through a configurable roster of frontier LLMs collaboratively.",
     "Terminal commands support background mode with notify_on_complete for long-running tasks.",
     "Terminal background processes support watch_patterns to alert on specific output lines.",
     "The terminal tool supports 6 backends: local, Docker, SSH, Modal, Daytona, and Singularity.",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -57,7 +57,7 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
-    ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
+    ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents (edit roster/providers/reasoning under `moa:` in config.yaml)"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
@@ -462,10 +462,9 @@ TOOL_CATEGORIES = {
 }
 
 # Simple env-var requirements for toolsets NOT in TOOL_CATEGORIES.
-# Used as a fallback for tools like vision/moa that just need an API key.
+# Used as a fallback for tools that still have a single fixed API-key backend.
 TOOLSET_ENV_REQUIREMENTS = {
     "vision":     [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
-    "moa":        [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
 }
 
 
@@ -1051,6 +1050,15 @@ def _toolset_has_keys(ts_key: str, config: dict = None) -> bool:
         except Exception:
             return False
 
+    if ts_key == "moa":
+        try:
+            from tools.mixture_of_agents_tool import get_moa_preflight_status
+
+            available, _hint = get_moa_preflight_status()
+            return available
+        except Exception:
+            return False
+
     if ts_key in {"web", "image_gen", "tts", "browser"}:
         features = get_nous_subscription_features(config)
         feature = features.features.get(ts_key)
@@ -1196,7 +1204,7 @@ def _configure_toolset(ts_key: str, config: dict):
     if cat:
         _configure_tool_category(ts_key, cat, config)
     else:
-        # Simple fallback for vision, moa, etc.
+        # Simple fallback for vision and other fixed-key toolsets.
         _configure_simple_requirements(ts_key)
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1025,6 +1025,33 @@ class TestKimiTemperatureOmitted:
 
         assert "temperature" not in kwargs
 
+    def test_public_temperature_resolver_omits_kimi(self):
+        from agent.auxiliary_client import resolve_chat_temperature
+
+        assert resolve_chat_temperature(
+            "kimi-k2.6",
+            "https://api.kimi.com/coding/v1",
+            0.3,
+        ) is None
+
+    def test_public_temperature_resolver_omits_anthropic_no_sampling_model(self):
+        from agent.auxiliary_client import resolve_chat_temperature
+
+        assert resolve_chat_temperature(
+            "claude-opus-4-7",
+            "https://api.anthropic.com",
+            0.3,
+        ) is None
+
+    def test_public_temperature_resolver_preserves_regular_model(self):
+        from agent.auxiliary_client import resolve_chat_temperature
+
+        assert resolve_chat_temperature(
+            "gpt-5.4",
+            "https://api.openai.com/v1",
+            0.3,
+        ) == 0.3
+
     def test_sync_call_omits_temperature(self):
         client = MagicMock()
         client.base_url = "https://api.kimi.com/coding/v1"

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -454,6 +454,52 @@ def test_setup_summary_marks_anthropic_auth_as_vision_available(tmp_path, monkey
     assert "missing run 'hermes setup' to configure" not in output
 
 
+def test_setup_summary_marks_codex_only_moa_as_available_without_openrouter(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    monkeypatch.setattr("agent.auxiliary_client._read_codex_access_token", lambda: "codex-token")
+
+    config = load_config()
+    config["moa"] = {
+        "enabled": True,
+        "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+        "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+    }
+    save_config(config)
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Mixture of Agents" in output
+    assert "missing OPENROUTER_API_KEY" not in output
+    assert "missing credentials for openai-codex" not in output
+
+
+def test_setup_summary_reports_configured_moa_provider_not_openrouter(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    monkeypatch.setattr("agent.auxiliary_client._read_codex_access_token", lambda: "")
+
+    config = load_config()
+    config["moa"] = {
+        "enabled": True,
+        "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+        "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+    }
+    save_config(config)
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Mixture of Agents" in output
+    assert "missing credentials for openai-codex" in output
+    assert "missing OPENROUTER_API_KEY" not in output
+
+
 def test_setup_summary_shows_camofox_when_browser_feature_is_camofox(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -269,6 +269,22 @@ def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     assert _toolset_has_keys("vision") is True
 
 
+def test_toolset_has_keys_for_moa_uses_config_aware_preflight(monkeypatch):
+    import tools.mixture_of_agents_tool as moa
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(moa, "get_moa_preflight_status", lambda: (True, None))
+
+    assert _toolset_has_keys("moa") is True
+
+    monkeypatch.setattr(
+        moa,
+        "get_moa_preflight_status",
+        lambda: (False, "credentials for openai-codex"),
+    )
+    assert _toolset_has_keys("moa") is False
+
+
 def test_save_platform_tools_preserves_mcp_server_names():
     """Ensure MCP server names are preserved when saving platform tools.
 

--- a/tests/tools/test_mixture_of_agents_tool.py
+++ b/tests/tools/test_mixture_of_agents_tool.py
@@ -33,12 +33,21 @@ async def test_reference_model_retry_warnings_avoid_exc_info_until_terminal_fail
     warn = MagicMock()
     err = MagicMock()
 
-    monkeypatch.setattr(moa, "_get_openrouter_client", lambda: fake_client)
+    monkeypatch.setattr(
+        moa,
+        "resolve_provider_client",
+        lambda *a, **k: (fake_client, "openai/gpt-5.4-pro"),
+    )
     monkeypatch.setattr(moa.logger, "warning", warn)
     monkeypatch.setattr(moa.logger, "error", err)
 
+    entry = {
+        "model": "openai/gpt-5.4-pro",
+        "provider": "openrouter",
+        "reasoning_config": None,
+    }
     model, message, success = await moa._run_reference_model_safe(
-        "openai/gpt-5.4-pro", "hello", max_retries=2
+        entry, "hello", max_retries=2
     )
 
     assert model == "openai/gpt-5.4-pro"

--- a/tests/tools/test_mixture_of_agents_tool_provider_routing.py
+++ b/tests/tools/test_mixture_of_agents_tool_provider_routing.py
@@ -1,0 +1,1367 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+import hermes_cli.models as models_mod
+from hermes_cli.config import DEFAULT_CONFIG, get_config_path
+from hermes_cli.model_normalize import normalize_model_for_provider
+
+import tools.mixture_of_agents_tool as moa
+
+
+VALID_PROVIDER_IDS = [
+    "openrouter",
+    "nous",
+    "openai-codex",
+    "lmstudio",
+    "google-gemini-cli",
+    "copilot",
+    "copilot-acp",
+    "gemini",
+    "huggingface",
+    "zai",
+    "kimi-coding",
+    "kimi-coding-cn",
+    "minimax",
+    "minimax-cn",
+    "kilocode",
+    "anthropic",
+    "alibaba",
+    "qwen-oauth",
+    "xiaomi",
+    "tencent-tokenhub",
+    "opencode-zen",
+    "opencode-go",
+    "ai-gateway",
+    "deepseek",
+    "arcee",
+    "xai",
+    "nvidia",
+    "ollama-cloud",
+    "bedrock",
+    "custom",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_moa_state():
+    for name in ("_TEMPERATURE_UNSUPPORTED", "_REASONING_UNSUPPORTED", "_codex_warning_seen"):
+        value = getattr(moa, name, None)
+        if isinstance(value, (dict, set)):
+            value.clear()
+
+
+@pytest.fixture(autouse=True)
+def _stable_provider_registry(monkeypatch):
+    monkeypatch.setattr(
+        models_mod,
+        "list_available_providers",
+        lambda: [{"id": provider_id} for provider_id in VALID_PROVIDER_IDS],
+    )
+
+
+def _write_config(data: dict):
+    config_path = get_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+@pytest.fixture
+def fake_catalogs(monkeypatch):
+    catalogs = {
+        "openrouter": [
+            "anthropic/claude-opus-4.7",
+            "google/gemini-2.5-pro",
+            "openai/gpt-5.5-pro",
+            "deepseek/deepseek-v3.2",
+            "qwen/qwen3.5-plus-02-15",
+            "minimax/minimax-m2.5",
+        ],
+        "anthropic": ["claude-opus-4-6"],
+        "openai-codex": ["gpt-5.4"],
+        "copilot": ["gpt-5.4", "gpt-4.1"],
+        "copilot-acp": ["gpt-5.4"],
+        "nous": ["minimax/minimax-m2.5"],
+        "ai-gateway": ["anthropic/claude-opus-4.7"],
+        "lmstudio": ["local-reasoner"],
+        "tencent-tokenhub": ["hy3-preview"],
+        "custom": [],
+    }
+
+    def _provider_model_ids(provider, *, force_refresh=False):
+        return list(catalogs.get(provider, []))
+
+    monkeypatch.setattr(models_mod, "provider_model_ids", _provider_model_ids)
+    return catalogs
+
+
+@pytest.mark.parametrize("reasoning_value", [None, "", "   "])
+def test_load_moa_config_absent_or_blank_reasoning_uses_defaults(fake_catalogs, reasoning_value):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "anthropic/claude-opus-4.7",
+                        "reasoning": reasoning_value,
+                    }
+                ],
+                "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["enabled"] is True
+    assert loaded["reference_models"][0]["provider"] == "openrouter"
+    assert loaded["reference_models"][0]["reasoning_config"] is None
+    assert loaded["aggregator_model"]["provider"] == "openrouter"
+    assert loaded["aggregator_model"]["reasoning_config"] is None
+    assert loaded["min_successful_references"] == 1
+
+
+def test_load_moa_config_defaults_when_block_absent(fake_catalogs):
+    _write_config({"model": "anthropic/claude-opus-4.7"})
+
+    loaded = moa._load_moa_config()
+
+    assert [entry["model"] for entry in loaded["reference_models"]] == moa.REFERENCE_MODELS
+    assert all(entry["provider"] == "openrouter" for entry in loaded["reference_models"])
+    assert all(entry["reasoning_config"] == {"enabled": True, "effort": "xhigh"} for entry in loaded["reference_models"])
+    assert loaded["aggregator_model"]["model"] == moa.AGGREGATOR_MODEL
+    assert loaded["aggregator_model"]["provider"] == "openrouter"
+    assert loaded["aggregator_model"]["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+    assert loaded["reference_temperature"] == moa.REFERENCE_TEMPERATURE
+    assert loaded["aggregator_temperature"] == moa.AGGREGATOR_TEMPERATURE
+    assert loaded["min_successful_references"] == 2
+
+
+def test_load_moa_config_accepts_string_shorthand(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["gpt-5.4"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["model"] == "gpt-5.4"
+    assert loaded["reference_models"][0]["provider"] == "openrouter"
+    assert loaded["reference_models"][0]["reasoning_config"] is None
+    assert loaded["aggregator_model"]["model"] == "anthropic/claude-opus-4.7"
+    assert loaded["aggregator_model"]["provider"] == "openrouter"
+
+
+def test_load_moa_config_preserves_dict_entries(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "gpt-5.4",
+                        "provider": "openai-codex",
+                        "reasoning": "high",
+                    }
+                ],
+                "aggregator_model": {
+                    "model": "claude-opus-4-6",
+                    "provider": "anthropic",
+                    "reasoning": "none",
+                },
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0] == {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "reasoning_config": {"enabled": True, "effort": "high"},
+    }
+    assert loaded["aggregator_model"] == {
+        "model": "claude-opus-4-6",
+        "provider": "anthropic",
+        "reasoning_config": {"enabled": False},
+    }
+
+
+def test_load_moa_config_normalizes_provider_aliases(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "hy3-preview", "provider": "tokenhub"}],
+                "aggregator_model": {"model": "local-reasoner", "provider": "lm-studio"},
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["provider"] == "tencent-tokenhub"
+    assert loaded["aggregator_model"]["provider"] == "lmstudio"
+
+
+def test_load_moa_config_accepts_named_custom_provider_slug(fake_catalogs):
+    _write_config(
+        {
+            "custom_providers": [
+                {
+                    "name": "internal",
+                    "base_url": "http://localhost:1234/v1",
+                    "api_key": "test",
+                }
+            ],
+            "moa": {
+                "reference_models": [{"model": "my-model", "provider": "custom:internal"}],
+                "aggregator_model": {"model": "my-model", "provider": "custom:internal"},
+            },
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["reference_models"][0]["provider"] == "custom:internal"
+    assert loaded["aggregator_model"]["provider"] == "custom:internal"
+
+
+def test_load_moa_config_rejects_unknown_provider(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {"model": "anthropic/claude-opus-4.7", "provider": "totally-made-up"}
+                ],
+                "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="unknown provider"):
+        moa._load_moa_config()
+
+
+@pytest.mark.parametrize("reasoning", ["extreme", "max"])
+def test_load_moa_config_rejects_invalid_reasoning(fake_catalogs, reasoning):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {"model": "anthropic/claude-opus-4.7", "reasoning": reasoning}
+                ],
+                "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+            }
+        }
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        moa._load_moa_config()
+
+    message = str(exc_info.value)
+    for effort in ("minimal", "low", "medium", "high", "xhigh", "none"):
+        assert effort in message
+    assert "max" not in message.replace(repr(reasoning), "")
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_match"),
+    [
+        (
+            {
+                "moa": {
+                    "reference_models": [],
+                    "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+                }
+            },
+            "reference_models",
+        ),
+        (
+            {
+                "moa": {
+                    "reference_models": ["anthropic/claude-opus-4.7"],
+                    "aggregator_model": None,
+                }
+            },
+            "aggregator_model",
+        ),
+        (
+            {
+                "moa": {
+                    "reference_models": ["anthropic/claude-opus-4.7"],
+                    "aggregator_model": {},
+                }
+            },
+            "aggregator_model",
+        ),
+        (
+            {
+                "moa": {
+                    "reference_models": [{}],
+                    "aggregator_model": {"model": "anthropic/claude-opus-4.7"},
+                }
+            },
+            "reference_models",
+        ),
+    ],
+)
+def test_load_moa_config_rejects_invalid_shapes(fake_catalogs, config, expected_match):
+    _write_config(config)
+
+    with pytest.raises(ValueError, match=expected_match):
+        moa._load_moa_config()
+
+
+@pytest.mark.parametrize(
+    ("roster", "explicit", "expected"),
+    [
+        (["a", "b", "c"], None, 2),
+        (["a"], None, 1),
+        (["a", "b", "c"], 1, 1),
+    ],
+)
+def test_min_successful_references_default_and_override(fake_catalogs, roster, explicit, expected):
+    config = {
+        "moa": {
+            "reference_models": roster,
+            "aggregator_model": "anthropic/claude-opus-4.7",
+        }
+    }
+    if explicit is not None:
+        config["moa"]["min_successful_references"] = explicit
+    _write_config(config)
+
+    loaded = moa._load_moa_config()
+
+    assert loaded["min_successful_references"] == expected
+
+
+@pytest.mark.parametrize("value", [0, 3, 1.5, True])
+def test_min_successful_references_out_of_range(fake_catalogs, value):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7", "gpt-5.4"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+                "min_successful_references": value,
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="min_successful_references"):
+        moa._load_moa_config()
+
+
+def test_model_catalog_mismatch_warns_but_does_not_raise(monkeypatch):
+    monkeypatch.setattr(
+        models_mod,
+        "provider_model_ids",
+        lambda provider, *, force_refresh=False: ["gpt-5.4"],
+    )
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "not-in-catalog", "provider": "openai-codex"}],
+                "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+            }
+        }
+    )
+
+    with patch.object(moa.logger, "warning") as warn:
+        loaded = moa._load_moa_config(emit_warnings=True)
+
+    assert loaded["reference_models"][0]["model"] == "not-in-catalog"
+    warn.assert_any_call(
+        "MoA: model %r not in %s catalog — may fail at call time",
+        "not-in-catalog",
+        "openai-codex",
+    )
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_short_circuits_fail_closed(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "enabled": False,
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result == {
+        "success": False,
+        "response": "",
+        "models_used": {"reference_models": [], "aggregator_model": ""},
+        "error": "MoA disabled via moa.enabled=false",
+    }
+    assert moa.check_moa_requirements() is False
+
+
+def test_check_moa_requirements_is_config_aware(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+                "aggregator_model": {"model": "gpt-5.4", "provider": "openai-codex"},
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_provider_has_credentials",
+        lambda provider, model=None: provider == "openai-codex",
+    )
+
+    assert moa.check_moa_requirements() is True
+
+
+def test_check_moa_requirements_reports_missing_provider(fake_catalogs, monkeypatch, caplog):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+    monkeypatch.setattr(moa, "_provider_has_credentials", lambda provider, model=None: False)
+
+    available, hint = moa.get_moa_preflight_status()
+
+    assert available is False
+    assert hint == "credentials for openrouter"
+    assert "openrouter" in caplog.text.lower()
+
+
+def test_custom_provider_slug_does_not_bypass_preflight(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "custom_providers": [
+                {
+                    "name": "internal",
+                    "base_url": "http://localhost:1234/v1",
+                    "api_key": "test",
+                }
+            ],
+            "moa": {
+                "reference_models": [{"model": "my-model", "provider": "custom:internal"}],
+                "aggregator_model": {"model": "my-model", "provider": "custom:internal"},
+            },
+        }
+    )
+    monkeypatch.setattr(moa, "resolve_provider_client", lambda *args, **kwargs: (None, "my-model"))
+
+    available, hint = moa.get_moa_preflight_status()
+
+    assert available is False
+    assert hint == "credentials for custom:internal"
+
+
+def test_preflight_uses_resolver_and_closes_clients(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [{"model": "gpt-5.4", "provider": "openai-codex"}],
+                "aggregator_model": {"model": "claude-opus-4-6", "provider": "anthropic"},
+            }
+        }
+    )
+    client = SimpleNamespace(close=MagicMock())
+    calls = []
+
+    def _resolve(provider, model=None, async_mode=False):
+        calls.append((provider, model, async_mode))
+        return client, model
+
+    monkeypatch.setattr(moa, "resolve_provider_client", _resolve)
+
+    available, hint = moa.get_moa_preflight_status()
+
+    assert available is True
+    assert hint is None
+    assert calls == [
+        ("openai-codex", "gpt-5.4", False),
+        ("anthropic", "claude-opus-4-6", False),
+    ]
+    assert client.close.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_supports_sync_create():
+    calls = []
+
+    def _create(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+
+    response = await moa._create_chat_completion(client, model="m", messages=[])
+
+    assert response.choices[0].message.content == "ok"
+    assert calls == [{"model": "m", "messages": []}]
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_awaits_sync_wrapper_awaitable_result():
+    calls = []
+
+    async def _response():
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    def _create(**kwargs):
+        calls.append(kwargs)
+        return _response()
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+
+    response = await moa._create_chat_completion(client, model="m", messages=[])
+
+    assert response.choices[0].message.content == "ok"
+    assert calls == [{"model": "m", "messages": []}]
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "reasoning_config", "expected"),
+    [
+        ("openrouter", "anthropic/claude-opus-4.7", None, {}),
+        (
+            "openrouter",
+            "qwen/qwen3.5-plus-02-15",
+            {"enabled": True, "effort": "xhigh"},
+            {"extra_body": {"reasoning": {"enabled": True, "effort": "xhigh"}}},
+        ),
+        (
+            "openrouter",
+            "tencent/hy3-preview",
+            {"enabled": True, "effort": "high"},
+            {"extra_body": {"reasoning": {"enabled": True, "effort": "high"}}},
+        ),
+        ("openrouter", "minimax/minimax-m2.5", {"enabled": True, "effort": "high"}, {}),
+        ("nous", "minimax/minimax-m2.5", {"enabled": False}, {}),
+        (
+            "ai-gateway",
+            "anthropic/claude-opus-4.7",
+            {"enabled": False},
+            {"extra_body": {"reasoning": {"enabled": False}}},
+        ),
+        (
+            "copilot",
+            "gpt-5.4",
+            {"enabled": True, "effort": "xhigh"},
+            {"extra_body": {"reasoning": {"effort": "high"}}},
+        ),
+        (
+            "copilot",
+            "gpt-5.4",
+            {"enabled": True, "effort": "minimal"},
+            {"extra_body": {"reasoning": {"effort": "low"}}},
+        ),
+        ("copilot", "gpt-5.4", {"enabled": False}, {}),
+        ("copilot", "gpt-4.1", {"enabled": True, "effort": "high"}, {}),
+        (
+            "custom",
+            "gpt-5.4",
+            {"enabled": True, "effort": "high"},
+            {"reasoning_effort": "high"},
+        ),
+        (
+            "custom",
+            "gpt-5.4",
+            {"enabled": False},
+            {"extra_body": {"think": False}},
+        ),
+        (
+            "kimi-coding",
+            "kimi-k2.6",
+            {"enabled": True, "effort": "minimal"},
+            {
+                "reasoning_effort": "low",
+                "extra_body": {"thinking": {"type": "enabled"}},
+            },
+        ),
+        (
+            "kimi-coding",
+            "kimi-k2.6",
+            {"enabled": True, "effort": "xhigh"},
+            {
+                "reasoning_effort": "high",
+                "extra_body": {"thinking": {"type": "enabled"}},
+            },
+        ),
+        (
+            "kimi-coding-cn",
+            "kimi-k2.6",
+            {"enabled": False},
+            {"extra_body": {"thinking": {"type": "disabled"}}},
+        ),
+        (
+            "tencent-tokenhub",
+            "hy3-preview",
+            {"enabled": True, "effort": "medium"},
+            {"reasoning_effort": "medium"},
+        ),
+        (
+            "tencent-tokenhub",
+            "hy3-preview",
+            {"enabled": True, "effort": "xhigh"},
+            {"reasoning_effort": "high"},
+        ),
+        ("tencent-tokenhub", "hy3-preview", {"enabled": False}, {}),
+        (
+            "openai-codex",
+            "gpt-5.4",
+            {"enabled": True, "effort": "high"},
+            {"reasoning_config": {"enabled": True, "effort": "high"}},
+        ),
+        (
+            "anthropic",
+            "claude-opus-4-6",
+            {"enabled": True, "effort": "high"},
+            {"reasoning_config": {"enabled": True, "effort": "high"}},
+        ),
+    ],
+)
+def test_reasoning_kwargs_translation(monkeypatch, provider, model, reasoning_config, expected):
+    efforts = {"gpt-5.4": ["low", "medium", "high"], "gpt-4.1": []}
+    monkeypatch.setattr(
+        models_mod,
+        "github_model_reasoning_efforts",
+        lambda model_id, catalog=None, api_key=None: list(efforts.get(model_id, [])),
+    )
+
+    assert moa._reasoning_kwargs(provider, model, reasoning_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("options", "reasoning_config", "expected"),
+    [
+        ([], {"enabled": True, "effort": "high"}, {}),
+        (["off"], {"enabled": True, "effort": "high"}, {}),
+        (["off", "low", "medium"], {"enabled": True, "effort": "high"}, {}),
+        (["off", "low", "medium"], {"enabled": True, "effort": "low"}, {"reasoning_effort": "low"}),
+        (["off", "on"], {"enabled": True, "effort": "medium"}, {"reasoning_effort": "medium"}),
+    ],
+)
+def test_reasoning_kwargs_lmstudio_uses_published_options(monkeypatch, options, reasoning_config, expected):
+    monkeypatch.setattr(
+        models_mod,
+        "lmstudio_model_reasoning_options",
+        lambda model, base_url=None, api_key=None: list(options),
+    )
+
+    assert moa._reasoning_kwargs(
+        "lmstudio",
+        "local-reasoner",
+        reasoning_config,
+        base_url="http://127.0.0.1:1234/v1",
+        api_key="test",
+    ) == expected
+
+
+def test_request_cache_key_includes_endpoint_port():
+    assert moa._request_cache_key(
+        "lmstudio",
+        "local-reasoner",
+        "http://localhost:1234/v1",
+    ) == ("lmstudio", "local-reasoner", "localhost:1234")
+    assert moa._request_cache_key(
+        "lmstudio",
+        "local-reasoner",
+        "http://localhost:5678/v1",
+    ) == ("lmstudio", "local-reasoner", "localhost:5678")
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+@pytest.fixture
+def agent_for_parity():
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.auxiliary_client.OpenAI"),
+    ):
+        agent = AIAgent(
+            base_url="https://example.test/v1",
+            api_key="test-key-1234567890",
+            provider="custom",
+            model="test-model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        yield agent
+
+
+def _agent_reasoning_view(agent, provider: str) -> dict:
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+    if provider in {"openrouter", "nous", "copilot", "ai-gateway"}:
+        reasoning = kwargs.get("extra_body", {}).get("reasoning")
+        return {"extra_body": {"reasoning": reasoning}} if reasoning is not None else {}
+    return {}
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url", "model", "reasoning_config", "supported_efforts"),
+    [
+        (
+            "openrouter",
+            "https://openrouter.ai/api/v1",
+            "qwen/qwen3.5-plus-02-15",
+            {"enabled": True, "effort": "xhigh"},
+            [],
+        ),
+        (
+            "openrouter",
+            "https://openrouter.ai/api/v1",
+            "minimax/minimax-m2.5",
+            {"enabled": True, "effort": "high"},
+            [],
+        ),
+        (
+            "nous",
+            "https://inference-api.nousresearch.com/v1",
+            "minimax/minimax-m2.5",
+            {"enabled": False},
+            [],
+        ),
+        (
+            "copilot",
+            "https://api.githubcopilot.com",
+            "gpt-5.4",
+            {"enabled": True, "effort": "xhigh"},
+            ["low", "medium", "high"],
+        ),
+        (
+            "ai-gateway",
+            "https://ai-gateway.vercel.sh/v1",
+            "anthropic/claude-opus-4.7",
+            {"enabled": False},
+            [],
+        ),
+    ],
+)
+def test_reasoning_translation_matches_main_agent(
+    monkeypatch,
+    agent_for_parity,
+    provider,
+    base_url,
+    model,
+    reasoning_config,
+    supported_efforts,
+):
+    monkeypatch.setattr(
+        models_mod,
+        "github_model_reasoning_efforts",
+        lambda model_id, catalog=None, api_key=None: list(supported_efforts),
+    )
+
+    agent_for_parity.provider = provider
+    agent_for_parity.base_url = base_url
+    agent_for_parity._base_url_lower = base_url.lower()
+    agent_for_parity.model = model
+    agent_for_parity.reasoning_config = reasoning_config
+
+    assert moa._reasoning_kwargs(provider, model, reasoning_config) == _agent_reasoning_view(
+        agent_for_parity,
+        provider,
+    )
+
+
+def test_omitted_moa_reasoning_intentionally_differs_from_main_agent_default(agent_for_parity):
+    agent_for_parity.provider = "openrouter"
+    agent_for_parity.base_url = "https://openrouter.ai/api/v1"
+    agent_for_parity._base_url_lower = agent_for_parity.base_url.lower()
+    agent_for_parity.model = "anthropic/claude-opus-4.7"
+    agent_for_parity.reasoning_config = None
+
+    assert moa._reasoning_kwargs("openrouter", "anthropic/claude-opus-4.7", None) == {}
+    assert _agent_reasoning_view(agent_for_parity, "openrouter") == {
+        "extra_body": {"reasoning": {"enabled": True, "effort": "medium"}}
+    }
+
+
+def test_build_api_params_omits_temperature_for_kimi_model():
+    params = moa._build_api_params(
+        "kimi-k2.6",
+        [{"role": "user", "content": "hi"}],
+        "kimi-coding",
+        {"enabled": True, "effort": "medium"},
+        0.6,
+        moa._request_cache_key("kimi-coding", "kimi-k2.6", "https://api.kimi.com/coding"),
+        base_url="https://api.kimi.com/coding",
+        max_tokens=32000,
+    )
+
+    assert "temperature" not in params
+    assert params["max_tokens"] == 32000
+    assert params["reasoning_effort"] == "medium"
+
+
+def test_build_api_params_omits_temperature_for_anthropic_no_sampling_model():
+    params = moa._build_api_params(
+        "claude-opus-4-7",
+        [{"role": "user", "content": "hi"}],
+        "anthropic",
+        None,
+        0.4,
+        moa._request_cache_key("anthropic", "claude-opus-4-7", "https://api.anthropic.com"),
+        base_url="https://api.anthropic.com",
+    )
+
+    assert "temperature" not in params
+
+
+def test_build_api_params_direct_openai_custom_uses_max_completion_tokens():
+    params = moa._build_api_params(
+        "gpt-5.4",
+        [{"role": "user", "content": "hi"}],
+        "custom",
+        None,
+        0.4,
+        moa._request_cache_key("custom", "gpt-5.4", "https://api.openai.com/v1"),
+        base_url="https://api.openai.com/v1",
+        max_tokens=123,
+    )
+
+    assert params["max_completion_tokens"] == 123
+    assert "max_tokens" not in params
+
+
+def test_build_api_params_nous_adds_product_tag_and_omits_disabled_reasoning():
+    params = moa._build_api_params(
+        "minimax/minimax-m2.5",
+        [{"role": "user", "content": "hi"}],
+        "nous",
+        {"enabled": False},
+        0.4,
+        moa._request_cache_key("nous", "minimax/minimax-m2.5", "https://inference-api.nousresearch.com/v1"),
+        base_url="https://inference-api.nousresearch.com/v1",
+    )
+
+    assert params["extra_body"] == {"tags": ["product=hermes-agent"]}
+
+
+def test_build_api_params_openrouter_keeps_max_tokens():
+    params = moa._build_api_params(
+        "anthropic/claude-opus-4.7",
+        [{"role": "user", "content": "hi"}],
+        "openrouter",
+        None,
+        0.4,
+        moa._request_cache_key("openrouter", "anthropic/claude-opus-4.7", "https://openrouter.ai/api/v1"),
+        base_url="https://openrouter.ai/api/v1",
+        max_tokens=456,
+    )
+
+    assert params["max_tokens"] == 456
+    assert "max_completion_tokens" not in params
+
+
+@pytest.mark.asyncio
+async def test_reference_model_forwards_default_max_tokens_and_reasoning(monkeypatch):
+    calls = []
+
+    async def _create(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+    monkeypatch.setattr(
+        moa,
+        "resolve_provider_client",
+        lambda *args, **kwargs: (fake_client, "anthropic/claude-opus-4.7"),
+    )
+    monkeypatch.setattr(
+        moa,
+        "extract_content_or_reasoning",
+        lambda response: response.choices[0].message.content,
+    )
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "reasoning_config": {"enabled": True, "effort": "xhigh"},
+        },
+        "hello",
+        max_retries=1,
+    )
+
+    assert (model_name, content, success) == (
+        "anthropic/claude-opus-4.7",
+        "ok",
+        True,
+    )
+    assert calls[0]["max_tokens"] == 32000
+    assert calls[0]["extra_body"] == {
+        "reasoning": {"enabled": True, "effort": "xhigh"}
+    }
+    assert "temperature" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_structured_unsupported_reasoning_retries_and_caches_by_endpoint(monkeypatch):
+    calls = []
+
+    class FakeError(Exception):
+        def __init__(self):
+            super().__init__("Unsupported parameter: reasoning_effort")
+            self.body = {"error": {"code": "unsupported_parameter", "param": "reasoning_effort"}}
+
+    async def _create(**kwargs):
+        calls.append(kwargs)
+        if "reasoning_effort" in kwargs:
+            raise FakeError()
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    fake_client = SimpleNamespace(
+        base_url="https://one.example/v1",
+        api_key="test",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create)),
+    )
+    monkeypatch.setattr(moa, "resolve_provider_client", lambda *args, **kwargs: (fake_client, "gpt-5.4"))
+    monkeypatch.setattr(moa, "extract_content_or_reasoning", lambda response: response.choices[0].message.content)
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "custom", "reasoning_config": {"enabled": True, "effort": "high"}},
+        "hello",
+        max_retries=2,
+    )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    assert calls[0]["reasoning_effort"] == "high"
+    assert "reasoning_effort" not in calls[1]
+    assert moa._REASONING_UNSUPPORTED[("custom", "gpt-5.4", "one.example")] is True
+
+    calls.clear()
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "custom", "reasoning_config": {"enabled": True, "effort": "high"}},
+        "hello again",
+        max_retries=2,
+    )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    assert len(calls) == 1
+    assert "reasoning_effort" not in calls[0]
+
+    fake_client.base_url = "https://two.example/v1"
+    calls.clear()
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "custom", "reasoning_config": {"enabled": True, "effort": "high"}},
+        "fresh endpoint",
+        max_retries=2,
+    )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    assert calls[0]["reasoning_effort"] == "high"
+    assert "reasoning_effort" not in calls[1]
+    assert moa._REASONING_UNSUPPORTED[("custom", "gpt-5.4", "two.example")] is True
+
+
+@pytest.mark.asyncio
+async def test_structured_unsupported_temperature_retries_and_caches(monkeypatch):
+    calls = []
+
+    class FakeError(Exception):
+        def __init__(self):
+            super().__init__("Unsupported parameter: temperature")
+            self.body = {"error": {"code": "unsupported_parameter", "param": "temperature"}}
+
+    async def _create(**kwargs):
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise FakeError()
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    fake_client = SimpleNamespace(
+        base_url="https://one.example/v1",
+        api_key="test",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create)),
+    )
+    monkeypatch.setattr(moa, "resolve_provider_client", lambda *args, **kwargs: (fake_client, "gpt-5.4"))
+    monkeypatch.setattr(moa, "extract_content_or_reasoning", lambda response: response.choices[0].message.content)
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "custom", "reasoning_config": None},
+        "hello",
+        max_retries=2,
+    )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    assert calls[0]["temperature"] == moa.REFERENCE_TEMPERATURE
+    assert "temperature" not in calls[1]
+    assert moa._TEMPERATURE_UNSUPPORTED[("custom", "gpt-5.4", "one.example")] is True
+
+    calls.clear()
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "custom", "reasoning_config": None},
+        "hello again",
+        max_retries=2,
+    )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    assert len(calls) == 1
+    assert "temperature" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_vague_unsupported_reasoning_retries_once_without_sticky_cache(monkeypatch):
+    calls = []
+
+    class FakeError(Exception):
+        pass
+
+    async def _create(**kwargs):
+        calls.append(kwargs)
+        if "reasoning_effort" in kwargs:
+            raise FakeError("reasoning is not supported for this model")
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    fake_client = SimpleNamespace(
+        base_url="https://one.example/v1",
+        api_key="test",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create)),
+    )
+    monkeypatch.setattr(moa, "resolve_provider_client", lambda *args, **kwargs: (fake_client, "gpt-5.4"))
+    monkeypatch.setattr(moa, "extract_content_or_reasoning", lambda response: response.choices[0].message.content)
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "custom", "reasoning_config": {"enabled": True, "effort": "high"}},
+        "hello",
+        max_retries=2,
+    )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    assert len(calls) == 2
+    assert moa._REASONING_UNSUPPORTED == {}
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "function tool_x is not supported",
+        "tool calls are not supported",
+        "streaming is unsupported",
+    ],
+)
+def test_vague_non_parameter_unsupported_errors_do_not_poison_sticky_cache(message):
+    class FakeError(Exception):
+        pass
+
+    dropped, sticky = moa._handle_unsupported_param(
+        FakeError(message),
+        moa._request_cache_key("custom", "gpt-5.4", "https://one.example/v1"),
+    )
+
+    assert (dropped, sticky) == (None, False)
+    assert moa._REASONING_UNSUPPORTED == {}
+    assert moa._TEMPERATURE_UNSUPPORTED == {}
+
+
+@pytest.mark.asyncio
+async def test_reference_model_init_failure_is_reported_as_model_failure(fake_catalogs, monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("bad provider state")
+
+    monkeypatch.setattr(moa, "resolve_provider_client", _boom)
+
+    model_name, content, success = await moa._run_reference_model_safe(
+        {"model": "gpt-5.4", "provider": "openai-codex", "reasoning_config": None},
+        "hello",
+        max_retries=1,
+    )
+
+    assert model_name == "gpt-5.4"
+    assert success is False
+    assert "could not be initialized" in content
+
+
+@pytest.mark.asyncio
+async def test_run_reference_model_safe_supports_copilot_acp(fake_catalogs):
+    from agent.copilot_acp_client import CopilotACPClient
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="ok",
+                    reasoning=None,
+                    reasoning_content=None,
+                    reasoning_details=None,
+                )
+            )
+        ]
+    )
+
+    with (
+        patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.4"),
+        patch.object(CopilotACPClient, "_create_chat_completion", return_value=fake_response) as mock_create,
+        patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "copilot-acp",
+                "api_key": "copilot-acp",
+                "base_url": "acp://copilot",
+                "command": "/usr/bin/copilot",
+                "args": ["--acp", "--stdio"],
+            },
+        ),
+    ):
+        model_name, content, success = await moa._run_reference_model_safe(
+            {"model": "gpt-5.4", "provider": "copilot-acp", "reasoning_config": None},
+            "hello",
+            max_retries=1,
+        )
+
+    assert (model_name, content, success) == ("gpt-5.4", "ok", True)
+    mock_create.assert_called_once()
+
+
+def test_default_config_moa_entries_exist_in_provider_catalogs(fake_catalogs):
+    default_moa = DEFAULT_CONFIG["moa"]
+    entries = list(default_moa["reference_models"]) + [default_moa["aggregator_model"]]
+
+    for entry in entries:
+        normalized_model = normalize_model_for_provider(entry["model"], entry["provider"])
+        assert normalized_model in fake_catalogs[entry["provider"]]
+
+
+def test_module_constant_fallbacks_exist_in_openrouter_catalog(fake_catalogs):
+    for model in moa.REFERENCE_MODELS + [moa.AGGREGATOR_MODEL]:
+        normalized_model = normalize_model_for_provider(model, "openrouter")
+        assert normalized_model in fake_catalogs["openrouter"]
+
+
+def test_debug_parameters_capture_provider_and_reasoning(fake_catalogs):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": [
+                    {
+                        "model": "anthropic/claude-opus-4.7",
+                        "provider": "openrouter",
+                        "reasoning": "high",
+                    },
+                    {"model": "gpt-5.4", "provider": "openai-codex"},
+                ],
+                "aggregator_model": {
+                    "model": "anthropic/claude-opus-4.7",
+                    "provider": "ai-gateway",
+                    "reasoning": "none",
+                },
+            }
+        }
+    )
+
+    loaded = moa._load_moa_config()
+
+    ref0 = loaded["reference_models"][0]
+    ref1 = loaded["reference_models"][1]
+    agg = loaded["aggregator_model"]
+
+    assert ref0["provider"] == "openrouter"
+    assert ref0["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert ref1["provider"] == "openai-codex"
+    assert ref1["reasoning_config"] is None
+    assert agg["provider"] == "ai-gateway"
+    assert agg["reasoning_config"] == {"enabled": False}
+
+
+def test_codex_adapter_receives_reasoning_config_from_moa_shape():
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    moa_kwargs = moa._reasoning_kwargs(
+        "openai-codex", "gpt-5.4", {"enabled": True, "effort": "high"}
+    )
+    assert moa_kwargs == {"reasoning_config": {"enabled": True, "effort": "high"}}
+
+    captured: dict = {}
+
+    class FakeStream:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def __iter__(self):
+            return iter(())
+
+        def get_final_response(self):
+            return SimpleNamespace(output=[], usage=None, model="gpt-5.4")
+
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kwargs: FakeStream(**kwargs))
+    )
+
+    adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.4")
+    adapter.create(
+        model="gpt-5.4",
+        messages=[{"role": "user", "content": "hi"}],
+        **moa_kwargs,
+    )
+
+    assert captured["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert captured["include"] == ["reasoning.encrypted_content"]
+
+
+def test_anthropic_adapter_receives_reasoning_config_from_moa_shape(monkeypatch):
+    from agent import auxiliary_client as aux
+
+    moa_kwargs = moa._reasoning_kwargs(
+        "anthropic", "claude-opus-4-6", {"enabled": True, "effort": "high"}
+    )
+    assert moa_kwargs == {"reasoning_config": {"enabled": True, "effort": "high"}}
+
+    captured_build_kwargs: dict = {}
+
+    def fake_build_kwargs(**kwargs):
+        captured_build_kwargs.update(kwargs)
+        return {
+            "model": kwargs["model"],
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": kwargs["max_tokens"],
+        }
+
+    fake_transport = SimpleNamespace(
+        normalize_response=lambda _response, strip_tool_prefix=False: SimpleNamespace(
+            content="",
+            tool_calls=None,
+            reasoning=None,
+            finish_reason="stop",
+        )
+    )
+    fake_client = SimpleNamespace(
+        messages=SimpleNamespace(create=lambda **kw: SimpleNamespace(
+            content=[],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=0, output_tokens=0),
+        ))
+    )
+
+    monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_kwargs", fake_build_kwargs)
+    monkeypatch.setattr("agent.transports.get_transport", lambda _mode: fake_transport)
+
+    adapter = aux._AnthropicCompletionsAdapter(fake_client, "claude-opus-4-6")
+    adapter.create(
+        model="claude-opus-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        **moa_kwargs,
+    )
+
+    assert captured_build_kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+
+def test_anthropic_adapter_does_not_clobber_thinking_temperature(monkeypatch):
+    from agent import auxiliary_client as aux
+
+    captured: dict = {}
+
+    def fake_build_kwargs(**kwargs):
+        return {
+            "model": kwargs["model"],
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": kwargs["max_tokens"],
+            "temperature": 1,
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+        }
+
+    fake_transport = SimpleNamespace(
+        normalize_response=lambda _response, strip_tool_prefix=False: SimpleNamespace(
+            content="",
+            tool_calls=None,
+            reasoning=None,
+            finish_reason="stop",
+        )
+    )
+    fake_client = SimpleNamespace(
+        messages=SimpleNamespace(create=lambda **kw: (captured.update(kw), SimpleNamespace(
+            content=[],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=0, output_tokens=0),
+        ))[1])
+    )
+
+    monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_kwargs", fake_build_kwargs)
+    monkeypatch.setattr("agent.transports.get_transport", lambda _mode: fake_transport)
+
+    adapter = aux._AnthropicCompletionsAdapter(fake_client, "claude-opus-4-6")
+    adapter.create(
+        model="claude-opus-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.4,
+        reasoning_config={"enabled": True, "effort": "high"},
+    )
+
+    assert captured["temperature"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mixture_of_agents_uses_adaptive_quorum(fake_catalogs, monkeypatch):
+    _write_config(
+        {
+            "moa": {
+                "reference_models": ["anthropic/claude-opus-4.7", "openai/gpt-5.5-pro"],
+                "aggregator_model": "anthropic/claude-opus-4.7",
+            }
+        }
+    )
+    monkeypatch.setattr(
+        moa,
+        "_run_reference_model_safe",
+        AsyncMock(side_effect=[
+            ("anthropic/claude-opus-4.7", "ok", True),
+            ("openai/gpt-5.5-pro", "failed", False),
+        ]),
+    )
+    monkeypatch.setattr(moa, "_run_aggregator_model", AsyncMock(return_value="final"))
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result["success"] is False
+    assert "Need at least 2 successful responses" in result["error"]

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -1,84 +1,47 @@
 #!/usr/bin/env python3
-"""
-Mixture-of-Agents Tool Module
+"""Mixture-of-Agents Tool Module.
 
-This module implements the Mixture-of-Agents (MoA) methodology that leverages
-the collective strengths of multiple LLMs through a layered architecture to
-achieve state-of-the-art performance on complex reasoning tasks.
-
-Based on the research paper: "Mixture-of-Agents Enhances Large Language Model Capabilities"
-by Junlin Wang et al. (arXiv:2406.04692v1)
-
-Key Features:
-- Multi-layer LLM collaboration for enhanced reasoning
-- Parallel processing of reference models for efficiency
-- Intelligent aggregation and synthesis of diverse responses
-- Specialized for extremely difficult problems requiring intense reasoning
-- Optimized for coding, mathematics, and complex analytical tasks
-
-Available Tool:
-- mixture_of_agents_tool: Process complex queries using multiple frontier models
-
-Architecture:
-1. Reference models generate diverse initial responses in parallel
-2. Aggregator model synthesizes responses into a high-quality output
-3. Multiple layers can be used for iterative refinement (future enhancement)
-
-Models Used (via OpenRouter):
-- Reference Models: claude-opus-4.6, gemini-3-pro-preview, gpt-5.4-pro, deepseek-v3.2
-- Aggregator Model: claude-opus-4.6 (highest capability for synthesis)
-
-Configuration:
-    To customize the MoA setup, modify the configuration constants at the top of this file:
-    - REFERENCE_MODELS: List of models for generating diverse initial responses
-    - AGGREGATOR_MODEL: Model used to synthesize the final response
-    - REFERENCE_TEMPERATURE/AGGREGATOR_TEMPERATURE: Sampling temperatures
-    - MIN_SUCCESSFUL_REFERENCES: Minimum successful models needed to proceed
-
-Usage:
-    from mixture_of_agents_tool import mixture_of_agents_tool
-    import asyncio
-    
-    # Process a complex query
-    result = await mixture_of_agents_tool(
-        user_prompt="Solve this complex mathematical proof..."
-    )
+Runs a hard prompt through multiple frontier LLMs in parallel (layer 1:
+reference models), then synthesizes their responses with an aggregator
+model (layer 2).  Per-model provider routing and reasoning effort are
+configured via ``config.yaml`` under the ``moa`` key; see
+``hermes_cli.config.DEFAULT_CONFIG`` for the default shape.  The module
+constants below are fallback defaults used only when the ``moa`` block
+is absent or incomplete.
 """
 
-import json
-import logging
-import os
 import asyncio
 import datetime
-from typing import Dict, Any, List, Optional
-from tools.openrouter_client import get_async_client as _get_openrouter_client, check_api_key as check_openrouter_api_key
-from agent.auxiliary_client import extract_content_or_reasoning
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+from agent.auxiliary_client import (
+    extract_content_or_reasoning,
+    resolve_chat_temperature,
+    resolve_provider_client,
+)
 from tools.debug_helpers import DebugSession
+from tools.openrouter_client import check_api_key as check_openrouter_api_key
+from utils import base_url_hostname
 
 logger = logging.getLogger(__name__)
 
-# Configuration for MoA processing
-# Reference models - these generate diverse initial responses in parallel.
-# Keep this list aligned with current top-tier OpenRouter frontier options.
+# Fallback defaults — used only when the `moa` config block is absent or
+# incomplete.  Mirrors DEFAULT_CONFIG["moa"] so upstream rotations flow in
+# cleanly via merge.  Configure via config.yaml; don't edit here.
 REFERENCE_MODELS = [
-    "anthropic/claude-opus-4.6",
+    "anthropic/claude-opus-4.7",
     "google/gemini-2.5-pro",
-    "openai/gpt-5.4-pro",
+    "openai/gpt-5.5-pro",
     "deepseek/deepseek-v3.2",
 ]
+AGGREGATOR_MODEL = "anthropic/claude-opus-4.7"
+REFERENCE_TEMPERATURE = 0.6
+AGGREGATOR_TEMPERATURE = 0.4
+MIN_SUCCESSFUL_REFERENCES = 2
 
-# Aggregator model - synthesizes reference responses into final output.
-# Prefer the strongest synthesis model in the current OpenRouter lineup.
-AGGREGATOR_MODEL = "anthropic/claude-opus-4.6"
-
-# Temperature settings optimized for MoA performance
-REFERENCE_TEMPERATURE = 0.6  # Balanced creativity for diverse perspectives
-AGGREGATOR_TEMPERATURE = 0.4  # Focused synthesis for consistency
-
-# Failure handling configuration
-MIN_SUCCESSFUL_REFERENCES = 1  # Minimum successful reference models needed to proceed
-
-# System prompt for the aggregator model (from the research paper)
 AGGREGATOR_SYSTEM_PROMPT = """You have been provided with a set of responses from various open-source models to the latest user query. Your task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.
 
 Responses from models:"""
@@ -86,203 +49,982 @@ Responses from models:"""
 _debug = DebugSession("moa_tools", env_var="MOA_TOOLS_DEBUG")
 
 
-def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
+# One-shot Codex plan-consumption warnings.  Re-fires when the set of
+# Codex-routed slots changes (e.g. profile switch flips the aggregator).
+_codex_warning_seen: set = set()
+
+
+# ---------------------------------------------------------------------------
+# Request kwarg compatibility helpers.
+#
+# Sticky unsupported-parameter caches are endpoint-aware because the same
+# provider/model slug can be served by different OpenAI-compatible endpoints
+# with different accepted parameters.  They are process-lifetime only; restart
+# to retry behavior if a provider starts accepting a parameter again.
+# ---------------------------------------------------------------------------
+_REQUEST_CACHE_KEY = Tuple[str, str, str]
+_TEMPERATURE_UNSUPPORTED: Dict[_REQUEST_CACHE_KEY, bool] = {}
+_REASONING_UNSUPPORTED: Dict[_REQUEST_CACHE_KEY, bool] = {}
+
+_OPENROUTER_REASONING_PREFIXES = (
+    "deepseek/",
+    "anthropic/",
+    "openai/",
+    "x-ai/",
+    "google/gemini-2",
+    "qwen/qwen3",
+    "tencent/hy3-preview",
+)
+
+
+def _request_cache_key(
+    provider: str,
+    resolved_model: str,
+    base_url: Optional[str],
+) -> _REQUEST_CACHE_KEY:
+    raw_base_url = str(base_url or "").strip()
+    endpoint = ""
+    if raw_base_url:
+        try:
+            parse_target = raw_base_url if "://" in raw_base_url else f"//{raw_base_url}"
+            parsed = urlparse(parse_target)
+            if parsed.hostname:
+                endpoint = (
+                    f"{parsed.hostname}:{parsed.port}"
+                    if parsed.port is not None
+                    else parsed.hostname
+                )
+        except ValueError:
+            endpoint = ""
+    endpoint = endpoint or base_url_hostname(raw_base_url) or raw_base_url
+    return (
+        str(provider or "").strip().lower(),
+        str(resolved_model or "").strip(),
+        endpoint,
+    )
+
+
+def _openrouter_family_supports_reasoning(resolved_model: str) -> bool:
+    model = (resolved_model or "").lower()
+    return any(model.startswith(prefix) for prefix in _OPENROUTER_REASONING_PREFIXES)
+
+
+def _openai_style_effort(effort: Optional[str]) -> Optional[str]:
+    normalized = str(effort or "").strip().lower()
+    return normalized or None
+
+
+def _copilot_remap_effort(requested_effort: str, supported_efforts: List[str]) -> str:
+    if (
+        requested_effort == "xhigh"
+        and "xhigh" not in supported_efforts
+        and "high" in supported_efforts
+    ):
+        return "high"
+    if requested_effort not in supported_efforts:
+        if requested_effort == "minimal" and "low" in supported_efforts:
+            return "low"
+        if "medium" in supported_efforts:
+            return "medium"
+        return supported_efforts[0]
+    return requested_effort
+
+
+def _kimi_reasoning_kwargs(reasoning_config: Optional[dict]) -> Dict[str, Any]:
+    if reasoning_config and isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            return {"extra_body": {"thinking": {"type": "disabled"}}}
+        effort = str(reasoning_config.get("effort") or "").strip().lower()
+        if effort == "minimal":
+            effort = "low"
+        elif effort == "xhigh":
+            effort = "high"
+        if effort in {"low", "medium", "high"}:
+            return {
+                "reasoning_effort": effort,
+                "extra_body": {"thinking": {"type": "enabled"}},
+            }
+    return {
+        "reasoning_effort": "medium",
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+
+
+def _tokenhub_reasoning_kwargs(reasoning_config: Optional[dict]) -> Dict[str, Any]:
+    if reasoning_config and isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            return {}
+        effort = str(reasoning_config.get("effort") or "").strip().lower()
+        if effort in {"low", "medium", "high"}:
+            return {"reasoning_effort": effort}
+    return {"reasoning_effort": "high"}
+
+
+def _lmstudio_reasoning_kwargs(
+    resolved_model: str,
+    reasoning_config: Optional[dict],
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    try:
+        from hermes_cli.models import lmstudio_model_reasoning_options
+
+        options = lmstudio_model_reasoning_options(
+            resolved_model,
+            base_url=base_url,
+            api_key=api_key,
+        )
+    except Exception:
+        options = []
+
+    if not any(option and option != "off" for option in (options or [])):
+        return {}
+
+    try:
+        from agent.lmstudio_reasoning import resolve_lmstudio_effort
+
+        effort = resolve_lmstudio_effort(reasoning_config, options)
+    except Exception:
+        effort = None
+    return {"reasoning_effort": effort} if effort is not None else {}
+
+
+def _reasoning_kwargs(
+    provider: str,
+    resolved_model: str,
+    reasoning_config: Optional[dict],
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Translate MoA reasoning config into provider-specific request kwargs."""
+    if reasoning_config is None:
+        return {}
+
+    normalized_provider = str(provider or "").strip().lower()
+    enabled = reasoning_config.get("enabled") is True
+    effort = _openai_style_effort(reasoning_config.get("effort")) if enabled else None
+
+    if normalized_provider in {"openai-codex", "anthropic"}:
+        return {"reasoning_config": reasoning_config}
+
+    if normalized_provider in {"nous", "ai-gateway"}:
+        if enabled:
+            return {"extra_body": {"reasoning": {"enabled": True, "effort": effort}}}
+        if normalized_provider == "nous":
+            return {}
+        return {"extra_body": {"reasoning": {"enabled": False}}}
+
+    if normalized_provider == "openrouter":
+        if not _openrouter_family_supports_reasoning(resolved_model):
+            return {}
+        if enabled:
+            return {"extra_body": {"reasoning": {"enabled": True, "effort": effort}}}
+        return {"extra_body": {"reasoning": {"enabled": False}}}
+
+    if normalized_provider in {"copilot", "copilot-acp"}:
+        try:
+            from hermes_cli.models import github_model_reasoning_efforts
+
+            supported = github_model_reasoning_efforts(resolved_model)
+        except Exception:
+            supported = []
+        if not supported or not enabled:
+            return {}
+        remapped = _copilot_remap_effort(effort or "medium", supported)
+        return {"extra_body": {"reasoning": {"effort": remapped}}}
+
+    if normalized_provider == "custom" or normalized_provider.startswith("custom:"):
+        if enabled:
+            return {"reasoning_effort": effort}
+        return {"extra_body": {"think": False}}
+
+    if normalized_provider in {"kimi-coding", "kimi-coding-cn"}:
+        return _kimi_reasoning_kwargs(reasoning_config)
+
+    if normalized_provider == "tencent-tokenhub":
+        return _tokenhub_reasoning_kwargs(reasoning_config)
+
+    if normalized_provider == "lmstudio":
+        return _lmstudio_reasoning_kwargs(
+            resolved_model,
+            reasoning_config,
+            base_url=base_url,
+            api_key=api_key,
+        )
+
+    return {}
+
+
+def _merge_extra_body(params: Dict[str, Any], additions: Dict[str, Any]) -> None:
+    if not additions:
+        return
+    existing = params.get("extra_body")
+    extra_body = dict(existing) if isinstance(existing, dict) else {}
+    for key, value in additions.items():
+        if key == "tags":
+            current = extra_body.get("tags")
+            tags = list(current) if isinstance(current, list) else []
+            for tag in value if isinstance(value, list) else [value]:
+                if tag not in tags:
+                    tags.append(tag)
+            extra_body["tags"] = tags
+        else:
+            extra_body[key] = value
+    params["extra_body"] = extra_body
+
+
+def _extract_error_metadata(exc: Exception) -> Tuple[str, str, str]:
+    msg = str(exc)
+    code = ""
+    param = ""
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error") if isinstance(body.get("error"), dict) else None
+        if err:
+            code = str(err.get("code") or "")
+            param = str(err.get("param") or "")
+
+    if not code or not param:
+        resp = getattr(exc, "response", None)
+        json_fn = getattr(resp, "json", None) if resp is not None else None
+        if callable(json_fn):
+            try:
+                data = json_fn()
+                err = data.get("error") if isinstance(data, dict) else None
+                if isinstance(err, dict):
+                    code = code or str(err.get("code") or "")
+                    param = param or str(err.get("param") or "")
+            except Exception:
+                pass
+
+    return code, param, msg
+
+
+_PARAM_ALIASES = {
+    "temperature": ("temperature",),
+    "reasoning": (
+        "reasoning",
+        "reasoning_effort",
+        "reasoning_config",
+        "thinking",
+        "extended_thinking",
+    ),
+}
+
+_STRONG_UNSUPPORTED_MARKERS = (
+    "unsupported parameter",
+    "unsupported_parameter",
+    "parameter is not supported",
+    "does not support parameter",
+    "unknown parameter",
+    "unrecognized request argument",
+    "unrecognized parameter",
+    "invalid parameter",
+)
+
+_WEAK_UNSUPPORTED_MARKERS = (
+    "not supported",
+    "unsupported",
+    "does not support",
+)
+
+
+def _param_kind_from_name(param: str) -> Optional[str]:
+    param_lower = str(param or "").strip().lower()
+    for kind, aliases in _PARAM_ALIASES.items():
+        if any(alias in param_lower for alias in aliases):
+            return kind
+    return None
+
+
+def _detect_unsupported_param(
+    code: str,
+    param: str,
+    msg: str,
+) -> Tuple[Optional[str], bool]:
+    """Return (parameter kind, safe_to_sticky_cache)."""
+    if str(code or "").strip().lower() == "unsupported_parameter" and param:
+        return _param_kind_from_name(param), True
+
+    low = str(msg or "").lower()
+    kind = _param_kind_from_name(low)
+    if not kind:
+        return None, False
+
+    if any(marker in low for marker in _STRONG_UNSUPPORTED_MARKERS):
+        return kind, True
+    if "parameter" in low and "not supported" in low:
+        return kind, True
+    if any(marker in low for marker in _WEAK_UNSUPPORTED_MARKERS):
+        return kind, False
+
+    return None, False
+
+
+def _handle_unsupported_param(
+    exc: Exception,
+    cache_key: _REQUEST_CACHE_KEY,
+) -> Tuple[Optional[str], bool]:
+    code, param, msg = _extract_error_metadata(exc)
+    dropped, sticky = _detect_unsupported_param(code, param, msg)
+    if sticky and dropped == "temperature":
+        _TEMPERATURE_UNSUPPORTED[cache_key] = True
+    elif sticky and dropped == "reasoning":
+        _REASONING_UNSUPPORTED[cache_key] = True
+    return dropped, sticky
+
+
+def _effort_label(entry: Dict[str, Any]) -> str:
+    """Return the raw reasoning label for logs / debug output."""
+    rc = entry.get("reasoning_config")
+    if rc is None:
+        return "default"
+    if rc.get("enabled") is False:
+        return "none"
+    return rc.get("effort") or "default"
+
+
+# ---------------------------------------------------------------------------
+# Config loading + validation
+# ---------------------------------------------------------------------------
+def _normalize_entry(entry: Any, idx: Optional[int], is_aggregator: bool) -> Dict[str, Any]:
+    """Expand string shorthand / validate dict shape.  Returns {model, provider, _raw_reasoning}."""
+    if is_aggregator:
+        where = "moa.aggregator_model"
+    else:
+        where = f"moa.reference_models[{idx}]"
+
+    if isinstance(entry, str):
+        model = entry.strip()
+        if not model:
+            raise ValueError(f"{where} must specify a non-empty model")
+        return {"model": model, "provider": "openrouter", "_raw_reasoning": None}
+
+    if not isinstance(entry, dict):
+        raise ValueError(f"{where} must be a string or a dict")
+
+    model = entry.get("model")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError(f"{where} must specify a 'model' field")
+    model = model.strip()
+
+    provider = entry.get("provider") or "openrouter"
+    if not isinstance(provider, str):
+        raise ValueError(f"{where}.provider must be a string")
+    try:
+        from hermes_cli.models import normalize_provider
+        provider = normalize_provider(provider)
+    except Exception:
+        provider = provider.strip().lower()
+
+    raw_reasoning = entry.get("reasoning")
+    return {
+        "model": model,
+        "provider": provider,
+        "_raw_reasoning": raw_reasoning,
+    }
+
+
+def _read_raw_moa_subtree() -> Dict[str, Any]:
+    """Re-read the YAML config for pre-merge empty-dict override detection.
+
+    ``_deep_merge`` recurses into dict-typed fields and preserves the default
+    when the override is ``{}``, so ``aggregator_model: {}`` is invisible
+    against the merged dict.  We load the raw file to catch that typo.
     """
-    Construct the final system prompt for the aggregator including all model responses.
-    
+    try:
+        import yaml
+        from hermes_cli.config import get_config_path
+        path = get_config_path()
+        if not path.exists():
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict):
+            return {}
+        return data.get("moa") or {}
+    except Exception:
+        return {}
+
+
+def _load_moa_config(emit_warnings: bool = False) -> Dict[str, Any]:
+    """Load and validate the ``moa`` config block.
+
     Args:
-        system_prompt (str): Base system prompt for aggregation
-        responses (List[str]): List of responses from reference models
-        
+        emit_warnings: When True, emit operational-guidance logs (Codex
+            plan-consumption warnings, catalog-drift soft warnings).
+            Suppressed during preflight and startup.
+
     Returns:
-        str: Complete system prompt with enumerated responses
+        Dict with keys: enabled, reference_models, aggregator_model,
+        reference_temperature, aggregator_temperature,
+        min_successful_references.  Reference/aggregator entries carry
+        {model, provider, reasoning_config}.
+
+    Raises:
+        ValueError: On shape errors, unknown providers, invalid reasoning
+        strings, out-of-range min_successful_references, or empty rosters.
+        Raised even when ``enabled`` is False so toggling back on is safe.
     """
-    response_text = "\n".join([f"{i+1}. {response}" for i, response in enumerate(responses)])
+    from hermes_cli.config import load_config
+    from hermes_cli.models import list_available_providers, provider_model_ids
+    from hermes_constants import parse_reasoning_effort
+
+    config = load_config()
+    moa_value = config.get("moa", {})
+    if moa_value is None:
+        moa = {}
+    elif not isinstance(moa_value, dict):
+        raise ValueError("moa must be a mapping")
+    else:
+        moa = moa_value
+    raw_moa = _read_raw_moa_subtree()
+    raw_moa_dict = raw_moa if isinstance(raw_moa, dict) else {}
+
+    # Kill switch
+    enabled_val = moa.get("enabled", True)
+    if not isinstance(enabled_val, bool):
+        raise ValueError("moa.enabled must be a boolean")
+    enabled = enabled_val
+
+    # Pre-merge empty-dict detection (raw YAML re-read; see _read_raw_moa_subtree)
+    if raw_moa_dict:
+        raw_agg = raw_moa_dict.get("aggregator_model")
+        if isinstance(raw_agg, dict) and raw_agg == {}:
+            raise ValueError("moa.aggregator_model must specify a 'model' field")
+        raw_refs = raw_moa_dict.get("reference_models")
+        if isinstance(raw_refs, list):
+            for i, item in enumerate(raw_refs):
+                if isinstance(item, dict) and item == {}:
+                    raise ValueError(
+                        f"moa.reference_models[{i}] must specify a 'model' field"
+                    )
+
+    # Reference models
+    missing = object()
+    if "reference_models" in raw_moa_dict:
+        ref_raw = raw_moa_dict["reference_models"]
+    elif "reference_models" in moa:
+        ref_raw = moa["reference_models"]
+    else:
+        ref_raw = missing
+
+    if ref_raw is not missing:
+        if ref_raw is None:
+            raise ValueError("moa.reference_models must be a non-empty list")
+        if not isinstance(ref_raw, list) or len(ref_raw) == 0:
+            raise ValueError("moa.reference_models must be a non-empty list")
+        ref_entries = [
+            _normalize_entry(e, idx=i, is_aggregator=False)
+            for i, e in enumerate(ref_raw)
+        ]
+    else:
+        ref_entries = [
+            {"model": m, "provider": "openrouter", "_raw_reasoning": None}
+            for m in REFERENCE_MODELS
+        ]
+
+    # Aggregator
+    if "aggregator_model" in raw_moa_dict:
+        agg_raw = raw_moa_dict["aggregator_model"]
+    elif "aggregator_model" in moa:
+        agg_raw = moa["aggregator_model"]
+    else:
+        agg_raw = missing
+
+    if agg_raw is not missing:
+        if agg_raw is None:
+            raise ValueError("moa.aggregator_model must specify a 'model' field")
+        agg_entry = _normalize_entry(agg_raw, idx=None, is_aggregator=True)
+    else:
+        agg_entry = {
+            "model": AGGREGATOR_MODEL,
+            "provider": "openrouter",
+            "_raw_reasoning": None,
+        }
+
+    # Valid provider ids (from the canonical list + named custom providers)
+    valid_providers = {p["id"] for p in list_available_providers()}
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        from hermes_cli.providers import custom_provider_slug
+
+        custom_provider_slugs = {
+            custom_provider_slug(str(entry.get("name") or ""))
+            for entry in get_compatible_custom_providers(config)
+            if isinstance(entry, dict) and str(entry.get("name") or "").strip()
+        }
+    except Exception:
+        custom_provider_slugs = set()
+
+    for e in ref_entries + [agg_entry]:
+        prov = e["provider"]
+        if prov in custom_provider_slugs:
+            continue
+        if prov not in valid_providers:
+            raise ValueError(
+                f"moa: unknown provider {prov!r}; "
+                f"valid ids: {sorted(valid_providers | custom_provider_slugs)}"
+            )
+
+    # Reasoning per entry (accepts unset/null/'' as "use provider default")
+    valid_reasoning_efforts = ("minimal", "low", "medium", "high", "xhigh")
+    valid_reasoning_values = valid_reasoning_efforts + ("none",)
+    for e in ref_entries + [agg_entry]:
+        raw = e.pop("_raw_reasoning", None)
+        if raw is None:
+            e["reasoning_config"] = None
+            continue
+        if isinstance(raw, str) and raw.strip() == "":
+            e["reasoning_config"] = None
+            continue
+        if not isinstance(raw, str):
+            raise ValueError(
+                f"moa: reasoning must be a string; valid: "
+                f"{list(valid_reasoning_values)}"
+            )
+        normalized_raw = raw.strip().lower()
+        if normalized_raw not in valid_reasoning_values:
+            raise ValueError(
+                f"moa: invalid reasoning {raw!r}; valid: "
+                f"{list(valid_reasoning_values)}"
+            )
+        parsed = parse_reasoning_effort(raw)
+        if parsed is None:
+            raise ValueError(
+                f"moa: invalid reasoning {raw!r}; valid: "
+                f"{list(valid_reasoning_values)}"
+            )
+        e["reasoning_config"] = parsed
+
+    # Temperatures
+    ref_temp = moa.get("reference_temperature", REFERENCE_TEMPERATURE)
+    agg_temp = moa.get("aggregator_temperature", AGGREGATOR_TEMPERATURE)
+
+    # min_successful_references (adaptive default)
+    if "min_successful_references" in moa:
+        msr = moa["min_successful_references"]
+        if isinstance(msr, bool) or not isinstance(msr, int):
+            raise ValueError("moa.min_successful_references must be an integer")
+        if msr < 1 or msr > len(ref_entries):
+            raise ValueError(
+                f"moa.min_successful_references must be between 1 and "
+                f"{len(ref_entries)} (got {msr})"
+            )
+    else:
+        msr = min(2, len(ref_entries))
+
+    # Soft catalog-drift warning (emit_warnings gates this; no raise)
+    if emit_warnings:
+        for e in ref_entries + [agg_entry]:
+            try:
+                catalog = provider_model_ids(e["provider"])
+            except Exception:
+                catalog = []
+            if catalog and e["model"] not in catalog:
+                logger.warning(
+                    "MoA: model %r not in %s catalog — may fail at call time",
+                    e["model"], e["provider"],
+                )
+
+    # Codex plan warning
+    codex_models = frozenset(
+        e["model"] for e in (ref_entries + [agg_entry])
+        if e["provider"] == "openai-codex"
+    )
+    aggregator_is_codex = agg_entry["provider"] == "openai-codex"
+    if emit_warnings and codex_models:
+        key = (codex_models, aggregator_is_codex)
+        if key not in _codex_warning_seen:
+            _codex_warning_seen.add(key)
+            msg_parts = [
+                "MoA: %d reference/aggregator slot(s) routed through "
+                "openai-codex; each invocation consumes a Codex plan request"
+                % len(codex_models)
+            ]
+            if aggregator_is_codex:
+                msg_parts.append(
+                    "aggregator is Codex-routed — aggregator failure fails "
+                    "the whole MoA call"
+                )
+            logger.warning("; ".join(msg_parts))
+
+    return {
+        "enabled": enabled,
+        "reference_models": ref_entries,
+        "aggregator_model": agg_entry,
+        "reference_temperature": ref_temp,
+        "aggregator_temperature": agg_temp,
+        "min_successful_references": msr,
+        "min_successful_references_explicit": "min_successful_references" in moa,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model runners
+# ---------------------------------------------------------------------------
+def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
+    response_text = "\n".join(
+        f"{i+1}. {response}" for i, response in enumerate(responses)
+    )
     return f"{system_prompt}\n\n{response_text}"
 
 
+async def _create_chat_completion(client, **kwargs):
+    """Create a chat completion with async and sync client compatibility."""
+    import inspect
+
+    create = client.chat.completions.create
+    if inspect.iscoroutinefunction(create):
+        return await create(**kwargs)
+    response = await asyncio.to_thread(create, **kwargs)
+    if inspect.isawaitable(response):
+        return await response
+    return response
+
+
+def _build_api_params(
+    resolved_model: str,
+    messages: List[Dict[str, Any]],
+    provider: str,
+    reasoning_config: Optional[dict],
+    temperature: Optional[float],
+    cache_key: _REQUEST_CACHE_KEY,
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+    local_unsupported: Optional[set[str]] = None,
+) -> Dict[str, Any]:
+    """Assemble chat.completions kwargs for the resolved provider endpoint."""
+    params: Dict[str, Any] = {
+        "model": resolved_model,
+        "messages": messages,
+    }
+    local_unsupported = local_unsupported or set()
+
+    if (
+        "reasoning" not in local_unsupported
+        and not _REASONING_UNSUPPORTED.get(cache_key)
+    ):
+        params.update(
+            _reasoning_kwargs(
+                provider,
+                resolved_model,
+                reasoning_config,
+                base_url=base_url,
+                api_key=api_key,
+            )
+        )
+
+    if (
+        "temperature" not in local_unsupported
+        and not _TEMPERATURE_UNSUPPORTED.get(cache_key)
+    ):
+        effective_temperature = resolve_chat_temperature(
+            resolved_model,
+            base_url,
+            temperature,
+        )
+        if effective_temperature is not None:
+            params["temperature"] = effective_temperature
+
+    if max_tokens is not None:
+        if (
+            (provider == "custom" or str(provider).startswith("custom:"))
+            and base_url_hostname(base_url or "") == "api.openai.com"
+        ):
+            params["max_completion_tokens"] = max_tokens
+        else:
+            params["max_tokens"] = max_tokens
+
+    if provider == "nous":
+        _merge_extra_body(params, {"tags": ["product=hermes-agent"]})
+
+    return params
+
+
 async def _run_reference_model_safe(
-    model: str,
+    model_entry: Dict[str, Any],
     user_prompt: str,
     temperature: float = REFERENCE_TEMPERATURE,
     max_tokens: int = 32000,
-    max_retries: int = 6
-) -> tuple[str, str, bool]:
-    """
-    Run a single reference model with retry logic and graceful failure handling.
-    
-    Args:
-        model (str): Model identifier to use
-        user_prompt (str): The user's query
-        temperature (float): Sampling temperature for response generation
-        max_tokens (int): Maximum tokens in response
-        max_retries (int): Maximum number of retry attempts
-        
-    Returns:
-        tuple[str, str, bool]: (model_name, response_content_or_error, success_flag)
-    """
-    for attempt in range(max_retries):
+    max_retries: int = 6,
+) -> Tuple[str, str, bool]:
+    """Call a single reference model with retry handling."""
+    model = model_entry["model"]
+    provider = model_entry["provider"]
+    reasoning_config = model_entry.get("reasoning_config")
+
+    try:
+        client, resolved_model = resolve_provider_client(
+            provider, model=model, async_mode=True
+        )
+    except Exception as exc:  # noqa: BLE001 — init failure is per-model, not fatal
+        err = f"{model} could not be initialized: {exc}"
+        logger.error("%s", err, exc_info=True)
+        return model, err, False
+    if client is None:
+        err = f"{model}: no credentials configured for provider {provider!r}"
+        logger.error("%s", err)
+        return model, err, False
+
+    base_url = str(getattr(client, "base_url", "") or "")
+    api_key = str(getattr(client, "api_key", "") or "")
+    cache_key = _request_cache_key(provider, resolved_model, base_url)
+    local_unsupported: set[str] = set()
+    messages = [{"role": "user", "content": user_prompt}]
+    logger.info(
+        "MoA reference %s via %s (resolved=%s, reasoning=%s)",
+        model, provider, resolved_model, _effort_label(model_entry),
+    )
+
+    attempt = 0
+    while attempt < max_retries:
         try:
-            logger.info("Querying %s (attempt %s/%s)", model, attempt + 1, max_retries)
-            
-            # Build parameters for the API call
-            api_params = {
-                "model": model,
-                "messages": [{"role": "user", "content": user_prompt}],
-                "max_tokens": max_tokens,
-                "extra_body": {
-                    "reasoning": {
-                        "enabled": True,
-                        "effort": "xhigh"
-                    }
-                }
-            }
-            
-            # GPT models (especially gpt-4o-mini) don't support custom temperature values
-            # Only include temperature for non-GPT models
-            if not model.lower().startswith('gpt-'):
-                api_params["temperature"] = temperature
-            
-            response = await _get_openrouter_client().chat.completions.create(**api_params)
-            
+            api_params = _build_api_params(
+                resolved_model,
+                messages,
+                provider,
+                reasoning_config,
+                temperature,
+                cache_key,
+                base_url=base_url,
+                api_key=api_key,
+                max_tokens=max_tokens,
+                local_unsupported=local_unsupported,
+            )
+            response = await _create_chat_completion(client, **api_params)
+
             content = extract_content_or_reasoning(response)
             if not content:
-                # Reasoning-only response — let the retry loop handle it
-                logger.warning("%s returned empty content (attempt %s/%s), retrying", model, attempt + 1, max_retries)
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(min(2 ** (attempt + 1), 60))
-                    continue
+                logger.warning(
+                    "%s returned empty content (attempt %s/%s), retrying",
+                    model, attempt + 1, max_retries,
+                )
+                attempt += 1
+                if attempt < max_retries:
+                    await asyncio.sleep(min(2 ** attempt, 60))
+                continue
             logger.info("%s responded (%s characters)", model, len(content))
             return model, content, True
-            
-        except Exception as e:
+
+        except Exception as e:  # noqa: BLE001
+            dropped, sticky = _handle_unsupported_param(e, cache_key)
+            if dropped and (sticky or dropped not in local_unsupported):
+                if not sticky:
+                    local_unsupported.add(dropped)
+                logger.info(
+                    "%s dropped unsupported parameter %r and retrying",
+                    model, dropped,
+                )
+                attempt += 1
+                continue
+
             error_str = str(e)
-            # Keep retry-path logging concise; full tracebacks are reserved for
-            # terminal failure paths so long-running MoA retries don't flood logs.
             if "invalid" in error_str.lower():
                 logger.warning("%s invalid request error (attempt %s): %s", model, attempt + 1, error_str)
             elif "rate" in error_str.lower() or "limit" in error_str.lower():
                 logger.warning("%s rate limit error (attempt %s): %s", model, attempt + 1, error_str)
             else:
-                logger.warning("%s unknown error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s error (attempt %s): %s", model, attempt + 1, error_str)
 
-            if attempt < max_retries - 1:
-                # Exponential backoff for rate limiting: 2s, 4s, 8s, 16s, 32s, 60s
-                sleep_time = min(2 ** (attempt + 1), 60)
-                logger.info("Retrying in %ss...", sleep_time)
+            attempt += 1
+            if attempt < max_retries:
+                sleep_time = min(2 ** attempt, 60)
+                logger.info("Retrying %s in %ss...", model, sleep_time)
                 await asyncio.sleep(sleep_time)
             else:
-                error_msg = f"{model} failed after {max_retries} attempts: {error_str}"
-                logger.error("%s", error_msg, exc_info=True)
-                return model, error_msg, False
+                err = f"{model} failed after {max_retries} attempts: {error_str}"
+                logger.error("%s", err, exc_info=True)
+                return model, err, False
+
+    return model, f"{model} exhausted retries", False
 
 
 async def _run_aggregator_model(
+    agg_entry: Dict[str, Any],
     system_prompt: str,
     user_prompt: str,
     temperature: float = AGGREGATOR_TEMPERATURE,
-    max_tokens: int = None
+    max_tokens: Optional[int] = None,
+    max_retries: int = 3,
 ) -> str:
-    """
-    Run the aggregator model to synthesize the final response.
-    
-    Args:
-        system_prompt (str): System prompt with all reference responses
-        user_prompt (str): Original user query
-        temperature (float): Focused temperature for consistent aggregation
-        max_tokens (int): Maximum tokens in final response
-        
-    Returns:
-        str: Synthesized final response
-    """
-    logger.info("Running aggregator model: %s", AGGREGATOR_MODEL)
+    """Call the aggregator with retry handling."""
+    model = agg_entry["model"]
+    provider = agg_entry["provider"]
+    reasoning_config = agg_entry.get("reasoning_config")
 
-    # Build parameters for the API call
-    api_params = {
-        "model": AGGREGATOR_MODEL,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt}
-        ],
-        "max_tokens": max_tokens,
-        "extra_body": {
-            "reasoning": {
-                "enabled": True,
-                "effort": "xhigh"
-            }
+    client, resolved_model = resolve_provider_client(
+        provider, model=model, async_mode=True
+    )
+    if client is None:
+        raise ValueError(
+            f"MoA aggregator: no credentials configured for provider {provider!r}"
+        )
+
+    base_url = str(getattr(client, "base_url", "") or "")
+    api_key = str(getattr(client, "api_key", "") or "")
+    cache_key = _request_cache_key(provider, resolved_model, base_url)
+    local_unsupported: set[str] = set()
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+    logger.info(
+        "MoA aggregator %s via %s (resolved=%s, reasoning=%s)",
+        model, provider, resolved_model, _effort_label(agg_entry),
+    )
+
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries):
+        try:
+            api_params = _build_api_params(
+                resolved_model,
+                messages,
+                provider,
+                reasoning_config,
+                temperature,
+                cache_key,
+                base_url=base_url,
+                api_key=api_key,
+                max_tokens=max_tokens,
+                local_unsupported=local_unsupported,
+            )
+            response = await _create_chat_completion(client, **api_params)
+            content = extract_content_or_reasoning(response)
+            if not content and attempt < max_retries - 1:
+                logger.warning("Aggregator returned empty content, retrying")
+                continue
+            logger.info("Aggregation complete (%s characters)", len(content) if content else 0)
+            return content or ""
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            dropped, sticky = _handle_unsupported_param(e, cache_key)
+            if dropped and (sticky or dropped not in local_unsupported):
+                if not sticky:
+                    local_unsupported.add(dropped)
+                logger.info(
+                    "Aggregator dropped unsupported parameter %r and retrying",
+                    dropped,
+                )
+                continue
+            logger.warning("Aggregator error (attempt %s): %s", attempt + 1, e)
+            if attempt < max_retries - 1:
+                await asyncio.sleep(min(2 ** (attempt + 1), 30))
+
+    raise RuntimeError(f"MoA aggregator failed after {max_retries} attempts: {last_error}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def _override_entries_from_strings(
+    reference_models: Optional[List[str]],
+    aggregator_model: Optional[str],
+    cfg: Dict[str, Any],
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Apply optional string-only per-invocation overrides (OpenRouter-only)."""
+    ref_entries = cfg["reference_models"]
+    agg_entry = cfg["aggregator_model"]
+    if reference_models is not None:
+        ref_entries = [
+            {"model": m.strip(), "provider": "openrouter", "reasoning_config": None}
+            for m in reference_models
+            if isinstance(m, str) and m.strip()
+        ]
+    if aggregator_model is not None:
+        agg_entry = {
+            "model": aggregator_model.strip(),
+            "provider": "openrouter",
+            "reasoning_config": None,
         }
-    }
+    return ref_entries, agg_entry
 
-    # GPT models (especially gpt-4o-mini) don't support custom temperature values
-    # Only include temperature for non-GPT models
-    if not AGGREGATOR_MODEL.lower().startswith('gpt-'):
-        api_params["temperature"] = temperature
 
-    response = await _get_openrouter_client().chat.completions.create(**api_params)
+def _effective_min_successful_references(
+    cfg: Dict[str, Any],
+    ref_entries: List[Dict[str, Any]],
+) -> int:
+    """Return the effective quorum after per-call roster overrides."""
+    if not ref_entries:
+        raise ValueError("MoA requires at least one reference model")
 
-    content = extract_content_or_reasoning(response)
-
-    # Retry once on empty content (reasoning-only response)
-    if not content:
-        logger.warning("Aggregator returned empty content, retrying once")
-        response = await _get_openrouter_client().chat.completions.create(**api_params)
-        content = extract_content_or_reasoning(response)
-
-    logger.info("Aggregation complete (%s characters)", len(content))
-    return content
+    configured = cfg["min_successful_references"]
+    if cfg.get("min_successful_references_explicit"):
+        if configured > len(ref_entries):
+            raise ValueError(
+                "MoA per-call overrides reduced the reference roster to "
+                f"{len(ref_entries)} model(s), but "
+                f"moa.min_successful_references is pinned to {configured}. "
+                "Lower the config quorum or remove the override."
+            )
+        return configured
+    return min(2, len(ref_entries))
 
 
 async def mixture_of_agents_tool(
     user_prompt: str,
     reference_models: Optional[List[str]] = None,
-    aggregator_model: Optional[str] = None
+    aggregator_model: Optional[str] = None,
 ) -> str:
-    """
-    Process a complex query using the Mixture-of-Agents methodology.
-    
-    This tool leverages multiple frontier language models to collaboratively solve
-    extremely difficult problems requiring intense reasoning. It's particularly
-    effective for:
-    - Complex mathematical proofs and calculations
-    - Advanced coding problems and algorithm design
-    - Multi-step analytical reasoning tasks
-    - Problems requiring diverse domain expertise
-    - Tasks where single models show limitations
-    
-    The MoA approach uses a fixed 2-layer architecture:
-    1. Layer 1: Multiple reference models generate diverse responses in parallel (temp=0.6)
-    2. Layer 2: Aggregator model synthesizes the best elements into final response (temp=0.4)
-    
-    Args:
-        user_prompt (str): The complex query or problem to solve
-        reference_models (Optional[List[str]]): Custom reference models to use
-        aggregator_model (Optional[str]): Custom aggregator model to use
-    
-    Returns:
-        str: JSON string containing the MoA results with the following structure:
-             {
-                 "success": bool,
-                 "response": str,
-                 "models_used": {
-                     "reference_models": List[str],
-                     "aggregator_model": str
-                 },
-                 "processing_time": float
-             }
-    
-    Raises:
-        Exception: If MoA processing fails or API key is not set
+    """Run a prompt through multiple frontier LLMs and synthesize the responses.
+
+    Configuration is loaded from ``config.yaml`` (the ``moa`` block) on every
+    invocation so profile switches take effect without a restart.  Per-model
+    provider routing and reasoning effort live in config; ``reference_models``
+    and ``aggregator_model`` parameters are OpenRouter-only string overrides
+    retained for backward compatibility.
     """
     start_time = datetime.datetime.now()
-    
-    debug_call_data = {
+
+    try:
+        cfg = _load_moa_config(emit_warnings=True)
+    except ValueError as exc:
+        error_msg = f"MoA config error: {exc}"
+        logger.error("%s", error_msg)
+        return json.dumps({
+            "success": False,
+            "response": "",
+            "models_used": {"reference_models": [], "aggregator_model": ""},
+            "error": error_msg,
+        }, indent=2, ensure_ascii=False)
+
+    # Kill switch: fail-closed.  Callers branching on ``success`` route to
+    # their normal error path; ``error`` string is distinct from real failures.
+    if not cfg["enabled"]:
+        logger.info("MoA disabled via config; short-circuiting without calling any model")
+        return json.dumps({
+            "success": False,
+            "response": "",
+            "models_used": {"reference_models": [], "aggregator_model": ""},
+            "error": "MoA disabled via moa.enabled=false",
+        }, indent=2, ensure_ascii=False)
+
+    ref_entries, agg_entry = _override_entries_from_strings(
+        reference_models, aggregator_model, cfg,
+    )
+    ref_temp = cfg["reference_temperature"]
+    agg_temp = cfg["aggregator_temperature"]
+
+    debug_call_data: Dict[str, Any] = {
         "parameters": {
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
-            "reference_models": reference_models or REFERENCE_MODELS,
-            "aggregator_model": aggregator_model or AGGREGATOR_MODEL,
-            "reference_temperature": REFERENCE_TEMPERATURE,
-            "aggregator_temperature": AGGREGATOR_TEMPERATURE,
-            "min_successful_references": MIN_SUCCESSFUL_REFERENCES
+            "reference_models": [
+                {"model": e["model"], "provider": e["provider"], "reasoning": _effort_label(e)}
+                for e in ref_entries
+            ],
+            "aggregator_model": {
+                "model": agg_entry["model"],
+                "provider": agg_entry["provider"],
+                "reasoning": _effort_label(agg_entry),
+            },
+            "reference_temperature": ref_temp,
+            "aggregator_temperature": agg_temp,
+            "min_successful_references": None,
         },
         "error": None,
         "success": False,
@@ -291,140 +1033,174 @@ async def mixture_of_agents_tool(
         "failed_models": [],
         "final_response_length": 0,
         "processing_time_seconds": 0,
-        "models_used": {}
+        "models_used": {},
     }
-    
+
     try:
+        msr = _effective_min_successful_references(cfg, ref_entries)
+        debug_call_data["parameters"]["min_successful_references"] = msr
+
         logger.info("Starting Mixture-of-Agents processing...")
         logger.info("Query: %s", user_prompt[:100])
-        
-        # Validate API key availability
-        if not os.getenv("OPENROUTER_API_KEY"):
-            raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        
-        # Use provided models or defaults
-        ref_models = reference_models or REFERENCE_MODELS
-        agg_model = aggregator_model or AGGREGATOR_MODEL
-        
-        logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_models))
-        
-        # Layer 1: Generate diverse responses from reference models (with failure handling)
+        logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_entries))
+
+        # Layer 1: parallel fanout
         logger.info("Layer 1: Generating reference responses...")
         model_results = await asyncio.gather(*[
-            _run_reference_model_safe(model, user_prompt, REFERENCE_TEMPERATURE)
-            for model in ref_models
+            _run_reference_model_safe(entry, user_prompt, ref_temp)
+            for entry in ref_entries
         ])
-        
-        # Separate successful and failed responses
-        successful_responses = []
-        failed_models = []
-        
+
+        successful_responses: List[str] = []
+        failed_models: List[str] = []
         for model_name, content, success in model_results:
             if success:
                 successful_responses.append(content)
             else:
                 failed_models.append(model_name)
-        
+
         successful_count = len(successful_responses)
         failed_count = len(failed_models)
-        
         logger.info("Reference model results: %s successful, %s failed", successful_count, failed_count)
-        
         if failed_models:
-            logger.warning("Failed models: %s", ', '.join(failed_models))
-        
-        # Check if we have enough successful responses to proceed
-        if successful_count < MIN_SUCCESSFUL_REFERENCES:
-            raise ValueError(f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). Need at least {MIN_SUCCESSFUL_REFERENCES} successful responses.")
-        
+            logger.warning("Failed models: %s", ", ".join(failed_models))
+
+        if successful_count < msr:
+            raise ValueError(
+                f"Insufficient successful reference models "
+                f"({successful_count}/{len(ref_entries)}). "
+                f"Need at least {msr} successful responses."
+            )
+
         debug_call_data["reference_responses_count"] = successful_count
         debug_call_data["failed_models_count"] = failed_count
         debug_call_data["failed_models"] = failed_models
-        
-        # Layer 2: Aggregate responses using the aggregator model
+
+        # Layer 2: aggregation
         logger.info("Layer 2: Synthesizing final response...")
         aggregator_system_prompt = _construct_aggregator_prompt(
-            AGGREGATOR_SYSTEM_PROMPT, 
-            successful_responses
+            AGGREGATOR_SYSTEM_PROMPT, successful_responses,
         )
-        
         final_response = await _run_aggregator_model(
-            aggregator_system_prompt,
-            user_prompt,
-            AGGREGATOR_TEMPERATURE
+            agg_entry, aggregator_system_prompt, user_prompt, agg_temp,
         )
-        
-        # Calculate processing time
+
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
         logger.info("MoA processing completed in %.2f seconds", processing_time)
-        
-        # Prepare successful response (only final aggregated result, minimal fields)
+
         result = {
             "success": True,
             "response": final_response,
             "models_used": {
-                "reference_models": ref_models,
-                "aggregator_model": agg_model
-            }
+                "reference_models": [e["model"] for e in ref_entries],
+                "aggregator_model": agg_entry["model"],
+            },
         }
-        
+
         debug_call_data["success"] = True
         debug_call_data["final_response_length"] = len(final_response)
         debug_call_data["processing_time_seconds"] = processing_time
         debug_call_data["models_used"] = result["models_used"]
-        
-        # Log debug information
+
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
         return json.dumps(result, indent=2, ensure_ascii=False)
-        
-    except Exception as e:
+
+    except Exception as e:  # noqa: BLE001
         error_msg = f"Error in MoA processing: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
-        
-        # Calculate processing time even for errors
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
-        # Prepare error response (minimal fields)
+
         result = {
             "success": False,
             "response": "MoA processing failed. Please try again or use a single model for this query.",
             "models_used": {
-                "reference_models": reference_models or REFERENCE_MODELS,
-                "aggregator_model": aggregator_model or AGGREGATOR_MODEL
+                "reference_models": [e["model"] for e in ref_entries],
+                "aggregator_model": agg_entry["model"],
             },
-            "error": error_msg
+            "error": error_msg,
         }
-        
         debug_call_data["error"] = error_msg
         debug_call_data["processing_time_seconds"] = processing_time
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
         return json.dumps(result, indent=2, ensure_ascii=False)
 
 
-def check_moa_requirements() -> bool:
-    """
-    Check if all requirements for MoA tools are met.
-    
-    Returns:
-        bool: True if requirements are met, False otherwise
-    """
-    return check_openrouter_api_key()
+# ---------------------------------------------------------------------------
+# Preflight / introspection
+# ---------------------------------------------------------------------------
+def _provider_has_credentials(provider: str, model: Optional[str] = None) -> bool:
+    """Return True when the runtime provider resolver can create a client."""
+    try:
+        client, _ = resolve_provider_client(
+            provider,
+            model=model,
+            async_mode=False,
+        )
+    except Exception:
+        return False
+    if client is None:
+        return False
+    try:
+        close_fn = getattr(client, "close", None)
+        if callable(close_fn):
+            close_fn()
+    except Exception:
+        pass
+    return True
 
+
+def get_moa_preflight_status() -> Tuple[bool, Optional[str]]:
+    """Return (available, hint) for setup/preflight surfaces.
+
+    The hint is phrased to fit setup output like ``(missing <hint>)``.
+    """
+    try:
+        cfg = _load_moa_config(emit_warnings=False)
+    except ValueError as exc:
+        logger.error("MoA config invalid: %s", exc)
+        return False, "valid MoA config"
+
+    if not cfg["enabled"]:
+        # Hide from preflight-gated menus when the kill switch is flipped.
+        return False, "enabled MoA config"
+
+    entries = list(cfg["reference_models"]) + [cfg["aggregator_model"]]
+    missing = sorted({
+        entry["provider"]
+        for entry in entries
+        if not _provider_has_credentials(entry["provider"], model=entry["model"])
+    })
+    if missing:
+        logger.error(
+            "MoA: missing credentials for provider(s): %s",
+            ", ".join(missing),
+        )
+        return False, f"credentials for {', '.join(missing)}"
+    return True, None
+
+
+def check_moa_requirements() -> bool:
+    """Preflight: return True iff all configured providers have credentials."""
+    available, _ = get_moa_preflight_status()
+    return available
+
+
+def get_available_models() -> List[str]:
+    """Return the module-constant fallback reference models.
+
+    Reflects fallback defaults, not the resolved roster.
+    """
+    return list(REFERENCE_MODELS)
 
 
 def get_moa_configuration() -> Dict[str, Any]:
-    """
-    Get the current MoA configuration settings.
-    
-    Returns:
-        Dict[str, Any]: Dictionary containing all configuration parameters
+    """Return module-constant fallback configuration.
+
+    Reflects fallback defaults, not the resolved roster from config.yaml.
     """
     return {
         "reference_models": REFERENCE_MODELS,
@@ -433,80 +1209,35 @@ def get_moa_configuration() -> Dict[str, Any]:
         "aggregator_temperature": AGGREGATOR_TEMPERATURE,
         "min_successful_references": MIN_SUCCESSFUL_REFERENCES,
         "total_reference_models": len(REFERENCE_MODELS),
-        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} models can fail"
+        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} models can fail",
     }
 
 
 if __name__ == "__main__":
-    """
-    Simple test/demo when run directly
-    """
     print("🤖 Mixture-of-Agents Tool Module")
     print("=" * 50)
-    
-    # Check if API key is available
+
     api_available = check_openrouter_api_key()
-    
     if not api_available:
-        print("❌ OPENROUTER_API_KEY environment variable not set")
-        print("Please set your API key: export OPENROUTER_API_KEY='your-key-here'")
-        print("Get API key at: https://openrouter.ai/")
-        exit(1)
+        print("⚠️  OPENROUTER_API_KEY not set — OpenRouter-routed entries will fail")
     else:
         print("✅ OpenRouter API key found")
-    
+
     print("🛠️  MoA tools ready for use!")
-    
-    # Show current configuration
     config = get_moa_configuration()
-    print("\n⚙️  Current Configuration:")
+    print("\n⚙️  Fallback constants (config.yaml overrides these):")
     print(f"  🤖 Reference models ({len(config['reference_models'])}): {', '.join(config['reference_models'])}")
     print(f"  🧠 Aggregator model: {config['aggregator_model']}")
     print(f"  🌡️  Reference temperature: {config['reference_temperature']}")
     print(f"  🌡️  Aggregator temperature: {config['aggregator_temperature']}")
     print(f"  🛡️  Failure tolerance: {config['failure_tolerance']}")
     print(f"  📊 Minimum successful models: {config['min_successful_references']}")
-    
-    # Show debug mode status
+
     if _debug.active:
         print(f"\n🐛 Debug mode ENABLED - Session ID: {_debug.session_id}")
         print(f"   Debug logs will be saved to: ./logs/moa_tools_debug_{_debug.session_id}.json")
     else:
         print("\n🐛 Debug mode disabled (set MOA_TOOLS_DEBUG=true to enable)")
-    
-    print("\nBasic usage:")
-    print("  from mixture_of_agents_tool import mixture_of_agents_tool")
-    print("  import asyncio")
-    print("")
-    print("  async def main():")
-    print("      result = await mixture_of_agents_tool(")
-    print("          user_prompt='Solve this complex mathematical proof...'")
-    print("      )")
-    print("      print(result)")
-    print("  asyncio.run(main())")
-    
-    print("\nBest use cases:")
-    print("  - Complex mathematical proofs and calculations")
-    print("  - Advanced coding problems and algorithm design")
-    print("  - Multi-step analytical reasoning tasks")
-    print("  - Problems requiring diverse domain expertise")
-    print("  - Tasks where single models show limitations")
-    
-    print("\nPerformance characteristics:")
-    print("  - Higher latency due to multiple model calls")
-    print("  - Significantly improved quality for complex tasks")
-    print("  - Parallel processing for efficiency")
-    print(f"  - Optimized temperatures: {REFERENCE_TEMPERATURE} for reference models, {AGGREGATOR_TEMPERATURE} for aggregation")
-    print("  - Token-efficient: only returns final aggregated response")
-    print("  - Resilient: continues with partial model failures")
-    print("  - Configurable: easy to modify models and settings at top of file")
-    print("  - State-of-the-art results on challenging benchmarks")
-    
-    print("\nDebug mode:")
-    print("  # Enable debug logging")
-    print("  export MOA_TOOLS_DEBUG=true")
-    print("  # Debug logs capture all MoA processing steps and metrics")
-    print("  # Logs saved to: ./logs/moa_tools_debug_UUID.json")
 
 
 # ---------------------------------------------------------------------------
@@ -516,7 +1247,7 @@ from tools.registry import registry
 
 MOA_SCHEMA = {
     "name": "mixture_of_agents",
-    "description": "Route a hard problem through multiple frontier LLMs collaboratively. Makes 5 API calls (4 reference models + 1 aggregator) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives.",
+    "description": "Route a hard problem through multiple frontier LLMs collaboratively. Fans out to a user-configured roster of reference models in parallel, then synthesizes their answers with an aggregator model (N reference calls + 1 aggregator call; roster size, providers, and per-entry reasoning are set under `moa:` in config.yaml). Use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -535,7 +1266,7 @@ registry.register(
     schema=MOA_SCHEMA,
     handler=lambda args, **kw: mixture_of_agents_tool(user_prompt=args.get("user_prompt", "")),
     check_fn=check_moa_requirements,
-    requires_env=["OPENROUTER_API_KEY"],
+    requires_env=[],
     is_async=True,
     emoji="🧠",
 )

--- a/website/docs/reference/mixture-of-agents.md
+++ b/website/docs/reference/mixture-of-agents.md
@@ -1,0 +1,139 @@
+---
+title: Mixture of Agents (MoA)
+---
+
+Mixture of Agents (MoA) runs several reference models in parallel, then sends their responses to a separate aggregator model that synthesizes the final answer.
+
+Use it for genuinely hard prompts where diversity helps: multi-step reasoning, architecture tradeoffs, difficult debugging, complex coding tasks, or synthesis across viewpoints.
+
+Configuration lives under `moa:` in `config.yaml`.
+
+## Shipped default config
+
+```yaml
+moa:
+  enabled: true
+  reference_models:
+    - model: "anthropic/claude-opus-4.7"
+      provider: "openrouter"
+      reasoning: "xhigh"
+    - model: "google/gemini-2.5-pro"
+      provider: "openrouter"
+      reasoning: "xhigh"
+    - model: "openai/gpt-5.5-pro"
+      provider: "openrouter"
+      reasoning: "xhigh"
+    - model: "deepseek/deepseek-v3.2"
+      provider: "openrouter"
+      reasoning: "xhigh"
+  aggregator_model:
+    model: "anthropic/claude-opus-4.7"
+    provider: "openrouter"
+    reasoning: "xhigh"
+  reference_temperature: 0.6
+  aggregator_temperature: 0.4
+```
+
+This is the fallback roster Hermes ships with when your `moa:` block is absent.
+`min_successful_references` is omitted by default and resolves to `2` for this
+four-model roster.
+
+Notes:
+
+- `enabled: false` disables the tool without deleting the roster.
+- String shorthand is allowed for convenience:
+
+```yaml
+moa:
+  reference_models:
+    - "anthropic/claude-opus-4.7"
+  aggregator_model: "anthropic/claude-opus-4.7"
+```
+
+Those shorthand entries default to `provider: openrouter`.
+
+## Provider routing
+
+Each entry chooses its own provider.
+
+That lets you mix:
+
+- OpenRouter for breadth and reliability
+- OpenAI Codex for GPT-5 via a Codex subscription
+- Anthropic direct for native Claude routing
+- Other configured providers supported by Hermes
+
+Preflight is roster-aware: Hermes checks the providers actually referenced by
+your MoA config. A Codex-only roster does not require `OPENROUTER_API_KEY`,
+while a mixed roster needs credentials for every provider it touches.
+
+If a provider/model pairing is not in the known provider catalog, Hermes logs a warning but does not block the call. This is intentional: catalogs can lag behind newly released model slugs.
+
+## Reasoning per model
+
+Each entry may optionally set `reasoning`.
+
+Accepted values are `minimal`, `low`, `medium`, `high`, `xhigh`, and `none`.
+`max` is not accepted for MoA entries.
+
+Behavior:
+
+- omitted / `null` / `""` => do not send any reasoning parameter; use the provider default
+- `none` => send an explicit reasoning-disabled config when supported
+- invalid value => load-time config error
+
+Reasoning is translated per provider:
+
+- OpenRouter => `extra_body.reasoning` only for known reasoning-capable model families
+- Nous / AI Gateway => `extra_body.reasoning`; Nous omits explicit disabled reasoning
+- Copilot / Copilot ACP => `extra_body.reasoning` with effort remapped to the model's supported set
+- OpenAI Codex / Anthropic => `reasoning_config` passed to the adapter layer
+- Custom OpenAI-compatible endpoints => top-level `reasoning_effort`, or `extra_body.think=false` for `none`
+- Kimi / Moonshot => top-level `reasoning_effort` plus `extra_body.thinking`; `minimal` maps to `low`, and `xhigh` maps to `high`
+- Tencent TokenHub => top-level `reasoning_effort`, limited to `low`, `medium`, and `high`
+- LM Studio => top-level `reasoning_effort` only when the model advertises reasoning support
+
+:::note Silent-accept providers
+OpenRouter proxies to many backends that silently accept and drop `extra_body.reasoning` without error; if a reasoning setting seems inert, cross-check against provider-side logs or billing.
+:::
+
+## Request compatibility
+
+MoA aligns its direct chat-completions requests with Hermes' provider contracts:
+
+- Kimi / Moonshot models omit `temperature`; the endpoint chooses the mode-specific default.
+- Anthropic models that reject sampling parameters omit `temperature`.
+- Custom endpoints hosted at `api.openai.com` receive `max_completion_tokens`; other OpenAI-compatible endpoints receive `max_tokens`.
+- Nous requests include the `product=hermes-agent` attribution tag.
+- If a provider rejects `temperature` or reasoning parameters with a clear unsupported-parameter error, MoA retries immediately without that parameter and remembers the drop for the same provider/model/endpoint for the rest of the process.
+
+## Operational notes
+
+- The aggregator is the final answer. If the aggregator fails, the whole MoA call fails.
+- `min_successful_references` is validated against the roster size.
+- When the key is omitted, Hermes uses an adaptive default: `2` for multi-model rosters, `1` for single-model rosters.
+
+## `/model` and `/reasoning_effort` do not cascade into MoA
+
+MoA has its own roster and per-entry reasoning configuration.
+
+Important:
+
+- `/model` changes the main agent model, not the MoA reference roster or aggregator
+- `/reasoning_effort` changes the main agent loop, not the `moa.*.reasoning` entries
+
+If you want MoA to track your main model or reasoning preferences, update both places.
+
+## Codex warning
+
+Routing one or more MoA slots through `openai-codex` can burn through a Codex plan quickly.
+
+Because MoA fans out in parallel, routing multiple reference models through Codex multiplies consumption against the plan's daily cap.
+
+If the aggregator itself is Codex-routed and fails, the whole MoA tool fails.
+
+## Related docs
+
+- [Tools Reference](./tools-reference.md)
+- [Toolsets Reference](./toolsets-reference.md)
+- [Providers](../integrations/providers.md)

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -125,7 +125,7 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `mixture_of_agents` | Route a hard problem through multiple frontier LLMs collaboratively. Makes 5 API calls (4 reference models + 1 aggregator) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced alg… | OPENROUTER_API_KEY |
+| `mixture_of_agents` | Route a hard problem through multiple frontier LLMs collaboratively. Roster, providers, and per-model reasoning effort are configured under `moa:` in `config.yaml` — see [Mixture of Agents](../user-guide/features/mixture-of-agents.md). | Credentials for each configured provider |
 
 ## `rl` toolset
 

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -1,0 +1,81 @@
+---
+title: Mixture of Agents
+description: Run a hard prompt through multiple frontier LLMs in parallel, then synthesize the responses with an aggregator.
+sidebar_label: Mixture of Agents
+sidebar_position: 16
+---
+
+# Mixture of Agents
+
+The **Mixture of Agents** (MoA) tool runs your prompt through several frontier models in parallel (the *reference* layer), then feeds the collected answers to a single aggregator model that synthesizes a final response. It is most useful for hard one-shot questions where you want to trade latency and token spend for higher answer quality.
+
+MoA is part of the `moa` toolset. It is OFF by default; enable it from the setup checklist or by adding `moa` under `enabled_toolsets` in `config.yaml`.
+
+## Configuring the roster
+
+MoA is configured entirely from `~/.hermes/config.yaml` under the `moa:` key. The module constants inside `tools/mixture_of_agents_tool.py` are fallbacks; do not edit them.
+
+```yaml
+moa:
+  enabled: true
+  reference_models:
+    - {model: anthropic/claude-opus-4.7,       provider: openrouter, reasoning: xhigh}
+    - {model: google/gemini-2.5-pro,           provider: openrouter, reasoning: xhigh}
+    - {model: openai/gpt-5.5-pro,              provider: openrouter, reasoning: xhigh}
+    - {model: deepseek/deepseek-v3.2,          provider: openrouter, reasoning: xhigh}
+  aggregator_model:
+    model: anthropic/claude-opus-4.7
+    provider: openrouter
+    reasoning: xhigh
+  reference_temperature: 0.6
+  aggregator_temperature: 0.4
+  min_successful_references: 2
+```
+
+Every entry in `reference_models` and `aggregator_model` accepts:
+
+- `model` — the provider-native model slug.
+- `provider` — any provider accepted by the main agent's router (`openrouter`, `openai-codex`, `nous`, `anthropic`, `copilot`, `ai-gateway`, `custom`, …). Defaults to `openrouter` if omitted.
+- `reasoning` *(optional)* — one of `minimal`, `low`, `medium`, `high`, `xhigh`, `none`. Omit the key (or set `null` / `""`) to send no MoA-specific reasoning override. `max` is not accepted for MoA entries.
+
+A bare string is accepted as shorthand for `{model: <string>, provider: openrouter}`.
+
+MoA translates `reasoning` to the provider's request shape. OpenRouter, Nous,
+AI Gateway, and Copilot use `extra_body.reasoning` where supported; Codex and
+Anthropic receive adapter-facing `reasoning_config`; Kimi / Moonshot and
+Tencent TokenHub use top-level `reasoning_effort` (Kimi maps `minimal` to
+`low` and `xhigh` to `high`); LM Studio only receives a reasoning field when
+the model advertises support.
+
+MoA also applies provider-specific request compatibility rules: Kimi /
+Moonshot and no-sampling Anthropic models omit `temperature`, direct OpenAI
+custom endpoints receive `max_completion_tokens`, and Nous requests include the
+`product=hermes-agent` tag. Clear unsupported-parameter errors trigger one
+immediate retry without the rejected temperature or reasoning field and are
+cached for that provider/model/endpoint for the rest of the process.
+
+### Kill switch
+
+Set `moa.enabled: false` to disable the tool without touching `enabled_toolsets`. Preflight will refuse to run, and calls to the tool return a structured failure (`error: "MoA disabled via moa.enabled=false"`). Invalid config under a disabled block still raises at load time — errors are not deferred.
+
+### `min_successful_references`
+
+Defaults to `min(2, len(reference_models))` so a typical 3–4 model roster tolerates one reference failure. Set it explicitly to override. Values outside `[1, len(reference_models)]` fail validation.
+
+## Interaction with `/model` and `/reasoning_effort`
+
+MoA keeps its own roster — **`/model` does not cascade into MoA**. Switching the main agent's model has no effect on the reference or aggregator models used by the tool.
+
+Similarly, **`/reasoning_effort` only affects the main agent loop**. MoA entries each carry their own `reasoning` field, and the tool does not read the session-level reasoning effort. If you want MoA to track a change, update both `/reasoning_effort` *and* the relevant `reasoning:` fields under `moa:`.
+
+## Provider cost warning
+
+Routing multiple reference models through `openai-codex` multiplies consumption against the Codex plan's daily cap. The tool logs a one-time warning per Codex-routed config shape; take it seriously if you're on a metered plan.
+
+## Credentials
+
+`check_moa_requirements` is config-aware: it asks Hermes' provider resolver to create a client for every `provider` in your roster (including the aggregator). An all-Codex roster with Codex credentials will pass even when `OPENROUTER_API_KEY` is unset. A mixed roster needs credentials for every provider it touches.
+
+## Debug mode
+
+Set `MOA_TOOLS_DEBUG=1` in your environment to dump per-call metadata (provider, resolved model, reasoning kwargs, reference successes/failures, final response length) to the Hermes debug directory.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -95,6 +95,7 @@ const sidebars: SidebarsConfig = {
           label: 'Advanced',
           items: [
             'user-guide/features/rl-training',
+            'user-guide/features/mixture-of-agents',
             'user-guide/features/spotify',
           ],
         },
@@ -234,6 +235,7 @@ const sidebars: SidebarsConfig = {
         'reference/environment-variables',
         'reference/tools-reference',
         'reference/toolsets-reference',
+        'reference/mixture-of-agents',
         'reference/mcp-config-reference',
         'reference/model-catalog',
         'reference/skills-catalog',


### PR DESCRIPTION
**Depends on https://github.com/NousResearch/hermes-agent/pull/19060 being merged first**

MoA is now provider-routed, but its direct request construction still needed to match the contracts Hermes already uses in the main agent, transports, and auxiliary client. Without that parity, the same configured model can behave differently when called via `mixture_of_agents`: reasoning kwargs sent in the wrong shape, Kimi/Anthropic endpoints rejecting sampling parameters, direct OpenAI custom endpoints needing `max_completion_tokens`, and one endpoint's unsupported-parameter response poisoning retries for another. The fix is scoped to MoA's request layer plus a small auxiliary helper extraction — no main agent refactor.

## What changed

- Adds config-backed MoA defaults with explicit per-entry `reasoning: xhigh`. An omitted/null/blank `reasoning` means MoA sends no reasoning override and leaves the provider/server default in control.
- Translates MoA reasoning into provider-specific request shapes for OpenRouter, Nous, AI Gateway, Copilot/Copilot ACP, Codex, Anthropic, custom OpenAI-compatible endpoints, Kimi/Moonshot, Tencent TokenHub, and LM Studio.
- Reuses a public `resolve_chat_temperature()` helper so MoA and auxiliary chat callers omit temperature for Kimi/Moonshot and Anthropic no-sampling models consistently.
- Handles direct OpenAI custom endpoints with `max_completion_tokens`, adds Nous attribution tags, and stays silent for unsupported providers instead of inventing kwargs.
- Makes sticky unsupported-parameter fallback endpoint+port-aware and only caches clear parameter rejections. Retries are immediate but still consume a retry attempt.
- Handles sync-shaped chat clients that return awaitables.
- Updates setup/tool preflight, docs, tool reference text, and tests to match.

## Tests

- `env HERMES_HOME=/private/tmp/hermes-empty-for-tests TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 uv run --extra dev --with pytest-split pytest -o addopts= -n 4 --ignore=tests/integration --ignore=tests/e2e -m 'not integration' tests/tools/test_mixture_of_agents_tool.py tests/tools/test_mixture_of_agents_tool_provider_routing.py tests/agent/test_auxiliary_client.py tests/agent/transports/test_chat_completions.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_tools_config.py -q`
- `uv run --extra dev ruff check --select F401,F821,F841 agent/auxiliary_client.py tools/mixture_of_agents_tool.py tests/tools/test_mixture_of_agents_tool_provider_routing.py`
- `git diff --check`

Not run: website build (no `website/node_modules` in clean worktree).

## Risk

The main behavior risk is provider drift: some OpenAI-compatible endpoints accept extra fields but ignore them silently. The new docs call this out, and the unsupported-parameter cache is process-local and endpoint-scoped so a bad assumption doesn't persist or leak across local endpoints.