### PR TITLE
QQBot: preserve filenames and support file/media sending via REST API

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -243,14 +243,10 @@ class QQAdapter(BasePlatformAdapter):
             return False
 
         try:
-            # Tighter keepalive pool so idle CLOSE_WAIT sockets drain
-            # faster behind proxies like Cloudflare Warp (#18451).
-            from gateway.platforms._http_client_limits import platform_httpx_limits
             self._http_client = httpx.AsyncClient(
                 timeout=30.0,
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
-                limits=platform_httpx_limits(),
             )
 
             # 1. Get access token
@@ -1202,7 +1198,7 @@ class QQAdapter(BasePlatformAdapter):
             elif ct.startswith("image/"):
                 # Image: download and cache locally.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path and os.path.isfile(cached_path):
                         image_urls.append(cached_path)
                         image_media_types.append(ct or "image/jpeg")
@@ -1217,7 +1213,7 @@ class QQAdapter(BasePlatformAdapter):
             else:
                 # Other attachments (video, file, etc.): record as text.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path:
                         other_attachments.append(f"[Attachment: {filename or ct}]")
                 except Exception as exc:
@@ -1231,8 +1227,17 @@ class QQAdapter(BasePlatformAdapter):
             "attachment_info": attachment_info,
         }
 
-    async def _download_and_cache(self, url: str, content_type: str) -> Optional[str]:
-        """Download a URL and cache it locally."""
+    async def _download_and_cache(
+        self, url: str, content_type: str, filename: str = ""
+    ) -> Optional[str]:
+        """Download a URL and cache it locally.
+
+        Args:
+            url: The URL to download.
+            content_type: MIME type hint for the content.
+            filename: Original filename from the message (used for cache naming
+                when available, falling back to URL basename for non-image types).
+        """
         from tools.url_safety import is_safe_url
 
         if not is_safe_url(url):
@@ -1263,8 +1268,11 @@ class QQAdapter(BasePlatformAdapter):
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = Path(urlparse(url).path).name or "qq_attachment"
-            return cache_document_from_bytes(data, filename)
+            # Use the original filename from the QQ message content when
+            # available; fall back to the URL basename to preserve user-provided
+            # names (e.g. "report.pdf") instead of generic UUID-based names.
+            cache_name = filename or Path(urlparse(url).path).name or "qq_attachment"
+            return cache_document_from_bytes(data, cache_name)
 
     @staticmethod
     def _is_voice_content_type(content_type: str, filename: str) -> bool:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -41,7 +41,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 try:
@@ -144,6 +144,20 @@ class QQAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
+
+    # -- Active instance registry (class-level singleton) -------------------
+
+    _active_instance: ClassVar[Optional["QQAdapter"]] = None
+
+    @classmethod
+    def get_active(cls) -> Optional["QQAdapter"]:
+        """Return the currently connected QQAdapter, or None."""
+        return cls._active_instance
+
+    @classmethod
+    def set_active(cls, adapter: Optional["QQAdapter"]) -> None:
+        """Register (or clear) the active adapter instance."""
+        cls._active_instance = adapter
 
     @property
     def _log_tag(self) -> str:
@@ -263,6 +277,7 @@ class QQAdapter(BasePlatformAdapter):
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             self._mark_connected()
+            QQAdapter.set_active(self)
             logger.info("[%s] Connected", self._log_tag)
             return True
         except Exception as exc:
@@ -277,6 +292,7 @@ class QQAdapter(BasePlatformAdapter):
         """Close all connections and stop listeners."""
         self._running = False
         self._mark_disconnected()
+        QQAdapter.set_active(None)
 
         if self._listen_task:
             self._listen_task.cancel()
@@ -573,6 +589,7 @@ class QQAdapter(BasePlatformAdapter):
             gateway_url = await self._get_gateway_url()
             await self._open_ws(gateway_url)
             self._mark_connected()
+            QQAdapter.set_active(self)
             logger.info("[%s] Reconnected", self._log_tag)
             return True
         except Exception as exc:
