### PR TITLE
fix: exclude ancestor PIDs from gateway process scan (#13242)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -237,6 +237,26 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     return False
 
 
+def _get_ancestor_pids() -> set[int]:
+    """Return the set of PIDs in the current process's ancestor chain.
+
+    Walks from the current PID up to PID 1 (init) so that process-table scans
+    never match the calling CLI process or any of its parents.  This prevents
+    ``hermes gateway status`` from falsely counting the ``hermes`` CLI that
+    invoked it as a running gateway instance (see #13242).
+    """
+    ancestors: set[int] = set()
+    pid = os.getpid()
+    # Cap iterations to avoid infinite loops on exotic platforms.
+    for _ in range(64):
+        ancestors.add(pid)
+        parent = _get_parent_pid(pid)
+        if parent is None or parent <= 0 or parent in ancestors:
+            break
+        pid = parent
+    return ancestors
+
+
 def _append_unique_pid(pids: list[int], pid: int | None, exclude_pids: set[int]) -> None:
     if pid is None or pid <= 0:
         return
@@ -252,6 +272,10 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
     a live gateway when the PID file is stale/missing, and ``--all`` sweeps can
     discover gateways outside the current profile.
     """
+    # Exclude the entire ancestor chain so the CLI process that invoked this
+    # scan (e.g. ``hermes gateway status``) is never mistaken for a running
+    # gateway.  See #13242.
+    exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
     patterns = [
         "hermes_cli.main gateway",


### PR DESCRIPTION
## Summary

Fixes #13242 — `_scan_gateway_pids()` false-positives on the calling CLI process.

## Problem

`_scan_gateway_pids()` uses `ps` pattern matching to find running gateways. When invoked from the CLI (e.g. `hermes gateway status`), the calling process command line contains `hermes gateway`, matching the scan patterns. While `_append_unique_pid()` already excludes `os.getpid()`, it does **not** exclude parent/ancestor processes — so wrapper scripts, shell invocations, or nested process trees can still produce false positives.

## Fix

- Add `_get_ancestor_pids()` that walks the process tree from the current PID up to init (PID 1), capped at 64 iterations.
- At the top of `_scan_gateway_pids()`, merge the ancestor set into `exclude_pids` so the entire chain is filtered out before any pattern matching.

This is a hardening fix — the primary duplicate-instance guard in `gateway/run.py` already uses PID-file-based detection (`get_running_pid()`), so the self-detection issue mostly manifests in status/stop paths that fall back to process scanning.

## Testing

- Verified `_get_parent_pid()` correctly walks the chain on Linux (uses `/proc/{pid}/status` with `ps -o ppid=` fallback).
- The existing `_is_pid_ancestor_of_current_process()` helper (used by `_request_gateway_self_restart`) validates the same walk logic.
- No behavioral change for legitimate gateway PIDs — only the invoking CLI's process tree is excluded.