### PR TITLE
feat(plugins): add Google image_gen backend (Imagen 4 + Gemini Flash Image)

### DIFF
--- a/plugins/image_gen/google/__init__.py
+++ b/plugins/image_gen/google/__init__.py
@@ -1,0 +1,373 @@
+"""Google image generation backend.
+
+Wires the Gemini API's two image-gen surfaces into hermes' ``image_gen``
+provider slot:
+
+* **Imagen 4** family (``imagen-4.0-fast-generate-001``,
+  ``imagen-4.0-generate-001``, ``imagen-4.0-ultra-generate-001``) via
+  the ``:predict`` endpoint.
+* **Gemini flash/pro image** models (``gemini-2.5-flash-image``,
+  ``gemini-3.1-flash-image-preview``, ``gemini-3-pro-image-preview``)
+  via ``:generateContent`` with ``responseModalities=["IMAGE"]``.
+
+Auth: ``GEMINI_API_KEY`` (preferred) or ``GOOGLE_API_KEY``. Both endpoints
+require Tier 1 (paid) on the project that minted the key — free-tier
+quota for image gen is zero.
+
+Selection precedence (first hit wins):
+1. ``GOOGLE_IMAGE_MODEL`` env var
+2. ``image_gen.google.model`` in ``config.yaml``
+3. :data:`DEFAULT_MODEL`
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+#
+# ``endpoint`` distinguishes the two API shapes:
+#   - "predict"         → /v1beta/models/{m}:predict  (Imagen)
+#   - "generateContent" → /v1beta/models/{m}:generateContent  (Gemini image)
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "imagen-4.0-fast-generate-001": {
+        "display": "Imagen 4 Fast",
+        "speed": "~5s",
+        "strengths": "Fast iteration, lowest cost in the Imagen 4 family",
+        "endpoint": "predict",
+    },
+    "imagen-4.0-generate-001": {
+        "display": "Imagen 4",
+        "speed": "~10s",
+        "strengths": "Balanced quality/cost — default Imagen 4 tier",
+        "endpoint": "predict",
+    },
+    "imagen-4.0-ultra-generate-001": {
+        "display": "Imagen 4 Ultra",
+        "speed": "~20s",
+        "strengths": "Highest fidelity, strongest prompt adherence",
+        "endpoint": "predict",
+    },
+    "gemini-2.5-flash-image": {
+        "display": "Gemini 2.5 Flash Image (Nano Banana)",
+        "speed": "~5s",
+        "strengths": "Conversational image edits, multimodal grounding",
+        "endpoint": "generateContent",
+    },
+    "gemini-3.1-flash-image-preview": {
+        "display": "Gemini 3.1 Flash Image (preview)",
+        "speed": "~5s",
+        "strengths": "Newer flash-tier image model",
+        "endpoint": "generateContent",
+    },
+    "gemini-3-pro-image-preview": {
+        "display": "Gemini 3 Pro Image (preview)",
+        "speed": "~15s",
+        "strengths": "Pro-tier reasoning + image generation",
+        "endpoint": "generateContent",
+    },
+}
+
+DEFAULT_MODEL = "imagen-4.0-fast-generate-001"
+
+# Imagen accepts explicit aspect ratios; Gemini flash-image infers from the prompt.
+_IMAGEN_ASPECTS: Dict[str, str] = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+
+# ---------------------------------------------------------------------------
+# Config / model resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_google_config() -> Dict[str, Any]:
+    """Read ``image_gen.google`` from config.yaml (returns {} on failure)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        google_section = section.get("google") if isinstance(section, dict) else None
+        return google_section if isinstance(google_section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.google config: %s", exc)
+        return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use and return ``(model_id, meta)``."""
+    env_override = os.environ.get("GOOGLE_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_google_config()
+    candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
+    if candidate and candidate in _MODELS:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_api_key() -> str:
+    return (
+        os.getenv("GEMINI_API_KEY", "").strip()
+        or os.getenv("GOOGLE_API_KEY", "").strip()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint dispatchers
+# ---------------------------------------------------------------------------
+
+
+def _call_imagen(
+    *, api_key: str, model_id: str, prompt: str, aspect: str
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Hit Imagen's ``:predict`` endpoint. Returns ``(b64_png, error_dict)``."""
+    url = f"{API_BASE}/models/{model_id}:predict"
+    payload: Dict[str, Any] = {
+        "instances": [{"prompt": prompt}],
+        "parameters": {
+            "sampleCount": 1,
+            "aspectRatio": _IMAGEN_ASPECTS.get(aspect, "1:1"),
+        },
+    }
+    try:
+        resp = requests.post(
+            url,
+            params={"key": api_key},
+            json=payload,
+            timeout=120,
+        )
+    except requests.Timeout:
+        return None, {"error": "Imagen request timed out (120s)", "error_type": "timeout"}
+    except requests.ConnectionError as exc:
+        return None, {"error": f"Connection error: {exc}", "error_type": "connection_error"}
+
+    if resp.status_code != 200:
+        try:
+            err_msg = resp.json().get("error", {}).get("message", resp.text[:300])
+        except Exception:
+            err_msg = resp.text[:300]
+        return None, {
+            "error": f"Imagen API failed ({resp.status_code}): {err_msg}",
+            "error_type": "api_error",
+        }
+
+    try:
+        body = resp.json()
+    except Exception as exc:
+        return None, {"error": f"Imagen returned invalid JSON: {exc}", "error_type": "invalid_response"}
+
+    preds = body.get("predictions") or []
+    if not preds:
+        return None, {"error": "Imagen returned no predictions", "error_type": "empty_response"}
+    b64 = preds[0].get("bytesBase64Encoded")
+    if not b64:
+        return None, {"error": "Imagen prediction missing bytesBase64Encoded", "error_type": "empty_response"}
+    return b64, None
+
+
+def _call_gemini_image(
+    *, api_key: str, model_id: str, prompt: str
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Hit Gemini's ``:generateContent`` with IMAGE response modality."""
+    url = f"{API_BASE}/models/{model_id}:generateContent"
+    payload: Dict[str, Any] = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"responseModalities": ["IMAGE"]},
+    }
+    try:
+        resp = requests.post(
+            url,
+            params={"key": api_key},
+            json=payload,
+            timeout=120,
+        )
+    except requests.Timeout:
+        return None, {"error": "Gemini request timed out (120s)", "error_type": "timeout"}
+    except requests.ConnectionError as exc:
+        return None, {"error": f"Connection error: {exc}", "error_type": "connection_error"}
+
+    if resp.status_code != 200:
+        try:
+            err_msg = resp.json().get("error", {}).get("message", resp.text[:300])
+        except Exception:
+            err_msg = resp.text[:300]
+        return None, {
+            "error": f"Gemini API failed ({resp.status_code}): {err_msg}",
+            "error_type": "api_error",
+        }
+
+    try:
+        body = resp.json()
+    except Exception as exc:
+        return None, {"error": f"Gemini returned invalid JSON: {exc}", "error_type": "invalid_response"}
+
+    cands = body.get("candidates") or []
+    if not cands:
+        return None, {"error": "Gemini returned no candidates", "error_type": "empty_response"}
+    parts = (cands[0].get("content") or {}).get("parts") or []
+    for part in parts:
+        inline = part.get("inlineData") or part.get("inline_data")
+        if isinstance(inline, dict) and inline.get("data"):
+            return inline["data"], None
+    return None, {"error": "Gemini response had no image inlineData", "error_type": "empty_response"}
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class GoogleImageGenProvider(ImageGenProvider):
+    """Google Gemini API image generation backend (Imagen + flash-image)."""
+
+    @property
+    def name(self) -> str:
+        return "google"
+
+    @property
+    def display_name(self) -> str:
+        return "Google (Imagen + Gemini)"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta.get("display", model_id),
+                "speed": meta.get("speed", ""),
+                "strengths": meta.get("strengths", ""),
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Google (Imagen + Gemini)",
+            "badge": "paid",
+            "tag": "Imagen 4 family + Gemini flash-image via Gemini API (Tier 1 required)",
+            "env_vars": [
+                {
+                    "key": "GEMINI_API_KEY",
+                    "prompt": "Gemini API key (or GOOGLE_API_KEY)",
+                    "url": "https://aistudio.google.com/apikey",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="google",
+                aspect_ratio=aspect,
+            )
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "GEMINI_API_KEY (or GOOGLE_API_KEY) not set. Get a key at "
+                    "https://aistudio.google.com/apikey — note that image-gen "
+                    "models require Tier 1 (paid) billing on the project."
+                ),
+                error_type="auth_required",
+                provider="google",
+                aspect_ratio=aspect,
+            )
+
+        model_id, meta = _resolve_model()
+        endpoint = meta.get("endpoint", "predict")
+
+        if endpoint == "predict":
+            b64, err = _call_imagen(
+                api_key=api_key, model_id=model_id, prompt=prompt, aspect=aspect
+            )
+        else:
+            b64, err = _call_gemini_image(
+                api_key=api_key, model_id=model_id, prompt=prompt
+            )
+
+        if err:
+            return error_response(
+                provider="google",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+                **err,
+            )
+
+        try:
+            saved_path = save_b64_image(b64, prefix=f"google_{model_id}")
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="google",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {"endpoint": endpoint}
+        if endpoint == "predict":
+            extra["aspect_ratio_sent"] = _IMAGEN_ASPECTS.get(aspect, "1:1")
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="google",
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Plugin entry point — wire ``GoogleImageGenProvider`` into the registry."""
+    ctx.register_image_gen_provider(GoogleImageGenProvider())

--- a/plugins/image_gen/google/plugin.yaml
+++ b/plugins/image_gen/google/plugin.yaml
@@ -1,0 +1,7 @@
+name: google
+version: 1.0.0
+description: "Google image generation backend (Imagen 4 + Gemini Flash Image). Saves generated images to $HERMES_HOME/cache/images/."
+author: ItachiDevv
+kind: backend
+requires_env:
+  - GEMINI_API_KEY

--- a/tests/plugins/image_gen/test_google_provider.py
+++ b/tests/plugins/image_gen/test_google_provider.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Tests for Google Imagen + Gemini Flash Image provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure GEMINI_API_KEY is set for all tests; clear GOOGLE_API_KEY so
+    tests that exercise key-fallback behaviour are explicit."""
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key-12345")
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_overrides(monkeypatch):
+    """Image-gen tests assume default model selection unless overridden."""
+    monkeypatch.delenv("GOOGLE_IMAGE_MODEL", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Provider class — surface
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        assert GoogleImageGenProvider().name == "google"
+
+    def test_display_name(self):
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        assert GoogleImageGenProvider().display_name == "Google (Imagen + Gemini)"
+
+    def test_is_available_with_gemini_key(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "k")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        assert GoogleImageGenProvider().is_available() is True
+
+    def test_is_available_falls_back_to_google_api_key(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "k")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        assert GoogleImageGenProvider().is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        assert GoogleImageGenProvider().is_available() is False
+
+    def test_list_models_includes_imagen_and_gemini(self):
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        ids = {m["id"] for m in GoogleImageGenProvider().list_models()}
+        assert "imagen-4.0-fast-generate-001" in ids
+        assert "imagen-4.0-ultra-generate-001" in ids
+        assert "gemini-2.5-flash-image" in ids
+
+    def test_default_model_is_fast_imagen(self):
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        assert GoogleImageGenProvider().default_model() == "imagen-4.0-fast-generate-001"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        schema = GoogleImageGenProvider().get_setup_schema()
+        assert schema["name"] == "Google (Imagen + Gemini)"
+        assert schema["badge"] == "paid"
+        assert schema["env_vars"][0]["key"] == "GEMINI_API_KEY"
+        assert "aistudio.google.com" in schema["env_vars"][0]["url"]
+
+
+# ---------------------------------------------------------------------------
+# Model resolution
+# ---------------------------------------------------------------------------
+
+
+class TestModelResolution:
+    def test_default(self):
+        from plugins.image_gen.google import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "imagen-4.0-fast-generate-001"
+        assert meta["endpoint"] == "predict"
+
+    def test_env_override_to_gemini(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "gemini-2.5-flash-image")
+        from plugins.image_gen.google import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "gemini-2.5-flash-image"
+        assert meta["endpoint"] == "generateContent"
+
+    def test_env_override_unknown_falls_back(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "definitely-not-real")
+        from plugins.image_gen.google import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "imagen-4.0-fast-generate-001"
+
+
+# ---------------------------------------------------------------------------
+# Imagen (:predict) endpoint dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestImagenEndpoint:
+    def test_success_saves_image(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "imagen-4.0-fast-generate-001")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "predictions": [
+                {"bytesBase64Encoded": "dGVzdC1pbWFnZS1kYXRh", "mimeType": "image/png"}
+            ]
+        }
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp) as post:
+            with patch(
+                "plugins.image_gen.google.save_b64_image", return_value="/tmp/google_img.png"
+            ):
+                result = GoogleImageGenProvider().generate(
+                    prompt="a robot", aspect_ratio="landscape"
+                )
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/google_img.png"
+        assert result["provider"] == "google"
+        assert result["model"] == "imagen-4.0-fast-generate-001"
+        assert result["endpoint"] == "predict"
+        assert result["aspect_ratio_sent"] == "16:9"
+
+        called_url = post.call_args.args[0]
+        assert ":predict" in called_url
+        body = post.call_args.kwargs["json"]
+        assert body["instances"][0]["prompt"] == "a robot"
+        assert body["parameters"]["aspectRatio"] == "16:9"
+
+    def test_aspect_ratio_mapping(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "imagen-4.0-fast-generate-001")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "predictions": [{"bytesBase64Encoded": "eA==", "mimeType": "image/png"}]
+        }
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp) as post:
+            with patch("plugins.image_gen.google.save_b64_image", return_value="/tmp/x.png"):
+                GoogleImageGenProvider().generate(prompt="x", aspect_ratio="portrait")
+        assert post.call_args.kwargs["json"]["parameters"]["aspectRatio"] == "9:16"
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp) as post:
+            with patch("plugins.image_gen.google.save_b64_image", return_value="/tmp/x.png"):
+                GoogleImageGenProvider().generate(prompt="x", aspect_ratio="square")
+        assert post.call_args.kwargs["json"]["parameters"]["aspectRatio"] == "1:1"
+
+    def test_api_error_returns_error_response(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "imagen-4.0-fast-generate-001")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = '{"error": {"message": "paid plan required"}}'
+        mock_resp.json.return_value = {"error": {"message": "paid plan required"}}
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp):
+            result = GoogleImageGenProvider().generate(prompt="x")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "paid plan" in result["error"]
+
+    def test_empty_predictions(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "imagen-4.0-fast-generate-001")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"predictions": []}
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp):
+            result = GoogleImageGenProvider().generate(prompt="x")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_timeout(self, monkeypatch):
+        import requests as req_lib
+
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "imagen-4.0-fast-generate-001")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        with patch("plugins.image_gen.google.requests.post", side_effect=req_lib.Timeout()):
+            result = GoogleImageGenProvider().generate(prompt="x")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Gemini (:generateContent) endpoint dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiImageEndpoint:
+    def test_success_inline_data(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "gemini-2.5-flash-image")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "(reasoning trace)"},
+                            {"inlineData": {"mimeType": "image/png", "data": "Zm9v"}},
+                        ]
+                    }
+                }
+            ]
+        }
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp) as post:
+            with patch("plugins.image_gen.google.save_b64_image", return_value="/tmp/gem.png"):
+                result = GoogleImageGenProvider().generate(prompt="a robot")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/gem.png"
+        assert result["model"] == "gemini-2.5-flash-image"
+        assert result["endpoint"] == "generateContent"
+
+        called_url = post.call_args.args[0]
+        assert ":generateContent" in called_url
+        body = post.call_args.kwargs["json"]
+        assert body["contents"][0]["parts"][0]["text"] == "a robot"
+        assert body["generationConfig"]["responseModalities"] == ["IMAGE"]
+
+    def test_snake_case_inline_data_accepted(self, monkeypatch):
+        """Some Gemini API revisions return ``inline_data`` instead of ``inlineData``."""
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "gemini-2.5-flash-image")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": {"mimeType": "image/png", "data": "Zm9v"}}
+                        ]
+                    }
+                }
+            ]
+        }
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp):
+            with patch("plugins.image_gen.google.save_b64_image", return_value="/tmp/gem.png"):
+                result = GoogleImageGenProvider().generate(prompt="x")
+        assert result["success"] is True
+
+    def test_no_image_part(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "gemini-2.5-flash-image")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "candidates": [{"content": {"parts": [{"text": "no image generated"}]}}]
+        }
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp):
+            result = GoogleImageGenProvider().generate(prompt="x")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_api_error(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "gemini-2.5-flash-image")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+        mock_resp.text = '{"error": {"message": "quota exceeded"}}'
+        mock_resp.json.return_value = {"error": {"message": "quota exceeded"}}
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp):
+            result = GoogleImageGenProvider().generate(prompt="x")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "quota" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Auth + arg validation
+# ---------------------------------------------------------------------------
+
+
+class TestAuthAndValidation:
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        result = GoogleImageGenProvider().generate(prompt="x")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+        assert "GEMINI_API_KEY" in result["error"]
+
+    def test_empty_prompt(self):
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        result = GoogleImageGenProvider().generate(prompt="")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_api_key_passed_in_query_param(self, monkeypatch):
+        """The plugin must pass the key via ``params={'key': ...}``, not in the URL or a header."""
+        monkeypatch.setenv("GOOGLE_IMAGE_MODEL", "imagen-4.0-fast-generate-001")
+        from plugins.image_gen.google import GoogleImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "predictions": [{"bytesBase64Encoded": "eA==", "mimeType": "image/png"}]
+        }
+
+        with patch("plugins.image_gen.google.requests.post", return_value=mock_resp) as post:
+            with patch("plugins.image_gen.google.save_b64_image", return_value="/tmp/x.png"):
+                GoogleImageGenProvider().generate(prompt="x")
+
+        assert post.call_args.kwargs["params"] == {"key": "test-key-12345"}
+        url = post.call_args.args[0]
+        assert "key=" not in url, "API key should not be in the URL"
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.google import GoogleImageGenProvider, register
+
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_image_gen_provider.assert_called_once()
+        provider = ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, GoogleImageGenProvider)
+        assert provider.name == "google"