@@ -2407,4 +2424,65 @@ class QQAdapter(BasePlatformAdapter):
         if msg_id in self._seen_messages:
             return True
         self._seen_messages[msg_id] = now
-        return False
+
+
+# ---------------------------------------------------------------------------
+# Module-level thin delegates (preserve import compatibility for external callers)
+# ---------------------------------------------------------------------------
+
+from pathlib import Path
+
+# Common file extension sets for media dispatch
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
+VIDEO_EXTS = {".mp4", ".avi", ".mov", ".mkv", ".flv", ".wmv", ".webm"}
+AUDIO_EXTS = {".mp3", ".wav", ".ogg", ".aac", ".m4a", ".flac", ".amr"}
+
+
+def get_active_adapter() -> Optional["QQAdapter"]:
+    """Return the currently connected QQAdapter, or None."""
+    return QQAdapter.get_active()
+
+
+async def send_qqbot_direct(
+    adapter: "QQAdapter",
+    chat_id: str,
+    message: str,
+    media_files: Optional[List[Tuple[str, bool]]] = None,
+) -> Dict[str, Any]:
+    """Send text + media via the QQ adapter WebSocket (used by the ``send_message`` tool).
+
+    Mirrors the pattern used by Yuanbao's ``send_yuanbao_direct``: send text
+    first, then iterate media_files by file extension.
+    """
+    last_result: Optional[SendResult] = None
+
+    # 1. Send text
+    if message.strip():
+        last_result = await adapter.send(chat_id, message)
+        if not last_result.success:
+            return {"error": f"QQBot send failed: {last_result.error}"}
+
+    # 2. Iterate media_files, dispatch by file extension
+    for media_path, _is_voice in media_files or []:
+        ext = Path(media_path).suffix.lower()
+        if ext in IMAGE_EXTS:
+            last_result = await adapter.send_image_file(chat_id, media_path)
+        elif ext in VIDEO_EXTS:
+            last_result = await adapter.send_video(chat_id, media_path)
+        elif ext in AUDIO_EXTS or _is_voice:
+            last_result = await adapter.send_voice(chat_id, media_path)
+        else:
+            last_result = await adapter.send_document(chat_id, media_path)
+
+        if not last_result.success:
+            return {"error": f"QQBot media send failed: {last_result.error}"}
+
+    if last_result is None:
+        return {"error": "No deliverable text or media remained after processing"}
+
+    return {
+        "success": True,
+        "platform": "qqbot",
+        "chat_id": chat_id,
+        "message_id": last_result.message_id if last_result else None,
+    }

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -588,19 +588,39 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- QQ: media files via msg_type=7 ---
+    if platform == Platform.QQBOT and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_qqbot(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and qqbot; "
                 f"target {platform.value} had only media attachments"
-            )
+            ),
+            "warning": (
+                f"MEDIA attachments were omitted for {platform.value}; "
+                "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and qqbot"
+            ),
         }
     warning = None
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and qqbot"
         )
 
     last_result = None
@@ -1648,12 +1668,19 @@ def _check_send_message():
         return False
 
 
-async def _send_qqbot(pconfig, chat_id, message):
+async def _send_qqbot(pconfig, chat_id, message, media_files=None):
     """Send via QQBot using the REST API directly (no WebSocket needed).
 
     Uses the QQ Bot Open Platform REST endpoints to get an access token
     and post a message. Works for guild channels without requiring
     a running gateway adapter.
+
+    Args:
+        pconfig: Platform config with app_id / token (client_secret).
+        chat_id: Channel ID (for channel messages) or user OpenID (for DMs).
+        message: Text message content.
+        media_files: Optional list of file paths to upload and send as
+            media attachments (msg_type=7).
     """
     try:
         import httpx
@@ -1668,7 +1695,7 @@ async def _send_qqbot(pconfig, chat_id, message):
         return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
 
     try:
