### PR TITLE
fix(mcp-oauth): persist metadata across restarts

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -414,6 +414,54 @@ class TestWaitForCallbackNoBlocking:
                 with pytest.raises(OAuthNonInteractiveError, match="callback timed out"):
                     asyncio.run(_wait_for_callback())
 
+    def test_clears_shared_callback_result_after_timeout(self):
+        """A completed/failed callback wait must not leak stale code/state."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = {"auth_code": None, "state": None, "error": None}
+
+        async def instant_sleep(_seconds):
+            pass
+
+        with patch.object(mod.asyncio, "sleep", instant_sleep):
+            with pytest.raises(OAuthNonInteractiveError, match="callback timed out"):
+                asyncio.run(_wait_for_callback())
+
+        assert mod._oauth_result is None
+
+    def test_localhost_redirect_host_binds_loopback_not_all_interfaces(self):
+        """redirect_host=localhost must not broaden the listener to 0.0.0.0."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_bind_host = "localhost"
+        mod._oauth_result = None
+        addresses = []
+
+        class FakeServer:
+            def __init__(self, address, _handler_cls):
+                addresses.append(address)
+
+            def handle_request(self):
+                return None
+
+            def server_close(self):
+                return None
+
+        async def instant_sleep(_seconds):
+            pass
+
+        with patch.object(mod, "HTTPServer", FakeServer), \
+             patch.object(mod.asyncio, "sleep", instant_sleep):
+            with pytest.raises(OAuthNonInteractiveError, match="callback timed out"):
+                asyncio.run(_wait_for_callback())
+
+        assert addresses
+        assert addresses[0][0] == "localhost"
+
 
 class TestBuildOAuthAuthNonInteractive:
     """build_oauth_auth() in non-interactive mode."""
@@ -546,7 +594,7 @@ def test_build_oauth_auth_preserves_server_url_path():
             captured.update(kwargs)
 
     with patch.object(mcp_oauth, "_OAUTH_AVAILABLE", True), \
-         patch.object(mcp_oauth, "OAuthClientProvider", _FakeProvider), \
+         patch.object(mcp_oauth, "_HermesOAuthProvider", _FakeProvider), \
          patch.object(mcp_oauth, "_is_interactive", return_value=True), \
          patch.object(mcp_oauth, "_maybe_preregister_client"), \
          patch.object(mcp_oauth, "HermesTokenStorage") as mock_storage_cls:
@@ -558,5 +606,4 @@ def test_build_oauth_auth_preserves_server_url_path():
         )
 
     assert captured["server_url"] == "https://mcp.notion.com/mcp"
-
 

