### PR TITLE
fix(auth): keep Spotify logout from resetting model config

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3682,6 +3682,14 @@ def _config_provider_matches(provider_id: Optional[str]) -> bool:
     return _get_config_provider() == provider_id.strip().lower()
 
 
+def _should_reset_config_provider_on_logout(provider_id: Optional[str]) -> bool:
+    """Return True when logout should reset the model provider config."""
+    if not provider_id:
+        return False
+    normalized = provider_id.strip().lower()
+    return normalized in PROVIDER_REGISTRY and _config_provider_matches(normalized)
+
+
 def _logout_default_provider_from_config() -> Optional[str]:
     """Fallback logout target when auth.json has no active provider.
 
@@ -4730,15 +4738,18 @@ def logout_command(args) -> None:
         print("No provider is currently logged in.")
         return
 
-    config_matches = _config_provider_matches(target)
+    should_reset_config = _should_reset_config_provider_on_logout(target)
     provider_name = get_auth_provider_display_name(target)
 
-    if clear_provider_auth(target) or config_matches:
-        _reset_config_provider()
+    if clear_provider_auth(target) or should_reset_config:
+        if should_reset_config:
+            _reset_config_provider()
         print(f"Logged out of {provider_name}.")
-        if os.getenv("OPENROUTER_API_KEY"):
+        if should_reset_config and os.getenv("OPENROUTER_API_KEY"):
             print("Hermes will use OpenRouter for inference.")
-        else:
+        elif should_reset_config:
             print("Run `hermes model` or configure an API key to use Hermes.")
+        else:
+            print("Model provider configuration was unchanged.")
     else:
         print(f"No auth state found for {provider_name}.")

--- a/tests/hermes_cli/test_spotify_auth.py
+++ b/tests/hermes_cli/test_spotify_auth.py
@@ -88,6 +88,51 @@ def test_auth_spotify_status_command_reports_logged_in(capsys, monkeypatch: pyte
     assert "client_id: spotify-client" in output
 
 
+def test_spotify_logout_does_not_reset_model_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "model:\n"
+        "  default: gemini-3-flash\n"
+        "  provider: custom:local\n"
+        "  base_url: http://localhost:11434/v1\n"
+        "  api_key: ${LOCAL_API_KEY}\n",
+        encoding="utf-8",
+    )
+
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        auth_mod._store_provider_state(
+            store,
+            "spotify",
+            {
+                "client_id": "spotify-client",
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "expires_at": "2099-01-01T00:00:00+00:00",
+            },
+            set_active=False,
+        )
+        auth_mod._save_auth_store(store)
+
+    auth_mod.logout_command(SimpleNamespace(provider="spotify"))
+
+    output = capsys.readouterr().out
+    assert "Logged out of Spotify." in output
+    assert "Model provider configuration was unchanged." in output
+    assert auth_mod.get_provider_auth_state("spotify") is None
+    assert config_path.read_text(encoding="utf-8") == (
+        "model:\n"
+        "  default: gemini-3-flash\n"
+        "  provider: custom:local\n"
+        "  base_url: http://localhost:11434/v1\n"
+        "  api_key: ${LOCAL_API_KEY}\n"
+    )
+
 
 def test_spotify_interactive_setup_persists_client_id(
     tmp_path,


### PR DESCRIPTION
## Summary

- Scope logout's model config reset to providers that are real inference providers and currently selected in `model.provider`
- Keep service-provider logout, including Spotify, limited to clearing its stored auth state
- Add a regression test for `hermes auth logout spotify` preserving a custom model provider and base URL

Closes #19165.

## Why

Spotify auth is a tool/service credential, not the active inference route. Logging out of it should not rewrite `model.provider` to `auto` or replace a custom `model.base_url` with OpenRouter.

## Verification

```bash
scripts/run_tests.sh tests/hermes_cli/test_spotify_auth.py tests/hermes_cli/test_auth_commands.py::test_logout_resets_codex_config_when_auth_state_already_cleared tests/hermes_cli/test_auth_commands.py::test_logout_defaults_to_configured_codex_when_no_active_provider tests/hermes_cli/test_auth_commands.py::test_logout_clears_stale_active_codex_without_provider_credentials tests/hermes_cli/test_auth_commands.py::test_reset_config_provider_uses_atomic_yaml_write
```

Result: `10 passed, 4 warnings`.

## Non-goals

- Does not change Spotify login or token refresh behavior
- Does not change Codex/Nous logout behavior when those providers are selected for inference
