### PR TITLE
feat: add post-market review for Hermes T runtime

### DIFF
--- a/docs/plans/2026-05-01-hermes-generalized-t-runtime-plan.md
+++ b/docs/plans/2026-05-01-hermes-generalized-t-runtime-plan.md
@@ -1,0 +1,644 @@
+# Hermes 通用股票做T系统升级实施计划
+
+> **For Hermes:** 执行本计划时，严格遵守 `test-driven-development`；每个代码行为先写失败测试，再最小实现，再回归。必要时再做独立代码审查。
+
+**Goal:** 把当前 `hermes_olin` 的“欧林专用最小正式 runtime”升级为“可迁移到其他股票、可剥离欧林数据、具备后续自动迭代能力”的通用做T系统骨架，并在第一阶段先完成运行时配置与状态存储的去欧林耦合。
+
+**Architecture:** 采用“通用运行时内核 + 股票策略/画像配置 + 每标的独立状态命名空间”的分层结构。第一阶段不直接重命名整个包，也不一次性引入复杂多股票调度，而是在保持当前 `hermes_olin` 兼容的前提下，先抽出通用 `RuntimeProfile/StateStore` 语义，让 runtime 的关键常量、状态目录、标的身份从欧林硬编码变成可注入配置。后续再分阶段推进策略插件化、观测闭环、自迭代闭环。
+
+**Tech Stack:** Python 3.11, pytest, pathlib, dataclass/pydantic风格轻量配置对象, 现有 `hermes_olin` 测试体系。
+
+---
+
+## 0. 当前审计结论
+
+### 已确认的现状
+
+当前 `hermes_olin` 还只是“欧林专用最小 runtime”，离老王要求的目标还有明显差距：
+
+1. **包名和公共语义仍然绑定欧林**
+   - `hermes_olin/__init__.py`
+   - `hermes_olin/__main__.py`
+   - `hermes_olin/store.py`
+   - `hermes_olin/runtime.py`
+   - `tests/test_hermes_olin_runtime.py`
+
+2. **状态存储类名直接写死为 `OlinStateStore`**
+   - `hermes_olin/store.py`
+   - 这意味着未来迁移到别的股票时，连基础状态层都带着欧林语义。
+
+3. **执行参数仍是 runtime 常量，不是 profile/config**
+   - `TRADE_UNIT`
+   - `MAX_T_TRADES`
+   - 文案里也直接写“第N次买入/卖出 10000 股”
+
+4. **状态目录只有单命名空间，没有“按标的隔离”能力**
+   - 目前是 `base_dir/state/realtime/`
+   - 删除欧林数据后复用别的股票，缺少正式 profile/symbol 目录边界
+
+5. **当前自愈主要是“派发/挂起状态自愈”，不是“策略自动迭代”**
+   - `recover_signal_runtime()`
+   - `deliver_pending_signal()`
+   - `confirm_dispatch_sent()`
+   - 它解决的是 runtime 状态一致性，不是参数日级进化、策略评估、标的画像更新
+
+### 第一阶段设计目标
+
+先做最小但方向正确的通用化收口：
+
+- 把“欧林专属状态存储”升级为“通用状态存储”
+- 把 `trade_unit/max_trades/symbol/profile_id` 变成可配置 profile
+- 把状态路径升级成“按 profile/symbol 隔离”的结构
+- 保持当前 CLI 和现有欧林测试大体兼容
+- 为第二阶段“通用股票画像/策略插件化”留接口
+
+---
+
+## 1. 分阶段路线图
+
+### Phase A — 运行时去欧林耦合（现在开始）
+
+目标：
+- 提炼通用运行时配置对象
+- 提炼通用状态存储类
+- 让 runtime 使用 profile 驱动，而不是硬编码欧林
+- 保持兼容别名，避免一次性破坏当前调用方
+
+### Phase B — 策略层参数化
+
+目标：
+- 把买卖阈值、trade unit、max trades、消息模板、交易窗口规则从 runtime 主流程中抽离
+- 形成 `profile -> signal policy -> runtime decision` 的可替换结构
+
+### Phase C — 多标的/多画像正式支持
+
+目标：
+- 同一套内核可运行多个 symbol/profile
+- 每个 symbol 独立状态目录、独立 dispatch ledger、独立 execution state
+- 删除欧林数据后不影响系统骨架
+
+### Phase D — 自动迭代/演进闭环
+
+目标：
+- 加入复盘输入、策略效果统计、参数建议器
+- 支持日级/周级评估与参数推荐
+- 把“能修 runtime 状态”升级为“能演进策略参数”
+
+---
+
+## 2. 本轮实施范围
+
+本轮只执行 **Phase A 的第一刀**，避免过度设计：
+
+1. 新增通用运行时 profile 对象
+2. 新增通用状态存储类 `TradingStateStore`
+3. 让 `OlinStateStore` 成为兼容别名/子类，而非唯一正式语义
+4. 让 runtime 核心函数支持从 store/profile 读取 `symbol / trade_unit / max_trades`
+5. 将状态目录从固定 `state/realtime` 升级为 `profiles/<profile_id>/state/realtime`
+6. 为兼容当前欧林调用方，默认 profile 仍指向 `olin-688319`
+
+**本轮不做：**
+- 不重命名包 `hermes_olin`
+- 不一次性改所有外部脚本
+- 不接入真实多股票调度器
+- 不实现自动调参算法
+- 不动盘中线上引擎
+
+---
+
+## 3. 目标文件
+
+### 重点修改文件
+- Modify: `hermes_olin/store.py`
+- Modify: `hermes_olin/runtime.py`
+- Modify: `hermes_olin/__main__.py`
+- Modify: `hermes_olin/__init__.py`
+- Modify: `hermes_olin/README.md`
+- Test: `tests/test_hermes_olin_runtime.py`
+
+### 可能新增文件
+- Create: `hermes_olin/profile.py`
+
+---
+
+## 4. 实施任务拆解
+
+## Task 1: 新增运行时 profile 对象
+
+**Objective:** 把 symbol、profile_id、trade_unit、max_trades 从 runtime 常量中抽出来，形成最小通用配置对象。
+
+**Files:**
+- Create: `hermes_olin/profile.py`
+- Modify: `hermes_olin/__init__.py`
+- Test: `tests/test_hermes_olin_runtime.py`
+
+**Step 1: Write failing test**
+
+在 `tests/test_hermes_olin_runtime.py` 新增测试，验证默认 profile 具备稳定的欧林兼容值，例如：
+
+```python
+def test_default_runtime_profile_keeps_olin_compatible_values():
+    from hermes_olin.profile import DEFAULT_RUNTIME_PROFILE
+
+    assert DEFAULT_RUNTIME_PROFILE.profile_id == "olin-688319"
+    assert DEFAULT_RUNTIME_PROFILE.symbol == "688319"
+    assert DEFAULT_RUNTIME_PROFILE.trade_unit == 10000
+    assert DEFAULT_RUNTIME_PROFILE.max_trades == 4
+```
+
+再补一个测试，验证可创建其他股票 profile：
+
+```python
+def test_runtime_profile_supports_non_olin_symbol():
+    from hermes_olin.profile import RuntimeProfile
+
+    profile = RuntimeProfile(
+        profile_id="test-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+
+    assert profile.profile_id == "test-600519"
+    assert profile.symbol == "600519"
+    assert profile.trade_unit == 200
+    assert profile.max_trades == 6
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_default_runtime_profile_keeps_olin_compatible_values tests/test_hermes_olin_runtime.py::test_runtime_profile_supports_non_olin_symbol -q
+```
+
+Expected:
+- FAIL
+- 原因应是 `hermes_olin.profile` 或 `RuntimeProfile` 尚不存在
+
+**Step 3: Write minimal implementation**
+
+在 `hermes_olin/profile.py` 中新增最小实现：
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    profile_id: str
+    symbol: str
+    trade_unit: int = 10000
+    max_trades: int = 4
+
+
+DEFAULT_RUNTIME_PROFILE = RuntimeProfile(
+    profile_id="olin-688319",
+    symbol="688319",
+    trade_unit=10000,
+    max_trades=4,
+)
+```
+
+并在 `hermes_olin/__init__.py` 导出。
+
+**Step 4: Run test to verify pass**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_default_runtime_profile_keeps_olin_compatible_values tests/test_hermes_olin_runtime.py::test_runtime_profile_supports_non_olin_symbol -q
+```
+
+Expected:
+- PASS
+
+**Step 5: Commit**
+
+```bash
+git add hermes_olin/profile.py hermes_olin/__init__.py tests/test_hermes_olin_runtime.py
+git commit -m "feat: add runtime profile for generalized trading runtime"
+```
+
+---
+
+## Task 2: 引入通用状态存储类并保留欧林兼容别名
+
+**Objective:** 让正式状态存储语义从 `OlinStateStore` 升级为通用 `TradingStateStore`，同时不破坏已有调用。
+
+**Files:**
+- Modify: `hermes_olin/store.py`
+- Modify: `hermes_olin/__init__.py`
+- Test: `tests/test_hermes_olin_runtime.py`
+
+**Step 1: Write failing test**
+
+新增测试验证：
+
+```python
+def test_trading_state_store_uses_profile_scoped_state_directory(tmp_path):
+    from hermes_olin.profile import RuntimeProfile
+    from hermes_olin.store import TradingStateStore
+
+    profile = RuntimeProfile(profile_id="demo-600519", symbol="600519")
+    store = TradingStateStore(tmp_path, profile=profile)
+
+    assert store.base_dir == tmp_path
+    assert store.profile.profile_id == "demo-600519"
+    assert store.state_dir == tmp_path / "profiles" / "demo-600519" / "state" / "realtime"
+```
+
+再补一个兼容测试：
+
+```python
+def test_olin_state_store_remains_backward_compatible(tmp_path):
+    from hermes_olin.store import OlinStateStore
+
+    store = OlinStateStore(tmp_path)
+
+    assert store.profile.profile_id == "olin-688319"
+    assert store.profile.symbol == "688319"
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_trading_state_store_uses_profile_scoped_state_directory tests/test_hermes_olin_runtime.py::test_olin_state_store_remains_backward_compatible -q
+```
+
+Expected:
+- FAIL
+- 因为 `TradingStateStore` 不存在，或 `profile` / 新目录结构尚未实现
+
+**Step 3: Write minimal implementation**
+
+在 `hermes_olin/store.py`：
+
+- 新增 `TradingStateStore`
+- 支持构造参数 `profile: RuntimeProfile = DEFAULT_RUNTIME_PROFILE`
+- `state_dir` 改为：
+  - `base_dir / "profiles" / profile.profile_id / "state" / "realtime"`
+- `OlinStateStore` 改为：
+  - `class OlinStateStore(TradingStateStore): ...`
+  - 默认 profile 固定为 `DEFAULT_RUNTIME_PROFILE`
+
+示意：
+
+```python
+class TradingStateStore:
+    def __init__(self, base_dir: str | Path, profile: RuntimeProfile = DEFAULT_RUNTIME_PROFILE):
+        self.base_dir = Path(base_dir)
+        self.profile = profile
+        self.profile_dir = self.base_dir / "profiles" / profile.profile_id
+        self.state_dir = self.profile_dir / "state" / "realtime"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+
+class OlinStateStore(TradingStateStore):
+    def __init__(self, base_dir: str | Path):
+        super().__init__(base_dir, profile=DEFAULT_RUNTIME_PROFILE)
+```
+
+**Step 4: Run test to verify pass**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_trading_state_store_uses_profile_scoped_state_directory tests/test_hermes_olin_runtime.py::test_olin_state_store_remains_backward_compatible -q
+```
+
+Expected:
+- PASS
+
+**Step 5: Commit**
+
+```bash
+git add hermes_olin/store.py hermes_olin/__init__.py tests/test_hermes_olin_runtime.py
+git commit -m "refactor: introduce generic trading state store"
+```
+
+---
+
+## Task 3: 让执行建议读取 profile 参数，而不是 runtime 常量
+
+**Objective:** 让 runtime 的建议生成逻辑真正支持其他股票画像，而不是只支持欧林 10000 股 / 4 笔。
+
+**Files:**
+- Modify: `hermes_olin/runtime.py`
+- Test: `tests/test_hermes_olin_runtime.py`
+
+**Step 1: Write failing test**
+
+新增测试：
+
+```python
+def test_build_execution_suggestion_uses_profile_trade_unit_and_max_trades(tmp_path):
+    from hermes_olin.profile import RuntimeProfile
+    from hermes_olin.store import TradingStateStore
+    from hermes_olin.runtime import build_execution_suggestion
+
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "sell", "score": {"total": 20}},
+        "20260501",
+    )
+
+    assert suggestion["trade_unit"] == 200
+    assert suggestion["max_trades"] == 6
+    assert suggestion["text"] == "第1次卖出 200 股"
+```
+
+再加边界测试：
+
+```python
+def test_build_execution_suggestion_respects_profile_max_trades_limit(tmp_path):
+    from hermes_olin.profile import RuntimeProfile
+    from hermes_olin.store import TradingStateStore
+
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=1,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+    store.save_execution_state({"trade_date": "20260501", "sell_count": 1})
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "sell", "score": {"total": 20}},
+        "20260501",
+    )
+
+    assert suggestion["next_action"] == "hold"
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_build_execution_suggestion_uses_profile_trade_unit_and_max_trades tests/test_hermes_olin_runtime.py::test_build_execution_suggestion_respects_profile_max_trades_limit -q
+```
+
+Expected:
+- FAIL
+- 因为当前代码仍读取 `TRADE_UNIT` / `MAX_T_TRADES`
+
+**Step 3: Write minimal implementation**
+
+在 `hermes_olin/runtime.py` 中：
+
+- 增加 profile 读取辅助函数，例如：
+
+```python
+def _profile_trade_unit(store: OlinStateStore) -> int:
+    return int(getattr(store, "profile", DEFAULT_RUNTIME_PROFILE).trade_unit)
+
+
+def _profile_max_trades(store: OlinStateStore) -> int:
+    return int(getattr(store, "profile", DEFAULT_RUNTIME_PROFILE).max_trades)
+```
+
+- 在 `build_execution_suggestion()` 中替换硬编码常量
+- 在相关分支中用 profile 值生成文本和阈值判断
+- 保持旧默认行为不变
+
+**Step 4: Run test to verify pass**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_build_execution_suggestion_uses_profile_trade_unit_and_max_trades tests/test_hermes_olin_runtime.py::test_build_execution_suggestion_respects_profile_max_trades_limit -q
+```
+
+Expected:
+- PASS
+
+**Step 5: Run nearby regression tests**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_build_execution_suggestion_uses_execution_state_sequence tests/test_hermes_olin_runtime.py::test_build_execution_suggestion_holds_when_active_signal_exists tests/test_hermes_olin_runtime.py::test_stage_pending_signal_sets_active_signal_in_execution_state -q
+```
+
+Expected:
+- PASS
+
+**Step 6: Commit**
+
+```bash
+git add hermes_olin/runtime.py tests/test_hermes_olin_runtime.py
+git commit -m "refactor: drive execution suggestions from runtime profile"
+```
+
+---
+
+## Task 4: CLI 注入 profile，并维持欧林默认入口兼容
+
+**Objective:** 让 CLI 默认仍能跑欧林，但技术上已经具备切换 profile 的能力。
+
+**Files:**
+- Modify: `hermes_olin/__main__.py`
+- Test: `tests/test_hermes_olin_runtime.py`
+
+**Step 1: Write failing test**
+
+新增测试：
+
+```python
+def test_cli_main_supports_profile_override(monkeypatch, tmp_path):
+    import hermes_olin.__main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["profile_id"] = store.profile.profile_id
+        captured["symbol"] = store.profile.symbol
+        return {
+            "trade_date": kwargs["effective_trade_date"],
+            "now": "2026-05-01 09:30:00",
+            "recovery": {},
+            "suggestion": {},
+            "pending": {},
+            "result": {},
+            "execution_state": {},
+            "push_state": {},
+        }
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes-olin",
+            "--base-dir", str(tmp_path),
+            "--trade-date", "20260501",
+            "--profile-id", "demo-600519",
+            "--symbol", "600519",
+        ],
+    )
+
+    main_mod.main()
+
+    assert captured["profile_id"] == "demo-600519"
+    assert captured["symbol"] == "600519"
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_cli_main_supports_profile_override -q
+```
+
+Expected:
+- FAIL
+- 因为 CLI 还没有 `--profile-id` / `--symbol`
+
+**Step 3: Write minimal implementation**
+
+在 `hermes_olin/__main__.py`：
+
+- 新增 CLI 参数：
+  - `--profile-id`
+  - `--symbol`
+  - 可选：`--trade-unit`
+  - 可选：`--max-trades`
+- 组装 `RuntimeProfile`
+- 用 `TradingStateStore(base_dir, profile=profile)` 替换直接 `OlinStateStore(base_dir)` 的正式路径
+- 若不传参数，则退回 `DEFAULT_RUNTIME_PROFILE`
+
+**Step 4: Run test to verify pass**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_cli_main_supports_profile_override -q
+```
+
+Expected:
+- PASS
+
+**Step 5: Run existing CLI regressions**
+
+Run:
+```bash
+pytest tests/test_hermes_olin_runtime.py::test_cli_main_defaults_base_dir_under_home_even_after_chdir tests/test_hermes_olin_runtime.py::test_cli_main_passes_explicit_dispatch_target tests/test_hermes_olin_runtime.py::test_cli_main_uses_env_dispatch_target tests/test_hermes_olin_runtime.py::test_cli_main_rejects_invalid_trade_date -q
+```
+
+Expected:
+- PASS
+
+**Step 6: Commit**
+
+```bash
+git add hermes_olin/__main__.py tests/test_hermes_olin_runtime.py
+git commit -m "feat: add profile-aware CLI entry for trading runtime"
+```
+
+---
+
+## Task 5: README 与正式语义收口
+
+**Objective:** 把 README 从“欧林专用最小 runtime”描述升级为“兼容欧林默认画像的通用化第一阶段内核”。
+
+**Files:**
+- Modify: `hermes_olin/README.md`
+
+**Step 1: Update docs**
+
+README 至少要同步以下几点：
+
+1. 当前仍是第一阶段，不是完整多股票产品
+2. 默认 profile 为 `olin-688319`
+3. 状态路径是 `~/.hermes_olin_runtime/profiles/<profile_id>/state/realtime/`
+4. CLI 支持 profile/symbol 覆盖
+5. 后续 Phase B/C/D 仍待推进
+
+**Step 2: Verification**
+
+人工检查 README 不再把系统描述成“只能服务欧林”的最终形态。
+
+**Step 3: Commit**
+
+```bash
+git add hermes_olin/README.md
+git commit -m "docs: document generalized runtime phase-1 semantics"
+```
+
+---
+
+## 5. 全量验证命令
+
+完成本轮后至少执行：
+
+```bash
+pytest tests/test_hermes_olin_runtime.py -q
+```
+
+如果新增了 profile/store 独立测试文件，也要跑：
+
+```bash
+pytest tests/test_hermes_olin_runtime.py tests/test_hermes_olin_profile.py -q
+```
+
+如有必要，补一次更广回归：
+
+```bash
+pytest tests/ -q
+```
+
+---
+
+## 6. 验收标准
+
+本轮完成后，必须满足：
+
+- [ ] `RuntimeProfile` 已存在，默认仍兼容欧林
+- [ ] `TradingStateStore` 已存在，`OlinStateStore` 仍可兼容使用
+- [ ] 状态目录已按 `profile_id` 隔离
+- [ ] `build_execution_suggestion()` 不再依赖硬编码 `TRADE_UNIT/MAX_T_TRADES`
+- [ ] CLI 可注入 profile/symbol
+- [ ] 现有欧林回归仍通过
+- [ ] README 已同步第一阶段通用化语义
+
+---
+
+## 7. 设计边界与注意事项
+
+1. **先做兼容抽象，不做激进重命名**
+   - 当前包名 `hermes_olin` 暂不改
+   - 先把内部语义做通用，再考虑第二阶段拆包
+
+2. **坚持 TDD**
+   - 每个行为改动先写失败测试
+   - 必须显式验证 RED，再写实现
+
+3. **避免过度设计**
+   - 本轮不引入策略注册中心
+   - 本轮不引入数据库
+   - 本轮不做多进程调度器
+
+4. **兼容优先**
+   - 旧的欧林默认入口不能被破坏
+   - 老测试如果表达的是正确业务语义，应继续通过
+
+5. **正式目标不是“换个类名”，而是建立可迁移边界**
+   - 真正关键是 profile/symbol/状态命名空间解耦
+   - 这是未来删除欧林数据后继续复用系统的前提
+
+---
+
+## 8. 本计划后的下一步
+
+完成本轮后，下一轮优先做：
+
+1. 把信号阈值和风控参数从 runtime 主函数抽到 profile/policy
+2. 建立 `symbol profile -> strategy policy -> runtime outcome` 三层结构
+3. 为“自动迭代”预留评估记录和参数建议输入面
+4. 再决定是否把 `hermes_olin` 演进为更中性的顶层包，例如 `hermes_t` 或 `hermes_trading`