--- a/tests/tools/test_mcp_oauth_metadata.py
+++ b/tests/tools/test_mcp_oauth_metadata.py
@@ -1,0 +1,286 @@
+"""Tests for OAuth server metadata persistence in tools/mcp_oauth.py.
+
+Covers the ``.meta.json`` roundtrip on ``HermesTokenStorage`` and the
+``_HermesOAuthProvider`` subclass behavior (restore on init, persist on
+auth flow completion).
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp.shared.auth import OAuthMetadata
+
+from tools.mcp_oauth import HermesTokenStorage, _HermesOAuthProvider
+from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS
+
+
+def _make_metadata(token_endpoint: str = "https://auth.example.com/oauth/token") -> OAuthMetadata:
+    return OAuthMetadata.model_validate(
+        {
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/oauth/authorize",
+            "token_endpoint": token_endpoint,
+            "response_types_supported": ["code"],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# HermesTokenStorage metadata roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataStorage:
+    def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("example-server")
+
+        meta = _make_metadata()
+        storage.save_oauth_metadata(meta)
+
+        meta_path = tmp_path / "mcp-tokens" / "example-server.meta.json"
+        assert meta_path.exists()
+
+        loaded = storage.load_oauth_metadata()
+        assert loaded is not None
+        assert str(loaded.token_endpoint) == "https://auth.example.com/oauth/token"
+        assert str(loaded.issuer).rstrip("/") == "https://auth.example.com"
+
+    def test_load_missing_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("nonexistent")
+        assert storage.load_oauth_metadata() is None
+
+    def test_load_corrupt_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("corrupt-server")
+
+        # Ensure dir exists and write garbage that is not a valid OAuthMetadata
+        meta_path = storage._meta_path()
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(json.dumps({"issuer": "not-a-url", "wrong_field": 123}))
+
+        assert storage.load_oauth_metadata() is None
+
+    def test_remove_deletes_meta_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("cleanup-server")
+
+        storage.save_oauth_metadata(_make_metadata())
+        assert storage._meta_path().exists()
+
+        storage.remove()
+        assert not storage._meta_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# _HermesOAuthProvider subclass behavior
+# ---------------------------------------------------------------------------
+
+
+def _provider_with_context(storage: HermesTokenStorage, **context_attrs) -> _HermesOAuthProvider:
+    """Build an uninitialized _HermesOAuthProvider with a mocked context.
+
+    Bypasses the full OAuthClientProvider init (which wants a working
+    OAuth config) so we can test override logic in isolation.
+    """
+    provider = _HermesOAuthProvider.__new__(_HermesOAuthProvider)
+    context = MagicMock()
+    context.storage = storage
+    context.oauth_metadata = context_attrs.get("oauth_metadata")
+    context.current_tokens = context_attrs.get("current_tokens")
+    context.server_url = context_attrs.get("server_url", "https://example.com")
+    provider.context = context
+    return provider
+
+
+class TestHermesOAuthProviderInitialize:
+    def test_restores_metadata_from_disk(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+        meta = _make_metadata("https://auth.example.com/restored/token")
+        storage.save_oauth_metadata(meta)
+
+        provider = _provider_with_context(storage, oauth_metadata=None)
+
+        with patch.object(
+            _HermesOAuthProvider.__bases__[0], "_initialize", new=AsyncMock()
+        ):
+            asyncio.run(provider._initialize())
+
+        assert provider.context.oauth_metadata is not None
+        assert str(provider.context.oauth_metadata.token_endpoint) == \
+            "https://auth.example.com/restored/token"
+
+    def test_skips_restore_when_metadata_already_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv2")
+        # Disk has older metadata; in-memory context already has a value
+        storage.save_oauth_metadata(_make_metadata("https://disk.example.com/token"))
+        in_memory = _make_metadata("https://memory.example.com/token")
+
+        provider = _provider_with_context(storage, oauth_metadata=in_memory)
+
+        with patch.object(
+            _HermesOAuthProvider.__bases__[0], "_initialize", new=AsyncMock()
+        ):
+            asyncio.run(provider._initialize())
+
+        # In-memory value should not be overwritten
+        assert str(provider.context.oauth_metadata.token_endpoint) == \
+            "https://memory.example.com/token"
+
+    def test_skips_when_storage_is_not_hermes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = _provider_with_context(
+            storage=MagicMock(),  # not a HermesTokenStorage
+            oauth_metadata=None,
+        )
+
+        with patch.object(
+            _HermesOAuthProvider.__bases__[0], "_initialize", new=AsyncMock()
+        ):
+            # Should complete without raising and without touching metadata
+            asyncio.run(provider._initialize())
+
+        assert provider.context.oauth_metadata is None
+
+
+class TestHermesOAuthProviderAuthFlow:
+    def test_async_auth_flow_persists_new_metadata(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("flow-srv")
+        assert storage.load_oauth_metadata() is None
+
+        discovered = _make_metadata("https://discovered.example.com/token")
+        provider = _provider_with_context(storage, oauth_metadata=discovered)
+
+        # Parent async_auth_flow is an async generator; simulate it completing
+        # immediately with zero yields.
+        async def fake_parent_flow(self, request):
+            if False:
+                yield  # pragma: no cover  -- make this an async generator
+            return
+
+        with patch.object(
+            _HermesOAuthProvider.__bases__[0],
+            "async_auth_flow",
+            new=fake_parent_flow,
+        ):
+            async def drive():
+                gen = provider.async_auth_flow(MagicMock())
+                async for _ in gen:
+                    pass
+
+            asyncio.run(drive())
+
+        # Metadata should now be persisted
+        loaded = storage.load_oauth_metadata()
+        assert loaded is not None
+        assert str(loaded.token_endpoint) == "https://discovered.example.com/token"
+
+    def test_async_auth_flow_noop_when_metadata_unchanged(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("noop-srv")
+        meta = _make_metadata("https://same.example.com/token")
+        storage.save_oauth_metadata(meta)
+
+        provider = _provider_with_context(storage, oauth_metadata=meta)
+
+        async def fake_parent_flow(self, request):
+            if False:
+                yield  # pragma: no cover
+            return
+
+        with patch.object(
+            _HermesOAuthProvider.__bases__[0],
+            "async_auth_flow",
+            new=fake_parent_flow,
+        ), patch.object(
+            HermesTokenStorage, "save_oauth_metadata"
+        ) as save_spy:
+            async def drive():
+                gen = provider.async_auth_flow(MagicMock())
+                async for _ in gen:
+                    pass
+
+            asyncio.run(drive())
+
+            # Should not re-save unchanged metadata
+            save_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# tools.mcp_oauth_manager production provider path
+# ---------------------------------------------------------------------------
+
+
+def _manager_provider_with_context(storage: HermesTokenStorage, **context_attrs):
+    """Build an uninitialized manager provider with a mocked context."""
+    if _HERMES_PROVIDER_CLS is None:
+        pytest.skip("MCP SDK auth not available")
+    provider = _HERMES_PROVIDER_CLS.__new__(_HERMES_PROVIDER_CLS)
+    provider._hermes_server_name = context_attrs.get("server_name", "srv")
+    context = MagicMock()
+    context.storage = storage
+    context.oauth_metadata = context_attrs.get("oauth_metadata")
+    context.current_tokens = context_attrs.get("current_tokens")
+    context.server_url = context_attrs.get("server_url", "https://example.com")
+    context.update_token_expiry = MagicMock()
+    provider.context = context
+    return provider
+
+
+class TestManagerOAuthProviderMetadata:
+    def test_initialize_restores_metadata_from_disk(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("mgr-srv")
+        storage.save_oauth_metadata(_make_metadata("https://mgr.example.com/token"))
+        provider = _manager_provider_with_context(storage, oauth_metadata=None)
+
+        with patch.object(
+            _HERMES_PROVIDER_CLS.__bases__[0], "_initialize", new=AsyncMock()
+        ):
+            asyncio.run(provider._initialize())
+
+        assert provider.context.oauth_metadata is not None
+        assert str(provider.context.oauth_metadata.token_endpoint) == \
+            "https://mgr.example.com/token"
+
+    def test_async_auth_flow_persists_metadata_from_production_provider(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("mgr-flow")
+        provider = _manager_provider_with_context(
+            storage,
+            oauth_metadata=_make_metadata("https://mgr-flow.example.com/token"),
+            server_name="mgr-flow",
+        )
+
+        async def fake_parent_flow(self, request):
+            if False:
+                yield  # pragma: no cover
+            return
+
+        manager = MagicMock()
+        manager.invalidate_if_disk_changed = AsyncMock(return_value=False)
+
+        with patch.object(
+            _HERMES_PROVIDER_CLS.__bases__[0],
+            "async_auth_flow",
+            new=fake_parent_flow,
+        ), patch("tools.mcp_oauth_manager.get_manager", return_value=manager):
+            async def drive():
+                gen = provider.async_auth_flow(MagicMock())
+                async for _ in gen:
+                    pass
+
+            asyncio.run(drive())
+
+        loaded = storage.load_oauth_metadata()
+        assert loaded is not None
+        assert str(loaded.token_endpoint) == "https://mgr-flow.example.com/token"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -61,6 +61,7 @@ try:
     from mcp.shared.auth import (
         OAuthClientInformationFull,
         OAuthClientMetadata,
+        OAuthMetadata,
         OAuthToken,
     )
 
@@ -87,9 +88,12 @@ class OAuthNonInteractiveError(RuntimeError):
 # Module-level state
 # ---------------------------------------------------------------------------
 
-# Port used by the most recent build_oauth_auth() call.  Exposed so that
-# tests can verify the callback server and the redirect_uri share a port.
+# Port/host used by the most recent build_oauth_auth() call. Exposed so that
+# tests can verify the callback server and the redirect_uri share the same
+# listener settings.
 _oauth_port: int | None = None
+_oauth_bind_host: str = "127.0.0.1"
+_oauth_result: dict[str, str | None] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +227,9 @@ class HermesTokenStorage:
     def _client_info_path(self) -> Path:
         return _get_token_dir() / f"{self._server_name}.client.json"
 
+    def _meta_path(self) -> Path:
+        return _get_token_dir() / f"{self._server_name}.meta.json"
+
     # -- tokens ------------------------------------------------------------
 
     async def get_tokens(self) -> "OAuthToken | None":
@@ -300,11 +307,30 @@ class HermesTokenStorage:
         _write_json(self._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
         logger.debug("OAuth client info saved for %s", self._server_name)
 
+    # -- oauth server metadata --------------------------------------------
+    # The MCP SDK keeps discovered ``OAuthMetadata`` (token endpoint URL
+    # etc.) in memory only. Persisting it here lets a restarted process
+    # refresh tokens without re-running the browser-based discovery.
+
+    def save_oauth_metadata(self, metadata: "OAuthMetadata") -> None:
+        _write_json(self._meta_path(), metadata.model_dump(exclude_none=True, mode="json"))
+        logger.debug("OAuth metadata saved for %s", self._server_name)
+
+    def load_oauth_metadata(self) -> "OAuthMetadata | None":
+        data = _read_json(self._meta_path())
+        if data is None:
+            return None
+        try:
+            return OAuthMetadata.model_validate(data)
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning("Corrupt OAuth metadata at %s -- ignoring: %s", self._meta_path(), exc)
+            return None
+
     # -- cleanup -----------------------------------------------------------
 
     def remove(self) -> None:
         """Delete all stored OAuth state for this server."""
-        for p in (self._tokens_path(), self._client_info_path()):
+        for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
             p.unlink(missing_ok=True)
 
     def has_cached_tokens(self) -> bool:
@@ -390,9 +416,9 @@ async def _redirect_handler(authorization_url: str) -> None:
 async def _wait_for_callback() -> tuple[str, str | None]:
     """Wait for the OAuth callback to arrive on the local callback server.
 
