### PR TITLE
feat(api_server): add /api/config/persona + /api/config/toolsets endpoints

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2260,6 +2260,96 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": str(e)}, status=500)
 
     # ------------------------------------------------------------------
+    # Config endpoints — persona (SOUL.md) + toolsets list
+    # ------------------------------------------------------------------
+
+    _MAX_PERSONA_LENGTH = 50_000  # SOUL.md is a system prompt; cap defensive
+    _TOOLSET_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+    async def _handle_get_persona(self, request: "web.Request") -> "web.Response":
+        """GET /api/config/persona — return SOUL.md contents (empty string if missing)."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            from hermes_constants import get_hermes_home
+            soul_path = get_hermes_home() / "SOUL.md"
+            content = soul_path.read_text(encoding="utf-8") if soul_path.exists() else ""
+            return web.json_response({"persona": content})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def _handle_set_persona(self, request: "web.Request") -> "web.Response":
+        """PUT /api/config/persona — overwrite SOUL.md with the provided content."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+            content = body.get("persona", "")
+            if not isinstance(content, str):
+                return web.json_response(
+                    {"error": "persona must be a string"}, status=400,
+                )
+            if len(content) > self._MAX_PERSONA_LENGTH:
+                return web.json_response(
+                    {"error": f"persona must be ≤ {self._MAX_PERSONA_LENGTH} characters"},
+                    status=400,
+                )
+            from hermes_constants import get_hermes_home
+            soul_path = get_hermes_home() / "SOUL.md"
+            soul_path.parent.mkdir(parents=True, exist_ok=True)
+            soul_path.write_text(content, encoding="utf-8")
+            return web.json_response({"ok": True, "persona": content})
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def _handle_get_toolsets(self, request: "web.Request") -> "web.Response":
+        """GET /api/config/toolsets — return the enabled-toolsets list from config.yaml."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            from hermes_cli.config import load_config
+            config = load_config()
+            toolsets = config.get("toolsets", [])
+            if not isinstance(toolsets, list):
+                toolsets = []
+            return web.json_response({"toolsets": toolsets})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def _handle_set_toolsets(self, request: "web.Request") -> "web.Response":
+        """PUT /api/config/toolsets — replace the enabled-toolsets list in config.yaml."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+            toolsets = body.get("toolsets")
+            if not isinstance(toolsets, list) or not all(
+                isinstance(t, str) and self._TOOLSET_KEY_RE.match(t) for t in toolsets
+            ):
+                return web.json_response(
+                    {"error": "toolsets must be a list of [a-zA-Z0-9_-]+ strings"},
+                    status=400,
+                )
+            # De-duplicate while preserving order
+            seen: set = set()
+            deduped = [t for t in toolsets if not (t in seen or seen.add(t))]
+            from hermes_cli.config import load_config, save_config
+            config = load_config()
+            config["toolsets"] = deduped
+            save_config(config)
+            return web.json_response({"ok": True, "toolsets": deduped})
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    # ------------------------------------------------------------------
     # Output extraction helper
     # ------------------------------------------------------------------
 
@@ -2795,6 +2885,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
             self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+            # Config CRUD — persona (SOUL.md) and enabled-toolsets list
+            self._app.router.add_get("/api/config/persona", self._handle_get_persona)
+            self._app.router.add_put("/api/config/persona", self._handle_set_persona)
+            self._app.router.add_get("/api/config/toolsets", self._handle_get_toolsets)
+            self._app.router.add_put("/api/config/toolsets", self._handle_set_toolsets)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2261,13 +2261,46 @@ class APIServerAdapter(BasePlatformAdapter):
 
     # ------------------------------------------------------------------
     # Config endpoints — persona (SOUL.md) + toolsets list
