### PR TITLE
Fix WhatsApp native delivery for generated media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1871,6 +1871,62 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
     @staticmethod
+    def _resolve_local_file_candidate(path_text: str) -> Optional[str]:
+        """Resolve model-written local paths against the configured safe root.
+
+        Small/local models sometimes report a path just outside the configured
+        Hermes workspace, e.g. ``~/weaver_output/movie.mp4`` when the file was
+        actually created under ``$HERMES_WRITE_SAFE_ROOT/weaver_output``.  Keep
+        delivery reliable without broad filesystem searching by trying the same
+        home-relative suffix under known safe roots.
+        """
+        raw = str(path_text or "").strip()
+        if not raw:
+            return None
+
+        expanded = os.path.expanduser(raw)
+        if os.path.isfile(expanded):
+            return expanded
+
+        roots: list[Path] = []
+        for root_text in (
+            os.getenv("HERMES_WRITE_SAFE_ROOT", ""),
+            os.getenv("HERMES_WORKSPACE", ""),
+        ):
+            if root_text:
+                root = Path(os.path.expanduser(root_text))
+                if root not in roots:
+                    roots.append(root)
+
+        # In normal gateway runs the cwd is the Hermes workspace; include it
+        # as a fallback for older configs that have not set HERMES_WRITE_SAFE_ROOT.
+        try:
+            cwd = Path.cwd()
+            if cwd not in roots:
+                roots.append(cwd)
+        except Exception:
+            pass
+
+        suffixes: list[Path] = []
+        expanded_path = Path(expanded)
+        try:
+            suffixes.append(expanded_path.relative_to(Path.home()))
+        except Exception:
+            pass
+        parts = expanded_path.parts
+        if len(parts) > 3 and parts[1] == "Users":
+            # Handles typo'd/macOS user homes like /Users/hedimand/foo/bar.mp4
+            suffixes.append(Path(*parts[3:]))
+
+        for root in roots:
+            for suffix in suffixes:
+                candidate = root / suffix
+                if os.path.isfile(candidate):
+                    return str(candidate)
+
+        return None
+
+    @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
@@ -1903,7 +1959,11 @@ class BasePlatformAdapter(ABC):
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+                media.append((
+                    BasePlatformAdapter._resolve_local_file_candidate(path)
+                    or os.path.expanduser(path),
+                    has_voice_tag,
+                ))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:
@@ -1958,9 +2018,9 @@ class BasePlatformAdapter(ABC):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
-            expanded = os.path.expanduser(raw)
-            if os.path.isfile(expanded):
-                found.append((raw, expanded))
+            resolved = BasePlatformAdapter._resolve_local_file_candidate(raw)
+            if resolved:
+                found.append((raw, resolved))
 
         # Deduplicate by expanded path, preserving discovery order
         seen: set = set()

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -810,11 +810,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 payload["caption"] = caption
             if file_name:
                 payload["fileName"] = file_name
+            media_upload_timeout_ms = self._media_upload_timeout_ms(file_path, media_type)
+            payload["mediaUploadTimeoutMs"] = media_upload_timeout_ms
 
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/send-media",
                 json=payload,
-                timeout=aiohttp.ClientTimeout(total=120),
+                timeout=aiohttp.ClientTimeout(total=(media_upload_timeout_ms / 1000) + 30),
             ) as resp:
                 if resp.status == 200:
                     data = await resp.json()
@@ -829,6 +831,21 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
         except Exception as e:
             return SendResult(success=False, error=str(e))
