### PR TITLE
feat(gateway): support [[as_document]] directive for skill media routing

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -5,6 +5,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
 import json
+import hashlib
 import logging
 import os
 import re
@@ -588,6 +589,22 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
+def _skills_manifest_digest(skills_dir: Path) -> str:
+    """Return a stable digest of one skills directory's manifest."""
+    manifest = _build_skills_manifest(skills_dir)
+    payload = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _skills_cache_state(skills_dir: Path, external_dirs: list[Path]) -> tuple[tuple[str, str], ...]:
+    """Return cache state tokens for local + external skill directories."""
+    dirs = [skills_dir, *external_dirs]
+    return tuple(
+        (str(directory.resolve()), _skills_manifest_digest(directory))
+        for directory in dirs
+    )
+
+
 def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
@@ -745,7 +762,7 @@ def build_skills_system_prompt(
     disabled = get_disabled_skill_names()
     cache_key = (
         str(skills_dir.resolve()),
-        tuple(str(d) for d in external_dirs),
+        _skills_cache_state(skills_dir, external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1854,23 +1854,38 @@ class BasePlatformAdapter(ABC):
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
-        
+
         The TTS tool returns responses like:
             [[audio_as_voice]]
             MEDIA:/path/to/audio.ogg
-        
+
+        Skills that produce large/lossless images (e.g. info-graph, where a
+        rendered JPG is 1-2 MB but Telegram's sendPhoto recompresses to
+        ~200 KB at 1280px) can use ``[[as_document]]`` to request unmodified
+        delivery via sendDocument instead of sendPhoto/sendMediaGroup. The
+        directive is detected at the dispatch sites (which have access to the
+        original response); this method just strips it so it never leaks into
+        user-visible text. Per-file granularity is intentionally not exposed —
+        when an agent emits ``[[as_document]]`` once, every image path in the
+        same response is delivered as a document, mirroring the all-or-nothing
+        scope of ``[[audio_as_voice]]``.
+
         Args:
             content: The response text to scan.
-        
+
         Returns:
             Tuple of (list of (path, is_voice) pairs, cleaned content with tags removed).
         """
         media = []
         cleaned = content
-        
+
         # Check for [[audio_as_voice]] directive
         has_voice_tag = "[[audio_as_voice]]" in content
         cleaned = cleaned.replace("[[audio_as_voice]]", "")
+        # Strip [[as_document]] directive — callers inspect the original
+        # ``content`` for it (so they can still react to it); here we just
+        # keep it out of the user-visible cleaned text.
+        cleaned = cleaned.replace("[[as_document]]", "")
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
@@ -2720,13 +2735,21 @@ class BasePlatformAdapter(ABC):
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
+                # Capture [[as_document]] before extract_media strips it, so the
+                # dispatch partition below can route image-extension files
+                # through send_document instead of send_multiple_images. Used
+                # by skills that produce large/lossless images (e.g. info-graph)
+                # where Telegram's sendPhoto recompression destroys legibility.
+                force_document_attachments = "[[as_document]]" in response
+
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
-                
+
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
                 # Strip any remaining internal directives from message body (fixes #1561)
                 text_content = text_content.replace("[[audio_as_voice]]", "").strip()
+                text_content = text_content.replace("[[as_document]]", "").strip()
                 text_content = re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
@@ -2823,19 +2846,26 @@ class BasePlatformAdapter(ABC):
                 _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
 
                 # Partition images out of media_files + local_files so they
-                # can be sent as a single batch (Signal RPC)
+                # can be sent as a single batch (Signal RPC). When
+                # ``[[as_document]]`` was set on the original response, image
+                # files skip the photo path and route to send_document below
+                # so they're delivered with original bytes (no Telegram
+                # sendPhoto recompression).
                 from urllib.parse import quote as _quote
                 _image_paths: list = []
                 _non_image_media: list = []
                 for media_path, is_voice in media_files:
                     _ext = Path(media_path).suffix.lower()
-                    if _ext in _IMAGE_EXTS and not is_voice:
+                    if (_ext in _IMAGE_EXTS
+                            and not is_voice
+                            and not force_document_attachments):
                         _image_paths.append(media_path)
                     else:
                         _non_image_media.append((media_path, is_voice))
                 _non_image_local: list = []
                 for file_path in local_files:
-                    if Path(file_path).suffix.lower() in _IMAGE_EXTS:
+                    if (Path(file_path).suffix.lower() in _IMAGE_EXTS
+                            and not force_document_attachments):
                         _image_paths.append(file_path)
                     else:
                         _non_image_local.append(file_path)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2193,7 +2193,12 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """Send a local image file natively as a Telegram photo."""
+        """Send a local image file natively as a Telegram photo.
+
+        If Telegram rejects the image as a photo (for example, invalid
+        dimensions on very tall screenshots), retry as a document so the
+        original file still reaches the user unchanged.
+        """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
@@ -2212,13 +2217,30 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.error(
-                "[%s] Failed to send Telegram local image, falling back to base adapter: %s",
+            logger.warning(
+                "[%s] Failed to send Telegram local image as photo, retrying as document: %s",
                 self.name,
                 e,
                 exc_info=True,
             )
-            return await super().send_image_file(chat_id, image_path, caption, reply_to)
+            try:
+                return await self.send_document(
+                    chat_id=chat_id,
+                    file_path=image_path,
+                    caption=caption,
+                    file_name=os.path.basename(image_path),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            except Exception:
+                logger.error(
+                    "[%s] Failed to send Telegram local image as both photo and document, falling back to base adapter",
+                    self.name,
+                    exc_info=True,
+                )
+                return await super().send_image_file(
+                    chat_id, image_path, caption, reply_to, metadata=metadata
+                )
 
     async def send_document(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8078,6 +8078,12 @@ class GatewayRunner:
         from urllib.parse import quote as _quote
 
         try:
+            # Capture [[as_document]] before extract_media strips it, so the
+            # dispatch partition below can route image-extension files
+            # through send_document (preserving bytes) instead of
+            # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
+            force_document_attachments = "[[as_document]]" in response
+
             media_files, _ = adapter.extract_media(response)
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
@@ -8090,19 +8096,24 @@ class GatewayRunner:
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
 
             # Partition out images so they can be sent as a single batch
-            # (e.g. Signal's multi-attachment RPC)
+            # (e.g. Signal's multi-attachment RPC). When [[as_document]] was
+            # set, image-extension files skip the photo path and route to
+            # send_document below — preserving original bytes.
             image_paths: list = []
             non_image_media: list = []
             for media_path, is_voice in media_files:
                 ext = Path(media_path).suffix.lower()
-                if ext in _IMAGE_EXTS and not is_voice:
+                if (ext in _IMAGE_EXTS
+                        and not is_voice
+                        and not force_document_attachments):
                     image_paths.append(media_path)
                 else:
                     non_image_media.append((media_path, is_voice))
 
             non_image_local: list = []
             for file_path in local_files:
-                if Path(file_path).suffix.lower() in _IMAGE_EXTS:
+                if (Path(file_path).suffix.lower() in _IMAGE_EXTS
+                        and not force_document_attachments):
                     image_paths.append(file_path)
                 else:
                     non_image_local.append(file_path)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2748,10 +2748,95 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_max_tokens_from_config(
+    model: str,
+    base_url: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Resolve a ``max_tokens`` override from ``config.yaml``.
+
+    Custom OpenAI-compatible providers (vLLM, llama.cpp, ollama, ...) that
+    do not advertise a max_tokens default via /models cause responses to
+    truncate with ``finish_reason='length'`` because the agent never sends
+    a max_tokens hint.  This helper resolves an override the user can set
+    in config.yaml, mirroring the existing ``context_length`` lookup.
+
+    Lookup order (first valid positive int wins):
+      1. Top-level ``model.max_tokens`` (applies to whichever model is active)
+      2. ``custom_providers.<>.models.<model>.max_tokens`` (per-model, scoped
+         to the entry whose ``base_url`` matches ``base_url``)
+
+    Returns ``None`` when neither location holds a valid value.  Trailing
+    slashes on URLs are normalised before comparison.
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return None
+    if not isinstance(config, dict):
+        return None
+
+    # 1. Top-level model.max_tokens
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        raw = model_cfg.get("max_tokens")
+        if raw is not None:
+            try:
+                v = int(raw)
+                if v > 0:
+                    return v
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid model.max_tokens in config.yaml: %r — "
+                    "must be a positive integer (e.g. 32768, not '32K'). "
+                    "Falling back to per-model / provider defaults.",
+                    raw,
+                )
+
+    # 2. custom_providers.<>.models.<model>.max_tokens
+    if not model or not base_url:
+        return None
+    try:
+        custom_providers = get_compatible_custom_providers(config)
+    except Exception:
+        raw_cps = config.get("custom_providers")
+        custom_providers = raw_cps if isinstance(raw_cps, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_mt = model_cfg.get("max_tokens")
+        if raw_mt is None:
+            continue
+        try:
+            v = int(raw_mt)
+        except (TypeError, ValueError):
+            continue
+        if v > 0:
+            return v
+    return None
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.
-    
+
     Returns (current_version, latest_version).
     """
     config = load_config()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1916,7 +1916,20 @@ class AIAgent:
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
 
-
+        # Read max_tokens override from config (mirrors context_length above).
+        # Custom providers without a server-side max_tokens default truncate
+        # long responses with finish_reason='length'; this lets the user pin
+        # an explicit cap via model.max_tokens (top-level) or
+        # custom_providers.<>.models.<>.max_tokens (per-model).
+        # Applied only when the constructor did not pass an explicit value.
+        try:
+            from hermes_cli.config import get_max_tokens_from_config as _gmtfc
+            _config_max_tokens = _gmtfc(self.model, self.base_url, _agent_cfg)
+        except Exception:
+            _config_max_tokens = None
+        self._config_max_tokens = _config_max_tokens
+        if _config_max_tokens is not None and self.max_tokens is None:
+            self.max_tokens = _config_max_tokens
 
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting

--- a/run_agent.py
+++ b/run_agent.py
@@ -8820,7 +8820,15 @@ class AIAgent:
         # This must happen before the unconditional empty-string fallback so
         # genuine reasoning content is not overwritten (#15812 regression in
         # PR #15478).
-        if isinstance(normalized_reasoning, str) and normalized_reasoning:
+        #
+        # Gate on needs_thinking_pad (DeepSeek/Kimi only).  Qwen-on-vLLM and
+        # other custom providers forbid re-feeding reasoning_content from
+        # prior turns (Qwen multi-turn spec) — causes context balloon and
+        # thinking-mode death loops.  OpenRouter, Anthropic, and OpenAI
+        # maintain reasoning continuity via the separate reasoning_details
+        # field, so dropping the promotion here is safe for them; only
+        # DeepSeek/Kimi rely on this path for genuine content.
+        if needs_thinking_pad and isinstance(normalized_reasoning, str) and normalized_reasoning:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
@@ -10857,6 +10865,8 @@ class AIAgent:
 
                 # For ALL assistant messages, pass reasoning back to the API
                 # This ensures multi-turn reasoning context is preserved
+                # (Qwen-on-vLLM is excluded inside the helper — see
+                # _copy_reasoning_content_for_api step 3.)
                 self._copy_reasoning_content_for_api(msg, api_msg)
 
                 # Remove 'reasoning' field - it's for trajectory storage only

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -372,6 +372,28 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_rebuilds_prompt_when_skill_files_change(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        first_skill = tmp_path / "skills" / "tools" / "first-skill"
+        first_skill.mkdir(parents=True)
+        (first_skill / "SKILL.md").write_text(
+            "---\nname: first-skill\ndescription: First skill\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "first-skill" in first
+        assert "second-skill" not in first
+
+        second_skill = tmp_path / "skills" / "tools" / "second-skill"
+        second_skill.mkdir(parents=True)
+        (second_skill / "SKILL.md").write_text(
+            "---\nname: second-skill\ndescription: Second skill\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "first-skill" in second
+        assert "second-skill" in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)
@@ -1086,6 +1108,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,37 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_as_document_directive_stripped_from_cleaned_text(self):
+        """[[as_document]] is a routing directive — strip it from
+        user-visible text just like [[audio_as_voice]]. Callers detect the
+        directive on the original content (before extract_media)."""
+        content = "Here is your infographic:\n[[as_document]]\nMEDIA:/tmp/x.jpg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/x.jpg", False)]
+        assert "[[as_document]]" not in cleaned
+        assert "Here is your infographic" in cleaned
+
+    def test_as_document_directive_alone_does_not_attach_voice_flag(self):
+        """[[as_document]] is independent of [[audio_as_voice]] — combining
+        them in the same response should not entangle the flags."""
+        content = "[[as_document]]\nMEDIA:/tmp/x.jpg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/x.jpg", False)]  # voice flag stays False
+        assert "[[as_document]]" not in cleaned
+
+    def test_both_directives_can_coexist(self):
+        """A response could (rarely) contain both [[audio_as_voice]] for an
+        ogg file AND [[as_document]] for an attached image. The voice flag
+        propagates per-tuple; [[as_document]] is detected at dispatch."""
+        content = "[[audio_as_voice]]\n[[as_document]]\nMEDIA:/tmp/x.ogg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        # Voice flag is propagated to every media tuple (this matches the
+        # existing extract_media contract)
+        assert media == [("/tmp/x.ogg", True)]
+        # Both directives stripped from cleaned text
+        assert "[[audio_as_voice]]" not in cleaned
+        assert "[[as_document]]" not in cleaned
+
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -167,6 +167,30 @@ class TestTelegramSendImageFile:
         call_kwargs = adapter._bot.send_photo.call_args.kwargs
         assert call_kwargs["message_thread_id"] == 789
 
+    def test_photo_failure_retries_as_document(self, adapter, tmp_path):
+        """When Telegram rejects photo dimensions, retry the original file as a document."""
+        img = tmp_path / "very-tall.jpg"
+        img.write_bytes(b"\xff\xd8\xff" + b"\x00" * 50)
+
+        adapter._bot.send_photo = AsyncMock(side_effect=Exception("Photo_invalid_dimensions"))
+        mock_msg = MagicMock()
+        mock_msg.message_id = 44
+        adapter._bot.send_document = AsyncMock(return_value=mock_msg)
+
+        result = _run(
+            adapter.send_image_file(chat_id="12345", image_path=str(img), caption="cap")
+        )
+
+        assert result.success
+        assert result.message_id == "44"
+        adapter._bot.send_photo.assert_awaited_once()
+        adapter._bot.send_document.assert_awaited_once()
+
+        call_kwargs = adapter._bot.send_document.call_args.kwargs
+        assert call_kwargs["chat_id"] == 12345
+        assert call_kwargs["filename"] == "very-tall.jpg"
+        assert call_kwargs["caption"] == "cap"
+
 
 # ---------------------------------------------------------------------------
 # Discord send_image_file tests

--- a/tests/hermes_cli/test_max_tokens_config.py
+++ b/tests/hermes_cli/test_max_tokens_config.py
@@ -1,0 +1,180 @@
+"""Tests for ``get_max_tokens_from_config`` — model.max_tokens override.
+
+Custom OpenAI-compatible providers that do not advertise a ``max_tokens``
+default cause responses to truncate with ``finish_reason='length'``.  The
+helper resolves an override from config.yaml, mirroring the existing
+``get_custom_provider_context_length`` lookup pattern.
+"""
+from __future__ import annotations
+
+from hermes_cli.config import get_max_tokens_from_config
+
+
+class TestTopLevelModelMaxTokens:
+    """Top-level ``model.max_tokens`` is the preferred location."""
+
+    def test_returns_value_when_present(self) -> None:
+        cfg = {"model": {"max_tokens": 32768}}
+        assert (
+            get_max_tokens_from_config(
+                "qwen3.6-27b-fp8", "http://vllm.invalid/v1", cfg
+            )
+            == 32768
+        )
+
+    def test_returns_value_when_no_model_or_base_url(self) -> None:
+        # Top-level lookup does NOT depend on model/base_url.
+        cfg = {"model": {"max_tokens": 16000}}
+        assert get_max_tokens_from_config("", "", cfg) == 16000
+
+    def test_string_int_is_coerced(self) -> None:
+        cfg = {"model": {"max_tokens": "8192"}}
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            == 8192
+        )
+
+    def test_invalid_value_falls_through(self) -> None:
+        # Bad value at top level must not raise; lookup continues to
+        # custom_providers and finds the per-model override.
+        cfg = {
+            "model": {"max_tokens": "32K"},
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"m": {"max_tokens": 4096}},
+                }
+            ],
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) == 4096
+        )
+
+    def test_zero_or_negative_top_level_ignored(self) -> None:
+        cfg = {"model": {"max_tokens": 0}}
+        assert get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) is None
+        cfg = {"model": {"max_tokens": -1}}
+        assert get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) is None
+
+
+class TestPerModelCustomProviderMaxTokens:
+    """``custom_providers.<>.models.<>.max_tokens`` is the per-model fallback."""
+
+    def test_returns_per_model_when_no_top_level(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"qwen": {"max_tokens": 16384}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("qwen", "http://h.invalid/v1", cfg)
+            == 16384
+        )
+
+    def test_top_level_wins_over_per_model(self) -> None:
+        cfg = {
+            "model": {"max_tokens": 99999},
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"qwen": {"max_tokens": 16384}},
+                }
+            ],
+        }
+        assert (
+            get_max_tokens_from_config("qwen", "http://h.invalid/v1", cfg)
+            == 99999
+        )
+
+    def test_trailing_slash_insensitive(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1/",
+                    "models": {"m": {"max_tokens": 4096}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg) == 4096
+        )
+
+    def test_url_mismatch_returns_none(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://other.invalid/v1",
+                    "models": {"m": {"max_tokens": 4096}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            is None
+        )
+
+    def test_model_mismatch_returns_none(self) -> None:
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "vllm",
+                    "base_url": "http://h.invalid/v1",
+                    "models": {"other-model": {"max_tokens": 4096}},
+                }
+            ]
+        }
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            is None
+        )
+
+
+class TestProvidersDictForm:
+    """The newer keyed ``providers:`` schema (v12+) is also covered via
+    ``get_compatible_custom_providers`` normalization."""
+
+    def test_providers_dict_with_models_subdict(self) -> None:
+        cfg = {
+            "providers": {
+                "vllm": {
+                    "name": "vllm",
+                    "api": "http://h.invalid/v1",
+                    "models": {"qwen": {"max_tokens": 8192}},
+                }
+            }
+        }
+        assert (
+            get_max_tokens_from_config("qwen", "http://h.invalid/v1", cfg)
+            == 8192
+        )
+
+
+class TestEdgeCases:
+    def test_empty_config_returns_none(self) -> None:
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", {}) is None
+        )
+
+    def test_none_config_arg_does_not_crash(self) -> None:
+        # Passing ``config=None`` triggers a load_config(); the call should
+        # not raise even when no override is configured.
+        result = get_max_tokens_from_config("nonexistent", "http://nowhere.invalid/v1")
+        assert result is None or isinstance(result, int)
+
+    def test_non_dict_config_returns_none(self) -> None:
+        assert get_max_tokens_from_config("m", "http://h.invalid/v1", "garbage") is None  # type: ignore[arg-type]
+
+    def test_no_model_section(self) -> None:
+        cfg = {"other": {}}
+        assert (
+            get_max_tokens_from_config("m", "http://h.invalid/v1", cfg)
+            is None
+        )

