### PR TITLE
fix: support Hermes backend OAuth bridge on Windows

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,7 +10,7 @@ Resolution order for text tasks (auto mode):
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
+  5. Native Anthropic / configured OAuth providers
   6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
   7. None
 
@@ -159,6 +159,8 @@ _PROVIDER_ALIASES = {
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
+    "gemini-cli": "google-gemini-cli",
+    "gemini-oauth": "google-gemini-cli",
 }
 
 
@@ -2077,6 +2079,43 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── Google Gemini OAuth / Code Assist ────────────────────────────
+    if provider == "google-gemini-cli":
+        if async_mode:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli auxiliary async "
+                "mode is not supported yet"
+            )
+            return None, None
+        try:
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient, MARKER_BASE_URL
+            from hermes_cli.auth import resolve_gemini_oauth_runtime_credentials
+        except ImportError as exc:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli requested but "
+                "Gemini OAuth support is unavailable: %s",
+                exc,
+            )
+            return None, None
+        try:
+            creds = resolve_gemini_oauth_runtime_credentials(force_refresh=False)
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli requested but "
+                "OAuth credentials are unavailable (run: hermes auth add "
+                "google-gemini-cli --type oauth): %s",
+                exc,
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or "gemini-3-pro-preview", provider)
+        client = GeminiCloudCodeClient(
+            api_key=str(creds.get("api_key") or "google-oauth"),
+            base_url=str(creds.get("base_url") or MARKER_BASE_URL),
+            project_id=str(creds.get("project_id") or ""),
+        )
+        logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+        return client, final_model
+
     # ── OpenAI Codex (OAuth → Responses API) ─────────────────────────
     if provider == "openai-codex":
         if not model:
