### PR TITLE
fix(ui-tui): heal same-dimension alt-screen resize drift

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'events'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Text from './components/Text.js'
+import Ink from './ink.js'
+import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 20
+  rows = 5
+  isTTY = true
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+    return true
+  }
+}
+
+const tick = () => new Promise<void>(resolve => queueMicrotask(resolve))
+
+describe('Ink resize healing', () => {
+  it('heals same-dimension alt-screen resize events with an erase before repaint', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const ink = new Ink({
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    ink.setAltScreenActive(true)
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    stdout.chunks = []
+
+    stdout.emit('resize')
+    ink.onRender()
+    await tick()
+
+    expect(stdout.chunks.join('')).toContain(ERASE_SCREEN + CURSOR_HOME)
+
+    ink.unmount()
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -435,17 +435,17 @@ export default class Ink {
   private handleResize = () => {
     const cols = this.options.stdout.columns || 80
     const rows = this.options.stdout.rows || 24
+    const dimsChanged = cols !== this.terminalColumns || rows !== this.terminalRows
 
-    // Terminals often emit 2+ resize events for one user action (window
-    // settling). Same-dimension events are no-ops; skip to avoid redundant
-    // frame resets and renders.
-    if (cols === this.terminalColumns && rows === this.terminalRows) {
+    if (!dimsChanged && !(this.altScreenActive && !this.isPaused && this.options.stdout.isTTY)) {
       return
     }
 
-    this.terminalColumns = cols
-    this.terminalRows = rows
-    this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows)
+    if (dimsChanged) {
+      this.terminalColumns = cols
+      this.terminalRows = rows
+      this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows)
+    }
 
     // Pending throttled/drain work captured stale dims — cancel so
     // the upcoming microtask owns the next frame.
@@ -472,26 +472,7 @@ export default class Ink {
     // doesn't exit alt-screen. Do NOT write ERASE_SCREEN: render() below
     // can take ~80ms; erasing first leaves the screen blank that whole time.
     if (this.altScreenActive && !this.isPaused && this.options.stdout.isTTY) {
-      if (this.altScreenMouseTracking) {
-        this.options.stdout.write(ENABLE_MOUSE_TRACKING)
-      }
-
-      this.resetFramesForAltScreen()
-      this.needsEraseBeforePaint = true
-
-      // One last repaint after the resize burst settles closes any host-side
-      // reflow drift the normal diff path can't see.
-      this.resizeSettleTimer = setTimeout(() => {
-        this.resizeSettleTimer = null
-
-        if (!this.canAltScreenRepaint()) {
-          return
-        }
-
-        this.resetFramesForAltScreen()
-        this.needsEraseBeforePaint = true
-        this.render(this.currentNode!)
-      }, 160)
+      this.prepareAltScreenResizeRepaint()
     }
 
     // Already queued: later events in this burst updated dims/alt-screen
@@ -522,6 +503,27 @@ export default class Ink {
       !!this.options.stdout.isTTY &&
       this.currentNode !== null
     )
+  }
+
+  private prepareAltScreenResizeRepaint(): void {
+    if (this.altScreenMouseTracking) {
+      this.options.stdout.write(ENABLE_MOUSE_TRACKING)
+    }
+
+    this.resetFramesForAltScreen()
+    this.needsEraseBeforePaint = true
+
+    this.resizeSettleTimer = setTimeout(() => {
+      this.resizeSettleTimer = null
+
+      if (!this.canAltScreenRepaint()) {
+        return
+      }
+
+      this.resetFramesForAltScreen()
+      this.needsEraseBeforePaint = true
+      this.render(this.currentNode!)
+    }, 160)
   }
 
   resolveExitPromise: () => void = () => {}
@@ -850,8 +852,9 @@ export default class Ink {
     const optimized = optimize(diff)
     const optimizeMs = performance.now() - tOptimize
     const hasDiff = optimized.length > 0
+    const needsAltScreenErase = this.altScreenActive && this.needsEraseBeforePaint
 
-    if (this.altScreenActive && hasDiff) {
+    if (this.altScreenActive && (hasDiff || needsAltScreenErase)) {
       // Prepend CSI H to anchor the physical cursor to (0,0) so
       // log-update's relative moves compute from a known spot (self-healing
       // against out-of-band cursor drift, see the ALT_SCREEN_ANCHOR_CURSOR
@@ -871,7 +874,7 @@ export default class Ink {
       // erase+paint lands, then swaps in one go. Writing ERASE_SCREEN
       // synchronously in handleResize would blank the screen for the ~80ms
       // render() takes.
-      if (this.needsEraseBeforePaint) {
+      if (needsAltScreenErase) {
         this.needsEraseBeforePaint = false
         optimized.unshift(ERASE_THEN_HOME_PATCH)
       } else {
@@ -993,7 +996,7 @@ export default class Ink {
     this.lastDrainMs = 0
 
     // Only track drain on TTY. Piped/non-TTY stdout bypasses flow control.
-    const trackDrain = this.options.stdout.isTTY && hasDiff
+    const trackDrain = this.options.stdout.isTTY && optimized.length > 0
     const drainStart = trackDrain ? tWrite : 0
 
     if (trackDrain) {


### PR DESCRIPTION
## Summary

Heals a resize drift bug in the Hermes Ink TUI where rapid or same-dimension terminal resize events cause corrupted output in alt-screen mode.

## Root Cause

In , the  handler had an early return for same-dimension resize events. However, when the terminal (especially WSL Ubuntu's PTY) fires repeated same-dimension resize events during window drag settling, the physical PTY buffer can accumulate stale content while Ink skips the repaint due to the early return.

Additionally,  was only set when  was true, but same-dimension resize events can produce no diff while the physical terminal still has stale characters.

## Fix

1. **Remove early return for same-dimension resizes in alt-screen mode** — The condition now allows alt-screen resize repaints even when dimensions haven't changed, ensuring ERASE_SCREEN is emitted to clear stale buffer content.

2. **Always erase before paint when  is set** — The original code checked  before applying the erase, but the erase is necessary even when the virtual diff is empty (the physical buffer still needs clearing).

3. **Extract ** — Refactored into a named method for clarity and testability.

4. **Add regression test** () — Tests that same-dimension resize events in alt-screen mode emit ERASE_SCREEN + CURSOR_HOME to heal buffer drift.

## Test

```bash
cd ui-tui && npm test
```

All 549 tests pass (including the new resize healing test).

## Related

- Issue: #18449