### PR TITLE
Add optional OpenRouter response caching headers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -99,6 +99,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
+from agent.openrouter_headers import OPENROUTER_ATTRIBUTION_HEADERS, openrouter_default_headers
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -260,11 +261,7 @@ _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
 })
 
 # OpenRouter app attribution headers
-_OR_HEADERS = {
-    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-    "X-OpenRouter-Title": "Hermes Agent",
-    "X-OpenRouter-Categories": "productivity,cli-agent",
-}
+_OR_HEADERS = dict(OPENROUTER_ATTRIBUTION_HEADERS)
 
 # Vercel AI Gateway app attribution headers. HTTP-Referer maps to
 # referrerUrl and X-Title maps to appName in the gateway's analytics.
@@ -1158,14 +1155,14 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
         return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+                       default_headers=openrouter_default_headers()), _OPENROUTER_MODEL
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+                   default_headers=openrouter_default_headers()), _OPENROUTER_MODEL
 
 
 def _describe_openrouter_unavailable() -> str:
@@ -1911,7 +1908,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     }
     sync_base_url = str(sync_client.base_url)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
-        async_kwargs["default_headers"] = dict(_OR_HEADERS)
+        async_kwargs["default_headers"] = openrouter_default_headers()
     elif base_url_host_matches(sync_base_url, "api.githubcopilot.com"):
         from hermes_cli.copilot_auth import copilot_request_headers
 

--- a/agent/openrouter_headers.py
+++ b/agent/openrouter_headers.py
@@ -1,0 +1,133 @@
+"""OpenRouter request header helpers.
+
+OpenRouter-specific transport features should stay opt-in so Hermes does not
+change behaviour for existing users by default.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any, Dict, Optional
+
+
+OPENROUTER_ATTRIBUTION_HEADERS: Dict[str, str] = {
+    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+    "X-OpenRouter-Title": "Hermes Agent",
+    "X-OpenRouter-Categories": "productivity,cli-agent",
+}
+
+OPENROUTER_RESPONSE_CACHE_HEADER = "X-OpenRouter-Cache"
+OPENROUTER_RESPONSE_CACHE_TTL_HEADER = "X-OpenRouter-Cache-TTL"
+OPENROUTER_RESPONSE_CACHE_ENV = "HERMES_OPENROUTER_RESPONSE_CACHE"
+OPENROUTER_RESPONSE_CACHE_TTL_ENV = "HERMES_OPENROUTER_RESPONSE_CACHE_TTL"
+OPENROUTER_RESPONSE_CACHE_MAX_TTL_SECONDS = 24 * 60 * 60
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _coerce_optional_bool(value: Any) -> Optional[bool]:
+    """Return a bool for known bool-ish values, otherwise ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_VALUES:
+            return True
+        if normalized in _FALSE_VALUES:
+            return False
+        return None
+    return bool(value)
+
+
+def _coerce_ttl_seconds(value: Any) -> Optional[int]:
+    """Return a valid OpenRouter response-cache TTL in seconds.
+
+    OpenRouter's documented maximum is 24 hours. Invalid values are ignored so a
+    bad optional cache setting never prevents client creation.
+    """
+    if value in (None, ""):
+        return None
+    try:
+        ttl = int(value)
+    except (TypeError, ValueError):
+        return None
+    if ttl < 1 or ttl > OPENROUTER_RESPONSE_CACHE_MAX_TTL_SECONDS:
+        return None
+    return ttl
+
+
+def _load_openrouter_config() -> Dict[str, Any]:
+    """Best-effort read of ``config.yaml``'s ``openrouter`` section."""
+    try:
+        from hermes_cli.config import load_config
+
+        section = (load_config() or {}).get("openrouter", {})
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
+def openrouter_response_cache_headers(
+    config: Optional[Mapping[str, Any]] = None,
+    environ: Optional[Mapping[str, str]] = None,
+) -> Dict[str, str]:
+    """Return OpenRouter response-cache headers when explicitly enabled.
+
+    Supported config shape::
+
+        openrouter:
+          response_cache:
+            enabled: true
+            ttl_seconds: 600
+
+    Environment variables override config:
+    ``HERMES_OPENROUTER_RESPONSE_CACHE`` and
+    ``HERMES_OPENROUTER_RESPONSE_CACHE_TTL``.
+    """
+    env = os.environ if environ is None else environ
+    openrouter_config: Mapping[str, Any]
+    if config is None:
+        openrouter_config = _load_openrouter_config()
+    else:
+        if "openrouter" in config:
+            section = config.get("openrouter")
+            openrouter_config = section if isinstance(section, Mapping) else {}
+        else:
+            openrouter_config = config
+
+    response_cache = openrouter_config.get("response_cache", {})
+    if not isinstance(response_cache, Mapping):
+        response_cache = {}
+
+    enabled = _coerce_optional_bool(response_cache.get("enabled")) or False
+    if OPENROUTER_RESPONSE_CACHE_ENV in env:
+        env_enabled = _coerce_optional_bool(env.get(OPENROUTER_RESPONSE_CACHE_ENV))
+        if env_enabled is not None:
+            enabled = env_enabled
+
+    if not enabled:
+        return {}
+
+    ttl_value = response_cache.get("ttl_seconds")
+    if OPENROUTER_RESPONSE_CACHE_TTL_ENV in env:
+        ttl_value = env.get(OPENROUTER_RESPONSE_CACHE_TTL_ENV)
+    ttl = _coerce_ttl_seconds(ttl_value)
+
+    headers = {OPENROUTER_RESPONSE_CACHE_HEADER: "true"}
+    if ttl is not None:
+        headers[OPENROUTER_RESPONSE_CACHE_TTL_HEADER] = str(ttl)
+    return headers
+
+
+def openrouter_default_headers(
+    config: Optional[Mapping[str, Any]] = None,
+    environ: Optional[Mapping[str, str]] = None,
+) -> Dict[str, str]:
+    """Return attribution headers plus optional opt-in response-cache headers."""
+    headers = dict(OPENROUTER_ATTRIBUTION_HEADERS)
+    headers.update(openrouter_response_cache_headers(config=config, environ=environ))
+    return headers

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -388,6 +388,12 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "openrouter": {
+        "response_cache": {
+            "enabled": False,
+            "ttl_seconds": None,
+        },
+    },
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,