+
+    @staticmethod
+    def _media_upload_timeout_ms(file_path: str, media_type: str) -> int:
+        """Return a size-aware timeout for bridge media uploads."""
+        try:
+            size_mb = os.path.getsize(file_path) / (1024 * 1024)
+        except OSError:
+            size_mb = 0
+        base = 120_000
+        if media_type in {"video", "document"}:
+            base = 300_000
+        # Slow residential/mobile paths can take a while to POST to WhatsApp's
+        # CDN.  Scale with size but cap to avoid hanging forever.
+        scaled = int(60_000 + (size_mb * 30_000))
+        return max(base, min(scaled, 900_000))
 
     async def send_image(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32,6 +32,91 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List, Union
 
+
+def _collect_current_turn_media_tags(
+    final_response: str,
+    result_messages: List[Dict[str, Any]],
+    history_media_paths: set,
+) -> tuple[List[str], bool]:
+    """Return MEDIA tags found in current tool results but not already delivered.
+
+    TTS tools already return MEDIA tags. Image generation providers generally
+    return JSON with an ``image`` field instead, so this normalizes both shapes
+    before gateway delivery.
+    """
+    media_tags: List[str] = []
+    has_voice_directive = False
+    existing_response_media_paths = set()
+    if "MEDIA:" in final_response:
+        for match in re.finditer(r'MEDIA:(\S+)', final_response):
+            path = match.group(1).strip().rstrip('",}')
+            if path:
+                existing_response_media_paths.add(path)
+
+    def add_media_path(path: str) -> None:
+        path = str(path or "").strip().strip("`\"'")
+        path = path.rstrip('",}')
+        if not path:
+            return
+        if path in history_media_paths or path in existing_response_media_paths:
+            return
+        media_tags.append(f"MEDIA:{path}")
+
+    for msg in result_messages:
+        if msg.get("role") not in ("tool", "function"):
+            continue
+        content = msg.get("content", "")
+        for path in _extract_media_paths_from_tool_content(content):
+            add_media_path(path)
+        if isinstance(content, str) and "[[audio_as_voice]]" in content:
+            has_voice_directive = True
+
+    seen = set()
+    unique_tags = []
+    for tag in media_tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique_tags.append(tag)
+    return unique_tags, has_voice_directive
+
+
+def _extract_media_paths_from_tool_content(content: Any) -> List[str]:
+    """Extract local/media paths from tool result content.
+
+    Covers both tools that return literal ``MEDIA:/path`` tags and tools that
+    return JSON payloads such as ``{"success": true, "image": "/path.png"}``.
+    """
+    paths: List[str] = []
+    if isinstance(content, str) and "MEDIA:" in content:
+        for match in re.finditer(r'MEDIA:(\S+)', content):
+            path = match.group(1).strip().rstrip('",}')
+            if path:
+                paths.append(path)
+
+    try:
+        tool_data = json.loads(content) if isinstance(content, str) else content
+    except Exception:
+        tool_data = None
+    if isinstance(tool_data, dict) and tool_data.get("success"):
+        image_value = tool_data.get("image")
+        if isinstance(image_value, str):
+            paths.append(image_value)
+        elif isinstance(image_value, dict):
+            image_path = image_value.get("path") or image_value.get("url")
+            if isinstance(image_path, str):
+                paths.append(image_path)
+        images_value = tool_data.get("images")
+        if isinstance(images_value, list):
+            for image_item in images_value:
+                if isinstance(image_item, str):
+                    paths.append(image_item)
+                elif isinstance(image_item, dict):
+                    image_path = image_item.get("path") or image_item.get("url")
+                    if isinstance(image_path, str):
+                        paths.append(image_path)
+    return paths
+
+
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
 # patches (tests/gateway/test_usage_command.py) target
@@ -646,6 +731,8 @@ def _build_media_placeholder(event) -> str:
         mtype = media_types[i] if i < len(media_types) else ""
         if mtype.startswith("image/") or getattr(event, "message_type", None) == MessageType.PHOTO:
             parts.append(f"[User sent an image: {url}]")
+        elif mtype.startswith("video/") or getattr(event, "message_type", None) == MessageType.VIDEO:
+            parts.append(f"[User sent a video: {url}]")
         elif mtype.startswith("audio/"):
             parts.append(f"[User sent audio: {url}]")
         else:
@@ -5431,12 +5518,15 @@ class GatewayRunner:
         if event.media_urls:
             image_paths = []
             audio_paths = []
+            video_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
                 if mtype.startswith("audio/") or event.message_type in (MessageType.VOICE, MessageType.AUDIO):
                     audio_paths.append(path)
+                if mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
+                    video_paths.append(path)
 
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
@@ -5496,6 +5586,17 @@ class GatewayRunner:
                             )
                         except Exception:
                             pass
