### PR TITLE
fix: drop malformed image data URLs before provider calls

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -18,6 +18,7 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+from agent.image_data_url import INVALID_IMAGE_ATTACHMENT_NOTE, sanitize_image_data_url
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,13 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
                 url = image_ref
             if not isinstance(url, str) or not url:
                 continue
-            image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+            sanitized_url, removed = sanitize_image_data_url(url)
+            if removed:
+                converted.append({"type": text_type, "text": INVALID_IMAGE_ATTACHMENT_NOTE})
+                continue
+            if not isinstance(sanitized_url, str) or not sanitized_url:
+                continue
+            image_part: Dict[str, Any] = {"type": "input_image", "image_url": sanitized_url}
             if isinstance(detail, str) and detail.strip():
                 image_part["detail"] = detail.strip()
             converted.append(image_part)
@@ -578,7 +585,13 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                             url = image_ref
                         if not isinstance(url, str):
                             url = str(url or "")
-                        image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+                        sanitized_url, removed = sanitize_image_data_url(url)
+                        if removed:
+                            validated.append({"type": text_type, "text": INVALID_IMAGE_ATTACHMENT_NOTE})
+                            continue
+                        if not isinstance(sanitized_url, str) or not sanitized_url:
+                            continue
+                        image_part: Dict[str, Any] = {"type": "input_image", "image_url": sanitized_url}
                         if isinstance(detail, str) and detail.strip():
                             image_part["detail"] = detail.strip()
                         validated.append(image_part)

--- a/agent/image_data_url.py
+++ b/agent/image_data_url.py
@@ -1,0 +1,113 @@
+"""Helpers for validating and sanitizing image data URLs.
+
+Native multimodal routing stores local images as ``data:image/*;base64,...``
+URLs.  Providers validate those payloads strictly; a malformed or truncated
+image in persisted history can make every subsequent turn fail with a
+non-retryable HTTP 400.  Keep this module small and side-effect free so provider
+adapters can sanitize per-call copies without mutating persisted sessions.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from typing import Optional, Tuple
+
+
+INVALID_IMAGE_ATTACHMENT_NOTE = "[Invalid image attachment removed before API call]"
+
+_DATA_IMAGE_RE = re.compile(r"^data:(image/[A-Za-z0-9.+-]+)(?:;[^,]*)?;base64,", re.IGNORECASE)
+
+
+def detect_image_mime(data: bytes) -> Optional[str]:
+    """Return the MIME type implied by known image magic bytes, if any."""
+    if not isinstance(data, (bytes, bytearray)) or len(data) < 2:
+        return None
+    raw = bytes(data)
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    if raw.startswith(b"BM"):
+        return "image/bmp"
+    return None
+
+
+def is_supported_image_bytes(data: bytes) -> bool:
+    """True when *data* starts with a supported image magic-byte sequence."""
+    return detect_image_mime(data) is not None
+
+
+def _decode_base64_payload(payload: str) -> Optional[bytes]:
+    compact = "".join(str(payload or "").split())
+    if not compact:
+        return None
+    # Data URLs in the wild sometimes omit padding.  Accept that while keeping
+    # ``validate=True`` so non-base64 characters do not slip through.
+    compact += "=" * (-len(compact) % 4)
+    try:
+        return base64.b64decode(compact, validate=True)
+    except Exception:
+        return None
+
+
+def parse_image_data_url(url: str) -> Optional[Tuple[str, bytes, str]]:
+    """Parse a base64 image data URL into ``(declared_mime, bytes, payload)``.
+
+    Returns ``None`` when the URL is not a syntactically valid image data URL.
+    """
+    if not isinstance(url, str):
+        return None
+    match = _DATA_IMAGE_RE.match(url.strip())
+    if not match:
+        return None
+    declared_mime = match.group(1).lower()
+    payload = url.strip()[match.end():]
+    decoded = _decode_base64_payload(payload)
+    if decoded is None:
+        return None
+    return declared_mime, decoded, payload
+
+
+def sanitize_image_data_url(url: str) -> Tuple[Optional[str], bool]:
+    """Return ``(sanitized_url, removed)`` for an image URL value.
+
+    - Non-data URLs are returned unchanged.
+    - Valid image data URLs are returned unchanged unless the declared MIME does
+      not match the bytes, in which case only the MIME prefix is normalized.
+    - Malformed/unsupported image data URLs return ``(None, True)`` so callers
+      can replace them with a textual note instead of sending bad payloads to a
+      provider.
+    """
+    if not isinstance(url, str) or not url:
+        return url if isinstance(url, str) else None, False
+
+    stripped = url.strip()
+    if not stripped.lower().startswith("data:image/"):
+        return url, False
+
+    parsed = parse_image_data_url(stripped)
+    if parsed is None:
+        return None, True
+
+    declared_mime, decoded, payload = parsed
+    actual_mime = detect_image_mime(decoded)
+    if actual_mime is None:
+        return None, True
+
+    if declared_mime != actual_mime:
+        return f"data:{actual_mime};base64,{payload}", False
+    return stripped, False
+
+
+__all__ = [
+    "INVALID_IMAGE_ATTACHMENT_NOTE",
+    "detect_image_mime",
+    "is_supported_image_bytes",
+    "parse_image_data_url",
+    "sanitize_image_data_url",
+]

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -36,9 +36,10 @@ from __future__ import annotations
 
 import base64
 import logging
-import mimetypes
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+from agent.image_data_url import detect_image_mime
 
 logger = logging.getLogger(__name__)
 
@@ -144,23 +145,6 @@ def decide_image_input_mode(
 # it fires, which is cheaper than permanent quality loss.
 
 
-def _guess_mime(path: Path) -> str:
-    mime, _ = mimetypes.guess_type(str(path))
-    if mime and mime.startswith("image/"):
-        return mime
-    # mimetypes on some Linux distros mis-maps .jpg; default to jpeg when
-    # the suffix looks imagey.
-    suffix = path.suffix.lower()
-    return {
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".png": "image/png",
-        ".gif": "image/gif",
-        ".webp": "image/webp",
-        ".bmp": "image/bmp",
-    }.get(suffix, "image/jpeg")
-
-
 def _file_to_data_url(path: Path) -> Optional[str]:
     """Encode a local image as a base64 data URL at its native size.
 