@@ -2417,6 +2456,8 @@ def resolve_provider_client(
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
+        if provider == "google-gemini-cli":
+            return resolve_provider_client("google-gemini-cli", model, async_mode)
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8786,6 +8786,59 @@ class GatewayRunner:
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
 
+    def _mirip_harness_approve_bridge_path(self) -> Path:
+        root = Path(os.environ.get("MIRIP_HARNESS_ROOT", r"C:\MIRIP-HARNESS"))
+        return root / "bin" / "telegram_approve_bridge.py"
+
+    def _looks_like_mirip_harness_approve(self, event: MessageEvent) -> bool:
+        args = (event.get_command_args() or "").strip()
+        if not args:
+            return False
+        lowered = args.lower()
+        return "task=" in lowered and ("worker=" in lowered or "reviewer=" in lowered or "mode=" in lowered)
+
+    async def _handle_mirip_harness_approve_command(self, event: MessageEvent) -> str:
+        """Route /approve task=... through the MIRIP-HARNESS approval bridge.
+
+        Hermes gateway already owns Telegram getUpdates for the Core bot, so
+        the external MIRIP poller cannot reliably consume the same update.
+        This fallback preserves normal /approve dangerous-command semantics,
+        but when there is no pending tool approval and the args look like a
+        MIRIP-HARNESS approval packet, it hands the original command text to
+        the HARNESS bridge's non-polling entrypoint.
+        """
+        bridge = self._mirip_harness_approve_bridge_path()
+        if not bridge.exists():
+            return f"MIRIP-HARNESS approve bridge not found: {bridge}"
+
+        cmd = [sys.executable, str(bridge), "--execute-text", event.text or ""]
+        import subprocess as _subprocess
+
+        def _run_bridge():
+            return _subprocess.run(
+                cmd,
+                cwd=str(bridge.parents[1]),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=930,
+            )
+
+        try:
+            proc = await asyncio.to_thread(_run_bridge)
+        except _subprocess.TimeoutExpired:
+            return "MIRIP-HARNESS approve bridge timed out before completing. Check HARNESS run evidence/logs."
+        except Exception as exc:
+            return f"MIRIP-HARNESS approve bridge failed to start: {exc}"
+
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+        summary = stdout[-3000:] if stdout else stderr[-1000:]
+        if proc.returncode == 0:
+            return "MIRIP-HARNESS approve executed.\n" + summary
+        return f"MIRIP-HARNESS approve failed with exit code {proc.returncode}.\n{summary}"
+
     async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /approve command — unblock waiting agent thread(s).
 
@@ -8817,6 +8870,8 @@ class GatewayRunner:
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return "⚠️ Approval expired (agent is no longer waiting). Ask the agent to try again."
+            if self._looks_like_mirip_harness_approve(event):
+                return await self._handle_mirip_harness_approve_command(event)
             return "No pending command to approve."
 
         # Parse args: support "all", "all session", "all always", "session", "always"

--- a/run_agent.py
+++ b/run_agent.py
@@ -861,6 +861,44 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _disable_oauth_1m_beta_for_long_context_tier(agent) -> bool:
+    """Disable Anthropic's 1M-context beta for OAuth subscriptions.
+
+    Claude Pro/Max OAuth traffic still goes through Anthropic's Messages API.
+    If the subscription is capped at the standard 200K context tier, retries
+    must rebuild the client without the 1M beta header or the request keeps
+    presenting as a long-context request.
+    """
+    if getattr(agent, "api_mode", None) != "anthropic_messages":
+        return False
+    if not getattr(agent, "_is_anthropic_oauth", False):
+        return False
+    if getattr(agent, "_oauth_1m_beta_disabled", False):
+        return False
+
+    agent._oauth_1m_beta_disabled = True
+    try:
+        client = getattr(agent, "_anthropic_client", None)
+        if client is not None:
+            client.close()
+    except Exception:
+        pass
+
+    rebuild = getattr(agent, "_rebuild_anthropic_client", None)
+    if callable(rebuild):
+        rebuild()
+
+    vprint = getattr(agent, "_vprint", None)
+    if callable(vprint):
+        vprint(
+            f"{getattr(agent, 'log_prefix', '')}🔕 Anthropic OAuth subscription "
+            "hit the 1M context tier gate — disabled the 1M beta for this "
+            "session and retrying at 200K context...",
+            force=True,
+        )
+    return True
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -11995,9 +12033,10 @@ class AIAgent:
                     # subscription doesn't include the 1M-context tier.  This
                     # is NOT a transient rate limit — retrying or switching
                     # credentials won't help.  Reduce context to 200k (the
-                    # standard tier) and compress.
+                    # standard tier), drop the OAuth 1M beta, and compress.
                     if classified.reason == FailoverReason.long_context_tier:
                         _reduced_ctx = 200000
+                        _disabled_1m_beta = _disable_oauth_1m_beta_for_long_context_tier(self)
                         compressor = self.context_compressor
                         old_ctx = compressor.context_length
                         if old_ctx > _reduced_ctx:
@@ -12036,11 +12075,17 @@ class AIAgent:
                             # so _flush_messages_to_session_db writes compressed
                             # messages to the new session, not skipping them.
                             conversation_history = None
-                            if len(messages) < original_len or old_ctx > _reduced_ctx:
-                                self._emit_status(
-                                    f"🗜️ Context reduced to {_reduced_ctx:,} tokens "
-                                    f"(was {old_ctx:,}), retrying..."
-                                )
+                            if len(messages) < original_len or old_ctx > _reduced_ctx or _disabled_1m_beta:
+                                if old_ctx > _reduced_ctx:
+                                    self._emit_status(
+                                        f"🗜️ Context reduced to {_reduced_ctx:,} tokens "
+                                        f"(was {old_ctx:,}), retrying..."
+                                    )
+                                elif _disabled_1m_beta:
+                                    self._emit_status(
+                                        f"🔕 Disabled Anthropic 1M context beta; "
+                                        f"retrying at {_reduced_ctx:,} tokens..."
+                                    )
                                 time.sleep(2)
                                 restart_with_compressed_messages = True
                                 break

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1124,6 +1124,30 @@ class TestProviderRegistration:
         assert result["project_id"] == "my-proj"
         assert result["email"] == "t@e.com"
 
+    def test_auxiliary_client_uses_google_gemini_cli_oauth(self, monkeypatch):
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+        from agent.google_oauth import GoogleCredentials, save_credentials
+        from agent.auxiliary_client import resolve_provider_client
+
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        save_credentials(GoogleCredentials(
+            access_token="live-tok",
+            refresh_token="rt",
+            expires_ms=int((time.time() + 3600) * 1000),
+            project_id="my-proj",
+            email="t@e.com",
+        ))
+
+        client, model = resolve_provider_client(
+            "google-gemini-cli",
+            model="gemini-3-pro-preview",
+        )
+
+        assert isinstance(client, GeminiCloudCodeClient)
+        assert model == "gemini-3-pro-preview"
+        assert str(client.base_url).startswith("cloudcode-pa://")
+
     def test_determine_api_mode(self):
         from hermes_cli.providers import determine_api_mode
 

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -257,6 +257,34 @@ class TestApproveCommand:
         assert session_key not in runner._pending_approvals
 
 
+    @pytest.mark.asyncio
+    async def test_approve_task_args_routes_to_mirip_harness_bridge_when_no_tool_approval(self, monkeypatch):
+        """/approve task=... should invoke MIRIP-HARNESS bridge instead of saying no pending command."""
+        runner = _make_runner()
+        calls = []
+
+        class Completed:
+            returncode = 0
+            stdout = '{"status":"executed","return_code":0,"stdout_tail":"run_id=dry-run-test validation=PASS"}'
+            stderr = ""
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return Completed()
+
+        monkeypatch.setenv("MIRIP_HARNESS_ROOT", r"C:\MIRIP-HARNESS")
+        monkeypatch.setattr("gateway.run.Path.exists", lambda self: True)
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        result = await runner._handle_approve_command(_make_event("/approve task=2026-05-01_claude-worker-smoke-test worker=worker-claude-code-opus reviewer=reviewer-gpt-5-4 mode=dry-run post=false"))
+
+        assert calls
+        assert "telegram_approve_bridge.py" in calls[0][0][1]
+        assert "--execute-text" in calls[0][0]
+        assert "MIRIP-HARNESS approve executed" in result
+        assert "run_id=dry-run-test" in result
+
+
 # ------------------------------------------------------------------
 # /deny command
 # ------------------------------------------------------------------

--- a/tests/run_agent/test_long_context_tier_429.py
+++ b/tests/run_agent/test_long_context_tier_429.py
@@ -12,6 +12,8 @@ import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from run_agent import _disable_oauth_1m_beta_for_long_context_tier
+
 
 # ---------------------------------------------------------------------------
 # Detection logic
@@ -207,3 +209,42 @@ class TestAgentErrorPath:
             or "rate limit" in error_msg
         )
         assert is_rate_limited
