### PR TITLE
fix: allow custom: prefixed providers to skip API key check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1461,7 +1461,7 @@ class AIAgent:
                     # but no credentials were found, fail fast with a clear
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                    if _explicit and _explicit not in ("auto", "openrouter", "custom") and not _explicit.startswith("custom:"):
                         # Look up the actual env var name from the provider
                         # config — some providers use non-standard names
                         # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).


### PR DESCRIPTION
## Problem

When WebUI passes provider like `custom:192.168.123.173:11434:qwen3.6` instead of bare `custom`, the provider check at line 1464 rejects it because it only matched exact `"custom"`, not strings starting with `"custom:"`. This causes false errors demanding a nonsense env var like `CUSTOM:192.168.123.173:11434:QWEN3.6_API_KEY`.

## Root Cause

In `run_agent.py` line 1464, the guard:
```python
if _explicit and _explicit not in ("auto", "openrouter", "custom"):
```
Only accepts exact `"custom"` but WebUI constructs provider IDs as `custom:<name>`, e.g. `custom:192.168.123.173:11434:qwen3.6` when matching against custom_providers entries.

## Fix

Add `and not _explicit.startswith("custom:")` to the guard so any custom provider variant (with base_url/model suffixes appended) is treated as a no-key-required OpenAI-compatible endpoint, just like plain `"custom"`.

This fixes the issue for:
- Hermes WebUI
- Gateway sessions  
- Any custom Ollama/LMStudio/vLLM/TabbyAPI endpoint configured via custom_providers

## Diff

```diff
@@ -1461,7 +1461,7 @@ class AIAgent:
                     # but no credentials were found, fail fast with a clear
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                    if _explicit and _explicit not in ("auto", "openrouter", "custom") and not _explicit.startswith("custom:"):
                         # Look up the actual env var name from the provider
```

## Testing

- Verified WebUI successfully starts agent runs with custom Ollama provider
- No regression for non-custom providers (openrouter, anthropic, openai, etc still demand keys as expected)
- Fix applies broadly across all platforms (CLI, WebUI, gateway)