### PR TITLE
feat(gateway): add video_processing config with size limit and ffmpeg path

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -409,6 +409,9 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
 
+    # Video processing settings
+    video_processing: dict = field(default_factory=lambda: {"enabled": True, "max_size_mb": 500, "ffmpeg_path": "ffmpeg"})
+
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
     thread_sessions_per_user: bool = False  # When False (default), threads are shared across all participants
@@ -573,6 +576,10 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        video_processing = data.get("video_processing", {})
+        if not isinstance(video_processing, dict):
+            video_processing = {}
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -588,6 +595,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            video_processing=video_processing,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -958,6 +966,11 @@ def load_gateway_config() -> GatewayConfig:
             _home / "config.yaml",
             e,
         )
+
+    # Video processing: read from config.yaml, default to enabled.
+    vp_cfg = yaml_cfg.get("video_processing")
+    if isinstance(vp_cfg, dict):
+        gw_data["video_processing"] = vp_cfg
 
     config = GatewayConfig.from_dict(gw_data)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5431,12 +5431,16 @@ class GatewayRunner:
         if event.media_urls:
             image_paths = []
             audio_paths = []
+            video_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
                 if mtype.startswith("audio/") or event.message_type in (MessageType.VOICE, MessageType.AUDIO):
                     audio_paths.append(path)
+
+                if mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
+                    video_paths.append(path)
 
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
@@ -5496,6 +5500,13 @@ class GatewayRunner:
                             )
                         except Exception:
                             pass
+
+
+            if video_paths:
+                message_text = await self._enrich_message_with_video(
+                    message_text,
+                    video_paths,
+                )
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
@@ -10626,6 +10637,155 @@ class GatewayRunner:
         # Combine: vision descriptions first, then the user's original text
         if enriched_parts:
             prefix = "\n\n".join(enriched_parts)