--- a/tests/run_agent/test_reasoning_content_provider_gate.py
+++ b/tests/run_agent/test_reasoning_content_provider_gate.py
@@ -1,0 +1,132 @@
+"""``_copy_reasoning_content_for_api`` step 3 promotion is gated to
+providers that actually need it (DeepSeek/Kimi).
+
+Step 3 promotes ``msg["reasoning"]`` → ``api_msg["reasoning_content"]``
+for any assistant message that carries reasoning text in the unified
+``reasoning`` field.  For Qwen-on-vLLM and other custom providers, this
+re-feed violates the provider's multi-turn spec and causes:
+  - context balloon across multi-turn conversations
+  - thinking-mode death loops where the model re-thinks its own
+    prior reasoning back at itself (Qwen's documented failure mode)
+
+OpenRouter / Anthropic / OpenAI carry reasoning continuity via the
+separate ``reasoning_details`` field (untouched by this helper), so
+gating step 3 is safe — they never relied on this path.
+
+DeepSeek / Kimi keep their existing behaviour because they are gated
+in via ``_needs_kimi_tool_reasoning`` / ``_needs_deepseek_tool_reasoning``.
+"""
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    return agent
+
+
+class TestStep3GatedToThinkingPadProviders:
+    """The reasoning→reasoning_content promotion only runs for DeepSeek/Kimi."""
+
+    def test_qwen_vllm_reasoning_not_promoted(self) -> None:
+        """Qwen on a self-hosted vLLM endpoint must NOT get reasoning_content
+        re-fed across turns — Qwen's multi-turn spec forbids it."""
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3.6-27b-fp8",
+            base_url="http://vllm.local:8000/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "final answer",
+            "reasoning": "long Qwen <think> trace captured on the prior turn",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_openrouter_reasoning_not_promoted(self) -> None:
+        """OpenRouter routes reasoning continuity via reasoning_details;
+        the reasoning_content path is not used."""
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "any reasoning text",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_minimax_reasoning_not_promoted(self) -> None:
+        """MiniMax was an early consumer of step 3 but never relied on
+        reasoning_content for multi-turn correctness; it should be safe
+        to drop now that DeepSeek/Kimi are the only confirmed users."""
+        agent = _make_agent(
+            provider="minimax",
+            model="MiniMax-M1",
+            base_url="https://api.minimax.chat/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "minimax reasoning",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_deepseek_reasoning_still_promoted(self) -> None:
+        """Regression check: DeepSeek must keep its reasoning re-feed
+        because the chat completions API requires it on tool-call replay."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "deepseek thought trace",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == "deepseek thought trace"
+
+    def test_kimi_reasoning_still_promoted(self) -> None:
+        """Regression check: Kimi multi-turn requires the reasoning re-feed."""
+        agent = _make_agent(
+            provider="moonshot",
+            model="kimi-k2-thinking",
+            base_url="https://api.moonshot.cn/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "kimi reasoning",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == "kimi reasoning"
+
+    def test_explicit_reasoning_content_still_preserved(self) -> None:
+        """Step 1 (explicit copy) is unaffected by the gate — explicit
+        reasoning_content is always passed through verbatim, regardless
+        of provider."""
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3.6-27b-fp8",
+            base_url="http://vllm.local:8000/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "explicit content set by build path",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "explicit content set by build path"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -241,6 +241,12 @@ def _handle_send(args):
 
     from gateway.platforms.base import BasePlatformAdapter
 
+    # Capture [[as_document]] directive before extract_media strips it.
+    # Image-extension files in this batch will route through send_document
+    # instead of send_photo so the original bytes survive (e.g. info-graph
+    # JPGs where Telegram's sendPhoto recompresses to 1280px).
+    force_document_attachments = "[[as_document]]" in message
+
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
@@ -276,6 +282,7 @@ def _handle_send(args):
                 cleaned_message,
                 thread_id=thread_id,
                 media_files=media_files,
+                force_document=force_document_attachments,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -436,7 +443,7 @@ async def _send_via_adapter(platform, pconfig, chat_id, chunk):
     return {"error": f"No live adapter for platform '{platform.value}'. Is the gateway running with this platform connected?"}
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -513,6 +520,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 media_files=media_files if is_last else [],
                 thread_id=thread_id,
                 disable_link_previews=disable_link_previews,
+                force_document=force_document,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -649,7 +657,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     return last_result
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -732,7 +740,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             ext = os.path.splitext(media_path)[1].lower()
             try:
                 with open(media_path, "rb") as f:
-                    if ext in _IMAGE_EXTS:
+                    if ext in _IMAGE_EXTS and not force_document:
                         last_msg = await bot.send_photo(
                             chat_id=int_chat_id, photo=f, **thread_kwargs
                         )


### PR DESCRIPTION
## Why

Skills that produce large/lossless images (e.g. info-graph, where a rendered JPG is 1-2 MB at 3840×2160) currently lose quality when delivered through Telegram, because Hermes' `_IMAGE_EXTS` membership routes the file through `send_multiple_images` → `sendMediaGroup`, which Telegram's server re-encodes to JPEG @ ~1280px max edge. Small-glyph legibility is destroyed (Chinese body text in a 28-32px font collapses to ~9px after compression).

The original bytes only survive when the file goes through `send_document`. The dispatch tables in three places (`_process_message_background`, `_deliver_media_from_response`, and the `send_message` tool's telegram path) only reach `send_document` for files whose extension is NOT in `_IMAGE_EXTS`. Skills can't currently override this from the response side.

This is independent of #15728 / #15837 / #18444 (which handle Telegram-server-side rejections via `Photo_invalid_dimensions`); those fix the case where Telegram gives up on a photo. **This PR fixes the case where the photo path succeeds but compresses too aggressively for the use case.**

## What

Adds an `[[as_document]]` directive that mirrors the existing `[[audio_as_voice]]` shape:

```
信息图已生成（高密度模块 × 实验室波普 × 横版）
[[as_document]]
MEDIA:/private/tmp/info-graph-x/infographic.jpg
```

When the directive is present in the agent's response, every image-extension MEDIA: file in that response routes through `send_document` instead of `send_multiple_images` / `sendPhoto`. Telegram's sendDocument doesn't recompress, so the original 1MB JPEG arrives intact.

The directive is detected at the dispatch sites (which see the raw response) and the directive string is stripped from user-visible cleaned text in `extract_media`, so it never leaks into the user's chat.

## Scope

- All-or-nothing per response (matches `[[audio_as_voice]]`'s scope). Skills that need fine control can split into two responses.
- Patches three dispatch paths: `BasePlatformAdapter._process_message_background`, `GatewayRunner._deliver_media_from_response`, and `send_message` tool's `_send_telegram` / `_send_to_platform`. The first two fix the agent's normal response path; the third fixes when an agent calls `send_message(target='telegram', message='[[as_document]]\n...')` explicitly.
- Telegram is the immediate beneficiary. Discord/Slack/Mattermost/Email send_multiple_images implementations don't recompress on upload, so they're unaffected; the directive is harmlessly honored on those platforms via the same `_image_paths` → `_non_image_media` swap.

## Tests

`+3` cases in `TestExtractMedia`:
- directive stripped from cleaned text
- directive doesn't entangle with `[[audio_as_voice]]`
- both directives can coexist in one response

All 113 pre-existing media/extract/send tests still pass.

## Verification

Tested locally with info-graph (https://github.com/leon7609/info-graph v0.2.2 emits the directive on every successful render). Before patch: 3840×2160 JPG → Telegram delivers compressed photo at ~1280px. After patch: same source → Telegram delivers original 1MB JPEG via `sendDocument`, fully legible.
