### PR TITLE
perf: port OpenClaw-style session and tool-loading optimizations

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -8,11 +8,13 @@ Handles:
 - Dynamic system prompt injection (agent knows its context)
 """
 
+import atexit
 import hashlib
 import logging
 import os
 import json
 import threading
+import time
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -20,6 +22,40 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
+
+
+def _session_index_debounce_seconds() -> float:
+    """Return debounce interval for sessions.json rewrites."""
+    raw = os.getenv("HERMES_GATEWAY_SESSION_INDEX_DEBOUNCE_SECS")
+    if raw is None:
+        return 0.25
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.debug(
+            "Invalid HERMES_GATEWAY_SESSION_INDEX_DEBOUNCE_SECS=%r; using default",
+            raw,
+        )
+        return 0.25
+
+
+def _legacy_transcript_mode() -> str:
+    """Return how aggressively to maintain legacy JSONL transcript mirrors.
+
+    Modes:
+      - auto  (default): mirror only when SQLite is unavailable or a legacy
+        JSONL transcript already exists for that session.
+      - on    : always mirror JSONL writes.
+      - off   : never mirror when SQLite is available.
+    """
+    raw = (os.getenv("HERMES_GATEWAY_LEGACY_TRANSCRIPT_MODE") or "auto").strip().lower()
+    if raw in {"auto", "on", "off"}:
+        return raw
+    logger.debug(
+        "Invalid HERMES_GATEWAY_LEGACY_TRANSCRIPT_MODE=%r; using auto",
+        raw,
+    )
+    return "auto"
 
 
 def _now() -> datetime:
@@ -675,6 +711,12 @@ class SessionStore:
         self._loaded = False
         self._lock = threading.Lock()
         self._has_active_processes_fn = has_active_processes_fn
+        self._save_debounce_seconds = _session_index_debounce_seconds()
+        self._legacy_transcript_mode = _legacy_transcript_mode()
+        self._dirty_index = False
+        self._last_index_save_monotonic = 0.0
+        self._save_force_requested = False
+        atexit.register(self._flush_pending_index_save)
         
         # Initialize SQLite session database
         self._db = None
@@ -712,8 +754,8 @@ class SessionStore:
 
         self._loaded = True
     
-    def _save(self) -> None:
-        """Save sessions index to disk (kept for session key -> ID mapping)."""
+    def _write_sessions_index_locked(self) -> None:
+        """Write sessions.json to disk. Must be called with self._lock held."""
         import tempfile
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
         sessions_file = self.sessions_dir / "sessions.json"
@@ -728,12 +770,46 @@ class SessionStore:
                 f.flush()
                 os.fsync(f.fileno())
             atomic_replace(tmp_path, sessions_file)
+            self._dirty_index = False
+            self._last_index_save_monotonic = time.monotonic()
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError as e:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
+
+    def _flush_pending_index_save(self) -> None:
+        """Best-effort atexit flush for debounced sessions.json updates."""
+        try:
+            with self._lock:
+                if self._dirty_index:
+                    self._write_sessions_index_locked()
+        except Exception as exc:
+            logger.debug("Failed to flush pending gateway session index: %s", exc)
+
+    def _save(self, *, force: bool = False) -> None:
+        """Persist sessions index, debouncing hot-path metadata-only rewrites.
+
+        Must be called with ``self._lock`` held.
+        """
+        if not force and self._save_force_requested:
+            force = True
+            self._save_force_requested = False
+        self._dirty_index = True
+        if not force and self._save_debounce_seconds > 0:
+            now = time.monotonic()
+            if (
+                self._last_index_save_monotonic > 0
+                and (now - self._last_index_save_monotonic) < self._save_debounce_seconds
+            ):
+                return
+        self._write_sessions_index_locked()
+
+    def _save_immediately(self) -> None:
+        """Compatibility wrapper for callers/tests that patch ``_save()``."""
+        self._save_force_requested = True
+        self._save()
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
@@ -926,7 +1002,7 @@ class SessionStore:
             )
 
             self._entries[session_key] = entry
-            self._save()
+            self._save_immediately()
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": source.platform.value,
@@ -975,7 +1051,7 @@ class SessionStore:
             self._ensure_loaded_locked()
             if session_key in self._entries:
                 self._entries[session_key].suspended = True
-                self._save()
+                self._save_immediately()
                 return True
         return False
 
@@ -1004,7 +1080,7 @@ class SessionStore:
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()
-                self._save()
+                self._save_immediately()
                 return True
         return False
 
@@ -1025,7 +1101,7 @@ class SessionStore:
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
-            self._save()
+            self._save_immediately()
             return True
 
     def prune_old_entries(self, max_age_days: int) -> int:
@@ -1076,7 +1152,7 @@ class SessionStore:
             for key in removed_keys:
                 self._entries.pop(key, None)
             if removed_keys:
-                self._save()
+                self._save_immediately()
 
         if removed_keys:
             logger.info(
@@ -1113,7 +1189,7 @@ class SessionStore:
                     entry.suspended = True
                     count += 1
             if count:
-                self._save()
+                self._save_immediately()
         return count
 
     def reset_session(self, session_key: str) -> Optional[SessionEntry]:
@@ -1147,7 +1223,7 @@ class SessionStore:
             )
 
             self._entries[session_key] = new_entry
-            self._save()
+            self._save_immediately()
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
@@ -1207,7 +1283,7 @@ class SessionStore:
             )
 
             self._entries[session_key] = new_entry
-            self._save()
+            self._save_immediately()
 
         if self._db and db_end_session_id:
             try:
@@ -1240,7 +1316,18 @@ class SessionStore:
     def get_transcript_path(self, session_id: str) -> Path:
         """Get the path to a session's legacy transcript file."""
         return self.sessions_dir / f"{session_id}.jsonl"
