### PR TITLE
fix: require memory schema fields by action

### DIFF
--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -1,0 +1,39 @@
+import json
+from tools.memory_tool import MEMORY_SCHEMA
+
+
+def test_memory_schema_requires_content_and_old_text_for_replace_action():
+    schema = MEMORY_SCHEMA["parameters"]
+    assert schema["required"] == ["action", "target"]
+
+    all_of = schema.get("allOf")
+    assert all_of, "memory schema should use conditional requirements"
+
+    replace_requirements = [
+        branch["then"].get("required", [])
+        for branch in all_of
+        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "replace"
+    ]
+    assert replace_requirements == [["old_text", "content"]]
+
+
+def test_memory_schema_requires_content_for_add_action():
+    add_requirements = [
+        branch["then"].get("required", [])
+        for branch in MEMORY_SCHEMA["parameters"].get("allOf", [])
+        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "add"
+    ]
+    assert add_requirements == [["content"]]
+
+
+def test_memory_schema_requires_old_text_for_remove_action():
+    remove_requirements = [
+        branch["then"].get("required", [])
+        for branch in MEMORY_SCHEMA["parameters"].get("allOf", [])
+        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "remove"
+    ]
+    assert remove_requirements == [["old_text"]]
+
+
+def test_memory_schema_is_json_serializable():
+    json.dumps(MEMORY_SCHEMA)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -560,6 +560,29 @@ MEMORY_SCHEMA = {
             },
         },
         "required": ["action", "target"],
+        "allOf": [
+            {
+                "if": {
+                    "properties": {"action": {"const": "add"}},
+                    "required": ["action"],
+                },
+                "then": {"required": ["content"]},
+            },
+            {
+                "if": {
+                    "properties": {"action": {"const": "replace"}},
+                    "required": ["action"],
+                },
+                "then": {"required": ["old_text", "content"]},
+            },
+            {
+                "if": {
+                    "properties": {"action": {"const": "remove"}},
+                    "required": ["action"],
+                },
+                "then": {"required": ["old_text"]},
+            },
+        ],
     },
 }
 


### PR DESCRIPTION
Closes #19171

## Summary
- Add conditional JSON schema requirements for memory tool actions
- Require content for add
- Require old_text and content for replace
- Require old_text for remove
- Add regression coverage for schema requirements

## Tests
- python -m pytest tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool.py -q
- python -m pytest tests/tools/test_memory_tool_import_fallback.py -q