### PR TITLE
fix(kanban): preserve shared board path for profile workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -62,13 +62,26 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
+    """Return the path to the active Kanban database.
+
+    Profile workers run with ``HERMES_HOME`` set to their profile directory,
+    but Kanban is a shared board owned by the dispatcher. The dispatcher passes
+    the canonical DB path through ``HERMES_KANBAN_DB`` so worker tools keep
+    talking to the same board after ``hermes -p <profile>`` rewrites
+    ``HERMES_HOME``.
+    """
+    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    if override:
+        return Path(override).expanduser()
     from hermes_constants import get_hermes_home
     return get_hermes_home() / "kanban.db"
 
 
 def workspaces_root() -> Path:
     """Return the directory under which ``scratch`` workspaces are created."""
+    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser()
     from hermes_constants import get_hermes_home
     return get_hermes_home() / "kanban" / "workspaces"
 
@@ -2070,6 +2083,8 @@ def _default_spawn(task: Task, workspace: str) -> Optional[int]:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    env["HERMES_KANBAN_DB"] = str(kanban_db_path())
+    env["HERMES_KANBAN_WORKSPACES_ROOT"] = str(workspaces_root())
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2215,6 +2215,33 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     env = captured["env"]
     assert env.get("HERMES_KANBAN_TASK") == tid
     assert env.get("HERMES_PROFILE") == "some-profile"
+    assert env.get("HERMES_KANBAN_DB") == str(kanban_home / "kanban.db")
+    assert env.get("HERMES_KANBAN_WORKSPACES_ROOT") == str(
+        kanban_home / "kanban" / "workspaces"
+    )
+
+
+def test_kanban_paths_prefer_dispatcher_env_over_profile_home(tmp_path, monkeypatch):
+    """A profile worker must keep using the dispatcher's shared board.
+
+    ``hermes -p researcher`` rewrites HERMES_HOME to the profile directory.
+    Without the explicit dispatcher env override, worker-side kanban tools
+    look at profiles/researcher/kanban.db instead of the shared board.
+    """
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "researcher"
+    shared_db = root / "kanban.db"
+    shared_workspaces = root / "kanban" / "workspaces"
+    profile_home.mkdir(parents=True)
+    shared_workspaces.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(shared_db))
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(shared_workspaces))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert kb.kanban_db_path() == shared_db
+    assert kb.workspaces_root() == shared_workspaces
 
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -112,6 +112,39 @@ def test_show_explicit_task_id(worker_env):
     assert d["task"]["id"] == other
 
 
+def test_worker_tools_use_shared_db_override(monkeypatch, tmp_path):
+    """Worker tools must find tasks on the dispatcher DB after -p switches home."""
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "researcher"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="shared board", assignee="researcher")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(root / "kanban.db"))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_show({})
+    d = json.loads(out)
+    assert d["task"]["id"] == tid
+    assert d["task"]["title"] == "shared board"
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({


### PR DESCRIPTION
## Summary

Fix Kanban profile-worker dispatch so workers spawned with `hermes -p <profile>` keep using the dispatcher's shared board instead of resolving `kanban.db` from the worker profile's rewritten `HERMES_HOME`.

When the dispatcher spawns a profile worker, it now passes:

- `HERMES_KANBAN_DB`
- `HERMES_KANBAN_WORKSPACES_ROOT`

The Kanban path helpers prefer those env overrides, while preserving the existing default behavior for standalone/profile-local boards.

## Problem

`hermes -p researcher` rewrites `HERMES_HOME` to `~/.hermes/profiles/researcher`.

Before this change, worker-side Kanban tools resolved the DB from that profile home:

`~/.hermes/profiles/researcher/kanban.db`

instead of the dispatcher-owned shared board:

`~/.hermes/kanban.db`

That caused dispatched workers to fail with `kanban_show: task not found` and prevented `kanban_complete` / `kanban_block` from closing the task on the shared board.

## Fix

- Add dispatcher-provided env overrides for Kanban DB and workspace root.
- Pass those env vars from `_default_spawn`.
- Add regression tests for:
  - spawned worker env includes the shared board paths
  - path helpers prefer dispatcher overrides over profile `HERMES_HOME`
  - worker tools can read the shared board after profile home switching

## Tests

```bash
python -m pytest \
  tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_auto_loads_kanban_worker_skill \
  tests/hermes_cli/test_kanban_core_functionality.py::test_kanban_paths_prefer_dispatcher_env_over_profile_home \
  tests/tools/test_kanban_tools.py::test_worker_tools_use_shared_db_override
