### PR TITLE
fix(skills): handle bytes values in bundle_content_hash — fixes AttributeError on skills check/update (#19090)

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -901,6 +901,46 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_handles_bytes_values(self):
+        """#19090 — bundle.files values may be bytes (e.g. read via Path.read_bytes()).
+
+        Calling .encode() on a bytes object raises AttributeError; the function
+        must normalise both str and bytes to bytes before hashing.
+        """
+        bundle_str = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "hello"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        bundle_bytes = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": b"hello"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        # Both should produce the same hash (str and its UTF-8 bytes equivalent)
+        assert bundle_content_hash(bundle_str) == bundle_content_hash(bundle_bytes)
+
+    def test_bundle_content_hash_mixed_str_and_bytes(self):
+        """#19090 — a bundle with mixed str and bytes file values must not crash."""
+        bundle = SkillBundle(
+            name="mixed-skill",
+            files={
+                "SKILL.md": "text content",
+                "assets/logo.png": b"\x89PNG\r\n\x1a\n",
+            },
+            source="github",
+            identifier="owner/repo/mixed-skill",
+            trust_level="community",
+        )
+        # Must not raise AttributeError; return value is a sha256:... string
+        result = bundle_content_hash(bundle)
+        assert result.startswith("sha256:")
+        assert len(result) == len("sha256:") + 16
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2798,10 +2798,20 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
 
 
 def bundle_content_hash(bundle: SkillBundle) -> str:
-    """Compute a deterministic hash for an in-memory skill bundle."""
+    """Compute a deterministic hash for an in-memory skill bundle.
+
+    ``bundle.files`` values may be ``str`` (text content fetched from a hub
+    API or extracted from a ZIP manifest) or ``bytes`` (binary content read
+    directly from disk with ``Path.read_bytes()``).  Calling ``.encode()``
+    on a ``bytes`` object raises ``AttributeError``; we normalise both to
+    ``bytes`` before hashing.
+    """
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        h.update(content)
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Problem

`hermes skills check` and `hermes skills update` crash with:

```
AttributeError: 'bytes' object has no attribute 'encode'. Did you mean: 'decode'?
```

Root cause: `bundle_content_hash()` calls `.encode("utf-8")` on every value in `bundle.files` unconditionally. But `SkillBundle.files` is typed `Dict[str, Union[str, bytes]]` and some code paths store raw bytes — notably the local-install scanner at line ~2396:

```python
files[rel_path] = f.read_bytes()  # bytes, not str
```

## Fix

```python
content = bundle.files[rel_path]
if isinstance(content, str):
    content = content.encode("utf-8")
h.update(content)  # hashlib.update() accepts bytes natively
```

String-only bundles (the common case from hub API responses) behave identically to before.

## Tests

Two regression tests added to `TestCheckForSkillUpdates`:

- `test_bundle_content_hash_handles_bytes_values` — str and bytes of the same content produce identical hashes
- `test_bundle_content_hash_mixed_str_and_bytes` — mixed str/bytes bundle does not crash, returns valid `sha256:...` digest

All 3 hash-related tests pass.

Fixes #19090