--- a/docs/plans/2026-05-01-hermes-phase2-generic-entry-plan.md
+++ b/docs/plans/2026-05-01-hermes-phase2-generic-entry-plan.md
@@ -1,0 +1,271 @@
+# Hermes 通用做T系统 Phase 2（去欧林化入口层）实施计划
+
+> **For Hermes:** 执行本计划时，严格遵守 `test-driven-development`；每个代码行为先写失败测试，再最小实现，再跑定向回归，最后跑全量 `tests/test_hermes_olin_runtime.py`。必要时做独立代码审查。
+
+**Goal:** 在不破坏现有 `hermes_olin` 兼容入口的前提下，引入一个正式的通用包入口层，把“对外入口语义仍绑定欧林”的问题先拆掉，为后续策略层/多标的调度层继续通用化铺路。
+
+**Architecture:** 保持当前 runtime/store/profile 核心实现继续驻留在现有模块中，第二阶段第一批改造先新增一个通用 facade 包 `hermes_t/`。`hermes_t` 负责提供去欧林化的导出 API、generic CLI 入口和更中性的默认 runtime 目录；`hermes_olin` 保留为兼容入口，不立即删除。这样能先把“对外品牌/入口”与“内部兼容层”分开，降低后续重命名和多标的扩展成本。
+
+**Tech Stack:** Python 3.11, pytest, argparse, pathlib, 现有 `hermes_olin` runtime/store/profile 实现。
+
+---
+
+## 0. 第二阶段边界审计结论
+
+### 已确认的事实
+
+1. `hermes_olin` 内部核心逻辑已经完成第一阶段 profile-aware 改造：
+   - `RuntimeProfile`
+   - `TradingStateStore`
+   - `run_runtime_cycle()` 主链按 profile 读取 `trade_unit/max_trades`
+
+2. 当前真正还“绑欧林”的主要是**对外入口层**：
+   - 包名：`hermes_olin`
+   - CLI 描述：`Run one Hermes Olin minimal runtime cycle`
+   - 默认状态根目录：`~/.hermes_olin_runtime`
+   - `__init__` 顶层文案仍写 Olin runtime
+
+3. 当前兼容层仍合理存在：
+   - `OlinStateStore` 仍有保留价值，因为默认欧林 profile 还要继续兼容旧调用方
+   - 但它不应该继续作为未来通用做T系统的唯一对外语义
+
+4. 现阶段最小高 ROI 改造不是重写 runtime，而是**补一个 generic facade 包**：
+   - 低风险
+   - 不扰动现有测试主链
+   - 立即把后续系统叙事从“欧林专用包”推进到“有正式通用入口、欧林入口仅作兼容”
+
+### 本批改造不做
+
+- 不在这一批里把所有内部模块重命名成 `hermes_t.*`
+- 不立即删除 `hermes_olin`
+- 不做多 profile 调度器
+- 不做策略插件系统
+- 不做自动调参/自进化引擎
+
+---
+
+## 1. 本批目标
+
+这批只做三件事：
+
+1. 新增 `hermes_t` 通用 facade 包
+2. 新增 `python -m hermes_t` generic CLI 入口
+3. 更新 README/正式口径，明确：
+   - `hermes_t` 是第二阶段开始后的正式通用入口
+   - `hermes_olin` 仍保留为兼容入口
+
+---
+
+## 2. 文件范围
+
+### 新增文件
+- Create: `hermes_t/__init__.py`
+- Create: `hermes_t/__main__.py`
+- Create: `hermes_t/README.md`
+
+### 修改文件
+- Modify: `pyproject.toml`
+- Modify: `tests/test_hermes_olin_runtime.py`
+- Modify: `hermes_olin/README.md`
+
+---
+
+## 3. TDD 任务拆解
+
+### Task 1: 为通用 facade 包写失败测试
+
+**Objective:** 先用测试定义 `hermes_t` 作为正式通用入口必须存在，并且导出 generic API。
+
+**Files:**
+- Modify: `tests/test_hermes_olin_runtime.py`
+
+**Step 1: Write failing tests**
+
+新增测试覆盖：
+
+```python
+def test_hermes_t_exports_generic_runtime_api():
+    import hermes_t
+
+    assert hermes_t.RuntimeProfile is RuntimeProfile
+    assert hermes_t.TradingStateStore is TradingStateStore
+    assert callable(hermes_t.run_runtime_cycle)
+```
+
+再补一个测试确认兼容层仍保留：
+
+```python
+def test_hermes_t_does_not_expose_olin_named_store_in_generic_all():
+    import hermes_t
+
+    assert "TradingStateStore" in hermes_t.__all__
+    assert "OlinStateStore" not in hermes_t.__all__
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+cd /Users/wj/hermes-agent && uv run python3 -m pytest tests/test_hermes_olin_runtime.py -q -k "hermes_t_exports_generic_runtime_api or hermes_t_does_not_expose_olin_named_store_in_generic_all"
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'hermes_t'`
+
+**Step 3: Write minimal implementation**
+
+- 新建 `hermes_t/__init__.py`
+- 从现有实现 re-export：
+  - `RuntimeProfile`
+  - `DEFAULT_RUNTIME_PROFILE`
+  - `TradingStateStore`
+  - runtime 主链函数
+- `__all__` 只暴露 generic 名称，不暴露 `OlinStateStore`
+
+**Step 4: Run test to verify pass**
+
+执行同一条 pytest，预期 PASS。
+
+---
+
+### Task 2: 为 generic CLI 入口写失败测试
+
+**Objective:** 先用测试定义 `python -m hermes_t` 的默认行为和目录口径。
+
+**Files:**
+- Modify: `tests/test_hermes_olin_runtime.py`
+
+**Step 1: Write failing tests**
+
+新增测试覆盖：
+
+```python
+def test_hermes_t_cli_uses_generic_home_based_default_dir(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["base_dir"] = str(store.base_dir)
+        captured["profile_id"] = store.profile.profile_id
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hermes_t", "--trade-date", "20260501", "--signal", "hold"],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(home_dir / ".hermes_t_runtime")
+    assert captured["profile_id"] == DEFAULT_RUNTIME_PROFILE.profile_id
+```
+```
+
+再补一个测试确认 generic CLI 不再走 `OlinStateStore`：
+
+```python
+def test_hermes_t_cli_uses_trading_state_store_even_for_default_profile(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["store_class"] = type(store).__name__
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hermes_t", "--base-dir", str(tmp_path), "--trade-date", "20260501"],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["store_class"] == "TradingStateStore"
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+cd /Users/wj/hermes-agent && uv run python3 -m pytest tests/test_hermes_olin_runtime.py -q -k "hermes_t_cli_uses_generic_home_based_default_dir or hermes_t_cli_uses_trading_state_store_even_for_default_profile"
+```
+
+Expected: FAIL — because `hermes_t.__main__` does not yet exist.
+
+**Step 3: Write minimal implementation**
+
+- 新建 `hermes_t/__main__.py`
+- 复用现有 `RuntimeProfile` / `TradingStateStore` / `run_runtime_cycle`
+- parser 描述改成 generic 文案，例如 `Run one Hermes generalized T-runtime cycle`
+- 默认 `--base-dir` 改为 `Path.home() / ".hermes_t_runtime"`
+- 即使是默认 profile，也统一实例化 `TradingStateStore`
+
+**Step 4: Run test to verify pass**
+
+执行同一条 pytest，预期 PASS。
+
+---
+
+### Task 3: 为 packaging 与文档口径补齐验证
+
+**Objective:** 确保 `hermes_t` 会被打包发现，且 README 口径和阶段结论同步。
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `hermes_t/README.md`
+- Modify: `hermes_olin/README.md`
+
+**Step 1: Write/extend verification tests if needed**
+
+如果已有 import 测试已足以覆盖包发现，可不额外增代码测试；至少要做人工验证：
+
+- `pyproject.toml` 的 `[tool.setuptools.packages.find].include` 包含：
+  - `hermes_t`
+  - `hermes_t.*`
+
+**Step 2: Implement docs/package updates**
+
+- 在 `pyproject.toml` 加入 `hermes_t`, `hermes_t.*`
+- 写 `hermes_t/README.md`：说明它是第二阶段起的通用入口 facade
+- 在 `hermes_olin/README.md` 追加兼容说明：
+  - 新通用入口优先 `python -m hermes_t`
+  - `hermes_olin` 继续保留给欧林默认兼容口径
+
+**Step 3: Run regression**
+
+Run:
+```bash
+cd /Users/wj/hermes-agent && uv run python3 -m pytest tests/test_hermes_olin_runtime.py -q
+```
+
+Expected: PASS
+
+---
+
+## 4. 第二阶段完成判定（本批）
+
+本批完成后，应满足：
+
+- 存在正式 generic 包入口：`hermes_t`
+- 存在正式 generic CLI：`python -m hermes_t`
+- generic CLI 默认目录不再是 `.hermes_olin_runtime`
+- generic facade 不把 `OlinStateStore` 作为主导出语义
+- `hermes_olin` 仍可继续兼容既有调用和文档语义
+
+---
+
+## 5. 下一批预留方向
+
+完成这批后，下一批可继续推进：
+
+1. 抽 shared CLI builder，减少 `hermes_t` / `hermes_olin` 的重复解析逻辑
+2. 引入 `signal policy` 层，把阈值/文本模板从 runtime 主文件剥离
+3. 增加多 profile 编排入口（例如 `profiles.yaml` + orchestrator）
+4. 继续把 `tests/test_hermes_olin_runtime.py` 拆成更通用的 `tests/test_trading_runtime.py`

--- a/docs/plans/2026-05-02-hermes-phase2-batch2-shared-cli-orchestrator-plan.md
+++ b/docs/plans/2026-05-02-hermes-phase2-batch2-shared-cli-orchestrator-plan.md
@@ -1,0 +1,60 @@
+# Hermes 通用做T系统 Phase 2 Batch 2（shared CLI + 多 Profile Orchestrator）实施计划
+
+> **For Hermes:** 严格遵守 `test-driven-development`。先写失败测试，再最小实现，再跑定向回归，最后跑全量 `tests/test_hermes_olin_runtime.py`。
+
+**Goal:** 在已完成 `hermes_t` 通用入口 facade 的基础上，继续推进第二阶段第二批：抽出 shared CLI builder 消除 `hermes_olin` / `hermes_t` 的重复解析逻辑，并补一个最小可用的多 profile orchestrator 骨架，为后续多股票调度做正式起点。
+
+**Architecture:** 不重写 runtime 主链，继续复用 `RuntimeProfile`、`TradingStateStore`、`run_runtime_cycle()`。新增一个共享 CLI 模块，负责统一 parser / args -> profile / args -> store 的装配；再新增 orchestrator 模块，负责把多个 profile 定义批量编排为一次多 runtime 调用。
+
+**Tech Stack:** Python 3.11, pytest, argparse, json, dataclasses/pathlib（如需要）, 现有 `hermes_olin` / `hermes_t` 代码。
+
+---
+
+## 1. 本批目标
+
+1. 抽 shared CLI builder，去掉两个 `__main__.py` 中的重复参数定义
+2. 新增多 profile orchestrator 骨架
+3. 保持现有 `hermes_olin` / `hermes_t` 行为不回退
+4. README / 正式口径同步到“已支持 generic facade + multi-profile skeleton”
+
+## 2. 文件范围
+
+### 新增
+- `hermes_t/cli_shared.py`
+- `hermes_t/orchestrator.py`
+
+### 修改
+- `hermes_t/__main__.py`
+- `hermes_olin/__main__.py`
+- `tests/test_hermes_olin_runtime.py`
+- `hermes_olin/README.md`
+- `hermes_t/README.md`
+
+## 3. TDD 任务拆解
+
+### Task A: shared CLI builder
+- 先写失败测试，锁定：
+  - shared builder 能按传入参数生成 parser
+  - shared builder 能构造 `RuntimeProfile`
+  - shared builder 能按 generic / legacy 模式构造 `TradingStateStore` 或 `OlinStateStore`
+- 再最小实现 `hermes_t/cli_shared.py`
+- 最后让 `hermes_olin.__main__` 与 `hermes_t.__main__` 都改为调用 shared helper
+
+### Task B: multi-profile orchestrator skeleton
+- 先写失败测试，锁定：
+  - 可从 JSON 文件读取多个 profile 定义
+  - 能对每个 profile 依次创建 `TradingStateStore`
+  - 能调用 runner（默认 `run_runtime_cycle`）并返回汇总结果
+- 再最小实现 `hermes_t/orchestrator.py`
+
+### Task C: docs + regression
+- README 同步
+- 全量回归
+
+## 4. 本批完成判定
+
+完成后应满足：
+- `hermes_olin.__main__` / `hermes_t.__main__` 共用同一套 CLI 构建逻辑
+- `hermes_t` 存在正式 `orchestrator` 模块
+- 可通过 API 对多个 profile 做最小批量编排
+- 现有单 profile 行为和默认欧林兼容行为不回退

--- a/hermes_olin/README.md
+++ b/hermes_olin/README.md
@@ -1,0 +1,134 @@
+# Hermes Olin Runtime (minimal, profile-aware)
+
+这是 Hermes 主仓内从欧林做T抽出来的最小正式 runtime 内核；当前默认 profile 仍是欧林，但状态存储与 runtime 主链已经支持按 profile 复用。
+
+> 第二阶段开始后，**通用入口优先使用 `hermes_t`**；本目录 `hermes_olin` 继续保留为欧林兼容入口与默认欧林口径文档。
+
+- `execution_state.json`：执行账本事实源
+- `pending_signal.json`：待 dispatch 信号槽
+- `push_state.json`：最近一次 dispatch 摘要
+- `signal_send_history.jsonl`：发送流水
+- `dispatch_ledger.jsonl`：dispatch ledger
+
+当前最小可运行闭环：
+
+1. `build_execution_suggestion()` 根据执行状态计算下一笔建议
+2. `stage_pending_signal()` 把建议挂起为 pending，并同步 `active_signal`
+3. `recover_signal_runtime()` 在每个 cycle 开始前执行最小自愈：清孤儿 active signal、跨日过期、超时升级、不可重试失败升级
+4. `deliver_pending_signal()` 在需要时发出 pending，并自动走 dispatch-confirm
+5. `confirm_dispatch_sent()` 在 sent 后提交账本、更新 push state、清空 pending
+6. `run_runtime_cycle()` 串起单次 cycle，可直接作为 Hermes 自有最小入口
+
+## 直接运行
+
+如果你现在是按“通用做T系统”口径启动，优先用新的 generic facade：
+
+```bash
+cd /Users/wj/hermes-agent
+uv run python3 -m hermes_t --signal sell --score 20 --trade-date 20260422
+```
+
+`hermes_olin` 则继续保留给默认欧林兼容入口。
+
+默认 profile 仍保持欧林兼容值：
+
+- `profile_id=olin-688319`
+- `symbol=688319`
+- `trade_unit=10000`
+- `max_trades=4`
+
+```bash
+cd /Users/wj/hermes-agent
+uv run python3 -m hermes_olin --signal sell --score 20 --trade-date 20260422
+```
+
+也可以显式切到其他标的 profile；第一阶段已经支持把运行时画像从欧林默认值中抽离出来：
+
+```bash
+uv run python3 -m hermes_olin \
+  --profile-id demo-600519 \
+  --symbol 600519 \
+  --trade-unit 200 \
+  --max-trades 6 \
+  --signal sell \
+  --score 20 \
+  --trade-date 20260501
+```
+
+显式指定发送目标时可直接带：
+
+```bash
+uv run python3 -m hermes_olin --signal sell --score 20 --trade-date 20260422 --dispatch --chat-id oc_xxx --thread-id omt_xxx
+```
+
+目前 dispatch channel 仍只支持 `feishu`；`--channel` / `HERMES_OLIN_CHANNEL` 现阶段主要用于显式声明该默认值。
+
+也支持环境变量回退：
+
+- `HERMES_OLIN_CHANNEL`（当前仅支持 `feishu`）
+- `HERMES_OLIN_CHAT_ID`
+- `HERMES_OLIN_THREAD_ID`
+
+默认只做本地状态演算，不真实发送；输出单次 cycle 的 JSON 结果。CLI 默认 `--base-dir` 为稳定的 home 目录口径：
+
+- `~/.hermes_olin_runtime/`
+
+各 profile 的状态文件会按独立命名空间落盘：
+
+- 默认欧林：`~/.hermes_olin_runtime/profiles/olin-688319/state/realtime/`
+- 其他 profile：`~/.hermes_olin_runtime/profiles/<profile-id>/state/realtime/`
+
+加 `--dispatch` 时，会尝试通过 Hermes gateway 走真实 dispatch；是否真的发到 Feishu 取决于当前 gateway 可用性以及目标 chat/channel 配置是否可解析。
+
+现阶段 `--base-dir` 仍建议遵守两条口径：
+
+1. 省略时，走稳定的 `Path.home() / ".hermes_olin_runtime"` 默认值，不随 `cwd` 漂移。
+2. 做隔离验证/无扰动联调时，显式传独立目录，例如 `/tmp/hermes_olin_probe`，不要直接写入正式状态树。
+
+## 当前最小自愈口径
+
+`run_runtime_cycle()` 现在会先执行 `recover_signal_runtime()`，当前正式规则如下：
+
+- `pending_signal` 不存在但 `active_signal` 还挂着：清掉孤儿 `active_signal`
+- `pending_signal.trade_date != effective_trade_date`：标记 `expired_cross_day`，并清掉匹配的 `active_signal`
+- `pending_signal` 超过 300 秒仍处于 `pending/failed`：标记 `timed_out`
+- `pending_signal.status=failed` 且 `last_error_retryable=false`：标记 `failed_exhausted`
+- `pending_signal.status=failed` 且仍有剩余重试次数：恢复为 `pending`，同次 cycle 允许继续走重试 dispatch
+- 当 recovery 结果为 `timed_out` 或 `failed_exhausted` 时，当次 cycle 不再重建新信号，而是返回 `suggestion.next_action=hold` 与 `reason=recovery_blocked`
+- 当 recovery 刚把 retryable failed pending 重新排回 `pending` 时，当次 cycle 直接复用该 `pending_signal`；dry-run 返回里保留原 failed 结果对象，store 内状态则已恢复为 `pending`
+- 当日已经发过同方向信号、且当前没有新的 pending 时，不会仅凭同一 `summary_signal` 直接推进到下一笔；当次 cycle 返回 `reason=duplicate_sent_signal`
+- 当 recovery 结果为跨日过期时，允许当次 cycle 在清理后继续按新交易日生成新 pending
+
+## 验证
+
+```bash
+cd /Users/wj/hermes-agent
+/Users/wj/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/test_hermes_olin_runtime.py -q
+```
+
+当前定向回归：`60 passed`
+
+## 当前推进阶段（2026-05-01）
+
+这轮第一阶段通用化 + 第二阶段入口去欧林化首批工作已经落到正式代码：
+
+- 已抽出 `RuntimeProfile`
+- 已引入 `TradingStateStore`，按 `profile_id` 隔离状态目录
+- `build_execution_suggestion()` / `stage_pending_signal()` / `run_runtime_cycle()` 已改为优先读取 profile 的 `trade_unit` / `max_trades`
+- CLI 已支持 `--profile-id` / `--symbol` / `--trade-unit` / `--max-trades`
+- 已新增 `hermes_t` 作为通用 facade 包与 generic CLI 入口
+- `python -m hermes_t` 默认使用 `~/.hermes_t_runtime/`，并统一走 `TradingStateStore`
+- `hermes_olin` / `hermes_t` CLI 已改为共用 shared CLI builder，避免参数解析逻辑双份漂移
+- 已新增多 profile orchestrator 骨架，可从 JSON 配置加载多个 `RuntimeProfile` 并逐个执行 runtime cycle
+- 默认欧林口径保持不变，兼容值仍是 `688319 / 10000 股 / 最多 4 笔`
+
+当前仍属于“通用 runtime 骨架的第二阶段”，还没有完成：
+
+- 内部模块/测试命名与文档口径的彻底去欧林化
+- 实时行情输入与策略插件化
+- 日级参数自适应进化、自愈守护闭环
+- 完整盘中生产调度链
+
+结论口径：Hermes 自有侧已经从“欧林专用最小 runtime”推进到“默认兼容欧林、但底层已 profile-aware 的最小正式内核”，不过离可迁移的完整通用做T系统还有后续阶段。
+
+这个目录仍然不接 OpenClaw 线上 daemon、实时 quote、runtime panel、自愈恢复全链路；当前只是在 Hermes 自有侧先立住正式最小状态核与最小自愈语义。

--- a/hermes_olin/__init__.py
+++ b/hermes_olin/__init__.py
@@ -1,0 +1,29 @@
+"""Hermes-native Olin intraday T-system minimal runtime package."""
+
+from .profile import DEFAULT_RUNTIME_PROFILE, RuntimeProfile
+from .runtime import (
+    arbitrate_candidate,
+    build_execution_suggestion,
+    confirm_dispatch_sent,
+    dispatch_ledger_sent_event,
+    deliver_pending_signal,
+    recover_signal_runtime,
+    run_runtime_cycle,
+    stage_pending_signal,
+)
+from .store import OlinStateStore, TradingStateStore
+
+__all__ = [
+    "RuntimeProfile",
+    "DEFAULT_RUNTIME_PROFILE",
+    "TradingStateStore",
+    "OlinStateStore",
+    "arbitrate_candidate",
+    "build_execution_suggestion",
+    "stage_pending_signal",
+    "confirm_dispatch_sent",
+    "dispatch_ledger_sent_event",
+    "deliver_pending_signal",
+    "recover_signal_runtime",
+    "run_runtime_cycle",
+]

--- a/hermes_olin/__main__.py
+++ b/hermes_olin/__main__.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+
+from hermes_t.cli_shared import build_runtime_parser, build_runtime_profile_from_args, build_runtime_store
+
+from .runtime import run_runtime_cycle
+
+
+def _build_parser():
+    return build_runtime_parser(
+        description="Run one Hermes Olin minimal runtime cycle",
+        default_base_dir_name=".hermes_olin_runtime",
+        channel_env_vars=("HERMES_OLIN_CHANNEL",),
+        chat_id_env_vars=("HERMES_OLIN_CHAT_ID",),
+        thread_id_env_vars=("HERMES_OLIN_THREAD_ID",),
+    )
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    profile = build_runtime_profile_from_args(args)
+    store = build_runtime_store(
+        base_dir=args.base_dir,
+        profile=profile,
+        prefer_legacy_olin_store=True,
+    )
+    payload = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": args.signal, "score": {"total": args.score}},
+        effective_trade_date=args.trade_date,
+        dispatch=args.dispatch,
+        channel=args.channel,
+        chat_id=args.chat_id,
+        thread_id=args.thread_id,
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_olin/profile.py
+++ b/hermes_olin/profile.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    profile_id: str
+    symbol: str
+    trade_unit: int = 10000
+    max_trades: int = 4
+
+
+DEFAULT_RUNTIME_PROFILE = RuntimeProfile(
+    profile_id="olin-688319",
+    symbol="688319",
+    trade_unit=10000,
+    max_trades=4,
+)

--- a/hermes_olin/runtime.py
+++ b/hermes_olin/runtime.py
@@ -1,0 +1,1160 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Optional
+
+from .profile import DEFAULT_RUNTIME_PROFILE
+from .signal_policy import DEFAULT_SIGNAL_POLICY, render_signal_text
+from .store import DEFAULT_EXECUTION_STATE, OlinStateStore, TradingStateStore
+
+DEFAULT_RUNTIME_POLICY = {
+    "pending_signal_timeout_sec": 300,
+    "pending_signal_max_attempts": 3,
+    "pending_retry_cooldown_sec": 60,
+    "candidate_freshness_limit_sec": 0,
+}
+
+
+def _now_str(now: Optional[datetime] = None) -> str:
+    return (now or datetime.now()).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _age_seconds(ts: Optional[str], now: Optional[datetime] = None) -> Optional[int]:
+    if not ts:
+        return None
+    try:
+        current = now or datetime.now()
+        return int((current - datetime.strptime(str(ts), "%Y-%m-%d %H:%M:%S")).total_seconds())
+    except Exception:
+        return None
+
+
+def load_runtime_policy() -> dict:
+    return dict(DEFAULT_RUNTIME_POLICY)
+
+
+def _runtime_profile(store: TradingStateStore):
+    return getattr(store, "profile", DEFAULT_RUNTIME_PROFILE)
+
+
+def _profile_trade_unit(store: TradingStateStore) -> int:
+    return int(getattr(_runtime_profile(store), "trade_unit", DEFAULT_RUNTIME_PROFILE.trade_unit) or DEFAULT_RUNTIME_PROFILE.trade_unit)
+
+
+def _profile_max_trades(store: TradingStateStore) -> int:
+    return int(getattr(_runtime_profile(store), "max_trades", DEFAULT_RUNTIME_PROFILE.max_trades) or DEFAULT_RUNTIME_PROFILE.max_trades)
+
+
+def _clear_active_signal_if_matches(execution_state: dict, signal_id: str) -> dict:
+    state = dict(execution_state or {})
+    active_signal = state.get("active_signal") or {}
+    if str(active_signal.get("signal_id") or "").strip() == str(signal_id or "").strip():
+        state["active_signal"] = None
+    return state
+
+
+def _pending_to_active_signal(pending: dict) -> dict:
+    return {
+        "signal_id": pending.get("signal_id"),
+        "signal_key": pending.get("signal_key"),
+        "trade_date": pending.get("trade_date"),
+        "action": pending.get("action"),
+        "sequence": int(pending.get("sequence", 0) or 0),
+        "status": pending.get("status"),
+        "created_at": pending.get("created_at"),
+        "last_attempt_at": pending.get("last_attempt_at"),
+        "last_error": pending.get("last_error"),
+    }
+
+
+def recover_signal_runtime(
+    store: TradingStateStore,
+    *,
+    trade_date: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> dict:
+    runtime_now = now or datetime.now()
+    policy = load_runtime_policy()
+    pending = store.load_pending_signal() or {}
+    execution_state = store.load_execution_state()
+    repairs: list[str] = []
+    result = {
+        "checked_at": _now_str(runtime_now),
+        "policy": policy,
+        "pending_status": pending.get("status") if pending else None,
+        "repairs": repairs,
+    }
+
+    active_signal = execution_state.get("active_signal") or None
+    if not pending:
+        if active_signal:
+            execution_state["active_signal"] = None
+            store.save_execution_state(execution_state)
+            repairs.append("cleared_orphan_active_signal")
+        result["pending_status"] = None
+        return result
+
+    pending = dict(pending)
+    signal_id = str(pending.get("signal_id") or "").strip()
+    pending_status = str(pending.get("status") or "").strip().lower()
+
+    if active_signal:
+        if str(active_signal.get("signal_id") or "").strip() != signal_id:
+            execution_state["active_signal"] = _pending_to_active_signal(pending)
+            store.save_execution_state(execution_state)
+            repairs.append("repaired_active_signal_mismatch")
+    else:
+        execution_state["active_signal"] = _pending_to_active_signal(pending)
+        store.save_execution_state(execution_state)
+        repairs.append("restored_missing_active_signal")
+
+    pending_trade_date = str(pending.get("trade_date") or "").strip()
+    if trade_date and pending_trade_date and pending_trade_date != trade_date:
+        pending["status"] = "expired_cross_day"
+        pending["last_attempt_status"] = "expired_cross_day"
+        pending["escalated"] = True
+        pending["escalation_reason"] = "cross_day_cleanup"
+        pending["escalated_at"] = _now_str(runtime_now)
+        pending["age_seconds"] = _age_seconds(pending.get("created_at"), runtime_now)
+        store.save_pending_signal(pending)
+        execution_state = _clear_active_signal_if_matches(execution_state, signal_id)
+        store.save_execution_state(execution_state)
+        store.append_signal_send_history(
+            "expired_cross_day",
+            {
+                "signal_id": signal_id,
+                "signal_key": pending.get("signal_key"),
+                "trade_date": pending_trade_date,
+                "current_trade_date": trade_date,
+            },
+        )
+        repairs.append("expired_cross_day_pending_signal")
+        result["pending_status"] = pending["status"]
+        return result
+
+    pending_age = _age_seconds(pending.get("created_at"), runtime_now)
+    result["pending_age_seconds"] = pending_age
+    max_attempts = int(policy.get("pending_signal_max_attempts", 3) or 3)
+    timeout_sec = int(policy.get("pending_signal_timeout_sec", 300) or 300)
+
+    if pending_status in ("pending", "failed") and pending_age is not None and pending_age > timeout_sec:
+        pending["status"] = "timed_out"
+        pending["last_attempt_status"] = "timed_out"
+        pending["escalated"] = True
+        pending["timed_out"] = True
+        pending["escalation_reason"] = "pending_timeout"
+        pending["escalated_at"] = _now_str(runtime_now)
+        pending["age_seconds"] = pending_age
+        pending["timeout_sec"] = timeout_sec
+        store.save_pending_signal(pending)
+        execution_state = _clear_active_signal_if_matches(execution_state, signal_id)
+        store.save_execution_state(execution_state)
+        store.append_signal_send_history(
+            "timed_out",
+            {
+                "signal_id": signal_id,
+                "signal_key": pending.get("signal_key"),
+                "attempts": pending.get("attempts", 0),
+                "age_seconds": pending_age,
+                "timeout_sec": timeout_sec,
+            },
+        )
+        repairs.append("timed_out_pending_signal")
+        result["pending_status"] = pending["status"]
+        return result
+
+    attempts = int(pending.get("attempts", 0) or 0)
+    non_retryable_failed = pending_status == "failed" and pending.get("last_error_retryable") is False
+    if non_retryable_failed:
+        pending["status"] = "failed_exhausted"
+        pending["last_attempt_status"] = "failed_exhausted"
+        pending["escalated"] = True
+        pending["escalation_reason"] = "non_retryable_dispatch_error"
+        pending["escalated_at"] = _now_str(runtime_now)
+        pending["max_attempts"] = max_attempts
+        store.save_pending_signal(pending)
+        execution_state = _clear_active_signal_if_matches(execution_state, signal_id)
+        store.save_execution_state(execution_state)
+        store.append_signal_send_history(
+            "failed_exhausted",
+            {
+                "signal_id": signal_id,
+                "signal_key": pending.get("signal_key"),
+                "attempts": attempts,
+                "max_attempts": max_attempts,
+                "error_class": pending.get("last_error_class"),
+                "escalation_reason": "non_retryable_dispatch_error",
+            },
+        )
+        repairs.append("non_retryable_failed_pending_signal")
+        result["pending_status"] = pending["status"]
+        return result
+
+    if pending_status == "failed" and attempts >= max_attempts:
+        pending["status"] = "failed_exhausted"
+        pending["last_attempt_status"] = "failed_exhausted"
+        pending["escalated"] = True
+        pending["escalation_reason"] = "max_attempts_exhausted"
+        pending["escalated_at"] = _now_str(runtime_now)
+        pending["max_attempts"] = max_attempts
+        store.save_pending_signal(pending)
+        execution_state = _clear_active_signal_if_matches(execution_state, signal_id)
+        store.save_execution_state(execution_state)
+        store.append_signal_send_history(
+            "failed_exhausted",
+            {
+                "signal_id": signal_id,
+                "signal_key": pending.get("signal_key"),
+                "attempts": attempts,
+                "max_attempts": max_attempts,
+            },
+        )
+        repairs.append("exhausted_failed_pending_signal")
+        result["pending_status"] = pending["status"]
+        return result
+
+    if pending_status == "failed" and attempts < max_attempts:
+        pending["status"] = "pending"
+        pending["last_attempt_status"] = "retry_scheduled"
+        pending["retry_scheduled_at"] = _now_str(runtime_now)
+        store.save_pending_signal(pending)
+        refreshed_state = _normalize_execution_state(store.load_execution_state(), trade_date or pending_trade_date)
+        active_signal = dict((refreshed_state or {}).get("active_signal") or {})
+        if active_signal and str(active_signal.get("signal_id") or "").strip() == signal_id:
+            active_signal["status"] = "pending"
+            active_signal["last_attempt_at"] = pending.get("last_attempt_at")
+            active_signal["last_error"] = pending.get("last_error")
+            active_signal["last_error_class"] = pending.get("last_error_class")
+            refreshed_state["active_signal"] = active_signal
+            store.save_execution_state(refreshed_state)
+        repairs.append("requeued_retryable_failed_pending_signal")
+        result["pending_status"] = pending["status"]
+        return result
+
+    if pending_status in ("sent", "timed_out", "failed_exhausted", "expired_cross_day"):
+        repaired_state = _clear_active_signal_if_matches(execution_state, signal_id)
+        if repaired_state.get("active_signal") != execution_state.get("active_signal"):
+            store.save_execution_state(repaired_state)
+            repairs.append("cleared_terminal_active_signal")
+
+    result["pending_status"] = pending_status or None
+    return result
+
+
+
+def _default_dispatch_pending_signal(payload: dict) -> dict:
+    from gateway.config import Platform, load_gateway_config
+    from gateway.session_context import get_session_env
+    from model_tools import _run_async
+    from tools.send_message_tool import _send_to_platform
+
+    config = load_gateway_config()
+    platform_name = str(payload.get("channel") or "feishu").strip().lower()
+    if platform_name != "feishu":
+        raise ValueError(f"Unsupported dispatch channel: {platform_name}")
+
+    platform = Platform.FEISHU
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        raise RuntimeError("Feishu platform is not configured or not enabled")
+
+    thread_id = str(payload.get("thread_id") or "").strip() or None
+    chat_id = str(payload.get("chat_id") or "").strip()
+    if not chat_id:
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        if session_platform == "feishu":
+            chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+            thread_id = thread_id or (get_session_env("HERMES_SESSION_THREAD_ID", "").strip() or None)
+    if not chat_id:
+        home = config.get_home_channel(platform)
+        if home:
+            chat_id = str(home.chat_id).strip()
+    if not chat_id:
+        raise RuntimeError("No Feishu chat_id available from session context or home channel")
+
+    result = _run_async(
+        _send_to_platform(
+            platform,
+            pconfig,
+            chat_id,
+            str(payload.get("message") or ""),
+            thread_id=thread_id,
+            media_files=None,
+        )
+    )
+    if not isinstance(result, dict):
+        raise RuntimeError(f"Unexpected dispatch result type: {type(result).__name__}")
+    if result.get("error") and "success" not in result:
+        return {"success": False, "error": result.get("error"), **result}
+    return {"chat_id": chat_id, "thread_id": thread_id, **result}
+
+
+def _mark_dispatch_failed(store: TradingStateStore, pending: dict, error: str) -> dict:
+    failed_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    attempts = int(pending.get("attempts", 0) or 0) + 1
+    failed = dict(pending)
+    failed.update(
+        {
+            "status": "failed",
+            "attempts": attempts,
+            "last_attempt_at": failed_at,
+            "last_attempt_status": "failed",
+            "last_error": error,
+        }
+    )
+    store.save_pending_signal(failed)
+
+    trade_date = str(failed.get("trade_date") or "")
+    if trade_date:
+        execution_state = _normalize_execution_state(store.load_execution_state(), trade_date)
+        active_signal = execution_state.get("active_signal") or {}
+        if active_signal.get("signal_id") == failed.get("signal_id"):
+            active_signal.update(
+                {
+                    "status": "failed",
+                    "last_attempt_at": failed_at,
+                    "last_error": error,
+                }
+            )
+            execution_state["active_signal"] = active_signal
+            execution_state["last_signal_id"] = failed.get("signal_id")
+            execution_state["last_signal_action"] = failed.get("action")
+            execution_state["last_signal_status"] = "failed"
+            execution_state["last_signal_at"] = failed_at
+            store.save_execution_state(execution_state)
+
+    store.record_dispatch_event(
+        "failed",
+        {
+            "signal_id": failed.get("signal_id"),
+            "signal_key": failed.get("signal_key"),
+            "trade_date": trade_date,
+            "action": failed.get("action"),
+            "sequence": int(failed.get("sequence", 0) or 0),
+            "attempts": attempts,
+            "error": error,
+        },
+    )
+    store.append_signal_send_history(
+        "failed",
+        {
+            "signal_id": failed.get("signal_id"),
+            "signal_key": failed.get("signal_key"),
+            "trade_date": trade_date,
+            "action": failed.get("action"),
+            "sequence": int(failed.get("sequence", 0) or 0),
+            "attempts": attempts,
+            "error": error,
+        },
+    )
+    return failed
+
+
+def _normalize_execution_state(state: Optional[dict], effective_trade_date: str) -> dict:
+    state = dict(state or {})
+    if state.get("trade_date") != effective_trade_date:
+        reset = dict(DEFAULT_EXECUTION_STATE)
+        reset["trade_date"] = effective_trade_date
+        return reset
+    merged = dict(DEFAULT_EXECUTION_STATE)
+    merged["trade_date"] = effective_trade_date
+    merged.update(state)
+    merged["actions"] = list(merged.get("actions") or [])
+    if merged.get("active_signal") in ({}, []):
+        merged["active_signal"] = None
+    return merged
+
+
+def _candidate_signal_key(candidate: dict) -> str:
+    signal_key = str(candidate.get("signal_key") or "").strip()
+    if signal_key:
+        return signal_key
+    action = str(candidate.get("action") or candidate.get("next_action") or "").strip()
+    sequence = int(candidate.get("sequence", 0) or 0)
+    if action and sequence > 0:
+        return f"{action}_{sequence}"
+    return ""
+
+
+def _freshness_ok(candidate: dict, policy: dict, now: Optional[datetime] = None) -> tuple[bool, Optional[int]]:
+    limit_sec = int(policy.get("candidate_freshness_limit_sec", 0) or 0)
+    if limit_sec <= 0:
+        return True, None
+    age = _age_seconds(candidate.get("signal_time"), now)
+    if age is None:
+        return True, None
+    return age <= limit_sec, age
+
+
+def _retry_cooldown_remaining_sec(pending: dict, policy: dict, now: Optional[datetime] = None) -> int:
+    cooldown_sec = int(policy.get("pending_retry_cooldown_sec", 0) or 0)
+    if cooldown_sec <= 0:
+        return 0
+    last_attempt_at = pending.get("last_attempt_at")
+    age = _age_seconds(last_attempt_at, now)
+    if age is None:
+        return 0
+    return max(cooldown_sec - age, 0)
+
+
+def arbitrate_candidate(
+    store: TradingStateStore,
+    candidate: dict,
+    *,
+    effective_trade_date: str,
+    now: Optional[datetime] = None,
+) -> dict:
+    runtime_now = now or datetime.now()
+    policy = load_runtime_policy()
+    next_action = str(candidate.get("next_action") or candidate.get("action") or "hold").strip().lower()
+    execution_state = _normalize_execution_state(store.load_execution_state(), effective_trade_date)
+    push_state = store.load_push_state()
+    pending = store.load_pending_signal() or {}
+    signal_key = _candidate_signal_key(candidate)
+    action = str(candidate.get("action") or next_action).strip().lower()
+    sequence = int(candidate.get("sequence", 0) or 0)
+
+    result = {
+        "decision": "stage_new_pending",
+        "reason": "candidate_allowed",
+        "candidate": dict(candidate),
+        "pending": {},
+        "policy": policy,
+        "cooldown_remaining_sec": 0,
+    }
+    if next_action in ("", "hold") or sequence <= 0:
+        result["decision"] = "blocked"
+        result["reason"] = "hold_candidate"
+        return result
+
+    freshness_ok, candidate_age = _freshness_ok(candidate, policy, runtime_now)
+    if not freshness_ok:
+        result["decision"] = "blocked"
+        result["reason"] = "candidate_stale"
+        result["candidate_age_sec"] = candidate_age
+        return result
+
+    pending_status = str(pending.get("status") or "").strip().lower()
+    pending_trade_date = str(pending.get("trade_date") or "").strip()
+    pending_signal_key = str(pending.get("signal_key") or "").strip()
+    if pending and pending_trade_date == effective_trade_date:
+        if pending_status == "pending":
+            if pending_signal_key == signal_key:
+                result["decision"] = "blocked"
+                result["reason"] = "duplicate_pending_signal"
+            else:
+                result["decision"] = "blocked"
+                result["reason"] = "another_pending_signal_active"
+            result["pending"] = dict(pending)
+            return result
+        if pending_status == "failed" and pending_signal_key == signal_key and bool(pending.get("last_error_retryable", True)):
+            remaining = _retry_cooldown_remaining_sec(pending, policy, runtime_now)
+            if remaining > 0:
+                result["decision"] = "blocked"
+                result["reason"] = "retry_cooldown_active"
+                result["pending"] = dict(pending)
+                result["cooldown_remaining_sec"] = remaining
+                return result
+            result["decision"] = "reuse_failed_pending"
+            result["reason"] = "retry_ready_reuse_failed_pending"
+            result["pending"] = dict(pending)
+            return result
+
+    if (
+        str(push_state.get("last_pushed_trade_date") or "").strip() == effective_trade_date
+        and str(push_state.get("last_pushed_signal") or "").strip() == signal_key
+    ):
+        result["decision"] = "blocked"
+        result["reason"] = "duplicate_sent_signal"
+        return result
+
+    for action_item in list(execution_state.get("actions") or []):
+        if (
+            str(action_item.get("trade_date") or "").strip() == effective_trade_date
+            and str(action_item.get("action") or "").strip().lower() == action
+            and int(action_item.get("sequence", 0) or 0) == sequence
+        ):
+            result["decision"] = "blocked"
+            result["reason"] = "duplicate_execution_signal"
+            return result
+
+    return result
+
+
+def build_execution_suggestion(store: OlinStateStore | TradingStateStore, tech_data: dict, effective_trade_date: str) -> dict:
+    state = _normalize_execution_state(store.load_execution_state(), effective_trade_date)
+    trade_unit = _profile_trade_unit(store)
+    max_trades = _profile_max_trades(store)
+    active_signal = state.get("active_signal") or {}
+    if active_signal and active_signal.get("status") == "pending":
+        return {
+            "signal": tech_data.get("summary_signal", "hold"),
+            "trade_unit": trade_unit,
+            "max_trades": max_trades,
+            "action": "hold",
+            "sequence": 0,
+            "text": DEFAULT_SIGNAL_POLICY.active_signal_hold_text,
+            "trade_date": effective_trade_date,
+            "reason": "active_signal_exists",
+            "state_snapshot": state,
+            "execution_state": state,
+            "next_action": "hold",
+        }
+
+    signal = tech_data.get("summary_signal", "hold")
+    score = tech_data.get("score", {}).get("total", 50)
+
+    candidate = {
+        "signal": signal,
+        "trade_unit": trade_unit,
+        "max_trades": max_trades,
+        "action": "hold",
+        "sequence": 0,
+        "text": DEFAULT_SIGNAL_POLICY.no_action_text,
+        "trade_date": effective_trade_date,
+        "reason": "",
+        "state_snapshot": state,
+        "execution_state": state,
+        "next_action": "hold",
+    }
+
+    if signal == "sell" and score <= DEFAULT_SIGNAL_POLICY.sell_score_threshold and state.get("sell_count", 0) < max_trades:
+        next_seq = state.get("sell_count", 0) + 1
+        candidate.update(
+            {
+                "action": "sell",
+                "next_action": "sell",
+                "sequence": next_seq,
+                "text": render_signal_text(action="sell", sequence=next_seq, trade_unit=trade_unit),
+                "reason": f"signal={signal}, score={score}",
+            }
+        )
+    elif signal == "buy" and score >= DEFAULT_SIGNAL_POLICY.buy_score_threshold and state.get("buy_count", 0) < max_trades:
+        next_seq = state.get("buy_count", 0) + 1
+        candidate.update(
+            {
+                "action": "buy",
+                "next_action": "buy",
+                "sequence": next_seq,
+                "text": render_signal_text(action="buy", sequence=next_seq, trade_unit=trade_unit),
+                "reason": f"signal={signal}, score={score}",
+            }
+        )
+
+    return candidate
+
+
+def stage_pending_signal(
+    store: TradingStateStore,
+    suggestion: dict,
+    execution_state: dict,
+    trade_date: str,
+    now: datetime,
+) -> dict:
+    pending_existing = store.load_pending_signal()
+    if pending_existing:
+        pending_trade_date = str(pending_existing.get("trade_date") or "")
+        if pending_trade_date != trade_date:
+            store.clear_pending_signal()
+            pending_existing = {}
+    if pending_existing and pending_existing.get("status") in ("pending", "failed"):
+        return pending_existing
+
+    action = suggestion.get("next_action") or suggestion.get("action") or "hold"
+    sequence = int(suggestion.get("sequence", 0) or 0)
+    if action not in {"buy", "sell"} or sequence <= 0:
+        return {}
+    signal_key = f"{action}_{sequence}"
+    signal_id = f"{signal_key}_{now.strftime('%Y%m%d_%H%M%S')}"
+    pending_signal = {
+        "signal_id": signal_id,
+        "signal_key": signal_key,
+        "status": "pending",
+        "created_at": now.strftime("%Y-%m-%d %H:%M:%S"),
+        "trade_date": trade_date,
+        "action": action,
+        "sequence": sequence,
+        "text": suggestion.get("text", ""),
+        "signal": suggestion.get("signal", action),
+        "trade_unit": int(suggestion.get("trade_unit", _profile_trade_unit(store)) or _profile_trade_unit(store)),
+        "attempts": 0,
+        "last_attempt_at": None,
+        "last_attempt_status": None,
+        "last_error": None,
+        "sent_at": None,
+        "state": execution_state,
+        "candidate_snapshot": suggestion,
+    }
+    store.save_pending_signal(pending_signal)
+
+    next_state = _normalize_execution_state(execution_state, trade_date)
+    next_state["active_signal"] = {
+        "signal_id": signal_id,
+        "signal_key": signal_key,
+        "action": action,
+        "sequence": sequence,
+        "status": "pending",
+        "created_at": pending_signal["created_at"],
+    }
+    store.save_execution_state(next_state)
+    return pending_signal
+
+
+def dispatch_ledger_sent_event(delivery_result: Optional[dict] = None) -> str:
+    result = delivery_result or {}
+    return "dry_run_sent" if bool(result.get("dry_run")) else "sent"
+
+
+def _reconcile_already_sent_signal(
+    store: TradingStateStore,
+    pending: dict,
+    *,
+    sent_at: Optional[str] = None,
+    channel: Optional[str] = None,
+    delivery_result: Optional[dict] = None,
+    fallback_trade_date: Optional[str] = None,
+) -> dict:
+    reconciled = dict(pending)
+    signal_id = str(reconciled.get("signal_id") or "").strip()
+    trade_date = str(reconciled.get("trade_date") or fallback_trade_date or "").strip()
+    action = str(reconciled.get("action") or "").strip()
+    sequence = int(reconciled.get("sequence", 0) or 0)
+    if not sent_at:
+        sent_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    persisted_pending = store.load_pending_signal()
+    execution_state_raw = store.load_execution_state()
+    active_signal_raw = (execution_state_raw or {}).get("active_signal") or {}
+    actions_raw = list((execution_state_raw or {}).get("actions") or [])
+    existing = next((item for item in actions_raw if str(item.get("signal_id") or "").strip() == signal_id), None)
+    if not trade_date:
+        trade_date = str(
+            active_signal_raw.get("trade_date")
+            or (existing or {}).get("trade_date")
+            or (execution_state_raw or {}).get("trade_date")
+            or ""
+        ).strip()
+
+    reconciled.update(
+        {
+            "status": "sent",
+            "sent_at": sent_at,
+            "dispatch_channel": channel,
+            "delivery_result": delivery_result or {},
+            "last_attempt_status": "sent",
+        }
+    )
+    if trade_date:
+        reconciled["trade_date"] = trade_date
+
+    if str(persisted_pending.get("signal_id") or "").strip() == signal_id:
+        store.clear_pending_signal()
+
+    if trade_date:
+        execution_state = _normalize_execution_state(execution_state_raw, trade_date)
+        active_signal = execution_state.get("active_signal") or {}
+        if active_signal.get("signal_id") == signal_id:
+            execution_state["active_signal"] = None
+        actions = list(execution_state.get("actions") or [])
+        existing = next((item for item in actions if item.get("signal_id") == signal_id), None)
+        if existing is None and action and sequence > 0:
+            actions.append(
+                {
+                    "signal_id": signal_id,
+                    "signal_key": reconciled.get("signal_key"),
+                    "trade_date": trade_date,
+                    "action": action,
+                    "sequence": sequence,
+                    "status": "sent",
+                    "sent_at": sent_at,
+                    "channel": channel,
+                    "text": reconciled.get("text", ""),
+                }
+            )
+        elif existing is not None:
+            existing.update(
+                {
+                    "signal_key": reconciled.get("signal_key"),
+                    "trade_date": trade_date,
+                    "action": action,
+                    "sequence": sequence,
+                    "status": "sent",
+                    "sent_at": sent_at,
+                    "channel": channel,
+                    "text": reconciled.get("text", ""),
+                }
+            )
+        execution_state.update(
+            {
+                "trade_date": trade_date,
+                "actions": actions,
+                "last_signal_id": signal_id,
+                "last_signal_action": action,
+                "last_signal_status": "sent",
+                "last_signal_at": sent_at,
+            }
+        )
+        if action == "sell":
+            execution_state["sell_count"] = max(int(execution_state.get("sell_count", 0) or 0), sequence)
+        elif action == "buy":
+            execution_state["buy_count"] = max(int(execution_state.get("buy_count", 0) or 0), sequence)
+        store.save_execution_state(execution_state)
+
+    return reconciled
+
+
+def deliver_pending_signal(
+    store: TradingStateStore,
+    pending: dict,
+    *,
+    dispatch_fn: Optional[Callable[[dict], dict]] = None,
+    channel: str = "feishu",
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+) -> dict:
+    pending = dict(pending or {})
+    signal_id = str(pending.get("signal_id") or "").strip()
+    message = str(pending.get("text") or "").strip()
+    if not signal_id:
+        raise ValueError("pending signal missing signal_id")
+    if not message:
+        raise ValueError("pending signal missing text")
+
+    status = str(pending.get("status") or "pending").strip().lower()
+    if status == "sent":
+        return pending
+    if status != "pending":
+        return pending
+
+    trade_date = str(pending.get("trade_date") or "").strip()
+    action = str(pending.get("action") or "").strip().lower()
+    sequence = int(pending.get("sequence", 0) or 0)
+
+    push_state = store.load_push_state()
+    if str(push_state.get("last_pushed_signal_id") or "").strip() == signal_id:
+        return _reconcile_already_sent_signal(
+            store,
+            pending,
+            sent_at=push_state.get("last_pushed_at"),
+            channel=push_state.get("last_dispatch_channel"),
+            delivery_result=push_state.get("last_delivery_result") or {},
+            fallback_trade_date=str(push_state.get("last_pushed_trade_date") or "").strip() or None,
+        )
+
+    execution_state = store.load_execution_state()
+    actions = list((execution_state or {}).get("actions") or [])
+    if any(str(item.get("signal_id") or "").strip() == signal_id for item in actions):
+        existing = next((item for item in actions if str(item.get("signal_id") or "").strip() == signal_id), {})
+        return _reconcile_already_sent_signal(
+            store,
+            pending,
+            sent_at=existing.get("sent_at"),
+            channel=existing.get("channel"),
+            delivery_result={},
+        )
+
+    if not trade_date or action not in {"buy", "sell"} or sequence <= 0:
+        return _mark_dispatch_failed(store, pending, "invalid pending signal payload")
+
+    persisted_pending = store.load_pending_signal()
+    persisted_signal_id = str(persisted_pending.get("signal_id") or "").strip()
+    persisted_status = str(persisted_pending.get("status") or "").strip().lower()
+    if persisted_signal_id and persisted_signal_id != signal_id:
+        return pending
+    if persisted_pending and persisted_status != "pending":
+        return dict(persisted_pending)
+
+    dispatch_payload = {
+        "signal_id": signal_id,
+        "signal_key": pending.get("signal_key"),
+        "trade_date": pending.get("trade_date"),
+        "action": pending.get("action"),
+        "sequence": pending.get("sequence"),
+        "channel": channel,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+        "message": message,
+    }
+    dispatcher = dispatch_fn or _default_dispatch_pending_signal
+
+    try:
+        delivery_result = dispatcher(dispatch_payload)
+    except Exception as exc:
+        return _mark_dispatch_failed(store, pending, str(exc))
+
+    if not isinstance(delivery_result, dict):
+        return _mark_dispatch_failed(store, pending, f"Unexpected dispatch result type: {type(delivery_result).__name__}")
+    if not delivery_result.get("success"):
+        return _mark_dispatch_failed(store, pending, str(delivery_result.get("error") or "dispatch failed"))
+
+    effective_channel = str(
+        delivery_result.get("channel")
+        or delivery_result.get("platform")
+        or channel
+    )
+    return confirm_dispatch_sent(
+        store,
+        pending,
+        channel=effective_channel,
+        delivery_result=delivery_result,
+    )
+
+
+def confirm_dispatch_sent(
+    store: TradingStateStore,
+    pending: dict,
+    *,
+    channel: str,
+    delivery_result: Optional[dict] = None,
+) -> dict:
+    pending = dict(pending)
+    sent_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    signal_id = pending.get("signal_id")
+    trade_date = str(pending.get("trade_date") or "")
+    action = str(pending.get("action") or "").strip()
+    sequence = int(pending.get("sequence", 0) or 0)
+    if not trade_date:
+        raise ValueError("pending signal missing trade_date")
+    pending.update(
+        {
+            "status": "sent",
+            "sent_at": sent_at,
+            "dispatch_channel": channel,
+            "delivery_result": delivery_result or {},
+            "last_attempt_status": "sent",
+        }
+    )
+
+    store.record_dispatch_event(
+        dispatch_ledger_sent_event(delivery_result),
+        {
+            "signal_id": signal_id,
+            "signal_key": pending.get("signal_key"),
+            "trade_date": trade_date,
+            "action": action,
+            "sequence": sequence,
+            "attempts": pending.get("attempts", 0),
+            "channel": channel,
+            "delivery_result": delivery_result or {},
+        },
+    )
+
+    push_state = store.load_push_state()
+    push_state.update(
+        {
+            "last_pushed_signal": pending.get("signal_key"),
+            "last_pushed_signal_id": signal_id,
+            "last_pushed_trade_date": trade_date,
+            "last_pushed_at": sent_at,
+            "last_pushed_text": pending.get("text", ""),
+            "last_dispatch_channel": channel,
+            "last_delivery_result": delivery_result or {},
+        }
+    )
+    store.save_push_state(push_state)
+
+    execution_state = _normalize_execution_state(store.load_execution_state(), trade_date)
+    actions = list(execution_state.get("actions") or [])
+    existing = next((item for item in actions if item.get("signal_id") == signal_id), None)
+    if existing is None and trade_date and action and sequence > 0:
+        actions.append(
+            {
+                "signal_id": signal_id,
+                "signal_key": pending.get("signal_key"),
+                "trade_date": trade_date,
+                "action": action,
+                "sequence": sequence,
+                "status": "sent",
+                "sent_at": sent_at,
+                "channel": channel,
+                "text": pending.get("text", ""),
+            }
+        )
+    elif existing is not None:
+        existing.update(
+            {
+                "signal_key": pending.get("signal_key"),
+                "trade_date": trade_date,
+                "action": action,
+                "sequence": sequence,
+                "status": "sent",
+                "sent_at": sent_at,
+                "channel": channel,
+                "text": pending.get("text", ""),
+            }
+        )
+    active_signal = execution_state.get("active_signal") or {}
+    if active_signal.get("signal_id") == signal_id:
+        execution_state["active_signal"] = None
+    execution_state.update(
+        {
+            "trade_date": trade_date,
+            "actions": actions,
+            "last_signal_id": signal_id,
+            "last_signal_action": action,
+            "last_signal_status": "sent",
+            "last_signal_at": sent_at,
+        }
+    )
+    if action == "sell":
+        execution_state["sell_count"] = max(int(execution_state.get("sell_count", 0) or 0), sequence)
+    elif action == "buy":
+        execution_state["buy_count"] = max(int(execution_state.get("buy_count", 0) or 0), sequence)
+    store.save_execution_state(execution_state)
+
+    store.save_pending_signal(pending)
+    store.clear_pending_signal()
+    store.append_signal_send_history(
+        "sent",
+        {
+            "signal_id": signal_id,
+            "signal_key": pending.get("signal_key"),
+            "trade_date": trade_date,
+            "action": action,
+            "sequence": sequence,
+            "attempts": pending.get("attempts", 0),
+            "sent_at": sent_at,
+            "channel": channel,
+            "delivery_result": delivery_result or {},
+        },
+    )
+    return pending
+
+
+def run_runtime_cycle(
+    store: TradingStateStore,
+    *,
+    tech_data: dict,
+    effective_trade_date: str,
+    now: Optional[datetime] = None,
+    dispatch: bool = False,
+    dispatch_fn: Optional[Callable[[dict], dict]] = None,
+    channel: str = "feishu",
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+) -> dict:
+    """Run one minimal Hermes-native trading runtime cycle."""
+
+    cycle_now = now or datetime.now()
+    pre_recovery_pending = store.load_pending_signal() or {}
+    recovery = recover_signal_runtime(
+        store,
+        trade_date=effective_trade_date,
+        now=cycle_now,
+    )
+    blocked_statuses = {"timed_out", "failed_exhausted"}
+    terminal_recovery_repairs = {
+        "timed_out_pending_signal",
+        "non_retryable_failed_pending_signal",
+        "exhausted_failed_pending_signal",
+    }
+    current_pending = store.load_pending_signal() or {}
+    current_execution_state = store.load_execution_state()
+    current_push_state = store.load_push_state()
+    current_signal = str(tech_data.get("summary_signal") or "hold").strip().lower()
+    recovery_repairs = set(recovery.get("repairs") or [])
+
+    if recovery.get("pending_status") in blocked_statuses:
+        if recovery_repairs & terminal_recovery_repairs:
+            suggestion = {
+                "next_action": "hold",
+                "sequence": 0,
+                "signal": "hold",
+                "reason": "recovery_blocked",
+                "recovery": recovery,
+                "execution_state": current_execution_state,
+                "state_snapshot": current_execution_state,
+            }
+            pending = current_pending
+            result = dict(pending)
+        else:
+            store.clear_pending_signal()
+            current_pending = {}
+            recovery["pending_status"] = None
+            recovery_repairs = set(recovery.get("repairs") or [])
+            recovery_repairs.add("cleared_terminal_pending_signal")
+            recovery["repairs"] = list(recovery_repairs)
+            current_execution_state = store.load_execution_state()
+            current_push_state = store.load_push_state()
+            suggestion = build_execution_suggestion(store, tech_data, effective_trade_date)
+            arbitration = arbitrate_candidate(
+                store,
+                suggestion,
+                effective_trade_date=effective_trade_date,
+                now=cycle_now,
+            )
+            decision = str(arbitration.get("decision") or "").strip().lower()
+            execution_state = suggestion.get("execution_state") or store.load_execution_state()
+
+            if decision == "blocked":
+                pending = store.load_pending_signal()
+                suggestion = {
+                    **suggestion,
+                    "next_action": "hold",
+                    "action": "hold",
+                    "sequence": 0,
+                    "reason": str(arbitration.get("reason") or "blocked"),
+                    "arbitration": arbitration,
+                }
+                result = dict(pending)
+            elif decision == "reuse_failed_pending":
+                pending = dict(arbitration.get("pending") or store.load_pending_signal() or {})
+                suggestion = {
+                    **suggestion,
+                    "reason": str(arbitration.get("reason") or suggestion.get("reason") or ""),
+                    "arbitration": arbitration,
+                }
+                result = dict(pending)
+                if dispatch and pending:
+                    result = deliver_pending_signal(
+                        store,
+                        pending,
+                        dispatch_fn=dispatch_fn,
+                        channel=channel,
+                        chat_id=chat_id,
+                        thread_id=thread_id,
+                    )
+            else:
+                pending = stage_pending_signal(
+                    store,
+                    suggestion,
+                    execution_state,
+                    effective_trade_date,
+                    cycle_now,
+                )
+                suggestion = {
+                    **suggestion,
+                    "arbitration": arbitration,
+                }
+                result = dict(pending)
+                if dispatch and pending:
+                    result = deliver_pending_signal(
+                        store,
+                        pending,
+                        dispatch_fn=dispatch_fn,
+                        channel=channel,
+                        chat_id=chat_id,
+                        thread_id=thread_id,
+                    )
+    elif current_pending and "requeued_retryable_failed_pending_signal" in recovery_repairs:
+        pending = dict(current_pending)
+        pending_action = str(pending.get("action") or "hold").strip().lower()
+        pending_sequence = int(pending.get("sequence", 0) or 0)
+        suggestion = {
+            "signal": pending.get("signal", pending_action),
+            "trade_unit": int(pending.get("trade_unit", store.profile.trade_unit) or store.profile.trade_unit),
+            "max_trades": int(store.profile.max_trades),
+            "action": pending_action,
+            "sequence": pending_sequence,
+            "text": pending.get("text", ""),
+            "trade_date": effective_trade_date,
+            "reason": "retry_ready_reuse_failed_pending",
+            "state_snapshot": current_execution_state,
+            "execution_state": current_execution_state,
+            "next_action": pending_action,
+            "recovery": recovery,
+        }
+        result = dict(pre_recovery_pending or pending)
+        if dispatch and pending:
+            result = deliver_pending_signal(
+                store,
+                pending,
+                dispatch_fn=dispatch_fn,
+                channel=channel,
+                chat_id=chat_id,
+                thread_id=thread_id,
+            )
+    elif (
+        not current_pending
+        and current_signal in {"buy", "sell"}
+        and str(current_push_state.get("last_pushed_trade_date") or "").strip() == effective_trade_date
+        and str(current_push_state.get("last_pushed_signal") or "").strip().startswith(f"{current_signal}_")
+    ):
+        suggestion = {
+            "signal": current_signal,
+            "trade_unit": int(store.profile.trade_unit),
+            "max_trades": int(store.profile.max_trades),
+            "action": "hold",
+            "sequence": 0,
+            "text": DEFAULT_SIGNAL_POLICY.no_action_text,
+            "trade_date": effective_trade_date,
+            "reason": "duplicate_sent_signal",
+            "state_snapshot": current_execution_state,
+            "execution_state": current_execution_state,
+            "next_action": "hold",
+            "recovery": recovery,
+        }
+        pending = {}
+        result = {}
+    else:
+        suggestion = build_execution_suggestion(store, tech_data, effective_trade_date)
+        arbitration = arbitrate_candidate(
+            store,
+            suggestion,
+            effective_trade_date=effective_trade_date,
+            now=cycle_now,
+        )
+        decision = str(arbitration.get("decision") or "").strip().lower()
+        execution_state = suggestion.get("execution_state") or store.load_execution_state()
+
+        if decision == "blocked":
+            pending = store.load_pending_signal()
+            suggestion = {
+                **suggestion,
+                "next_action": "hold",
+                "action": "hold",
+                "sequence": 0,
+                "reason": str(arbitration.get("reason") or "blocked"),
+                "arbitration": arbitration,
+            }
+            result = dict(pending)
+        elif decision == "reuse_failed_pending":
+            pending = dict(arbitration.get("pending") or store.load_pending_signal() or {})
+            suggestion = {
+                **suggestion,
+                "reason": str(arbitration.get("reason") or suggestion.get("reason") or ""),
+                "arbitration": arbitration,
+            }
+            result = dict(pending)
+            if dispatch and pending:
+                result = deliver_pending_signal(
+                    store,
+                    pending,
+                    dispatch_fn=dispatch_fn,
+                    channel=channel,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                )
+        else:
+            pending = stage_pending_signal(
+                store,
+                suggestion,
+                execution_state,
+                effective_trade_date,
+                cycle_now,
+            )
+            suggestion = {
+                **suggestion,
+                "arbitration": arbitration,
+            }
+            result = dict(pending)
+            if dispatch and pending:
+                result = deliver_pending_signal(
+                    store,
+                    pending,
+                    dispatch_fn=dispatch_fn,
+                    channel=channel,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                )
+    current_pending = store.load_pending_signal()
+    return {
+        "trade_date": effective_trade_date,
+        "now": cycle_now.strftime("%Y-%m-%d %H:%M:%S"),
+        "recovery": recovery,
+        "suggestion": suggestion,
+        "pending": current_pending,
+        "result": result,
+        "execution_state": store.load_execution_state(),
+        "push_state": store.load_push_state(),
+    }

--- a/hermes_olin/signal_policy.py
+++ b/hermes_olin/signal_policy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SignalPolicy:
+    """Signal policy config: score thresholds and text templates.
+
+    Attributes:
+        buy_score_threshold: Minimum score to trigger a buy signal (>= this value).
+        sell_score_threshold: Maximum score to trigger a sell signal (<= this value).
+        active_signal_hold_text: Text returned when an active pending signal blocks new suggestions.
+        no_action_text: Default text returned when no execution suggestion is generated.
+    """
+
+    buy_score_threshold: int = 70
+    sell_score_threshold: int = 30
+    active_signal_hold_text: str = "当前已有待处理信号，暂停生成下一笔执行建议"
+    no_action_text: str = "暂无新增执行建议"
+
+
+DEFAULT_SIGNAL_POLICY: SignalPolicy = SignalPolicy()
+
+
+def render_signal_text(
+    *,
+    action: str,
+    sequence: int,
+    trade_unit: int,
+    policy: Optional[SignalPolicy] = None,
+) -> str:
+    """Render the human-readable execution text for a signal action.
+
+    Args:
+        action: "buy", "sell", or "hold".
+        sequence: Execution sequence number (1-indexed).
+        trade_unit: Number of shares per execution unit.
+        policy: Signal policy used for default text/template selection.
+
+    Returns:
+        Formatted string like "第2次卖出 500 股".
+    """
+    effective_policy = policy or DEFAULT_SIGNAL_POLICY
+    if action == "buy":
+        return f"第{sequence}次买入 {trade_unit} 股"
+    if action == "sell":
+        return f"第{sequence}次卖出 {trade_unit} 股"
+    return effective_policy.no_action_text

--- a/hermes_olin/store.py
+++ b/hermes_olin/store.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .profile import DEFAULT_RUNTIME_PROFILE, RuntimeProfile
+
+DEFAULT_EXECUTION_STATE = {
+    "trade_date": "",
+    "sell_count": 0,
+    "buy_count": 0,
+    "actions": [],
+    "active_signal": None,
+    "last_signal_id": None,
+    "last_signal_action": None,
+    "last_signal_status": None,
+    "last_signal_at": None,
+}
+
+
+class TradingStateStore:
+    def __init__(self, base_dir: str | Path, profile: RuntimeProfile = DEFAULT_RUNTIME_PROFILE):
+        self.base_dir = Path(base_dir)
+        self.profile = profile
+        self.profile_dir = self.base_dir / "profiles" / self.profile.profile_id
+        self.state_dir = self.profile_dir / "state" / "realtime"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, name: str) -> Path:
+        return self.state_dir / name
+
+    def load_json(self, name: str, default: Any = None) -> Any:
+        path = self._path(name)
+        if not path.exists():
+            return default
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return default
+
+    def save_json(self, name: str, payload: Any) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self._path(name).write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def append_jsonl(self, name: str, payload: dict) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        with self._path(name).open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    def read_jsonl(self, name: str) -> list[dict]:
+        path = self._path(name)
+        if not path.exists():
+            return []
+        rows = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+        return rows
+
+    def load_execution_state(self) -> dict:
+        state = self.load_json("execution_state.json", {}) or {}
+        merged = dict(DEFAULT_EXECUTION_STATE)
+        merged.update(state)
+        merged["actions"] = list(merged.get("actions") or [])
+        if merged.get("active_signal") in ({}, []):
+            merged["active_signal"] = None
+        return merged
+
+    def save_execution_state(self, state: dict) -> None:
+        merged = dict(DEFAULT_EXECUTION_STATE)
+        merged.update(state or {})
+        merged["actions"] = list(merged.get("actions") or [])
+        if merged.get("active_signal") in ({}, []):
+            merged["active_signal"] = None
+        self.save_json("execution_state.json", merged)
+
+    def load_pending_signal(self) -> dict:
+        return self.load_json("pending_signal.json", {}) or {}
+
+    def save_pending_signal(self, state: dict) -> None:
+        self.save_json("pending_signal.json", state)
+
+    def clear_pending_signal(self) -> None:
+        self.save_pending_signal({})
+
+    def load_push_state(self) -> dict:
+        return self.load_json("push_state.json", {}) or {}
+
+    def save_push_state(self, state: dict) -> None:
+        self.save_json("push_state.json", state)
+
+    def append_signal_send_history(self, event_type: str, payload: dict) -> None:
+        self.append_jsonl(
+            "signal_send_history.jsonl",
+            {
+                "ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "event": event_type,
+                **payload,
+            },
+        )
+
+    def record_dispatch_event(self, event_type: str, payload: dict) -> None:
+        self.append_jsonl(
+            "dispatch_ledger.jsonl",
+            {
+                "ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "event": event_type,
+                **payload,
+            },
+        )
+
+
+class OlinStateStore(TradingStateStore):
+    def __init__(self, base_dir: str | Path):
+        super().__init__(base_dir, profile=DEFAULT_RUNTIME_PROFILE)

--- a/hermes_t/README.md
+++ b/hermes_t/README.md
@@ -1,0 +1,101 @@
+# Hermes T Runtime
+
+`hermes_t` 是第二阶段开始后的**通用入口 facade**。
+
+当前定位：
+- 默认仍兼容欧林 profile（`olin-688319`）
+- 但对外入口语义已经去欧林化
+- CLI 默认工作目录改为 `~/.hermes_t_runtime`
+- `hermes_t` / `hermes_olin` 已共用 shared CLI builder
+- 已提供多 profile orchestrator 骨架（JSON config -> 多 `RuntimeProfile` 顺序执行）
+- 已提供最小 `TechDataProvider` 插件层：支持 fixed fallback、`--tech-data-config` JSON provider、`--quote-data-config` -> `quote_payload.tech_data` 适配，以及 `--quote-snapshot-config` -> `quote snapshot/real source` 适配
+- 已提供多 profile CLI 编排入口（`--profiles-config` + 可选 `--tech-data-config` / `--quote-data-config` / `--quote-snapshot-config`）
+- 内部继续复用已验证的 `RuntimeProfile` / `TradingStateStore` / `run_runtime_cycle`
+
+## 推荐入口
+
+### 单 profile
+
+```bash
+cd /Users/wj/hermes-agent
+python -m hermes_t --trade-date 20260501 --signal hold
+```
+
+### 多 profile 编排
+
+```bash
+cd /Users/wj/hermes-agent
+python -m hermes_t \
+  --profiles-config ./profiles.json \
+  --tech-data-config ./tech_data.json \
+  --trade-date 20260501
+```
+
+### quote/realtime 适配输入
+
+```bash
+cd /Users/wj/hermes-agent
+python -m hermes_t \
+  --quote-data-config ./quote_data.json \
+  --trade-date 20260501
+```
+
+### quote snapshot / live source 适配输入
+
+```bash
+cd /Users/wj/hermes-agent
+python -m hermes_t \
+  --quote-snapshot-config ./quote_snapshot_config.json \
+  --trade-date 20260501
+```
+
+其中：
+- `profiles.json`：定义多个 `profile_id/symbol/trade_unit/max_trades`
+- `tech_data.json`：可选，定义 `symbol -> tech_data`
+- `quote_data.json`：可选，定义 `symbol -> quote payload`，当前最小口径只读取其中的 `tech_data` 子字段
+- `quote_snapshot_config.json`：可选，可为原始 `symbol -> snapshot` map，或 factory config（如 `{"source":"file"}` / `{"source":"mock"}` / `{"source":"tdx"}`）
+- 若某 symbol 未在 `tech_data.json` / `quote_data.json` / `quote_snapshot_config.json` 中产出可用 `tech_data`，则回退到 CLI 传入的 `--signal/--score`
+- 若同时提供 `--tech-data-config` 与 `--quote-data-config`，当前优先使用 `--tech-data-config`
+- 若同时提供 `--quote-data-config` 与 `--quote-snapshot-config`，当前优先使用 `--quote-data-config`
+
+## quote snapshot source 当前口径
+
+当前 factory 支持：
+- `file`：从 JSON 文件读取 snapshot map
+- `mock`：从 config 内联 `snapshots_by_symbol` 读取
+- `tdx`：最小真实源，使用 `pytdx` 通过 TDX TCP 拉取实时 quote snapshot
+- `eastmoney`：仅占位，当前 `get()` 仍会抛 `NotImplementedError`
+
+### TDX 依赖
+
+若要使用 `{"source":"tdx"}`：
+- 项目依赖已纳入 `pytdx>=1.72,<2`
+- 推荐在项目根目录执行：
+
+```bash
+cd /Users/wj/hermes-agent
+uv sync
+```
+
+### TDX 失败语义（当前正式口径）
+
+- `TdxQuoteSnapshotSource.get(symbol)` 自身仍保持严格语义：
+  - `pytdx` 不可用 -> 抛 `RuntimeError("pytdx unavailable")`
+  - 全部 server 连接失败 / 空 quote / `price <= 0` -> 抛运行时错误
+- 但 `QuoteSnapshotTechDataAdapter` 在 runtime 适配层会兜底：
+  - 若上游 snapshot source 抛异常，则回退到默认 `tech_data`
+  - 因此 `--quote-snapshot-config {"source":"tdx"}` 在运行期临时取数失败时，不会直接把 runtime 主链打崩，而是回退到默认信号口径
+
+## 当前边界
+
+这还不是最终的多股票自动编排系统；当前只是把正式入口从“欧林专用包”推进到“通用 facade + 欧林兼容层 + 最小多 profile 编排入口”。
+
+当前 `quote/realtime` 插件化仍是**最小适配层**：
+- `run_runtime_cycle()` 继续只消费 `tech_data`
+- `hermes_t` 入口层负责把外部 quote/realtime 原始输入适配成 `tech_data`
+- 后续若接 TDX / 东财 / 真实实时源，再在这一层继续扩 provider，而不侵入 runtime 主链
+
+## 兼容关系
+
+- `hermes_t`：今后优先使用的通用入口
+- `hermes_olin`：保留，继续服务现有欧林兼容调用

--- a/hermes_t/__init__.py
+++ b/hermes_t/__init__.py
@@ -12,6 +12,7 @@ from hermes_olin.runtime import (
     stage_pending_signal,
 )
 from hermes_olin.store import TradingStateStore
+from hermes_t.post_market_review import build_post_market_review
 from hermes_t.tech_data import FixedTechDataProvider, JsonSymbolTechDataProvider, TechDataProvider, build_tech_data_provider
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "TechDataProvider",
     "FixedTechDataProvider",
     "JsonSymbolTechDataProvider",
+    "build_post_market_review",
     "build_tech_data_provider",
     "arbitrate_candidate",
     "build_execution_suggestion",

--- a/hermes_t/__init__.py
+++ b/hermes_t/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from hermes_olin.profile import DEFAULT_RUNTIME_PROFILE, RuntimeProfile
+from hermes_olin.runtime import (
+    arbitrate_candidate,
+    build_execution_suggestion,
+    confirm_dispatch_sent,
+    deliver_pending_signal,
+    dispatch_ledger_sent_event,
+    recover_signal_runtime,
+    run_runtime_cycle,
+    stage_pending_signal,
+)
+from hermes_olin.store import TradingStateStore
+from hermes_t.tech_data import FixedTechDataProvider, JsonSymbolTechDataProvider, TechDataProvider, build_tech_data_provider
+
+__all__ = [
+    "RuntimeProfile",
+    "DEFAULT_RUNTIME_PROFILE",
+    "TradingStateStore",
+    "TechDataProvider",
+    "FixedTechDataProvider",
+    "JsonSymbolTechDataProvider",
+    "build_tech_data_provider",
+    "arbitrate_candidate",
+    "build_execution_suggestion",
+    "stage_pending_signal",
+    "confirm_dispatch_sent",
+    "dispatch_ledger_sent_event",
+    "deliver_pending_signal",
+    "recover_signal_runtime",
+    "run_runtime_cycle",
+]

--- a/hermes_t/__main__.py
+++ b/hermes_t/__main__.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_t.cli_shared import build_runtime_parser, build_runtime_profile_from_args, build_runtime_store
+from hermes_t.orchestrator import run_profiles_from_config
+from hermes_t.tech_data import build_tech_data_provider
+from hermes_olin.runtime import run_runtime_cycle
+
+
+def _build_parser():
+    parser = build_runtime_parser(
+        description="Run one Hermes generalized T-runtime cycle",
+        default_base_dir_name=".hermes_t_runtime",
+        channel_env_vars=("HERMES_T_CHANNEL", "HERMES_OLIN_CHANNEL"),
+        chat_id_env_vars=("HERMES_T_CHAT_ID", "HERMES_OLIN_CHAT_ID"),
+        thread_id_env_vars=("HERMES_T_THREAD_ID", "HERMES_OLIN_THREAD_ID"),
+    )
+    parser.add_argument("--profiles-config", help="JSON file defining multiple runtime profiles for orchestrated execution.")
+    parser.add_argument("--tech-data-config", help="Optional JSON file mapping symbol -> tech_data payload for multi-profile runs.")
+    parser.add_argument("--quote-data-config", help="Optional JSON file mapping symbol -> quote payload; when provided, nested quote_payload.tech_data is used as runtime tech_data.")
+    parser.add_argument("--quote-snapshot-config", help="Optional JSON file for offline quote snapshots: either a raw symbol -> snapshot map, or a factory config like {source, snapshot_path|snapshots_by_symbol}; nested snapshot.tech_data is used as runtime tech_data.")
+    return parser
+
+
+def _runtime_delivery_kwargs(args) -> dict[str, object]:
+    return {
+        "effective_trade_date": args.trade_date,
+        "dispatch": args.dispatch,
+        "channel": args.channel,
+        "chat_id": args.chat_id,
+        "thread_id": args.thread_id,
+    }
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    default_tech_data = {"summary_signal": args.signal, "score": {"total": args.score}}
+    tech_data_provider = build_tech_data_provider(
+        tech_data_config_path=args.tech_data_config,
+        quote_data_config_path=args.quote_data_config,
+        quote_snapshot_config_path=args.quote_snapshot_config,
+        default_tech_data=default_tech_data,
+    )
+    runtime_kwargs = _runtime_delivery_kwargs(args)
+    if args.profiles_config:
+        payload = run_profiles_from_config(
+            config_path=args.profiles_config,
+            base_dir=args.base_dir,
+            tech_data_provider=tech_data_provider,
+            **runtime_kwargs,
+        )
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+
+    profile = build_runtime_profile_from_args(args)
+    store = build_runtime_store(
+        base_dir=args.base_dir,
+        profile=profile,
+        prefer_legacy_olin_store=False,
+    )
+    payload = run_runtime_cycle(
+        store,
+        tech_data=tech_data_provider.get(profile.symbol),
+        **runtime_kwargs,
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_t/cli_shared.py
+++ b/hermes_t/cli_shared.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+from hermes_olin.profile import DEFAULT_RUNTIME_PROFILE, RuntimeProfile
+from hermes_olin.store import OlinStateStore, TradingStateStore
+from hermes_t.orchestrator import _build_runtime_profile_from_item
+
+
+def parse_trade_date(value: str) -> str:
+    try:
+        datetime.strptime(value, "%Y%m%d")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("trade-date must use YYYYMMDD format") from exc
+    return value
+
+
+def build_runtime_parser(
+    *,
+    description: str,
+    default_base_dir_name: str,
+    channel_env_vars: Sequence[str],
+    chat_id_env_vars: Sequence[str] = (),
+    thread_id_env_vars: Sequence[str] = (),
+) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--base-dir",
+        default=str(Path.home() / default_base_dir_name),
+        help="Runtime working directory. State files are stored under profiles/<profile-id>/state/realtime/",
+    )
+    parser.add_argument("--profile-id", default=DEFAULT_RUNTIME_PROFILE.profile_id, help="Runtime profile id used to scope state and metadata.")
+    parser.add_argument("--symbol", default=DEFAULT_RUNTIME_PROFILE.symbol, help="Stock symbol for this runtime profile.")
+    parser.add_argument("--trade-unit", type=int, default=DEFAULT_RUNTIME_PROFILE.trade_unit, help="Shares per execution unit for this runtime profile.")
+    parser.add_argument("--max-trades", type=int, default=DEFAULT_RUNTIME_PROFILE.max_trades, help="Max intraday T trades per side for this runtime profile.")
+    parser.add_argument("--trade-date", type=parse_trade_date, default=datetime.now().strftime("%Y%m%d"), help="Effective trade date, format YYYYMMDD")
+    parser.add_argument("--signal", choices=["buy", "sell", "hold"], default="hold", help="Summary signal for this cycle")
+    parser.add_argument("--score", type=int, default=50, help="Total score used to decide buy/sell thresholds")
+    parser.add_argument("--dispatch", action="store_true", help="Dispatch pending signal through Hermes gateway")
+    parser.add_argument("--channel", default=_env_first(channel_env_vars, "feishu"), help="Dispatch channel, default feishu.")
+    parser.add_argument("--chat-id", default=_env_first(chat_id_env_vars, None), help="Explicit dispatch chat_id.")
+    parser.add_argument("--thread-id", default=_env_first(thread_id_env_vars, None), help="Explicit dispatch thread_id.")
+    return parser
+
+
+def build_runtime_profile_from_args(args: argparse.Namespace) -> RuntimeProfile:
+    return _build_runtime_profile_from_item(
+        item={
+            "profile_id": args.profile_id,
+            "symbol": args.symbol,
+            "trade_unit": args.trade_unit,
+            "max_trades": args.max_trades,
+        },
+        idx=0,
+    )
+
+
+def build_runtime_store(*, base_dir: str | os.PathLike[str], profile: RuntimeProfile, prefer_legacy_olin_store: bool) -> TradingStateStore:
+    if prefer_legacy_olin_store and profile == DEFAULT_RUNTIME_PROFILE:
+        return OlinStateStore(base_dir)
+    return TradingStateStore(base_dir, profile=profile)
+
+
+def _env_first(names: Sequence[str], fallback: str | None) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return fallback

--- a/hermes_t/orchestrator.py
+++ b/hermes_t/orchestrator.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+from hermes_olin.profile import RuntimeProfile
+from hermes_olin.runtime import run_runtime_cycle
+from hermes_olin.store import TradingStateStore
+from hermes_t.tech_data import TechDataProvider
+
+
+def _missing_required_fields(item: dict, required_fields: tuple[str, ...]) -> list[str]:
+    missing_fields: list[str] = []
+    for field in required_fields:
+        value = item.get(field)
+        if isinstance(value, str):
+            if not value.strip():
+                missing_fields.append(field)
+            continue
+        if not value:
+            missing_fields.append(field)
+    return missing_fields
+
+
+def _validated_positive_int(*, value: object, field_name: str, idx: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"profile item {idx} field {field_name} must be a positive integer")
+    return value
+
+
+def _build_runtime_profile_from_item(*, item: dict, idx: int) -> RuntimeProfile:
+    missing_fields = _missing_required_fields(item, ("profile_id", "symbol"))
+    if missing_fields:
+        raise ValueError(f"profile item {idx} missing required fields: {', '.join(missing_fields)}")
+
+    for field_name in ("profile_id", "symbol"):
+        value = item[field_name]
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"profile item {idx} field {field_name} must be a non-empty string")
+
+    trade_unit = _validated_positive_int(value=item.get("trade_unit", 10000), field_name="trade_unit", idx=idx)
+    max_trades = _validated_positive_int(value=item.get("max_trades", 4), field_name="max_trades", idx=idx)
+    return RuntimeProfile(
+        profile_id=item["profile_id"],
+        symbol=item["symbol"],
+        trade_unit=trade_unit,
+        max_trades=max_trades,
+    )
+
+
+def load_runtime_profiles_from_json(config_path: str | Path) -> list[RuntimeProfile]:
+    payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("runtime profiles config must be a JSON list")
+
+    profiles: list[RuntimeProfile] = []
+    seen_profile_ids: set[str] = set()
+    for idx, item in enumerate(payload):
+        if not isinstance(item, dict):
+            raise ValueError(f"profile item {idx} must be a JSON object")
+
+        profile = _build_runtime_profile_from_item(item=item, idx=idx)
+        if profile.profile_id in seen_profile_ids:
+            raise ValueError(f"duplicate profile_id '{profile.profile_id}' at item {idx}")
+        seen_profile_ids.add(profile.profile_id)
+        profiles.append(profile)
+    return profiles
+
+
+def run_profiles_from_config(
+    *,
+    config_path: str | Path,
+    base_dir: str | Path,
+    tech_data_provider: TechDataProvider,
+    effective_trade_date: str,
+    dispatch: bool = False,
+    channel: str = "feishu",
+    chat_id: str | None = None,
+    thread_id: str | None = None,
+    runner: Callable = run_runtime_cycle,
+) -> dict:
+    results = []
+    for profile in load_runtime_profiles_from_json(config_path):
+        store = TradingStateStore(base_dir, profile=profile)
+        payload = runner(
+            store,
+            tech_data=tech_data_provider.get(profile.symbol),
+            effective_trade_date=effective_trade_date,
+            dispatch=dispatch,
+            channel=channel,
+            chat_id=chat_id,
+            thread_id=thread_id,
+        )
+        results.append({"profile_id": profile.profile_id, "symbol": profile.symbol, "payload": payload})
+    return {"config_path": str(config_path), "total_profiles": len(results), "results": results}

--- a/hermes_t/post_market_review.py
+++ b/hermes_t/post_market_review.py
@@ -1,0 +1,223 @@
+"""Post-market review for T-trading: P&L, cost reduction, position tracking.
+
+Reads execution state + position config, computes daily and monthly summary.
+No state mutation — pure reader + calculator.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hermes_olin.store import TradingStateStore
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+_POSITION_FILENAME = "position.json"
+
+
+def _load_position(store: TradingStateStore) -> dict | None:
+    """Load position.json from store's state directory."""
+    pos_path = store.state_dir / _POSITION_FILENAME
+    if not pos_path.exists():
+        return None
+    try:
+        return store.load_json(_POSITION_FILENAME)
+    except Exception:
+        return None
+
+
+def _calc_round_trip_pnl(pairs: list[tuple[dict, dict]]) -> float:
+    """Calculate realized P&L from paired sell→buy sequences.
+
+    Each pair is (sell_action, buy_action).
+    P&L per round = (sell_price - buy_price) * shares
+    """
+    total = 0.0
+    for sell, buy in pairs:
+        sell_px = float(sell.get("price", 0) or 0)
+        buy_px = float(buy.get("price", 0) or 0)
+        # Use min shares between sell and buy to cap at round-trip size
+        shares = min(
+            int(sell.get("shares", 0) or 0),
+            int(buy.get("shares", 0) or 0),
+        )
+        total += (sell_px - buy_px) * shares
+    return total
+
+
+def _pair_actions(actions: list[dict]) -> tuple[list[tuple[dict, dict]], int, int]:
+    """Greedy pair sell→buy sequences from an ordered action list.
+
+    Returns (pairs, unpaired_sell_shares, unpaired_buy_shares).
+    Only pairs if a sell is followed by a buy (T-short-first pattern).
+    """
+    sells: list[dict] = []
+    buys: list[dict] = []
+    for a in actions:
+        a_action = str(a.get("action", "") or "").strip().lower()
+        if a_action == "sell":
+            sells.append(a)
+        elif a_action == "buy":
+            buys.append(a)
+
+    # Greedy pairing: pair sells[i] with buys[i] in order
+    min_len = min(len(sells), len(buys))
+    pairs: list[tuple[dict, dict]] = []
+    for i in range(min_len):
+        pairs.append((sells[i], buys[i]))
+
+    unpaired_sells = sells[min_len:]
+    unpaired_buys = buys[min_len:]
+
+    unpaired_sell_shares = sum(int(a.get("shares", 0) or 0) for a in unpaired_sells)
+    unpaired_buy_shares = sum(int(a.get("shares", 0) or 0) for a in unpaired_buys)
+
+    return pairs, unpaired_sell_shares, unpaired_buy_shares
+
+
+def _summarize_month_ledger(store: TradingStateStore, *, trade_date: str) -> float:
+    """Read dispatch_ledger.jsonl and sum same-month prior realized P&L only.
+
+    Rows from other months are ignored. Rows with a matching trade_date are also
+    skipped to avoid double-counting today's realized P&L, which is already
+    computed from today's execution actions. If a row has no trade_date field,
+    keep backward compatibility by including it.
+    """
+    month_prefix = trade_date[:7]
+    rows = store.read_jsonl("dispatch_ledger.jsonl")
+    total = 0.0
+    for row in rows:
+        row_trade_date = str(row.get("trade_date", "") or "")
+        if row_trade_date:
+            if month_prefix and not row_trade_date.startswith(month_prefix):
+                continue
+            if row_trade_date == trade_date:
+                continue
+        profit = row.get("profit")
+        if profit is not None:
+            total += float(profit)
+    return total
+
+
+# ── main entry ───────────────────────────────────────────────────────────────
+
+TRADE_DATE_REQUIRED = "trade_date is required"
+
+
+def build_post_market_review(
+    store: TradingStateStore,
+    *,
+    trade_date: str = "",
+) -> dict[str, Any]:
+    """Build a post-market review from store state.
+
+    Args:
+        store: TradingStateStore pointing to the profile's state directory.
+        trade_date: YYYY-MM-DD trade date (required).
+
+    Returns:
+        dict with keys: trade_date, symbol, summary, trades
+    """
+    if not trade_date:
+        raise ValueError(TRADE_DATE_REQUIRED)
+
+    exec_state = store.load_execution_state()
+    actions: list[dict] = list(exec_state.get("actions") or [])
+    position = _load_position(store)
+
+    # ── symbol ──────────────────────────────────────────────────────────
+    symbol = str(store.profile.symbol)
+    if position:
+        symbol = str(position.get("symbol", symbol))
+
+    # ── position stats ──────────────────────────────────────────────────
+    if position:
+        total_shares = int(position.get("total_shares", 0) or 0)
+        avg_cost_before = float(position.get("avg_cost", 0.0) or 0.0)
+        available_cash = float(position.get("available_cash", 0.0) or 0.0)
+        month_start_cost = float(position.get("month_start_cost", avg_cost_before) or avg_cost_before)
+        month_target_pct = float(position.get("month_target_reduction_pct", 0.03) or 0.03) * 100.0
+    else:
+        total_shares = 0
+        avg_cost_before = 0.0
+        available_cash = 0.0
+        month_start_cost = 0.0
+        month_target_pct = 3.0
+
+    # ── tally ───────────────────────────────────────────────────────────
+    sell_count = sum(1 for a in actions if str(a.get("action", "") or "").strip().lower() == "sell")
+    buy_count = sum(1 for a in actions if str(a.get("action", "") or "").strip().lower() == "buy")
+
+    pairs, unpaired_sell_shares, unpaired_buy_shares = _pair_actions(actions)
+
+    realized_pnl = _calc_round_trip_pnl(pairs)
+    net_shares_sold = unpaired_sell_shares - unpaired_buy_shares
+
+    # ── cost reduction ──────────────────────────────────────────────────
+    cost_reduction_per_share = 0.0
+    avg_cost_after = avg_cost_before
+    if total_shares > 0:
+        reduction_abs = realized_pnl / total_shares
+        cost_reduction_per_share = reduction_abs
+        avg_cost_after = avg_cost_before - reduction_abs
+
+    # ── month cumulative ────────────────────────────────────────────────
+    prior_month_pnl = _summarize_month_ledger(store, trade_date=trade_date)
+    month_cumulative_pnl = prior_month_pnl + realized_pnl
+    month_cumulative_reduction_per_share = 0.0
+    if total_shares > 0:
+        month_cumulative_reduction_abs = month_cumulative_pnl / total_shares
+        month_cumulative_reduction_per_share = month_cumulative_reduction_abs
+    month_target_met = False
+    if total_shares > 0 and month_start_cost > 0:
+        target_per_share = (month_target_pct / 100.0) * month_start_cost
+        month_target_met = month_cumulative_reduction_per_share >= target_per_share
+
+    # ── available_cash change estimation ────────────────────────────────
+    # Net cash flow: sells bring in cash, buys take it out
+    cash_flow = 0.0
+    for a in actions:
+        px = float(a.get("price", 0) or 0)
+        shares = int(a.get("shares", 0) or 0)
+        a_action = str(a.get("action", "") or "").strip().lower()
+        if a_action == "sell":
+            cash_flow += px * shares
+        elif a_action == "buy":
+            cash_flow -= px * shares
+
+    available_cash_after = available_cash + cash_flow
+
+    # ── build output ────────────────────────────────────────────────────
+    trades_out = []
+    for a in actions:
+        trades_out.append({
+            "seq": int(a.get("seq", 0) or 0),
+            "action": str(a.get("action", "") or ""),
+            "price": float(a.get("price", 0) or 0),
+            "shares": int(a.get("shares", 0) or 0),
+            "signal": str(a.get("signal", "") or ""),
+            "score": int(a.get("score", 0) or 0),
+            "timestamp": str(a.get("timestamp", "") or ""),
+        })
+
+    return {
+        "trade_date": trade_date,
+        "symbol": symbol,
+        "summary": {
+            "total_trades": sell_count + buy_count,
+            "sell_count": sell_count,
+            "buy_count": buy_count,
+            "net_shares_sold": net_shares_sold,
+            "realized_pnl": realized_pnl,
+            "avg_cost_before": round(avg_cost_before, 3),
+            "avg_cost_after": round(avg_cost_after, 6),
+            "cost_reduction_per_share": round(cost_reduction_per_share, 8),
+            "month_cumulative_pnl": round(month_cumulative_pnl, 2),
+            "month_cumulative_reduction_per_share": round(month_cumulative_reduction_per_share, 8),
+            "month_target_pct": round(month_target_pct, 2),
+            "month_target_met": month_target_met,
+            "available_cash": round(available_cash_after, 2),
+            "available_cash_change": round(cash_flow, 2),
+        },
+        "trades": trades_out,
+    }

--- a/hermes_t/tech_data.py
+++ b/hermes_t/tech_data.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime
+import json
+import logging
+from pathlib import Path
+from typing import Any, Protocol, TypedDict
+
+try:
+    from pytdx.hq import TdxHq_API
+except Exception:  # pragma: no cover - optional dependency fallback
+    TdxHq_API = None
+
+
+class QuoteProvider(Protocol):
+    def get(self, symbol: str) -> dict:
+        ...
+
+
+class RealtimeSource(Protocol):
+    def get(self, symbol: str) -> QuoteSnapshot | dict:
+        ...
+
+
+class TechDataProvider(Protocol):
+    def get(self, symbol: str) -> dict:
+        ...
+
+
+class QuoteSnapshot(TypedDict, total=False):
+    symbol: str
+    last_price: float
+    source: str
+    as_of: str
+    tech_data: dict
+
+
+logger = logging.getLogger(__name__)
+
+
+def _deepcopy_dict(payload: dict) -> dict:
+    return deepcopy(payload or {})
+
+
+def _default_tech_data_payload(default_tech_data: dict | None = None) -> dict:
+    return _deepcopy_dict(default_tech_data or {"summary_signal": "hold", "score": {"total": 50}})
+
+
+def _normalize_quote_snapshot(symbol: str, payload: dict | None) -> QuoteSnapshot | dict:
+    raw = dict(payload or {})
+    if not raw:
+        return {}
+
+    normalized_symbol = str(raw.get("symbol") or symbol)
+    snapshot: QuoteSnapshot = {"symbol": normalized_symbol}
+    if raw.get("last_price") is not None:
+        snapshot["last_price"] = raw["last_price"]
+    if raw.get("source") is not None:
+        snapshot["source"] = str(raw["source"])
+    if raw.get("as_of") is not None:
+        snapshot["as_of"] = str(raw["as_of"])
+    if raw.get("tech_data") is not None:
+        snapshot["tech_data"] = _deepcopy_dict(raw["tech_data"] or {})
+    return snapshot
+
+
+def _load_json_file(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+_DEFAULT_TDX_SERVERS: list[tuple[str, str, int]] = [
+    ("广发深圳", "183.60.224.178", 7709),
+    ("招商深圳云", "39.108.28.83", 7709),
+    ("招商武汉电信", "119.97.185.5", 7709),
+    ("华泰南京", "221.231.141.60", 7709),
+    ("银河北京", "218.108.98.244", 7709),
+]
+
+
+def _infer_tdx_market(symbol: str) -> int:
+    normalized = str(symbol)
+    if normalized.startswith(("5", "6", "9")):
+        return 1
+    return 0
+
+
+class FixedTechDataProvider:
+    def __init__(self, tech_data: dict):
+        self._tech_data = _deepcopy_dict(tech_data)
+
+    def get(self, symbol: str) -> dict:
+        return _deepcopy_dict(self._tech_data)
+
+
+class JsonSymbolTechDataProvider:
+    def __init__(self, *, tech_data_by_symbol: dict[str, dict], default_tech_data: dict | None = None):
+        self._tech_data_by_symbol = {str(symbol): _deepcopy_dict(payload or {}) for symbol, payload in (tech_data_by_symbol or {}).items()}
+        self._default_tech_data = _default_tech_data_payload(default_tech_data)
+
+    def get(self, symbol: str) -> dict:
+        return _deepcopy_dict(self._tech_data_by_symbol.get(str(symbol), self._default_tech_data))
+
+
+class JsonQuoteDataProvider:
+    def __init__(self, *, quote_data_by_symbol: dict[str, dict]):
+        self._quote_data_by_symbol = {str(symbol): _deepcopy_dict(payload or {}) for symbol, payload in (quote_data_by_symbol or {}).items()}
+
+    def get(self, symbol: str) -> dict:
+        return _deepcopy_dict(self._quote_data_by_symbol.get(str(symbol), {}))
+
+
+class InMemoryQuoteSnapshotProvider:
+    def __init__(self, *, snapshots_by_symbol: dict[str, dict]):
+        self._snapshots_by_symbol = {
+            str(symbol): _normalize_quote_snapshot(str(symbol), payload)
+            for symbol, payload in (snapshots_by_symbol or {}).items()
+        }
+
+    def get(self, symbol: str) -> QuoteSnapshot | dict:
+        snapshot = self._snapshots_by_symbol.get(str(symbol), {})
+        return _deepcopy_dict(snapshot)
+
+
+class FileQuoteSnapshotProvider:
+    def __init__(self, *, snapshot_path: str | Path):
+        payload = _load_json_file(snapshot_path)
+        self._provider = InMemoryQuoteSnapshotProvider(snapshots_by_symbol=payload)
+
+    def get(self, symbol: str) -> QuoteSnapshot | dict:
+        return self._provider.get(symbol)
+
+
+class TdxQuoteSnapshotSource:
+    def __init__(
+        self,
+        *,
+        api_cls: type | None = None,
+        servers: list[tuple[str, str, int]] | None = None,
+        market_by_symbol: dict[str, int] | None = None,
+    ):
+        self._api_cls = api_cls or TdxHq_API
+        self._servers = list(servers or _DEFAULT_TDX_SERVERS)
+        self._market_by_symbol = {str(symbol): int(market) for symbol, market in (market_by_symbol or {}).items()}
+
+    def get(self, symbol: str) -> QuoteSnapshot | dict:
+        if self._api_cls is None:
+            raise RuntimeError("pytdx unavailable")
+
+        normalized_symbol = str(symbol)
+        market = self._market_by_symbol.get(normalized_symbol, _infer_tdx_market(normalized_symbol))
+        last_error: Exception | None = None
+
+        for _server_name, host, port in self._servers:
+            api = self._api_cls(heartbeat=True, auto_retry=True, raise_exception=False)
+            try:
+                ok = api.connect(host, port, time_out=3)
+                if not ok:
+                    raise RuntimeError(f"connect failed: {host}:{port}")
+
+                rows = api.get_security_quotes([(market, normalized_symbol)])
+                if not rows:
+                    raise RuntimeError(f"empty quote: {host}:{port}")
+
+                row = rows[0] or {}
+                price = float(row.get("price") or 0)
+                if price <= 0:
+                    raise RuntimeError(
+                        f"invalid quote price={price} from {host}:{port} servertime={row.get('servertime')}"
+                    )
+
+                servertime = str(row.get("servertime") or datetime.now().strftime("%H:%M:%S"))
+                snapshot: QuoteSnapshot = {
+                    "symbol": normalized_symbol,
+                    "last_price": price,
+                    "source": "tdx_tcp",
+                    "as_of": servertime,
+                }
+                if row.get("tech_data") is not None:
+                    snapshot["tech_data"] = _deepcopy_dict(row.get("tech_data") or {})
+                return snapshot
+            except Exception as exc:
+                last_error = exc
+            finally:
+                try:
+                    api.disconnect()
+                except Exception:
+                    pass
+
+        raise RuntimeError(f"all tdx servers failed or returned invalid quotes: {last_error}")
+
+
+class EastmoneyQuoteSnapshotSource:
+    def get(self, symbol: str) -> QuoteSnapshot | dict:
+        raise NotImplementedError("eastmoney quote snapshot source is not implemented")
+
+
+def build_quote_snapshot_provider(
+    *,
+    source: str,
+    snapshot_path: str | Path | None = None,
+    snapshots_by_symbol: dict[str, dict] | None = None,
+) -> RealtimeSource:
+    normalized_source = str(source).strip().lower()
+    if normalized_source == "file":
+        if snapshot_path is None:
+            raise ValueError("snapshot_path is required for file quote snapshot source")
+        return FileQuoteSnapshotProvider(snapshot_path=snapshot_path)
+    if normalized_source == "mock":
+        return InMemoryQuoteSnapshotProvider(snapshots_by_symbol=snapshots_by_symbol or {})
+    if normalized_source == "tdx":
+        return TdxQuoteSnapshotSource()
+    if normalized_source == "eastmoney":
+        return EastmoneyQuoteSnapshotSource()
+    raise ValueError(f"Unsupported quote snapshot source: {source}")
+
+
+class QuoteTechDataAdapter:
+    def __init__(self, *, quote_provider: QuoteProvider, default_tech_data: dict | None = None):
+        self._quote_provider = quote_provider
+        self._default_tech_data = _default_tech_data_payload(default_tech_data)
+
+    def get(self, symbol: str) -> dict:
+        payload = _deepcopy_dict(self._quote_provider.get(symbol) or {})
+        tech_data = payload.get("tech_data") or self._default_tech_data
+        return _deepcopy_dict(tech_data)
+
+
+class QuoteSnapshotTechDataAdapter:
+    def __init__(self, *, quote_source: RealtimeSource, default_tech_data: dict | None = None):
+        self._quote_source = quote_source
+        self._default_tech_data = _default_tech_data_payload(default_tech_data)
+
+    def get(self, symbol: str) -> dict:
+        try:
+            payload = _deepcopy_dict(self._quote_source.get(symbol) or {})
+        except Exception as exc:
+            logger.warning(
+                "quote snapshot source failed; falling back to default tech_data",
+                extra={"symbol": str(symbol), "error": repr(exc)},
+            )
+            return _deepcopy_dict(self._default_tech_data)
+        tech_data = payload.get("tech_data") or self._default_tech_data
+        return _deepcopy_dict(tech_data)
+
+
+def _build_quote_snapshot_provider_from_config_path(config_path: str | Path) -> RealtimeSource:
+    config_file = Path(config_path)
+    payload = _load_json_file(config_file)
+    if isinstance(payload, dict) and payload.get("source"):
+        snapshot_path = payload.get("snapshot_path")
+        if snapshot_path is not None:
+            snapshot_path = Path(snapshot_path)
+            if not snapshot_path.is_absolute():
+                snapshot_path = config_file.parent / snapshot_path
+        return build_quote_snapshot_provider(
+            source=payload["source"],
+            snapshot_path=snapshot_path,
+            snapshots_by_symbol=payload.get("snapshots_by_symbol"),
+        )
+    return InMemoryQuoteSnapshotProvider(snapshots_by_symbol=payload)
+
+
+def build_tech_data_provider(
+    *,
+    tech_data_config_path: str | Path | None,
+    quote_data_config_path: str | Path | None = None,
+    quote_snapshot_config_path: str | Path | None = None,
+    default_tech_data: dict | None = None,
+) -> TechDataProvider:
+    if tech_data_config_path:
+        payload = _load_json_file(tech_data_config_path)
+        return JsonSymbolTechDataProvider(
+            tech_data_by_symbol=payload,
+            default_tech_data=default_tech_data,
+        )
+    if quote_data_config_path:
+        payload = _load_json_file(quote_data_config_path)
+        return QuoteTechDataAdapter(
+            quote_provider=JsonQuoteDataProvider(quote_data_by_symbol=payload),
+            default_tech_data=default_tech_data,
+        )
+    if quote_snapshot_config_path:
+        return QuoteSnapshotTechDataAdapter(
+            quote_source=_build_quote_snapshot_provider_from_config_path(quote_snapshot_config_path),
+            default_tech_data=default_tech_data,
+        )
+    return FixedTechDataProvider(_default_tech_data_payload(default_tech_data))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.12.0"
+version = "0.10.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -30,8 +30,8 @@ dependencies = [
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",
   "fal-client>=0.13.1,<1",
-  # Cron scheduler (built-in feature — scheduled cron/interval jobs use croniter).
-  "croniter>=6.0.0,<7",
+  # Live quote source used by hermes_t quote_snapshot_config={\"source\":\"tdx\"}
+  "pytdx>=1.72,<2",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts>=7.2.7,<8",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
@@ -41,12 +41,11 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
-vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
-messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
-cron = []  # croniter is now a core dependency; this extra kept for back-compat
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
+messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
+cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
-matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29", "aiohttp-socks>=0.10,<1"]
+matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29"]
 cli = ["simple-term-menu>=1.0,<2"]
 tts-premium = ["elevenlabs>=1.0,<2"]
 voice = [
@@ -79,18 +78,8 @@ termux = [
   "hermes-agent[honcho]",
   "hermes-agent[acp]",
 ]
-dingtalk = ["dingtalk-stream>=0.20,<1", "alibabacloud-dingtalk>=2.0.0", "qrcode>=7.0,<8"]
-feishu = ["lark-oapi>=1.5.3,<2", "qrcode>=7.0,<8"]
-google = [
-  # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
-  # Sheets, Docs).  Declared here so packagers (Nix, Homebrew) ship them with
-  # the [all] extra and users don't hit runtime `pip install` paths that fail
-  # in environments without pip (e.g. Nix-managed Python).
-  "google-api-python-client>=2.100,<3",
-  "google-auth-oauthlib>=1.0,<2",
-  "google-auth-httplib2>=0.2,<1",
-]
-# `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
+dingtalk = ["dingtalk-stream>=0.1.0,<1"]
+feishu = ["lark-oapi>=1.5.3,<2"]
 web = ["fastapi>=0.104.0,<1", "uvicorn[standard]>=0.24.0,<1"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git@c20c85256e5a45ad31edf8b7276e9c5ee1995a30",
@@ -103,7 +92,6 @@ yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git@bfb0c88
 all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
-  "hermes-agent[vercel]",
   "hermes-agent[messaging]",
   # matrix: python-olm (required by matrix-nio[e2e]) is upstream-broken on
   # modern macOS (archived libolm, C++ errors with Clang 21+).  On Linux the
@@ -123,7 +111,6 @@ all = [
   "hermes-agent[voice]",
   "hermes-agent[dingtalk]",
   "hermes-agent[feishu]",
-  "hermes-agent[google]",
   "hermes-agent[mistral]",
   "hermes-agent[bedrock]",
   "hermes-agent[web]",
@@ -141,7 +128,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "hermes_olin", "hermes_olin.*", "hermes_t", "hermes_t.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -149,28 +136,3 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
 addopts = "-m 'not integration' -n auto"
-
-[tool.ty.environment]
-python-version = "3.13"
-
-[tool.ty.rules]
-unknown-argument = "warn"
-redundant-cast = "ignore"
-
-[tool.ty.src]
-exclude = ["**"]
-
-[[tool.ty.overrides]]
-include = ["**"]
-
-[tool.ty.overrides.rules]
-unresolved-import = "ignore"
-invalid-method-override = "ignore"
-invalid-assignment = "ignore"
-not-iterable = "ignore"
-
-[tool.ruff]
-exclude = ["*"]
-
-[tool.uv]
-exclude-newer = "7 days"

--- a/tests/test_hermes_olin_runtime.py
+++ b/tests/test_hermes_olin_runtime.py
@@ -1,0 +1,1861 @@
+from datetime import datetime
+import json
+import sys
+
+import pytest
+
+from hermes_olin.profile import RuntimeProfile
+from hermes_olin.runtime import (
+    arbitrate_candidate,
+    build_execution_suggestion,
+    confirm_dispatch_sent,
+    deliver_pending_signal,
+    recover_signal_runtime,
+    run_runtime_cycle,
+    stage_pending_signal,
+)
+from hermes_olin.store import OlinStateStore, TradingStateStore
+
+def test_default_runtime_profile_keeps_olin_compatible_values():
+    from hermes_olin.profile import DEFAULT_RUNTIME_PROFILE
+
+    assert DEFAULT_RUNTIME_PROFILE.profile_id == "olin-688319"
+    assert DEFAULT_RUNTIME_PROFILE.symbol == "688319"
+    assert DEFAULT_RUNTIME_PROFILE.trade_unit == 10000
+    assert DEFAULT_RUNTIME_PROFILE.max_trades == 4
+
+def test_olin_state_store_remains_backward_compatible(tmp_path):
+    store = OlinStateStore(tmp_path)
+
+    assert store.profile.profile_id == "olin-688319"
+    assert store.profile.symbol == "688319"
+
+def test_build_execution_suggestion_uses_execution_state_sequence(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 2,
+            "buy_count": 1,
+            "actions": [{"signal_id": "older"}],
+            "active_signal": None,
+            "last_signal_id": "older",
+            "last_signal_action": "sell",
+            "last_signal_status": "sent",
+            "last_signal_at": "2026-04-22 09:20:00",
+        }
+    )
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "sell", "score": {"total": 20}},
+        "20260422",
+    )
+
+    assert suggestion["next_action"] == "sell"
+    assert suggestion["sequence"] == 3
+    assert suggestion["execution_state"]["sell_count"] == 2
+    assert suggestion["state_snapshot"]["actions"][0]["signal_id"] == "older"
+
+
+def test_build_execution_suggestion_holds_when_active_signal_exists(tmp_path):
+    from hermes_olin.signal_policy import DEFAULT_SIGNAL_POLICY
+
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        }
+    )
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "sell", "score": {"total": 20}},
+        "20260422",
+    )
+
+    assert suggestion["next_action"] == "hold"
+    assert suggestion["sequence"] == 0
+    assert suggestion["reason"] == "active_signal_exists"
+    assert suggestion["text"] == DEFAULT_SIGNAL_POLICY.active_signal_hold_text
+
+
+def test_build_execution_suggestion_uses_policy_no_action_text(tmp_path):
+    from hermes_olin.signal_policy import DEFAULT_SIGNAL_POLICY
+
+    store = OlinStateStore(tmp_path)
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "hold", "score": {"total": 50}},
+        "20260422",
+    )
+
+    assert suggestion["next_action"] == "hold"
+    assert suggestion["sequence"] == 0
+    assert suggestion["text"] == DEFAULT_SIGNAL_POLICY.no_action_text
+
+
+def test_stage_pending_signal_sets_active_signal_in_execution_state(tmp_path):
+    store = OlinStateStore(tmp_path)
+    suggestion = {
+        "next_action": "sell",
+        "sequence": 3,
+        "signal": "sell",
+        "text": "第3次卖出 10000 股",
+        "trade_unit": 10000,
+        "execution_state": {
+            "trade_date": "20260422",
+            "sell_count": 2,
+            "buy_count": 1,
+            "actions": [{"signal_id": "older"}],
+            "active_signal": None,
+            "last_signal_id": "older",
+            "last_signal_action": "sell",
+            "last_signal_status": "sent",
+            "last_signal_at": "2026-04-22 09:20:00",
+        },
+    }
+
+    pending = stage_pending_signal(
+        store,
+        suggestion,
+        suggestion["execution_state"],
+        "20260422",
+        datetime(2026, 4, 22, 9, 30, 0),
+    )
+
+    execution_state = store.load_execution_state()
+    assert pending["signal_id"] == "sell_3_20260422_093000"
+    assert store.load_pending_signal()["signal_id"] == "sell_3_20260422_093000"
+    assert execution_state["trade_date"] == "20260422"
+    assert execution_state["sell_count"] == 2
+    assert execution_state["active_signal"]["signal_id"] == "sell_3_20260422_093000"
+    assert execution_state["active_signal"]["sequence"] == 3
+    assert execution_state["actions"][0]["signal_id"] == "older"
+
+
+def test_stage_pending_signal_skips_hold_candidate(tmp_path):
+    store = OlinStateStore(tmp_path)
+    suggestion = {
+        "next_action": "hold",
+        "sequence": 0,
+        "signal": "hold",
+        "text": "暂无新增执行建议",
+        "trade_unit": 10000,
+        "execution_state": {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": None,
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        },
+    }
+
+    pending = stage_pending_signal(
+        store,
+        suggestion,
+        suggestion["execution_state"],
+        "20260422",
+        datetime(2026, 4, 22, 9, 30, 0),
+    )
+
+    assert pending == {}
+    assert store.load_pending_signal() == {}
+    assert store.load_execution_state()["active_signal"] is None
+
+
+def test_stage_pending_signal_clears_stale_previous_trade_date_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260421_145000",
+            "signal_key": "sell_1",
+            "trade_date": "20260421",
+            "status": "failed",
+            "action": "sell",
+            "sequence": 1,
+            "text": "old",
+        }
+    )
+    suggestion = {
+        "next_action": "buy",
+        "sequence": 1,
+        "signal": "buy",
+        "text": "第1次买入 10000 股",
+        "trade_unit": 10000,
+        "execution_state": {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": None,
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        },
+    }
+
+    pending = stage_pending_signal(
+        store,
+        suggestion,
+        suggestion["execution_state"],
+        "20260422",
+        datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert pending["signal_id"] == "buy_1_20260422_093100"
+    assert store.load_pending_signal()["trade_date"] == "20260422"
+
+
+def test_stage_pending_signal_clears_stale_missing_trade_date_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_legacy",
+            "signal_key": "sell_1",
+            "status": "pending",
+            "action": "sell",
+            "sequence": 1,
+            "text": "legacy",
+        }
+    )
+    suggestion = {
+        "next_action": "buy",
+        "sequence": 1,
+        "signal": "buy",
+        "text": "第1次买入 10000 股",
+        "trade_unit": 10000,
+        "execution_state": {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": None,
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        },
+    }
+
+    pending = stage_pending_signal(
+        store,
+        suggestion,
+        suggestion["execution_state"],
+        "20260422",
+        datetime(2026, 4, 22, 9, 32, 0),
+    )
+
+    assert pending["signal_id"] == "buy_1_20260422_093200"
+    assert store.load_pending_signal()["trade_date"] == "20260422"
+
+
+def test_confirm_dispatch_sent_updates_pending_push_state_and_history(tmp_path):
+    store = OlinStateStore(tmp_path)
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 1,
+    }
+    store.save_pending_signal(pending)
+    store.save_push_state({"existing": "value"})
+
+    result = confirm_dispatch_sent(
+        store,
+        pending,
+        channel="feishu_webhook",
+        delivery_result={"channel": "feishu_webhook", "dry_run": True},
+    )
+
+    saved_push_state = store.load_push_state()
+    history = store.read_jsonl("signal_send_history.jsonl")
+    ledger = store.read_jsonl("dispatch_ledger.jsonl")
+    assert result["status"] == "sent"
+    assert store.load_pending_signal() == {}
+    assert saved_push_state["existing"] == "value"
+    assert saved_push_state["last_pushed_signal"] == "sell_1"
+    assert saved_push_state["last_pushed_signal_id"] == "sell_1_20260422_093000"
+    assert saved_push_state["last_dispatch_channel"] == "feishu_webhook"
+    assert history[-1]["event"] == "sent"
+    assert history[-1]["signal_id"] == "sell_1_20260422_093000"
+    assert ledger[-1]["event"] == "dry_run_sent"
+    assert ledger[-1]["signal_id"] == "sell_1_20260422_093000"
+
+
+def test_confirm_dispatch_sent_commits_execution_state_and_clears_active_signal(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        }
+    )
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 1,
+    }
+
+    confirm_dispatch_sent(
+        store,
+        pending,
+        channel="feishu_session",
+        delivery_result={"channel": "feishu_session", "dry_run": False},
+    )
+
+    execution_state = store.load_execution_state()
+    assert execution_state["active_signal"] is None
+    assert execution_state["last_signal_id"] == "sell_1_20260422_093000"
+    assert execution_state["last_signal_action"] == "sell"
+    assert execution_state["last_signal_status"] == "sent"
+    assert execution_state["sell_count"] == 1
+    assert execution_state["actions"][-1]["signal_id"] == "sell_1_20260422_093000"
+    assert execution_state["actions"][-1]["status"] == "sent"
+
+
+def test_confirm_dispatch_sent_rejects_missing_trade_date(tmp_path):
+    store = OlinStateStore(tmp_path)
+
+    try:
+        confirm_dispatch_sent(
+            store,
+            {
+                "signal_id": "sell_1_legacy",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "text": "legacy",
+                "attempts": 1,
+            },
+            channel="feishu_session",
+            delivery_result={"channel": "feishu_session", "dry_run": False},
+        )
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "trade_date" in str(exc)
+
+def test_deliver_pending_signal_confirms_state_after_successful_dispatch(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        }
+    )
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 0,
+    }
+    store.save_pending_signal(pending)
+
+    calls = []
+
+    def fake_dispatch(payload: dict) -> dict:
+        calls.append(payload)
+        return {
+            "success": True,
+            "platform": "feishu",
+            "chat_id": "oc_8bdfeacaaffbbb9b8a74a3e6450ea49f",
+            "message_id": "om_xxx",
+        }
+
+    result = deliver_pending_signal(
+        store,
+        pending,
+        dispatch_fn=fake_dispatch,
+    )
+
+    assert calls[0]["channel"] == "feishu"
+    assert calls[0]["message"] == "第1次卖出 10000 股"
+    assert calls[0]["signal_id"] == "sell_1_20260422_093000"
+    assert result["status"] == "sent"
+    assert store.load_pending_signal() == {}
+    assert store.load_execution_state()["sell_count"] == 1
+    assert store.load_push_state()["last_dispatch_channel"] == "feishu"
+
+
+def test_deliver_pending_signal_marks_failed_attempt_when_dispatch_fails(tmp_path):
+    store = OlinStateStore(tmp_path)
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 0,
+    }
+    store.save_pending_signal(pending)
+
+    def fake_dispatch(_: dict) -> dict:
+        return {"success": False, "error": "boom"}
+
+    result = deliver_pending_signal(
+        store,
+        pending,
+        dispatch_fn=fake_dispatch,
+    )
+
+    saved = store.load_pending_signal()
+    assert result["status"] == "failed"
+    assert saved["status"] == "failed"
+    assert saved["attempts"] == 1
+    assert saved["last_attempt_status"] == "failed"
+    assert saved["last_error"] == "boom"
+
+
+def test_deliver_pending_signal_is_noop_for_stale_non_matching_store_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "buy_2_20260422_094000",
+            "signal_key": "buy_2",
+            "trade_date": "20260422",
+            "action": "buy",
+            "sequence": 2,
+            "status": "pending",
+            "text": "第2次买入 10000 股",
+            "attempts": 0,
+        }
+    )
+    stale_pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 0,
+    }
+    called = {"count": 0}
+
+    def fake_dispatch(_payload):
+        called["count"] += 1
+        return {"success": True}
+
+    result = deliver_pending_signal(store, stale_pending, dispatch_fn=fake_dispatch)
+
+    assert called["count"] == 0
+    assert result["signal_id"] == "sell_1_20260422_093000"
+    assert store.load_pending_signal()["signal_id"] == "buy_2_20260422_094000"
+
+
+def test_deliver_pending_signal_is_noop_for_already_sent_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "sent",
+        "text": "第1次卖出 10000 股",
+        "attempts": 1,
+    }
+    called = {"count": 0}
+
+    def fake_dispatch(_payload):
+        called["count"] += 1
+        return {"success": True}
+
+    result = deliver_pending_signal(store, pending, dispatch_fn=fake_dispatch)
+
+    assert called["count"] == 0
+    assert result["status"] == "sent"
+
+
+def test_deliver_pending_signal_is_idempotent_when_push_state_already_sent(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "text": "第1次卖出 10000 股",
+            "attempts": 0,
+        }
+    )
+    store.save_push_state(
+        {
+            "last_pushed_signal_id": "sell_1_20260422_093000",
+            "last_pushed_trade_date": "20260422",
+            "last_pushed_at": "2026-04-22 09:30:05",
+            "last_dispatch_channel": "feishu",
+            "last_delivery_result": {"message_id": "om_xxx"},
+        }
+    )
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 0,
+    }
+    called = {"count": 0}
+
+    def fake_dispatch(_payload):
+        called["count"] += 1
+        return {"success": True}
+
+    result = deliver_pending_signal(store, pending, dispatch_fn=fake_dispatch)
+
+    execution_state = store.load_execution_state()
+    assert called["count"] == 0
+    assert result["status"] == "sent"
+    assert result["dispatch_channel"] == "feishu"
+    assert store.load_pending_signal() == {}
+    assert execution_state["active_signal"] is None
+    assert execution_state["sell_count"] == 1
+
+
+def test_deliver_pending_signal_marks_failed_for_missing_trade_date_without_resetting_execution_state(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [{"signal_id": "older", "status": "sent"}],
+            "active_signal": None,
+            "last_signal_id": "older",
+            "last_signal_action": "sell",
+            "last_signal_status": "sent",
+            "last_signal_at": "2026-04-22 09:20:00",
+        }
+    )
+    pending = {
+        "signal_id": "sell_2_legacy",
+        "signal_key": "sell_2",
+        "action": "sell",
+        "sequence": 2,
+        "status": "pending",
+        "text": "legacy missing trade_date",
+        "attempts": 0,
+    }
+
+    result = deliver_pending_signal(store, pending, dispatch_fn=lambda _payload: {"success": True})
+
+    execution_state = store.load_execution_state()
+    assert result["status"] == "failed"
+    assert result["last_error"] == "invalid pending signal payload"
+    assert execution_state["trade_date"] == "20260422"
+    assert execution_state["sell_count"] == 1
+    assert execution_state["actions"][0]["signal_id"] == "older"
+
+
+def test_deliver_pending_signal_reconciles_actions_only_sent_signal_and_clears_stale_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [
+                {
+                    "signal_id": "sell_1_20260422_093000",
+                    "signal_key": "sell_1",
+                    "trade_date": "20260422",
+                    "action": "sell",
+                    "sequence": 1,
+                    "status": "sent",
+                    "sent_at": "2026-04-22 09:30:05",
+                    "channel": "feishu",
+                    "text": "第1次卖出 10000 股",
+                }
+            ],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "text": "第1次卖出 10000 股",
+            "attempts": 0,
+        }
+    )
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "trade_date": "20260422",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 0,
+    }
+    called = {"count": 0}
+
+    def fake_dispatch(_payload):
+        called["count"] += 1
+        return {"success": True}
+
+    result = deliver_pending_signal(store, pending, dispatch_fn=fake_dispatch)
+
+    execution_state = store.load_execution_state()
+    assert called["count"] == 0
+    assert result["status"] == "sent"
+    assert store.load_pending_signal() == {}
+    assert execution_state["active_signal"] is None
+    assert execution_state["last_signal_id"] == "sell_1_20260422_093000"
+
+
+def test_deliver_pending_signal_reconciles_missing_trade_date_when_push_state_matches(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+            "last_signal_id": None,
+            "last_signal_action": None,
+            "last_signal_status": None,
+            "last_signal_at": None,
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "text": "第1次卖出 10000 股",
+            "attempts": 0,
+        }
+    )
+    store.save_push_state(
+        {
+            "last_pushed_signal_id": "sell_1_20260422_093000",
+            "last_pushed_trade_date": "20260422",
+            "last_pushed_at": "2026-04-22 09:30:05",
+            "last_dispatch_channel": "feishu",
+            "last_delivery_result": {"message_id": "om_xxx"},
+        }
+    )
+    pending = {
+        "signal_id": "sell_1_20260422_093000",
+        "signal_key": "sell_1",
+        "action": "sell",
+        "sequence": 1,
+        "status": "pending",
+        "text": "第1次卖出 10000 股",
+        "attempts": 0,
+    }
+    called = {"count": 0}
+
+    def fake_dispatch(_payload):
+        called["count"] += 1
+        return {"success": True}
+
+    result = deliver_pending_signal(store, pending, dispatch_fn=fake_dispatch)
+
+    execution_state = store.load_execution_state()
+    assert called["count"] == 0
+    assert result["status"] == "sent"
+    assert result["trade_date"] == "20260422"
+    assert store.load_pending_signal() == {}
+    assert execution_state["active_signal"] is None
+    assert execution_state["sell_count"] == 1
+    assert execution_state["last_signal_id"] == "sell_1_20260422_093000"
+
+
+def test_run_runtime_cycle_stages_pending_signal_without_dispatch(tmp_path):
+    store = OlinStateStore(tmp_path)
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 30, 0),
+        dispatch=False,
+    )
+
+    assert result["trade_date"] == "20260422"
+    assert result["pending"]["signal_id"] == "sell_1_20260422_093000"
+    assert result["result"]["status"] == "pending"
+    assert store.load_pending_signal()["signal_id"] == "sell_1_20260422_093000"
+    assert store.load_execution_state()["active_signal"]["signal_id"] == "sell_1_20260422_093000"
+
+def test_run_runtime_cycle_dispatches_and_confirms_sent(tmp_path):
+    store = OlinStateStore(tmp_path)
+    calls = []
+
+    def fake_dispatch(payload: dict) -> dict:
+        calls.append(payload)
+        return {"success": True, "platform": "feishu", "message_id": "om_test"}
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 30, 0),
+        dispatch=True,
+        dispatch_fn=fake_dispatch,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["signal_id"] == "sell_1_20260422_093000"
+    assert result["pending"] == {}
+    assert result["result"]["status"] == "sent"
+    assert store.load_pending_signal() == {}
+    assert store.load_execution_state()["sell_count"] == 1
+    assert store.load_push_state()["last_pushed_signal_id"] == "sell_1_20260422_093000"
+
+
+def test_cli_main_passes_explicit_dispatch_target(monkeypatch, tmp_path, capsys):
+    from hermes_olin import __main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["base_dir"] = str(store.base_dir)
+        captured.update(kwargs)
+        return {"ok": True, "chat_id": kwargs.get("chat_id"), "thread_id": kwargs.get("thread_id")}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_olin",
+            "--base-dir",
+            str(tmp_path),
+            "--trade-date",
+            "20260422",
+            "--signal",
+            "sell",
+            "--score",
+            "20",
+            "--dispatch",
+            "--channel",
+            "feishu",
+            "--chat-id",
+            "oc_test",
+            "--thread-id",
+            "omt_test",
+        ],
+    )
+
+    main_mod.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(tmp_path)
+    assert captured["effective_trade_date"] == "20260422"
+    assert captured["dispatch"] is True
+    assert captured["channel"] == "feishu"
+    assert captured["chat_id"] == "oc_test"
+    assert captured["thread_id"] == "omt_test"
+    assert out["chat_id"] == "oc_test"
+    assert out["thread_id"] == "omt_test"
+
+
+def test_cli_main_uses_env_dispatch_target(monkeypatch, tmp_path, capsys):
+    from hermes_olin import __main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["base_dir"] = str(store.base_dir)
+        captured.update(kwargs)
+        return {"ok": True, "chat_id": kwargs.get("chat_id"), "thread_id": kwargs.get("thread_id")}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setenv("HERMES_OLIN_CHANNEL", "feishu")
+    monkeypatch.setenv("HERMES_OLIN_CHAT_ID", "oc_env")
+    monkeypatch.setenv("HERMES_OLIN_THREAD_ID", "omt_env")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_olin",
+            "--base-dir",
+            str(tmp_path),
+            "--trade-date",
+            "20260422",
+            "--signal",
+            "sell",
+            "--score",
+            "20",
+            "--dispatch",
+        ],
+    )
+
+    main_mod.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(tmp_path)
+    assert captured["dispatch"] is True
+    assert captured["channel"] == "feishu"
+    assert captured["chat_id"] == "oc_env"
+    assert captured["thread_id"] == "omt_env"
+    assert out["chat_id"] == "oc_env"
+    assert out["thread_id"] == "omt_env"
+
+
+
+def test_cli_main_supports_profile_override(monkeypatch, tmp_path, capsys):
+    from hermes_olin import __main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["base_dir"] = str(store.base_dir)
+        captured["profile_id"] = store.profile.profile_id
+        captured["symbol"] = store.profile.symbol
+        captured["trade_unit"] = store.profile.trade_unit
+        captured["max_trades"] = store.profile.max_trades
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_olin",
+            "--base-dir",
+            str(tmp_path),
+            "--trade-date",
+            "20260501",
+            "--profile-id",
+            "demo-600519",
+            "--symbol",
+            "600519",
+            "--trade-unit",
+            "200",
+            "--max-trades",
+            "6",
+        ],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(tmp_path)
+    assert captured["profile_id"] == "demo-600519"
+    assert captured["symbol"] == "600519"
+    assert captured["trade_unit"] == 200
+    assert captured["max_trades"] == 6
+
+
+def test_cli_shared_build_runtime_store_keeps_olin_compatibility_for_legacy_mode(tmp_path):
+    from hermes_t.cli_shared import build_runtime_store
+    from hermes_olin.profile import DEFAULT_RUNTIME_PROFILE
+    from hermes_olin.store import OlinStateStore, TradingStateStore
+
+    default_store = build_runtime_store(
+        base_dir=tmp_path,
+        profile=DEFAULT_RUNTIME_PROFILE,
+        prefer_legacy_olin_store=True,
+    )
+    generic_store = build_runtime_store(
+        base_dir=tmp_path,
+        profile=DEFAULT_RUNTIME_PROFILE,
+        prefer_legacy_olin_store=False,
+    )
+
+    assert isinstance(default_store, OlinStateStore)
+    assert isinstance(generic_store, TradingStateStore)
+    assert type(generic_store).__name__ == "TradingStateStore"
+
+
+
+def test_load_runtime_profiles_from_json_rejects_profile_missing_required_fields(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {
+                "profile_id": "demo-1",
+                "trade_unit": 200,
+                "max_trades": 6,
+            }
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 missing required fields: symbol"):
+        load_runtime_profiles_from_json(config_path)
+
+
+
+def test_load_runtime_profiles_from_json_rejects_non_list_payload(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps({"profile_id": "demo-1", "symbol": "600519"}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="runtime profiles config must be a JSON list"):
+        load_runtime_profiles_from_json(config_path)
+
+
+
+def test_cli_main_defaults_base_dir_under_home_even_after_chdir(monkeypatch, tmp_path, capsys):
+    from hermes_olin import __main__ as main_mod
+
+    captured = {}
+    home_dir = tmp_path / "home"
+    cwd_dir = tmp_path / "workspace"
+    home_dir.mkdir()
+    cwd_dir.mkdir()
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["base_dir"] = str(store.base_dir)
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(cwd_dir)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_olin",
+            "--trade-date",
+            "20260422",
+            "--signal",
+            "hold",
+        ],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(home_dir / ".hermes_olin_runtime")
+
+def test_cli_main_rejects_invalid_trade_date(monkeypatch, tmp_path, capsys):
+    from hermes_olin import __main__ as main_mod
+
+    called = {"ran": False}
+
+    def fake_run_runtime_cycle(*args, **kwargs):
+        called["ran"] = True
+        return {}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_olin",
+            "--base-dir",
+            str(tmp_path),
+            "--trade-date",
+            "2026-04-22",
+            "--signal",
+            "sell",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    err = capsys.readouterr().err
+    assert exc.value.code == 2
+    assert "trade-date" in err
+    assert "YYYYMMDD" in err
+    assert called["ran"] is False
+
+
+def test_recover_signal_runtime_clears_orphan_active_signal_without_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+        }
+    )
+
+    result = recover_signal_runtime(
+        store,
+        trade_date="20260422",
+        now=datetime(2026, 4, 22, 10, 0, 0),
+    )
+
+    assert result["pending_status"] is None
+    assert "cleared_orphan_active_signal" in result["repairs"]
+    assert store.load_execution_state()["active_signal"] is None
+
+
+def test_recover_signal_runtime_expires_cross_day_pending_and_clears_active_signal(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 0,
+        }
+    )
+
+    result = recover_signal_runtime(
+        store,
+        trade_date="20260423",
+        now=datetime(2026, 4, 23, 9, 31, 0),
+    )
+
+    pending = store.load_pending_signal()
+    assert result["pending_status"] == "expired_cross_day"
+    assert "expired_cross_day_pending_signal" in result["repairs"]
+    assert pending["status"] == "expired_cross_day"
+    assert pending["escalation_reason"] == "cross_day_cleanup"
+    assert store.load_execution_state()["active_signal"] is None
+    assert store.read_jsonl("signal_send_history.jsonl")[-1]["event"] == "expired_cross_day"
+
+
+def test_recover_signal_runtime_marks_timeout_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "created_at": "2026-04-22 09:20:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+        }
+    )
+
+    result = recover_signal_runtime(
+        store,
+        trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    pending = store.load_pending_signal()
+    assert result["pending_status"] == "timed_out"
+    assert result["pending_age_seconds"] == 660
+    assert "timed_out_pending_signal" in result["repairs"]
+    assert pending["status"] == "timed_out"
+    assert pending["timed_out"] is True
+    assert pending["timeout_sec"] == 300
+    assert store.load_execution_state()["active_signal"] is None
+
+
+def test_recover_signal_runtime_marks_failed_exhausted_for_non_retryable_failed_signal(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "action": "sell",
+                "sequence": 1,
+                "status": "failed",
+                "created_at": "2026-04-22 09:30:00",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+            "last_error_retryable": False,
+            "last_error_class": "AuthError",
+        }
+    )
+
+    result = recover_signal_runtime(
+        store,
+        trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 32, 0),
+    )
+
+    pending = store.load_pending_signal()
+    assert result["pending_status"] == "failed_exhausted"
+    assert "non_retryable_failed_pending_signal" in result["repairs"]
+    assert pending["status"] == "failed_exhausted"
+    assert pending["escalation_reason"] == "non_retryable_dispatch_error"
+    assert pending["max_attempts"] == 3
+    assert store.load_execution_state()["active_signal"] is None
+
+
+def test_run_runtime_cycle_clears_cross_day_stale_pending_before_new_suggestion(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "trade_date": "20260422",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:30:00",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 0,
+        }
+    )
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260423",
+        dispatch=False,
+        now=datetime(2026, 4, 23, 9, 31, 0),
+    )
+
+    assert result["recovery"]["pending_status"] == "expired_cross_day"
+    assert result["suggestion"]["next_action"] == "sell"
+    assert result["suggestion"]["sequence"] == 1
+    assert result["pending"]["signal_id"] == "sell_1_20260423_093100"
+    assert store.load_execution_state()["trade_date"] == "20260423"
+
+
+def test_run_runtime_cycle_returns_timeout_recovery_without_restaging_same_cycle(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_092000",
+                "signal_key": "sell_1",
+                "trade_date": "20260422",
+                "action": "sell",
+                "sequence": 1,
+                "status": "pending",
+                "created_at": "2026-04-22 09:20:00",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_092000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "created_at": "2026-04-22 09:20:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+        }
+    )
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        dispatch=False,
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["recovery"]["pending_status"] == "timed_out"
+    assert result["suggestion"]["next_action"] == "hold"
+    assert result["suggestion"]["reason"] == "recovery_blocked"
+    assert result["pending"]["status"] == "timed_out"
+
+
+
+def test_run_runtime_cycle_allows_new_candidate_after_terminal_pending_recovery(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "buy_1_20260422_093100",
+                "signal_key": "buy_1",
+                "trade_date": "20260422",
+                "action": "buy",
+                "sequence": 1,
+                "status": "failed",
+                "created_at": "2026-04-22 09:31:00",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "buy_1_20260422_093100",
+            "signal_key": "buy_1",
+            "trade_date": "20260422",
+            "action": "buy",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:31:00",
+            "text": "第1次买入 10000 股",
+            "attempts": 1,
+            "last_error_retryable": False,
+            "last_error_class": "AuthError",
+        }
+    )
+
+    first = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        dispatch=False,
+        now=datetime(2026, 4, 22, 9, 32, 0),
+    )
+
+    assert first["recovery"]["pending_status"] == "failed_exhausted"
+    assert first["suggestion"]["reason"] == "recovery_blocked"
+    assert first["pending"]["status"] == "failed_exhausted"
+
+    second = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        dispatch=False,
+        now=datetime(2026, 4, 22, 9, 33, 0),
+    )
+
+    assert second["recovery"]["pending_status"] is None
+    assert second["suggestion"]["next_action"] == "sell"
+    assert second["suggestion"]["sequence"] == 1
+    assert second["pending"]["signal_id"] == "sell_1_20260422_093300"
+    assert second["pending"]["status"] == "pending"
+    assert store.load_execution_state()["active_signal"]["signal_id"] == "sell_1_20260422_093300"
+
+
+
+def test_run_runtime_cycle_retries_retryable_failed_pending_with_dispatch(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "trade_date": "20260422",
+                "action": "sell",
+                "sequence": 1,
+                "status": "failed",
+                "created_at": "2026-04-22 09:30:00",
+                "last_attempt_at": "2026-04-22 09:30:30",
+                "last_error": "temporary gateway error",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+            "last_attempt_at": "2026-04-22 09:30:30",
+            "last_attempt_status": "failed",
+            "last_error": "temporary gateway error",
+            "last_error_retryable": True,
+            "last_error_class": "RuntimeError",
+        }
+    )
+
+    calls = []
+
+    def fake_dispatch(payload):
+        calls.append(payload)
+        return {"success": True, "message_id": "msg_retry_1", "channel": "feishu"}
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        dispatch=True,
+        dispatch_fn=fake_dispatch,
+        now=datetime(2026, 4, 22, 9, 32, 0),
+    )
+
+    assert result["recovery"]["pending_status"] == "pending"
+    assert len(calls) == 1
+    assert calls[0]["signal_id"] == "sell_1_20260422_093000"
+    assert result["result"]["status"] == "sent"
+    assert result["pending"] == {}
+    execution_state = store.load_execution_state()
+    assert execution_state["active_signal"] is None
+    assert execution_state["sell_count"] == 1
+
+
+def test_arbitrate_candidate_blocks_duplicate_pending(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "pending",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 0,
+        }
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "duplicate_pending_signal"
+
+
+def test_arbitrate_candidate_blocks_pending_active_for_different_signal(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "buy_1_20260422_093000",
+            "signal_key": "buy_1",
+            "trade_date": "20260422",
+            "action": "buy",
+            "sequence": 1,
+            "status": "pending",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次买入 10000 股",
+            "attempts": 0,
+        }
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "another_pending_signal_active"
+
+
+def test_arbitrate_candidate_blocks_duplicate_sent_summary(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_push_state(
+        {
+            "last_pushed_signal": "sell_1",
+            "last_pushed_signal_id": "sell_1_20260422_093000",
+            "last_pushed_trade_date": "20260422",
+            "last_pushed_at": "2026-04-22 09:30:05",
+        }
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "duplicate_sent_signal"
+
+
+def test_arbitrate_candidate_blocks_duplicate_execution(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [
+                {
+                    "signal_id": "sell_1_20260422_093000",
+                    "signal_key": "sell_1",
+                    "trade_date": "20260422",
+                    "action": "sell",
+                    "sequence": 1,
+                    "status": "sent",
+                    "sent_at": "2026-04-22 09:30:05",
+                    "channel": "feishu",
+                    "text": "第1次卖出 10000 股",
+                }
+            ],
+            "active_signal": None,
+            "last_signal_id": "sell_1_20260422_093000",
+            "last_signal_action": "sell",
+            "last_signal_status": "sent",
+            "last_signal_at": "2026-04-22 09:30:05",
+        }
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "duplicate_execution_signal"
+
+
+def test_arbitrate_candidate_blocks_retry_cooldown_active(tmp_path, monkeypatch):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+            "last_attempt_at": "2026-04-22 09:30:40",
+            "last_attempt_status": "failed",
+            "last_error": "temporary gateway error",
+            "last_error_retryable": True,
+        }
+    )
+    import hermes_olin.runtime as runtime_mod
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "load_runtime_policy",
+        lambda: {
+            "pending_signal_timeout_sec": 300,
+            "pending_signal_max_attempts": 3,
+            "pending_retry_cooldown_sec": 120,
+        },
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "retry_cooldown_active"
+    assert result["cooldown_remaining_sec"] == 100
+
+
+def test_arbitrate_candidate_allows_retry_ready_and_reuses_failed_pending(tmp_path, monkeypatch):
+    store = OlinStateStore(tmp_path)
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+            "last_attempt_at": "2026-04-22 09:30:00",
+            "last_attempt_status": "failed",
+            "last_error": "temporary gateway error",
+            "last_error_retryable": True,
+        }
+    )
+    import hermes_olin.runtime as runtime_mod
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "load_runtime_policy",
+        lambda: {
+            "pending_signal_timeout_sec": 300,
+            "pending_signal_max_attempts": 3,
+            "pending_retry_cooldown_sec": 30,
+        },
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "reuse_failed_pending"
+    assert result["reason"] == "retry_ready_reuse_failed_pending"
+    assert result["pending"]["signal_id"] == "sell_1_20260422_093000"
+
+
+def test_arbitrate_candidate_blocks_freshness_failure(tmp_path, monkeypatch):
+    store = OlinStateStore(tmp_path)
+    import hermes_olin.runtime as runtime_mod
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "load_runtime_policy",
+        lambda: {
+            "pending_signal_timeout_sec": 300,
+            "pending_signal_max_attempts": 3,
+            "pending_retry_cooldown_sec": 30,
+            "candidate_freshness_limit_sec": 60,
+        },
+    )
+    result = arbitrate_candidate(
+        store,
+        {
+            "next_action": "sell",
+            "action": "sell",
+            "sequence": 1,
+            "signal": "sell",
+            "text": "第1次卖出 10000 股",
+            "trade_date": "20260422",
+            "signal_time": "2026-04-22 09:28:00",
+        },
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+    )
+
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "candidate_stale"
+
+def test_run_runtime_cycle_blocks_duplicate_sent_candidate_without_restaging(tmp_path):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [
+                {
+                    "signal_id": "sell_1_20260422_093000",
+                    "signal_key": "sell_1",
+                    "trade_date": "20260422",
+                    "action": "sell",
+                    "sequence": 1,
+                    "status": "sent",
+                    "sent_at": "2026-04-22 09:30:05",
+                    "channel": "feishu",
+                    "text": "第1次卖出 10000 股",
+                }
+            ],
+            "active_signal": None,
+            "last_signal_id": "sell_1_20260422_093000",
+            "last_signal_action": "sell",
+            "last_signal_status": "sent",
+            "last_signal_at": "2026-04-22 09:30:05",
+        }
+    )
+    store.save_push_state(
+        {
+            "last_pushed_signal": "sell_1",
+            "last_pushed_signal_id": "sell_1_20260422_093000",
+            "last_pushed_trade_date": "20260422",
+            "last_pushed_at": "2026-04-22 09:30:05",
+        }
+    )
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+        dispatch=False,
+    )
+
+    assert result["suggestion"]["next_action"] == "hold"
+    assert result["suggestion"]["reason"] == "duplicate_sent_signal"
+    assert result["pending"] == {}
+    assert store.load_pending_signal() == {}
+    assert store.load_execution_state()["active_signal"] is None
+
+
+def test_run_runtime_cycle_reuses_failed_pending_after_cooldown_instead_of_restaging(tmp_path, monkeypatch):
+    store = OlinStateStore(tmp_path)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "trade_date": "20260422",
+                "action": "sell",
+                "sequence": 1,
+                "status": "failed",
+                "created_at": "2026-04-22 09:30:00",
+                "last_attempt_at": "2026-04-22 09:30:00",
+                "last_error": "temporary gateway error",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 10000 股",
+            "attempts": 1,
+            "last_attempt_at": "2026-04-22 09:30:00",
+            "last_attempt_status": "failed",
+            "last_error": "temporary gateway error",
+            "last_error_retryable": True,
+        }
+    )
+    import hermes_olin.runtime as runtime_mod
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "load_runtime_policy",
+        lambda: {
+            "pending_signal_timeout_sec": 300,
+            "pending_signal_max_attempts": 3,
+            "pending_retry_cooldown_sec": 30,
+            "candidate_freshness_limit_sec": 0,
+        },
+    )
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+        dispatch=False,
+    )
+
+    assert result["suggestion"]["next_action"] == "sell"
+    assert result["result"]["signal_id"] == "sell_1_20260422_093000"
+    assert result["result"]["status"] == "failed"
+    assert result["pending"]["signal_id"] == "sell_1_20260422_093000"
+    assert store.load_pending_signal()["signal_id"] == "sell_1_20260422_093000"

