### PR TITLE
fix: guard interactive startup without tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ Works on Linux, macOS, WSL2, and Android via Termux. The installer handles the p
 >
 > **Windows:** Native Windows is not supported. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above.
 
-After installation:
+After installation, reload the shell config for your current shell and then start Hermes:
 
 ```bash
-source ~/.bashrc    # reload shell (or: source ~/.zshrc)
+# zsh (macOS default):
+source ~/.zshrc
+
+# bash:
+source ~/.bashrc
+
 hermes              # start chatting!
 ```
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1262,6 +1262,20 @@ def cmd_chat(args):
         print("You can run 'hermes setup' at any time to configure.")
         sys.exit(1)
 
+    # Interactive chat needs a real terminal.  `hermes chat -q ...` remains
+    # valid in pipes, scripts, and installer subprocesses, but the prompt_toolkit
+    # UI will crash on some platforms (notably macOS/kqueue) if stdin is not a
+    # selectable TTY.  Fail early with actionable guidance instead of showing a
+    # traceback from loop.add_reader(fd=0).
+    if not getattr(args, "query", None) and not sys.stdin.isatty():
+        print(
+            "Error: interactive Hermes chat requires a terminal.\n"
+            "Run `hermes` directly in your terminal, or use "
+            "`hermes chat -q \"your prompt\"` for non-interactive use.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Start update check in background (runs while other init happens)
     try:
         from hermes_cli.banner import prefetch_update_check

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -389,11 +389,19 @@ echo "  hermes cron list     # View scheduled jobs"
 echo "  hermes doctor        # Diagnose issues"
 echo ""
 
-# Ask if they want to run setup wizard now
-read -p "Would you like to run the setup wizard now? [Y/n] " -n 1 -r
-echo
-if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-    echo ""
-    # Run directly with venv Python (no activation needed)
-    "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main setup
+# Ask if they want to run setup wizard now, but only when stdin is a real
+# terminal.  When this script is run from a non-interactive context, `read`
+# returns an empty reply; treating that as the default "yes" launches the
+# interactive setup wizard without a usable TTY.
+if [ -t 0 ]; then
+    read -p "Would you like to run the setup wizard now? [Y/n] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+        echo ""
+        # Run directly with venv Python (no activation needed)
+        "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main setup
+    fi
+else
+    echo "Skipping setup wizard prompt (no interactive terminal detected)."
+    echo "Run 'hermes setup' in a terminal when you're ready to configure Hermes."
 fi

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -19,3 +19,10 @@ def test_setup_hermes_script_has_termux_path():
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
     assert "Skipping tinker-atropos on Termux" in content
+
+
+def test_setup_hermes_script_skips_wizard_prompt_without_tty():
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "if [ -t 0 ]; then" in content
+    assert "Skipping setup wizard prompt (no interactive terminal detected)." in content

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -144,6 +144,47 @@ class TestNonInteractiveSetup:
         out = capsys.readouterr().out
         assert "hermes config set model.provider custom" in out
 
+    def test_chat_headless_with_provider_exits_before_prompt_toolkit(self, capsys):
+        """Configured bare `hermes` should fail clearly without a TTY instead of crashing in prompt_toolkit."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args()
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("hermes_cli.banner.prefetch_update_check"),
+            patch("tools.skills_sync.sync_skills"),
+            patch("cli.main", side_effect=AssertionError("prompt_toolkit should not start")),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            with pytest.raises(SystemExit) as exc:
+                cmd_chat(args)
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "interactive Hermes chat requires a terminal" in err
+        assert "hermes chat -q" in err
+
+    def test_chat_headless_query_mode_still_runs(self):
+        """`hermes chat -q ...` is the supported non-interactive chat mode."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args(query="hello")
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("hermes_cli.banner.prefetch_update_check"),
+            patch("tools.skills_sync.sync_skills"),
+            patch("sys.stdin") as mock_stdin,
+            patch("cli.main") as mock_cli_main,
+        ):
+            mock_stdin.isatty.return_value = False
+            cmd_chat(args)
+
+        mock_cli_main.assert_called_once()
+        assert mock_cli_main.call_args.kwargs["query"] == "hello"
+
     def test_main_accepts_tts_setup_section(self, monkeypatch):
         """`hermes setup tts` should parse and dispatch like other setup sections."""
         from hermes_cli import main as main_mod


### PR DESCRIPTION
## Problem
During initial setup, Hermes could offer to start the setup/chat flow even when it did not have a usable interactive TTY. In that state, the prompt_toolkit CLI could print the welcome/goodbye text and then crash with a traceback like:

```text
KeyError: '0 is not registered'
...
OSError: [Errno 22] Invalid argument
```

This happens because the interactive CLI tries to attach an asyncio reader to stdin fd 0, but fd 0 is not a selectable terminal in non-interactive contexts. The resulting traceback is confusing for new users and makes setup look broken.

There was also a README post-install example that led with `source ~/.bashrc`, even though macOS users on the default zsh shell need `source ~/.zshrc`.

## Summary
- fail early with a clear error when interactive `hermes`/`hermes chat` is launched without a TTY, while preserving `hermes chat -q` for non-interactive use
- skip the legacy setup script's "run setup wizard now" prompt when stdin is not interactive, instead telling users to run `hermes setup` later
- update README post-install instructions to show zsh/macOS and bash shell reload commands separately

## Test Plan
- `/Users/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_setup_hermes_script.py -q`
- `/Users/hermes/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/main.py hermes_cli/setup.py`
- `bash -n setup-hermes.sh`