+    #
+    # All four handlers (GET/PUT persona, GET/PUT toolsets) gate on the
+    # existing ``_check_auth`` bearer-token middleware — same guard as
+    # ``/api/jobs/*``. When the api_server platform has no ``key`` configured
+    # the auth check no-ops (matching the rest of the surface), so behavior
+    # is identical to the existing 401-or-allow contract.
+    #
+    # Schema stability: response bodies are intentionally a thin pass-through
+    # of existing on-disk shapes:
+    #   - ``persona``  is the raw text contents of ``SOUL.md`` (string).
+    #   - ``toolsets`` is the list-of-strings under ``toolsets:`` in
+    #     ``config.yaml``, validated as ``^[a-zA-Z0-9_-]+$`` on PUT.
+    # No separate API version is introduced; these inherit whatever stability
+    # contract those config fields already have. If the underlying schema
+    # gains nested fields, the response body shape can grow (additive) without
+    # breaking existing clients.
+    #
+    # Reload behavior:
+    #   - PUT persona    → rewrites SOUL.md atomically. Picked up the next
+    #                     time an agent session starts (SOUL.md is loaded
+    #                     fresh per agent boot, not cached cross-session).
+    #                     In-flight conversations don't observe mid-session
+    #                     persona changes.
+    #   - PUT toolsets   → goes through ``hermes_cli.config.save_config``
+    #                     (atomic write); subsequent ``load_config`` calls
+    #                     re-read via mtime-based caching, so the next agent
+    #                     invocation in this gateway picks the new value up
+    #                     without a restart.
+    # If callers need true mid-session reload (rare), restart the gateway —
+    # there is no hot-swap of an active agent's persona/toolsets today.
     # ------------------------------------------------------------------
 
     _MAX_PERSONA_LENGTH = 50_000  # SOUL.md is a system prompt; cap defensive
     _TOOLSET_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
     async def _handle_get_persona(self, request: "web.Request") -> "web.Response":
-        """GET /api/config/persona — return SOUL.md contents (empty string if missing)."""
+        """GET /api/config/persona — return SOUL.md contents (empty string if missing).
+
+        Auth: bearer token via ``_check_auth`` (same as ``/api/jobs/*``).
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -2280,7 +2313,12 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": str(e)}, status=500)
 
     async def _handle_set_persona(self, request: "web.Request") -> "web.Response":
-        """PUT /api/config/persona — overwrite SOUL.md with the provided content."""
+        """PUT /api/config/persona — overwrite SOUL.md with the provided content.
+
+        Auth: bearer token via ``_check_auth``. Reload: takes effect on the
+        next agent session boot (SOUL.md is loaded fresh per session, not
+        hot-swapped into in-flight conversations).
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -2307,7 +2345,12 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": str(e)}, status=500)
 
     async def _handle_get_toolsets(self, request: "web.Request") -> "web.Response":
-        """GET /api/config/toolsets — return the enabled-toolsets list from config.yaml."""
+        """GET /api/config/toolsets — return the enabled-toolsets list from config.yaml.
+
+        Auth: bearer token via ``_check_auth``. Response shape is
+        ``{"toolsets": [str, ...]}`` — a thin pass-through of the
+        ``toolsets:`` field in ``config.yaml``.
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -2322,7 +2365,14 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": str(e)}, status=500)
 
     async def _handle_set_toolsets(self, request: "web.Request") -> "web.Response":
-        """PUT /api/config/toolsets — replace the enabled-toolsets list in config.yaml."""
+        """PUT /api/config/toolsets — replace the enabled-toolsets list in config.yaml.
+
+        Auth: bearer token via ``_check_auth``. Items validated against
+        ``^[a-zA-Z0-9_-]+$`` and de-duplicated server-side preserving order.
+        Reload: ``save_config`` writes atomically; next ``load_config`` call
+        in any agent invocation picks up the new value via mtime-based cache
+        (no gateway restart required for new sessions).
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err