+            if user_text:
+                return f"{prefix}\n\n{user_text}"
+            return prefix
+        return user_text
+
+    async def _extract_video_components(
+        self,
+        video_path: str,
+    ) -> tuple:
+        """Extract audio track and keyframes from a video file using ffmpeg.
+
+        Returns:
+            (audio_path, frame_paths) — audio_path may be None if extraction
+            fails; frame_paths is a list of JPEG paths (may be empty).
+        """
+        import subprocess
+        import tempfile
+
+        _tmp_dir = tempfile.mkdtemp(prefix="hermes_video_")
+        audio_out = os.path.join(_tmp_dir, "audio.wav")
+        frame_pattern = os.path.join(_tmp_dir, "frame_%03d.jpg")
+
+        audio_path = None
+        frame_paths: list = []
+
+        # --- Extract audio track ---
+        try:
+            proc = await asyncio.to_thread(
+                subprocess.run,
+                [
+                    "ffmpeg", "-i", video_path,
+                    "-vn", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1",
+                    "-y", audio_out,
+                ],
+                capture_output=True, timeout=120,
+            )
+            if proc.returncode == 0 and os.path.isfile(audio_out) and os.path.getsize(audio_out) > 44:
+                audio_path = audio_out
+            else:
+                logger.debug("ffmpeg audio extraction returned %d or empty file", proc.returncode)
+        except FileNotFoundError:
+            logger.warning("ffmpeg not found — cannot extract audio from video")
+        except subprocess.TimeoutExpired:
+            logger.warning("ffmpeg audio extraction timed out for %s", video_path)
+        except Exception:
+            logger.debug("ffmpeg audio extraction failed", exc_info=True)
+
+        # --- Extract keyframes (I-frames first, then fallback to fps sampling) ---
+        for vf_filter in ["select=eq(pict_type\\,I)", "fps=1/10"]:
+            try:
+                proc = await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        "ffmpeg", "-i", video_path,
+                        "-vf", vf_filter,
+                        "-frames:v", "3", "-vsync", "vfr",
+                        "-y", frame_pattern,
+                    ],
+                    capture_output=True, timeout=120,
+                )
+                # Collect any frames that were written
+                for idx in range(1, 4):
+                    fp = os.path.join(_tmp_dir, f"frame_{idx:03d}.jpg")
+                    if os.path.isfile(fp) and os.path.getsize(fp) > 0:
+                        frame_paths.append(fp)
+                if frame_paths:
+                    break  # Got frames, skip fallback
+            except FileNotFoundError:
+                logger.warning("ffmpeg not found — cannot extract frames from video")
+                break
+            except subprocess.TimeoutExpired:
+                logger.warning("ffmpeg frame extraction timed out for %s", video_path)
+                break
+            except Exception:
+                logger.debug("ffmpeg frame extraction failed", exc_info=True)
+                break
+
+        return audio_path, frame_paths
+
+    async def _enrich_message_with_video(
+        self,
+        user_text: str,
+        video_paths: list,
+    ) -> str:
+        """Process inbound video messages by extracting audio + keyframes.
+
+        Audio is transcribed via the STT pipeline; keyframes are analyzed via
+        the vision pipeline.  If ffmpeg is unavailable the user gets a graceful
+        note instead of a silent drop.
+        """
+        import shutil
+
+        enriched_parts: list = []
+        _tmp_dirs_to_clean: list = []
+
+        for vpath in video_paths:
+            logger.info("Processing inbound video: %s", vpath)
+            audio_path, frame_paths = await self._extract_video_components(vpath)
+
+            # Track temp dir for cleanup
+            if audio_path:
+                _tmp_dirs_to_clean.append(os.path.dirname(audio_path))
+            elif frame_paths:
+                _tmp_dirs_to_clean.append(os.path.dirname(frame_paths[0]))
+
+            if not audio_path and not frame_paths:
+                enriched_parts.append(
+                    "[The user sent a video but it could not be processed. "
+                    "ffmpeg may not be installed or the video format is unsupported.]"
+                )
+                continue
+
+            # Transcribe audio track
+            if audio_path:
+                try:
+                    _video_audio_text = await self._enrich_message_with_transcription(
+                        "",
+                        [audio_path],
+                    )
+                    if _video_audio_text.strip():
+                        enriched_parts.append(
+                            f"[Video audio transcription: {_video_audio_text.strip()}]"
+                        )
+                except Exception:
+                    logger.debug("Video audio transcription failed", exc_info=True)
+
+            # Analyze keyframes
+            if frame_paths:
+                try:
+                    _video_vision_text = await self._enrich_message_with_vision(
+                        "",
+                        frame_paths,
+                    )
+                    if _video_vision_text.strip():
+                        enriched_parts.append(
+                            f"[Video visual analysis: {_video_vision_text.strip()}]"
+                        )
+                except Exception:
+                    logger.debug("Video frame analysis failed", exc_info=True)
+
+        # Cleanup temp dirs
+        for td in _tmp_dirs_to_clean:
+            try:
+                shutil.rmtree(td, ignore_errors=True)
+            except Exception:
+                pass
+
+        if enriched_parts:
+            prefix = "\n".join(enriched_parts)
             if user_text:
                 return f"{prefix}\n\n{user_text}"
             return prefix

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10757,7 +10757,8 @@ class GatewayRunner:
             logger.info("Processing inbound video: %s", vpath)
             audio_path, frame_paths = await self._extract_video_components(vpath)
 
-            # Track temp dir for cleanup
+            # Audio and frame files share the same temp dir — track it once
+            # so shutil.rmtree can clean everything.
             if audio_path:
                 _tmp_dirs_to_clean.append(os.path.dirname(audio_path))
             elif frame_paths:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10655,6 +10655,22 @@ class GatewayRunner:
         import subprocess
         import tempfile
 
+        # Read config: ffmpeg path and size limit
+        vp = getattr(self.config, "video_processing", {}) or {}
+        ffmpeg_bin = vp.get("ffmpeg_path", "ffmpeg")
+        max_bytes = (vp.get("max_size_mb", 500) or 500) * 1024 * 1024
+
+        # Pre-check: skip videos over the size limit
+        try:
+            if os.path.getsize(video_path) > max_bytes:
+                logger.warning(
+                    "Skipping video %s (%d bytes > %d limit)",
+                    video_path, os.path.getsize(video_path), max_bytes,
+                )
+                return None, []
+        except OSError:
+            logger.debug("Cannot stat video %s", video_path)
+
         _tmp_dir = tempfile.mkdtemp(prefix="hermes_video_")
         audio_out = os.path.join(_tmp_dir, "audio.wav")
         frame_pattern = os.path.join(_tmp_dir, "frame_%03d.jpg")