--- a/tests/test_post_market_review.py
+++ b/tests/test_post_market_review.py
@@ -1,0 +1,419 @@
+"""Tests for hermes_t.post_market_review — TDD RED phase."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_olin.profile import RuntimeProfile
+from hermes_olin.store import TradingStateStore
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def position_data() -> dict:
+    return {
+        "symbol": "688319",
+        "total_shares": 220000,
+        "avg_cost": 16.685,
+        "t_shares": 40000,
+        "available_cash": 1_000_000.0,
+        "month_start_cost": 16.685,
+        "month_target_reduction_pct": 0.03,
+    }
+
+
+@pytest.fixture
+def t_store(tmp_path: Path, position_data: dict) -> TradingStateStore:
+    profile = RuntimeProfile(
+        profile_id="olin-688319",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+    store = TradingStateStore(base_dir=str(tmp_path), profile=profile)
+    # write empty execution state
+    store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 0,
+        "buy_count": 0,
+        "actions": [],
+        "active_signal": None,
+        "last_signal_id": None,
+        "last_signal_action": None,
+        "last_signal_status": None,
+        "last_signal_at": None,
+    })
+    # write position file
+    pos_path = store.state_dir / "position.json"
+    pos_path.write_text(json.dumps(position_data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return store
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+def test_review_with_no_trades_returns_zero_pnl(t_store: TradingStateStore):
+    """RED: when no trades occurred, review shows zero P&L and same avg cost."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+
+    assert review["trade_date"] == "2026-05-03"
+    assert review["symbol"] == "688319"
+    assert review["summary"]["total_trades"] == 0
+    assert review["summary"]["sell_count"] == 0
+    assert review["summary"]["buy_count"] == 0
+    assert review["summary"]["net_shares_sold"] == 0
+    assert review["summary"]["realized_pnl"] == 0.0
+    assert review["summary"]["avg_cost_before"] == 16.685
+    assert review["summary"]["avg_cost_after"] == 16.685
+    assert review["summary"]["cost_reduction_per_share"] == 0.0
+    assert review["summary"]["available_cash"] == 1_000_000.0
+    assert review["trades"] == []
+
+
+def test_review_with_single_sell_detects_net_position_change(
+    t_store: TradingStateStore,
+):
+    """RED: a sell-only action reduces position; review must reflect net shares sold."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    action = {
+        "seq": 1,
+        "action": "sell",
+        "price": 17.20,
+        "shares": 10000,
+        "signal": "sell",
+        "score": 20,
+        "timestamp": "2026-05-03 10:00:00",
+    }
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 1,
+        "buy_count": 0,
+        "actions": [action],
+        "active_signal": None,
+        "last_signal_id": "sig-001",
+        "last_signal_action": "sell",
+        "last_signal_status": "dispatched",
+        "last_signal_at": "2026-05-03 10:00:00",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+
+    assert review["summary"]["total_trades"] == 1
+    assert review["summary"]["sell_count"] == 1
+    assert review["summary"]["buy_count"] == 0
+    assert review["summary"]["net_shares_sold"] == 10000
+    assert len(review["trades"]) == 1
+    assert review["trades"][0]["action"] == "sell"
+    assert review["trades"][0]["price"] == 17.20
+
+
+def test_review_with_complete_t_trade_calculates_pnl(
+    t_store: TradingStateStore,
+):
+    """RED: sell at 17.20 then buy back at 16.80 should show 0.40 * 10000 = 4000 P&L."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 1,
+        "buy_count": 1,
+        "actions": [
+            {
+                "seq": 1,
+                "action": "sell",
+                "price": 17.20,
+                "shares": 10000,
+                "signal": "sell",
+                "score": 20,
+                "timestamp": "2026-05-03 10:00:00",
+            },
+            {
+                "seq": 2,
+                "action": "buy",
+                "price": 16.80,
+                "shares": 10000,
+                "signal": "buy",
+                "score": -15,
+                "timestamp": "2026-05-03 11:00:00",
+            },
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-002",
+        "last_signal_action": "buy",
+        "last_signal_status": "dispatched",
+        "last_signal_at": "2026-05-03 11:00:00",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+
+    assert review["summary"]["total_trades"] == 2
+    assert review["summary"]["sell_count"] == 1
+    assert review["summary"]["buy_count"] == 1
+    assert review["summary"]["net_shares_sold"] == 0  # 10000 - 10000 = 0
+    assert review["summary"]["realized_pnl"] == pytest.approx(4000.0)
+    assert review["summary"]["avg_cost_before"] == 16.685
+    # cost reduction: 4000 / 220000 = ~0.01818
+    expected_reduction = 4000.0 / 220000
+    assert review["summary"]["cost_reduction_per_share"] == pytest.approx(expected_reduction, rel=1e-6)
+    # avg_cost_after: 16.685 - reduction
+    assert review["summary"]["avg_cost_after"] == pytest.approx(16.685 - expected_reduction, rel=1e-6)
+    assert len(review["trades"]) == 2
+
+
+def test_review_with_losing_t_trade_increases_avg_cost(
+    t_store: TradingStateStore,
+):
+    """RED: a losing sell-then-buy round should raise avg_cost_after and show negative per-share reduction."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 1,
+        "buy_count": 1,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 16.80, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "buy", "price": 17.20, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 11:00:00"},
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-loss-001",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+
+    expected_reduction = -4000.0 / 220000
+    assert review["summary"]["realized_pnl"] == pytest.approx(-4000.0)
+    assert review["summary"]["cost_reduction_per_share"] == pytest.approx(expected_reduction, rel=1e-6)
+    assert review["summary"]["avg_cost_after"] == pytest.approx(16.685 - expected_reduction, rel=1e-6)
+    assert review["summary"]["month_cumulative_pnl"] == pytest.approx(-4000.0)
+    assert review["summary"]["month_cumulative_reduction_per_share"] == pytest.approx(expected_reduction, rel=1e-6)
+
+
+def test_review_with_multiple_t_trades_accumulates_pnl(
+    t_store: TradingStateStore,
+):
+    """RED: two complete T-rounds accumulate P&L correctly."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 2,
+        "buy_count": 2,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 17.20, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "buy", "price": 16.80, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 11:00:00"},
+            {"seq": 3, "action": "sell", "price": 17.50, "shares": 10000, "signal": "sell", "score": 25, "timestamp": "2026-05-03 13:00:00"},
+            {"seq": 4, "action": "buy", "price": 16.90, "shares": 10000, "signal": "buy", "score": -10, "timestamp": "2026-05-03 14:00:00"},
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-004",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+
+    # First round: (17.20 - 16.80) * 10000 = 4000
+    # Second round: (17.50 - 16.90) * 10000 = 6000
+    # Total: 10000
+    assert review["summary"]["realized_pnl"] == pytest.approx(10000.0)
+    assert review["summary"]["total_trades"] == 4
+    assert review["summary"]["sell_count"] == 2
+    assert review["summary"]["buy_count"] == 2
+    assert review["summary"]["net_shares_sold"] == 0
+    assert len(review["trades"]) == 4
+
+
+def test_review_with_unpaired_buy_sell_treats_as_net_position_change(
+    t_store: TradingStateStore,
+):
+    """RED: when sell > buy, the difference is a net position decrease (no P&L for unmatched)."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 2,
+        "buy_count": 1,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 17.20, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "sell", "price": 17.50, "shares": 10000, "signal": "sell", "score": 25, "timestamp": "2026-05-03 11:00:00"},
+            {"seq": 3, "action": "buy", "price": 16.80, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 14:00:00"},
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-005",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+    # Pair: first sell+first buy = 10000 round, P&L = (17.20-16.80)*10000 = 4000
+    # Net: 10000 shares sold extra
+    assert review["summary"]["realized_pnl"] == pytest.approx(4000.0)
+    assert review["summary"]["net_shares_sold"] == 10000
+
+
+def test_review_infers_symbol_from_store_if_position_missing(
+    tmp_path: Path, t_store: TradingStateStore,
+):
+    """RED: when position.json is missing, use store.profile.symbol as fallback."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    # remove position file
+    pos_path = t_store.state_dir / "position.json"
+    if pos_path.exists():
+        pos_path.unlink()
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+
+    assert review["symbol"] == "688319"
+    assert review["summary"]["realized_pnl"] == 0.0
+    # Without position, avg_cost_before defaults to 0.0
+    assert review["summary"]["avg_cost_before"] == 0.0
+
+
+def test_review_rejects_missing_trade_date(t_store: TradingStateStore):
+    """RED: trade_date is required."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    with pytest.raises(ValueError, match="trade_date"):
+        build_post_market_review(t_store, trade_date="")
+
+
+def test_review_month_cumulative_accumulation(
+    t_store: TradingStateStore,
+):
+    """RED: tracks this month's cumulative cost reduction by reading from store."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    # simulate a prior day's dispatch record in ledger
+    t_store.record_dispatch_event("sent", {
+        "signal_id": "sig-prev",
+        "trade_date": "2026-05-02",
+        "action": "sell",
+        "sequence": 1,
+        "profit": 2000.0,
+    })
+
+    # today's trades: P&L 4000
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 1,
+        "buy_count": 1,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 17.20, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "buy", "price": 16.80, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 11:00:00"},
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-003",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+    # Total month P&L from ledger: 2000
+    # Today's P&L: 4000
+    # Month cumulative: 6000
+    assert review["summary"]["month_cumulative_pnl"] == pytest.approx(6000.0)
+    # 3% monthly target means 16.685 * 3% = 0.50055 元/股; 6000/220000=0.02727, not met.
+    assert review["summary"]["month_target_met"] is False
+
+
+def test_review_dispatch_ledger_missing_does_not_crash(
+    t_store: TradingStateStore,
+):
+    """RED: when dispatch_ledger.jsonl doesn't exist, month cumulative is just today's P&L."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    # write ledger as a non-existent / empty scenario
+    ledger_path = t_store.state_dir / "dispatch_ledger.jsonl"
+    if ledger_path.exists():
+        ledger_path.unlink()
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 2,
+        "buy_count": 2,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 17.20, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "buy", "price": 16.80, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 11:00:00"},
+        ],
+        "active_signal": None,
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+    assert review["summary"]["month_cumulative_pnl"] == pytest.approx(4000.0)
+    assert review["summary"]["month_cumulative_reduction_per_share"] == pytest.approx(4000.0 / 220000, rel=1e-6)
+
+
+def test_review_skips_same_day_ledger_profit_to_avoid_double_counting(
+    t_store: TradingStateStore,
+):
+    """RED: same-day ledger profit must not be added on top of today's action-derived P&L."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    t_store.record_dispatch_event("sent", {
+        "signal_id": "sig-prev",
+        "trade_date": "2026-05-02",
+        "action": "sell",
+        "sequence": 1,
+        "profit": 2000.0,
+    })
+    t_store.record_dispatch_event("sent", {
+        "signal_id": "sig-today",
+        "trade_date": "2026-05-03",
+        "action": "sell",
+        "sequence": 1,
+        "profit": 4000.0,
+    })
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 1,
+        "buy_count": 1,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 17.20, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "buy", "price": 16.80, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 11:00:00"},
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-003",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+    # prior day ledger 2000 + today's action-derived 4000; same-day ledger 4000 should be ignored
+    assert review["summary"]["month_cumulative_pnl"] == pytest.approx(6000.0)
+    assert review["summary"]["month_cumulative_reduction_per_share"] == pytest.approx(6000.0 / 220000, rel=1e-6)
+
+
+def test_review_ignores_prior_month_ledger_profit(
+    t_store: TradingStateStore,
+):
+    """RED: monthly cumulative should exclude prior-month ledger profit."""
+    from hermes_t.post_market_review import build_post_market_review
+
+    t_store.record_dispatch_event("sent", {
+        "signal_id": "sig-apr",
+        "trade_date": "2026-04-30",
+        "action": "sell",
+        "sequence": 1,
+        "profit": 9000.0,
+    })
+    t_store.record_dispatch_event("sent", {
+        "signal_id": "sig-may-prev",
+        "trade_date": "2026-05-02",
+        "action": "sell",
+        "sequence": 1,
+        "profit": 2000.0,
+    })
+
+    t_store.save_execution_state({
+        "trade_date": "2026-05-03",
+        "sell_count": 1,
+        "buy_count": 1,
+        "actions": [
+            {"seq": 1, "action": "sell", "price": 17.20, "shares": 10000, "signal": "sell", "score": 20, "timestamp": "2026-05-03 10:00:00"},
+            {"seq": 2, "action": "buy", "price": 16.80, "shares": 10000, "signal": "buy", "score": -15, "timestamp": "2026-05-03 11:00:00"},
+        ],
+        "active_signal": None,
+        "last_signal_id": "sig-004",
+    })
+
+    review = build_post_market_review(t_store, trade_date="2026-05-03")
+    # only same-month prior 2000 + today 4000; April 9000 must be excluded
+    assert review["summary"]["month_cumulative_pnl"] == pytest.approx(6000.0)

