### PR TITLE
fix: scope gateway status to current profile

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -79,28 +79,20 @@ def _get_service_pids() -> set:
 
     # --- systemd (Linux): user and system scopes ---
     if supports_systemd_services():
+        svc_name = get_service_name()
         for scope_args in [["systemctl", "--user"], ["systemctl"]]:
             try:
                 result = subprocess.run(
-                    scope_args + ["list-units", "hermes-gateway*",
-                                  "--plain", "--no-legend", "--no-pager"],
+                    scope_args + ["show", f"{svc_name}.service",
+                                  "--property=MainPID", "--value"],
                     capture_output=True, text=True, timeout=5,
                 )
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if not parts or not parts[0].endswith(".service"):
-                        continue
-                    svc = parts[0]
+                if result.returncode == 0:
                     try:
-                        show = subprocess.run(
-                            scope_args + ["show", svc,
-                                          "--property=MainPID", "--value"],
-                            capture_output=True, text=True, timeout=5,
-                        )
-                        pid = int(show.stdout.strip())
+                        pid = int(result.stdout.strip())
                         if pid > 0:
                             pids.add(pid)
-                    except (ValueError, subprocess.TimeoutExpired):
+                    except ValueError:
                         pass
             except (FileNotFoundError, subprocess.TimeoutExpired):
                 pass
@@ -4455,6 +4447,24 @@ def _gateway_command_inner(args):
                 else:
                     print("  hermes gateway install  # Install as user service")
                     print("  sudo hermes gateway install --system  # Install as boot-time system service")
+
+        # Show all profile gateways when multiple profiles exist
+        try:
+            from hermes_cli.profiles import list_profiles
+            profiles = list_profiles()
+            if len(profiles) > 1:
+                procs = find_profile_gateway_processes()
+                proc_map = {p.profile: p for p in procs}
+                print()
+                print("All profiles:")
+                for profile in profiles:
+                    proc = proc_map.get(profile.name)
+                    if proc:
+                        print(f"  ✓ {profile.name:<16} PID {proc.pid}")
+                    else:
+                        print(f"  ✗ {profile.name:<16} not running")
+        except Exception:
+            pass
 
     elif subcmd == "migrate-legacy":
         # Stop, disable, and remove legacy Hermes gateway unit files from

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -317,6 +317,33 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     assert gateway.find_gateway_pids() == [321]
 
 
+def test_get_service_pids_uses_exact_service_name_not_wildcard(monkeypatch):
+    """_get_service_pids() must query the exact service name, not a wildcard
+    that would match other profiles' services (e.g. hermes-gateway* matching
+    hermes-gateway-wx1 when checking the default profile)."""
+    commands_run = []
+
+    def fake_run(cmd, **kwargs):
+        commands_run.append(cmd)
+        # Simulate systemd returning a PID for the exact service
+        if "show" in cmd and "MainPID" in " ".join(cmd):
+            return SimpleNamespace(returncode=0, stdout="12345\n")
+        return SimpleNamespace(returncode=1, stdout="")
+
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "get_service_name", lambda: "hermes-gateway")
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    pids = gateway._get_service_pids()
+
+    assert 12345 in pids
+    # Verify exact service name was used — no wildcard glob
+    for cmd in commands_run:
+        assert "*" not in " ".join(cmd), f"Wildcard found in command: {cmd}"
+        assert "hermes-gateway.service" in " ".join(cmd)
+
+
 # ---------------------------------------------------------------------------
 # _wait_for_gateway_exit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #19113

## Root Cause

`_get_service_pids()` used `hermes-gateway*` wildcard when querying systemd, matching services from ALL profiles. Checking profile wx1 would pick up the default profile service PID.

## Fix

1. Use `get_service_name()` (profile-scoped) to query exact service name via `systemctl show` instead of wildcard `list-units`
2. Show multi-profile overview in `gateway status` when multiple profiles exist

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway.py` — 24 passed
- New test verifies no wildcard in systemd commands