### PR TITLE
fix(slack): use Block Kit markdown block type instead of legacy mrkdwn

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -281,7 +281,7 @@ class SlackAdapter(BasePlatformAdapter):
       - Typing indicators (not natively supported by Slack bots)
     """
 
-    MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
+    MAX_MESSAGE_LENGTH = 11800  # Slack markdown block type caps at 12,000 chars; leave margin
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SLACK)
@@ -707,11 +707,15 @@ class SlackAdapter(BasePlatformAdapter):
                     slash_ctx, content,
                 )
 
-            # Convert standard markdown → Slack mrkdwn
-            formatted = self.format_message(content)
+            # Use raw content for the Block Kit markdown block type which
+            # natively renders standard markdown (tables, bold, links, etc.).
+            # format_message() converts to legacy mrkdwn and is only used for
+            # the plain-text fallback (notifications, search, accessibility).
+            fallback = self.format_message(content)
 
             # Split long messages, preserving code block boundaries
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+            fallback_chunks = self.truncate_message(fallback, self.MAX_MESSAGE_LENGTH)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
@@ -721,10 +725,11 @@ class SlackAdapter(BasePlatformAdapter):
             broadcast = self.config.extra.get("reply_broadcast", False)
 
             for i, chunk in enumerate(chunks):
+                fallback_chunk = fallback_chunks[i] if i < len(fallback_chunks) else chunk
                 kwargs = {
                     "channel": chat_id,
-                    "text": chunk,
-                    "mrkdwn": True,
+                    "text": fallback_chunk,
+                    "blocks": [{"type": "markdown", "text": chunk}],
                 }
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
@@ -809,11 +814,29 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
-            formatted = self.format_message(content)
+            # Use raw content for the markdown block; mrkdwn fallback for text field.
+            # Slack markdown block type caps at 12,000 chars — truncate to stay
+            # within the limit to avoid `markdown_text_too_long` errors.
+            fallback = self.format_message(content)
+            chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+            fallback_chunks = self.truncate_message(fallback, self.MAX_MESSAGE_LENGTH)
+
+            # If the content fits in a single block, update in place.
+            # Otherwise send the first chunk and log a warning — chat_update
+            # only replaces one message, so multi-chunk means the rest is lost.
+            update_content = chunks[0]
+            update_fallback = fallback_chunks[0] if fallback_chunks else update_content
+            if len(chunks) > 1:
+                logger.warning(
+                    "[Slack] edit_message() truncated content from %d chunks to 1 "
+                    "(markdown block limit is 12,000 chars).",
+                    len(chunks),
+                )
             await self._get_client(chat_id).chat_update(
                 channel=chat_id,
                 ts=message_id,
-                text=formatted,
+                text=update_fallback,
+                blocks=[{"type": "markdown", "text": update_content}],
             )
             if finalize:
                 await self.stop_typing(chat_id)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3040,3 +3040,103 @@ class TestSlashEphemeralAck:
         # the normal single-user case; the ContextVar path is the precise one.
         # The key invariant is: when the ContextVar IS set, it matches exactly.
         assert ctx is not None  # fallback path finds the entry
+
+
+# ---------------------------------------------------------------------------
+# Slack Block Kit markdown block type tests (PR #8554)
+# ---------------------------------------------------------------------------
+
+class TestSlackMarkdownBlockType:
+    """Tests for Slack Block Kit `markdown` block type rendering.
+
+    Verifies that messages use `blocks` with the `markdown` type instead of
+    legacy `mrkdwn`, enabling native GFM table rendering, bold, italic, and
+    link support in Slack.
+    """
+
+    @pytest.fixture()
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="***")
+        a = SlackAdapter(config)
+        a._app = MagicMock()
+        a._app.client = AsyncMock()
+        a._bot_user_id = "U_BOT"
+        a._running = True
+        a.handle_message = AsyncMock()
+        return a
+
+    @pytest.mark.asyncio
+    async def test_send_uses_markdown_block_type(self, adapter):
+        """send() should use blocks with markdown type, not mrkdwn."""
+        content = "Hello **world**"
+        result = await adapter.send("C123", content)
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args[1]
+        assert "blocks" in call_kwargs, "send() must include blocks parameter"
+        assert call_kwargs["blocks"] == [{"type": "markdown", "text": content}]
+        assert "mrkdwn" not in call_kwargs, "send() should not pass mrkdwn flag"
+
+    @pytest.mark.asyncio
+    async def test_send_passes_tables_unchanged(self, adapter):
+        """send() should pass markdown tables unchanged to the markdown block."""
+        table = "| Column A | Column B |\n|----------|----------|\n| Value 1  | Value 2  |"
+        result = await adapter.send("C123", table)
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args[1]
+        assert call_kwargs["blocks"][0]["text"] == table
+
+    @pytest.mark.asyncio
+    async def test_send_text_fallback_is_mrkdwn(self, adapter):
+        """send() should pass format_message() output as the text fallback."""
+        content = "**bold text**"
+        result = await adapter.send("C123", content)
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args[1]
+        # text field should have the mrkdwn-formatted version
+        assert call_kwargs["text"] == "*bold text*"
+
+    @pytest.mark.asyncio
+    async def test_send_chunking_respects_markdown_limit(self, adapter):
+        """send() should chunk long messages within the 12,000 char markdown block limit."""
+        # Content that exceeds MAX_MESSAGE_LENGTH (11,800)
+        content = "Line\n" * 12000  # ~60,000 chars
+
+        result = await adapter.send("C123", content)
+        assert result.success
+
+        # Should have been called multiple times (chunked)
+        calls = adapter._app.client.chat_postMessage.call_args_list
+        assert len(calls) > 1, "Long messages should be chunked"
+
+        # Each chunk should use markdown block type
+        for call in calls:
+            kwargs = call[1]
+            assert kwargs["blocks"][0]["type"] == "markdown"
+            assert len(kwargs["blocks"][0]["text"]) <= SlackAdapter.MAX_MESSAGE_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_edit_message_uses_markdown_block_type(self, adapter):
+        """edit_message() should use blocks with markdown type."""
+        content = "Updated **content**"
+        result = await adapter.edit_message("C123", "12345.67890", content)
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_update.call_args[1]
+        assert "blocks" in call_kwargs, "edit_message() must include blocks parameter"
+        assert call_kwargs["blocks"] == [{"type": "markdown", "text": content}]
+
+    @pytest.mark.asyncio
+    async def test_edit_message_truncates_long_content(self, adapter):
+        """edit_message() should truncate content to markdown block limit."""
+        # Content that exceeds MAX_MESSAGE_LENGTH
+        content = "X" * 20000
+
+        result = await adapter.edit_message("C123", "12345.67890", content)
+        assert result.success
+
+        call_kwargs = adapter._app.client.chat_update.call_args[1]
+        # Content should be truncated to fit within MAX_MESSAGE_LENGTH
+        assert len(call_kwargs["blocks"][0]["text"]) <= SlackAdapter.MAX_MESSAGE_LENGTH

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -464,12 +464,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     media_files = media_files or []
 
-    if platform == Platform.SLACK and message:
-        try:
-            slack_adapter = SlackAdapter.__new__(SlackAdapter)
-            message = slack_adapter.format_message(message)
-        except Exception:
-            logger.debug("Failed to apply Slack mrkdwn formatting in _send_to_platform", exc_info=True)
+    # NOTE: Do NOT call format_message() for Slack here.
+    # The _send_slack() function uses the `markdown` block type which requires
+    # raw standard markdown — format_message() converts to legacy mrkdwn and
+    # corrupts table syntax, bold, and links before they reach the block.
 
     # Platform message length limits (from adapter class attributes)
     _MAX_LENGTHS = {
@@ -1012,7 +1010,18 @@ async def _send_slack(token, chat_id, message):
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
-            payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            # Use raw markdown for the `markdown` block type; format_message() output
+            # as plain-text fallback for notifications/search.
+            try:
+                slack_adapter = SlackAdapter.__new__(SlackAdapter)
+                fallback_text = slack_adapter.format_message(message)
+            except Exception:
+                fallback_text = message
+            payload = {
+                "channel": chat_id,
+                "text": fallback_text,
+                "blocks": [{"type": "markdown", "text": message}],
+            }
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary

- Use Block Kit `markdown` block type for Slack message rendering instead of legacy `mrkdwn`
- Keep `format_message()` output only as `text` fallback for notifications/search
- Fix `edit_message()` to include `blocks` in `chat_update` with truncation guard
- Remove `format_message()` pre-conversion in `send_message_tool.py` for Slack
- **Lower `MAX_MESSAGE_LENGTH` to 11,800** (markdown block caps at 12,000 chars)
- **Add truncation guard to `edit_message()`** to avoid `markdown_text_too_long` errors
- **Add `format_message()` fallback text to `_send_slack()`** for notifications/search
- **Add 6 tests** covering markdown block type, tables, chunking, truncation, and fallback

## Problem

`format_message()` converts standard markdown to Slack's legacy `mrkdwn` format before sending, which strips/breaks tables and other markdown constructs. The `markdown` block type in Block Kit natively renders standard markdown including tables.

The critical issue was that `edit_message()` was sending only `text` with no `blocks`, so streaming responses reverted to legacy rendering.

## Changes

| File | Change |
|------|--------|
| `gateway/platforms/slack.py` `send()` | Raw content → `blocks`, `format_message()` → `text` fallback |
| `gateway/platforms/slack.py` `edit_message()` | Added `blocks` + truncation guard to `chat_update` |
| `gateway/platforms/slack.py` `MAX_MESSAGE_LENGTH` | 39,000 → 11,800 (markdown block limit is 12,000) |
| `tools/send_message_tool.py` `_send_to_platform()` | Removed `format_message()` call for Slack |
| `tools/send_message_tool.py` `_send_slack()` | `mrkdwn: True` → `blocks` with fallback text |
| `tests/gateway/test_slack.py` | 6 new tests for markdown block, tables, chunking, truncation |

Fixes #8552