### PR TITLE
Persist session workspace context

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -588,6 +588,20 @@ def load_cli_config() -> Dict[str, Any]:
 
     return defaults
 
+
+def _current_workspace_path() -> str:
+    """Return the session workspace path Hermes tools will use by default."""
+    return os.getenv("TERMINAL_CWD") or os.getcwd()
+
+
+def _session_workspace_metadata() -> dict:
+    workspace_path = _current_workspace_path()
+    return {
+        "workspace_path": workspace_path,
+        "last_cwd": workspace_path,
+    }
+
+
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
 
@@ -5042,6 +5056,7 @@ class HermesCLI:
                             "max_iterations": self.max_turns,
                             "reasoning_config": self.reasoning_config,
                         },
+                        **_session_workspace_metadata(),
                     )
                     self.agent._session_db_created = True
                 except Exception:
@@ -5259,6 +5274,7 @@ class HermesCLI:
                     "reasoning_config": self.reasoning_config,
                 },
                 parent_session_id=parent_session_id,
+                **_session_workspace_metadata(),
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -68,6 +68,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     pricing_version TEXT,
     title TEXT,
     api_call_count INTEGER DEFAULT 0,
+    workspace_path TEXT,
+    last_cwd TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -523,13 +525,15 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        workspace_path: str = None,
+        last_cwd: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, workspace_path, last_cwd)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -539,6 +543,8 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    workspace_path,
+                    last_cwd,
                 ),
             )
         self._execute_write(_do)
@@ -547,6 +553,16 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def update_session_cwd(self, session_id: str, last_cwd: str) -> None:
+        """Persist the most recent working directory for a session."""
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET last_cwd = ? WHERE id = ?",
+                (last_cwd, session_id),
+            )
+        self._execute_write(_do)
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 
@@ -2627,4 +2643,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/run_agent.py
+++ b/run_agent.py
@@ -808,6 +808,11 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+def _session_workspace_metadata() -> Dict[str, str]:
+    workspace_path = os.getenv("TERMINAL_CWD") or os.getcwd()
+    return {"workspace_path": workspace_path, "last_cwd": workspace_path}
+
+
 
 
 
@@ -2199,6 +2204,7 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
+                **_session_workspace_metadata(),
             )
             self._session_db_created = True
         except Exception as e:
@@ -9162,6 +9168,7 @@ class AIAgent:
                     model=self.model,
                     model_config=self._session_init_model_config,
                     parent_session_id=old_session_id,
+                    **_session_workspace_metadata(),
                 )
                 self._session_db_created = True
                 # Auto-number the title for the continuation session

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -35,6 +35,44 @@ class TestSessionLifecycle:
         assert session["model"] == "test-model"
         assert session["ended_at"] is None
 
+    def test_create_session_stores_workspace_context(self, db):
+        db.create_session(
+            session_id="s1",
+            source="cli",
+            workspace_path="/work/project",
+            last_cwd="/work/project/src",
+        )
+
+        session = db.get_session("s1")
+        assert session["workspace_path"] == "/work/project"
+        assert session["last_cwd"] == "/work/project/src"
+
+    def test_update_session_cwd(self, db):
+        db.create_session(
+            session_id="s1",
+            source="cli",
+            workspace_path="/work/project",
+            last_cwd="/work/project",
+        )
+
+        db.update_session_cwd("s1", "/work/project/packages/app")
+
+        session = db.get_session("s1")
+        assert session["workspace_path"] == "/work/project"
+        assert session["last_cwd"] == "/work/project/packages/app"
+
+    def test_ensure_session_stores_workspace_context(self, db):
+        db.ensure_session(
+            "s1",
+            source="cli",
+            model="test-model",
+            workspace_path="/work/project",
+            last_cwd="/work/project",
+        )
+
+        session = db.get_session("s1")
+        assert session["workspace_path"] == "/work/project"
+        assert session["last_cwd"] == "/work/project"
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
@@ -1059,13 +1097,21 @@ class TestDeleteAndExport:
         assert db.resolve_session_id("20260315_092437") == "20260315_092437_c9a6ff"
 
     def test_export_session(self, db):
-        db.create_session(session_id="s1", source="cli", model="test")
+        db.create_session(
+            session_id="s1",
+            source="cli",
+            model="test",
+            workspace_path="/work/project",
+            last_cwd="/work/project",
+        )
         db.append_message("s1", role="user", content="Hello")
         db.append_message("s1", role="assistant", content="Hi")
 
         export = db.export_session("s1")
         assert isinstance(export, dict)
         assert export["source"] == "cli"
+        assert export["workspace_path"] == "/work/project"
+        assert export["last_cwd"] == "/work/project"
         assert len(export["messages"]) == 2
 
     def test_export_nonexistent(self, db):
@@ -1414,13 +1460,15 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 12
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
+        assert "workspace_path" in columns
+        assert "last_cwd" in columns
 
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
         """Opening an old DB should not add topic-mode columns until /topic opts in.
@@ -1706,17 +1754,19 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to the current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 12
 
-        # Verify title column exists and is NULL for existing sessions
+        # Verify added columns exist and are NULL for existing sessions
         session = migrated_db.get_session("existing")
         assert session is not None
         assert session["title"] is None
+        assert session["workspace_path"] is None
+        assert session["last_cwd"] is None
 
         # Verify api_call_count column was added with default 0
         cursor = migrated_db._conn.execute(
@@ -2906,7 +2956,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 12
         finally:
             session_db.close()
-


### PR DESCRIPTION
Hi! Context: I’m a Korean developer and a heavy user of Codex and Claude Code-style agentic coding workflows. In those tools, persisted workspace context is part of what makes session resume feel reliable; I noticed Hermes doesn’t currently persist that context.

Hermes can restore transcript history, but it doesn’t persist which workspace/directories a session was associated with. For local CLI use this is often implicit, but for dashboards, remote clients, resume flows, and multi-repo workflows, it would be useful to persist at least the primary workspace and last cwd.

## Summary

This PR adds a small first step toward persisted workspace context for sessions:

- Adds `workspace_path` and `last_cwd` columns to the session store.
- Allows `create_session()` and `ensure_session()` to persist those values.
- Stores the current `TERMINAL_CWD`/`os.getcwd()` context for CLI-created sessions and fallback session creation.
- Adds `update_session_cwd()` as a small SessionDB helper for callers that can observe cwd changes.
- Covers creation, fallback creation, migration, and export behavior in `tests/test_hermes_state.py`.

I kept this intentionally narrow. A richer follow-up could track multiple referenced workspaces/directories per session, but this gives clients a stable primary workspace and current/last cwd field without changing existing session behavior.

## Tests

- `python3 -m py_compile hermes_state.py cli.py run_agent.py`
- `uv run --extra dev pytest tests/test_hermes_state.py -q`
- `git diff --check`