+
+
+class TestOAuthLongContextRecovery:
+    """OAuth subscription traffic must drop the 1M beta after Anthropic
+    returns the long-context tier gate, otherwise retries keep failing even
+    after the compressor reduces context to 200k."""
+
+    def test_oauth_long_context_tier_disables_1m_beta_and_rebuilds_client(self):
+        client = MagicMock()
+        agent = SimpleNamespace(
+            api_mode="anthropic_messages",
+            _is_anthropic_oauth=True,
+            _oauth_1m_beta_disabled=False,
+            _anthropic_client=client,
+            _rebuild_anthropic_client=MagicMock(),
+            _vprint=MagicMock(),
+            log_prefix="",
+        )
+
+        assert _disable_oauth_1m_beta_for_long_context_tier(agent) is True
+
+        assert agent._oauth_1m_beta_disabled is True
+        client.close.assert_called_once_with()
+        agent._rebuild_anthropic_client.assert_called_once_with()
+        agent._vprint.assert_called_once()
+
+    def test_non_oauth_long_context_tier_does_not_rebuild_client(self):
+        agent = SimpleNamespace(
+            api_mode="anthropic_messages",
+            _is_anthropic_oauth=False,
+            _oauth_1m_beta_disabled=False,
+            _anthropic_client=MagicMock(),
+            _rebuild_anthropic_client=MagicMock(),
+            _vprint=MagicMock(),
+        )
+
+        assert _disable_oauth_1m_beta_for_long_context_tier(agent) is False
+        assert agent._oauth_1m_beta_disabled is False
+        agent._rebuild_anthropic_client.assert_not_called()

