### PR TITLE
feat(agent): per-model / per-provider compression threshold overrides

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -22,7 +22,7 @@ import json
 import logging
 import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from agent.auxiliary_client import call_llm
 from agent.context_engine import ContextEngine
@@ -72,6 +72,110 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+
+# ── Per-model / per-provider compression threshold overrides (issue #18733) ──
+
+# Bounds on the resolved threshold ratio. Values outside this range are treated
+# as configuration errors and fall through to the next precedence level.
+_THRESHOLD_MIN = 0.10
+_THRESHOLD_MAX = 0.95
+_THRESHOLD_DEFAULT = 0.50
+
+# Module-level dedup so a misconfigured override doesn't spam the gateway log
+# on every model switch / fallback. Keys are (scope, identifier) tuples:
+#   ("model",    "google/gemini-2.5-pro")
+#   ("provider", "anthropic")
+#   ("global",   "")
+# The set is intentionally NOT reset on config reload — long-lived gateway
+# processes prioritize log-noise control over reload feedback. If reload
+# feedback becomes important, expose a _reset_threshold_warnings() hook.
+_LOGGED_INVALID_OVERRIDE: set = set()
+
+
+def _validate_threshold(raw: Any, *, origin: str, dedup_key: tuple) -> Optional[float]:
+    """Coerce and range-check a threshold override.
+
+    Returns the validated float, or None if the value is invalid (in which
+    case a one-time warning is logged for ``dedup_key`` and the caller should
+    fall through to the next precedence level).
+    """
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        if dedup_key not in _LOGGED_INVALID_OVERRIDE:
+            _LOGGED_INVALID_OVERRIDE.add(dedup_key)
+            logger.warning(
+                "Invalid %s=%r — must be numeric, falling through.", origin, raw,
+            )
+        return None
+    if not (_THRESHOLD_MIN <= value <= _THRESHOLD_MAX):
+        if dedup_key not in _LOGGED_INVALID_OVERRIDE:
+            _LOGGED_INVALID_OVERRIDE.add(dedup_key)
+            logger.warning(
+                "Invalid %s=%s — must be within [%.2f, %.2f], falling through.",
+                origin, value, _THRESHOLD_MIN, _THRESHOLD_MAX,
+            )
+        return None
+    return value
+
+
+def resolve_compression_threshold(
+    model: str,
+    provider: str,
+    config: Mapping[str, Any],
+) -> float:
+    """Resolve the compression threshold for the active (model, provider).
+
+    Precedence (highest first):
+      1. ``compression.model_thresholds[model]``
+      2. ``compression.provider_thresholds[provider]``
+      3. ``compression.threshold``
+      4. ``_THRESHOLD_DEFAULT`` (0.50)
+
+    Provider keys must be exact ``hermes_cli/auth.py:PROVIDER_REGISTRY`` ids
+    (e.g. ``anthropic``, ``gemini``, ``kimi-coding``, ``xai``, ``openrouter``).
+    Aliases such as ``google``, ``moonshot``, or ``claude`` will silently fall
+    through to the global default — those aliases are scoped to auxiliary
+    model routing, not the main agent's ``self.provider``.
+
+    Invalid override values (non-numeric, outside ``[_THRESHOLD_MIN,
+    _THRESHOLD_MAX]``) emit a one-time warning per scope+identifier and fall
+    through to the next precedence level. Empty dicts and missing keys are
+    silent fall-throughs.
+    """
+    if not isinstance(config, Mapping):
+        return _THRESHOLD_DEFAULT
+
+    model_overrides = config.get("model_thresholds") or {}
+    if isinstance(model_overrides, Mapping) and model and model in model_overrides:
+        candidate = _validate_threshold(
+            model_overrides[model],
+            origin="compression.model_thresholds[%r]" % model,
+            dedup_key=("model", model),
+        )
+        if candidate is not None:
+            return candidate
+
+    provider_overrides = config.get("provider_thresholds") or {}
+    if isinstance(provider_overrides, Mapping) and provider and provider in provider_overrides:
+        candidate = _validate_threshold(
+            provider_overrides[provider],
+            origin="compression.provider_thresholds[%r]" % provider,
+            dedup_key=("provider", provider),
+        )
+        if candidate is not None:
+            return candidate
+
+    if "threshold" in config:
+        candidate = _validate_threshold(
+            config["threshold"],
+            origin="compression.threshold",
+            dedup_key=("global", ""),
+        )
+        if candidate is not None:
+            return candidate
+
+    return _THRESHOLD_DEFAULT
 
 
 def _content_length_for_budget(raw_content: Any) -> int:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -22,7 +22,7 @@ import json
 import logging
 import re
 import time
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 from agent.auxiliary_client import call_llm
 from agent.context_engine import ContextEngine
@@ -86,10 +86,37 @@ _THRESHOLD_DEFAULT = 0.50
 #   ("model",    "google/gemini-2.5-pro")
 #   ("provider", "anthropic")
 #   ("global",   "")
+#   ("alias",    "google")           — alias-not-canonical hint, see below
 # The set is intentionally NOT reset on config reload — long-lived gateway
 # processes prioritize log-noise control over reload feedback. If reload
 # feedback becomes important, expose a _reset_threshold_warnings() hook.
 _LOGGED_INVALID_OVERRIDE: set = set()
+
+# Known aliases for canonical PROVIDER_REGISTRY ids. Used only to emit a
+# hint when a user writes an alias key (e.g. "google") in
+# provider_thresholds — the lookup falls through silently (since
+# self.provider is the canonical id), but we want to tell the user *why*
+# their override didn't apply. Mirrors the alias map in
+# agent/auxiliary_client.py:_PROVIDER_ALIASES (auxiliary-routing-only;
+# the main agent's self.provider is always the canonical id).
+_PROVIDER_ALIAS_HINTS: Dict[str, str] = {
+    "google": "gemini",
+    "google-gemini": "gemini",
+    "google-ai-studio": "gemini",
+    "x-ai": "xai",
+    "x.ai": "xai",
+    "grok": "xai",
+    "glm": "zai",
+    "z-ai": "zai",
+    "z.ai": "zai",
+    "zhipu": "zai",
+    "kimi": "kimi-coding",
+    "moonshot": "kimi-coding",
+    "kimi-cn": "kimi-coding-cn",
+    "moonshot-cn": "kimi-coding-cn",
+    "claude": "anthropic",
+    "claude-code": "anthropic",
+}
 
 
 def _validate_threshold(raw: Any, *, origin: str, dedup_key: tuple) -> Optional[float]:
