### PR TITLE
Add DeepSeek V4 fallback max reasoning

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -99,6 +99,36 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
     return normalized.endswith("/openai")
 
 
+def _is_direct_deepseek_route(provider_name: str, base_url: Any) -> bool:
+    """Return True for DeepSeek's direct OpenAI-compatible API route."""
+    provider = (provider_name or "").strip().lower()
+    if provider == "deepseek":
+        return True
+    normalized = str(base_url or "").strip().rstrip("/").lower()
+    return "api.deepseek.com" in normalized and not normalized.endswith("/anthropic")
+
+
+def _deepseek_reasoning_effort(reasoning_config: dict | None) -> str | None:
+    """Map Hermes reasoning levels to direct DeepSeek V4 effort values.
+
+    DeepSeek's direct Chat Completions API accepts top-level
+    ``reasoning_effort`` of ``high`` or ``max`` when thinking mode is enabled.
+    Their compatibility contract maps low/medium to high and xhigh to max.
+    """
+    if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
+        return None
+
+    effort = "high"
+    if isinstance(reasoning_config, dict):
+        effort = str(reasoning_config.get("effort") or "high").strip().lower()
+
+    if effort in {"xhigh", "max"}:
+        return "max"
+    if effort == "none":
+        return None
+    return "high"
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -338,6 +368,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_github_models = params.get("is_github_models", False)
         provider_name = str(params.get("provider_name") or "").strip().lower()
         base_url = params.get("base_url")
+        is_direct_deepseek = _is_direct_deepseek_route(provider_name, base_url)
 
         provider_prefs = params.get("provider_preferences")
         if provider_prefs and is_openrouter:
@@ -353,9 +384,24 @@ class ChatCompletionsTransport(ProviderTransport):
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
             }
 
+        # Direct DeepSeek V4: thinking is controlled by top-level
+        # reasoning_effort plus extra_body.thinking. Do not use
+        # OpenRouter-style extra_body.reasoning on the direct API.
+        if is_direct_deepseek and model_lower.startswith("deepseek-v4"):
+            _ds_effort = _deepseek_reasoning_effort(reasoning_config)
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_effort else "disabled",
+            }
+            if _ds_effort:
+                api_kwargs["reasoning_effort"] = _ds_effort
+
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,
         # so skip emitting extra_body.reasoning for it.
-        if params.get("supports_reasoning", False) and not params.get("is_lmstudio", False):
+        if (
+            params.get("supports_reasoning", False)
+            and not params.get("is_lmstudio", False)
+            and not is_direct_deepseek
+        ):
             if is_github_models:
                 gh_reasoning = params.get("github_reasoning_extra")
                 if gh_reasoning is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1493,6 +1493,7 @@ class AIAgent:
                             if _fb_client is not None:
                                 self.provider = _fb["provider"]
                                 self.model = _fb_model or _fb["model"]