-    Uses the module-level ``_oauth_port`` which is set by ``build_oauth_auth``
-    before this is ever called.  Polls for the result without blocking the
-    event loop.
+    Uses the module-level listener settings prepared by ``build_oauth_auth``.
+    If a callback server is already running on that port, we reuse the shared
+    result container instead of failing on a second bind attempt.
 
     Raises:
         OAuthNonInteractiveError: If the callback times out (no user present
@@ -407,45 +433,189 @@ async def _wait_for_callback() -> tuple[str, str | None]:
             "before _wait_for_oauth_callback"
         )
 
-    # The callback server is already running (started in build_oauth_auth).
-    # We just need to poll for the result.
-    handler_cls, result = _make_callback_handler()
+    global _oauth_result
+    if _oauth_result is None:
+        handler_cls, result = _make_callback_handler()
+        _oauth_result = result
+    else:
+        handler_cls = None
+        result = _oauth_result
 
-    # Start a temporary server on the known port
+    server = None
+    server_thread = None
+    bind_host = _oauth_bind_host or "127.0.0.1"
+
     try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-    except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
-        )
+        if handler_cls is not None:
+            try:
+                server = HTTPServer((bind_host, _oauth_port), handler_cls)
+                server_thread = threading.Thread(target=server.handle_request, daemon=True)
+                server_thread.start()
+            except OSError:
+                # Another callback listener for this flow is already active.
+                server = None
+                server_thread = None
 
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
-    server_thread.start()
-
-    timeout = 300.0
-    poll_interval = 0.5
-    elapsed = 0.0
-    try:
+        timeout = 300.0
+        poll_interval = 0.5
+        elapsed = 0.0
         while elapsed < timeout:
             if result["auth_code"] is not None or result["error"] is not None:
                 break
             await asyncio.sleep(poll_interval)
             elapsed += poll_interval
