### PR TITLE
fix(weixin): send_weixin_direct cross-loop session check

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2030,7 +2030,9 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    if (live_adapter is not None and send_session is not None
+            and not send_session.closed
+            and send_session._loop is asyncio.get_running_loop()):
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ AUTHOR_MAP = {
     "leone.parise@gmail.com": "leoneparise",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "2093036+exiao@users.noreply.github.com": "exiao",
     "rylen.anil@gmail.com": "rylena",


### PR DESCRIPTION
Closes #18890. Salvages MottledShadow's fix onto current main with authorship preserved.

## Summary
`send_message` → weixin and cron→weixin fail with `Timeout context manager should be used inside a task` whenever the call originates outside the gateway's own event loop. Fix gates the live-adapter shortcut in `send_weixin_direct()` on a loop-identity check; cross-loop calls fall through to the existing fresh-session path.

## Root cause
`_run_async()` in `model_tools.py` runs tool coroutines on a worker-thread loop. `send_weixin_direct()` was preferring the live adapter's `_send_session`, which was created on the gateway's main loop. aiohttp 3.13's `TimerContext.__enter__` calls `asyncio.current_task(loop=session._loop)` → returns None on the worker thread → raises.

## Changes
- gateway/platforms/weixin.py: gate live-adapter branch with `send_session._loop is asyncio.get_running_loop()` (MottledShadow, cherry-picked from #18890)
- scripts/release.py: add MottledShadow to AUTHOR_MAP

## Validation
- Same-loop (inbound→reply): still takes live-adapter path ✓
- Cross-loop (send_message / cron): falls through to fresh `aiohttp.ClientSession()` ✓
- Only one `_LIVE_ADAPTERS.get()` call site; no sibling fixes needed.
- weixin is the only platform using this pattern.

Co-authored-by: MottledShadow <159539633+MottledShadow@users.noreply.github.com>