### PR TITLE
fix(gateway): show other profiles in `gateway status` to prevent confusion

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -690,6 +690,32 @@ def _print_gateway_process_mismatch(snapshot: GatewayRuntimeSnapshot) -> None:
     print("  can refuse to start another copy until this process stops.")
 
 
+def _print_other_profiles_gateway_status() -> None:
+    """Print a summary of gateway status across all profiles.
+
+    Shown at the bottom of ``hermes gateway status`` output so users with
+    multiple profiles can tell at a glance which gateways are running and
+    avoid confusing another profile's process with the current one.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        current = get_active_profile_name()
+        other_processes = [
+            p for p in find_profile_gateway_processes()
+            if p.profile != current
+        ]
+        if not other_processes:
+            return
+
+        print()
+        print("Other profiles:")
+        for proc in other_processes:
+            print(f"  ✓ {proc.profile:<16s} — PID {proc.pid}")
+    except Exception:
+        pass
+
+
 def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None,
                            all_profiles: bool = False) -> int:
     """Kill any running gateway processes. Returns count killed.
@@ -4455,6 +4481,9 @@ def _gateway_command_inner(args):
                 else:
                     print("  hermes gateway install  # Install as user service")
                     print("  sudo hermes gateway install --system  # Install as boot-time system service")
+
+        # Show other profiles' gateway status for multi-profile awareness
+        _print_other_profiles_gateway_status()
 
     elif subcmd == "migrate-legacy":
         # Stop, disable, and remove legacy Hermes gateway unit files from


### PR DESCRIPTION
## Summary

When running multiple gateway profiles (e.g. `default` and `wx1`), `hermes gateway status` can be misleading — stopping one profile's gateway and checking status may still show the other profile's process without clearly indicating which profile it belongs to.

This PR adds an "Other profiles" section at the bottom of the `gateway status` output that shows running gateways from other profiles:

```
✓ Gateway is running (PID: 155469)
  (Running manually, not as a system service)

To install as a service:
  hermes gateway install
  sudo hermes gateway install --system

Other profiles:
  ✓ wx1              — PID 166893
```

## Changes

- Added `_print_other_profiles_gateway_status()` in `hermes_cli/gateway.py`
  - Uses existing `find_profile_gateway_processes()` to discover running gateways across all profiles
  - Uses `get_active_profile_name()` to filter out the current profile
  - Wrapped in try/except — silently degrades if profile discovery fails
- Called at the end of the `status` subcommand handler (after both service and manual process paths)

## How to Test

1. Start two gateways: `hermes gateway run` and `hermes --profile wx1 gateway run`
2. Run `hermes gateway status` — should show current profile status plus "Other profiles: wx1"
3. Run `hermes --profile wx1 gateway status` — should show wx1 status plus "Other profiles: default"
4. Stop wx1: `hermes --profile wx1 gateway stop`
5. Run `hermes --profile wx1 gateway status` — should show "not running" with no misleading PID from the default gateway

## Platform

Tested on Amazon Linux 2 with manual (non-service) gateways.

Closes #19113
Related: #4402, #4587