### PR TITLE
feat(gateway): add `hermes gateway list` to show all profiles' gateway status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -690,6 +690,72 @@ def _print_gateway_process_mismatch(snapshot: GatewayRuntimeSnapshot) -> None:
     print("  can refuse to start another copy until this process stops.")
 
 
+def _print_other_profiles_gateway_status() -> None:
+    """Print a summary of gateway status across all profiles.
+
+    Shown at the bottom of ``hermes gateway status`` output so users with
+    multiple profiles can tell at a glance which gateways are running and
+    avoid confusing another profile's process with the current one.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        current = get_active_profile_name()
+        other_processes = [
+            p for p in find_profile_gateway_processes()
+            if p.profile != current
+        ]
+        if not other_processes:
+            return
+
+        print()
+        print("Other profiles:")
+        for proc in other_processes:
+            print(f"  ✓ {proc.profile:<16s} — PID {proc.pid}")
+    except Exception:
+        pass
+
+
+def _gateway_list() -> None:
+    """List all profiles and their gateway running status.
+
+    Provides a single-command overview of every known profile and whether
+    its gateway is currently running, so multi-profile users don't have to
+    check each profile individually.
+    """
+    try:
+        from hermes_cli.profiles import list_profiles, get_active_profile_name
+    except Exception:
+        print("Unable to list profiles.")
+        return
+
+    profiles = list_profiles()
+    if not profiles:
+        print("No profiles found.")
+        return
+
+    current = get_active_profile_name()
+
+    print("Gateways:")
+    for prof in profiles:
+        marker = "✓" if prof.gateway_running else "✗"
+        label = prof.name
+        if prof.name == current:
+            label += " (current)"
+        parts = [f"  {marker} {label:<24s}"]
+        if prof.gateway_running:
+            try:
+                from gateway.status import get_running_pid
+                pid = get_running_pid(prof.path / "gateway.pid", cleanup_stale=False)
+                if pid:
+                    parts.append(f"PID {pid}")
+            except Exception:
+                pass
+        else:
+            parts.append("not running")
+        print(" — ".join(parts))
+
+
 def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None,
                            all_profiles: bool = False) -> int:
     """Kill any running gateway processes. Returns count killed.
@@ -4455,6 +4521,12 @@ def _gateway_command_inner(args):
                 else:
                     print("  hermes gateway install  # Install as user service")
                     print("  sudo hermes gateway install --system  # Install as boot-time system service")
+
+        # Show other profiles' gateway status for multi-profile awareness
+        _print_other_profiles_gateway_status()
+
+    elif subcmd == "list":
+        _gateway_list()
 
     elif subcmd == "migrate-legacy":
         # Stop, disable, and remove legacy Hermes gateway unit files from

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8333,6 +8333,9 @@ def main():
         help="Target the Linux system-level gateway service",
     )
 
+    # gateway list
+    gateway_subparsers.add_parser("list", help="List all profiles and their gateway status")
+
     # gateway setup
     gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
 


### PR DESCRIPTION
## Summary

Adds a new `hermes gateway list` subcommand that shows the running status of gateways across all profiles in a single view:

```
Gateways:
  ✓ default (current)        — PID 207910
  ✗ builder                  — not running
  ✗ wx1                      — not running
```

Also includes `_print_other_profiles_gateway_status()` which appends an "Other profiles" section to `hermes gateway status` output when other profile gateways are running — addressing the confusion reported in #19113.

## Changes

- **`hermes_cli/gateway.py`**:
  - Added `_gateway_list()` — iterates `list_profiles()`, shows running/stopped status with PIDs, marks the current profile
  - Added `_print_other_profiles_gateway_status()` — shown at the bottom of `hermes gateway status` when other profiles have running gateways
  - Both called from the status subcommand handler
- **`hermes_cli/main.py`**:
  - Added `list` subparser under `gateway` subcommands

Uses existing `list_profiles()`, `find_profile_gateway_processes()`, and `get_active_profile_name()` — no new dependencies.

## How to Test

```bash
# List all profiles and their gateway status
hermes gateway list

# With multiple gateways running, status now shows other profiles
hermes gateway status
```

## Platform

Tested on Amazon Linux 2 with manual (non-service) gateways.

Closes #19127
Related: #19113, #19115, #4402, #4587