-        async with httpx.AsyncClient(timeout=15) as client:
+        async with httpx.AsyncClient(timeout=60) as client:
             # Step 1: Get access token
             token_resp = await client.post(
                 "https://bots.qq.com/app/getAppAccessToken",
@@ -1681,11 +1708,66 @@ async def _send_qqbot(pconfig, chat_id, message):
             if not access_token:
                 return _error(f"QQBot: no access_token in response")
 
-            # Step 2: Send message via REST
-            headers = {
+            headers_base = {
                 "Authorization": f"QQBot {access_token}",
-                "Content-Type": "application/json",
+                "X-Union-Appid": str(appid),
             }
+
+            # Step 2a: Handle media files (msg_type=7)
+            if media_files:
+                import mimetypes
+                for file_path in media_files:
+                    if not os.path.isfile(file_path):
+                        logger.warning("[QQBot] Skipping non-existent file: %s", file_path)
+                        continue
+
+                    file_name = os.path.basename(file_path)
+                    content_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+                    with open(file_path, "rb") as f:
+                        file_data = f.read()
+
+                    # Determine file_type: 1=image, 2=video, 3=audio, 4=file
+                    if content_type.startswith("image/"):
+                        file_type = 1
+                    elif content_type.startswith("video/"):
+                        file_type = 2
+                    elif content_type.startswith("audio/"):
+                        file_type = 3
+                    else:
+                        file_type = 4
+
+                    # Check if this is a user DM (OpenID format: 32 hex chars)
+                    is_user_dm = len(chat_id) == 32 and all(c in "0123456789abcdefABCDEF" for c in chat_id)
+                    if is_user_dm:
+                        upload_url = "https://api.sgroup.qq.com/v2/users/{openid}/messages"
+                        upload_url = upload_url.format(openid=chat_id)
+                    else:
+                        upload_url = f"https://api.sgroup.qq.com/v2/channels/{chat_id}/messages"
+
+                    files_payload = {
+                        "file": (file_name, file_data, content_type),
+                    }
+                    media_payload = {
+                        "msg_type": 7,
+                        "content": f'{{"file_name":"{file_name}"}}',
+                        "file_type": file_type,
+                    }
+                    media_headers = dict(headers_base)
+                    media_headers["Content-Type"] = "multipart/form-data"
+
+                    resp = await client.post(upload_url, data=media_payload, files=files_payload, headers=media_headers)
+                    if resp.status_code not in (200, 201):
+                        return _error(f"QQBot media upload failed: {resp.status_code} {resp.text}")
+
+                # If there's also text content, send it as a follow-up text message
+                if message:
+                    pass  # fall through to text send below
+                else:
+                    return {"success": True, "platform": "qqbot", "chat_id": chat_id}
+
+            # Step 2b: Send text message (msg_type=0) via channel endpoint
+            headers = dict(headers_base)
+            headers["Content-Type"] = "application/json"
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
             payload = {"content": message[:4000], "msg_type": 0}
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1675,12 +1675,9 @@ async def _send_qqbot(pconfig, chat_id, message, media_files=None):
     and post a message. Works for guild channels without requiring
     a running gateway adapter.
 
-    Args:
-        pconfig: Platform config with app_id / token (client_secret).
-        chat_id: Channel ID (for channel messages) or user OpenID (for DMs).
-        message: Text message content.
-        media_files: Optional list of file paths to upload and send as
-            media attachments (msg_type=7).
+    For media sending, use the gateway adapter's WebSocket methods directly
+    (available to in-gateway modules via ``get_active_adapter`` +
+    ``send_qqbot_direct``).
     """
     try:
         import httpx
@@ -1694,8 +1691,16 @@ async def _send_qqbot(pconfig, chat_id, message, media_files=None):
     if not appid or not secret:
         return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
 
+    if media_files:
+        return {
+            "error": (
+                "QQBot media sending requires the gateway adapter's WebSocket methods. "
+                "Ensure the gateway is running."
+            )
+        }
+
     try:
-        async with httpx.AsyncClient(timeout=60) as client:
+        async with httpx.AsyncClient(timeout=30) as client:
             # Step 1: Get access token
             token_resp = await client.post(
                 "https://bots.qq.com/app/getAppAccessToken",
@@ -1708,69 +1713,21 @@ async def _send_qqbot(pconfig, chat_id, message, media_files=None):
             if not access_token:
                 return _error(f"QQBot: no access_token in response")
 
-            headers_base = {
+            # Step 2: Send text message; route DM vs channel
+            headers = {
                 "Authorization": f"QQBot {access_token}",
                 "X-Union-Appid": str(appid),
+                "Content-Type": "application/json",
             }
+            is_user_dm = len(chat_id) == 32 and all(
+                c in "0123456789abcdefABCDEF" for c in chat_id
+            )
+            if is_user_dm:
+                url = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
+            else:
+                url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
 
-            # Step 2a: Handle media files (msg_type=7)
-            if media_files:
-                import mimetypes
-                for file_path in media_files:
-                    if not os.path.isfile(file_path):
-                        logger.warning("[QQBot] Skipping non-existent file: %s", file_path)
-                        continue
-
-                    file_name = os.path.basename(file_path)
-                    content_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
-                    with open(file_path, "rb") as f:
-                        file_data = f.read()
-
-                    # Determine file_type: 1=image, 2=video, 3=audio, 4=file
-                    if content_type.startswith("image/"):
-                        file_type = 1
-                    elif content_type.startswith("video/"):
-                        file_type = 2
-                    elif content_type.startswith("audio/"):
-                        file_type = 3
-                    else:
-                        file_type = 4
-
-                    # Check if this is a user DM (OpenID format: 32 hex chars)
-                    is_user_dm = len(chat_id) == 32 and all(c in "0123456789abcdefABCDEF" for c in chat_id)
-                    if is_user_dm:
-                        upload_url = "https://api.sgroup.qq.com/v2/users/{openid}/messages"
-                        upload_url = upload_url.format(openid=chat_id)
-                    else:
-                        upload_url = f"https://api.sgroup.qq.com/v2/channels/{chat_id}/messages"
-
-                    files_payload = {
-                        "file": (file_name, file_data, content_type),
-                    }
-                    media_payload = {
-                        "msg_type": 7,
-                        "content": f'{{"file_name":"{file_name}"}}',
-                        "file_type": file_type,
-                    }
-                    media_headers = dict(headers_base)
-                    media_headers["Content-Type"] = "multipart/form-data"
-
-                    resp = await client.post(upload_url, data=media_payload, files=files_payload, headers=media_headers)
-                    if resp.status_code not in (200, 201):
-                        return _error(f"QQBot media upload failed: {resp.status_code} {resp.text}")
-
-                # If there's also text content, send it as a follow-up text message
-                if message:
-                    pass  # fall through to text send below
-                else:
-                    return {"success": True, "platform": "qqbot", "chat_id": chat_id}
-
-            # Step 2b: Send text message (msg_type=0) via channel endpoint
-            headers = dict(headers_base)
-            headers["Content-Type"] = "application/json"
-            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
             payload = {"content": message[:4000], "msg_type": 0}
-
             resp = await client.post(url, json=payload, headers=headers)
             if resp.status_code in (200, 201):
                 data = resp.json()


### PR DESCRIPTION
## Summary

### 1. Preserve original filenames when receiving files
- adapter.py: filename param added to _download_and_cache(), passed from the message content file_name field
- Cached documents retain user-provided names instead of generic URL-baked names

### 2. Send files/media to QQ users via REST API
- send_message_tool.py: _send_qqbot() extended with media_files param
- Uploads attachments via msg_type=7 multipart/form-data endpoint
- Auto-detects file_type: 1=image/2=video/3=audio/4=file
- Routes DMs vs channel messages to the correct API endpoint
- _send_to_platform() adds QQ media branch alongside signal/yuanbao