-    
+
+    def _should_write_legacy_transcript(self, session_id: str) -> bool:
+        """Return whether this session should maintain a JSONL mirror."""
+        mode = self._legacy_transcript_mode
+        if mode == "on":
+            return True
+        if mode == "off":
+            return self._db is None
+        if self._db is None:
+            return True
+        return self.get_transcript_path(session_id).exists()
+
     def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
         """Append a message to a session's transcript (SQLite + legacy JSONL).
 
@@ -1268,8 +1355,12 @@ class SessionStore:
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
-        
-        # Also write legacy JSONL (keeps existing tooling working during transition)
+
+        if not self._should_write_legacy_transcript(session_id):
+            return
+
+        # Also write legacy JSONL when explicitly enabled or preserving an
+        # existing pre-SQLite transcript file.
         transcript_path = self.get_transcript_path(session_id)
         with open(transcript_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(message, ensure_ascii=False) + "\n")
@@ -1288,11 +1379,12 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
         
-        # JSONL: overwrite the file
-        transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        # JSONL: overwrite only when mirroring is enabled for this session.
+        if self._should_write_legacy_transcript(session_id):
+            transcript_path = self.get_transcript_path(session_id)
+            with open(transcript_path, "w", encoding="utf-8") as f:
+                for msg in messages:
+                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1165,7 +1165,7 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
     Returns a list of non-``None`` return values from plugin callbacks.
     """
-    return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+    return _ensure_plugins_discovered().invoke_hook(hook_name, **kwargs)
 
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -4,9 +4,9 @@ Model Tools Module
 
 Thin orchestration layer over the tool registry. Each tool file in tools/
 self-registers its schema, handler, and metadata via tools.registry.register().
-This module triggers discovery (by importing all tool modules), then provides
-the public API that run_agent.py, cli.py, batch_runner.py, and the RL
-environments consume.
+This module keeps public compatibility APIs for run_agent.py, cli.py,
+batch_runner.py, and RL environments while letting built-in tool modules load
+lazily on demand.
 
 Public API (signatures preserved from the original 2,400-line version):
     get_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode) -> list
@@ -27,7 +27,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import discover_builtin_tools, registry
+from tools.registry import registry
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
@@ -174,10 +174,8 @@ def _run_async(coro):
 
 
 # =============================================================================
-# Tool Discovery  (importing each module triggers its registry.register calls)
+# Tool Discovery  (built-in modules now import lazily on demand)
 # =============================================================================
-
-discover_builtin_tools()
 
 # MCP tool discovery (external MCP servers from config) used to run here as
 # a module-level side effect.  It was removed because discover_mcp_tools()
@@ -192,21 +190,46 @@ discover_builtin_tools()
 #   - tui_gateway/server.py     -> inline on startup (no event loop)
 #   - acp_adapter/server.py     -> asyncio.to_thread on session init
 
-# Plugin tool discovery (user/project/pip plugins)
-try:
-    from hermes_cli.plugins import discover_plugins
-    discover_plugins()
-except Exception as e:
-    logger.debug("Plugin discovery failed: %s", e)
+# Plugin discovery is intentionally lazy.
+#
+# Import-time plugin loading used to make every model_tools import pay the cost
+# of scanning manifests and importing enabled plugin modules, even for commands
+# that never build tool schemas. We now defer this until the first actual tool
+# resolution / hook dispatch path.
 
 
 # =============================================================================
-# Backward-compat constants  (built once after discovery)
+# Backward-compat constants  (kept in sync with the live registry)
 # =============================================================================
 
-TOOL_TO_TOOLSET_MAP: Dict[str, str] = registry.get_tool_to_toolset_map()
+TOOL_TO_TOOLSET_MAP: Dict[str, str] = {}
 
-TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
+TOOLSET_REQUIREMENTS: Dict[str, dict] = {}
+
+
+def _refresh_registry_snapshots(include_toolset_requirements: bool = False) -> None:
+    """Refresh mutable compatibility dicts from the live registry."""
+    TOOL_TO_TOOLSET_MAP.clear()
+    TOOL_TO_TOOLSET_MAP.update(registry.get_tool_to_toolset_map())
+    if include_toolset_requirements:
+        TOOLSET_REQUIREMENTS.clear()
+        TOOLSET_REQUIREMENTS.update(registry.get_toolset_requirements())
+
+
+def _ensure_plugin_tools_loaded() -> None:
+    """Load plugin-provided tools on first real tool resolution."""
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        before_generation = registry._generation
+        discover_plugins()
+        if registry._generation != before_generation:
+            _refresh_registry_snapshots()
+    except Exception as e:
+        logger.debug("Plugin discovery failed: %s", e)
+
+
+_refresh_registry_snapshots()
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.
@@ -286,6 +309,11 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    # Ensure plugin-provided tools are registered before cache-keying on the
+    # registry generation. This keeps the first schema build lazy while still
+    # making later cache hits deterministic.
+    _ensure_plugin_tools_loaded()
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -294,6 +322,7 @@ def get_tool_definitions(
     # user-visible config edits that affect dynamic schemas (execute_code
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
+    cfg_fp = None
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -320,6 +349,14 @@ def get_tool_definitions(
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode)
     if quiet_mode:
+        # Cache under the post-computation generation, because lazy built-in
+        # imports can register tools while _compute_tool_definitions() runs.
+        cache_key = (
+            frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
+            frozenset(disabled_toolsets) if disabled_toolsets else None,
+            registry._generation,
+            cfg_fp,
+        )
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a
@@ -667,6 +704,9 @@ def handle_function_call(
     Returns:
         Function result as a JSON string.
     """
+    # Ensure plugin tools are present before schema lookup / dispatch.
+    _ensure_plugin_tools_loaded()
+
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
 
@@ -789,24 +829,37 @@ def handle_function_call(
 
 def get_all_tool_names() -> List[str]:
     """Return all registered tool names."""
+    _ensure_plugin_tools_loaded()
+    _refresh_registry_snapshots()
     return registry.get_all_tool_names()
 
 
 def get_toolset_for_tool(tool_name: str) -> Optional[str]:
     """Return the toolset a tool belongs to."""
+    toolset = registry.get_toolset_for_tool(tool_name)
+    if toolset is not None:
+        return toolset
+    _ensure_plugin_tools_loaded()
+    _refresh_registry_snapshots()
     return registry.get_toolset_for_tool(tool_name)
 
 
 def get_available_toolsets() -> Dict[str, dict]:
     """Return toolset availability info for UI display."""
+    _ensure_plugin_tools_loaded()
+    _refresh_registry_snapshots(include_toolset_requirements=True)
     return registry.get_available_toolsets()
 
 
 def check_toolset_requirements() -> Dict[str, bool]:
     """Return {toolset: available_bool} for every registered toolset."""
+    _ensure_plugin_tools_loaded()
+    _refresh_registry_snapshots(include_toolset_requirements=True)
     return registry.check_toolset_requirements()
 
 
 def check_tool_availability(quiet: bool = False) -> Tuple[List[str], List[dict]]:
     """Return (available_toolsets, unavailable_info)."""
+    _ensure_plugin_tools_loaded()
+    _refresh_registry_snapshots(include_toolset_requirements=True)
     return registry.check_tool_availability(quiet=quiet)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -543,6 +543,7 @@ class TestLoadTranscriptPreferLongerSource:
     def test_jsonl_longer_than_sqlite_returns_jsonl(self, store_with_db):
         """Legacy session: JSONL has full history, SQLite has only recent turn."""
         sid = "legacy_session"
+        store_with_db._legacy_transcript_mode = "on"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         # JSONL has 10 messages (legacy history — written before SQLite existed)
         for i in range(10):
@@ -561,6 +562,7 @@ class TestLoadTranscriptPreferLongerSource:
     def test_sqlite_longer_than_jsonl_returns_sqlite(self, store_with_db):
         """Fully migrated session: SQLite has more (JSONL stopped growing)."""
         sid = "migrated_session"
+        store_with_db._legacy_transcript_mode = "on"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         # JSONL has 2 old messages
         store_with_db.append_to_transcript(
@@ -581,6 +583,7 @@ class TestLoadTranscriptPreferLongerSource:
     def test_sqlite_empty_falls_back_to_jsonl(self, store_with_db):
         """No SQLite rows — falls back to JSONL (original behavior preserved)."""
         sid = "no_db_rows"
+        store_with_db._legacy_transcript_mode = "on"
         store_with_db.append_to_transcript(
             sid, {"role": "user", "content": "hello"}, skip_db=True,
         )
@@ -600,6 +603,7 @@ class TestLoadTranscriptPreferLongerSource:
     def test_equal_length_prefers_sqlite(self, store_with_db):
         """When both have same count, SQLite wins (has richer fields like reasoning)."""
         sid = "equal_session"
+        store_with_db._legacy_transcript_mode = "on"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         # Write 2 messages to JSONL only
         store_with_db.append_to_transcript(
@@ -1284,3 +1288,81 @@ class TestRewriteTranscriptPreservesReasoning:
             "before user",
             "before assistant",
         ]
+
+
+class TestSessionIndexPersistenceDebounce:
+    def _make_store(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = None
+        return store
+
+    def test_update_session_debounces_repeated_sessions_json_writes(self, tmp_path, monkeypatch):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        store = self._make_store(tmp_path)
+        store._save_debounce_seconds = 0.25
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        store._entries = {"k1": entry}
+
+        writes = []
+        clock = {"now": 100.0}
+
+        def fake_write():
+            writes.append(clock["now"])
+            store._dirty_index = False
+            store._last_index_save_monotonic = clock["now"]
+
+        monkeypatch.setattr("gateway.session.time.monotonic", lambda: clock["now"])
+        monkeypatch.setattr(store, "_write_sessions_index_locked", fake_write)
+
+        store.update_session("k1", last_prompt_tokens=10)
+        clock["now"] = 100.10
+        store.update_session("k1", last_prompt_tokens=20)
+        clock["now"] = 100.40
+        store.update_session("k1", last_prompt_tokens=30)
+
+        assert writes == [100.0, 100.4]
+        assert entry.last_prompt_tokens == 30
+        assert store._dirty_index is False
+
+    def test_flush_pending_index_save_persists_debounced_updates(self, tmp_path, monkeypatch):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        store = self._make_store(tmp_path)
+        store._save_debounce_seconds = 0.25
+        store._last_index_save_monotonic = 100.0
+        entry = SessionEntry(
+            session_key="k1",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        store._entries = {"k1": entry}
+
+        writes = []
+        monkeypatch.setattr("gateway.session.time.monotonic", lambda: 100.1)
+
+        def fake_write():
+            writes.append("flush")
+            store._dirty_index = False
+            store._last_index_save_monotonic = 100.1
+
+        monkeypatch.setattr(store, "_write_sessions_index_locked", fake_write)
+
+        store.update_session("k1", last_prompt_tokens=77)
+        assert writes == []
+        assert store._dirty_index is True
+
+        store._flush_pending_index_save()
+        assert writes == ["flush"]
+        assert store._dirty_index is False

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -408,6 +408,26 @@ class TestPluginHooks:
         assert len(results) == 1
         assert results[0] == {"context": "memory from plugin"}
 
+    def test_invoke_hook_discovers_plugins_lazily(self, tmp_path, monkeypatch):
+        """Module-level invoke_hook() should work before explicit discovery."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "lazy_hook_plugin",
+            register_body=(
+                'ctx.register_hook("pre_tool_call", '
+                'lambda **kw: {"tool": kw.get("tool_name")})'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        import hermes_cli.plugins as plugins_mod
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            results = invoke_hook("pre_tool_call", tool_name="lazy-tool", args={}, task_id="t1")
+
+        assert results == [{"tool": "lazy-tool"}]
+
     def test_hook_none_returns_excluded(self, tmp_path, monkeypatch):
         """invoke_hook() excludes None returns from the result list."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"
@@ -622,6 +642,38 @@ class TestPluginToolVisibility:
         tools3 = get_tool_definitions(quiet_mode=True)
         tool_names3 = [t["function"]["name"] for t in tools3]
         assert "vis_tool" in tool_names3
+
+    def test_plugin_tools_discovered_lazily_by_get_tool_definitions(self, tmp_path, monkeypatch):
+        """get_tool_definitions() should load enabled plugin tools on first use."""
+        import hermes_cli.plugins as plugins_mod
+
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "lazy_tool_plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "lazy_tool_plugin"}))
+        (plugin_dir / "__init__.py").write_text(
+            'def register(ctx):\n'
+            '    ctx.register_tool(\n'
+            '        name="lazy_vis_tool",\n'
+            '        toolset="plugin_lazy_tool_plugin",\n'
+            '        schema={"name": "lazy_vis_tool", "description": "Lazy visible", "parameters": {"type": "object", "properties": {}}},\n'
+            '        handler=lambda args, **kw: "ok",\n'
+            '    )\n'
+        )
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["lazy_tool_plugin"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from model_tools import TOOL_TO_TOOLSET_MAP, get_tool_definitions
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            tools = get_tool_definitions(enabled_toolsets=["plugin_lazy_tool_plugin"], quiet_mode=True)
+
+        tool_names = [t["function"]["name"] for t in tools]
+        assert "lazy_vis_tool" in tool_names
+        assert TOOL_TO_TOOLSET_MAP["lazy_vis_tool"] == "plugin_lazy_tool_plugin"
 
 
 # ── TestPluginManagerList ──────────────────────────────────────────────────

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -198,11 +198,13 @@ class TestAppendToTranscriptSkipDb:
         parsed = json.loads(lines[0])
         assert parsed["content"] == "hello world"
 
-    def test_skip_db_prevents_sqlite_write(self, tmp_path):
-        """With skip_db=True and a real DB, message does NOT appear in SQLite."""
+    def test_skip_db_prevents_sqlite_write(self, tmp_path, monkeypatch):
+        """With skip_db=True and legacy mirroring on, message does NOT appear in SQLite."""
         from gateway.config import GatewayConfig
         from gateway.session import SessionStore
         from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_GATEWAY_LEGACY_TRANSCRIPT_MODE", "on")
 
         db_path = tmp_path / "test_skip.db"
         db = SessionDB(db_path=db_path)
@@ -229,8 +231,8 @@ class TestAppendToTranscriptSkipDb:
             lines = f.readlines()
         assert len(lines) == 1
 
-    def test_default_writes_both(self, tmp_path):
-        """Without skip_db, message appears in both JSONL and SQLite."""
+    def test_default_auto_prefers_sqlite_only_for_new_sessions(self, tmp_path):
+        """Auto mode should avoid creating new JSONL mirrors when SQLite exists."""
         from gateway.config import GatewayConfig
         from gateway.session import SessionStore
         from hermes_state import SessionDB
@@ -250,15 +252,61 @@ class TestAppendToTranscriptSkipDb:
         msg = {"role": "user", "content": "test message"}
         store.append_to_transcript(session_id, msg)
 
-        # JSONL should have the message
+        # New SQLite-backed sessions no longer create a legacy mirror by default.
         jsonl_path = store.get_transcript_path(session_id)
-        with open(jsonl_path) as f:
-            lines = f.readlines()
-        assert len(lines) == 1
+        assert not jsonl_path.exists()
 
-        # SQLite should also have the message
+        # SQLite should still have the message
         rows = db.get_messages(session_id)
         assert len(rows) == 1
+
+    def test_auto_mode_preserves_existing_jsonl_mirror(self, tmp_path):
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "test_auto_existing.db"
+        db = SessionDB(db_path=db_path)
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        session_id = "test-auto-existing"
+        db.create_session(session_id=session_id, source="test")
+        store.get_transcript_path(session_id).write_text('{"role":"user","content":"legacy"}\n', encoding="utf-8")
+
+        msg = {"role": "assistant", "content": "new reply"}
+        store.append_to_transcript(session_id, msg)
+
+        with open(store.get_transcript_path(session_id), encoding="utf-8") as f:
+            lines = f.readlines()
+        assert len(lines) == 2
+        assert json.loads(lines[-1])["content"] == "new reply"
+
+    def test_off_mode_disables_jsonl_even_for_skip_db(self, tmp_path, monkeypatch):
+        """Explicit off mode should force SQLite-primary behavior."""
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_GATEWAY_LEGACY_TRANSCRIPT_MODE", "off")
+        db_path = tmp_path / "test_off_mode.db"
+        db = SessionDB(db_path=db_path)
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        session_id = "test-off-mode"
+        db.create_session(session_id=session_id, source="test")
+        store.append_to_transcript(session_id, {"role": "assistant", "content": "hello"}, skip_db=True)
+
+        assert not store.get_transcript_path(session_id).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,6 +1,7 @@
 """Tests for the central tool registry."""
 
 import json
+import os
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -343,6 +344,55 @@ class TestBuiltinDiscovery:
         assert imported == ["tools.alpha"]
         mock_import.assert_called_once_with("tools.alpha")
 
+    def test_discovers_toolset_string_constants_without_importing(self, tmp_path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "__init__.py").write_text("", encoding="utf-8")
+        (tools_dir / "alpha.py").write_text(
+            "_TOOLSET = 'x'\n"
+            "from tools.registry import registry\n"
+            "registry.register(name='alpha', toolset=_TOOLSET, schema={}, handler=lambda *_a, **_k: '{}')\n",
+            encoding="utf-8",
+        )
+
+        with patch("tools.registry.importlib.import_module") as mock_import:
+            imported = discover_builtin_tools(tools_dir)
+
+        assert imported == ["tools.alpha"]
+        mock_import.assert_called_once_with("tools.alpha")
+
+    def test_reuses_cached_module_scan_until_file_changes(self, tmp_path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "__init__.py").write_text("", encoding="utf-8")
+        (tools_dir / "alpha.py").write_text(
+            "from tools.registry import registry\nregistry.register(name='alpha', toolset='x', schema={}, handler=lambda *_a, **_k: '{}')\n",
+            encoding="utf-8",
+        )
+
+        from tools import registry as registry_mod
+        real_parse = registry_mod._module_tool_specs
+        calls = {"count": 0}
+
+        def counting_parse(path, module_prefix):
+            calls["count"] += 1
+            return real_parse(path, module_prefix)
+
+        with patch("tools.registry._module_tool_specs", side_effect=counting_parse), \
+             patch("tools.registry.importlib.import_module"):
+            discover_builtin_tools(tools_dir)
+            discover_builtin_tools(tools_dir)
+
+        assert calls["count"] == 1
+
+        before = os.stat(tools_dir / "alpha.py").st_mtime_ns
+        os.utime(tools_dir / "alpha.py", ns=(before + 1_000_000, before + 1_000_000))
+        with patch("tools.registry._module_tool_specs", side_effect=counting_parse), \
+             patch("tools.registry.importlib.import_module"):
+            discover_builtin_tools(tools_dir)
+
+        assert calls["count"] == 2
+
     def test_skips_mcp_tool_even_if_it_registers(self, tmp_path):
         tools_dir = tmp_path / "tools"
         tools_dir.mkdir()
@@ -419,6 +469,48 @@ class TestEntryLookup:
     def test_get_entry_returns_none_for_unknown_tool(self):
         reg = ToolRegistry()
         assert reg.get_entry("missing") is None
+
+    def test_builtin_metadata_is_available_without_import(self, tmp_path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "__init__.py").write_text("", encoding="utf-8")
+        (tools_dir / "alpha.py").write_text(
+            "from tools.registry import registry\nregistry.register(name='alpha', toolset='x', schema={}, handler=lambda *_a, **_k: '{}')\n",
+            encoding="utf-8",
+        )
+        reg = ToolRegistry(builtin_tools_dir=tools_dir)
+
+        with patch("tools.registry.importlib.import_module") as mock_import:
+            assert reg.get_toolset_for_tool("alpha") == "x"
+            assert reg.get_all_tool_names() == ["alpha"]
+
+        mock_import.assert_not_called()
+
+    def test_builtin_schema_loads_on_first_lookup(self, tmp_path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "__init__.py").write_text("", encoding="utf-8")
+        (tools_dir / "alpha.py").write_text(
+            "from tools.registry import registry\nregistry.register(name='alpha', toolset='x', schema={}, handler=lambda *_a, **_k: '{}')\n",
+            encoding="utf-8",
+        )
+        reg = ToolRegistry(builtin_tools_dir=tools_dir)
+
+        def fake_import(module_name):
+            assert module_name == "tools.alpha"
+            reg.register(
+                name="alpha",
+                toolset="x",
+                schema=_make_schema("alpha"),
+                handler=_dummy_handler,
+            )
+            return object()
+
+        with patch("tools.registry.importlib.import_module", side_effect=fake_import) as mock_import:
+            schema = reg.get_schema("alpha")
+
+        assert schema == _make_schema("alpha")
+        mock_import.assert_called_once_with("tools.alpha")
 
 
 class TestSecretCaptureResultContract:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -7,9 +7,9 @@ queries the registry instead of maintaining its own parallel data structures.
 Import chain (circular-import safe):
     tools/registry.py  (no imports from model_tools or tool files)
            ^
-    tools/*.py  (import from tools.registry at module level)
+    tools/*.py  (import from tools.registry at module level when lazily loaded)
            ^
-    model_tools.py  (imports tools.registry + all tool modules)
+    model_tools.py  (imports tools.registry and resolves tools on demand)
            ^
     run_agent.py, cli.py, batch_runner.py, etc.
 """
@@ -20,10 +20,22 @@ import json
 import logging
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+_DISCOVERED_BUILTIN_MODULES_CACHE: Dict[tuple[str, str, tuple[tuple[str, int, int], ...]], List[str]] = {}
+_DISCOVERED_BUILTIN_SPECS_CACHE: Dict[tuple[str, str, tuple[tuple[str, int, int], ...]], List["BuiltinToolSpec"]] = {}
+_DISCOVERED_BUILTIN_MODULES_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class BuiltinToolSpec:
+    module_name: str
+    tool_name: str
+    toolset: str
 
 
 def _is_registry_register_call(node: ast.AST) -> bool:
@@ -54,15 +66,109 @@ def _module_registers_tools(module_path: Path) -> bool:
     return any(_is_registry_register_call(stmt) for stmt in tree.body)
 
 
+def _resolve_static_string(node: ast.AST | None, bindings: Dict[str, str]) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id)
+    return None
+
+
+def _module_string_bindings(tree: ast.AST) -> Dict[str, str]:
+    bindings: Dict[str, str] = {}
+    for stmt in getattr(tree, "body", []):
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+            value = _resolve_static_string(stmt.value, bindings)
+            if value is not None:
+                bindings[stmt.targets[0].id] = value
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            value = _resolve_static_string(stmt.value, bindings)
+            if value is not None:
+                bindings[stmt.target.id] = value
+    return bindings
+
+
+def _module_tool_specs(module_path: Path, module_prefix: str) -> List[BuiltinToolSpec]:
+    try:
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(module_path))
+    except (OSError, SyntaxError):
+        return []
+
+    bindings = _module_string_bindings(tree)
+    specs: List[BuiltinToolSpec] = []
+    module_name = f"{module_prefix}.{module_path.stem}"
+    for stmt in tree.body:
+        if not _is_registry_register_call(stmt):
+            continue
+        call = stmt.value
+        keywords = {kw.arg: kw.value for kw in call.keywords if kw.arg}
+        name = _resolve_static_string(keywords.get("name"), bindings)
+        toolset = _resolve_static_string(keywords.get("toolset"), bindings)
+        if name and toolset:
+            specs.append(BuiltinToolSpec(module_name=module_name, tool_name=name, toolset=toolset))
+    return specs
+
+
+def _discoverable_tool_paths(tools_path: Path) -> List[Path]:
+    return [
+        path
+        for path in sorted(tools_path.glob("*.py"))
+        if path.name not in {"__init__.py", "registry.py", "mcp_tool.py"}
+    ]
+
+
+def _builtin_discovery_cache_key(
+    tools_path: Path,
+    module_prefix: str = "tools",
+) -> tuple[str, str, tuple[tuple[str, int, int], ...]]:
+    paths = _discoverable_tool_paths(tools_path)
+    fingerprint = tuple(
+        (path.name, path.stat().st_mtime_ns, path.stat().st_size)
+        for path in paths
+    )
+    return (str(tools_path.resolve()), module_prefix, fingerprint)
+
+
+def discover_builtin_tool_specs(
+    tools_dir: Optional[Path] = None,
+    *,
+    module_prefix: str = "tools",
+) -> List[BuiltinToolSpec]:
+    """Return statically-discovered built-in tool specs without importing modules."""
+    tools_path = Path(tools_dir) if tools_dir is not None else Path(__file__).resolve().parent
+    cache_key = _builtin_discovery_cache_key(tools_path, module_prefix=module_prefix)
+    with _DISCOVERED_BUILTIN_MODULES_LOCK:
+        cached = _DISCOVERED_BUILTIN_SPECS_CACHE.get(cache_key)
+    if cached is not None:
+        return list(cached)
+
+    specs: List[BuiltinToolSpec] = []
+    for path in _discoverable_tool_paths(tools_path):
+        specs.extend(_module_tool_specs(path, module_prefix))
+
+    with _DISCOVERED_BUILTIN_MODULES_LOCK:
+        _DISCOVERED_BUILTIN_SPECS_CACHE.clear()
+        _DISCOVERED_BUILTIN_SPECS_CACHE[cache_key] = list(specs)
+    return specs
+
+
 def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
     """Import built-in self-registering tool modules and return their module names."""
     tools_path = Path(tools_dir) if tools_dir is not None else Path(__file__).resolve().parent
-    module_names = [
-        f"tools.{path.stem}"
-        for path in sorted(tools_path.glob("*.py"))
-        if path.name not in {"__init__.py", "registry.py", "mcp_tool.py"}
-        and _module_registers_tools(path)
-    ]
+    cache_key = _builtin_discovery_cache_key(tools_path)
+    with _DISCOVERED_BUILTIN_MODULES_LOCK:
+        cached = _DISCOVERED_BUILTIN_MODULES_CACHE.get(cache_key)
+    if cached is None:
+        module_names = []
+        for spec in discover_builtin_tool_specs(tools_path):
+            if spec.module_name not in module_names:
+                module_names.append(spec.module_name)
+        with _DISCOVERED_BUILTIN_MODULES_LOCK:
+            _DISCOVERED_BUILTIN_MODULES_CACHE.clear()
+            _DISCOVERED_BUILTIN_MODULES_CACHE[cache_key] = list(module_names)
+    else:
+        module_names = list(cached)
 
     imported: List[str] = []
     for mod_name in module_names:
@@ -143,10 +249,17 @@ def invalidate_check_fn_cache() -> None:
 class ToolRegistry:
     """Singleton registry that collects tool schemas + handlers from tool files."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        builtin_tools_dir: Path | None = None,
+        builtin_module_prefix: str = "tools",
+    ):
         self._tools: Dict[str, ToolEntry] = {}
         self._toolset_checks: Dict[str, Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
+        self._builtin_tools_dir = Path(builtin_tools_dir) if builtin_tools_dir is not None else None
+        self._builtin_module_prefix = builtin_module_prefix
         # MCP dynamic refresh can mutate the registry while other threads are
         # reading tool metadata, so keep mutations serialized and readers on
         # stable snapshots.
@@ -157,6 +270,61 @@ class ToolRegistry:
         # against it: a cache entry keyed on the generation is valid for as
         # long as the generation hasn't changed.
         self._generation: int = 0
+
+    def _builtin_specs(self) -> List[BuiltinToolSpec]:
+        if self._builtin_tools_dir is None:
+            return []
+        return discover_builtin_tool_specs(
+            self._builtin_tools_dir,
+            module_prefix=self._builtin_module_prefix,
+        )
+
+    def _import_builtin_modules(self, module_names: List[str]) -> List[str]:
+        imported: List[str] = []
+        for mod_name in module_names:
+            try:
+                importlib.import_module(mod_name)
+                imported.append(mod_name)
+            except Exception as e:
+                logger.warning("Could not import tool module %s: %s", mod_name, e)
+        return imported
+
+    def ensure_builtin_tools_loaded(self, tool_names: Set[str] | List[str]) -> List[str]:
+        if self._builtin_tools_dir is None:
+            return []
+        requested = set(tool_names)
+        if not requested:
+            return []
+        with self._lock:
+            missing = requested.difference(self._tools)
+        if not missing:
+            return []
+        module_names: List[str] = []
+        for spec in self._builtin_specs():
+            if spec.tool_name in missing and spec.module_name not in module_names:
+                module_names.append(spec.module_name)
+        return self._import_builtin_modules(module_names)
+
+    def ensure_builtin_toolsets_loaded(self, toolsets: Set[str] | List[str]) -> List[str]:
+        if self._builtin_tools_dir is None:
+            return []
+        requested = set(toolsets)
+        if not requested:
+            return []
+        module_names: List[str] = []
+        for spec in self._builtin_specs():
+            if spec.toolset in requested and spec.module_name not in module_names:
+                module_names.append(spec.module_name)
+        return self._import_builtin_modules(module_names)
+
+    def ensure_all_builtin_tools_loaded(self) -> List[str]:
+        if self._builtin_tools_dir is None:
+            return []
+        module_names: List[str] = []
+        for spec in self._builtin_specs():
+            if spec.module_name not in module_names:
+                module_names.append(spec.module_name)
+        return self._import_builtin_modules(module_names)
 
     def _snapshot_state(self) -> tuple[List[ToolEntry], Dict[str, Callable]]:
         """Return a coherent snapshot of registry entries and toolset checks."""
@@ -184,7 +352,12 @@ class ToolRegistry:
     def get_entry(self, name: str) -> Optional[ToolEntry]:
         """Return a registered tool entry by name, or None."""
         with self._lock:
-            return self._tools.get(name)
+            entry = self._tools.get(name)
+        if entry is None:
+            self.ensure_builtin_tools_loaded({name})
+            with self._lock:
+                entry = self._tools.get(name)
+        return entry
 
     def get_registered_toolset_names(self) -> List[str]:
         """Return sorted unique toolset names present in the registry."""
@@ -318,6 +491,7 @@ class ToolRegistry:
         still take effect in near-real-time without forcing a full cache
         flush on every call.
         """
+        self.ensure_builtin_tools_loaded(tool_names)
         result = []
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
         # same check_fn within one definitions pass without re-reading the
@@ -379,7 +553,10 @@ class ToolRegistry:
 
     def get_all_tool_names(self) -> List[str]:
         """Return sorted list of all registered tool names."""
-        return sorted(entry.name for entry in self._snapshot_entries())
+        names = {entry.name for entry in self._snapshot_entries()}
+        for spec in self._builtin_specs():
+            names.add(spec.tool_name)
+        return sorted(names)
 
     def get_schema(self, name: str) -> Optional[dict]:
         """Return a tool's raw schema dict, bypassing check_fn filtering.
@@ -392,8 +569,14 @@ class ToolRegistry:
 
     def get_toolset_for_tool(self, name: str) -> Optional[str]:
         """Return the toolset a tool belongs to, or None."""
-        entry = self.get_entry(name)
-        return entry.toolset if entry else None
+        with self._lock:
+            entry = self._tools.get(name)
+        if entry is not None:
+            return entry.toolset
+        for spec in self._builtin_specs():
+            if spec.tool_name == name:
+                return spec.toolset
+        return None
 
     def get_emoji(self, name: str, default: str = "⚡") -> str:
         """Return the emoji for a tool, or *default* if unset."""
@@ -402,7 +585,10 @@ class ToolRegistry:
 
     def get_tool_to_toolset_map(self) -> Dict[str, str]:
         """Return ``{tool_name: toolset_name}`` for every registered tool."""
-        return {entry.name: entry.toolset for entry in self._snapshot_entries()}
+        mapping = {entry.name: entry.toolset for entry in self._snapshot_entries()}
+        for spec in self._builtin_specs():
+            mapping.setdefault(spec.tool_name, spec.toolset)
+        return mapping
 
     def is_toolset_available(self, toolset: str) -> bool:
         """Check if a toolset's requirements are met.
@@ -416,6 +602,7 @@ class ToolRegistry:
 
     def check_toolset_requirements(self) -> Dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
+        self.ensure_all_builtin_tools_loaded()
         entries, toolset_checks = self._snapshot_state()
         toolsets = sorted({entry.toolset for entry in entries})
         return {
@@ -425,6 +612,7 @@ class ToolRegistry:
 
     def get_available_toolsets(self) -> Dict[str, dict]:
         """Return toolset metadata for UI display."""
+        self.ensure_all_builtin_tools_loaded()
         toolsets: Dict[str, dict] = {}
         entries, toolset_checks = self._snapshot_state()
         for entry in entries:
@@ -447,6 +635,7 @@ class ToolRegistry:
 
     def get_toolset_requirements(self) -> Dict[str, dict]:
         """Build a TOOLSET_REQUIREMENTS-compatible dict for backward compat."""
+        self.ensure_all_builtin_tools_loaded()
         result: Dict[str, dict] = {}
         entries, toolset_checks = self._snapshot_state()
         for entry in entries:
@@ -468,6 +657,7 @@ class ToolRegistry:
 
     def check_tool_availability(self, quiet: bool = False):
         """Return (available_toolsets, unavailable_info) like the old function."""
+        self.ensure_all_builtin_tools_loaded()
         available = []
         unavailable = []
         seen = set()
@@ -489,7 +679,10 @@ class ToolRegistry:
 
 
 # Module-level singleton
-registry = ToolRegistry()
+registry = ToolRegistry(
+    builtin_tools_dir=Path(__file__).resolve().parent,
+    builtin_module_prefix="tools",
+)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- debounce gateway session index writes and force immediate flush only for structural changes
- make legacy transcript JSONL mirror conditional on SQLite/compat mode to trim hot-path IO
- lazy-load built-in and plugin tool registration so Hermes avoids eager startup imports
- preserve backward-compatible toolset/registry surfaces with targeted regression coverage

## Test Plan
- ./scripts/run_tests.sh tests/gateway/test_session.py tests/run_agent/test_860_dedup.py tests/tools/test_registry.py tests/test_model_tools.py tests/hermes_cli/test_plugins.py tests/test_toolsets.py
