### PR TITLE
fix(teams): repair interactive setup imports

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -589,7 +589,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
 def interactive_setup() -> None:
     """Guide the user through Teams setup using the Teams CLI."""
-    from hermes_cli.config import (
+    from hermes_cli.setup import (
         get_env_value,
         save_env_value,
         prompt,

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -313,6 +313,33 @@ class TestTeamsPluginRegistration:
 
 
 # ---------------------------------------------------------------------------
+# Tests: Interactive setup
+# ---------------------------------------------------------------------------
+
+class TestTeamsInteractiveSetup:
+    def test_interactive_setup_uses_setup_prompt_helpers(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli import setup as setup_mod
+
+        answers = iter(["client-id", "client-secret", "tenant-id", "aad-1, aad-2"])
+        monkeypatch.setattr(setup_mod, "prompt", lambda *_args, **_kwargs: next(answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(setup_mod, "print_info", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(setup_mod, "print_success", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(setup_mod, "print_warning", lambda *_args, **_kwargs: None)
+
+        _teams_mod.interactive_setup()
+
+        env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+        assert "TEAMS_CLIENT_ID=client-id" in env_text
+        assert "TEAMS_CLIENT_SECRET=client-secret" in env_text
+        assert "TEAMS_TENANT_ID=tenant-id" in env_text
+        assert "TEAMS_ALLOWED_USERS=aad-1,aad-2" in env_text
+
+
+# ---------------------------------------------------------------------------
 # Tests: Connect / Disconnect
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Import Teams interactive setup helpers from `hermes_cli.setup`, matching the gateway/platform setup helper surface
- Add a regression that runs `interactive_setup()` with mocked prompts and verifies Teams credentials are persisted to `.env`

Closes #19173.

## Why

`plugins/platforms/teams/adapter.py` imported `prompt`, `prompt_yes_no`, and print helpers from `hermes_cli.config`, but those helpers live in `hermes_cli.setup`. That made full gateway setup crash when the Teams setup entry was reached.

## Verification

```bash
scripts/run_tests.sh tests/gateway/test_teams.py::TestTeamsInteractiveSetup::test_interactive_setup_uses_setup_prompt_helpers
```

Result: `1 passed, 1 warning`.

Also tried:

```bash
scripts/run_tests.sh tests/gateway/test_teams.py
```

That exposed an existing unrelated local failure in `TestTeamsSend::test_send_typing` where `mock_app.send` is not awaited; the new interactive setup regression passed in that run.

## Non-goals

- Does not change Teams runtime delivery or typing behavior
- Does not add defensive plugin-loader exception handling beyond fixing this concrete import crash
