### PR TITLE
fix(tui): dispatch plugin slashes in live gateway

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1891,6 +1891,36 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     assert "failed" in resp["error"]["message"]
 
 
+def test_slash_exec_rejects_plugin_commands_for_live_dispatch(monkeypatch):
+    server._sessions["sid"] = _session()
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_commands",
+        lambda: {"lcm": {"description": "LCM diagnostics"}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_SlashWorker",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("plugin command should not start slash worker")
+        ),
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "lcm doctor", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4018
+    assert "plugin command: use command.dispatch for /lcm" in resp["error"]["message"]
+
+
 def test_plugins_list_surfaces_loader_error(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", side_effect=Exception("boom")):
         resp = server.handle_request(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5038,6 +5038,16 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
 
+    try:
+        from hermes_cli.plugins import get_plugin_commands
+
+        if _cmd_base.lower() in get_plugin_commands():
+            return _err(
+                rid, 4018, f"plugin command: use command.dispatch for /{_cmd_base}"
+            )
+    except Exception:
+        pass
+
     worker = session.get("slash_worker")
     if not worker:
         try:


### PR DESCRIPTION
Fixes #18993

## Summary
- Make `slash.exec` reject plugin-registered slash commands, matching the existing skill/pending-input guard.
- This forces the TUI frontend fallback through `command.dispatch`, where plugin handlers run in the live gateway process instead of the slash-worker subprocess.
- Add a regression proving plugin commands do not start the slash worker.

## Verification
- `scripts/run_tests.sh tests/test_tui_gateway_server.py::test_slash_exec_rejects_plugin_commands_for_live_dispatch tests/test_tui_gateway_server.py::test_command_dispatch_exec_nonzero_surfaces_error`
  - `2 passed, 2 warnings`