--- a/tests/gateway/test_api_server_config.py
+++ b/tests/gateway/test_api_server_config.py
@@ -1,0 +1,330 @@
+"""
+Tests for the config endpoints on the API server adapter.
+
+Covers:
+- GET /api/config/persona  — read SOUL.md (returns "" when missing)
+- PUT /api/config/persona  — write SOUL.md, validate type/length
+- GET /api/config/toolsets — read toolsets list from config.yaml
+- PUT /api/config/toolsets — write toolsets list, validate items + de-dup
+- Auth enforcement (401 when key configured)
+- Bad JSON body handling
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/config/persona", adapter._handle_get_persona)
+    app.router.add_put("/api/config/persona", adapter._handle_set_persona)
+    app.router.add_get("/api/config/toolsets", adapter._handle_get_toolsets)
+    app.router.add_put("/api/config/toolsets", adapter._handle_set_toolsets)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+@pytest.fixture
+def auth_adapter():
+    return _make_adapter(api_key="sk-secret")
+
+
+# ---------------------------------------------------------------------------
+# Persona — GET
+# ---------------------------------------------------------------------------
+
+class TestGetPersona:
+    @pytest.mark.asyncio
+    async def test_returns_empty_string_when_missing(self, adapter, tmp_path):
+        soul_path = tmp_path / "SOUL.md"  # does not exist
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.get("/api/config/persona")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"persona": ""}
+        assert not soul_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_returns_file_contents(self, adapter, tmp_path):
+        soul_path = tmp_path / "SOUL.md"
+        soul_path.write_text("You are Hermes.", encoding="utf-8")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.get("/api/config/persona")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"persona": "You are Hermes."}
+
+
+# ---------------------------------------------------------------------------
+# Persona — PUT
+# ---------------------------------------------------------------------------
+
+class TestSetPersona:
+    @pytest.mark.asyncio
+    async def test_writes_file(self, adapter, tmp_path):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.put(
+                    "/api/config/persona", json={"persona": "Hello world"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"ok": True, "persona": "Hello world"}
+                assert (tmp_path / "SOUL.md").read_text() == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_dir(self, adapter, tmp_path):
+        nested = tmp_path / "profiles" / "p1"  # does not exist yet
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=nested):
+                resp = await cli.put("/api/config/persona", json={"persona": "x"})
+                assert resp.status == 200
+                assert (nested / "SOUL.md").read_text() == "x"
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string(self, adapter, tmp_path):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.put(
+                    "/api/config/persona", json={"persona": 123},
+                )
+                assert resp.status == 400
+                data = await resp.json()
+                assert "must be a string" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_too_long(self, adapter, tmp_path):
+        app = _create_app(adapter)
+        too_long = "x" * 60_000
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.put(
+                    "/api/config/persona", json={"persona": too_long},
+                )
+                assert resp.status == 400
+                data = await resp.json()
+                assert "≤" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_json(self, adapter, tmp_path):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.put(
+                    "/api/config/persona",
+                    data="not json",
+                    headers={"Content-Type": "application/json"},
+                )
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["error"] == "Invalid JSON body"
+
+
+# ---------------------------------------------------------------------------
+# Toolsets — GET
+# ---------------------------------------------------------------------------
+
+class TestGetToolsets:
+    @pytest.mark.asyncio
+    async def test_returns_list_from_config(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={"toolsets": ["hermes-cli", "web", "browser"]},
+            ):
+                resp = await cli.get("/api/config/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"toolsets": ["hermes-cli", "web", "browser"]}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_missing(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "hermes_cli.config.load_config", return_value={},
+            ):
+                resp = await cli.get("/api/config/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"toolsets": []}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_not_a_list(self, adapter):
+        # Config has ``toolsets: "everything"`` — bad shape on disk; coerce to []
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={"toolsets": "everything"},
+            ):
+                resp = await cli.get("/api/config/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"toolsets": []}
+
+
+# ---------------------------------------------------------------------------
+# Toolsets — PUT
+# ---------------------------------------------------------------------------
+
+class TestSetToolsets:
+    @pytest.mark.asyncio
+    async def test_writes_list(self, adapter):
+        app = _create_app(adapter)
+        captured = {}
+
+        def fake_save(cfg):
+            captured["cfg"] = cfg
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={"toolsets": ["hermes-cli"], "model": "x"},
+            ), patch(
+                "hermes_cli.config.save_config", side_effect=fake_save,
+            ):
+                resp = await cli.put(
+                    "/api/config/toolsets", json={"toolsets": ["web", "browser"]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"ok": True, "toolsets": ["web", "browser"]}
+                assert captured["cfg"]["toolsets"] == ["web", "browser"]
+                assert captured["cfg"]["model"] == "x"  # other keys preserved
+
+    @pytest.mark.asyncio
+    async def test_dedupes_preserving_order(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "hermes_cli.config.load_config", return_value={},
+            ), patch(
+                "hermes_cli.config.save_config",
+            ):
+                resp = await cli.put(
+                    "/api/config/toolsets",
+                    json={"toolsets": ["web", "browser", "web", "file"]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["toolsets"] == ["web", "browser", "file"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_list(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/config/toolsets", json={"toolsets": "web,browser"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string_items(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/config/toolsets", json={"toolsets": ["web", 5]},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_chars(self, adapter):
+        # Path-traversal / injection guard — keys are constrained to [a-zA-Z0-9_-]
+        app = _create_app(adapter)
+        for bad in ["web/file", "../etc", "with space", "semi;colon"]:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.put(
+                    "/api/config/toolsets", json={"toolsets": [bad]},
+                )
+                assert resp.status == 400, f"expected reject for {bad!r}"
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_json(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/config/toolsets",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement
+# ---------------------------------------------------------------------------
+
+class TestAuthEnforced:
+    @pytest.mark.asyncio
+    async def test_persona_get_unauth(self, auth_adapter, tmp_path):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/config/persona")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_persona_put_unauth(self, auth_adapter, tmp_path):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/config/persona", json={"persona": "x"},
+            )
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_toolsets_get_unauth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/config/toolsets")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_toolsets_put_unauth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/config/toolsets", json={"toolsets": ["web"]},
+            )
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_persona_get_with_correct_key(self, auth_adapter, tmp_path):
+        soul_path = tmp_path / "SOUL.md"
+        soul_path.write_text("hi", encoding="utf-8")
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+                resp = await cli.get(
+                    "/api/config/persona",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                assert (await resp.json()) == {"persona": "hi"}


### PR DESCRIPTION
## Summary

Today the API server platform exposes cron, chat, and runs surfaces but no config-style CRUD. The downstream effect is that Hermes Desktop's remote mode (where the renderer talks to a remote Hermes server instead of a local install) treats Persona, Tools, Memory, Skills, Profiles, Sessions, etc. as off-limits — its local IPC handlers do filesystem ops on `~/.hermes/...` and there's no remote equivalent.

This PR adds the two smallest such endpoints — Persona (SOUL.md) and the enabled-toolsets list:

```
GET  /api/config/persona   -> {"persona": "<SOUL.md contents or ''>"}
PUT  /api/config/persona   -> {"ok": true, "persona": "..."}    # writes SOUL.md
GET  /api/config/toolsets  -> {"toolsets": [...]}               # config.yaml -> "toolsets"
PUT  /api/config/toolsets  -> {"ok": true, "toolsets": [...]}   # writes config.yaml
```

Both reuse the existing `_check_auth()` bearer-token middleware. Persona reads/writes `get_hermes_home() / "SOUL.md"`. Toolsets goes through `hermes_cli.config.{load_config, save_config}` so we don't bypass migration / atomic-write / cache logic.

## Why these two first

Lowest-risk, highest-value config endpoints. Persona is literally `read SOUL.md / write SOUL.md`; toolsets is a list of strings in `config.yaml`. No new persistence, no new state machine, no new dependencies.

Once these land, the matching `fathah/hermes-desktop` screens (Persona, Tools) become ~30-line PRs that fork on `isRemoteMode()` and call these endpoints — the same pattern just used in [fathah/hermes-desktop#54](https://github.com/fathah/hermes-desktop/pull/54) for `/api/jobs`.

Happy to follow this with `/api/config/memory` (next-easiest after these two) if it lands well.

## Validation

- **Persona** — must be a string, ≤ 50,000 chars (defensive cap on a system prompt). Non-string → 400, oversized → 400, bad JSON body → 400.
- **Toolsets** — must be a list of strings matching `^[a-zA-Z0-9_-]+$`. Any non-conforming item → 400 (rejects path traversal, spaces, special chars). The list is de-duplicated server-side while preserving the caller's order; other config keys are preserved untouched on save.

## Tests

New `tests/gateway/test_api_server_config.py` — 21 tests, all pass:

- GET persona returns `""` when SOUL.md is missing; returns contents when present.
- PUT persona writes the file (creating parent dir if needed); rejects non-string, oversized, and malformed JSON bodies.
- GET toolsets returns the list; defaults to `[]` when missing or when the on-disk value isn't a list (defensive coerce).
- PUT toolsets writes the list, de-duplicates preserving order, preserves other config keys, rejects non-list payloads, non-string items, and path-traversal-y characters (`/`, `..`, spaces, semicolons).
- All four endpoints return 401 without the bearer token (when one is configured); one happy-path round-trip with a valid token.

Existing `test_api_server*.py` suites (171 tests) still pass.

## Manual e2e

Smoke-tested against a live `api_server` platform: all four endpoints round-trip cleanly, validation rejects malformed input with structured error bodies, 401 returns the existing OpenAI-style error envelope.

```
$ curl ... GET  /api/config/persona  -> {"persona":"You are Hermes Agent, ..."}
$ curl ... PUT  /api/config/persona  -> {"ok":true,"persona":"..."}
$ curl ... GET  /api/config/toolsets -> {"toolsets":["hermes-cli"]}
$ curl ... PUT  /api/config/toolsets -> {"ok":true,"toolsets":["hermes-cli","web"]}
$ curl ... PUT  /api/config/toolsets ['../../etc/passwd']
  -> 400 {"error":"toolsets must be a list of [a-zA-Z0-9_-]+ strings"}
$ curl ... PUT  /api/config/persona  (no auth header)
  -> 401 {"error":{"message":"Invalid API key", ...}}
```

## Test plan

- [x] `pytest tests/gateway/test_api_server_config.py` (21 pass)
- [x] `pytest tests/gateway/test_api_server*.py` (existing 171 pass)
- [x] Live e2e against an `api_server`-enabled gateway (manual smoke as above)
- [ ] Reviewer: any preference on whether toolset keys should be validated against a known set (e.g. only the keys actually shipped by Hermes runtime), or kept open as I have here? I went open for forward-compatibility.
