### PR TITLE
fix(image-routing): sniff magic bytes for image MIME, ignore misleading suffix

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -144,7 +144,51 @@ def decide_image_input_mode(
 # it fires, which is cheaper than permanent quality loss.
 
 
-def _guess_mime(path: Path) -> str:
+def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
+    """Detect image MIME from magic bytes. Returns None if unrecognised.
+
+    Filename-based detection (``mimetypes.guess_type``) is unreliable when
+    upstream platforms lie about content-type. Discord, for example, can
+    serve a PNG with ``content_type=image/webp`` for proxied/animated
+    stickers, custom emoji previews, or images uploaded via certain bots.
+    Anthropic strictly validates that declared media_type matches the
+    actual bytes and returns HTTP 400 on mismatch, so we sniff to be safe.
+    """
+    if not raw:
+        return None
+    # PNG: 89 50 4E 47 0D 0A 1A 0A
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    # JPEG: FF D8 FF
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    # GIF87a / GIF89a
+    if raw[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    # WEBP: "RIFF" .... "WEBP"
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    # BMP: "BM"
+    if raw.startswith(b"BM"):
+        return "image/bmp"
+    # HEIC/HEIF: ftypheic / ftypheix / ftypmif1 / ftypmsf1 etc.
+    if len(raw) >= 12 and raw[4:8] == b"ftyp" and raw[8:12] in (
+        b"heic", b"heix", b"hevc", b"hevx", b"mif1", b"msf1", b"heim", b"heis",
+    ):
+        return "image/heic"
+    return None
+
+
+def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
+    """Return image MIME type for *path*.
+
+    If *raw* bytes are provided, magic-byte sniffing wins (authoritative).
+    Otherwise we fall back to ``mimetypes`` then suffix-based defaults.
+    """
+    if raw is not None:
+        sniffed = _sniff_mime_from_bytes(raw)
+        if sniffed:
+            return sniffed
     mime, _ = mimetypes.guess_type(str(path))
     if mime and mime.startswith("image/"):
         return mime
@@ -178,7 +222,7 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)
         return None
-    mime = _guess_mime(path)
+    mime = _guess_mime(path, raw=raw)
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -159,18 +159,33 @@ class TestBuildNativeContentParts:
         assert len(image_parts) == 2
 
     def test_mime_inference_jpg(self, tmp_path: Path):
+        # Real JPEG bytes (SOI marker FF D8 FF): sniffing now wins over suffix.
         img = tmp_path / "photo.jpg"
-        img.write_bytes(_png_bytes())  # bytes are PNG but extension is jpg
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01" + b"\x00" * 32)
         parts, _ = build_native_content_parts("x", [str(img)])
         url = parts[1]["image_url"]["url"]
         assert url.startswith("data:image/jpeg;base64,")
 
     def test_mime_inference_webp(self, tmp_path: Path):
+        # Real WEBP bytes (RIFF....WEBP): sniffing now wins over suffix.
         img = tmp_path / "pic.webp"
-        img.write_bytes(_png_bytes())
+        img.write_bytes(b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 32)
         parts, _ = build_native_content_parts("", [str(img)])
         url = parts[1]["image_url"]["url"]
         assert url.startswith("data:image/webp;base64,")
+
+    def test_mime_sniff_overrides_misleading_extension(self, tmp_path: Path):
+        """Discord-style bug: file is named .webp but contains PNG bytes.
+        Anthropic rejects on MIME mismatch (HTTP 400) so we MUST sniff.
+        Regression guard for the user-reported Discord PNG-as-WEBP failure.
+        """
+        img = tmp_path / "discord_cached.webp"
+        img.write_bytes(_png_bytes())  # bytes are PNG, suffix lies
+        parts, _ = build_native_content_parts("", [str(img)])
+        url = parts[1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,"), (
+            f"Expected MIME sniffing to detect PNG bytes regardless of .webp suffix, got: {url[:60]}"
+        )
 
 
 # ─── Oversize handling ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes a hard HTTP 400 from Anthropic when Hermes attaches a user image whose file suffix lies about the actual bytes. The most common trigger is Discord caching a PNG as `discord_xxx.webp` because Discord's CDN reports `content_type: image/webp` for proxied stickers, custom emoji, animated images, and some bot-uploaded images even when the bytes are PNG.

The current `agent/image_routing.py::_guess_mime()` trusts the file suffix and declares `media_type=image/webp` in the data URL. Anthropic strict-validates the bytes against the declared media type and rejects the entire turn:

```
HTTP 400 messages.N.content.M.image.source.base64:
The image was specified using the image/webp media type,
but the image appears to be a image/png image
```

The fix is to sniff magic bytes when raw bytes are available (which they always are inside `_file_to_data_url`) and fall back to the existing suffix heuristic only when bytes are not in hand. This matches what every other multimodal client does and is what Anthropic expects.

## Related Issue

Fixes #19195

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/image_routing.py`
  - Added `_sniff_mime_from_bytes()` helper that detects PNG, JPEG, GIF, WEBP, BMP, and HEIC/HEIF from the standard magic-byte signatures.
  - `_guess_mime(path, raw=None)` now takes optional bytes; sniffing wins over suffix when bytes are provided. Behaviour is unchanged when `raw` is None.
  - `_file_to_data_url()` already had the bytes in hand; it now passes them through.
- `tests/agent/test_image_routing.py`
  - Two existing tests (`test_mime_inference_jpg`, `test_mime_inference_webp`) asserted the old broken behaviour (PNG bytes in `.jpg` or `.webp` should report jpeg/webp). Rewritten with real JPEG / WEBP magic bytes so they still cover the suffix-aligned case while letting sniffing be authoritative.
  - New regression test `test_mime_sniff_overrides_misleading_extension` reproduces the exact Discord scenario (PNG bytes saved as `discord_cached.webp`) and asserts the data URL comes back as `data:image/png;base64,...`.

## How to Test

```bash
source venv/bin/activate
python -m pytest tests/agent/test_image_routing.py -q
```

All 28 tests pass on this branch.

End-to-end: Send a PNG image to a Hermes Discord bot that previously triggered the 400 (any animated PNG / proxied PNG that Discord serves with `content_type: image/webp` works as a repro). With Anthropic active, the agent now describes / OCRs the image instead of failing on `HTTP 400 ... media type ... appears to be image/png`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(image-routing): ...`)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/agent/test_image_routing.py -q` and all tests pass
- [x] I've added a regression test for the exact reported scenario
- [x] I've tested on my platform: WSL2 Ubuntu on Windows 11

### Documentation & Housekeeping

- [x] No documentation update needed : internal helper, no behaviour change for callers : N/A
- [x] No config keys added : N/A
- [x] No architecture/workflow change : N/A
- [x] Cross-platform impact considered: pure-Python magic-byte check, no OS-specific behaviour
- [x] No tool description/schema changes : N/A

## Screenshots / Logs

Before (gateway log on the failing turn):

```
⚠️ Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error',
'message': 'messages.44.content.1.image.source.base64: The image was specified using
the image/webp media type, but the image appears to be a image/png image'}}
```

After: same image, same model, same Discord channel. Agent OCRs the image normally.

## Notes for reviewers

- The change is intentionally narrow: only `_guess_mime` and the one call site in `_file_to_data_url` are touched. The retry/shrink path in `run_agent._try_shrink_image_parts_in_messages` reads MIME from the embedded data URL header, so once the initial attachment carries the correct media type the retry path is correct without further changes.
- `_sniff_mime_from_bytes` returns `None` for unknown signatures, which lets the existing suffix fallback handle exotic image types (TIFF, AVIF, etc.) the same way it does today rather than silently misclassifying them.
- HEIC/HEIF detection is included for completeness (iOS Photos uploads) even though Anthropic doesn't currently accept them; this keeps `_guess_mime` honest if any platform layer ever forwards them.