@@ -10667,7 +10683,7 @@ class GatewayRunner:
             proc = await asyncio.to_thread(
                 subprocess.run,
                 [
-                    "ffmpeg", "-i", video_path,
+                    ffmpeg_bin, "-i", video_path,
                     "-vn", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1",
                     "-y", audio_out,
                 ],
@@ -10690,7 +10706,7 @@ class GatewayRunner:
                 proc = await asyncio.to_thread(
                     subprocess.run,
                     [
-                        "ffmpeg", "-i", video_path,
+                        ffmpeg_bin, "-i", video_path,
                         "-vf", vf_filter,
                         "-frames:v", "3", "-vsync", "vfr",
                         "-y", frame_pattern,
@@ -10728,6 +10744,11 @@ class GatewayRunner:
         note instead of a silent drop.
         """
         import shutil
+
+        # Check config: skip if video processing is disabled
+        vp = getattr(self.config, "video_processing", {}) or {}
+        if not vp.get("enabled", True):
+            return user_text
 
         enriched_parts: list = []
         _tmp_dirs_to_clean: list = []

--- a/tests/gateway/test_video_media_processing.py
+++ b/tests/gateway/test_video_media_processing.py
@@ -1,0 +1,165 @@
+"""Tests for inbound video media processing in the gateway.
+
+Covers the video_paths routing in the media loop and the
+_extract_video_components / _enrich_message_with_video helpers.
+"""
+
+import asyncio
+import os
+import subprocess
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(media_urls=None, media_types=None, message_type=MessageType.TEXT, text=""):
+    """Build a minimal MessageEvent for testing."""
+    evt = MagicMock(spec=MessageEvent)
+    evt.text = text
+    evt.message_type = message_type
+    evt.media_urls = media_urls or []
+    evt.media_types = media_types or []
+    return evt
+
+
+# ---------------------------------------------------------------------------
+# Media-loop routing tests (unit-level, no I/O)
+# ---------------------------------------------------------------------------
+
+class TestVideoMediaRouting:
+    """Verify that video/* MIME types and MessageType.VIDEO are routed correctly."""
+
+    def test_video_mime_detected(self):
+        """video/mp4 should be classified into video_paths."""
+        image_paths = []
+        audio_paths = []
+        video_paths = []
+        media_urls = ["/tmp/clip.mp4"]
+        media_types = ["video/mp4"]
+
+        for i, path in enumerate(media_urls):
+            mtype = media_types[i] if i < len(media_types) else ""
+            if mtype.startswith("image/") or False:
+                image_paths.append(path)
+            if mtype.startswith("audio/") or False:
+                audio_paths.append(path)
+            if mtype.startswith("video/") or False:
+                video_paths.append(path)
+
+        assert video_paths == ["/tmp/clip.mp4"]
+        assert not image_paths
+        assert not audio_paths
+
+    def test_video_message_type_detected(self):
+        """MessageType.VIDEO should route to video_paths even without MIME."""
+        evt = _make_event(
+            media_urls=["/tmp/clip.mov"],
+            media_types=[""],
+            message_type=MessageType.VIDEO,
+        )
+
+        video_paths = []
+        for i, path in enumerate(evt.media_urls):
+            mtype = evt.media_types[i] if i < len(evt.media_types) else ""
+            if mtype.startswith("video/") or evt.message_type == MessageType.VIDEO:
+                video_paths.append(path)
+
+        assert video_paths == ["/tmp/clip.mov"]
+
+    def test_mixed_media_routing(self):
+        """Mixed image + video + audio should each go to the right bucket."""
+        urls = ["/tmp/pic.jpg", "/tmp/clip.mp4", "/tmp/voice.ogg"]
+        types = ["image/jpeg", "video/mp4", "audio/ogg"]
+
+        image_paths, audio_paths, video_paths = [], [], []
+        for i, path in enumerate(urls):
+            mtype = types[i]
+            if mtype.startswith("image/"):
+                image_paths.append(path)
+            if mtype.startswith("audio/"):
+                audio_paths.append(path)
+            if mtype.startswith("video/"):
+                video_paths.append(path)
+
+        assert len(image_paths) == 1
+        assert len(audio_paths) == 1
+        assert len(video_paths) == 1
+
+
+# ---------------------------------------------------------------------------
+# _extract_video_components tests
+# ---------------------------------------------------------------------------
+
+class TestExtractVideoComponents:
+    """Test ffmpeg-based extraction (mocked subprocess)."""
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_not_found_graceful(self):
+        """When ffmpeg is missing, should return (None, []) without raising."""
+        from gateway.run import GatewayRunner
+
+        app = MagicMock(spec=GatewayRunner)
+        app._extract_video_components = GatewayRunner._extract_video_components.__get__(app)
+
+        with patch("asyncio.to_thread", side_effect=FileNotFoundError("ffmpeg")):
+            audio, frames = await app._extract_video_components("/tmp/fake.mp4")
+
+        assert audio is None
+        assert frames == []
+
+    @pytest.mark.asyncio
+    async def test_audio_extraction_timeout(self):
+        """Timeout during audio extraction should be handled gracefully."""
+        from gateway.run import GatewayRunner
+
+        app = MagicMock(spec=GatewayRunner)
+        app._extract_video_components = GatewayRunner._extract_video_components.__get__(app)
+
+        with patch("asyncio.to_thread", side_effect=subprocess.TimeoutExpired("ffmpeg", 120)):
+            audio, frames = await app._extract_video_components("/tmp/fake.mp4")
+
+        assert audio is None
+        assert frames == []
+
+
+# ---------------------------------------------------------------------------
+# _enrich_message_with_video tests
+# ---------------------------------------------------------------------------
+
+class TestEnrichMessageWithVideo:
+    """Test the high-level video enrichment method."""
+
+    @pytest.mark.asyncio
+    async def test_no_ffmpeg_returns_fallback_note(self):
+        """When extraction fails completely, user gets a note."""
+        from gateway.run import GatewayRunner
+
+        app = MagicMock(spec=GatewayRunner)
+        app._enrich_message_with_video = GatewayRunner._enrich_message_with_video.__get__(app)
+        app._extract_video_components = AsyncMock(return_value=(None, []))
+
+        result = await app._enrich_message_with_video("hello", ["/tmp/clip.mp4"])
+        assert "could not be processed" in result
+        assert "hello" in result
+
+    @pytest.mark.asyncio
+    async def test_audio_only_enrichment(self):
+        """When only audio is extracted, transcription is prepended."""
+        from gateway.run import GatewayRunner
+
+        app = MagicMock(spec=GatewayRunner)
+        app._enrich_message_with_video = GatewayRunner._enrich_message_with_video.__get__(app)
+        app._extract_video_components = AsyncMock(return_value=("/tmp/audio.wav", []))
+        app._enrich_message_with_transcription = AsyncMock(return_value="Hello world")
+        app._enrich_message_with_vision = AsyncMock(return_value="")
+
+        result = await app._enrich_message_with_video("", ["/tmp/clip.mp4"])
+        assert "transcription" in result.lower() or "Hello world" in result
+        app._enrich_message_with_transcription.assert_called_once()

--- a/tests/gateway/test_video_media_processing.py
+++ b/tests/gateway/test_video_media_processing.py
@@ -107,8 +107,9 @@ class TestExtractVideoComponents:
 
         app = MagicMock(spec=GatewayRunner)
         app._extract_video_components = GatewayRunner._extract_video_components.__get__(app)
+        app.config = MagicMock(video_processing={"enabled": True, "ffmpeg_path": "ffmpeg", "max_size_mb": 500})
 
-        with patch("asyncio.to_thread", side_effect=FileNotFoundError("ffmpeg")):
+        with patch("subprocess.run", side_effect=FileNotFoundError("ffmpeg")):
             audio, frames = await app._extract_video_components("/tmp/fake.mp4")
 
         assert audio is None
@@ -121,6 +122,7 @@ class TestExtractVideoComponents:
 
         app = MagicMock(spec=GatewayRunner)
         app._extract_video_components = GatewayRunner._extract_video_components.__get__(app)
+        app.config = MagicMock(video_processing={"enabled": True, "ffmpeg_path": "ffmpeg", "max_size_mb": 500})
 
         with patch("asyncio.to_thread", side_effect=subprocess.TimeoutExpired("ffmpeg", 120)):
             audio, frames = await app._extract_video_components("/tmp/fake.mp4")
@@ -144,6 +146,7 @@ class TestEnrichMessageWithVideo:
         app = MagicMock(spec=GatewayRunner)
         app._enrich_message_with_video = GatewayRunner._enrich_message_with_video.__get__(app)
         app._extract_video_components = AsyncMock(return_value=(None, []))
+        app.config = MagicMock(video_processing={"enabled": True})
 
         result = await app._enrich_message_with_video("hello", ["/tmp/clip.mp4"])
         assert "could not be processed" in result
@@ -159,7 +162,76 @@ class TestEnrichMessageWithVideo:
         app._extract_video_components = AsyncMock(return_value=("/tmp/audio.wav", []))
         app._enrich_message_with_transcription = AsyncMock(return_value="Hello world")
         app._enrich_message_with_vision = AsyncMock(return_value="")
+        app.config = MagicMock(video_processing={"enabled": True})
 
         result = await app._enrich_message_with_video("", ["/tmp/clip.mp4"])
         assert "transcription" in result.lower() or "Hello world" in result
         app._enrich_message_with_transcription.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_full_extraction_enriches_both(self):
+        """Audio + frames -> transcription + vision both prepended."""
+        import tempfile
+        from pathlib import Path
+        from gateway.run import GatewayRunner
+
+        app = MagicMock(spec=GatewayRunner)
+        app._enrich_message_with_video = GatewayRunner._enrich_message_with_video.__get__(app)
+        app._enrich_message_with_transcription = AsyncMock(return_value="hello world")
+        app._enrich_message_with_vision = AsyncMock(return_value="a red lobster")
+
+        td = tempfile.mkdtemp()
+        audio = os.path.join(td, "audio.wav")
+        frame = os.path.join(td, "frame.jpg")
+        Path(audio).touch()
+        Path(frame).touch()
+        app._extract_video_components = AsyncMock(return_value=(audio, [frame]))
+
+        # Mock config for video_processing
+        app.config = MagicMock()
+        app.config.video_processing = {"enabled": True}
+
+        result = await app._enrich_message_with_video("user text", ["/tmp/clip.mp4"])
+        app._enrich_message_with_transcription.assert_called_once()
+        app._enrich_message_with_vision.assert_called_once()
+        assert "hello world" in result
+        assert "a red lobster" in result
+        assert "user text" in result
+
+
+class TestExtractVideoComponentsIntegration:
+    """Integration tests that exercise real ffmpeg."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not __import__("shutil").which("ffmpeg"),
+        reason="ffmpeg not installed",
+    )
+    async def test_ffmpeg_real_extraction(self):
+        """End-to-end: create a real tiny video, extract audio + frames."""
+        import shutil
+        import subprocess
+        import tempfile
+        from gateway.run import GatewayRunner
+
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            video = os.path.join(tmp_dir, "test.mp4")
+            subprocess.run(
+                ["ffmpeg", "-f", "lavfi",
+                 "-i", "testsrc=duration=1:size=320x240:rate=10",
+                 "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+                 "-t", "1", "-y", video],
+                check=True, capture_output=True,
+            )
+
+            app = MagicMock(spec=GatewayRunner)
+            app._extract_video_components = GatewayRunner._extract_video_components.__get__(app)
+            app.config = MagicMock()
+            app.config.video_processing = {"ffmpeg_path": "ffmpeg", "max_size_mb": 500}
+
+            audio, frames = await app._extract_video_components(video)
+            assert audio and os.path.getsize(audio) > 44
+            assert len(frames) >= 1
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Builds on #18243 by @luyao618 — inbound video messages via ffmpeg extraction. Adds a `video_processing` gateway config block with size limiting and configurable ffmpeg path, plus two new tests (mock orchestration and real ffmpeg integration).

## What This Adds (on top of #18243)

### Config block

```yaml
# gateway:
video_processing:
  enabled: true        # default
  max_size_mb: 500     # default — skip videos larger than this
  ffmpeg_path: ffmpeg  # default — custom path to ffmpeg binary
```

When `enabled: false`, video processing is skipped entirely.

### Size guard

Videos over `max_size_mb` are skipped before ffmpeg is launched, preventing timeout on large files.

### Configurable ffmpeg path

`_extract_video_components` reads `ffmpeg_path` from config instead of hardcoding `"ffmpeg"`.

### Tests

- Mock orchestration test — verifies that successful extraction calls both enrichment pipelines and formats output correctly.
- Real ffmpeg integration test — creates a test video with lavfi `testsrc` + `sine`, extracts audio and frames, asserts valid output.

## Files changed

| File | Change |
|---|---|
| `gateway/config.py` | `video_processing` dict field on `GatewayConfig`, parsing in `from_dict()`, YAML mapping in `load_gateway_config()` |
| `gateway/run.py` | Config reads in `_enrich_message_with_video` (early return if disabled) and `_extract_video_components` (ffmpeg_path, max_size_mb guard) |
| `tests/gateway/test_video_media_processing.py` | +2 tests, config mocks on existing tests |

## Credits

Foundation: @luyao618's ffmpeg extraction pipeline from #18243.