### PR TITLE
fix(openviking): support local file upload via temp_upload

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -120,6 +120,17 @@ class _VikingClient:
         resp.raise_for_status()
         return resp.json()
 
+    def post_multipart(self, path: str, files: dict = None, data: dict = None, **kwargs) -> dict:
+        """POST multipart/form-data (for temp_upload)."""
+        headers = self._headers()
+        headers.pop("Content-Type", None)  # httpx sets it automatically for multipart
+        resp = self._httpx.post(
+            self._url(path), files=files or {}, data=data or {}, headers=headers,
+            timeout=_TIMEOUT, **kwargs
+        )
+        resp.raise_for_status()
+        return resp.json()
+
     def health(self) -> bool:
         try:
             resp = self._httpx.get(
@@ -744,7 +755,36 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not url:
             return tool_error("url is required")
 
-        payload: Dict[str, Any] = {"path": url}
+        # Determine if this is a local file path
+        is_local_file = url.startswith("file://") or (url.startswith("/") and os.path.exists(url))
+
+        payload: Dict[str, Any] = {}
+
+        if is_local_file:
+            # Local files require temp_upload first
+            local_path = url[7:] if url.startswith("file://") else url
+            if not os.path.exists(local_path):
+                return tool_error(f"Local file not found: {local_path}")
+
+            # Step 1: temp_upload
+            filename = os.path.basename(local_path)
+            try:
+                upload_resp = self._client.post_multipart(
+                    "/api/v1/resources/temp_upload",
+                    files={"file": (filename, open(local_path, "rb"))},
+                )
+            except Exception as e:
+                return tool_error(f"temp_upload failed: {e}")
+
+            temp_file_id = upload_resp.get("result", {}).get("temp_file_id")
+            if not temp_file_id:
+                return tool_error(f"temp_upload returned no temp_file_id: {upload_resp}")
+
+            payload["temp_file_id"] = temp_file_id
+        else:
+            # Remote URL
+            payload["path"] = url
+
         if args.get("reason"):
             payload["reason"] = args["reason"]
 


### PR DESCRIPTION
## Problem

The `viking_add_resource` MCP tool fails with 403 PERMISSION_DENIED when attempting to upload local files (e.g. `file:///home/user/doc.md` or absolute paths like `/home/user/doc.md`).

OpenViking's server security policy explicitly rejects direct filesystem paths:
> "HTTP server only accepts remote resource URLs or temp-uploaded files; direct host filesystem paths are not allowed."

## Solution

Implement the correct two-step upload flow as documented in the OpenViking API:

1. **temp_upload**: `POST /api/v1/resources/temp_upload` (multipart/form-data)  
   Uploads the local file to server temporary storage, returns a `temp_file_id`.

2. **add_resource**: `POST /api/v1/resources` with `temp_file_id`  
   Imports the temp file into the knowledge base.

## Changes

- `_VikingClient`: add `post_multipart()` method for multipart/form-data uploads
- `_tool_add_resource`: auto-detect local paths and route through `temp_upload` before calling `add_resource`
- Remote URLs continue to use the existing direct `path` parameter (no regression)

## Testing

Verified locally with `REPORT.md`:
- Before: 403 PERMISSION_DENIED
- After: `Resource added: viking://resources/REPORT_1` ✅

## Related

OpenViking API docs: `POST /api/v1/resources` requires `temp_file_id` for local files (mutually exclusive with `path`).
