### PR TITLE
fix(tools): write_file rejects missing 'content'/'path' instead of creating zero-byte files (#19096)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -104,6 +104,44 @@ class TestWriteFileHandler:
         assert result["error"] == "boom"
         assert any("write_file error" in r.getMessage() for r in caplog.records)
 
+    def test_missing_content_key_returns_error(self):
+        """#19096 — handler must reject tool calls where 'content' key is absent."""
+        from tools.file_tools import _handle_write_file
+
+        result = json.loads(_handle_write_file({"path": "/tmp/oops.md"}))
+        assert "error" in result
+        assert "content" in result["error"]
+        assert "path" not in result.get("error", "").lower() or "missing" not in result.get("error", "").lower() or True  # just check error present
+
+    def test_missing_path_key_returns_error(self):
+        """#19096 — handler must reject tool calls where 'path' key is absent."""
+        from tools.file_tools import _handle_write_file
+
+        result = json.loads(_handle_write_file({"content": "hello"}))
+        assert "error" in result
+
+    def test_explicit_empty_content_is_allowed(self):
+        """#19096 — explicit empty string content (file truncation) must still work."""
+        from tools.file_tools import _handle_write_file
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            mock_ops = MagicMock()
+            result_obj = MagicMock()
+            result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/empty.txt", "bytes": 0}
+            mock_ops.write_file.return_value = result_obj
+            mock_get.return_value = mock_ops
+
+            result = json.loads(_handle_write_file({"path": "/tmp/empty.txt", "content": ""}))
+            assert result["status"] == "ok"
+
+    def test_non_string_content_returns_error(self):
+        """#19096 — content must be a string, not a dict or list."""
+        from tools.file_tools import _handle_write_file
+
+        result = json.loads(_handle_write_file({"path": "/tmp/x.txt", "content": {"nested": "dict"}}))
+        assert "error" in result
+        assert "string" in result["error"].lower() or "content" in result["error"].lower()
+
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1097,7 +1097,25 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return write_file_tool(path=args.get("path", ""), content=args.get("content", ""), task_id=tid)
+    if not args.get("path") or not isinstance(args.get("path"), str):
+        return tool_error(
+            "write_file: missing required field 'path'. Re-emit the tool call with "
+            "both 'path' and 'content' set."
+        )
+    if "content" not in args:
+        return tool_error(
+            "write_file: missing required field 'content'. The tool call included a "
+            "path but no content argument — this is almost always a dropped-arg bug "
+            "under context pressure. Re-emit the tool call with the full content "
+            "payload, or use execute_code with hermes_tools.write_file() for very "
+            "large files."
+        )
+    if not isinstance(args["content"], str):
+        return tool_error(
+            f"write_file: 'content' must be a string, got "
+            f"{type(args['content']).__name__}."
+        )
+    return write_file_tool(path=args["path"], content=args["content"], task_id=tid)
 
 
 def _handle_patch(args, **kw):


### PR DESCRIPTION
## Problem

`_handle_write_file` used `args.get("content", "")` which silently substitutes an empty string when the `content` key is absent. This creates a zero-byte file, reports `{"bytes_written": 0}`, and the model believes the write succeeded. Downstream steps (read-after-write, lint, deploy) look normal until someone notices the file is empty.

This bites under **context pressure**: deep into a session some frontier models emit tool calls with the large `content` arg dropped while keeping the small `path` arg. The bug was silent; `terminal`/`execute_code` at least returned errors the model could read.

## Fix

Key-presence check (`"content" not in args`) instead of truthiness check — distinguishing a deliberately empty file from a dropped argument:

```python
if "content" not in args:
    return tool_error(
        "write_file: missing required field 'content'. ... Re-emit the tool call "
        "with the full content payload, or use execute_code with hermes_tools.write_file() "
        "for very large files."
    )
```

- Missing `path` → error (no file created)
- Missing `content` key → error (no file created)  
- `content=""` (explicit empty) → creates 0-byte file ✅ (file truncation still works)
- `content={...}` (wrong type) → error

## Tests

Four regression tests added to `TestWriteFileHandler`:
- `test_missing_content_key_returns_error`
- `test_missing_path_key_returns_error`
- `test_explicit_empty_content_is_allowed`
- `test_non_string_content_returns_error`

All 7 tests pass (`pytest tests/tools/test_file_tools.py::TestWriteFileHandler`).

Fixes #19096