### PR TITLE
fix(tools): guard write_file against missing required args

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -105,6 +105,81 @@ class TestWriteFileHandler:
         assert any("write_file error" in r.getMessage() for r in caplog.records)
 
 
+class TestWriteFileHandlerRequiredArgGuard:
+    """Regression tests for the dropped-argument guard.
+
+    Some frontier models, deep into a long working context, emit tool calls
+    that retain the small `path` argument but drop the large `content`
+    payload entirely. Before this guard, the handler defaulted the missing
+    field to ``""`` and the underlying write reported a cheerful
+    ``{"bytes_written": 0, "dirs_created": true}`` success — producing a
+    zero-byte file the model then assumed it had populated. The guard
+    converts that silent-success into a loud error, while still allowing an
+    explicit empty string for legitimate file-truncation calls.
+    """
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_missing_content_key_returns_error_and_does_not_write(self, mock_get):
+        from tools.file_tools import _handle_write_file
+        result = json.loads(_handle_write_file({"path": "/tmp/should-not-exist.md"}))
+        assert "error" in result
+        assert "missing required field 'content'" in result["error"]
+        # Underlying file_ops must never have been touched.
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_missing_path_key_returns_error_and_does_not_write(self, mock_get):
+        from tools.file_tools import _handle_write_file
+        result = json.loads(_handle_write_file({"content": "hello"}))
+        assert "error" in result
+        assert "missing required field 'path'" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_empty_path_string_returns_error(self, mock_get):
+        from tools.file_tools import _handle_write_file
+        result = json.loads(_handle_write_file({"path": "", "content": "x"}))
+        assert "error" in result
+        assert "missing required field 'path'" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_explicit_empty_content_string_is_allowed(self, mock_get):
+        # Truncate-to-empty must still work — only a *missing* key is rejected.
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"bytes_written": 0, "dirs_created": False}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_write_file
+        result = json.loads(_handle_write_file({"path": "/tmp/truncate.txt", "content": ""}))
+        assert "error" not in result
+        mock_ops.write_file.assert_called_once_with("/tmp/truncate.txt", "")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_normal_write_still_works(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"bytes_written": 12, "dirs_created": False}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_write_file
+        result = json.loads(_handle_write_file({"path": "/tmp/out.txt", "content": "hello world\n"}))
+        assert "error" not in result
+        assert result["bytes_written"] == 12
+        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world\n")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_non_string_content_returns_error(self, mock_get):
+        from tools.file_tools import _handle_write_file
+        result = json.loads(_handle_write_file({"path": "/tmp/x", "content": {"oops": "dict"}}))
+        assert "error" in result
+        assert "must be a string" in result["error"]
+        mock_get.assert_not_called()
+
+
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_calls_patch_replace(self, mock_get):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1097,7 +1097,32 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return write_file_tool(path=args.get("path", ""), content=args.get("content", ""), task_id=tid)
+    # Required-field guard: refuse silently-malformed tool calls that omit
+    # `content` or `path` entirely. Under context pressure some models drop
+    # large args while keeping small ones, which previously produced a
+    # cheerful {"bytes_written": 0, "dirs_created": true} success and a
+    # zero-byte file. Distinguish "key missing" from "explicitly empty
+    # string" — the latter is a legitimate way to truncate a file.
+    if "path" not in args or not isinstance(args.get("path"), str) or not args.get("path"):
+        return tool_error(
+            "write_file: missing required field 'path'. The tool call did "
+            "not include a path argument. Re-emit the tool call with both "
+            "'path' and 'content' set."
+        )
+    if "content" not in args:
+        return tool_error(
+            "write_file: missing required field 'content'. The tool call "
+            "included a path but no content argument — this is almost "
+            "always a dropped-arg bug under context pressure. Re-emit the "
+            "tool call with the full content payload, or use execute_code "
+            "with hermes_tools.write_file() for very large files."
+        )
+    if not isinstance(args.get("content"), str):
+        return tool_error(
+            "write_file: 'content' must be a string. Got "
+            f"{type(args.get('content')).__name__}."
+        )
+    return write_file_tool(path=args["path"], content=args["content"], task_id=tid)
 
 
 def _handle_patch(args, **kw):


### PR DESCRIPTION
Closes #19096.

## Summary

The `write_file` tool handler accepted calls missing the `content` key by silently substituting `""`, then reported a successful zero-byte write. The schema marked `content` as required but the handler enforced nothing.

This failure mode shows up in long-context turns: a model's tool-call payload sometimes retains the small `path` argument while dropping the multi-KB `content` string entirely. The handler accepts the malformed call, the underlying `write_file` op happily writes zero bytes, and the model gets a `bytes_written: 0, dirs_created: ...` response that reads like success. Subsequent steps assume the file is populated when it is empty.

## Fix

Guard `_handle_write_file` to reject calls where:

- `path` key is missing or is an empty string
- `content` key is missing entirely
- `content` is present but not a string

Each rejection returns a `tool_error` with a precise message identifying the missing/wrong field, instead of falling through to the file op.

A legitimate truncate-to-empty (`content: ""`) is still allowed — only an absent key is rejected.

## Tests

Six regression tests added in `tests/tools/test_file_tools.py::TestWriteFileHandlerRequiredArgGuard`:

| Case | Expected |
|---|---|
| `{path: "/tmp/x"}` (missing content) | error, file_ops not called |
| `{content: "x"}` (missing path) | error, file_ops not called |
| `{path: "", content: "x"}` (empty path) | error, file_ops not called |
| `{path: "/tmp/x", content: ""}` (empty string content) | success, write proceeds |
| `{path: "/tmp/x", content: "hello\n"}` (normal) | success |
| `{path: "/tmp/x", content: {dict}}` (wrong type) | error, file_ops not called |

Full suite passes: `29 passed, 8 warnings in 2.35s`.

## Scope

This PR addresses `write_file` only. The same dropped-large-arg pattern can in principle hit `terminal` (empty `command`) and `execute_code` (empty `code`), but those tools fail loudly via downstream validation already; they are out of scope here. Happy to follow up with matching guards if maintainers want symmetry.