+
+        if result["error"]:
+            raise RuntimeError(f"OAuth authorization failed: {result['error']}")
+        if result["auth_code"] is None:
+            raise OAuthNonInteractiveError(
+                "OAuth callback timed out — no authorization code received. "
+                "Ensure you completed the browser authorization flow."
+            )
+
+        return result["auth_code"], result["state"]
     finally:
-        server.server_close()
+        if server is not None:
+            server.server_close()
+        if _oauth_result is result:
+            _oauth_result = None
 
-    if result["error"]:
-        raise RuntimeError(f"OAuth authorization failed: {result['error']}")
-    if result["auth_code"] is None:
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — no authorization code received. "
-            "Ensure you completed the browser authorization flow."
-        )
 
-    return result["auth_code"], result["state"]
+# ---------------------------------------------------------------------------
+# OAuth provider subclass -- restores & persists OAuth server metadata
+# ---------------------------------------------------------------------------
+
+if _OAUTH_AVAILABLE:
+
+    class _HermesOAuthProvider(OAuthClientProvider):
+        """OAuthClientProvider subclass that restores and persists OAuth
+        server metadata (``token_endpoint`` etc.) across process restarts.
+
+        The MCP SDK keeps ``oauth_metadata`` in memory only. Without disk
+        persistence, a restart causes refresh requests to POST to a guessed
+        ``/token`` path, which returns 404 on most OAuth providers and
+        forces a full browser re-authorization.
+
+        Token expiry persistence is handled separately in
+        ``HermesTokenStorage.get_tokens()`` via ``expires_in`` rewriting.
+        """
+
+        async def _initialize(self) -> None:
+            await super()._initialize()
+            storage = self.context.storage
+            if not isinstance(storage, HermesTokenStorage):
+                return
+
+            # Restore metadata from disk
+            if not self.context.oauth_metadata:
+                meta = storage.load_oauth_metadata()
+                if meta:
+                    self.context.oauth_metadata = meta
+                    logger.debug(
+                        "OAuth[%s] restored metadata from disk (token_endpoint=%s)",
+                        storage._server_name,
+                        meta.token_endpoint,
+                    )
+
+            # Discover via well-known endpoints if we still have no metadata
+            # but have a refresh token we'll need to use
+            if (
+                not self.context.oauth_metadata
+                and self.context.current_tokens
+                and self.context.current_tokens.refresh_token
+            ):
+                import asyncio as _asyncio
+                try:
+                    await _asyncio.wait_for(
+                        self._discover_oauth_metadata(storage._server_name),
+                        timeout=10.0,
+                    )
+                except _asyncio.TimeoutError:
+                    logger.warning(
+                        "OAuth[%s] metadata discovery timed out", storage._server_name
+                    )
+
+        async def _discover_oauth_metadata(self, server_name: str) -> None:
+            """Discover OAuth metadata via well-known endpoints and persist it."""
+            import httpx as _httpx
+            from mcp.client.auth.utils import (
+                build_oauth_authorization_server_metadata_discovery_urls,
+                build_protected_resource_metadata_discovery_urls,
+            )
+            from mcp.shared.auth import OAuthMetadata as _OAuthMeta
+            from mcp.shared.auth import ProtectedResourceMetadata as _PRM
+
+            server_url = self.context.server_url
+            try:
+                async with _httpx.AsyncClient(timeout=5.0) as client:
+                    # Protected Resource Metadata -> auth server URL
+                    auth_server_url = None
+                    for url in build_protected_resource_metadata_discovery_urls(
+                        None, server_url
+                    ):
+                        resp = await client.get(str(url))
+                        if resp.status_code == 200:
+                            try:
+                                prm = _PRM.model_validate_json(resp.content)
+                                self.context.protected_resource_metadata = prm
+                                if prm.authorization_servers:
+                                    auth_server_url = str(prm.authorization_servers[0])
+                                break
+                            except Exception:
+                                continue
+
+                    # Authorization Server Metadata -> token endpoint etc.
+                    for url in build_oauth_authorization_server_metadata_discovery_urls(
+                        auth_server_url, server_url
+                    ):
+                        resp = await client.get(str(url))
+                        if resp.status_code == 200:
+                            try:
+                                meta = _OAuthMeta.model_validate_json(resp.content)
+                                self.context.oauth_metadata = meta
+                                storage = self.context.storage
+                                if isinstance(storage, HermesTokenStorage):
+                                    storage.save_oauth_metadata(meta)
+                                logger.debug(
+                                    "OAuth[%s] discovered metadata (token_endpoint=%s)",
+                                    server_name,
+                                    meta.token_endpoint,
+                                )
+                                break
+                            except Exception:
+                                continue
+            except Exception as exc:
+                logger.warning(
+                    "OAuth[%s] metadata discovery failed: %s", server_name, exc
+                )
+
+        async def async_auth_flow(self, request):
+            """Wrap parent auth flow to persist metadata after initial discovery.
+
+            The MCP SDK discovers ``oauth_metadata`` during the 401 auth flow
+            but never writes it to disk. After the parent flow exits we
+            snapshot the metadata so a subsequent process can skip discovery.
+            """
+            flow = super().async_auth_flow(request)
+            response = None
+            try:
+                while True:
+                    if response is None:
+                        out_request = await flow.__anext__()
+                    else:
+                        out_request = await flow.asend(response)
+                    response = yield out_request
+            except StopAsyncIteration:
+                pass
+
+            storage = self.context.storage
+            if isinstance(storage, HermesTokenStorage) and self.context.oauth_metadata:
+                existing = storage.load_oauth_metadata()
+                if (
+                    not existing
+                    or existing.token_endpoint != self.context.oauth_metadata.token_endpoint
+                ):
+                    storage.save_oauth_metadata(self.context.oauth_metadata)
 
 
 # ---------------------------------------------------------------------------