--- a/tests/test_trading_runtime.py
+++ b/tests/test_trading_runtime.py
@@ -1,0 +1,1748 @@
+from datetime import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_olin.profile import RuntimeProfile
+from hermes_olin.runtime import (
+    build_execution_suggestion,
+    dispatch_ledger_sent_event,
+    run_runtime_cycle,
+    stage_pending_signal,
+)
+from hermes_olin.store import TradingStateStore
+
+
+def test_fixed_tech_data_provider_returns_same_payload_for_any_symbol():
+    from hermes_t.tech_data import FixedTechDataProvider
+
+    provider = FixedTechDataProvider({"summary_signal": "sell", "score": {"total": 20}})
+
+    assert provider.get("600519") == {"summary_signal": "sell", "score": {"total": 20}}
+    assert provider.get("300750") == {"summary_signal": "sell", "score": {"total": 20}}
+
+
+def test_json_symbol_tech_data_provider_reads_symbol_specific_payload_and_falls_back():
+    from hermes_t.tech_data import JsonSymbolTechDataProvider
+
+    provider = JsonSymbolTechDataProvider(
+        tech_data_by_symbol={"600519": {"summary_signal": "buy", "score": {"total": 88}}},
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert provider.get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+    assert provider.get("300750") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+def test_json_quote_data_provider_returns_raw_quote_payload():
+    from hermes_t.tech_data import JsonQuoteDataProvider
+
+    provider = JsonQuoteDataProvider(
+        quote_data_by_symbol={
+            "600519": {"last_price": 1688.0, "tech_data": {"summary_signal": "sell", "score": {"total": 12}}}
+        }
+    )
+
+    assert provider.get("600519") == {"last_price": 1688.0, "tech_data": {"summary_signal": "sell", "score": {"total": 12}}}
+    assert provider.get("300750") == {}
+
+
+def test_in_memory_quote_snapshot_provider_normalizes_snapshot_and_returns_default_for_missing_symbol():
+    from hermes_t.tech_data import InMemoryQuoteSnapshotProvider
+
+    provider = InMemoryQuoteSnapshotProvider(
+        snapshots_by_symbol={
+            "600519": {
+                "symbol": 600519,
+                "last_price": 1688.0,
+                "source": "mock",
+                "as_of": "2026-05-02T10:00:00+08:00",
+                "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+            }
+        }
+    )
+
+    snapshot = provider.get("600519")
+    assert snapshot["symbol"] == "600519"
+    assert snapshot["last_price"] == 1688.0
+    assert snapshot["source"] == "mock"
+    assert snapshot["as_of"] == "2026-05-02T10:00:00+08:00"
+    assert snapshot["tech_data"] == {"summary_signal": "sell", "score": {"total": 18}}
+    assert provider.get("300750") == {}
+
+
+def test_file_quote_snapshot_provider_reads_json_file_and_normalizes_symbol(tmp_path):
+    from hermes_t.tech_data import FileQuoteSnapshotProvider
+
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "symbol": 600519,
+                    "last_price": 1688.0,
+                    "source": "file",
+                    "as_of": "2026-05-02T10:01:00+08:00",
+                    "tech_data": {"summary_signal": "buy", "score": {"total": 88}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    provider = FileQuoteSnapshotProvider(snapshot_path=snapshot_path)
+
+    assert provider.get("600519") == {
+        "symbol": "600519",
+        "last_price": 1688.0,
+        "source": "file",
+        "as_of": "2026-05-02T10:01:00+08:00",
+        "tech_data": {"summary_signal": "buy", "score": {"total": 88}},
+    }
+    assert provider.get("300750") == {}
+
+
+def test_quote_snapshot_tech_data_adapter_extracts_tech_data_and_uses_default_fallback():
+    from hermes_t.tech_data import InMemoryQuoteSnapshotProvider, QuoteSnapshotTechDataAdapter
+
+    provider = InMemoryQuoteSnapshotProvider(
+        snapshots_by_symbol={
+            "600519": {
+                "symbol": "600519",
+                "last_price": 1688.0,
+                "source": "mock",
+                "as_of": "2026-05-02T10:00:00+08:00",
+                "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+            }
+        }
+    )
+    adapter = QuoteSnapshotTechDataAdapter(
+        quote_source=provider,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert adapter.get("600519") == {"summary_signal": "sell", "score": {"total": 18}}
+    assert adapter.get("300750") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+def test_quote_snapshot_tech_data_adapter_returns_deep_copied_payloads():
+    from hermes_t.tech_data import InMemoryQuoteSnapshotProvider, QuoteSnapshotTechDataAdapter
+
+    adapter = QuoteSnapshotTechDataAdapter(
+        quote_source=InMemoryQuoteSnapshotProvider(
+            snapshots_by_symbol={
+                "600519": {
+                    "symbol": "600519",
+                    "last_price": 1688.0,
+                    "source": "mock",
+                    "as_of": "2026-05-02T10:00:00+08:00",
+                    "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+                }
+            }
+        ),
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    first = adapter.get("600519")
+    first["score"]["total"] = 999
+    second = adapter.get("600519")
+
+    assert second == {"summary_signal": "sell", "score": {"total": 18}}
+
+    fallback_first = adapter.get("300750")
+    fallback_first["score"]["total"] = 1
+    fallback_second = adapter.get("300750")
+
+    assert fallback_second == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+
+def test_build_quote_snapshot_provider_uses_file_source(tmp_path):
+    from hermes_t.tech_data import FileQuoteSnapshotProvider, build_quote_snapshot_provider
+
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "symbol": 600519,
+                    "last_price": 1688.0,
+                    "source": "file",
+                    "as_of": "2026-05-02T10:01:00+08:00",
+                    "tech_data": {"summary_signal": "buy", "score": {"total": 88}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    provider = build_quote_snapshot_provider(source="file", snapshot_path=snapshot_path)
+
+    assert isinstance(provider, FileQuoteSnapshotProvider)
+    assert provider.get("600519")["tech_data"] == {"summary_signal": "buy", "score": {"total": 88}}
+
+
+
+def test_build_quote_snapshot_provider_uses_mock_source():
+    from hermes_t.tech_data import InMemoryQuoteSnapshotProvider, build_quote_snapshot_provider
+
+    provider = build_quote_snapshot_provider(
+        source="mock",
+        snapshots_by_symbol={
+            "600519": {
+                "symbol": 600519,
+                "last_price": 1688.0,
+                "source": "mock",
+                "as_of": "2026-05-02T10:00:00+08:00",
+                "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+            }
+        },
+    )
+
+    assert isinstance(provider, InMemoryQuoteSnapshotProvider)
+    assert provider.get("600519")["tech_data"] == {"summary_signal": "sell", "score": {"total": 18}}
+
+
+
+def test_build_quote_snapshot_provider_file_source_requires_snapshot_path():
+    from hermes_t.tech_data import build_quote_snapshot_provider
+
+    with pytest.raises(ValueError, match="snapshot_path is required"):
+        build_quote_snapshot_provider(source="file")
+
+
+
+def test_build_quote_snapshot_provider_supports_tdx_placeholder_source():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource, build_quote_snapshot_provider
+
+    provider = build_quote_snapshot_provider(source="tdx")
+
+    assert isinstance(provider, TdxQuoteSnapshotSource)
+
+
+
+def test_tdx_quote_snapshot_source_fetches_first_valid_server_and_normalizes_snapshot():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    class FakeTdxApi:
+        instances = []
+
+        def __init__(self, *, heartbeat, auto_retry, raise_exception):
+            self.heartbeat = heartbeat
+            self.auto_retry = auto_retry
+            self.raise_exception = raise_exception
+            self.connected_to = None
+            self.disconnected = False
+            FakeTdxApi.instances.append(self)
+
+        def connect(self, host, port, time_out):
+            self.connected_to = (host, port, time_out)
+            return host == "good-host"
+
+        def get_security_quotes(self, symbols):
+            assert symbols == [(1, "600519")]
+            return [
+                {
+                    "price": 14.23,
+                    "servertime": "10:15:30",
+                }
+            ]
+
+        def disconnect(self):
+            self.disconnected = True
+
+    provider = TdxQuoteSnapshotSource(
+        api_cls=FakeTdxApi,
+        servers=[("bad", "bad-host", 7709), ("good", "good-host", 7709)],
+    )
+
+    snapshot = provider.get("600519")
+
+    assert snapshot["symbol"] == "600519"
+    assert snapshot["last_price"] == 14.23
+    assert snapshot["source"] == "tdx_tcp"
+    assert snapshot["as_of"] == "10:15:30"
+    assert len(FakeTdxApi.instances) == 2
+    assert FakeTdxApi.instances[0].connected_to == ("bad-host", 7709, 3)
+    assert FakeTdxApi.instances[1].connected_to == ("good-host", 7709, 3)
+    assert all(instance.disconnected for instance in FakeTdxApi.instances)
+
+
+
+def test_tdx_quote_snapshot_source_raises_when_pytdx_unavailable(monkeypatch):
+    from hermes_t import tech_data as tech_data_module
+
+    original_api_cls = tech_data_module.TdxHq_API
+    monkeypatch.setattr(tech_data_module, "TdxHq_API", None)
+    try:
+        provider = tech_data_module.TdxQuoteSnapshotSource()
+        with pytest.raises(RuntimeError, match="pytdx unavailable"):
+            provider.get("600519")
+    finally:
+        monkeypatch.setattr(tech_data_module, "TdxHq_API", original_api_cls)
+
+
+
+def test_tdx_quote_snapshot_source_raises_after_all_servers_return_invalid_quotes():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    class FakeTdxApi:
+        instances = []
+
+        def __init__(self, *, heartbeat, auto_retry, raise_exception):
+            self.disconnected = False
+            self.connected_to = None
+            FakeTdxApi.instances.append(self)
+
+        def connect(self, host, port, time_out):
+            self.connected_to = (host, port, time_out)
+            return True
+
+        def get_security_quotes(self, symbols):
+            return [{"price": 0, "servertime": "10:01:00"}]
+
+        def disconnect(self):
+            self.disconnected = True
+
+    provider = TdxQuoteSnapshotSource(
+        api_cls=FakeTdxApi,
+        servers=[("s1", "host-1", 7709), ("s2", "host-2", 7709)],
+    )
+
+    with pytest.raises(RuntimeError, match="all tdx servers failed or returned invalid quotes"):
+        provider.get("600519")
+
+    assert len(FakeTdxApi.instances) == 2
+    assert all(instance.disconnected for instance in FakeTdxApi.instances)
+
+
+
+def test_quote_snapshot_tech_data_adapter_falls_back_to_default_when_source_raises_and_logs_warning(caplog):
+    import logging
+
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter
+
+    class FailingSnapshotSource:
+        def get(self, symbol):
+            raise RuntimeError(f"boom for {symbol}")
+
+    adapter = QuoteSnapshotTechDataAdapter(
+        quote_source=FailingSnapshotSource(),
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert adapter.get("600519") == {"summary_signal": "hold", "score": {"total": 50}}
+
+    assert any(
+        record.levelno == logging.WARNING
+        and "quote snapshot source failed; falling back to default tech_data" in record.message
+        and record.__dict__.get("symbol") == "600519"
+        for record in caplog.records
+    )
+
+
+
+def test_build_tech_data_provider_from_quote_snapshot_config_tdx_source_falls_back_to_default_on_runtime_error(tmp_path):
+    from hermes_t import tech_data as tech_data_module
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+
+    class StubFailingTdxQuoteSnapshotSource:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+
+        def get(self, symbol):
+            self.calls.append(symbol)
+            raise RuntimeError("tdx temporarily unavailable")
+
+    stub_source = StubFailingTdxQuoteSnapshotSource()
+    original_cls = tech_data_module.TdxQuoteSnapshotSource
+    tech_data_module.TdxQuoteSnapshotSource = lambda *args, **kwargs: stub_source
+    try:
+        config_path = tmp_path / "quote_snapshot_config_tdx.json"
+        config_path.write_text(json.dumps({"source": "tdx"}), encoding="utf-8")
+
+        provider = build_tech_data_provider(
+            tech_data_config_path=None,
+            quote_data_config_path=None,
+            quote_snapshot_config_path=config_path,
+            default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+        )
+
+        assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+        assert provider.get("600519") == {"summary_signal": "hold", "score": {"total": 50}}
+        assert stub_source.calls == ["600519"]
+    finally:
+        tech_data_module.TdxQuoteSnapshotSource = original_cls
+
+
+
+def test_build_tech_data_provider_from_quote_snapshot_config_tdx_source_uses_runtime_quote_snapshot(tmp_path):
+    from hermes_t import tech_data as tech_data_module
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+
+    class StubTdxQuoteSnapshotSource:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+
+        def get(self, symbol):
+            self.calls.append(symbol)
+            return {
+                "symbol": symbol,
+                "last_price": 14.23,
+                "source": "tdx_tcp",
+                "as_of": "10:15:30",
+                "tech_data": {"summary_signal": "buy", "score": {"total": 88}},
+            }
+
+    stub_source = StubTdxQuoteSnapshotSource()
+    original_cls = tech_data_module.TdxQuoteSnapshotSource
+    tech_data_module.TdxQuoteSnapshotSource = lambda *args, **kwargs: stub_source
+    try:
+        config_path = tmp_path / "quote_snapshot_config_tdx.json"
+        config_path.write_text(json.dumps({"source": "tdx"}), encoding="utf-8")
+
+        provider = build_tech_data_provider(
+            tech_data_config_path=None,
+            quote_data_config_path=None,
+            quote_snapshot_config_path=config_path,
+            default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+        )
+
+        assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+        assert provider.get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+        assert stub_source.calls == ["600519"]
+    finally:
+        tech_data_module.TdxQuoteSnapshotSource = original_cls
+
+
+
+def test_build_quote_snapshot_provider_supports_eastmoney_placeholder_source():
+    from hermes_t.tech_data import EastmoneyQuoteSnapshotSource, build_quote_snapshot_provider
+
+    provider = build_quote_snapshot_provider(source="eastmoney")
+
+    assert isinstance(provider, EastmoneyQuoteSnapshotSource)
+    with pytest.raises(NotImplementedError, match="eastmoney quote snapshot source is not implemented"):
+        provider.get("600519")
+
+
+
+def test_build_quote_snapshot_provider_rejects_unknown_source():
+    from hermes_t.tech_data import build_quote_snapshot_provider
+
+    with pytest.raises(ValueError, match="Unsupported quote snapshot source"):
+        build_quote_snapshot_provider(source="not-a-real-source")
+
+
+
+def test_build_tech_data_provider_quote_snapshot_factory_config_resolves_relative_snapshot_path_from_config_dir(tmp_path, monkeypatch):
+    from hermes_t.tech_data import build_tech_data_provider
+
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    snapshot_path = config_dir / "quote_snapshot.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "symbol": 600519,
+                    "last_price": 1688.0,
+                    "source": "file",
+                    "as_of": "2026-05-02T10:02:00+08:00",
+                    "tech_data": {"summary_signal": "buy", "score": {"total": 91}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = config_dir / "quote_snapshot_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "source": "file",
+                "snapshot_path": "quote_snapshot.json",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    other_cwd = tmp_path / "elsewhere"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=None,
+        quote_data_config_path=None,
+        quote_snapshot_config_path=config_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert provider.get("600519") == {"summary_signal": "buy", "score": {"total": 91}}
+
+
+
+def test_build_tech_data_provider_from_quote_snapshot_config_uses_snapshot_adapter(tmp_path):
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "symbol": "600519",
+                    "last_price": 1688.0,
+                    "source": "file",
+                    "tech_data": {"summary_signal": "buy", "score": {"total": 88}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "quote_snapshot_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "source": "file",
+                "snapshot_path": str(snapshot_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=None,
+        quote_data_config_path=None,
+        quote_snapshot_config_path=config_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+    assert provider.get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+
+
+
+def test_build_tech_data_provider_from_quote_snapshot_config_eastmoney_placeholder_falls_back_to_default_on_get(tmp_path):
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+
+    config_path = tmp_path / "quote_snapshot_config_eastmoney.json"
+    config_path.write_text(json.dumps({"source": "eastmoney"}), encoding="utf-8")
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=None,
+        quote_data_config_path=None,
+        quote_snapshot_config_path=config_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+    assert provider.get("600519") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+
+def test_build_tech_data_provider_prefers_explicit_quote_data_config_over_quote_snapshot_config(tmp_path):
+    from hermes_t.tech_data import QuoteTechDataAdapter, build_tech_data_provider
+
+    quote_data_path = tmp_path / "quote_data.json"
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    quote_data_path.write_text(
+        json.dumps({"600519": {"last_price": 1688.0, "tech_data": {"summary_signal": "sell", "score": {"total": 12}}}}),
+        encoding="utf-8",
+    )
+    snapshot_path.write_text(
+        json.dumps({"600519": {"symbol": "600519", "last_price": 1688.0, "source": "file", "as_of": "2026-05-02T10:01:00+08:00", "tech_data": {"summary_signal": "buy", "score": {"total": 88}}}}),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=None,
+        quote_data_config_path=quote_data_path,
+        quote_snapshot_config_path=snapshot_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert isinstance(provider, QuoteTechDataAdapter)
+    assert provider.get("600519") == {"summary_signal": "sell", "score": {"total": 12}}
+
+
+def test_build_tech_data_provider_from_paths_uses_json_provider(tmp_path):
+    from hermes_t.tech_data import JsonSymbolTechDataProvider, build_tech_data_provider
+
+    tech_data_path = tmp_path / "tech_data.json"
+    tech_data_path.write_text(
+        json.dumps({"600519": {"summary_signal": "buy", "score": {"total": 88}}}),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=tech_data_path,
+        default_tech_data={"summary_signal": "sell", "score": {"total": 20}},
+    )
+
+    assert isinstance(provider, JsonSymbolTechDataProvider)
+    assert provider.get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+    assert provider.get("300750") == {"summary_signal": "sell", "score": {"total": 20}}
+
+
+def test_build_tech_data_provider_from_quote_config_extracts_nested_tech_data(tmp_path):
+    from hermes_t.tech_data import QuoteTechDataAdapter, build_tech_data_provider
+
+    quote_data_path = tmp_path / "quote_data.json"
+    quote_data_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "last_price": 1688.0,
+                    "bid_price": 1687.5,
+                    "ask_price": 1688.5,
+                    "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=None,
+        quote_data_config_path=quote_data_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert isinstance(provider, QuoteTechDataAdapter)
+    assert provider.get("600519") == {"summary_signal": "sell", "score": {"total": 18}}
+    assert provider.get("300750") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+def test_json_quote_data_provider_returns_raw_quote_payload_and_falls_back_to_empty_dict():
+    from hermes_t.tech_data import JsonQuoteDataProvider
+
+    provider = JsonQuoteDataProvider(
+        quote_data_by_symbol={
+            "600519": {
+                "last_price": 1688.0,
+                "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+            }
+        }
+    )
+
+    assert provider.get("600519") == {
+        "last_price": 1688.0,
+        "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+    }
+    assert provider.get("300750") == {}
+
+
+def test_quote_tech_data_adapter_extracts_nested_tech_data_and_uses_default_fallback():
+    from hermes_t.tech_data import JsonQuoteDataProvider, QuoteTechDataAdapter
+
+    quote_provider = JsonQuoteDataProvider(
+        quote_data_by_symbol={
+            "600519": {
+                "last_price": 1688.0,
+                "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+            }
+        }
+    )
+    adapter = QuoteTechDataAdapter(
+        quote_provider=quote_provider,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert adapter.get("600519") == {"summary_signal": "sell", "score": {"total": 18}}
+    assert adapter.get("300750") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+def test_signal_policy_defaults_and_templates_are_available():
+    from hermes_olin.signal_policy import DEFAULT_SIGNAL_POLICY, render_signal_text
+
+    assert DEFAULT_SIGNAL_POLICY.buy_score_threshold == 70
+    assert DEFAULT_SIGNAL_POLICY.sell_score_threshold == 30
+    assert DEFAULT_SIGNAL_POLICY.active_signal_hold_text == "当前已有待处理信号，暂停生成下一笔执行建议"
+    assert DEFAULT_SIGNAL_POLICY.no_action_text == "暂无新增执行建议"
+    assert render_signal_text(action="sell", sequence=2, trade_unit=500, policy=DEFAULT_SIGNAL_POLICY) == "第2次卖出 500 股"
+    assert render_signal_text(action="buy", sequence=3, trade_unit=200, policy=DEFAULT_SIGNAL_POLICY) == "第3次买入 200 股"
+    assert render_signal_text(action="hold", sequence=0, trade_unit=0, policy=DEFAULT_SIGNAL_POLICY) == DEFAULT_SIGNAL_POLICY.no_action_text
+
+
+def test_runtime_profile_supports_non_olin_symbol():
+    from hermes_olin.profile import RuntimeProfile
+
+    profile = RuntimeProfile(
+        profile_id="test-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+
+    assert profile.profile_id == "test-600519"
+    assert profile.symbol == "600519"
+    assert profile.trade_unit == 200
+    assert profile.max_trades == 6
+
+
+def test_hermes_t_exports_generic_runtime_api():
+    import hermes_t
+
+    assert hermes_t.RuntimeProfile is RuntimeProfile
+    assert hermes_t.TradingStateStore is TradingStateStore
+    assert callable(hermes_t.run_runtime_cycle)
+
+
+def test_hermes_t_does_not_expose_olin_named_store_in_generic_all():
+    import hermes_t
+
+    assert "TradingStateStore" in hermes_t.__all__
+    assert "OlinStateStore" not in hermes_t.__all__
+
+
+def test_trading_state_store_uses_profile_scoped_state_directory(tmp_path):
+    from hermes_olin.profile import RuntimeProfile
+    from hermes_olin.store import TradingStateStore
+
+    profile = RuntimeProfile(profile_id="demo-600519", symbol="600519")
+    store = TradingStateStore(tmp_path, profile=profile)
+
+    assert store.base_dir == tmp_path
+    assert store.profile.profile_id == "demo-600519"
+    assert store.state_dir == tmp_path / "profiles" / "demo-600519" / "state" / "realtime"
+
+
+def test_build_execution_suggestion_uses_profile_trade_unit_and_max_trades(tmp_path):
+    from hermes_olin.profile import RuntimeProfile
+    from hermes_olin.store import TradingStateStore
+
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "sell", "score": {"total": 20}},
+        "20260501",
+    )
+
+    assert suggestion["trade_unit"] == 200
+    assert suggestion["max_trades"] == 6
+    assert suggestion["text"] == "第1次卖出 200 股"
+
+
+def test_build_execution_suggestion_respects_profile_max_trades_limit(tmp_path):
+    from hermes_olin.profile import RuntimeProfile
+    from hermes_olin.store import TradingStateStore
+
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=1,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+    store.save_execution_state({"trade_date": "20260501", "sell_count": 1})
+
+    suggestion = build_execution_suggestion(
+        store,
+        {"summary_signal": "sell", "score": {"total": 20}},
+        "20260501",
+    )
+
+    assert suggestion["next_action"] == "hold"
+
+
+def test_stage_pending_signal_falls_back_to_profile_trade_unit_for_generic_store(tmp_path):
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+    suggestion = {
+        "next_action": "sell",
+        "action": "sell",
+        "sequence": 1,
+        "text": "第1次卖出 200 股",
+        "signal": "sell",
+    }
+
+    pending = stage_pending_signal(
+        store,
+        suggestion,
+        store.load_execution_state(),
+        "20260501",
+        datetime(2026, 5, 1, 9, 30, 0),
+    )
+
+    assert pending["trade_unit"] == 200
+    assert store.load_pending_signal()["trade_unit"] == 200
+
+
+def test_dispatch_ledger_sent_event_uses_dry_run_variant():
+    assert dispatch_ledger_sent_event({"dry_run": True}) == "dry_run_sent"
+    assert dispatch_ledger_sent_event({"dry_run": False}) == "sent"
+    assert dispatch_ledger_sent_event(None) == "sent"
+
+
+def test_run_runtime_cycle_uses_profile_trade_unit_for_generic_store(tmp_path):
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260501",
+        now=datetime(2026, 5, 1, 9, 30, 0),
+        dispatch=False,
+    )
+
+    assert result["pending"]["trade_unit"] == 200
+    assert result["suggestion"]["trade_unit"] == 200
+    assert result["suggestion"]["text"] == "第1次卖出 200 股"
+    assert store.load_pending_signal()["trade_unit"] == 200
+
+
+def test_cli_shared_builds_parser_with_custom_runtime_defaults(monkeypatch, tmp_path):
+    from hermes_t.cli_shared import build_runtime_parser
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("HERMES_T_CHANNEL", "feishu-test")
+
+    parser = build_runtime_parser(
+        description="generic runtime",
+        default_base_dir_name=".custom_runtime",
+        channel_env_vars=("HERMES_T_CHANNEL",),
+    )
+    args = parser.parse_args(["--trade-date", "20260502"])
+
+    assert args.base_dir == str(home_dir / ".custom_runtime")
+    assert args.channel == "feishu-test"
+    assert args.trade_date == "20260502"
+
+
+def test_build_runtime_profile_from_args_rejects_blank_required_strings():
+    import argparse
+
+    from hermes_t.cli_shared import build_runtime_profile_from_args
+
+    args = argparse.Namespace(profile_id="   ", symbol="", trade_unit=10000, max_trades=4)
+
+    with pytest.raises(ValueError, match="profile item 0 missing required fields: profile_id, symbol"):
+        build_runtime_profile_from_args(args)
+
+
+def test_build_runtime_profile_from_args_rejects_non_positive_ints():
+    import argparse
+
+    from hermes_t.cli_shared import build_runtime_profile_from_args
+
+    args = argparse.Namespace(profile_id="demo-600519", symbol="600519", trade_unit=0, max_trades=4)
+    with pytest.raises(ValueError, match="profile item 0 field trade_unit must be a positive integer"):
+        build_runtime_profile_from_args(args)
+
+    args = argparse.Namespace(profile_id="demo-600519", symbol="600519", trade_unit=10000, max_trades=True)
+    with pytest.raises(ValueError, match="profile item 0 field max_trades must be a positive integer"):
+        build_runtime_profile_from_args(args)
+
+
+def test_hermes_t_cli_uses_generic_home_based_default_dir(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["base_dir"] = str(store.base_dir)
+        captured["profile_id"] = store.profile.profile_id
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hermes_t", "--trade-date", "20260501", "--signal", "hold"],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(home_dir / ".hermes_t_runtime")
+    assert captured["profile_id"] == "olin-688319"
+
+
+def test_hermes_t_cli_uses_trading_state_store_even_for_default_profile(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["store_class"] = type(store).__name__
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hermes_t", "--base-dir", str(tmp_path), "--trade-date", "20260501"],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["store_class"] == "TradingStateStore"
+
+
+def test_hermes_t_cli_passes_runtime_delivery_kwargs_to_single_profile_runner(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--trade-date",
+            "20260501",
+            "--dispatch",
+            "--channel",
+            "feishu",
+            "--chat-id",
+            "oc_demo",
+            "--thread-id",
+            "omt_demo",
+        ],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["effective_trade_date"] == "20260501"
+    assert captured["dispatch"] is True
+    assert captured["channel"] == "feishu"
+    assert captured["chat_id"] == "oc_demo"
+    assert captured["thread_id"] == "omt_demo"
+
+
+def test_load_runtime_profiles_from_json_reads_multiple_profiles(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps(
+            [
+                {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 6},
+                {"profile_id": "demo-300750", "symbol": "300750", "trade_unit": 100, "max_trades": 3},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    profiles = load_runtime_profiles_from_json(config_path)
+
+    assert [profile.profile_id for profile in profiles] == ["demo-600519", "demo-300750"]
+    assert profiles[0].trade_unit == 200
+    assert profiles[1].max_trades == 3
+
+
+def test_load_runtime_profiles_from_json_rejects_non_positive_trade_unit(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 0, "max_trades": 6}
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 field trade_unit must be a positive integer"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_load_runtime_profiles_from_json_rejects_non_positive_max_trades(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": -1}
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 field max_trades must be a positive integer"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_load_runtime_profiles_from_json_rejects_non_int_trade_unit(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": "100", "max_trades": 6}
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 field trade_unit must be a positive integer"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_load_runtime_profiles_from_json_rejects_non_int_max_trades(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 3.5}
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 field max_trades must be a positive integer"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_load_runtime_profiles_from_json_rejects_bool_trade_unit(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": True, "max_trades": 6}
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 field trade_unit must be a positive integer"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_load_runtime_profiles_from_json_rejects_bool_max_trades(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": True}
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile item 0 field max_trades must be a positive integer"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_build_runtime_profile_from_item_builds_profile_with_defaults():
+    from hermes_t.orchestrator import _build_runtime_profile_from_item
+
+    profile = _build_runtime_profile_from_item(
+        item={"profile_id": "demo-600519", "symbol": "600519"},
+        idx=0,
+    )
+
+    assert profile.profile_id == "demo-600519"
+    assert profile.symbol == "600519"
+    assert profile.trade_unit == 10000
+    assert profile.max_trades == 4
+
+
+def test_build_runtime_profile_from_item_rejects_missing_required_fields():
+    from hermes_t.orchestrator import _build_runtime_profile_from_item
+
+    with pytest.raises(ValueError, match="profile item 0 missing required fields: symbol"):
+        _build_runtime_profile_from_item(item={"profile_id": "demo-600519"}, idx=0)
+
+
+def test_validated_positive_int_accepts_positive_int():
+    from hermes_t.orchestrator import _validated_positive_int
+
+    assert _validated_positive_int(value=200, field_name="trade_unit", idx=0) == 200
+
+
+def test_validated_positive_int_rejects_bool():
+    from hermes_t.orchestrator import _validated_positive_int
+
+    with pytest.raises(ValueError, match="profile item 0 field max_trades must be a positive integer"):
+        _validated_positive_int(value=True, field_name="max_trades", idx=0)
+
+
+def test_missing_required_fields_returns_missing_field_names_in_order():
+    from hermes_t.orchestrator import _missing_required_fields
+
+    assert _missing_required_fields(
+        {"profile_id": "", "symbol": None, "trade_unit": "   "},
+        ("profile_id", "symbol", "trade_unit"),
+    ) == ["profile_id", "symbol", "trade_unit"]
+
+
+def test_build_runtime_profile_from_item_rejects_blank_required_string_fields():
+    from hermes_t.orchestrator import _build_runtime_profile_from_item
+
+    with pytest.raises(ValueError, match="profile item 0 missing required fields: profile_id, symbol"):
+        _build_runtime_profile_from_item(item={"profile_id": "   ", "symbol": ""}, idx=0)
+
+
+def test_build_runtime_profile_from_item_rejects_non_string_required_fields():
+    from hermes_t.orchestrator import _build_runtime_profile_from_item
+
+    with pytest.raises(ValueError, match="profile item 0 field profile_id must be a non-empty string"):
+        _build_runtime_profile_from_item(item={"profile_id": 123, "symbol": "600519"}, idx=0)
+
+    with pytest.raises(ValueError, match="profile item 0 field symbol must be a non-empty string"):
+        _build_runtime_profile_from_item(item={"profile_id": "demo-600519", "symbol": True}, idx=0)
+
+
+def test_missing_required_fields_returns_empty_list_when_all_required_fields_present():
+    from hermes_t.orchestrator import _missing_required_fields
+
+    assert _missing_required_fields(
+        {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 10000},
+        ("profile_id", "symbol", "trade_unit"),
+    ) == []
+
+
+def test_load_runtime_profiles_from_json_rejects_duplicate_profile_ids(tmp_path):
+    from hermes_t.orchestrator import load_runtime_profiles_from_json
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519"},
+            {"profile_id": "demo-600519", "symbol": "300750"},
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate profile_id 'demo-600519' at item 1"):
+        load_runtime_profiles_from_json(config_path)
+
+
+def test_run_profiles_from_config_returns_empty_summary_for_empty_profiles_config(tmp_path):
+    from hermes_t.orchestrator import run_profiles_from_config
+    from hermes_t.tech_data import FixedTechDataProvider
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text("[]", encoding="utf-8")
+
+    result = run_profiles_from_config(
+        config_path=config_path,
+        base_dir=tmp_path / "runtime",
+        tech_data_provider=FixedTechDataProvider({"summary_signal": "hold", "score": {"total": 50}}),
+        effective_trade_date="20260502",
+        dispatch=False,
+    )
+
+    assert result == {
+        "config_path": str(config_path),
+        "total_profiles": 0,
+        "results": [],
+    }
+
+
+def test_run_profiles_from_config_propagates_runner_exception(tmp_path):
+    from hermes_t.orchestrator import run_profiles_from_config
+    from hermes_t.tech_data import FixedTechDataProvider
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 6}
+        ]),
+        encoding="utf-8",
+    )
+
+    def fake_runner(store, **kwargs):
+        raise RuntimeError("runner boom")
+
+    with pytest.raises(RuntimeError, match="runner boom"):
+        run_profiles_from_config(
+            config_path=config_path,
+            base_dir=tmp_path / "runtime",
+            tech_data_provider=FixedTechDataProvider({"summary_signal": "hold", "score": {"total": 50}}),
+            effective_trade_date="20260502",
+            dispatch=False,
+            runner=fake_runner,
+        )
+
+
+def test_run_profiles_from_config_executes_each_profile_and_returns_summary(tmp_path):
+    from hermes_t.orchestrator import run_profiles_from_config
+    from hermes_t.tech_data import JsonSymbolTechDataProvider
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps(
+            [
+                {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 6},
+                {"profile_id": "demo-300750", "symbol": "300750", "trade_unit": 100, "max_trades": 3},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_runner(store, **kwargs):
+        calls.append(
+            {
+                "profile_id": store.profile.profile_id,
+                "symbol": store.profile.symbol,
+                "base_dir": str(store.base_dir),
+                "trade_date": kwargs["effective_trade_date"],
+                "tech_data": kwargs["tech_data"],
+            }
+        )
+        return {"next_action": "hold", "symbol": store.profile.symbol}
+
+    result = run_profiles_from_config(
+        config_path=config_path,
+        base_dir=tmp_path / "runtime",
+        tech_data_provider=JsonSymbolTechDataProvider(
+            tech_data_by_symbol={
+                "600519": {"summary_signal": "sell", "score": {"total": 20}},
+                "300750": {"summary_signal": "buy", "score": {"total": 80}},
+            },
+            default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+        ),
+        effective_trade_date="20260502",
+        dispatch=False,
+        runner=fake_runner,
+    )
+
+    assert [call["profile_id"] for call in calls] == ["demo-600519", "demo-300750"]
+    assert calls[0]["trade_date"] == "20260502"
+    assert calls[0]["tech_data"] == {"summary_signal": "sell", "score": {"total": 20}}
+    assert calls[1]["tech_data"] == {"summary_signal": "buy", "score": {"total": 80}}
+    assert result["total_profiles"] == 2
+    assert [item["profile_id"] for item in result["results"]] == ["demo-600519", "demo-300750"]
+    assert result["results"][1]["payload"]["symbol"] == "300750"
+
+
+def test_run_profiles_from_config_uses_default_tech_data_when_symbol_missing(tmp_path):
+    from hermes_t.orchestrator import run_profiles_from_config
+    from hermes_t.tech_data import FixedTechDataProvider
+
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 6}
+        ]),
+        encoding="utf-8",
+    )
+
+    captured = {}
+
+    def fake_runner(store, **kwargs):
+        captured["tech_data"] = kwargs["tech_data"]
+        return {"ok": True}
+
+    run_profiles_from_config(
+        config_path=config_path,
+        base_dir=tmp_path / "runtime",
+        tech_data_provider=FixedTechDataProvider({"summary_signal": "sell", "score": {"total": 20}}),
+        effective_trade_date="20260502",
+        dispatch=False,
+        runner=fake_runner,
+    )
+
+    assert captured["tech_data"] == {"summary_signal": "sell", "score": {"total": 20}}
+
+
+def test_hermes_t_cli_routes_profiles_config_to_orchestrator(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    config_path = tmp_path / "profiles.json"
+    tech_data_path = tmp_path / "tech_data.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 6}
+        ]),
+        encoding="utf-8",
+    )
+    tech_data_path.write_text(
+        json.dumps({"600519": {"summary_signal": "buy", "score": {"total": 88}}}),
+        encoding="utf-8",
+    )
+
+    def fake_run_profiles_from_config(**kwargs):
+        captured.update(kwargs)
+        return {"mode": "multi", "total_profiles": 1}
+
+    monkeypatch.setattr(main_mod, "run_profiles_from_config", fake_run_profiles_from_config)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path / "runtime"),
+            "--trade-date",
+            "20260502",
+            "--profiles-config",
+            str(config_path),
+            "--tech-data-config",
+            str(tech_data_path),
+            "--signal",
+            "sell",
+            "--score",
+            "20",
+            "--dispatch",
+            "--channel",
+            "feishu",
+            "--chat-id",
+            "oc_demo",
+            "--thread-id",
+            "omt_demo",
+        ],
+    )
+
+    main_mod.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out["mode"] == "multi"
+    assert captured["config_path"] == str(config_path)
+    assert captured["effective_trade_date"] == "20260502"
+    assert captured["dispatch"] is True
+    assert captured["channel"] == "feishu"
+    assert captured["chat_id"] == "oc_demo"
+    assert captured["thread_id"] == "omt_demo"
+    assert captured["tech_data_provider"].get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+    assert captured["tech_data_provider"].get("300750") == {"summary_signal": "sell", "score": {"total": 20}}
+
+
+def test_hermes_t_cli_routes_profiles_config_with_quote_data_to_orchestrator(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    config_path = tmp_path / "profiles.json"
+    quote_data_path = tmp_path / "quote_data.json"
+    config_path.write_text(
+        json.dumps([
+            {"profile_id": "demo-600519", "symbol": "600519", "trade_unit": 200, "max_trades": 6},
+            {"profile_id": "demo-300750", "symbol": "300750", "trade_unit": 100, "max_trades": 3},
+        ]),
+        encoding="utf-8",
+    )
+    quote_data_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "last_price": 1688.0,
+                    "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_profiles_from_config(**kwargs):
+        captured.update(kwargs)
+        return {"mode": "multi", "total_profiles": 2}
+
+    monkeypatch.setattr(main_mod, "run_profiles_from_config", fake_run_profiles_from_config)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path / "runtime"),
+            "--trade-date",
+            "20260502",
+            "--profiles-config",
+            str(config_path),
+            "--quote-data-config",
+            str(quote_data_path),
+            "--signal",
+            "hold",
+            "--score",
+            "50",
+        ],
+    )
+
+    main_mod.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert out["mode"] == "multi"
+    assert captured["config_path"] == str(config_path)
+    assert captured["tech_data_provider"].get("600519") == {"summary_signal": "sell", "score": {"total": 18}}
+    assert captured["tech_data_provider"].get("300750") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+def test_hermes_t_cli_multi_profile_passes_quote_snapshot_config_to_provider(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    config_path = tmp_path / "profiles.json"
+    config_path.write_text(
+        json.dumps(
+            [
+                {
+                    "profile_id": "demo-600519",
+                    "symbol": "600519",
+                    "label": "贵州茅台",
+                    "trade_unit": 100,
+                    "max_trades": 4,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "symbol": 600519,
+                    "last_price": 1688.0,
+                    "source": "file",
+                    "as_of": "2026-05-02T10:01:00+08:00",
+                    "tech_data": {"summary_signal": "buy", "score": {"total": 88}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_profiles_from_config(**kwargs):
+        captured.update(kwargs)
+        return {"mode": "multi", "total_profiles": 1}
+
+    monkeypatch.setattr(main_mod, "run_profiles_from_config", fake_run_profiles_from_config)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path / "runtime"),
+            "--trade-date",
+            "20260502",
+            "--profiles-config",
+            str(config_path),
+            "--quote-snapshot-config",
+            str(snapshot_path),
+            "--signal",
+            "hold",
+            "--score",
+            "50",
+        ],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["tech_data_provider"].get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+    assert captured["tech_data_provider"].get("300750") == {"summary_signal": "hold", "score": {"total": 50}}
+
+
+
+def test_hermes_t_cli_single_profile_uses_quote_snapshot_config(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "symbol": 600519,
+                    "last_price": 1688.0,
+                    "source": "file",
+                    "as_of": "2026-05-02T10:01:00+08:00",
+                    "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["symbol"] = store.profile.symbol
+        captured["tech_data"] = kwargs["tech_data"]
+        return {"ok": True}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path / "runtime"),
+            "--trade-date",
+            "20260502",
+            "--symbol",
+            "600519",
+            "--quote-snapshot-config",
+            str(snapshot_path),
+            "--signal",
+            "hold",
+            "--score",
+            "50",
+        ],
+    )
+
+    main_mod.main()
+    json.loads(capsys.readouterr().out)
+
+    assert captured["symbol"] == "600519"
+    assert captured["tech_data"] == {"summary_signal": "sell", "score": {"total": 18}}
+
+
+def test_build_tech_data_provider_prefers_explicit_tech_data_config_over_quote_snapshot_config(tmp_path):
+    from hermes_t.tech_data import JsonSymbolTechDataProvider, build_tech_data_provider
+
+    tech_data_path = tmp_path / "tech_data.json"
+    snapshot_path = tmp_path / "quote_snapshot.json"
+    tech_data_path.write_text(
+        json.dumps({"600519": {"summary_signal": "sell", "score": {"total": 12}}}),
+        encoding="utf-8",
+    )
+    snapshot_path.write_text(
+        json.dumps({"600519": {"symbol": "600519", "last_price": 1688.0, "source": "file", "as_of": "2026-05-02T10:01:00+08:00", "tech_data": {"summary_signal": "buy", "score": {"total": 88}}}}),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=tech_data_path,
+        quote_data_config_path=None,
+        quote_snapshot_config_path=snapshot_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert isinstance(provider, JsonSymbolTechDataProvider)
+    assert provider.get("600519") == {"summary_signal": "sell", "score": {"total": 12}}
+
+
+
+def test_build_tech_data_provider_prefers_explicit_tech_data_config_over_quote_data_config(tmp_path):
+    from hermes_t.tech_data import JsonSymbolTechDataProvider, build_tech_data_provider
+
+    tech_data_path = tmp_path / "tech_data.json"
+    quote_data_path = tmp_path / "quote_data.json"
+    tech_data_path.write_text(
+        json.dumps({"600519": {"summary_signal": "buy", "score": {"total": 88}}}),
+        encoding="utf-8",
+    )
+    quote_data_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "last_price": 1688.0,
+                    "tech_data": {"summary_signal": "sell", "score": {"total": 18}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        tech_data_config_path=tech_data_path,
+        quote_data_config_path=quote_data_path,
+        default_tech_data={"summary_signal": "hold", "score": {"total": 50}},
+    )
+
+    assert isinstance(provider, JsonSymbolTechDataProvider)
+    assert provider.get("600519") == {"summary_signal": "buy", "score": {"total": 88}}
+
+
+def test_hermes_t_cli_routes_quote_data_config_through_provider(monkeypatch, tmp_path, capsys):
+    import hermes_t.__main__ as main_mod
+
+    captured = {}
+    quote_data_path = tmp_path / "quote_data.json"
+    quote_data_path.write_text(
+        json.dumps(
+            {
+                "600519": {
+                    "last_price": 1688.0,
+                    "tech_data": {"summary_signal": "sell", "score": {"total": 12}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_runtime_cycle(store, **kwargs):
+        captured["tech_data"] = kwargs["tech_data"]
+        captured["base_dir"] = str(store.base_dir)
+        return {"ok": True, "tech_data": kwargs["tech_data"]}
+
+    monkeypatch.setattr(main_mod, "run_runtime_cycle", fake_run_runtime_cycle)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path / "runtime"),
+            "--trade-date",
+            "20260502",
+            "--symbol",
+            "600519",
+            "--quote-data-config",
+            str(quote_data_path),
+            "--signal",
+            "hold",
+            "--score",
+            "50",
+        ],
+    )
+
+    main_mod.main()
+    out = json.loads(capsys.readouterr().out)
+
+    assert captured["base_dir"] == str(tmp_path / "runtime")
+    assert captured["tech_data"] == {"summary_signal": "sell", "score": {"total": 12}}
+    assert out["tech_data"] == {"summary_signal": "sell", "score": {"total": 12}}
+
+
+def test_run_runtime_cycle_blocks_duplicate_sent_candidate_without_restaging_for_custom_profile(tmp_path):
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 1,
+            "buy_count": 0,
+            "actions": [
+                {
+                    "signal_id": "sell_1_20260422_093000",
+                    "signal_key": "sell_1",
+                    "trade_date": "20260422",
+                    "action": "sell",
+                    "sequence": 1,
+                    "status": "sent",
+                    "sent_at": "2026-04-22 09:30:05",
+                    "channel": "feishu",
+                    "text": "第1次卖出 200 股",
+                }
+            ],
+            "active_signal": None,
+            "last_signal_id": "sell_1_20260422_093000",
+            "last_signal_action": "sell",
+            "last_signal_status": "sent",
+            "last_signal_at": "2026-04-22 09:30:05",
+        }
+    )
+    store.save_push_state(
+        {
+            "last_pushed_signal": "sell_1",
+            "last_pushed_signal_id": "sell_1_20260422_093000",
+            "last_pushed_trade_date": "20260422",
+            "last_pushed_at": "2026-04-22 09:30:05",
+        }
+    )
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+        dispatch=False,
+    )
+
+    assert result["suggestion"]["next_action"] == "hold"
+    assert result["suggestion"]["reason"] == "duplicate_sent_signal"
+    assert result["suggestion"]["trade_unit"] == 200
+    assert result["suggestion"]["max_trades"] == 6
+    assert result["pending"] == {}
+    assert store.load_pending_signal() == {}
+    assert store.load_execution_state()["active_signal"] is None
+
+
+def test_run_runtime_cycle_reuses_failed_pending_after_cooldown_with_custom_profile(tmp_path, monkeypatch):
+    profile = RuntimeProfile(
+        profile_id="demo-600519",
+        symbol="600519",
+        trade_unit=200,
+        max_trades=6,
+    )
+    store = TradingStateStore(tmp_path, profile=profile)
+    store.save_execution_state(
+        {
+            "trade_date": "20260422",
+            "sell_count": 0,
+            "buy_count": 0,
+            "actions": [],
+            "active_signal": {
+                "signal_id": "sell_1_20260422_093000",
+                "signal_key": "sell_1",
+                "trade_date": "20260422",
+                "action": "sell",
+                "sequence": 1,
+                "status": "failed",
+                "created_at": "2026-04-22 09:30:00",
+                "last_attempt_at": "2026-04-22 09:30:00",
+                "last_error": "temporary gateway error",
+            },
+        }
+    )
+    store.save_pending_signal(
+        {
+            "signal_id": "sell_1_20260422_093000",
+            "signal_key": "sell_1",
+            "trade_date": "20260422",
+            "action": "sell",
+            "sequence": 1,
+            "status": "failed",
+            "created_at": "2026-04-22 09:30:00",
+            "text": "第1次卖出 200 股",
+            "trade_unit": 200,
+            "attempts": 1,
+            "last_attempt_at": "2026-04-22 09:30:00",
+            "last_attempt_status": "failed",
+            "last_error": "temporary gateway error",
+            "last_error_retryable": True,
+        }
+    )
+    import hermes_olin.runtime as runtime_mod
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "load_runtime_policy",
+        lambda: {
+            "pending_signal_timeout_sec": 300,
+            "pending_signal_max_attempts": 3,
+            "pending_retry_cooldown_sec": 30,
+            "candidate_freshness_limit_sec": 0,
+        },
+    )
+
+    result = run_runtime_cycle(
+        store,
+        tech_data={"summary_signal": "sell", "score": {"total": 20}},
+        effective_trade_date="20260422",
+        now=datetime(2026, 4, 22, 9, 31, 0),
+        dispatch=False,
+    )
+
+    assert result["suggestion"]["next_action"] == "sell"
+    assert result["suggestion"]["reason"] == "retry_ready_reuse_failed_pending"
+    assert result["suggestion"]["trade_unit"] == 200
+    assert result["suggestion"]["max_trades"] == 6
+    assert result["result"]["signal_id"] == "sell_1_20260422_093000"
+    assert result["result"]["status"] == "failed"
+    assert result["pending"]["signal_id"] == "sell_1_20260422_093000"
+    assert store.load_pending_signal()["signal_id"] == "sell_1_20260422_093000"

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "agent-client-protocol"
 version = "0.9.0"
@@ -157,19 +153,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiohttp-socks"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "python-socks" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
-]
-
-[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -189,120 +172,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
-]
-
-[[package]]
-name = "alibabacloud-credentials"
-version = "1.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "alibabacloud-credentials-api" },
-    { name = "alibabacloud-tea" },
-    { name = "apscheduler" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/15/2b01b4a6cbed4cc2c8a1c801efec43af945af22fd3ca5f78c932117fd4ce/alibabacloud_credentials-1.0.8.tar.gz", hash = "sha256:364c22abef2d240b259ceadf1ce6800017f19a336729553956928a1edd12e769", size = 40465, upload-time = "2026-03-11T09:13:59.398Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/24/7c47501b24897a1379cd57cc8b8de376161f2487548fc8233b2b74ab25c7/alibabacloud_credentials-1.0.8-py3-none-any.whl", hash = "sha256:66677c3fa54aeb66cfb9cc97da4a787534f38a04d09bbfa0bc6c815fe1af7e28", size = 48799, upload-time = "2026-03-11T09:13:58.113Z" },
-]
-
-[[package]]
-name = "alibabacloud-credentials-api"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/87/1d7019d23891897cb076b2f7e3c81ab3c2ba91de3bb067196f675d60d34c/alibabacloud-credentials-api-1.0.0.tar.gz", hash = "sha256:8c340038d904f0218d7214a8f4088c31912bfcf279af2cbc7d9be4897a97dd2f", size = 2330, upload-time = "2025-01-13T05:53:04.931Z" }
-
-[[package]]
-name = "alibabacloud-dingtalk"
-version = "2.2.42"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alibabacloud-endpoint-util" },
-    { name = "alibabacloud-gateway-dingtalk" },
-    { name = "alibabacloud-gateway-spi" },
-    { name = "alibabacloud-openapi-util" },
-    { name = "alibabacloud-tea-openapi" },
-    { name = "alibabacloud-tea-util" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/66/36efc03a2a8ed16c2ce176fd5ab6ff9725d0048aef33eaf867e85e625401/alibabacloud_dingtalk-2.2.42.tar.gz", hash = "sha256:220b1d52f5ef82a23ea625d3c8a91a733a685417248e217cf5aa30fe0b3a8978", size = 2023797, upload-time = "2026-04-10T03:58:28.143Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/80/7d1c1438e17c1fc90d037f1b73debe3fc2dfa348eb91e12818c2584d1865/alibabacloud_dingtalk-2.2.42-py3-none-any.whl", hash = "sha256:5f5c2ef3351b7926eb870af11089e14f802e4caa51d5f72920ad79a67f03d3e4", size = 2142688, upload-time = "2026-04-10T03:58:26.33Z" },
-]
-
-[[package]]
-name = "alibabacloud-endpoint-util"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/7d/8cc92a95c920e344835b005af6ea45a0db98763ad6ad19299d26892e6c8d/alibabacloud_endpoint_util-0.0.4.tar.gz", hash = "sha256:a593eb8ddd8168d5dc2216cd33111b144f9189fcd6e9ca20e48f358a739bbf90", size = 2813, upload-time = "2025-06-12T07:20:52.572Z" }
-
-[[package]]
-name = "alibabacloud-gateway-dingtalk"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alibabacloud-gateway-spi" },
-    { name = "alibabacloud-tea-util" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/40/751d8bdf133d7fcf053f10c98e8e506810e7bee06458a02eaaa14d30ac26/alibabacloud_gateway_dingtalk-1.0.2.tar.gz", hash = "sha256:acea8b0b1d11e0394913f0b0899ddd19c0bfceab716060449b57fcc250ceb300", size = 2938, upload-time = "2023-04-25T09:48:42.249Z" }
-
-[[package]]
-name = "alibabacloud-gateway-spi"
-version = "0.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alibabacloud-credentials" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/98/d7111245f17935bf72ee9bea60bbbeff2bc42cdfe24d2544db52bc517e1a/alibabacloud_gateway_spi-0.0.3.tar.gz", hash = "sha256:10d1c53a3fc5f87915fbd6b4985b98338a776e9b44a0263f56643c5048223b8b", size = 4249, upload-time = "2025-02-23T16:29:54.222Z" }
-
-[[package]]
-name = "alibabacloud-openapi-util"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alibabacloud-tea-util" },
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/51/be5802851a4ed20ac2c6db50ac8354a6e431e93db6e714ca39b50983626f/alibabacloud_openapi_util-0.2.4.tar.gz", hash = "sha256:87022b9dcb7593a601f7a40ca698227ac3ccb776b58cb7b06b8dc7f510995c34", size = 7981, upload-time = "2026-01-15T08:05:03.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/46/9b217343648b366eb93447f5d93116e09a61956005794aed5ef95a2e9e2e/alibabacloud_openapi_util-0.2.4-py3-none-any.whl", hash = "sha256:a2474f230b5965ae9a8c286e0dc86132a887928d02d20b8182656cf6b1b6c5bd", size = 7661, upload-time = "2026-01-15T08:05:01.374Z" },
-]
-
-[[package]]
-name = "alibabacloud-tea"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/7d/b22cb9a0d4f396ee0f3f9d7f26b76b9ed93d4101add7867a2c87ed2534f5/alibabacloud-tea-0.4.3.tar.gz", hash = "sha256:ec8053d0aa8d43ebe1deb632d5c5404339b39ec9a18a0707d57765838418504a", size = 8785, upload-time = "2025-03-24T07:34:42.958Z" }
-
-[[package]]
-name = "alibabacloud-tea-openapi"
-version = "0.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alibabacloud-credentials" },
-    { name = "alibabacloud-gateway-spi" },
-    { name = "alibabacloud-tea-util" },
-    { name = "cryptography" },
-    { name = "darabonba-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/93/138bcdc8fc596add73e37cf2073798f285284d1240bda9ee02f9384fc6be/alibabacloud_tea_openapi-0.4.4.tar.gz", hash = "sha256:1b0917bc03cd49417da64945e92731716d53e2eb8707b235f54e45b7473221ce", size = 21960, upload-time = "2026-03-26T10:16:16.792Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/5a/6bfc4506438c1809c486f66217ad11eab78157192b3d5707b4e2f4212f6c/alibabacloud_tea_openapi-0.4.4-py3-none-any.whl", hash = "sha256:cea6bc1fe35b0319a8752cb99eb0ecb0dab7ca1a71b99c12970ba0867410995f", size = 26236, upload-time = "2026-03-26T10:16:15.861Z" },
-]
-
-[[package]]
-name = "alibabacloud-tea-util"
-version = "0.3.14"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alibabacloud-tea" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/ee/ea90be94ad781a5055db29556744681fc71190ef444ae53adba45e1be5f3/alibabacloud_tea_util-0.3.14.tar.gz", hash = "sha256:708e7c9f64641a3c9e0e566365d2f23675f8d7c2a3e2971d9402ceede0408cdb", size = 7515, upload-time = "2025-11-19T06:01:08.504Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/9e/c394b4e2104766fb28a1e44e3ed36e4c7773b4d05c868e482be99d5635c9/alibabacloud_tea_util-0.3.14-py3-none-any.whl", hash = "sha256:10d3e5c340d8f7ec69dd27345eb2fc5a1dab07875742525edf07bbe86db93bfe", size = 6697, upload-time = "2025-11-19T06:01:07.355Z" },
 ]
 
 [[package]]
