### PR TITLE
fix: handle bytes values in bundle_content_hash()

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -901,6 +901,22 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_handles_bytes_values(self):
+        """bundle_content_hash must not crash when files contain bytes (not str)."""
+        bundle = SkillBundle(
+            name="binary-skill",
+            files={
+                "SKILL.md": "text content",
+                "assets/icon.png": b"\x89PNG\r\n\x1a\n",
+            },
+            source="github",
+            identifier="owner/repo/binary-skill",
+            trust_level="community",
+        )
+        # Must not raise AttributeError
+        result = bundle_content_hash(bundle)
+        assert result.startswith("sha256:")
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2801,7 +2801,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Summary

`bundle_content_hash()` crashes with `AttributeError` when `SkillBundle.files` contains `bytes` values (e.g. binary assets like images).

Fixes #13408
Fixes #19073

## Root Cause

`bundle_content_hash()` (line 2804) unconditionally calls `.encode("utf-8")` on every file content, but `SkillBundle.files` is typed as `Dict[str, Union[str, bytes]]`. Any bundle with raw `bytes` values crashes.

## Fix

Check `isinstance(content, bytes)` before encoding — if already bytes, hash directly.

## Test

Added `test_bundle_content_hash_handles_bytes_values` covering mixed `str` + `bytes` bundle files.

## Validation

- `scripts/run_tests.sh tests/tools/test_skills_hub.py` — 104 passed
- `py_compile` both files — OK
- Note: PR #13531 addresses the same bug but is still in DRAFT since April.