@@ -482,11 +652,12 @@ def _configure_callback_port(cfg: dict) -> int:
     flows); replacing it with a ContextVar is out of scope for this
     consolidation PR.
     """
-    global _oauth_port
+    global _oauth_port, _oauth_bind_host
     requested = int(cfg.get("redirect_port", 0))
     port = _find_free_port() if requested == 0 else requested
     cfg["_resolved_port"] = port
     _oauth_port = port  # legacy consumer: _wait_for_callback reads this
+    _oauth_bind_host = str(cfg.get("redirect_host", "127.0.0.1"))
     return port
 
 
@@ -503,7 +674,8 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
         )
     client_name = cfg.get("client_name", "Hermes Agent")
     scope = cfg.get("scope")
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    redirect_host = cfg.get("redirect_host", "127.0.0.1")
+    redirect_uri = f"http://{redirect_host}:{port}/callback"
 
     metadata_kwargs: dict[str, Any] = {
         "client_name": client_name,
@@ -530,7 +702,8 @@ def _maybe_preregister_client(
     if not client_id:
         return
     port = cfg["_resolved_port"]
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    redirect_host = cfg.get("redirect_host", "127.0.0.1")
+    redirect_uri = f"http://{redirect_host}:{port}/callback"
 
     info_dict: dict[str, Any] = {
         "client_id": client_id,
@@ -582,6 +755,9 @@ def build_oauth_auth(
     cfg = dict(oauth_config or {})  # copy — we mutate _resolved_port
     storage = HermesTokenStorage(server_name)
 
+    global _oauth_result
+    _oauth_result = None
+
     if not _is_interactive() and not storage.has_cached_tokens():
         logger.warning(
             "MCP OAuth for '%s': non-interactive environment and no cached tokens "
@@ -595,7 +771,7 @@ def build_oauth_auth(
     client_metadata = _build_client_metadata(cfg)
     _maybe_preregister_client(storage, cfg, client_metadata)
 
-    return OAuthClientProvider(
+    return _HermesOAuthProvider(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -148,6 +148,22 @@ def _make_hermes_provider_class() -> Optional[type]:
             if tokens is not None and tokens.expires_in is not None:
                 self.context.update_token_expiry(tokens)
 
+            storage = self.context.storage
+            from tools.mcp_oauth import HermesTokenStorage
+            if (
+                isinstance(storage, HermesTokenStorage)
+                and self.context.oauth_metadata is None
+            ):
+                meta = storage.load_oauth_metadata()
+                if meta is not None:
+                    self.context.oauth_metadata = meta
+                    logger.debug(
+                        "MCP OAuth '%s': restored metadata from disk "
+                        "(token_endpoint=%s)",
+                        self._hermes_server_name,
+                        meta.token_endpoint,
+                    )
+
             # Pre-flight OAuth AS discovery so ``_refresh_token`` has a
             # correct ``token_endpoint`` before the first refresh attempt.
             # Only runs when we have tokens on cold-load but no cached
@@ -229,12 +245,32 @@ def _make_hermes_provider_class() -> Optional[type]:
                         break
                     if asm:
                         self.context.oauth_metadata = asm
+                        storage = self.context.storage
+                        from tools.mcp_oauth import HermesTokenStorage
+                        if isinstance(storage, HermesTokenStorage):
+                            storage.save_oauth_metadata(asm)
                         logger.debug(
                             "MCP OAuth '%s': pre-flight ASM discovered "
                             "token_endpoint=%s",
                             self._hermes_server_name, asm.token_endpoint,
                         )
                         break
+
+        def _persist_oauth_metadata_if_changed(self) -> None:
+            """Persist discovered OAuth metadata for future process restarts."""
+            meta = self.context.oauth_metadata
+            if meta is None:
+                return
+            storage = self.context.storage
+            from tools.mcp_oauth import HermesTokenStorage
+            if not isinstance(storage, HermesTokenStorage):
+                return
+            existing = storage.load_oauth_metadata()
+            if (
+                existing is None
+                or str(existing.token_endpoint) != str(meta.token_endpoint)
+            ):
+                storage.save_oauth_metadata(meta)
 
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
@@ -271,6 +307,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                     incoming = yield outgoing
                     outgoing = await inner.asend(incoming)
             except StopAsyncIteration:
+                self._persist_oauth_metadata_if_changed()
                 return
 
     return HermesMCPOAuthProvider


### PR DESCRIPTION
## Summary

Persist MCP OAuth server metadata across Hermes restarts and preserve explicit callback listener settings during OAuth flows.

## Changes

- Store discovered `OAuthMetadata` next to cached OAuth tokens/client info as `<server>.meta.json`.
- Restore persisted metadata during provider initialization so cached tokens can be refreshed after a process restart without rediscovering the OAuth server metadata.
- Persist metadata discovered by both the standalone OAuth provider path and the production `MCPOAuthManager` provider path.
- Remove persisted metadata when OAuth state for a server is removed.
- Preserve configured OAuth callback `redirect_host` / `redirect_port` so the advertised `redirect_uri` and callback listener use matching host/port settings.
- Keep `localhost` callback binding loopback-only rather than broadening it to all interfaces.
- Clear shared callback result state after completed/failed waits so stale callback data cannot leak into a future flow.
- Add focused tests for metadata persistence, corrupt metadata handling, manager-provider restore/persist behavior, callback timeout cleanup, and callback host binding.

## Why

The MCP SDK keeps discovered OAuth server metadata in memory. If Hermes restarts with cached tokens but no in-memory metadata, token refresh and OAuth recovery can fail or require rediscovery/browser auth again. Persisting the metadata with the existing OAuth token storage makes OAuth-backed MCP servers more reliable across restarts.

Preserving callback listener settings also avoids mismatches between the redirect URI registered with the provider and the local callback server Hermes actually starts.

## Verification

Focused tests:

```bash
ulimit -n 4096
uv run --extra dev pytest -q -n 4 \
  tests/tools/test_mcp_oauth.py \
  tests/tools/test_mcp_oauth_metadata.py \
  tests/tools/test_mcp_oauth_manager.py \
  tests/tools/test_mcp_oauth_integration.py \
  --tb=short
```

Result:

```text
62 passed in 2.32s
```

Review:

```text
Codex read-only blocking review: VERDICT: CLEAN
```