@@ -127,21 +154,33 @@ def resolve_compression_threshold(
     """Resolve the compression threshold for the active (model, provider).
 
     Precedence (highest first):
-      1. ``compression.model_thresholds[model]``
-      2. ``compression.provider_thresholds[provider]``
-      3. ``compression.threshold``
-      4. ``_THRESHOLD_DEFAULT`` (0.50)
+      1. ``compression.model_thresholds[model]``       (exact-match)
+      2. ``compression.provider_thresholds[provider]`` (exact-match)
+      3. ``compression.threshold``                     (global)
+      4. ``_THRESHOLD_DEFAULT`` (0.50)                 (built-in)
 
-    Provider keys must be exact ``hermes_cli/auth.py:PROVIDER_REGISTRY`` ids
-    (e.g. ``anthropic``, ``gemini``, ``kimi-coding``, ``xai``, ``openrouter``).
-    Aliases such as ``google``, ``moonshot``, or ``claude`` will silently fall
-    through to the global default — those aliases are scoped to auxiliary
-    model routing, not the main agent's ``self.provider``.
+    Each level falls through to the next on miss. The resolver short-circuits
+    the FIRST valid value it finds — a valid model override is final, even if
+    a provider override or global threshold is also present.
 
-    Invalid override values (non-numeric, outside ``[_THRESHOLD_MIN,
-    _THRESHOLD_MAX]``) emit a one-time warning per scope+identifier and fall
-    through to the next precedence level. Empty dicts and missing keys are
-    silent fall-throughs.
+    Lookup is exact-string. Provider keys must be canonical
+    ``hermes_cli/auth.py:PROVIDER_REGISTRY`` ids (``anthropic``, ``gemini``,
+    ``kimi-coding``, ``xai``, ``openrouter``, ...). Aliases like ``google``,
+    ``moonshot``, ``claude`` silently fall through (those aliases are scoped
+    to auxiliary-model routing, not the main agent's ``self.provider``). To
+    help operators notice this, the resolver emits a one-time hint when an
+    alias key is detected in ``provider_thresholds``.
+
+    Invalid override values fall through to the next precedence level and
+    emit a one-time warning per scope+identifier:
+      * Non-numeric (``"high"``, ``None``, ``object()``)              → warn + skip
+      * Outside ``[_THRESHOLD_MIN=0.10, _THRESHOLD_MAX=0.95]``        → warn + skip
+      * Boundary values (``0.10`` or ``0.95``) are accepted as valid
+
+    Silent fall-throughs (no warning):
+      * Empty or missing override dict
+      * Override dict missing the active model / provider key
+      * ``config`` is not a Mapping (defensive: returns built-in default)
     """
     if not isinstance(config, Mapping):
         return _THRESHOLD_DEFAULT
@@ -157,14 +196,28 @@ def resolve_compression_threshold(
             return candidate
 
     provider_overrides = config.get("provider_thresholds") or {}
-    if isinstance(provider_overrides, Mapping) and provider and provider in provider_overrides:
-        candidate = _validate_threshold(
-            provider_overrides[provider],
-            origin="compression.provider_thresholds[%r]" % provider,
-            dedup_key=("provider", provider),
-        )
-        if candidate is not None:
-            return candidate
+    if isinstance(provider_overrides, Mapping):
+        if provider and provider in provider_overrides:
+            candidate = _validate_threshold(
+                provider_overrides[provider],
+                origin="compression.provider_thresholds[%r]" % provider,
+                dedup_key=("provider", provider),
+            )
+            if candidate is not None:
+                return candidate
+        else:
+            # Hint when the user wrote an alias key. The lookup itself silently
+            # fell through above; this is purely a usability nudge.
+            for alias_key in provider_overrides:
+                canonical = _PROVIDER_ALIAS_HINTS.get(alias_key)
+                if canonical and ("alias", alias_key) not in _LOGGED_INVALID_OVERRIDE:
+                    _LOGGED_INVALID_OVERRIDE.add(("alias", alias_key))
+                    logger.warning(
+                        "compression.provider_thresholds[%r] looks like an alias — "
+                        "main agent providers use the canonical PROVIDER_REGISTRY id "
+                        "%r. Override silently falls through to the global threshold.",
+                        alias_key, canonical,
+                    )
 
     if "threshold" in config:
         candidate = _validate_threshold(
@@ -477,6 +530,77 @@ class ContextCompressor(ContextEngine):
             int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )
 
+    def re_resolve_threshold(self) -> None:
+        """Re-pick threshold_percent from the configured compression policy
+        for the current ``(self.model, self.provider)`` pair (issue #18733).
+
+        Callers invoke this *after* ``update_model()`` so per-model /
+        per-provider overrides take effect when the user switches models,
+        a fallback fires, or the primary runtime is restored. Safe to call
+        when no ``compression_config`` was supplied — silent no-op.
+
+        Composition contract w.r.t. PR #18638's ``threshold_percent=`` param:
+          * ``re_resolve_threshold()`` is the canonical *policy* step. It
+            applies whatever the user's compression config currently says
+            for the active (model, provider) pair.
+          * #18638's ``threshold_percent=`` param is the canonical
+            *preservation* step (issue #18617's regression fix).
+          * The 3 in-scope runtime callsites in run_agent.py call them in
+            the order ``update_model() → re_resolve_threshold()``. The
+            user's per-model / per-provider override always wins over a
+            preserved value, because that's the user's stated intent.
+          * Callers who want to bypass policy (rare; explicit override path)
+            should call ``update_model(threshold_percent=...)`` *without*
+            calling ``re_resolve_threshold()``.
+
+        Live-config / hot-reload note: when ``compression_config`` is a
+        callable, it is invoked on every call so the resolver sees the
+        current config snapshot. When it's a Mapping, the snapshot is
+        captured at __init__ — restart required for changes to take effect.
+        """
+        if self._compression_config is None:
+            return
+        config = self._compression_config
+        if callable(config):
+            try:
+                config = config()
+            except Exception as exc:
+                # Don't break the model switch over a broken getter, but DO
+                # surface the failure in logs (deduplicated) so a persistent
+                # misconfiguration is visible without a process restart.
+                if ("getter_raise", type(exc).__name__) not in _LOGGED_INVALID_OVERRIDE:
+                    _LOGGED_INVALID_OVERRIDE.add(("getter_raise", type(exc).__name__))
+                    logger.warning(
+                        "compression_config getter raised %s — threshold "
+                        "re-resolution skipped; threshold_percent stays at %s. "
+                        "Fix the getter to restore per-model / per-provider overrides.",
+                        type(exc).__name__, self.threshold_percent,
+                    )
+                return
+        if not isinstance(config, Mapping):
+            if ("getter_bad_type", type(config).__name__) not in _LOGGED_INVALID_OVERRIDE:
+                _LOGGED_INVALID_OVERRIDE.add(("getter_bad_type", type(config).__name__))
+                logger.warning(
+                    "compression_config returned %s instead of Mapping — "
+                    "threshold re-resolution skipped; threshold_percent stays at %s.",
+                    type(config).__name__, self.threshold_percent,
+                )
+            return
+        new_threshold = resolve_compression_threshold(
+            model=self.model,
+            provider=self.provider,
+            config=config,
+        )
+        if new_threshold == self.threshold_percent:
+            return
+        self.threshold_percent = new_threshold
+        self.threshold_tokens = max(
+            int(self.context_length * new_threshold),
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
+        self.tail_token_budget = target_tokens
+
     def __init__(
         self,
         model: str,
@@ -491,6 +615,9 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        compression_config: Optional[
+            Union[Mapping[str, Any], Callable[[], Mapping[str, Any]]]
+        ] = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -498,6 +625,11 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.threshold_percent = threshold_percent
+        # Source for re_resolve_threshold(). Accepts EITHER a Mapping (snapshot
+        # — fast path; ok for set-once configs) OR a zero-arg callable that
+        # returns the current Mapping (live path; the caller controls when the
+        # config can change, e.g. behind /reload-config). Issue #18733.
+        self._compression_config = compression_config
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -204,3 +204,11 @@ class ContextEngine(ABC):
         """
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self.threshold_percent)
+
+    def re_resolve_threshold(self) -> None:
+        """Hook for engines that derive threshold_percent from a config snapshot
+        (e.g. per-model / per-provider overrides — issue #18733). Default no-op
+        so callers can invoke this after ``update_model()`` regardless of
+        which engine is active.
+        """
+        return None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -346,6 +346,31 @@ compression:
   # compression of older turns.
   protect_last_n: 20
 
+  # ── Per-provider / per-model threshold overrides (issue #18733) ──
+  # Resolution precedence (highest first):
+  #   1. model_thresholds[<exact model id>]
+  #   2. provider_thresholds[<exact PROVIDER_REGISTRY id>]
+  #   3. threshold (above)
+  #   4. 0.50 (built-in default)
+  #
+  # Provider keys must be exact PROVIDER_REGISTRY ids from
+  # hermes_cli/auth.py — e.g. "anthropic", "gemini", "kimi-coding", "xai",
+  # "openrouter". Aliases like "google", "moonshot", or "claude" silently
+  # fall through to the global default (those aliases are scoped to
+  # auxiliary-model routing, not the main agent's provider).
+  #
+  # Valid range for any override: 0.10 - 0.95. Out-of-range or non-numeric
+  # values log a one-time warning and fall through to the next level.
+  #
+  # provider_thresholds:
+  #   anthropic: 0.65        # compress later — Claude tolerates long context well
+  #   gemini: 0.50
+  #   kimi-coding: 0.40      # compress earlier on smaller-window models
+  #
+  # model_thresholds:
+  #   "google/gemini-2.5-pro": 0.30
+  #   "claude-sonnet-4-20250514": 0.65
+
   # To pin a specific model/provider for compression summaries, use the
   # auxiliary section below (auxiliary.compression.provider / model).
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -636,6 +636,12 @@ DEFAULT_CONFIG = {
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
+        # Per-provider / per-model threshold overrides (issue #18733).
+        # Resolution precedence: model_thresholds[model] > provider_thresholds[provider] > threshold > 0.50.
+        # Keys must be exact PROVIDER_REGISTRY ids (e.g. "anthropic", "gemini", "kimi-coding"),
+        # not aliases like "google" or "moonshot". Empty dicts = no overrides.
+        "provider_thresholds": {},
+        "model_thresholds": {},
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/run_agent.py
+++ b/run_agent.py
@@ -2010,9 +2010,15 @@ class AIAgent:
             if not self.quiet_mode:
                 logger.info("Using context engine: %s", _selected_engine.name)
         else:
+            from agent.context_compressor import resolve_compression_threshold
+            _resolved_threshold = resolve_compression_threshold(
+                model=self.model,
+                provider=self.provider,
+                config=_compression_cfg,
+            )
             self.context_compressor = ContextCompressor(
                 model=self.model,
-                threshold_percent=compression_threshold,
+                threshold_percent=_resolved_threshold,
                 protect_first_n=3,
                 protect_last_n=compression_protect_last,
                 summary_target_ratio=compression_target_ratio,
@@ -2143,7 +2149,11 @@ class AIAgent:
 
         if not self.quiet_mode:
             if compression_enabled:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                # Use the compressor's resolved threshold (may differ from the
+                # global compression.threshold when per-model/per-provider
+                # overrides apply — issue #18733).
+                _display_pct = int(self.context_compressor.threshold_percent * 100)
+                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {_display_pct}% = {self.context_compressor.threshold_tokens:,})")
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2029,6 +2029,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                compression_config=_compression_cfg,
             )
         self.compression_enabled = compression_enabled
 
@@ -2415,6 +2416,11 @@ class AIAgent:
                 provider=self.provider,
                 api_mode=self.api_mode,
             )
+            # Ordering invariant (#18733): re_resolve_threshold() reads
+            # self.model and self.provider from the compressor, which the
+            # update_model() call just rewrote. Reordering would resolve
+            # against the OLD pair. Keep this immediately after update_model.
+            self.context_compressor.re_resolve_threshold()
 
         # ── Invalidate cached system prompt so it rebuilds next turn ──
         self._cached_system_prompt = None
@@ -7654,6 +7660,8 @@ class AIAgent:
                     api_key=getattr(self, "api_key", ""),
                     provider=self.provider,
                 )
+                # Ordering invariant (#18733): see comment at switch_model().
+                self.context_compressor.re_resolve_threshold()
 
             self._emit_status(
                 f"🔄 Primary model failed — switching to fallback: "
@@ -7733,6 +7741,8 @@ class AIAgent:
                 api_key=rt["compressor_api_key"],
                 provider=rt["compressor_provider"],
             )
+            # Ordering invariant (#18733): see comment at switch_model().
+            cc.re_resolve_threshold()
 
             # ── Reset fallback chain for the new turn ──
             self._fallback_activated = False

--- a/tests/agent/test_compression_threshold_resolution.py
+++ b/tests/agent/test_compression_threshold_resolution.py
@@ -1,13 +1,15 @@
 """Tests for issue #18733 — per-model / per-provider compression overrides.
 
 Covers the pure-function ``resolve_compression_threshold()`` resolver in
-``agent/context_compressor.py`` plus the wire-up at the ``ContextCompressor``
-instantiation site in ``run_agent.py``.
+``agent/context_compressor.py``, the wire-up at the ``ContextCompressor``
+instantiation site in ``run_agent.py``, and the ``re_resolve_threshold()``
+method that lets a model switch pick up overrides at runtime.
 
-Note: ``ContextCompressor.update_model()`` re-resolution on model switch is
-intentionally NOT exercised here — that's owned by the ``threshold_percent=``
-parameter introduced by PR #18638. Once that lands, callers compose the two:
-``update_model(threshold_percent=resolve_compression_threshold(...))``.
+The ``re_resolve_threshold()`` method composes cleanly with the
+``threshold_percent=`` parameter being added by PR #18638: this PR adds the
+override-picking, that PR forwards an explicit value through. They live in
+different lines of ``update_model``'s callsites so neither blocks the other
+on merge order.
 """
 
 import logging
@@ -100,7 +102,13 @@ class TestValidation:
         with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
             result = resolve_compression_threshold("m", "anthropic", cfg)
         assert result == 0.40
-        assert any("Invalid" in rec.message and "high" in rec.message for rec in caplog.records)
+        # Lock log level so a future change can't silently demote to DEBUG.
+        assert any(
+            "Invalid" in rec.message
+            and "high" in rec.message
+            and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        )
 
     def test_below_min_falls_through(self, caplog):
         cfg = {"threshold": 0.40, "model_thresholds": {"m": 0.05}}
@@ -148,6 +156,13 @@ class TestValidation:
         with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
             result = resolve_compression_threshold("m", "p", cfg)
         assert result == _THRESHOLD_DEFAULT
+        # An invalid global threshold is the most operator-visible misconfig
+        # case; log level must stay at WARNING so it surfaces in default
+        # logging configurations.
+        assert any(
+            "compression.threshold" in rec.message and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        )
 
 
 class TestWireUpComposition:
@@ -185,6 +200,250 @@ class TestWireUpComposition:
         assert compressor.threshold_percent == 0.65
         # 200_000 * 0.65 = 130_000
         assert compressor.threshold_tokens == 130_000
+
+
+class TestAliasHint:
+    """When a user writes an alias key like ``google``, the resolver emits a
+    one-time hint pointing at the canonical PROVIDER_REGISTRY id."""
+
+    def test_alias_key_warns_with_canonical_hint(self, caplog):
+        cfg = {"threshold": 0.40, "provider_thresholds": {"google": 0.30}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("any", "gemini", cfg)
+        assert result == 0.40  # silently fell through to global
+        alias_records = [
+            r for r in caplog.records if "looks like an alias" in r.message
+        ]
+        assert len(alias_records) == 1
+        assert "'google'" in alias_records[0].message
+        assert "'gemini'" in alias_records[0].message  # canonical hint
+        # Pin level: alias hint is the operator's only feedback that their
+        # config didn't take effect, so it has to surface above DEBUG.
+        assert alias_records[0].levelno == logging.WARNING
+
+    def test_alias_hint_deduplicated(self, caplog):
+        cfg = {"provider_thresholds": {"moonshot": 0.40}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            for _ in range(5):
+                resolve_compression_threshold("m", "kimi-coding", cfg)
+        alias_records = [
+            r for r in caplog.records if "looks like an alias" in r.message
+        ]
+        assert len(alias_records) == 1
+
+    def test_canonical_key_does_not_trigger_alias_warning(self, caplog):
+        cfg = {"provider_thresholds": {"gemini": 0.30}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("m", "gemini", cfg)
+        assert result == 0.30
+        alias_records = [
+            r for r in caplog.records if "looks like an alias" in r.message
+        ]
+        assert len(alias_records) == 0
+
+    def test_alias_warning_does_not_fire_when_canonical_match_succeeds(self, caplog):
+        # Both an alias AND the canonical present; canonical match should win
+        # without the alias hint firing for the unused alias entry.
+        cfg = {"provider_thresholds": {"google": 0.30, "gemini": 0.55}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("m", "gemini", cfg)
+        assert result == 0.55
+        alias_records = [
+            r for r in caplog.records if "looks like an alias" in r.message
+        ]
+        assert len(alias_records) == 0  # canonical-match path returned early
+
+
+class TestModelSwitchReResolution:
+    """``ContextCompressor.re_resolve_threshold()`` picks up overrides at runtime."""
+
+    def _build(self, *, model, provider, cfg, ctx=200_000, threshold_percent=0.50):
+        with patch("agent.context_compressor.get_model_context_length", return_value=ctx):
+            return ContextCompressor(
+                model=model,
+                threshold_percent=threshold_percent,
+                provider=provider,
+                quiet_mode=True,
+                compression_config=cfg,
+            )
+
+    def test_picks_up_provider_override_after_model_switch(self):
+        cfg = {"threshold": 0.50, "provider_thresholds": {"anthropic": 0.65}}
+        cc = self._build(model="m1", provider="openrouter", cfg=cfg)
+        assert cc.threshold_percent == 0.50  # init: no override matches
+
+        cc.update_model(model="claude-sonnet-4", context_length=200_000,
+                        provider="anthropic")
+        # Without re_resolve, threshold_percent would still be 0.50.
+        assert cc.threshold_percent == 0.50
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.65
+        # threshold_tokens recomputes: 200_000 * 0.65 = 130_000
+        assert cc.threshold_tokens == 130_000
+
+    def test_picks_up_model_override_when_provider_unmatched(self):
+        cfg = {"threshold": 0.50, "model_thresholds": {"claude-sonnet-4": 0.30}}
+        cc = self._build(model="m1", provider="openrouter", cfg=cfg)
+        cc.update_model(model="claude-sonnet-4", context_length=200_000,
+                        provider="anthropic")
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.30
+
+    def test_falls_back_to_global_when_no_overrides_match(self):
+        cfg = {"threshold": 0.40, "provider_thresholds": {"anthropic": 0.65}}
+        cc = self._build(model="m1", provider="anthropic", cfg=cfg, threshold_percent=0.65)
+        # Switch away from anthropic — provider override no longer applies.
+        cc.update_model(model="some-model", context_length=200_000,
+                        provider="openrouter")
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.40
+
+    def test_no_op_when_no_compression_config(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            cc = ContextCompressor(model="m", threshold_percent=0.60, provider="p", quiet_mode=True)
+        assert cc._compression_config is None
+        cc.update_model(model="m2", context_length=200_000, provider="p2")
+        cc.re_resolve_threshold()
+        # Nothing changes: threshold_percent stays at the value update_model
+        # didn't touch (BF-2 doesn't modify update_model).
+        assert cc.threshold_percent == 0.60
+
+    def test_minimum_context_length_floor_respected(self):
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        cfg = {"model_thresholds": {"tiny-model": 0.10}}
+        cc = self._build(model="big", provider="p", cfg=cfg, ctx=80_000, threshold_percent=0.50)
+        cc.update_model(model="tiny-model", context_length=80_000, provider="p")
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.10
+        # 80_000 * 0.10 = 8_000 < MINIMUM_CONTEXT_LENGTH → floor kicks in
+        assert cc.threshold_tokens == MINIMUM_CONTEXT_LENGTH
+
+    def test_idempotent_when_threshold_unchanged(self):
+        cfg = {"provider_thresholds": {"anthropic": 0.65}}
+        cc = self._build(model="m", provider="anthropic", cfg=cfg, threshold_percent=0.65)
+        before_tokens = cc.threshold_tokens
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.65
+        assert cc.threshold_tokens == before_tokens
+
+    def test_ordering_invariant_re_resolve_reads_current_state(self):
+        """Documents the ordering contract: re_resolve_threshold() always
+        reads the *current* (model, provider) from the compressor instance,
+        so re-resolving without first calling update_model() is harmless —
+        but it also means update_model() MUST run first for a model switch
+        to apply per-model overrides correctly.
+
+        Catches a future refactor that reorders the two calls at any of the
+        three model-switch sites in run_agent.py.
+        """
+        cfg = {"provider_thresholds": {"anthropic": 0.65, "openrouter": 0.40}}
+        cc = self._build(model="m1", provider="anthropic", cfg=cfg, threshold_percent=0.65)
+
+        # Resolving without any state change → same answer.
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.65
+
+        # Resolving twice in a row → idempotent.
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.65
+
+        # Now flip provider directly and re-resolve. The resolver picks up
+        # the change because it reads self.provider on every call. This
+        # demonstrates re_resolve is "current-state driven" — exactly why
+        # the run_agent.py ordering invariant works.
+        cc.provider = "openrouter"
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.40
+
+
+class TestCallableConfigGetter:
+    """``compression_config`` may be a callable for live / hot-reload semantics."""
+
+    def _build(self, *, model, provider, cfg, ctx=200_000, threshold_percent=0.50):
+        with patch("agent.context_compressor.get_model_context_length", return_value=ctx):
+            return ContextCompressor(
+                model=model,
+                threshold_percent=threshold_percent,
+                provider=provider,
+                quiet_mode=True,
+                compression_config=cfg,
+            )
+
+    def test_getter_invoked_on_each_re_resolve(self):
+        # Mutating the dict that the getter returns is visible on the next call.
+        live_cfg = {"threshold": 0.40, "provider_thresholds": {}}
+        cc = self._build(model="m", provider="anthropic", cfg=lambda: live_cfg)
+        cc.update_model(model="m", context_length=200_000, provider="anthropic")
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.40
+
+        # Add an override; the getter sees it on the next call.
+        live_cfg["provider_thresholds"]["anthropic"] = 0.65
+        cc.re_resolve_threshold()
+        assert cc.threshold_percent == 0.65
+
+    def test_getter_returning_non_mapping_warns_and_is_no_op(self, caplog):
+        cc = self._build(model="m", provider="p", cfg=lambda: "not a mapping")  # type: ignore[arg-type]
+        before = cc.threshold_percent
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            cc.re_resolve_threshold()
+        assert cc.threshold_percent == before
+        assert any(
+            "instead of Mapping" in rec.message and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), "non-Mapping return must surface as a WARNING, not silent skip"
+
+    def test_getter_raising_warns_and_is_tolerated(self, caplog):
+        def _bad_getter():
+            raise RuntimeError("config source unavailable")
+
+        cc = self._build(model="m", provider="p", cfg=_bad_getter)
+        before = cc.threshold_percent
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            cc.re_resolve_threshold()  # must not raise
+        assert cc.threshold_percent == before
+        assert any(
+            "getter raised" in rec.message and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), "raising getter must surface as a WARNING so persistent failures are visible"
+
+    def test_getter_failure_warning_deduplicated(self, caplog):
+        def _bad_getter():
+            raise RuntimeError("persistent failure")
+
+        cc = self._build(model="m", provider="p", cfg=_bad_getter)
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            for _ in range(5):
+                cc.re_resolve_threshold()
+        getter_warnings = [r for r in caplog.records if "getter raised" in r.message]
+        assert len(getter_warnings) == 1, (
+            "Repeated failures of the same exception type should warn once, not five times"
+        )
+
+
+class TestBaseEngineNoOp:
+    """ContextEngine base class provides a no-op so plugins are safe."""
+
+    def test_base_engine_re_resolve_is_no_op(self):
+        from agent.context_engine import ContextEngine
+
+        class _FakeEngine(ContextEngine):
+            name = "fake"
+
+            def should_compress(self, prompt_tokens=None):
+                return False
+
+            def compress(self, messages):
+                return messages
+
+            def update_from_response(self, usage):
+                return None
+
+        engine = _FakeEngine()
+        engine.threshold_percent = 0.42
+        # Should not raise, should not change state.
+        engine.re_resolve_threshold()
+        assert engine.threshold_percent == 0.42
 
 
 class TestWireUpSourcePresence:
@@ -229,4 +488,22 @@ class TestWireUpSourcePresence:
         assert "PROVIDER_REGISTRY" in src, (
             "Example yaml should reference the canonical-id source so users "
             "don't write aliases like 'google'/'moonshot'"
+        )
+
+    def test_re_resolve_called_after_each_update_model_in_runtime_paths(self, run_agent_src):
+        """The 3 model-switch sites that update the runtime compressor must
+        invoke ``re_resolve_threshold()`` so per-model / per-provider overrides
+        take effect when the user switches models or a fallback fires.
+
+        A floor of 3 catches a future edit that adds a new model-switch path
+        and forgets the override re-pick.
+        """
+        # Three model-switch sites: switch_model, _try_activate_fallback,
+        # _restore_primary_runtime. Auxiliary handlers (compressor.update_model)
+        # and the plugin-init path are out of scope.
+        re_resolve_calls = run_agent_src.count(".re_resolve_threshold()")
+        assert re_resolve_calls >= 3, (
+            f"Expected ≥3 re_resolve_threshold() calls in run_agent.py "
+            f"(switch_model + _try_activate_fallback + _restore_primary_runtime); "
+            f"found {re_resolve_calls}"
         )

--- a/tests/agent/test_compression_threshold_resolution.py
+++ b/tests/agent/test_compression_threshold_resolution.py
@@ -1,0 +1,232 @@
+"""Tests for issue #18733 — per-model / per-provider compression overrides.
+
+Covers the pure-function ``resolve_compression_threshold()`` resolver in
+``agent/context_compressor.py`` plus the wire-up at the ``ContextCompressor``
+instantiation site in ``run_agent.py``.
+
+Note: ``ContextCompressor.update_model()`` re-resolution on model switch is
+intentionally NOT exercised here — that's owned by the ``threshold_percent=``
+parameter introduced by PR #18638. Once that lands, callers compose the two:
+``update_model(threshold_percent=resolve_compression_threshold(...))``.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _LOGGED_INVALID_OVERRIDE,
+    _THRESHOLD_DEFAULT,
+    _THRESHOLD_MAX,
+    _THRESHOLD_MIN,
+    resolve_compression_threshold,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_dedup():
+    """Reset the module-level dedup set so warnings re-fire each test."""
+    _LOGGED_INVALID_OVERRIDE.clear()
+    yield
+    _LOGGED_INVALID_OVERRIDE.clear()
+
+
+class TestResolutionPrecedence:
+    """Per-model > per-provider > global > built-in default."""
+
+    def test_default_when_config_empty(self):
+        assert resolve_compression_threshold("any-model", "any-provider", {}) == _THRESHOLD_DEFAULT
+
+    def test_default_when_config_none_typed(self):
+        # Defensive: callers pass dicts in practice, but a stray None shouldn't crash.
+        assert resolve_compression_threshold("m", "p", None) == _THRESHOLD_DEFAULT  # type: ignore[arg-type]
+
+    def test_global_threshold_used_when_no_overrides(self):
+        cfg = {"threshold": 0.40}
+        assert resolve_compression_threshold("m", "p", cfg) == 0.40
+
+    def test_provider_override_beats_global(self):
+        cfg = {"threshold": 0.50, "provider_thresholds": {"anthropic": 0.65}}
+        assert resolve_compression_threshold("any-model", "anthropic", cfg) == 0.65
+
+    def test_model_override_beats_provider(self):
+        cfg = {
+            "threshold": 0.50,
+            "provider_thresholds": {"anthropic": 0.65},
+            "model_thresholds": {"claude-sonnet-4": 0.30},
+        }
+        assert resolve_compression_threshold("claude-sonnet-4", "anthropic", cfg) == 0.30
+
+    def test_model_override_beats_global_when_no_provider_match(self):
+        cfg = {
+            "threshold": 0.50,
+            "model_thresholds": {"claude-sonnet-4": 0.30},
+        }
+        assert resolve_compression_threshold("claude-sonnet-4", "unknown-provider", cfg) == 0.30
+
+    def test_unknown_model_falls_to_provider(self):
+        cfg = {"provider_thresholds": {"anthropic": 0.65}}
+        assert resolve_compression_threshold("unknown", "anthropic", cfg) == 0.65
+
+    def test_unknown_provider_falls_to_global(self):
+        cfg = {"threshold": 0.40, "provider_thresholds": {"anthropic": 0.65}}
+        assert resolve_compression_threshold("unknown", "openrouter", cfg) == 0.40
+
+    def test_no_provider_no_model_falls_to_global(self):
+        cfg = {"threshold": 0.40, "provider_thresholds": {"anthropic": 0.65}}
+        assert resolve_compression_threshold("", "", cfg) == 0.40
+
+    def test_empty_override_dicts_silent_fall_through(self):
+        cfg = {"threshold": 0.40, "provider_thresholds": {}, "model_thresholds": {}}
+        assert resolve_compression_threshold("m", "p", cfg) == 0.40
+
+    def test_aliased_provider_key_falls_through(self):
+        # Per the resolver docstring: aliases like "google" / "moonshot" are
+        # auxiliary-routing-only and won't match the main agent's canonical
+        # PROVIDER_REGISTRY id. They should silently fall through.
+        cfg = {"threshold": 0.40, "provider_thresholds": {"google": 0.30}}
+        # self.provider would be "gemini", not "google"
+        assert resolve_compression_threshold("any", "gemini", cfg) == 0.40
+
+
+class TestValidation:
+    """Out-of-range / non-numeric overrides log once and fall through."""
+
+    def test_non_numeric_override_falls_through(self, caplog):
+        cfg = {"threshold": 0.40, "provider_thresholds": {"anthropic": "high"}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("m", "anthropic", cfg)
+        assert result == 0.40
+        assert any("Invalid" in rec.message and "high" in rec.message for rec in caplog.records)
+
+    def test_below_min_falls_through(self, caplog):
+        cfg = {"threshold": 0.40, "model_thresholds": {"m": 0.05}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("m", "p", cfg)
+        assert result == 0.40
+        assert any("Invalid" in rec.message for rec in caplog.records)
+
+    def test_above_max_falls_through(self, caplog):
+        cfg = {"threshold": 0.40, "model_thresholds": {"m": 1.5}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("m", "p", cfg)
+        assert result == 0.40
+
+    def test_at_min_boundary_accepted(self):
+        cfg = {"model_thresholds": {"m": _THRESHOLD_MIN}}
+        assert resolve_compression_threshold("m", "p", cfg) == _THRESHOLD_MIN
+
+    def test_at_max_boundary_accepted(self):
+        cfg = {"model_thresholds": {"m": _THRESHOLD_MAX}}
+        assert resolve_compression_threshold("m", "p", cfg) == _THRESHOLD_MAX
+
+    def test_dedup_warning_per_key(self, caplog):
+        cfg = {"model_thresholds": {"m": "bad"}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            for _ in range(3):
+                resolve_compression_threshold("m", "p", cfg)
+        invalid_records = [r for r in caplog.records if "Invalid" in r.message]
+        assert len(invalid_records) == 1, (
+            "Module-level dedup should suppress repeated warnings for the same key"
+        )
+
+    def test_dedup_distinct_keys_each_warn_once(self, caplog):
+        cfg = {"model_thresholds": {"a": "bad", "b": 99}}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            resolve_compression_threshold("a", "p", cfg)
+            resolve_compression_threshold("a", "p", cfg)  # dedup
+            resolve_compression_threshold("b", "p", cfg)
+            resolve_compression_threshold("b", "p", cfg)  # dedup
+        invalid_records = [r for r in caplog.records if "Invalid" in r.message]
+        assert len(invalid_records) == 2
+
+    def test_invalid_global_falls_to_built_in_default(self, caplog):
+        cfg = {"threshold": "not-a-float"}
+        with caplog.at_level(logging.WARNING, logger="agent.context_compressor"):
+            result = resolve_compression_threshold("m", "p", cfg)
+        assert result == _THRESHOLD_DEFAULT
+
+
+class TestWireUpComposition:
+    """The resolver composes correctly with ContextCompressor at the call site."""
+
+    def test_resolved_value_flows_into_compressor(self):
+        cfg = {
+            "threshold": 0.50,
+            "model_thresholds": {"test-model": 0.30},
+        }
+        resolved = resolve_compression_threshold("test-model", "anthropic", cfg)
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            compressor = ContextCompressor(
+                model="test-model",
+                threshold_percent=resolved,
+                quiet_mode=True,
+            )
+        assert compressor.threshold_percent == 0.30
+        # 200_000 * 0.30 = 60_000, but MINIMUM_CONTEXT_LENGTH (64_000) floor applies
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        assert compressor.threshold_tokens == max(60_000, MINIMUM_CONTEXT_LENGTH)
+
+    def test_provider_override_flows_into_compressor(self):
+        cfg = {
+            "threshold": 0.50,
+            "provider_thresholds": {"anthropic": 0.65},
+        }
+        resolved = resolve_compression_threshold("any-model", "anthropic", cfg)
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            compressor = ContextCompressor(
+                model="any-model",
+                threshold_percent=resolved,
+                quiet_mode=True,
+            )
+        assert compressor.threshold_percent == 0.65
+        # 200_000 * 0.65 = 130_000
+        assert compressor.threshold_tokens == 130_000
+
+
+class TestWireUpSourcePresence:
+    """Source-level checks that the resolver is wired in at run_agent.py:2013."""
+
+    @pytest.fixture(scope="class")
+    def run_agent_src(self) -> str:
+        path = Path(__file__).resolve().parents[2] / "run_agent.py"
+        return path.read_text(encoding="utf-8")
+
+    def test_resolver_imported_at_instantiation_site(self, run_agent_src):
+        assert "from agent.context_compressor import resolve_compression_threshold" in run_agent_src, (
+            "Wire-up missing: resolver must be imported in run_agent.py"
+        )
+
+    def test_resolver_called_with_self_model_and_provider(self, run_agent_src):
+        # Locate the ContextCompressor instantiation block and assert the
+        # resolver call appears in the same window. Window size of 30 lines
+        # is generous; the actual gap is ~5 lines.
+        idx = run_agent_src.find("self.context_compressor = ContextCompressor(")
+        assert idx >= 0, "ContextCompressor instantiation site not found"
+        window = run_agent_src[max(0, idx - 1500):idx]
+        assert "resolve_compression_threshold(" in window, (
+            "Resolver call missing immediately before ContextCompressor() instantiation"
+        )
+        assert "model=self.model" in window
+        assert "provider=self.provider" in window
+
+    def test_compression_schema_keys_added(self):
+        path = Path(__file__).resolve().parents[2] / "hermes_cli" / "config.py"
+        src = path.read_text(encoding="utf-8")
+        assert '"provider_thresholds": {}' in src, "Schema add missing: provider_thresholds"
+        assert '"model_thresholds": {}' in src, "Schema add missing: model_thresholds"
+
+    def test_yaml_example_documents_canonical_provider_keys(self):
+        path = Path(__file__).resolve().parents[2] / "cli-config.yaml.example"
+        src = path.read_text(encoding="utf-8")
+        # Either the literal canonical keys or a docstring-style note. Accept
+        # either form so reviewers can polish wording without breaking tests.
+        assert "provider_thresholds" in src
+        assert "model_thresholds" in src
+        assert "PROVIDER_REGISTRY" in src, (
+            "Example yaml should reference the canonical-id source so users "
+            "don't write aliases like 'google'/'moonshot'"
+        )


### PR DESCRIPTION
## What does this PR do?

Adds two empty-by-default override maps to the `compression` config schema and a pure-function resolver that picks the active compression threshold per the precedence:

```
compression.model_thresholds[<model>]
  > compression.provider_thresholds[<provider>]
  > compression.threshold
  > 0.50  (built-in default)
```

User-visible effect: a Claude user running 200K-context conversations can keep `threshold: 0.50` as a sensible default for most providers, then lift it to `0.65` just for `anthropic` (or just for one specific model) without touching the rest of their setup.

The override fires on initial agent startup *and* whenever the runtime switches models — model switching, fallback activation, and primary-runtime restoration all re-pick the threshold so a per-model rule applies the moment that model becomes active.

Schema additions are additive and default to empty dicts, so existing configs behave identically. No migration version bump required.

## Related Issue

[#18733](https://github.com/NousResearch/hermes-agent/issues/18733) — *"Per-model or per-provider compression threshold overrides"*. Closes the feature request via Option B of the issue body (per-model with per-provider as the fall-back), without removing or reshaping the existing global `compression.threshold`.

## Type of Change

- [x] ✨ New feature

## Changes Made

`hermes_cli/config.py:633` — extends `DEFAULT_CONFIG["compression"]` with `provider_thresholds: {}` and `model_thresholds: {}`.

`agent/context_compressor.py`:
- Module-level constants: `_THRESHOLD_MIN`, `_THRESHOLD_MAX`, `_THRESHOLD_DEFAULT`.
- Module-level dedup state: `_LOGGED_INVALID_OVERRIDE`. One warning per scope+identifier; intentionally not reset on reload (long-lived gateway processes prioritize log-noise control over reload feedback).
- Module-level `_PROVIDER_ALIAS_HINTS` map. When a user writes an alias key (e.g. `provider_thresholds: {google: 0.50}`) the resolver still falls through silently (since `self.provider` is the canonical id), but emits a one-time *hint* line pointing at the canonical id (`gemini`) so the operator notices.
- `_validate_threshold(...)` private helper — coerces to float, range-checks, logs once on failure at `WARNING` level.
- `resolve_compression_threshold(model, provider, config) -> float` public resolver.
- `ContextCompressor.__init__` — new optional `compression_config` kwarg accepting either a `Mapping` (snapshot — fast path; matches existing CLI_CONFIG semantics) **or** a zero-arg callable returning a `Mapping` (live path — usable behind a future `/reload-config` hook without API changes).
- `ContextCompressor.re_resolve_threshold()` — re-runs the resolver against the current `(self.model, self.provider)` pair and recomputes `threshold_tokens`. No-op when `_compression_config` is `None`. **Loud-failure** path: when a callable getter raises an exception or returns a non-Mapping, a deduplicated `WARNING` is logged so a persistent misconfiguration is visible without restart.

`agent/context_engine.py` — `ContextEngine.re_resolve_threshold()` no-op so plugin engines are safe to invoke generically (no `hasattr()` checks at call sites).

`run_agent.py`:
- At the existing `ContextCompressor` instantiation site, calls the resolver and passes the result as `threshold_percent`. Also passes `compression_config=_compression_cfg` so the snapshot is available for runtime re-resolution.
- After each of the three runtime model-switch sites (`switch_model`, `_try_activate_fallback`, `_restore_primary_runtime`), invokes `self.context_compressor.re_resolve_threshold()`. Each call site has an inline ordering-invariant comment so a future refactor that reorders the two calls is forced to read the rationale.
- The `📊 Context limit:` startup banner now reads `threshold_percent` from the compressor instance instead of the global config so override values are reflected in the printed line.

`cli-config.yaml.example` — appends a documented, commented-out example block in the existing `compression:` section, including the canonical-vs-alias note.

`tests/agent/test_compression_threshold_resolution.py` (new) — 42 tests across eight classes:
- `TestResolutionPrecedence` (11): default, global-only, provider-beats-global, model-beats-provider, model-beats-global-when-no-provider, fall-throughs (unknown model / unknown provider / both empty / empty dicts), aliased-key-falls-through.
- `TestValidation` (8): non-numeric, below-min, above-max, at-min-boundary, at-max-boundary, dedup-per-key, dedup-distinct-keys, invalid-global-falls-to-built-in (with explicit `WARNING`-level assertions to prevent silent log-level demotion).
- `TestAliasHint` (4): alias key emits canonical-id hint at `WARNING`, hint deduplicated, canonical key doesn't trigger hint, alias-warning suppressed when canonical match wins.
- `TestModelSwitchReResolution` (7): provider override picked up after switch, model override picked up after switch, fall-back-to-global when no override matches, no-op when no `compression_config`, MINIMUM_CONTEXT_LENGTH floor respected, idempotent when threshold unchanged, **ordering-invariant doc test** that asserts `re_resolve_threshold()` reads current state on every call.
- `TestCallableConfigGetter` (4): getter invoked per-call (proves live semantics), getter returning non-Mapping warns + is no-op, getter raising warns + is tolerated, getter-failure warning is deduplicated by exception type.
- `TestBaseEngineNoOp` (1): plugin engines that don't override `re_resolve_threshold` get a safe no-op from the base class.
- `TestWireUpComposition` (2): resolved value flows into `ContextCompressor.threshold_percent` and `threshold_tokens` via direct construction.
- `TestWireUpSourcePresence` (5): resolver imported, called with `model=self.model` / `provider=self.provider` next to instantiation, schema keys present, yaml example references canonical-id source, `re_resolve_threshold()` invoked at ≥3 model-switch sites in `run_agent.py`.

## Coordination with PR #18638 (issue #18617)

[PR #18638](https://github.com/NousResearch/hermes-agent/pull/18638) is in active review for [#18617](https://github.com/NousResearch/hermes-agent/issues/18617). It adds a `threshold_percent: float | None = None` parameter on `ContextCompressor.update_model()` and forwards the existing value at three runtime callsites so a model switch doesn't reset the threshold to whatever the legacy default would set.

This PR deliberately does **not** modify `update_model()`'s signature. Override re-picking lives in a separate `re_resolve_threshold()` method invoked *after* `update_model()` returns:

```python
self.context_compressor.update_model(model=..., context_length=..., provider=..., ...)
# Ordering invariant: re_resolve reads self.model / self.provider that update_model just set.
self.context_compressor.re_resolve_threshold()
```

The two diffs add lines to the same callsite blocks but don't overlap line-for-line, so neither blocks the other on merge order.

**Composition contract** (when both PRs land):

| Step | Owner | Effect |
|---|---|---|
| `update_model(threshold_percent=cc.threshold_percent)` | #18638 | *Preservation* — the existing value is forwarded across the switch (regression fix for #18617) |
| `re_resolve_threshold()` | this PR | *Policy* — re-picks per-model / per-provider override for the new active pair |

Policy wins over preservation — that's the user's stated intent. When no override matches the new pair, the resolver falls through to the global threshold, which is what `__init__` would have picked anyway, so #18638's preservation is a no-op in realistic configs. The two are corrective only when an override explicitly disagrees with the preserved value, in which case the user's configured override is correct.

Callers that want to bypass policy should call `update_model(threshold_percent=...)` *without* a follow-up `re_resolve_threshold()`.

## Failure-mode posture

- **Invalid override values** (non-numeric, out of `[0.10, 0.95]`): logged once at `WARNING`, fall through to next precedence level. Tests pin the log level so a future change can't silently demote to `DEBUG`.
- **Alias keys** (`google`, `moonshot`, `claude`, ...): logged once at `WARNING` with a canonical-id hint, fall through. Tests assert the level.
- **Callable getter raises**: `WARNING` logged once per exception type, threshold stays at current value, model switch continues.
- **Callable getter returns non-Mapping**: `WARNING` logged once per type, threshold stays at current value, model switch continues.
- **`compression_config` is `None`**: silent no-op; this is the not-configured case.

The "log loudly, never crash the model switch" posture is intentional: a misconfigured threshold should never break the user's session. All warnings hit the standard `agent.context_compressor` logger so they appear in default logging configurations.

## Out of scope (intentional)

- **Migration version bump.** Not required: additive empty-dict defaults match the host pattern for the existing `compression:` block.
- **Provider-key alias *normalization*** (auto-rewriting `google` → `gemini` before lookup). The lookup stays exact-string; aliases fall through with a one-time hint. Auto-normalization would couple the resolver to `_PROVIDER_ALIASES` and create a drift surface.
- **Plugin context engines.** Plugins use whatever `threshold_percent` they're initialized with; they receive a default no-op `re_resolve_threshold()` from the base class.
- **Auxiliary handler `update_model` callsites** (around `run_agent.py:12219` / `:12492`) — not user-visible model switches; not followed by `re_resolve_threshold()`.

## How to Test

```bash
# Targeted: 42 tests covering precedence, validation (with log-level pins),
# alias hints, model-switch re-resolution, callable getters, ordering invariant,
# wire-up composition, source presence
pytest tests/agent/test_compression_threshold_resolution.py -v

# Smoke regression on the agent test surface
pytest tests/agent/ -q

# Manual: configure an override, start hermes, verify the startup banner
cat <<'YAML' >> ~/.hermes/config.yaml
compression:
  provider_thresholds:
    anthropic: 0.65
YAML
hermes chat -q "say hi" --max-turns 2
# Expect banner: "📊 Context limit: ... tokens (compress at 65% = ...)" if you're on Claude.

# Manual model-switch test:
# 1. Start hermes on a non-anthropic model
# 2. /model claude-sonnet-4
# 3. Banner / next compression should reflect the 0.65 override

# Manual alias-hint test:
cat <<'YAML' >> ~/.hermes/config.yaml
compression:
  provider_thresholds:
    google: 0.40    # alias — should warn once and fall through
YAML
# Expect log: "compression.provider_thresholds['google'] looks like an alias — main agent providers use the canonical PROVIDER_REGISTRY id 'gemini'."
```

I ran `pytest tests/agent/ -q` locally on this branch — 2397 passed, 0 failed, no new warnings traceable to this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (relevant adjacent PR is #18638; coordination above)
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/agent/ -q` and the changes don't introduce new failures
- [x] Tests added (`tests/agent/test_compression_threshold_resolution.py` — 42 tests)
- [x] I've tested on my platform: Linux (Debian 13)

### Documentation & Housekeeping

- [x] `cli-config.yaml.example` updated with a commented-out example block in the existing `compression:` section
- [N/A] CONTRIBUTING.md / AGENTS.md (no contributor-facing change)
- [N/A] Cross-platform impact (pure config + Python; no platform primitives)
- [N/A] Tool descriptions / schemas

---
Ridden with [Loa](https://github.com/0xHoneyJar/loa).
