### PR TITLE
docs(readme): drop misleading RL install-extras claim, defer to CONTRIBUTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ uv pip install -e ".[all,dev]"
 scripts/run_tests.sh
 ```
 
-> **RL Training (optional):** The RL/Atropos integration (`environments/`) ships via the `atroposlib` and `tinker` dependencies pulled in by `.[all,dev]` — no submodule setup required.
+> **RL Training (optional):** The RL/Atropos integration (`environments/`) — see [`CONTRIBUTING.md`](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#development-setup) for the full setup.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

`README.md:163` claimed:

> **RL Training (optional):** The RL/Atropos integration (`environments/`) ships via the `atroposlib` and `tinker` dependencies pulled in by `.[all,dev]` — no submodule setup required.

`pyproject.toml`'s `[all]` extra does NOT include `[rl]` — `atroposlib` and `tinker` only appear in the `[rl]` extra (lines 95-101). I verified locally: after `uv pip install -e ".[all,dev]"` neither `atroposlib` nor `tinker` is importable; both require `[rl]`.

The original wording would also send readers down a different path from what the bundled installers (`scripts/install.{sh,ps1}`, `setup-hermes.sh`, `nix/hermes-agent.nix`, `hermes_cli/doctor.py`) actually use, which is the `tinker-atropos` git submodule. Replacing one extra name with another would just swap the false claim for another path that's not what the tooling expects.

This PR removes the specific install command from the README and links to `CONTRIBUTING.md#development-setup` — which already documents the canonical development setup — instead. One less factual claim in a high-traffic doc, no position taken on which install path (`[rl]` extra vs submodule) the project should consider primary going forward.

I verified the linked section (`CONTRIBUTING.md:65-81`) before sending the reader there: it currently shows clone with `--recurse-submodules`, `uv venv venv --python 3.11`, `uv pip install -e ".[all,dev]"`, and a commented `git submodule update --init tinker-atropos && uv pip install -e "./tinker-atropos"` line for RL. That matches what `scripts/install.sh`, `scripts/install.ps1`, `setup-hermes.sh`, `nix/hermes-agent.nix`, and `hermes_cli/doctor.py` all expect — readers following the link land on instructions consistent with the bundled installers.

## Related Issue

(No tracking issue — drift caught while reading the file.)

## Type of Change

- [x] 📝 Documentation update

## Changes Made

`README.md:163` — removed the `.[all,dev]` claim and "no submodule setup required" line. Replaced with a single-sentence pointer to `CONTRIBUTING.md#development-setup`.

## Ground truth

```
pyproject.toml:78  — all = [hermes-agent[modal], ..., hermes-agent[dev], ...]   # no rl
pyproject.toml:95  — rl = [atroposlib @ git+..., tinker @ git+..., wandb, ...]
hermes_cli/doctor.py:1188-1203 — looks for tinker-atropos/pyproject.toml
scripts/install.sh:1010-1013 — submodule install path
scripts/install.ps1:566 — submodule install path
setup-hermes.sh:206 — submodule install path
nix/hermes-agent.nix:191 — submodule install path
CONTRIBUTING.md:73-77 — current development setup
```

## How to Test

```bash
# Original wording would have implied [all,dev] was sufficient:
git fetch upstream main
git checkout upstream/main -- README.md
uv pip install -e ".[all,dev]"
python -c "import atroposlib"   # ModuleNotFoundError

# After this PR, README points at CONTRIBUTING.md instead, which still
# documents the canonical (submodule-based) RL setup.
git checkout HEAD -- README.md
grep -A 1 "RL Training" README.md
```

Verified locally on Linux (Debian 13).

## Out of scope

- **Choosing a canonical RL install path.** The codebase actively supports both the `tinker-atropos` submodule (used by all bundled installers and `hermes_cli/doctor.py`) and the `[rl]` pyproject extra (alternative; pulls `atroposlib` + `tinker` via `git+`). Deciding which to prefer site-wide is a maintainer call distinct from this factual correction.
- **`pyproject.toml [rl]` extra missing `orjson`.** `tinker==0.18.0` imports `orjson` but doesn't declare it in `Requires-Dist`. Reportable upstream to tinker, or worked around by adding `orjson` to the `[rl]` extra. Out of scope here.
- **`CONTRIBUTING.md:73-77`** has the existing `git submodule update --init tinker-atropos` block; that text is accurate and unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q`; tests are unaffected by this docs-only diff
- [N/A] Tests added (docs-only)
- [x] I've tested on my platform: Linux (Debian 13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [N/A] cli-config.yaml.example
- [N/A] CONTRIBUTING.md / AGENTS.md
- [N/A] Cross-platform impact
- [N/A] Tool descriptions/schemas

---
Ridden with [Loa](https://github.com/0xHoneyJar/loa).