+                                self.reasoning_config = self._resolve_fallback_reasoning_config(_fb)
                                 self._fallback_activated = True
                                 client_kwargs = {
                                     "api_key": _fb_client.api_key,
@@ -2166,6 +2167,7 @@ class AIAgent:
             "api_mode": self.api_mode,
             "api_key": getattr(self, "api_key", ""),
             "client_kwargs": dict(self._client_kwargs),
+            "reasoning_config": copy.deepcopy(self.reasoning_config),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
             # Context engine state that _try_activate_fallback() overwrites.
@@ -7488,6 +7490,53 @@ class AIAgent:
 
     # ── Provider fallback ──────────────────────────────────────────────────
 
+    def _resolve_fallback_reasoning_config(self, fallback_entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Return reasoning config for a fallback entry.
+
+        Fallback entries inherit the primary ``reasoning_config`` unless they
+        declare ``reasoning_config`` or ``reasoning_effort``. This lets a
+        primary GPT/Codex route use high reasoning while a direct DeepSeek V4
+        fallback requests max thinking without changing the global setting.
+        """
+        if not isinstance(fallback_entry, dict):
+            return copy.deepcopy(self.reasoning_config)
+
+        explicit_config = fallback_entry.get("reasoning_config")
+        if isinstance(explicit_config, dict):
+            return copy.deepcopy(explicit_config)
+
+        raw_effort = str(
+            fallback_entry.get("reasoning_effort")
+            or fallback_entry.get("thinking_effort")
+            or ""
+        ).strip().lower()
+        if not raw_effort:
+            return copy.deepcopy(self.reasoning_config)
+
+        provider = str(fallback_entry.get("provider") or "").strip().lower()
+        model = str(fallback_entry.get("model") or "").strip().lower()
+        if raw_effort == "max":
+            # DeepSeek V4's direct API accepts top-level reasoning_effort=max.
+            # Other OpenAI-compatible backends commonly don't, so treat max as
+            # Hermes' strongest portable level (xhigh) outside direct DeepSeek.
+            effort = "max" if provider == "deepseek" and model.startswith("deepseek-v4") else "xhigh"
+            return {"enabled": True, "effort": effort}
+
+        try:
+            from hermes_constants import parse_reasoning_effort
+            parsed = parse_reasoning_effort(raw_effort)
+        except Exception:
+            parsed = None
+        if parsed is None:
+            logging.warning(
+                "Ignoring unknown fallback reasoning_effort '%s' for %s/%s; inheriting primary reasoning config",
+                raw_effort,
+                provider or "unknown",
+                model or "unknown",
+            )
+            return copy.deepcopy(self.reasoning_config)
+        return copy.deepcopy(parsed)
+
     def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
         """Switch to the next fallback model/provider in the chain.
 
@@ -7587,6 +7636,7 @@ class AIAgent:
             self.provider = fb_provider
             self.base_url = fb_base_url
             self.api_mode = fb_api_mode
+            self.reasoning_config = self._resolve_fallback_reasoning_config(fb)
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self._fallback_activated = True
@@ -7714,6 +7764,7 @@ class AIAgent:
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
             self._client_kwargs = dict(rt["client_kwargs"])
+            self.reasoning_config = copy.deepcopy(rt.get("reasoning_config"))
             self._use_prompt_caching = rt["use_prompt_caching"]
             # Default to native layout when the restored snapshot predates the
             # native-vs-proxy split (older sessions saved before this PR).
@@ -7821,6 +7872,7 @@ class AIAgent:
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
+            self.reasoning_config = copy.deepcopy(rt.get("reasoning_config"))
 
             if self.api_mode == "anthropic_messages":
                 from agent.anthropic_adapter import build_anthropic_client

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -113,6 +113,34 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["options"]["num_ctx"] == 32768
 
+    def test_direct_deepseek_v4_xhigh_maps_to_max_thinking(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=msgs,
+            provider_name="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            supports_reasoning=True,
+        )
+        assert kw["reasoning_effort"] == "max"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+        assert "reasoning" not in kw["extra_body"]
+
+    def test_direct_deepseek_v4_disabled_turns_thinking_off(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=msgs,
+            provider_name="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            reasoning_config={"enabled": False},
+            supports_reasoning=True,
+        )
+        assert "reasoning_effort" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+        assert "reasoning" not in kw["extra_body"]
+
     def test_custom_think_false(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3980,6 +3980,67 @@ class TestFallbackAnthropicProvider:
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
 
+    def test_fallback_entry_can_override_reasoning_effort_to_deepseek_max(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        fb = {
+            "provider": "deepseek",
+            "model": "deepseek-v4-pro",
+            "reasoning_effort": "max",
+        }
+
+        assert agent._resolve_fallback_reasoning_config(fb) == {
+            "enabled": True,
+            "effort": "max",
+        }
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_fallback_activation_applies_entry_reasoning_effort(self, agent):
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent._fallback_activated = False
+        agent._fallback_model = {
+            "provider": "deepseek",
+            "model": "deepseek-v4-pro",
+            "reasoning_effort": "max",
+        }
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.deepseek.com"
+        mock_client.api_key = "sk-ds-test"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.provider == "deepseek"
+        assert agent.model == "deepseek-v4-pro"
+        assert agent.reasoning_config == {"enabled": True, "effort": "max"}
+
+    def test_direct_deepseek_v4_max_reasoning_payload(self, agent):
+        agent.provider = "deepseek"
+        agent.base_url = "https://api.deepseek.com"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "deepseek-v4-pro"
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["reasoning_effort"] == "max"
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+        assert "reasoning" not in kwargs["extra_body"]
+
+    def test_restore_primary_runtime_restores_reasoning_config(self, agent):
+        agent._fallback_activated = True
+        agent._rate_limited_until = 0
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
+        agent._primary_runtime["reasoning_config"] = {"enabled": True, "effort": "high"}
+
+        with patch.object(agent, "_create_openai_client", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1235,7 +1235,10 @@ fallback_model:
   model: anthropic/claude-sonnet-4        # required
   # base_url: http://localhost:8000/v1    # optional, for custom endpoints
   # key_env: MY_CUSTOM_KEY               # optional, env var name for custom endpoint API key
+  # reasoning_effort: high               # optional, overrides agent.reasoning_effort while active
 ```
+
+Per-fallback `reasoning_effort` accepts the normal Hermes levels (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`). Direct DeepSeek V4 fallbacks can also use `max`, which Hermes sends to DeepSeek as top-level `reasoning_effort=max`.
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. It fires **at most once** per session.
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -35,9 +35,10 @@ If you'd rather edit the YAML directly, add a `fallback_model` section to `~/.he
 fallback_model:
   provider: openrouter
   model: anthropic/claude-sonnet-4
+  # reasoning_effort: high   # optional per-fallback override
 ```
 
-Both `provider` and `model` are **required**. If either is missing, the fallback is disabled.
+Both `provider` and `model` are **required**. If either is missing, the fallback is disabled. `reasoning_effort` is optional and overrides `agent.reasoning_effort` only while that fallback is active (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`; `max` is accepted for direct DeepSeek V4 fallbacks and sent as `reasoning_effort=max`).
 
 :::note `fallback_model` vs `fallback_providers`
 `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat. `fallback_providers` (plural, list) supports multiple fallbacks tried in order; `hermes fallback` writes to this key. When both are set, Hermes merges them with `fallback_providers` taking priority.
@@ -149,6 +150,17 @@ fallback_model:
   model: llama-3.1-70b
   base_url: http://localhost:8000/v1
   key_env: LOCAL_API_KEY
+```
+
+**DeepSeek V4 Pro as max-reasoning fallback for a high-reasoning primary:**
+```yaml
+agent:
+  reasoning_effort: high
+
+fallback_providers:
+  - provider: deepseek
+    model: deepseek-v4-pro
+    reasoning_effort: max
 ```
 
 **Codex OAuth as fallback:**


### PR DESCRIPTION
## Summary
- allow per-fallback reasoning_effort overrides to restore the primary reasoning config after fallback attempts
- map direct DeepSeek V4 max reasoning to top-level reasoning_effort=max plus extra_body.thinking={type: enabled}
- document DeepSeek V4 Pro as a max-reasoning fallback for high-reasoning primary routes

## Tests
- python -m pytest tests/run_agent/test_run_agent.py -k 'direct_deepseek_v4_max_reasoning_payload or fallback_entry_can_override_reasoning_effort_to_deepseek_max or fallback_activation_applies_entry_reasoning_effort or restore_primary_runtime_restores_reasoning_config' -q
- python -m pytest tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider -q
- python -m pytest tests/agent/transports/test_chat_completions.py -q
- python -m py_compile run_agent.py agent/transports/chat_completions.py