### PR TITLE
fix(skills): handle bytes content in bundle_content_hash

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2801,7 +2801,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Problem

`bundle_content_hash()` calls `.encode("utf-8")` on every file entry in `SkillBundle.files`, but the type annotation explicitly declares `files: Dict[str, Union[str, bytes]]`.

When a `SkillBundle` is constructed by `LocalSource.fetch()` — which reads skill files from disk via `f.read_bytes()` — the `files` dict contains `bytes` values. Calling `.encode()` on a `bytes` object raises `AttributeError`.

## Fix

Check `isinstance(content, bytes)` before encoding. Bytes content is fed directly into the SHA-256 hasher; string content is UTF-8 encoded as before.

## Evidence

- `SkillBundle` annotation: `files: Dict[str, Union[str, bytes]]` (line 81)
- `LocalSource.fetch()` reads files as bytes: `files[rel_path] = f.read_bytes()` (line 2396 in current main)
- `content_hash()` in `tools/skills_guard.py` already handles both paths — it calls `f.read_bytes()` directly, the in-memory equivalent should match

## Verification

- Existing test `test_bundle_content_hash_matches_installed_content_hash` passes (it uses string-only bundles)
- A test with a binary file in the bundle would demonstrate the crash

Co-authored-by: Jason Kuo <jason@yechiu.com.cn>