+
+            if video_paths:
+                notes = []
+                for path in video_paths:
+                    basename = os.path.basename(path)
+                    notes.append(
+                        f"[The user sent a video: '{basename}'. "
+                        f"The file is saved at: {path}. "
+                        f"Use this local path directly for video-processing tools or terminal commands.]"
+                    )
+                message_text = "\n".join(notes + ([message_text] if message_text else []))
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
@@ -12559,18 +12660,18 @@ class GatewayRunner:
                                     entry[_rkey] = _rval
                         agent_history.append(entry)
             
-            # Collect MEDIA paths already in history so we can exclude them
-            # from the current turn's extraction. This is compression-safe:
-            # even if the message list shrinks, we know which paths are old.
+            # Collect media paths already in history so we can exclude them
+            # from the current turn's extraction. This covers both literal
+            # MEDIA tags and JSON tool payloads from image generation.
+            # Compression-safe: even if the message list shrinks, we know
+            # which paths are old.
             _history_media_paths: set = set()
             for _hm in agent_history:
                 if _hm.get("role") in ("tool", "function"):
                     _hc = _hm.get("content", "")
-                    if "MEDIA:" in _hc:
-                        for _match in re.finditer(r'MEDIA:(\S+)', _hc):
-                            _p = _match.group(1).strip().rstrip('",}')
-                            if _p:
-                                _history_media_paths.add(_p)
+                    for _p in _extract_media_paths_from_tool_content(_hc):
+                        if _p:
+                            _history_media_paths.add(_p)
             
             # Register per-session gateway approval callback so dangerous
             # command approval blocks the agent thread (mirrors CLI input()).
@@ -12827,30 +12928,15 @@ class GatewayRunner:
             # Uses path-based deduplication against _history_media_paths (collected
             # before run_conversation) instead of index slicing. This is safe even
             # when context compression shrinks the message list. (Fixes #160)
