### PR TITLE
feat(discord): configurable auto-thread auto-archive duration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2428,6 +2428,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        "auto_thread_auto_archive_duration": 1440,  # Minutes before auto-thread archive (60, 1440, 4320, 10080)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -41,7 +41,37 @@ class _Snowflake:
         self.id = id
 
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
+DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES = 1440
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
+
+
+def _discord_auto_thread_auto_archive_duration() -> int:
+    """Resolve the auto-thread archive duration from env, with validation.
+
+    Reads ``DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION`` and falls back to
+    ``DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES`` (1440) for missing or invalid
+    values — both non-numeric strings and unsupported integers.
+    """
+    raw = os.getenv("DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION", str(DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES))
+    try:
+        duration = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION=%s is invalid; must be one of %s. Falling back to %s.",
+            raw,
+            ", ".join(str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES)),
+            DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES,
+        )
+        return DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES
+    if duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
+        logger.warning(
+            "DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION=%s is invalid; must be one of %s. Falling back to %s.",
+            duration,
+            ", ".join(str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES)),
+            DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES,
+        )
+        return DEFAULT_THREAD_AUTO_ARCHIVE_MINUTES
+    return duration
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
@@ -5346,13 +5376,14 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_name = self._derive_auto_thread_name(message.content or "")
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
         reason = f"Auto-threaded from mention by {display_name}"
+        auto_archive_duration = _discord_auto_thread_auto_archive_duration()
 
         last_direct_error: Exception | None = None
         last_fallback_error: Exception | None = None
 
         for attempt in range(2):
             try:
-                thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+                thread = await message.create_thread(name=thread_name, auto_archive_duration=auto_archive_duration)
                 try:
                     setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
                 except Exception:
@@ -5366,7 +5397,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     thread = await seed_msg.create_thread(
                         name=thread_name,
-                        auto_archive_duration=1440,
+                        auto_archive_duration=auto_archive_duration,
                         reason=reason,
                     )
                     try:
@@ -8287,6 +8318,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+    if "auto_thread_auto_archive_duration" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION"):
+        os.environ["DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION"] = str(discord_cfg["auto_thread_auto_archive_duration"])
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     # ignored_channels: channels where bot never responds (even when mentioned)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -283,6 +283,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
+| `DISCORD_AUTO_THREAD_AUTO_ARCHIVE_DURATION` | Auto-thread archive duration in minutes. Valid: 60, 1440, 4320, 10080. Default 1440. |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | When `true`, accept attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached and surfaced to the agent as a local path so it can inspect them via `terminal` / `read_file` / `ffprobe`. Default `false`. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | Maximum bytes per attachment the gateway will cache. Default `33554432` (32 MiB). Set to `0` for no cap (attachments are held in memory while being written). |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -384,6 +384,12 @@ When enabled, every `@mention` in a regular text channel automatically creates a
 
 Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
 
+#### `discord.auto_thread_auto_archive_duration`
+
+**Type:** integer — **Default:** `1440`
+
+Controls how long after the last message before an auto-created thread is automatically archived by Discord. Valid values: `60`, `1440` (24h, default), `4320` (3 days), `10080` (7 days). Invalid values are rejected with a warning and fall back to `1440`.
+
 #### `discord.reactions`
 
 **Type:** boolean — **Default:** `true`


### PR DESCRIPTION
## What
Adds a configurable  for Discord auto-threads.

## Problem
The auto-thread archive duration was hardcoded to  minutes (24 hours). Users who wanted a shorter archive time (e.g. 60 minutes, like OpenClaw's default) had no way to change it without editing source code.

## Solution
- Introduce  in 
- Also read from  env var (env takes precedence)
- Validate against Discord's allowed values: , , , 
- Invalid values log a warning and fall back to 

## Backwards Compatibility
Default remains . Existing setups are unaffected.

## Example


## Files Changed
-  — read validated duration from env/config
-  — bridge  key to env var