@@ -378,18 +247,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
-name = "apscheduler"
-version = "3.11.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzlocal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
 ]
 
 [[package]]
@@ -577,30 +434,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.89"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/0c/f7bccb22b245cabf392816baba20f9e95f78ace7dbc580fd40136e80e732/boto3-1.42.89.tar.gz", hash = "sha256:3e43aacc0801bba9bcd23a8c271c089af297a69565f783fcdd357ae0e330bf1e", size = 113165, upload-time = "2026-04-13T19:36:17.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/2d/69fb3acd50bab83fb295c167d33c4b653faeb5fb0f42bfca4d9b69d6fb68/boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68", size = 113203, upload-time = "2026-04-24T19:47:18.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/33/55103ba5ef9975ea54b8d39e69b76eb6e9fded3beae5f01065e26951a3a1/boto3-1.42.89-py3-none-any.whl", hash = "sha256:6204b189f4d0c655535f43d7eaa57ff4e8d965b8463c97e45952291211162932", size = 140556, upload-time = "2026-04-13T19:36:13.894Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9d/b3f617d011c42eb804d993103b8fa9acdce153e181a3042f58bfe33d7cb4/boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24", size = 140557, upload-time = "2026-04-24T19:47:15.824Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.89"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/cc/e6be943efa9051bd15c2ee14077c2b10d6e27c9e9385fc43a03a5c4ed8b5/botocore-1.42.89.tar.gz", hash = "sha256:95ac52f472dad29942f3088b278ab493044516c16dbf9133c975af16527baa99", size = 15206290, upload-time = "2026-04-13T19:36:02.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/77/2c333622a1d47cf5bf73cdcab0cb6c92addafbef2ec05f81b9f75687d9e5/botocore-1.42.96.tar.gz", hash = "sha256:75b3b841ffacaa944f645196655a21ca777591dd8911e732bfb6614545af0250", size = 15263344, upload-time = "2026-04-24T19:47:05.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/f1/90a7b8eda38b7c3a65ca7ee0075bdf310b6b471cb1b95fab6e8994323a50/botocore-1.42.89-py3-none-any.whl", hash = "sha256:d9b786c8d9db6473063b4cc5be0ba7e6a381082307bd6afb69d4216f9fa95f35", size = 14887287, upload-time = "2026-04-13T19:35:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/45/56/152c3a859ca1b9d77ed16deac3cf81682013677c68cf5715698781fc81bd/botocore-1.42.96-py3-none-any.whl", hash = "sha256:db2c3e2006628be6fde81a24124a6563c363d6982fb92728837cf174bad9d98a", size = 14945920, upload-time = "2026-04-24T19:47:00.323Z" },
 ]
 
 [[package]]