### PR DESCRIPTION
## What

Adds a third image-gen backend at `plugins/image_gen/google/`, mirroring the existing `openai/` and `xai/` plugins. Six models exposed through one provider:

| Model | Endpoint |
|---|---|
| `imagen-4.0-fast-generate-001` (default) | `:predict` |
| `imagen-4.0-generate-001` | `:predict` |
| `imagen-4.0-ultra-generate-001` | `:predict` |
| `gemini-2.5-flash-image` | `:generateContent` |
| `gemini-3.1-flash-image-preview` | `:generateContent` |
| `gemini-3-pro-image-preview` | `:generateContent` |

## Why

Resolves the "Google as image-gen provider" gap discussed in #13798. Closest existing options route through Composio's MCP middleware; this plugin uses a direct Gemini API key, matching the existing `openai`/`xai` plugin pattern.

## Auth

`GEMINI_API_KEY` (preferred) or `GOOGLE_API_KEY`. Image-gen requires Tier 1 (paid) on the project — the plugin surfaces the upstream "paid plan required" / quota errors verbatim.

## Selection precedence

1. `GOOGLE_IMAGE_MODEL` env var
2. `image_gen.google.model` in `config.yaml`
3. `DEFAULT_MODEL` (`imagen-4.0-fast-generate-001`)

## How to test

```bash
export GEMINI_API_KEY=...   # Tier 1 project required
hermes -q "generate an image of a small wooden boat at dawn"
# with image_gen.provider=google and image_gen.google.model=imagen-4.0-ultra-generate-001
```

Output saves to `~/.hermes/cache/images/google_<model>_<ts>_<id>.png`.

## Tests

24 tests in `tests/plugins/image_gen/test_google_provider.py` covering availability (with `GEMINI_API_KEY`, `GOOGLE_API_KEY` fallback, neither), model resolution (default, env override, unknown-fallback), both endpoint shapes (success / empty response / API error / timeout), aspect ratio mapping (landscape→16:9, portrait→9:16, square→1:1), auth correctness (key passed as `params={"key": ...}`, never in URL or header), and registration via `register(ctx)`.

All 97 sibling image_gen tests still pass.

## Platforms tested

Linux (Ubuntu 24.04 / WSL2). Plugin is pure-Python with `requests`; no OS-specific paths or process logic.

Refs: #13798
