### PR TITLE
fix(cli): honor positive display.tool_preview_length in status previews

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -852,13 +852,15 @@ def get_cute_tool_message(
         s = str(s)
         if _tool_preview_max_len == 0:
             return s  # no limit
-        return (s[:n-3] + "...") if len(s) > n else s
+        limit = _tool_preview_max_len
+        return (s[:limit-3] + "...") if len(s) > limit else s
 
     def _path(p, n=35):
         p = str(p)
         if _tool_preview_max_len == 0:
             return p  # no limit
-        return ("..." + p[-(n-3):]) if len(p) > n else p
+        limit = _tool_preview_max_len
+        return ("..." + p[-(limit-3):]) if len(p) > limit else p
 
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -8,10 +8,19 @@ from agent.display import (
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
+    get_cute_tool_message,
+    set_tool_preview_max_len,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_tool_preview_max_len():
+    set_tool_preview_max_len(0)
+    yield
+    set_tool_preview_max_len(0)
 
 
 class TestBuildToolPreview:
@@ -100,6 +109,45 @@ class TestBuildToolPreview:
         assert build_tool_preview("terminal", 0) is None
         assert build_tool_preview("terminal", "") is None
         assert build_tool_preview("terminal", []) is None
+
+
+class TestCuteToolMessagePreviewLength:
+    def test_terminal_preview_unlimited_when_config_is_zero(self):
+        set_tool_preview_max_len(0)
+        command = "curl -s http://localhost:9222/json/list | jq -r '.[] | select(.type==\"page\")' | head -5"
+
+        line = get_cute_tool_message("terminal", {"command": command}, 0.1)
+
+        assert command in line
+        assert "..." not in line
+
+    def test_terminal_preview_uses_positive_configured_limit(self):
+        set_tool_preview_max_len(80)
+        command = "curl -s http://localhost:9222/json/list | jq -r '.[] | select(.type==\"page\")' | head -5"
+
+        line = get_cute_tool_message("terminal", {"command": command}, 0.1)
+
+        assert command[:77] in line
+        assert "..." in line
+        assert "head -5" not in line
+
+    def test_search_files_preview_uses_positive_configured_limit_not_default(self):
+        set_tool_preview_max_len(80)
+        pattern = "function.formatToolCall.context.preview.compactPreview.maxLength.truncate"
+
+        line = get_cute_tool_message("search_files", {"pattern": pattern}, 0.1)
+
+        assert pattern in line
+        assert "..." not in line
+
+    def test_path_preview_uses_positive_configured_limit_not_default(self):
+        set_tool_preview_max_len(80)
+        path = "/tmp/hermes-test-preview-length/deeply/nested/path/test-output.txt"
+
+        line = get_cute_tool_message("read_file", {"path": path}, 0.1)
+
+        assert path in line
+        assert "..." not in line
 
 
 class TestEditDiffPreview:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes CLI tool status previews so positive `display.tool_preview_length` values are used as the actual preview length limit.

Before this change, CLI `get_cute_tool_message()` treated `display.tool_preview_length` as a boolean-like flag:

- `0` disabled truncation
- positive values enabled truncation

However, when a positive value was configured, the actual truncation length still came from hardcoded per-tool defaults like 35/42 characters.

For example:

```yaml
display:
  tool_preview_length: 99999
```

could still render a CLI status line like:

```text
┊ 💻 $         curl -s http://localhost:9222/json/list...
```

This PR makes the CLI `_trunc()` and `_path()` helpers use `_tool_preview_max_len` as the actual max length when it is positive, while preserving `0` as "no limit".

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Related to #3841, which introduced `display.tool_preview_length`.

Separate from gateway fixes #5937 and #8735.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `agent/display.py`
  - Updated CLI `get_cute_tool_message()` helper functions:
    - `_trunc()` now uses `_tool_preview_max_len` as the actual limit when positive.
    - `_path()` now uses `_tool_preview_max_len` as the actual limit when positive.
  - Preserves existing `tool_preview_length: 0` behavior as unlimited/no truncation.
- `tests/agent/test_display.py`
  - Added regression coverage for:
    - unlimited `tool_preview_length: 0`
    - positive configured limit truncating terminal previews
    - positive configured limit not falling back to the old `search_files` default
    - positive configured limit not falling back to the old path default

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure a positive preview length, e.g.:

   ```yaml
   display:
     tool_preview_length: 80
   ```

2. Run a CLI task that triggers a long `terminal` command or `search_files` pattern. The preview should use the configured limit instead of the old hardcoded 35/42-character limit.

3. Run the regression test:

   ```bash
   scripts/run_tests.sh tests/agent/test_display.py -q
   ```

   Result:

   ```text
   29 passed in 1.58s
   ```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```text
▶ running pytest with 4 workers, hermetic env, in /Users/wu/.hermes/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
.............................                                            [100%]
29 passed in 1.58s
```