@@ -1029,19 +886,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
-]
-
-[[package]]
-name = "darabonba-core"
-version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "alibabacloud-tea" },
-    { name = "requests" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/d3/a7daaee544c904548e665829b51a9fa2572acb82c73ad787a8ff90273002/darabonba_core-1.0.5-py3-none-any.whl", hash = "sha256:671ab8dbc4edc2a8f88013da71646839bb8914f1259efc069353243ef52ea27c", size = 24580, upload-time = "2025-12-12T07:53:59.494Z" },
 ]
 
 [[package]]
@@ -1773,77 +1617,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-api-core"
-version = "2.30.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
-]
-
-[[package]]
-name = "google-api-python-client"
-version = "2.194.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-    { name = "google-auth-httplib2" },
-    { name = "httplib2" },
-    { name = "uritemplate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/ab/e83af0eb043e4ccc49571ca7a6a49984e9d00f4e9e6e6f1238d60bc84dce/google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023", size = 14443469, upload-time = "2026-04-08T23:07:35.757Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/34/5a624e49f179aa5b0cb87b2ce8093960299030ff40423bfbde09360eb908/google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717", size = 15016514, upload-time = "2026-04-08T23:07:33.093Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.49.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
-]
-
-[[package]]
-name = "google-auth-httplib2"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "httplib2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
-]
-
-[[package]]
-name = "google-auth-oauthlib"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "requests-oauthlib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
-]
-
-[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1954,11 +1727,10 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.12.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
-    { name = "croniter" },
     { name = "edge-tts" },
     { name = "exa-py" },
     { name = "fal-client" },
@@ -1971,6 +1743,7 @@ dependencies = [
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pytdx" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1985,11 +1758,10 @@ acp = [
 all = [
     { name = "agent-client-protocol" },
     { name = "aiohttp" },
-    { name = "aiohttp-socks", marker = "sys_platform == 'linux'" },
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
-    { name = "alibabacloud-dingtalk" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
     { name = "boto3" },
+    { name = "croniter" },
     { name = "daytona" },
     { name = "debugpy" },
     { name = "dingtalk-stream" },
@@ -1997,9 +1769,6 @@ all = [
     { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "faster-whisper" },
-    { name = "google-api-python-client" },
-    { name = "google-auth-httplib2" },
-    { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
     { name = "markdown", marker = "sys_platform == 'linux'" },
@@ -2014,21 +1783,20 @@ all = [
     { name = "pytest-xdist" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
-    { name = "qrcode" },
-    { name = "ruff" },
     { name = "simple-term-menu" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sounddevice" },
-    { name = "ty" },
     { name = "uvicorn", extra = ["standard"] },
-    { name = "vercel" },
 ]
 bedrock = [
     { name = "boto3" },
 ]
 cli = [
     { name = "simple-term-menu" },
+]
+cron = [
+    { name = "croniter" },
 ]
 daytona = [
     { name = "daytona" },
@@ -2039,22 +1807,12 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
-    { name = "ruff" },
-    { name = "ty" },
 ]
 dingtalk = [
-    { name = "alibabacloud-dingtalk" },
     { name = "dingtalk-stream" },
-    { name = "qrcode" },
 ]
 feishu = [
     { name = "lark-oapi" },
-    { name = "qrcode" },
-]
-google = [
-    { name = "google-api-python-client" },
-    { name = "google-auth-httplib2" },
-    { name = "google-auth-oauthlib" },
 ]
 homeassistant = [
     { name = "aiohttp" },
@@ -2063,7 +1821,6 @@ honcho = [
     { name = "honcho-ai" },
 ]
 matrix = [
-    { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "markdown" },
@@ -2076,7 +1833,6 @@ messaging = [
     { name = "aiohttp" },
     { name = "discord-py", extra = ["voice"] },
     { name = "python-telegram-bot", extra = ["webhooks"] },
-    { name = "qrcode" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
@@ -2106,6 +1862,7 @@ sms = [
 ]
 termux = [
     { name = "agent-client-protocol" },
+    { name = "croniter" },
     { name = "honcho-ai" },
     { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
@@ -2115,9 +1872,6 @@ termux = [
 ]
 tts-premium = [
     { name = "elevenlabs" },
-]
-vercel = [
-    { name = "vercel" },
 ]
 voice = [
     { name = "faster-whisper" },
@@ -2138,17 +1892,15 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = ">=3.9.0,<4" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = ">=3.13.3,<4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = ">=3.9.0,<4" },
-    { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = ">=0.10,<1" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = ">=0.20" },
-    { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = ">=2.0.0" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = ">=0.29" },
     { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
-    { name = "croniter", specifier = ">=6.0.0,<7" },
+    { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
-    { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = ">=0.20,<1" },
+    { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = ">=0.1.0,<1" },
     { name = "discord-py", extras = ["voice"], marker = "extra == 'messaging'", specifier = ">=2.7.1,<3" },
     { name = "edge-tts", specifier = ">=7.2.7,<8" },
     { name = "elevenlabs", marker = "extra == 'tts-premium'", specifier = ">=1.0,<2" },
@@ -2159,9 +1911,6 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
-    { name = "google-api-python-client", marker = "extra == 'google'", specifier = ">=2.100,<3" },
-    { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = ">=0.2,<1" },
-    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.0,<2" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
@@ -2173,7 +1922,6 @@ requires-dist = [
     { name = "hermes-agent", extras = ["dev"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["dingtalk"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'all'" },
-    { name = "hermes-agent", extras = ["google"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
@@ -2188,7 +1936,6 @@ requires-dist = [
     { name = "hermes-agent", extras = ["slack"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["tts-premium"], marker = "extra == 'all'" },
-    { name = "hermes-agent", extras = ["vercel"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["voice"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.0.1,<3" },
@@ -2208,6 +1955,7 @@ requires-dist = [
     { name = "ptyprocess", marker = "sys_platform != 'win32' and extra == 'pty'", specifier = ">=0.7.0,<1" },
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<3" },
+    { name = "pytdx", specifier = ">=1.72,<2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2,<10" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
@@ -2216,12 +1964,8 @@ requires-dist = [
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = ">=22.6,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
-    { name = "qrcode", marker = "extra == 'dingtalk'", specifier = ">=7.0,<8" },
-    { name = "qrcode", marker = "extra == 'feishu'", specifier = ">=7.0,<8" },
-    { name = "qrcode", marker = "extra == 'messaging'", specifier = ">=7.0,<8" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
-    { name = "ruff", marker = "extra == 'dev'" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = ">=1.18.0,<2" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18.0,<2" },
@@ -2230,14 +1974,12 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
     { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a29,<0.0.22" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.24.0,<1" },
-    { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.7,<0.6.0" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "vercel", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "google", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2337,18 +2079,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httplib2"
-version = "0.31.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -3391,15 +3121,6 @@ wheels = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
-]
-
-[[package]]
 name = "obstore"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3978,18 +3699,6 @@ wheels = [
 ]
 
 [[package]]
-name = "proto-plus"
-version = "1.27.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
-]
-
-[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4061,27 +3770,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
-]
-
-[[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -4327,13 +4015,16 @@ wheels = [
 ]
 
 [[package]]
-name = "pypng"
-version = "0.20220715.0"
+name = "pytdx"
+version = "1.72"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
+dependencies = [
+    { name = "click" },
+    { name = "cryptography" },
+    { name = "pandas" },
+    { name = "six" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/26/64/588bd37a7f531f8e059ad5357126b2cfbc3e99ae82551aee3589196031d0/pytdx-1.72.tar.gz", hash = "sha256:91ccac0919cc28a9f8c4aee19d770fab06d38da9503148dfe78bdc200706afad", size = 80432, upload-time = "2019-08-26T06:36:20.166Z" }
 
 [[package]]
 name = "pytest"
@@ -4422,15 +4113,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/56/652349f97dc2ce6d1aed43481d179c775f565e68796517836406fb7794c7/python_olm-3.2.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16bbb209d43d62135450696526ed0a811150e9de9df32ed91542bf9434e79030", size = 293671, upload-time = "2023-11-28T19:25:21.525Z" },
     { url = "https://files.pythonhosted.org/packages/39/ee/1e15304ac67d3a7ebecbcac417d6479abb7186aad73c6a035647938eaa8e/python_olm-3.2.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45e76b3f5060a5cf8451140d6c7e3b438f972ff432b6f39d0ca2c7f2296509bb", size = 301030, upload-time = "2023-11-28T19:25:26.634Z" },
     { url = "https://files.pythonhosted.org/packages/79/93/f6729f10149305262194774d6c8b438c0b084740cf239f48ab97b4df02fa/python_olm-3.2.16-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10a5e68a2f4b5a2bfa5fdb5dbfa22396a551730df6c4a572235acaa96e997d3f", size = 297000, upload-time = "2023-11-28T19:25:31.045Z" },
-]
-
-[[package]]
-name = "python-socks"
-version = "2.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
 ]
 
 [[package]]
@@ -4544,20 +4226,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "qrcode"
-version = "7.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pypng" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/35/ad6d4c5a547fe9a5baf85a9edbafff93fc6394b014fab30595877305fa59/qrcode-7.4.2.tar.gz", hash = "sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845", size = 535974, upload-time = "2023-02-05T22:11:46.548Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/79/aaf0c1c7214f2632badb2771d770b1500d3d7cbdf2590ae62e721ec50584/qrcode-7.4.2-py3-none-any.whl", hash = "sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a", size = 46197, upload-time = "2023-02-05T22:11:43.4Z" },
 ]
 
 [[package]]
@@ -4694,19 +4362,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4840,40 +4495,15 @@ wheels = [
 ]
 
 [[package]]
-name = "ruff"
-version = "0.15.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
-]
-
-[[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801, upload-time = "2026-04-22T20:36:06.475Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825, upload-time = "2026-04-22T20:36:04.992Z" },
 ]
 
 [[package]]
@@ -5326,30 +4956,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ty"
-version = "0.0.21"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/20/2ba8fd9493c89c41dfe9dbb73bc70a28b28028463bc0d2897ba8be36230a/ty-0.0.21.tar.gz", hash = "sha256:a4c2ba5d67d64df8fcdefd8b280ac1149d24a73dbda82fa953a0dff9d21400ed", size = 5297967, upload-time = "2026-03-06T01:57:13.809Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/70/edf38bb37517531681d1c37f5df64744e5ad02673c02eb48447eae4bea08/ty-0.0.21-py3-none-linux_armv6l.whl", hash = "sha256:7bdf2f572378de78e1f388d24691c89db51b7caf07cf90f2bfcc1d6b18b70a76", size = 10299222, upload-time = "2026-03-06T01:57:16.64Z" },
-    { url = "https://files.pythonhosted.org/packages/72/62/0047b0bd19afeefbc7286f20a5f78a2aa39f92b4d89853f0d7185ab89edc/ty-0.0.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7e9613994610431ab8625025bd2880dbcb77c5c9fabdd21134cda12d840a529d", size = 10130513, upload-time = "2026-03-06T01:57:29.93Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/20/0b93a9e91aaed23155780258cdfdb4726ef68b6985378ac069bc427291a0/ty-0.0.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56d3b198b64dd0a19b2b66e257deaed2ecea568e722ae5352f3c6fb62027f89d", size = 9605425, upload-time = "2026-03-06T01:57:27.115Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/fd/9945e2fa2996a1287b1e1d7ce050e97e1f420233b271e770934bfa0880a0/ty-0.0.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d23d2c34f7a77d974bb08f0860ef700addc8a683d81a0319f71c08f87506cfd0", size = 10108298, upload-time = "2026-03-06T01:57:35.429Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e7/4ec52fcb15f3200826c9f048472c062549a05b0d1ef0b51f32d527b513c4/ty-0.0.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56b01fd2519637a4ca88344f61c96225f540c98ff18bca321d4eaa7bb0f7aa2f", size = 10121556, upload-time = "2026-03-06T01:57:03.242Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/c0/ad457be2a8abea0f25549598bd098554540ced66229488daa0d558dad3c8/ty-0.0.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9de7e11c63c6afc40f3e9ba716374add171aee7fabc70b5146a510705c6d41b", size = 10603264, upload-time = "2026-03-06T01:56:52.134Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5b/2ecc7a2175243a4bcb72f5298ae41feabbb93b764bb0dc45722f3752c2c2/ty-0.0.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62f7f5b235c4f7876db305c36997aea07b7af29b1a068f373d0e2547e25f32ff", size = 11196428, upload-time = "2026-03-06T01:57:32.94Z" },
-    { url = "https://files.pythonhosted.org/packages/37/f5/aff507d6a901f328ef96a298032b0c11aaaf950a146ed7dd3b5bf2cd3acf/ty-0.0.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8399f7c453a425291e6688efe430cfae7ab0ac4ffd50eba9f872bf878b54f6", size = 10866355, upload-time = "2026-03-06T01:56:57.831Z" },
-    { url = "https://files.pythonhosted.org/packages/be/30/822bbcb92d55b65989aa7ed06d9585f28ade9c9447369194ed4b0fb3b5b9/ty-0.0.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210e7568c9f886c4d01308d751949ee714ad7ad9d7d928d2ba90d329dd880367", size = 10738177, upload-time = "2026-03-06T01:57:11.256Z" },
-    { url = "https://files.pythonhosted.org/packages/57/cc/46e7991b6469e93ac2c7e533a028983e402485580150ac864c56352a3a82/ty-0.0.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:53508e345b11569f78b21ba8e2b4e61df38a9754947fb3cd9f2ef574367338fb", size = 10079158, upload-time = "2026-03-06T01:57:00.516Z" },
-    { url = "https://files.pythonhosted.org/packages/15/c2/0bbdadfbd008240f8f1a87dc877433cb3884436097926107ccf06e618199/ty-0.0.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:553e43571f4a35604c36cfd07d8b61a5eb7a714e3c67f8c4ff2cf674fefbaef9", size = 10150535, upload-time = "2026-03-06T01:57:08.815Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b5/2dbdb7b57b5362200ef0a39738ebd31331726328336def0143ac097ee59d/ty-0.0.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:666f6822e3b9200abfa7e95eb0ddd576460adb8d66b550c0ad2c70abc84a2048", size = 10319803, upload-time = "2026-03-06T01:57:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/72/84/70e52c0b7abc7c2086f9876ef454a73b161d3125315536d8d7e911c94ca4/ty-0.0.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0854d008347ce4a5fb351af132f660a390ab2a1163444d075251d43e6f74b9b", size = 10826239, upload-time = "2026-03-06T01:57:21.727Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/8a/1f72480fd013bbc6cd1929002abbbcde9a0b08ead6a15154de9d7f7fa37e/ty-0.0.21-py3-none-win32.whl", hash = "sha256:bef3ab4c7b966bcc276a8ac6c11b63ba222d21355b48d471ea782c4104eee4e0", size = 9693196, upload-time = "2026-03-06T01:57:24.126Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f8/1104808b875c26c640e536945753a78562d606bef4e241d9dbf3d92477f6/ty-0.0.21-py3-none-win_amd64.whl", hash = "sha256:a709d576e5bea84b745d43058d8b9cd4f27f74a0b24acb4b0cbb7d3d41e0d050", size = 10668660, upload-time = "2026-03-06T01:56:55.06Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/b8/25e0adc404bbf986977657b25318991f93097b49f8aea640d93c0b0db68e/ty-0.0.21-py3-none-win_arm64.whl", hash = "sha256:f72047996598ac20553fb7e21ba5741e3c82dee4e9eadf10d954551a5fe09391", size = 10104161, upload-time = "2026-03-06T01:57:06.072Z" },
-]
-
-[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5425,33 +5031,12 @@ wheels = [
 ]
 
 [[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
-]
-
-[[package]]
 name = "unpaddedbase64"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f8/114266b21a7a9e3d09b352bb63c9d61d918bb7aa35d08c722793bfbfd28f/unpaddedbase64-2.1.0.tar.gz", hash = "sha256:7273c60c089de39d90f5d6d4a7883a79e319dc9d9b1c8924a7fab96178a5f005", size = 5621, upload-time = "2021-03-09T11:35:47.729Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a7/563b2d8fb7edc07320bf69ac6a7eedcd7a1a9d663a6bb90a4d9bd2eda5f7/unpaddedbase64-2.1.0-py3-none-any.whl", hash = "sha256:485eff129c30175d2cd6f0cd8d2310dff51e666f7f36175f738d75dfdbd0b1c6", size = 6083, upload-time = "2021-03-09T11:35:46.7Z" },
-]
-
-[[package]]
-name = "uritemplate"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]
@@ -5523,39 +5108,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
-]
-
-[[package]]
-name = "vercel"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "cbor2" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "vercel-workers", marker = "python_full_version >= '3.12'" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/68/a671ebc656afbb5e25fb88c681b61511cc13670ea771c87b2f711782022b/vercel-0.5.7.tar.gz", hash = "sha256:8070ea1b33962adfed98498f9273f24ea2066a20c74d38643d479d8280801c6e", size = 118597, upload-time = "2026-04-15T17:58:20.424Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/2e/bacf1ccc0ec95464a68398e64bf5e36f859cd51f3e379623f103802f85f1/vercel-0.5.7-py3-none-any.whl", hash = "sha256:90eb2689c34e403db2170fec3eb47e1a91092c200d91baf4b4501fb3e2a44d28", size = 139698, upload-time = "2026-04-15T17:58:18.945Z" },
-]
-
-[[package]]
-name = "vercel-workers"
-version = "0.0.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/d8/17ba256fceff42be231ca8ff0567dcf2da54ee8de633e949fa08b9403b1f/vercel_workers-0.0.16.tar.gz", hash = "sha256:38df45dbf42fbae39ffa0e419f0908bf1beb047e38fc5ddd0a479feac340fb8c", size = 51615, upload-time = "2026-04-13T21:23:27.649Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/3a/0137d5b157845e1d41a70130d8dce8ba15d8712f34619693cda04ecb8f02/vercel_workers-0.0.16-py3-none-any.whl", hash = "sha256:542be839e46e236a68cc308695ccc3c970d76de72c978d7f416cc6ce09688896", size = 50141, upload-time = "2026-04-13T21:23:28.652Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a post-market review module for the Hermes T runtime and export it from `hermes_t`.

This change adds:
- post-market review summary generation
- realized P&L / per-share cost reduction calculation
- month cumulative review metrics
- package export for `build_post_market_review`
- focused regression coverage for normal, edge, and ledger-specific cases

## What changed

- add `hermes_t/post_market_review.py`
- export `build_post_market_review` from `hermes_t/__init__.py`
- add focused tests in `tests/test_post_market_review.py`

## Behavior clarified

This PR also formalizes the handling of losing T trades:

- if `realized_pnl > 0`, `avg_cost_after` decreases
- if `realized_pnl < 0`, `avg_cost_after` increases

Previously the review logic only updated cost reduction metrics for positive realized P&L, which made losing trades look artificially neutral. The implementation now reflects negative realized P&L truthfully.

## Edge cases covered

- zero-profit trades
- missing ledger/state behavior
- same-day ledger rows not double-counted with same-day actions
- prior-month ledger rows excluded from current month cumulative metrics
- losing T trades increase `avg_cost_after`

## Validation

Targeted:
- `uv run python3 -m pytest tests/test_post_market_review.py -q`
- result: `12 passed`

Broad regression:
- `uv run python3 -m pytest -q`
- result: `12136 passed, 59 failed, 50 errors, 89 skipped`

The remaining broad-suite failures/errors are pre-existing and unrelated to the post-market review change set.
