### PR TITLE
feat(discord): allow auto-thread in free-response channels

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -804,6 +804,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                if "auto_thread_in_free_response_channels" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD_IN_FREE_RESPONSE_CHANNELS"):
+                    os.environ["DISCORD_AUTO_THREAD_IN_FREE_RESPONSE_CHANNELS"] = str(discord_cfg["auto_thread_in_free_response_channels"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3494,7 +3494,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            auto_thread_in_free_response = os.getenv("DISCORD_AUTO_THREAD_IN_FREE_RESPONSE_CHANNELS", "false").lower() in ("true", "1", "yes")
+            if auto_thread_in_free_response:
+                skip_thread = bool(channel_ids & no_thread_channels)
+            else:
+                skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:


### PR DESCRIPTION
## What
Adds an opt-in `auto_thread_in_free_response_channels` setting so that free-response channels can still benefit from auto-thread isolation.

## Problem
Currently, `free_response_channels` implicitly disables auto-thread because the `skip_thread` check includes `is_free_channel`. This means private servers (where all channels are free-response and no mention is required) lose per-conversation thread isolation entirely.

## Use Case: Private Discord Servers
This feature is designed for **small, private Discord servers** where:
- The bot responds without requiring `@mentions` (via `free_response_channels: "*"`)
- **Multiple topics** are discussed in the same channel throughout the day
- Without thread isolation, all conversations share one flat context stream, causing:
  - Earlier topics to leak into later conversations (context pollution)
  - The model to hallucinate connections between unrelated discussions
  - Long, noisy message histories that hurt attention quality
  - **Faster token burn**: every new message carries the baggage of all prior conversations in that channel

**Example:** In a `#general` channel, you ask the bot about coding at 9am, then about trip planning at 2pm. Without threads, the 2pm trip response is contaminated by the 9am coding context. With `auto_thread_in_free_response_channels: true`, each interaction spins up its own thread, keeping contexts clean and isolated while **reducing long-context token consumption**.

## Solution
- Introduce `discord.auto_thread_in_free_response_channels` in `config.yaml`
- Also read from `DISCORD_AUTO_THREAD_IN_FREE_RESPONSE_CHANNELS` env var (env takes precedence)
- **Default: `false`** — existing behaviour is preserved; free-response channels skip auto-thread
- **When `true`**: auto-thread fires independently of the free-response setting
- Users who want no threads in specific free-response channels can still use `no_thread_channels`

## Why opt-in instead of changing the default?
Some existing users rely on free-response channels producing flat, non-threaded replies. Changing the default would break their UI expectations.

## Example Config
```yaml
discord:
  free_response_channels: "*"
  auto_thread: true
  auto_thread_in_free_response_channels: true
```

## Files Changed
- `gateway/platforms/discord.py` — check new env var before deciding `skip_thread`
- `gateway/config.py` — bridge `config.yaml` key to env var