### PR TITLE
fix(skills): handle bytes values in bundle_content_hash

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2801,7 +2801,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Fix: Handle `bytes` values in `bundle_content_hash`

`SkillBundle.files` is typed as `Dict[str, Union[str, bytes]]` — dict values can be either `str` or `bytes` depending on how the bundle was loaded. However, `bundle_content_hash()` unconditionally called `.encode("utf-8")` on every value, causing `AttributeError: 'bytes' object has no attribute 'encode'` when the value was already `bytes`.

**Before:**
```python
h.update(bundle.files[rel_path].encode("utf-8"))
```

**After:**
```python
content = bundle.files[rel_path]
if isinstance(content, bytes):
    h.update(content)
else:
    h.update(content.encode("utf-8"))
```

Fixes #19073