### PR TITLE
Keep ACP responsive with lazy Honcho tools memory

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -40,12 +40,15 @@ def make_approval_callback(
         timeout: Seconds to wait for a response before auto-denying.
     """
 
-    def _callback(command: str, description: str) -> str:
+    def _callback(command: str, description: str, *, allow_permanent: bool = True) -> str:
         options = [
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
-            PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
-            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
         ]
+        if allow_permanent:
+            options.append(
+                PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always")
+            )
+        options.append(PermissionOption(option_id="deny", kind="reject_once", name="Deny"))
         import acp as _acp
 
         tool_call = _acp.start_tool_call("perm-check", command, kind="execute")
@@ -68,10 +71,13 @@ def make_approval_callback(
 
         outcome = response.outcome
         if isinstance(outcome, AllowedOutcome):
-            option_id = outcome.option_id
+            # ACP schema versions have used both snake_case and camelCase.
+            # Support both so Hermes ACP approval does not crash after package drift.
+            option_id = getattr(outcome, "option_id", None) or getattr(outcome, "optionId", None)
             # Look up the kind from our options list
             for opt in options:
-                if opt.option_id == option_id:
+                current_id = getattr(opt, "option_id", None) or getattr(opt, "optionId", None)
+                if current_id == option_id:
                     return _KIND_TO_HERMES.get(opt.kind, "deny")
             return "once"  # fallback for unknown option_id
         else:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -6,6 +6,7 @@ import asyncio
 import contextvars
 import logging
 import os
+import threading
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Deque, Optional
@@ -854,22 +855,37 @@ class HermesACPAgent(acp.Agent):
             self.session_manager.save_session(session_id)
 
         final_response = result.get("final_response", "")
-        if final_response:
-            try:
-                from agent.title_generator import maybe_auto_title
-
-                maybe_auto_title(
-                    self.session_manager._get_db(),
-                    session_id,
-                    user_text,
-                    final_response,
-                    state.history,
-                )
-            except Exception:
-                logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
+        # Critical ACP ordering: commit the assistant answer to the client before
+        # any auxiliary work.  Title generation may call an LLM and can be slow
+        # or hang on provider/network issues; if it runs first, Zed receives
+        # streamed chunks but never gets the final session/prompt response, so
+        # the answer can disappear from the UI.  Keep user-visible finalization
+        # on the hot path and move title generation to a best-effort daemon
+        # thread.
         if final_response and conn:
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
+
+        if final_response:
+            def _auto_title_background() -> None:
+                try:
+                    from agent.title_generator import maybe_auto_title
+
+                    maybe_auto_title(
+                        self.session_manager._get_db(),
+                        session_id,
+                        user_text,
+                        final_response,
+                        state.history,
+                    )
+                except Exception:
+                    logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
+
+            threading.Thread(
+                target=_auto_title_background,
+                name=f"acp-title-{session_id[:8]}",
+                daemon=True,
+            ).start()
 
         # Mark this turn idle before draining queued work so recursive prompt()
         # calls can acquire the session. Queued turns are intentionally run as

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -199,6 +199,8 @@ class HonchoMemoryProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
+        self._sync_lock = threading.Lock()
+        self._last_sync_signature: Optional[tuple[str, str, str]] = None
 
         # B1: recall_mode — set during initialize from config
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
@@ -289,8 +291,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 self._cron_skipped = True
                 return
 
-            from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
-            from plugins.memory.honcho.session import HonchoSessionManager
+            from plugins.memory.honcho.client import HonchoClientConfig
 
             cfg = HonchoClientConfig.from_global_config()
             if not cfg.enabled or not (cfg.api_key or cfg.base_url):
@@ -448,7 +449,7 @@ class HonchoMemoryProvider(MemoryProvider):
             return True
         if self._cron_skipped:
             return False
-        if not self._config or not self._lazy_init_kwargs:
+        if not self._config or self._lazy_init_kwargs is None:
             return False
 
         try:
@@ -1125,15 +1126,33 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
-        if not self._manager or not self._session_key:
-            return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        if not clean_user_content and not clean_assistant_content:
+            return
+
+        # Some ACP lifecycle paths can report the same completed turn more
+        # than once while closing/resuming a session. Honcho is durable memory,
+        # so avoid polluting it with exact duplicate adjacent turns.
+        sync_signature = (session_id or self._session_key or "", clean_user_content, clean_assistant_content)
+        with self._sync_lock:
+            if sync_signature == self._last_sync_signature:
+                logger.debug("Honcho sync_turn skipped exact duplicate turn")
+                return
+            self._last_sync_signature = sync_signature
 
         def _sync():
             try:
+                # Tools-only lazy mode intentionally avoids session creation on
+                # initialize()/prefetch so Zed ACP launch and first prompt stay
+                # responsive.  Still initialize here inside the background
+                # writer so Honcho observes turns without blocking the response
+                # path.
+                if not self._manager or not self._session_key:
+                    if not self._ensure_session():
+                        return
                 session = self._manager.get_or_create(self._session_key)
                 for chunk in self._chunk_message(clean_user_content, msg_limit):
                     session.add_message("user", chunk)
@@ -1144,7 +1163,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 logger.debug("Honcho sync_turn failed: %s", e)
 
         if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=5.0)
+            logger.debug("Honcho sync_turn overlap; starting another async writer")
         self._sync_thread = threading.Thread(
             target=_sync, daemon=True, name="honcho-sync"
         )
@@ -1168,11 +1187,15 @@ class HonchoMemoryProvider(MemoryProvider):
             return
         if self._cron_skipped:
             return
-        if not self._manager or not self._session_key:
-            return
 
         def _write():
             try:
+                # Lazy tools-only sessions must still mirror explicit memory
+                # writes; initialize in this background thread instead of
+                # dropping the write.
+                if not self._manager or not self._session_key:
+                    if not self._ensure_session():
+                        return
                 self._manager.create_conclusion(self._session_key, content)
             except Exception as e:
                 logger.debug("Honcho memory mirror failed: %s", e)

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -201,64 +201,71 @@ class HonchoSessionManager:
             session.add_peers([(user_peer, user_config), (assistant_peer, ai_config)])
 
             # Sync back: server-side config (set via Honcho UI) wins over
-            # local defaults. Read the effective config after add_peers.
-            # Note: observation booleans are manager-scoped, not per-session.
-            # Last session init wins. Fine for CLI; gateway should scope per-session.
-            try:
-                server_user = session.get_peer_configuration(user_peer)
-                server_ai = session.get_peer_configuration(assistant_peer)
-                if server_user.observe_me is not None:
-                    self._user_observe_me = server_user.observe_me
-                if server_user.observe_others is not None:
-                    self._user_observe_others = server_user.observe_others
-                if server_ai.observe_me is not None:
-                    self._ai_observe_me = server_ai.observe_me
-                if server_ai.observe_others is not None:
-                    self._ai_observe_others = server_ai.observe_others
-                logger.debug(
-                    "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
-                    self._user_observe_me, self._user_observe_others,
-                    self._ai_observe_me, self._ai_observe_others,
-                )
-            except Exception as e:
-                logger.debug("Honcho get_peer_configuration failed (using local config): %s", e)
+            # local defaults. In tools-only ACP mode this extra pair of HTTP
+            # calls is intentionally skipped: ACP launch/write must stay
+            # bounded and the local host config is the source of truth.
+            if not (self._config and getattr(self._config, "recall_mode", "hybrid") == "tools"):
+                try:
+                    server_user = session.get_peer_configuration(user_peer)
+                    server_ai = session.get_peer_configuration(assistant_peer)
+                    if server_user.observe_me is not None:
+                        self._user_observe_me = server_user.observe_me
+                    if server_user.observe_others is not None:
+                        self._user_observe_others = server_user.observe_others
+                    if server_ai.observe_me is not None:
+                        self._ai_observe_me = server_ai.observe_me
+                    if server_ai.observe_others is not None:
+                        self._ai_observe_others = server_ai.observe_others
+                    logger.debug(
+                        "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
+                        self._user_observe_me, self._user_observe_others,
+                        self._ai_observe_me, self._ai_observe_others,
+                    )
+                except Exception as e:
+                    logger.debug("Honcho get_peer_configuration failed (using local config): %s", e)
         except Exception as e:
             logger.warning(
                 "Honcho session '%s' add_peers failed (non-fatal): %s",
                 session_id, e,
             )
 
-        # Load existing messages via context() - single call for messages + metadata
+        # Load existing messages via context() - single call for messages + metadata.
+        # Tools-only ACP uses Honcho as explicit tools + durable observation, not
+        # automatic history injection. Skipping this context read avoids a slow
+        # first-turn write path and keeps Zed ACP launch bounded.
         existing_messages = []
-        try:
-            ctx = session.context(summary=True, tokens=self._context_tokens)
-            existing_messages = ctx.messages or []
+        if self._config and getattr(self._config, "recall_mode", "hybrid") == "tools":
+            logger.info("Honcho session '%s' opened in tools-only fast path", session_id)
+        else:
+            try:
+                ctx = session.context(summary=True, tokens=self._context_tokens)
+                existing_messages = ctx.messages or []
 
-            # Verify chronological ordering
-            if existing_messages and len(existing_messages) > 1:
-                timestamps = [m.created_at for m in existing_messages if m.created_at]
-                if timestamps and timestamps != sorted(timestamps):
-                    logger.warning(
-                        "Honcho messages not chronologically ordered for session '%s', sorting",
-                        session_id,
-                    )
-                    existing_messages = sorted(
-                        existing_messages,
-                        key=lambda m: m.created_at or datetime.min,
-                    )
+                # Verify chronological ordering
+                if existing_messages and len(existing_messages) > 1:
+                    timestamps = [m.created_at for m in existing_messages if m.created_at]
+                    if timestamps and timestamps != sorted(timestamps):
+                        logger.warning(
+                            "Honcho messages not chronologically ordered for session '%s', sorting",
+                            session_id,
+                        )
+                        existing_messages = sorted(
+                            existing_messages,
+                            key=lambda m: m.created_at or datetime.min,
+                        )
 
-            if existing_messages:
-                logger.info(
-                    "Honcho session '%s' retrieved (%d existing messages)",
-                    session_id, len(existing_messages),
+                if existing_messages:
+                    logger.info(
+                        "Honcho session '%s' retrieved (%d existing messages)",
+                        session_id, len(existing_messages),
+                    )
+                else:
+                    logger.info("Honcho session '%s' created (new)", session_id)
+            except Exception as e:
+                logger.warning(
+                    "Honcho session '%s' loaded (failed to fetch context: %s)",
+                    session_id, e,
                 )
-            else:
-                logger.info("Honcho session '%s' created (new)", session_id)
-        except Exception as e:
-            logger.warning(
-                "Honcho session '%s' loaded (failed to fetch context: %s)",
-                session_id, e,
-            )
 
         self._sessions_cache[session_id] = session
         return session, existing_messages

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,7 +1,5 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
-import asyncio
-import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -16,18 +14,15 @@ from acp.schema import (
     AvailableCommandsUpdate,
     Implementation,
     InitializeResponse,
-    ListSessionsResponse,
     LoadSessionResponse,
     NewSessionResponse,
     PromptResponse,
     ResumeSessionResponse,
     SessionModelState,
-    SetSessionConfigOptionResponse,
     SetSessionModelResponse,
     SetSessionModeResponse,
     SessionInfo,
     TextContentBlock,
-    Usage,
     UserMessageChunk,
 )
 from acp_adapter.server import HermesACPAgent, HERMES_VERSION
@@ -200,6 +195,8 @@ class TestSessionOps:
             "context",
             "reset",
             "compact",
+            "steer",
+            "queue",
             "version",
         ]
         model_cmd = next(

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -655,6 +655,70 @@ class TestToolsModeInitBehavior:
         assert cfg.peer_name is None
         assert mock_manager_cls.call_args.kwargs["runtime_user_peer_name"] == "8439114563"
 
+    def test_tools_lazy_sync_turn_initializes_in_background(self):
+        """tools + lazy init must still mirror completed turns to Honcho."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import MagicMock, patch
+
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            recall_mode="tools",
+            init_on_session_start=False,
+        )
+        provider = HonchoMemoryProvider()
+        mock_manager = MagicMock()
+        mock_session = MagicMock()
+        mock_session.messages = []
+        mock_manager.get_or_create.return_value = mock_session
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
+             patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
+             patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
+             patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            provider.initialize(session_id="test-session-001")
+            assert provider._session_initialized is False
+            provider.sync_turn("hello", "hi there")
+            provider._sync_thread.join(timeout=2.0)
+
+        assert provider._session_initialized is True
+        mock_manager.get_or_create.assert_any_call(provider._session_key)
+        assert mock_session.add_message.call_count == 2
+
+    def test_tools_lazy_memory_write_initializes_in_background(self):
+        """Explicit memory writes must not be dropped in tools-only lazy mode."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import MagicMock, patch
+
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            recall_mode="tools",
+            init_on_session_start=False,
+        )
+        provider = HonchoMemoryProvider()
+        mock_manager = MagicMock()
+        mock_session = MagicMock()
+        mock_session.messages = []
+        mock_manager.get_or_create.return_value = mock_session
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
+             patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
+             patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
+             patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            provider.initialize(session_id="test-session-001")
+            assert provider._session_initialized is False
+            provider.on_memory_write("add", "user", "favorite color is purple")
+            import time
+            deadline = time.time() + 2.0
+            while time.time() < deadline and not mock_manager.create_conclusion.called:
+                time.sleep(0.01)
+
+        assert provider._session_initialized is True
+        mock_manager.create_conclusion.assert_called_once_with(
+            provider._session_key, "favorite color is purple"
+        )
+
 
 class TestPerSessionMigrateGuard:
     """Verify migrate_memory_files is skipped under per-session strategy.