@@ -170,15 +154,22 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     accept large images (OpenAI 49 MB+, Gemini 100 MB) don't pay a silent
     quality tax just because one other provider is stricter.
 
-    Returns None only if the file can't be read (missing, permission
-    denied, etc.); the caller reports those paths in ``skipped``.
+    Returns None if the file can't be read or does not start with a supported
+    image magic-byte sequence; the caller reports those paths in ``skipped``.
     """
     try:
         raw = path.read_bytes()
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)
         return None
-    mime = _guess_mime(path)
+    mime = detect_image_mime(raw)
+    if mime is None:
+        logger.warning(
+            "image_routing: skipping invalid image bytes at %s (size=%d)",
+            path,
+            len(raw),
+        )
+        return None
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from agent.image_data_url import detect_image_mime, sanitize_image_data_url
 from agent.image_routing import (
     _coerce_mode,
     _explicit_aux_vision_override,
@@ -120,6 +121,34 @@ def _png_bytes() -> bytes:
     )
 
 
+def _jpeg_bytes() -> bytes:
+    """Return minimal JPEG-like bytes with a valid magic-byte prefix."""
+    return b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01" + b"\x00" * 16
+
+
+# ─── image_data_url helpers ─────────────────────────────────────────────────
+
+
+def test_valid_png_and_jpeg_data_urls_pass_validation():
+    png_url = "data:image/png;base64," + base64.b64encode(_png_bytes()).decode("ascii")
+    jpeg_url = "data:image/jpeg;base64," + base64.b64encode(_jpeg_bytes()).decode("ascii")
+
+    assert detect_image_mime(_png_bytes()) == "image/png"
+    assert detect_image_mime(_jpeg_bytes()) == "image/jpeg"
+    assert sanitize_image_data_url(png_url) == (png_url, False)
+    assert sanitize_image_data_url(jpeg_url) == (jpeg_url, False)
+
+
+def test_malformed_jpeg_data_url_is_invalid():
+    # Observed bad persisted payloads started with base64 "EEpGSUY...", which
+    # decodes to bytes beginning 10 4a 46 49 46 instead of JPEG ff d8 ff.
+    bad_bytes = b"\x10JFIF\x00\x01\x01\x01"
+    bad_url = "data:image/jpeg;base64," + base64.b64encode(bad_bytes).decode("ascii")
+
+    assert bad_url.startswith("data:image/jpeg;base64,EEpGSUY")
+    assert sanitize_image_data_url(bad_url) == (None, True)
+
+
 class TestBuildNativeContentParts:
     def test_text_then_image(self, tmp_path: Path):
         img = tmp_path / "cat.png"
@@ -158,19 +187,27 @@ class TestBuildNativeContentParts:
         image_parts = [p for p in parts if p.get("type") == "image_url"]
         assert len(image_parts) == 2
 
-    def test_mime_inference_jpg(self, tmp_path: Path):
+    def test_mime_comes_from_bytes_not_extension_jpg(self, tmp_path: Path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(_png_bytes())  # bytes are PNG but extension is jpg
         parts, _ = build_native_content_parts("x", [str(img)])
         url = parts[1]["image_url"]["url"]
-        assert url.startswith("data:image/jpeg;base64,")
+        assert url.startswith("data:image/png;base64,")
 
-    def test_mime_inference_webp(self, tmp_path: Path):
+    def test_mime_comes_from_bytes_not_extension_webp(self, tmp_path: Path):
         img = tmp_path / "pic.webp"
         img.write_bytes(_png_bytes())
         parts, _ = build_native_content_parts("", [str(img)])
         url = parts[1]["image_url"]["url"]
-        assert url.startswith("data:image/webp;base64,")
+        assert url.startswith("data:image/png;base64,")
+
+    def test_invalid_image_file_is_skipped(self, tmp_path: Path):
+        img = tmp_path / "bad.jpg"
+        img.write_bytes(b"\x10JFIF\x00\x01\x01\x01")
+        parts, skipped = build_native_content_parts("hi", [str(img)])
+
+        assert skipped == [str(img)]
+        assert parts == [{"type": "text", "text": "hi"}]
 
 
 # ─── Oversize handling ───────────────────────────────────────────────────────

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,4 @@
+import base64
 import sys
 import types
 from types import SimpleNamespace
@@ -196,6 +197,19 @@ def _codex_request_kwargs():
         "tools": None,
         "store": False,
     }
+
+
+def _valid_png_data_url():
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABpfZFQAAAAABJRU5ErkJggg=="
+    )
+    return "data:image/png;base64," + base64.b64encode(png_bytes).decode("ascii")
+
+
+def _invalid_jpeg_data_url():
+    # Observed corrupted persisted payloads started with "EEpGSUY...".
+    bad_bytes = b"\x10JFIF\x00\x01\x01\x01"
+    return "data:image/jpeg;base64," + base64.b64encode(bad_bytes).decode("ascii")
 
 
 def test_api_mode_uses_explicit_provider_when_codex(monkeypatch):
@@ -780,6 +794,103 @@ def test_chat_messages_to_responses_input_accepts_call_pipe_fc_ids(monkeypatch):
     assert function_call["call_id"] == "call_pair123"
     assert "id" not in function_call
     assert function_output["call_id"] == "call_pair123"
+
+
+def test_chat_messages_to_responses_input_replaces_invalid_image_data_url(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+    from agent.image_data_url import INVALID_IMAGE_ATTACHMENT_NOTE
+
+    bad_url = _invalid_jpeg_data_url()
+    assert bad_url.startswith("data:image/jpeg;base64,EEpGSUY")
+
+    items = _chat_messages_to_responses_input(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "antes"},
+                    {"type": "image_url", "image_url": {"url": bad_url}},
+                    {"type": "text", "text": "depois"},
+                ],
+            }
+        ]
+    )
+
+    assert items == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "antes"},
+                {"type": "input_text", "text": INVALID_IMAGE_ATTACHMENT_NOTE},
+                {"type": "input_text", "text": "depois"},
+            ],
+        }
+    ]
+    assert bad_url not in str(items)
+
+
+def test_preflight_codex_api_kwargs_preserves_valid_image_data_url(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    png_url = _valid_png_data_url()
+    preflight = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "veja"},
+                        {"type": "input_image", "image_url": png_url},
+                    ],
+                }
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    assert preflight["input"][0]["content"] == [
+        {"type": "input_text", "text": "veja"},
+        {"type": "input_image", "image_url": png_url},
+    ]
+
+
+def test_preflight_codex_api_kwargs_replaces_invalid_image_data_url(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+    from agent.image_data_url import INVALID_IMAGE_ATTACHMENT_NOTE
+
+    bad_url = _invalid_jpeg_data_url()
+    preflight = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "antes"},
+                        {"type": "input_image", "image_url": bad_url},
+                        {"type": "input_text", "text": "depois"},
+                    ],
+                }
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    content = preflight["input"][0]["content"]
+    assert content == [
+        {"type": "input_text", "text": "antes"},
+        {"type": "input_text", "text": INVALID_IMAGE_ATTACHMENT_NOTE},
+        {"type": "input_text", "text": "depois"},
+    ]
+    assert bad_url not in str(content)
 
 
 def test_preflight_codex_api_kwargs_strips_optional_function_call_id(monkeypatch):


### PR DESCRIPTION
## Summary
- Validate image data URLs by base64 decoding and checking image magic bytes before provider calls.
- Replace malformed persisted `data:image/*;base64,...` image parts with `[Invalid image attachment removed before API call]` so surrounding user text still reaches the Responses/Codex backend.
- Validate local image bytes before creating native image data URLs, so non-image/corrupt files are skipped instead of being encoded from their extension.

## Why
A malformed persisted native image part such as `data:image/jpeg;base64,EEpGSUY...` decodes to bytes beginning `10 4a 46 49 46` instead of a valid JPEG magic prefix (`ff d8 ff`). When this contaminated history is replayed to the OpenAI Responses/Codex path, the provider rejects the request with HTTP 400 and Hermes falls back repeatedly on later turns.

## Test plan
- `python -m py_compile agent/image_data_url.py agent/image_routing.py agent/codex_responses_adapter.py tests/agent/test_image_routing.py tests/run_agent/test_run_agent_codex_responses.py`
- `python -m pytest tests/agent/test_image_routing.py tests/run_agent/test_run_agent_codex_responses.py`

Note: running the bare `pytest` console script in this worktree currently fails because its shebang points to a missing old `.venv`; `python -m pytest` works and passed.