--- a/tests/tools/test_local_windows_backend.py
+++ b/tests/tools/test_local_windows_backend.py
@@ -1,0 +1,46 @@
+import platform
+
+import pytest
+
+from tools.environments import local
+from tools.environments.local import LocalEnvironment
+
+
+def test_windows_bash_resolution_prefers_git_bash_over_wsl_shim(monkeypatch):
+    monkeypatch.setattr(local, "_IS_WINDOWS", True)
+    monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+    monkeypatch.setattr(local.shutil, "which", lambda name: r"C:\Windows\System32\bash.exe")
+
+    def fake_isfile(path):
+        return path == r"C:\Program Files\Git\bin\bash.exe"
+
+    monkeypatch.setattr(local.os.path, "isfile", fake_isfile)
+    monkeypatch.setenv("ProgramFiles", r"C:\Program Files")
+    monkeypatch.setenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\test\AppData\Local")
+
+    assert local._find_bash() == r"C:\Program Files\Git\bin\bash.exe"
+
+
+def test_windows_popen_cwd_converts_git_bash_paths(monkeypatch):
+    monkeypatch.setattr(local, "_IS_WINDOWS", True)
+    monkeypatch.setattr(local.tempfile, "gettempdir", lambda: r"C:\Users\test\AppData\Local\Temp")
+
+    assert local._windows_popen_cwd("/c/MIRIP") == r"C:\MIRIP"
+    assert local._windows_popen_cwd("/mnt/c/MIRIP") == r"C:\MIRIP"
+    assert local._windows_popen_cwd("/tmp/hermes") == r"C:\Users\test\AppData\Local\Temp\hermes"
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows pipe behavior")
+def test_windows_local_environment_captures_git_bash_stdout(monkeypatch):
+    git_bash = r"C:\Program Files\Git\bin\bash.exe"
+    if not local.os.path.isfile(git_bash):
+        pytest.skip("Git Bash is not installed at the standard path")
+
+    monkeypatch.setenv("HERMES_GIT_BASH_PATH", git_bash)
+
+    env = LocalEnvironment(cwd=".", timeout=10)
+    result = env.execute("echo HERMES_WINDOWS_STDOUT_OK", timeout=10)
+
+    assert result["returncode"] == 0
+    assert "HERMES_WINDOWS_STDOUT_OK" in result["output"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -487,6 +487,17 @@ class BaseEnvironment(ABC):
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
         def _drain():
+            if os.name == "nt":
+                # select() does not support anonymous pipe handles on Windows.
+                # A daemon reader thread can block safely while the main thread
+                # owns timeout/interrupt handling and closes the pipe on exit.
+                try:
+                    for line in proc.stdout:
+                        output_chunks.append(line)
+                except (ValueError, OSError):
+                    pass
+                return
+
             fd = proc.stdout.fileno()
             idle_after_exit = 0
             try:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -158,10 +159,6 @@ def _find_bash() -> str:
     if custom and os.path.isfile(custom):
         return custom
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -169,6 +166,16 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found:
+        normalized = os.path.normcase(os.path.abspath(found))
+        is_wsl_shim = (
+            normalized.endswith(os.path.normcase(r"\Windows\System32\bash.exe"))
+            or normalized.endswith(os.path.normcase(r"\Microsoft\WindowsApps\bash.exe"))
+        )
+        if not is_wsl_shim:
+            return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"
@@ -186,6 +193,28 @@ _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
+
+
+def _windows_popen_cwd(cwd: str) -> str:
+    """Convert Git Bash/MSYS cwd forms back to Windows paths for Popen."""
+    if not _IS_WINDOWS or not cwd:
+        return cwd
+
+    normalized = cwd.replace("\\", "/")
+    if normalized == "/tmp" or normalized.startswith("/tmp/"):
+        temp_root = tempfile.gettempdir().rstrip("\\/")
+        suffix = normalized[5:] if normalized.startswith("/tmp/") else ""
+        return temp_root + (("\\" + suffix.replace("/", "\\")) if suffix else "")
+
+    drive_path_match = re.match(r"^/([a-zA-Z])(?:/(.*))?$", normalized)
+    if not drive_path_match:
+        drive_path_match = re.match(r"^/mnt/([a-zA-Z])(?:/(.*))?$", normalized)
+    if not drive_path_match:
+        return cwd
+
+    drive = drive_path_match.group(1).upper()
+    rest = drive_path_match.group(2) or ""
+    return drive + ":\\" + rest.replace("/", "\\")
 
 
 def _make_run_env(env: dict) -> dict:
@@ -368,7 +397,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            cwd=self.cwd,
+            cwd=_windows_popen_cwd(self.cwd),
         )
         if not _IS_WINDOWS:
             try:


### PR DESCRIPTION
## Summary
- support the Hermes backend OAuth bridge on Windows in the local backend path
- include the committed gateway and test updates already present on this branch

## Local verification caveats
-  has 1 Windows file-permission assertion failure ( vs )
-  needs local pytest-asyncio support for async cases