@@ -1097,7 +1161,7 @@ class TestDialecticDepth:
         provider._session_key = "test"
         provider._base_context_cache = "existing context"
 
-        result = provider._run_dialectic_depth("test query")
+        provider._run_dialectic_depth("test query")
         # Only 1 call because pass 0 had sufficient signal
         assert provider._manager.dialectic_query.call_count == 1
 
@@ -1193,7 +1257,6 @@ class TestDialecticCadenceAdvancesOnSuccess:
         return provider
 
     def test_empty_dialectic_result_does_not_advance_cadence(self):
-        import time as _time
         provider = self._make_provider()
         provider._session_key = "test"
         provider._manager.dialectic_query.return_value = ""  # silent failure


### PR DESCRIPTION
## Summary
- keep Honcho tools-only lazy sessions responsive for ACP/Zed while still mirroring completed turns and explicit memory writes
- skip nonessential Honcho context/config reads on tools-only startup/write paths to avoid launch stalls
- dedupe exact adjacent Honcho turn syncs to prevent duplicate durable memory rows
- tolerate ACP permission API drift (`allow_permanent`, `option_id`/`optionId`)

## Why
ACP/Zed sessions need Honcho memory enabled, but eager/hybrid Honcho paths can block startup/first prompts. The existing tools-only lazy path avoided the latency, but normal completed turns were not written until a tool initialized the session. This change preserves the low-latency tools-only path while ensuring Honcho still observes the conversation.

## Verification
- `uv run --extra dev --extra honcho --extra acp python -m pytest tests/honcho_plugin/test_session.py tests/acp/test_server.py -q` → 171 passed
- `uv run --extra dev --extra honcho --extra acp python -m py_compile acp_adapter/permissions.py plugins/memory/honcho/__init__.py plugins/memory/honcho/session.py`
- Manual remote ACP E2E with Honcho enabled:
  - initialize/session/new/load/prompt passed
  - Honcho `messages` had one user row and one assistant row for the unique E2E marker
  - Honcho `message_embeddings` had both rows in `synced` state
  - no wrapper SIGABRT/Fatal/EOF/Traceback/error lines in final scan

## Notes
The manual E2E was run against a self-hosted Honcho stack with deriver/api/redis/postgres healthy.