-            if "MEDIA:" not in final_response:
-                media_tags = []
-                has_voice_directive = False
-                for msg in result.get("messages", []):
-                    if msg.get("role") in ("tool", "function"):
-                        content = msg.get("content", "")
-                        if "MEDIA:" in content:
-                            for match in re.finditer(r'MEDIA:(\S+)', content):
-                                path = match.group(1).strip().rstrip('",}')
-                                if path and path not in _history_media_paths:
-                                    media_tags.append(f"MEDIA:{path}")
-                            if "[[audio_as_voice]]" in content:
-                                has_voice_directive = True
-                
-                if media_tags:
-                    seen = set()
-                    unique_tags = []
-                    for tag in media_tags:
-                        if tag not in seen:
-                            seen.add(tag)
-                            unique_tags.append(tag)
-                    if has_voice_directive:
-                        unique_tags.insert(0, "[[audio_as_voice]]")
-                    final_response = final_response + "\n" + "\n".join(unique_tags)
+            media_tags, has_voice_directive = _collect_current_turn_media_tags(
+                final_response,
+                result.get("messages", []),
+                _history_media_paths,
+            )
+            if media_tags:
+                if has_voice_directive and "[[audio_as_voice]]" not in final_response:
+                    media_tags.insert(0, "[[audio_as_voice]]")
+                final_response = final_response + "\n" + "\n".join(media_tags)
             
             # Sync session_id: the agent may have created a new session during
             # mid-run context compression (_compress_context splits sessions).

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -492,27 +492,26 @@ app.post('/send-media', async (req, res) => {
       return res.status(404).json({ error: `File not found: ${filePath}` });
     }
 
-    const buffer = readFileSync(filePath);
     const ext = filePath.toLowerCase().split('.').pop();
     const type = mediaType || inferMediaType(ext);
     let msgPayload;
 
     switch (type) {
       case 'image':
-        msgPayload = { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
+        msgPayload = { image: { url: filePath }, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
         break;
       case 'video':
-        msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
+        msgPayload = { video: { url: filePath }, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
         break;
       case 'audio': {
         const audioMime = (ext === 'ogg' || ext === 'opus') ? 'audio/ogg; codecs=opus' : 'audio/mpeg';
-        msgPayload = { audio: buffer, mimetype: audioMime, ptt: ext === 'ogg' || ext === 'opus' };
+        msgPayload = { audio: { url: filePath }, mimetype: audioMime, ptt: ext === 'ogg' || ext === 'opus' };
         break;
       }
       case 'document':
       default:
         msgPayload = {
-          document: buffer,
+          document: readFileSync(filePath),
           fileName: fileName || path.basename(filePath),
           caption: caption || undefined,
           mimetype: MIME_MAP[ext] || 'application/octet-stream',

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,7 +23,7 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
@@ -53,6 +53,7 @@ const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n──────────
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
   : process.env.WHATSAPP_REPLY_PREFIX.replace(/\\n/g, '\n');
+const DEFAULT_MEDIA_UPLOAD_TIMEOUT_MS = parseInt(process.env.WHATSAPP_MEDIA_UPLOAD_TIMEOUT_MS || '300000', 10);
 
 function formatOutgoingMessage(message) {
   // In bot mode, messages come from a different number so the prefix is
@@ -60,6 +61,19 @@ function formatOutgoingMessage(message) {
   // self-chat mode where bot and user share the same number.
   if (WHATSAPP_MODE !== 'self-chat') return message;
   return REPLY_PREFIX ? `${REPLY_PREFIX}${message}` : message;
+}
+
+function mediaUploadTimeoutMs(filePath, requestedTimeoutMs) {
+  const requested = Number(requestedTimeoutMs);
+  if (Number.isFinite(requested) && requested > 0) {
+    return requested;
+  }
+  let sizeMb = 0;
+  try {
+    sizeMb = statSync(filePath).size / (1024 * 1024);
+  } catch {}
+  const scaled = Math.floor(60000 + (sizeMb * 30000));
+  return Math.max(DEFAULT_MEDIA_UPLOAD_TIMEOUT_MS, Math.min(scaled, 900000));
 }
 
 function normalizeWhatsAppId(value) {
@@ -482,7 +496,7 @@ app.post('/send-media', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, filePath, mediaType, caption, fileName } = req.body;
+  const { chatId, filePath, mediaType, caption, fileName, mediaUploadTimeoutMs: requestedUploadTimeoutMs } = req.body;
   if (!chatId || !filePath) {
     return res.status(400).json({ error: 'chatId and filePath are required' });
   }
@@ -519,7 +533,11 @@ app.post('/send-media', async (req, res) => {
         break;
     }
 
-    const sent = await sock.sendMessage(chatId, msgPayload);
+    const sent = await sock.sendMessage(
+      chatId,
+      msgPayload,
+      { mediaUploadTimeoutMs: mediaUploadTimeoutMs(filePath, requestedUploadTimeoutMs) },
+    );
 
     // Track sent message ID to prevent echo-back loops
     if (sent?.key?.id) {

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -9,6 +9,7 @@ times per reply. (Regression test for #160)
 
 import pytest
 import re
+import json
 
 
 def extract_media_tags_fixed(result_messages, history_len):
@@ -178,6 +179,95 @@ class TestMediaExtraction:
         seen = set()
         unique = [t for t in tags if t not in seen and not seen.add(t)]
         assert len(unique) == 2  # After dedup: same.ogg and different.ogg
+
+    def test_image_generate_json_becomes_media_tag(self):
+        """Successful image_generate JSON should be delivered as native MEDIA."""
+        from gateway.run import _collect_current_turn_media_tags
+
+        image_path = "/Users/example/.hermes/cache/images/openai_codex_test.png"
+        messages = [
+            {"role": "user", "content": "Generate an image"},
+            {
+                "role": "tool",
+                "tool_call_id": "img1",
+                "content": json.dumps({
+                    "success": True,
+                    "image": image_path,
+                    "provider": "openai-codex",
+                }),
+            },
+            {"role": "assistant", "content": "Here is the image."},
+        ]
+
+        tags, voice_directive = _collect_current_turn_media_tags(
+            "Here is the image.",
+            messages,
+            set(),
+        )
+
+        assert tags == [f"MEDIA:{image_path}"]
+        assert voice_directive is False
+
+    def test_image_generate_json_dedupes_existing_response_media(self):
+        """Do not append the image path twice if the model already emitted MEDIA."""
+        from gateway.run import _collect_current_turn_media_tags
+
+        image_path = "/Users/example/.hermes/cache/images/openai_codex_test.png"
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "img1",
+                "content": json.dumps({"success": True, "image": image_path}),
+            },
+        ]
+
+        tags, _ = _collect_current_turn_media_tags(
+            f"Done\nMEDIA:{image_path}",
+            messages,
+            set(),
+        )
+
+        assert tags == []
+
+    def test_old_image_generate_json_is_not_resent_from_history(self):
+        """Prior image_generate JSON paths should be treated as already delivered."""
+        from gateway.run import (
+            _collect_current_turn_media_tags,
+            _extract_media_paths_from_tool_content,
+        )
+
+        old_image = "/Users/example/.hermes/cache/images/old.png"
+        new_image = "/Users/example/.hermes/cache/images/new.png"
+        history_tool_content = json.dumps({
+            "success": True,
+            "image": old_image,
+            "provider": "openai-codex",
+        })
+        history_paths = set(_extract_media_paths_from_tool_content(history_tool_content))
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "old",
+                "content": history_tool_content,
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "new",
+                "content": json.dumps({
+                    "success": True,
+                    "image": new_image,
+                    "provider": "openai-codex",
+                }),
+            },
+        ]
+
+        tags, _ = _collect_current_turn_media_tags(
+            "Here is the latest image.",
+            messages,
+            history_paths,
+        )
+
+        assert tags == [f"MEDIA:{new_image}"]
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_native_image_buffer_isolation.py
+++ b/tests/gateway/test_native_image_buffer_isolation.py
@@ -37,6 +37,16 @@ def _image_event(source: SessionSource, path: str) -> MessageEvent:
     )
 
 
+def _video_event(source: SessionSource, path: str) -> MessageEvent:
+    return MessageEvent(
+        text="please process this",
+        message_type=MessageType.VIDEO,
+        source=source,
+        media_urls=[path],
+        media_types=["video/mp4"],
+    )
+
+
 @pytest.mark.asyncio
 async def test_native_image_buffer_isolated_per_session():
     runner = _make_runner()
@@ -77,3 +87,20 @@ async def test_native_image_buffer_not_cleared_by_other_sessions_without_images(
 
     assert runner._consume_pending_native_image_paths(build_session_key(source_a)) == ["/tmp/a.png"]
     assert runner._consume_pending_native_image_paths(build_session_key(source_b)) == []
+
+
+@pytest.mark.asyncio
+async def test_video_attachment_path_is_added_to_inbound_text():
+    runner = _make_runner()
+    source = _source("chat-video")
+
+    result = await runner._prepare_inbound_message_text(
+        event=_video_event(source, "/tmp/clip.mp4"),
+        source=source,
+        history=[],
+    )
+
+    assert "The user sent a video" in result
+    assert "clip.mp4" in result
+    assert "/tmp/clip.mp4" in result
+    assert "please process this" in result

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,33 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_resolves_home_relative_safe_root_path(self, tmp_path, monkeypatch):
+        safe_root = tmp_path / "Hermes"
+        movie = safe_root / "weaver_output" / "final_weaver_movie.mp4"
+        movie.parent.mkdir(parents=True)
+        movie.write_bytes(b"movie")
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+
+        content = f"MEDIA:{os.path.expanduser('~')}/weaver_output/final_weaver_movie.mp4"
+
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+
+        assert media == [(str(movie), False)]
+        assert cleaned == ""
+
+    def test_bare_local_file_resolves_typoed_user_home_under_safe_root(self, tmp_path, monkeypatch):
+        safe_root = tmp_path / "Hermes"
+        movie = safe_root / "weaver_output" / "final_weaver_movie.mp4"
+        movie.parent.mkdir(parents=True)
+        movie.write_bytes(b"movie")
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
+        content = "The film is ready: /Users/hedimand/weaver_output/final_weaver_movie.mp4"
+
+        local_files, cleaned = BasePlatformAdapter.extract_local_files(content)
+
+        assert local_files == [str(movie)]
+        assert "final_weaver_movie.mp4" not in cleaned
+
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio
@@ -676,4 +703,3 @@ class TestProxyKwargsForAiohttp:
             sess_kw, req_kw = proxy_kwargs_for_aiohttp("http://proxy:8080")
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
-

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -145,6 +145,14 @@ class TestMessageLimits:
         from gateway.platforms.whatsapp import WhatsAppAdapter
         assert WhatsAppAdapter.MAX_MESSAGE_LENGTH == 4096
 
+    def test_video_upload_timeout_scales_above_default(self, tmp_path):
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        video = tmp_path / "large.mp4"
+        video.write_bytes(b"0" * (20 * 1024 * 1024))
+
+        assert WhatsAppAdapter._media_upload_timeout_ms(str(video), "video") > 300_000
+
 
 # ---------------------------------------------------------------------------
 # send() chunking tests

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -622,6 +622,31 @@ class TestSendToPlatformWhatsapp:
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
 
+    def test_whatsapp_media_routes_via_live_adapter(self, tmp_path):
+        chat_id = "test-user@lid"
+        image_path = tmp_path / "generated.png"
+        image_path.write_bytes(b"png")
+        async_mock = AsyncMock(return_value={"success": True, "message_id": "media123"})
+
+        with patch("tools.send_message_tool._send_whatsapp_via_adapter", async_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    chat_id,
+                    "",
+                    media_files=[(str(image_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        async_mock.assert_awaited_once_with(
+            chat_id,
+            "",
+            media_files=[(str(image_path), False)],
+            thread_id=None,
+        )
+
 
 class TestSendTelegramHtmlDetection:
     """Verify that messages containing HTML tags are sent with parse_mode=HTML

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -136,7 +136,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "message": {
                 "type": "string",
-                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/hermes/cache/img_xxx.jpg') in the message — the platform will deliver it as a native media attachment."
+                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/hermes/cache/img_xxx.jpg') in the message — the platform will deliver it as a native media attachment. When already replying inside WhatsApp after image_generate, prefer returning MEDIA:/exact/path in the final response instead of calling send_message; do not add TTS audio unless explicitly requested."
             }
         },
         "required": []
@@ -588,11 +588,27 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- WhatsApp: native media attachment support via the live bridge adapter ---
+    if platform == Platform.WHATSAPP and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_whatsapp_via_adapter(
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp and yuanbao; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -600,7 +616,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp and yuanbao"
         )
 
     last_result = None
@@ -647,6 +663,84 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         warnings.append(warning)
         last_result["warnings"] = warnings
     return last_result
+
+
+async def _send_whatsapp_via_adapter(chat_id, message, media_files=None, thread_id=None):
+    """Send WhatsApp text and MEDIA attachments through the running bridge adapter."""
+    media_files = media_files or []
+    try:
+        from gateway.config import Platform
+        from gateway.platforms.base import should_send_media_as_audio
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform.WHATSAPP) if runner else None
+        if not adapter:
+            return {"error": "No live WhatsApp adapter available. Is the Hermes gateway running with WhatsApp connected?"}
+
+        metadata = {"thread_id": thread_id} if thread_id else None
+        last_message_id = None
+        warnings = []
+
+        if message and message.strip():
+            text_result = await adapter.send(
+                chat_id=chat_id,
+                content=message,
+                metadata=metadata,
+            )
+            if not text_result.success:
+                return {"error": f"WhatsApp text send failed: {text_result.error}"}
+            last_message_id = text_result.message_id
+
+        for media_path, is_voice in media_files:
+            if not os.path.exists(media_path):
+                warning = f"Media file not found, skipping: {media_path}"
+                logger.warning(warning)
+                warnings.append(warning)
+                continue
+
+            ext = os.path.splitext(media_path)[1].lower()
+            if ext in _IMAGE_EXTS and not is_voice:
+                media_result = await adapter.send_image_file(
+                    chat_id=chat_id,
+                    image_path=media_path,
+                    metadata=metadata,
+                )
+            elif ext in _VIDEO_EXTS:
+                media_result = await adapter.send_video(
+                    chat_id=chat_id,
+                    video_path=media_path,
+                    metadata=metadata,
+                )
+            elif should_send_media_as_audio("whatsapp", ext, is_voice=is_voice):
+                media_result = await adapter.send_voice(
+                    chat_id=chat_id,
+                    audio_path=media_path,
+                    metadata=metadata,
+                )
+            else:
+                media_result = await adapter.send_document(
+                    chat_id=chat_id,
+                    file_path=media_path,
+                    metadata=metadata,
+                )
+
+            if not media_result.success:
+                warning = _sanitize_error_text(f"Failed to send WhatsApp media {media_path}: {media_result.error}")
+                logger.warning(warning)
+                warnings.append(warning)
+            else:
+                last_message_id = media_result.message_id
+
+        if not last_message_id and warnings:
+            return {"error": "; ".join(warnings)}
+
+        result = {"success": True, "message_id": last_message_id}
+        if warnings:
+            result["warnings"] = warnings
+        return result
+    except Exception as e:
+        return _error(f"WhatsApp media send failed: {e}")
 
 
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False):


### PR DESCRIPTION
## Summary

Fixes #19105.

Fixes several WhatsApp media delivery paths:

- Converts successful `image_generate` JSON results into `MEDIA:/path` attachments at the gateway layer.
- Prevents old generated images from being re-sent by extracting history media paths from both `MEDIA:` tags and JSON tool payloads.
- Adds native WhatsApp `MEDIA:` support to `send_message` through the live WhatsApp bridge adapter.
- Sends WhatsApp images/videos/audio through native Baileys file URL payloads instead of treating them like document-style uploads.
- Adds inbound WhatsApp video paths to the model-facing message so tools can process the real cached file.
- Adds regression coverage for image JSON extraction, history dedupe, WhatsApp media routing, and inbound video path visibility.

## Why

Generated media could succeed locally but fail or degrade at WhatsApp delivery.

For image generation, providers return JSON with an `image` field rather than a `MEDIA:/path` tag. The gateway therefore depended on the model restating the exact path correctly. Once JSON extraction was added, old image JSON in history also needed to be treated as already delivered, otherwise Hermes could send every previous generated image again.

For generated MP4 outputs, such as ASCII-video renders, delivery depends on `MEDIA:/path` routing correctly through WhatsApp.

For inbound WhatsApp videos, the agent needs the real cached path, not just a placeholder.

## Tests

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest \
  tests/gateway/test_media_extraction.py \
  tests/gateway/test_native_image_buffer_isolation.py \
  tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp -q
```

Result:

```text
12 passed
```

Also ran:

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/tools/test_send_message_tool.py -q
```

Result:

```text
96 passed
```

Also checked syntax:

```bash
node --check scripts/whatsapp-bridge/bridge.js
python -c "import ast, pathlib; ast.parse(pathlib.Path('gateway/run.py').read_text()); ast.parse(pathlib.Path('tools/send_message_tool.py').read_text())"
```

## Notes

This fixes the gateway and WhatsApp delivery side. Tools still need to create real output files and emit or return usable local paths. For ASCII-video specifically, an MP4 output should now be sent successfully when the skill/tool produces an actual file and returns it as `MEDIA:/path/to/output.mp4`.
