### PR TITLE
fix: improve Codex OAuth credential labels

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import _decode_jwt_claims, _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 
@@ -124,20 +124,52 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
-def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
-    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
+def _codex_account_id_from_token(access_token: str) -> Optional[str]:
+    claims = _decode_jwt_claims(access_token)
+    auth = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth, dict):
+        return None
+    account_id = auth.get("chatgpt_account_id")
+    if isinstance(account_id, str) and account_id.strip():
+        return account_id.strip()
+    return None
+
+
+def _fetch_codex_account_usage(
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    access_token = str(api_key or "").strip()
+    resolved_base_url = str(base_url or "").strip()
+    account_id = _codex_account_id_from_token(access_token) if access_token else None
+
+    if not access_token:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        access_token = str(creds.get("api_key", "") or "").strip()
+        resolved_base_url = resolved_base_url or str(creds.get("base_url", "") or "").strip()
+        account_id = _codex_account_id_from_token(access_token) if access_token else None
+
+        # Backward-compatible fallback for older singleton auth state that stored
+        # account_id separately from the access token. Credential-pool entries do
+        # not use this shape, so prefer the live token above when available.
+        if not account_id:
+            token_data = _read_codex_tokens()
+            tokens = token_data.get("tokens") or {}
+            account_id = str(tokens.get("account_id", "") or "").strip() or None
+
+    if not access_token:
+        return None
+
     headers = {
-        "Authorization": f"Bearer {creds['api_key']}",
+        "Authorization": f"Bearer {access_token}",
         "Accept": "application/json",
         "User-Agent": "codex-cli",
     }
     if account_id:
         headers["ChatGPT-Account-Id"] = account_id
     with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
+        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
         response.raise_for_status()
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
@@ -316,7 +348,7 @@ def fetch_account_usage(
         return None
     try:
         if normalized == "openai-codex":
-            return _fetch_codex_account_usage()
+            return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -176,6 +176,28 @@ def label_from_token(token: str, fallback: str) -> str:
         value = claims.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
+
+    # OpenAI Codex / ChatGPT OAuth tokens keep profile details in a namespaced
+    # JWT claim instead of the top-level email claim.  Without this, multiple
+    # linked Codex accounts all show up as generic labels such as
+    # ``openai-codex-oauth-8`` even when the token contains the account email.
+    profile = claims.get("https://api.openai.com/profile")
+    if isinstance(profile, dict):
+        for key in ("email", "preferred_username", "upn"):
+            value = profile.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    auth = claims.get("https://api.openai.com/auth")
+    if isinstance(auth, dict):
+        account_id = auth.get("chatgpt_account_id")
+        plan_type = auth.get("chatgpt_plan_type")
+        if isinstance(account_id, str) and account_id.strip():
+            prefix = "codex"
+            if isinstance(plan_type, str) and plan_type.strip():
+                prefix = f"codex-{plan_type.strip()}"
+            return f"{prefix}-{account_id.strip()[:8]}"
+
     return fallback
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -110,6 +110,21 @@ def _display_source(source: str) -> str:
     return source.split(":", 1)[1] if source.startswith("manual:") else source
 
 
+def _display_label(label: str, width: int = 20) -> str:
+    """Return a compact label for fixed-width `hermes auth list` output."""
+    label = str(label or "").strip()
+    if len(label) <= width:
+        return label
+
+    if "@" in label:
+        local, domain = label.split("@", 1)
+        domain_suffix = f"@{domain}"
+        if len(domain_suffix) < width - 4:
+            return f"{local[: width - len(domain_suffix) - 1]}…{domain_suffix}"
+
+    return f"{label[: width - 1]}…"
+
+
 def _classify_exhausted_status(entry) -> tuple[str, bool]:
     code = getattr(entry, "last_error_code", None)
     reason = str(getattr(entry, "last_error_reason", "") or "").strip().lower()
@@ -380,7 +395,8 @@ def auth_list_command(args) -> None:
                 marker = "← "
             status = _format_exhausted_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            label = _display_label(entry.label)
+            print(f"  #{idx}  {label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
         print()
 
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -14,6 +14,44 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
     (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
 
 
+def _jwt_with_claims(claims: dict) -> str:
+    import base64
+    import json
+
+    def enc(payload: dict) -> str:
+        raw = json.dumps(payload, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{enc({'alg': 'none'})}.{enc(claims)}."
+
+
+def test_label_from_token_reads_codex_nested_profile_email():
+    from agent.credential_pool import label_from_token
+
+    token = _jwt_with_claims({
+        "https://api.openai.com/profile": {"email": "codex@example.test", "email_verified": True},
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "97feb16e-be2d-40b8-b57e-495485376aab",
+            "chatgpt_plan_type": "plus",
+        },
+    })
+
+    assert label_from_token(token, "openai-codex-oauth-9") == "codex@example.test"
+
+
+def test_label_from_token_falls_back_to_codex_account_id_when_email_absent():
+    from agent.credential_pool import label_from_token
+
+    token = _jwt_with_claims({
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "97feb16e-be2d-40b8-b57e-495485376aab",
+            "chatgpt_plan_type": "plus",
+        },
+    })
+
+    assert label_from_token(token, "openai-codex-oauth-9") == "codex-plus-97feb16e"
+
+
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -624,6 +624,37 @@ def test_reset_config_provider_uses_atomic_yaml_write(tmp_path, monkeypatch):
     assert config_path.read_text(encoding="utf-8") == original_text
 
 
+def test_auth_list_truncates_long_email_labels(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_list_command
+
+    class _Entry:
+        id = "cred-1"
+        label = "verylongemailaccount@example.com"
+        auth_type = "oauth"
+        source = "manual:device_code"
+        last_status = None
+        last_error_code = None
+        last_status_at = None
+
+    class _Pool:
+        def entries(self):
+            return [_Entry()]
+
+        def peek(self):
+            return None
+
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
+
+    class _Args:
+        provider = "openai-codex"
+
+    auth_list_command(_Args())
+
+    out = capsys.readouterr().out
+    assert "verylon…@example.com" in out
+    assert "verylongemailaccount@example.com" not in out
+
+
 def test_auth_list_does_not_call_mutating_select(monkeypatch, capsys):
     from hermes_cli.auth_commands import auth_list_command
 

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from datetime import datetime, timezone
 
 from agent.account_usage import (
@@ -33,6 +35,30 @@ class _Client:
 
     def get(self, url, headers=None):
         return _Response(self._payload)
+
+
+class _RecordingClient:
+    def __init__(self, payload):
+        self._payload = payload
+        self.requests = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        self.requests.append((url, headers or {}))
+        return _Response(self._payload)
+
+
+def _jwt_with_claims(claims: dict) -> str:
+    def encode(part: dict) -> str:
+        raw = json.dumps(part, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{encode({'alg': 'none'})}.{encode(claims)}.sig"
 
 
 class _RoutingClient:
@@ -93,6 +119,39 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_uses_live_pool_token_for_account_id(monkeypatch):
+    pool_token = _jwt_with_claims(
+        {"https://api.openai.com/auth": {"chatgpt_account_id": "acct_pool_live"}}
+    )
+    recorded = _RecordingClient(
+        {
+            "plan_type": "pro",
+            "rate_limit": {"primary_window": {"used_percent": 10}},
+        }
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: (_ for _ in ()).throw(AssertionError("singleton auth should not be used")),
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: (_ for _ in ()).throw(AssertionError("singleton token store should not be read")),
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: recorded)
+
+    snapshot = fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key=pool_token,
+    )
+
+    assert snapshot is not None
+    assert recorded.requests
+    _, headers = recorded.requests[0]
+    assert headers["Authorization"] == f"Bearer {pool_token}"
+    assert headers["ChatGPT-Account-Id"] == "acct_pool_live"
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Summary
- derive Codex OAuth credential labels from the nested OpenAI profile JWT claim so accounts show meaningful identifiers instead of generic openai-codex-oauth-N labels
- fall back to a short Codex account-id label when no email claim is available
- truncate long labels in hermes auth list to keep the credential table aligned

## Test Plan
- python -m pytest tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_commands.py -q -o 'addopts='