--- a/run_agent.py
+++ b/run_agent.py
@@ -148,6 +148,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
+from agent.openrouter_headers import openrouter_default_headers
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
@@ -1421,11 +1422,7 @@ class AIAgent:
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
                 if base_url_host_matches(effective_base, "openrouter.ai"):
-                    client_kwargs["default_headers"] = {
-                        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-                        "X-OpenRouter-Title": "Hermes Agent",
-                        "X-OpenRouter-Categories": "productivity,cli-agent",
-                    }
+                    client_kwargs["default_headers"] = openrouter_default_headers()
                 elif base_url_host_matches(effective_base, "api.routermint.com"):
                     client_kwargs["default_headers"] = _routermint_headers()
                 elif base_url_host_matches(effective_base, "api.githubcopilot.com"):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -33,6 +33,7 @@ def _clean_env(monkeypatch):
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "HERMES_OPENROUTER_RESPONSE_CACHE", "HERMES_OPENROUTER_RESPONSE_CACHE_TTL",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -65,6 +66,17 @@ class TestNormalizeAuxProvider:
     def test_maps_github_copilot_acp_aliases(self):
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
+
+
+def test_openrouter_auxiliary_client_uses_configurable_headers(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    expected_headers = {"X-Test-OpenRouter": "cache-enabled"}
+
+    with patch("agent.auxiliary_client.openrouter_default_headers", return_value=expected_headers), \
+         patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        resolve_provider_client("openrouter")
+
+    assert mock_openai.call_args.kwargs["default_headers"] == expected_headers
 
 
 class TestReadCodexAccessToken:

--- a/tests/agent/test_openrouter_headers.py
+++ b/tests/agent/test_openrouter_headers.py
@@ -1,0 +1,60 @@
+from agent.openrouter_headers import (
+    OPENROUTER_ATTRIBUTION_HEADERS,
+    OPENROUTER_RESPONSE_CACHE_HEADER,
+    OPENROUTER_RESPONSE_CACHE_TTL_HEADER,
+    openrouter_default_headers,
+    openrouter_response_cache_headers,
+)
+
+
+def test_response_cache_disabled_by_default():
+    headers = openrouter_default_headers(config={}, environ={})
+
+    assert headers == OPENROUTER_ATTRIBUTION_HEADERS
+    assert OPENROUTER_RESPONSE_CACHE_HEADER not in headers
+    assert OPENROUTER_RESPONSE_CACHE_TTL_HEADER not in headers
+
+
+def test_response_cache_config_enabled_with_ttl():
+    headers = openrouter_response_cache_headers(
+        config={"openrouter": {"response_cache": {"enabled": True, "ttl_seconds": 600}}},
+        environ={},
+    )
+
+    assert headers == {
+        OPENROUTER_RESPONSE_CACHE_HEADER: "true",
+        OPENROUTER_RESPONSE_CACHE_TTL_HEADER: "600",
+    }
+
+
+def test_response_cache_env_overrides_config():
+    headers = openrouter_response_cache_headers(
+        config={"response_cache": {"enabled": False, "ttl_seconds": 300}},
+        environ={
+            "HERMES_OPENROUTER_RESPONSE_CACHE": "true",
+            "HERMES_OPENROUTER_RESPONSE_CACHE_TTL": "900",
+        },
+    )
+
+    assert headers == {
+        OPENROUTER_RESPONSE_CACHE_HEADER: "true",
+        OPENROUTER_RESPONSE_CACHE_TTL_HEADER: "900",
+    }
+
+
+def test_response_cache_env_can_disable_config():
+    headers = openrouter_response_cache_headers(
+        config={"response_cache": {"enabled": True, "ttl_seconds": 600}},
+        environ={"HERMES_OPENROUTER_RESPONSE_CACHE": "false"},
+    )
+
+    assert headers == {}
+
+
+def test_response_cache_invalid_ttl_is_ignored():
+    headers = openrouter_response_cache_headers(
+        config={"response_cache": {"enabled": True, "ttl_seconds": 999999}},
+        environ={},
+    )
+
+    assert headers == {OPENROUTER_RESPONSE_CACHE_HEADER: "true"}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -151,6 +151,25 @@ def test_aiagent_reuses_existing_errors_log_handler():
             root_logger.addHandler(handler)
 
 
+def test_aiagent_openrouter_uses_configurable_headers():
+    expected_headers = {"X-Test-OpenRouter": "cache-enabled"}
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.openrouter_default_headers", return_value=expected_headers),
+        patch("run_agent.OpenAI") as mock_openai,
+    ):
+        AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert mock_openai.call_args.kwargs["default_headers"] == expected_headers
+
+
 class TestProviderModelNormalization:
     def test_aiagent_strips_matching_native_provider_prefix(self):
         with (


### PR DESCRIPTION
## Context
OpenRouter announced beta support for response caching:
https://openrouter.ai/announcements/response-caching

This lets clients opt into caching completed responses for identical OpenRouter requests. Hermes already sends OpenRouter attribution headers; this PR adds a small, explicit opt-in path for the new cache headers without changing default behaviour.

The intent is to make response caching available for workflows where repeat requests are expected and safe, such as retries, test runs, cron/batch jobs, and stable auxiliary tasks. It stays disabled by default because live agent conversations and fresh tool-context workflows should not silently change transport behaviour.

## Summary
- add a shared OpenRouter header helper that preserves existing attribution headers
- add optional OpenRouter response caching headers behind explicit config/env opt-in
- apply the helper to the main agent OpenRouter client and auxiliary OpenRouter clients

## Config
Default remains disabled:

```yaml
openrouter:
  response_cache:
    enabled: false
    ttl_seconds: null
```

To enable:

```yaml
openrouter:
  response_cache:
    enabled: true
    ttl_seconds: 600
```

Environment overrides:

```bash
HERMES_OPENROUTER_RESPONSE_CACHE=true
HERMES_OPENROUTER_RESPONSE_CACHE_TTL=600
```

## Tests
- `python -m pytest tests/agent/test_openrouter_headers.py tests/agent/test_auxiliary_client.py tests/run_agent/test_run_agent.py -q`
- `python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_drift.py -q`
- `python -m py_compile agent/openrouter_headers.py agent/auxiliary_client.py run_agent.py hermes_cli/config.py`
- `git diff --check`
