### PR TITLE
fix(gateway): interrupt active runs on resume and branch

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2577,8 +2577,8 @@ class BasePlatformAdapter(ABC):
             from hermes_cli.commands import should_bypass_active_session
 
             if should_bypass_active_session(cmd):
-                # /stop, /new, /reset must cancel the in-flight adapter task
-                # and preserve ordering of queued follow-ups.  Route those
+                # Session-boundary commands must cancel the in-flight adapter
+                # task and preserve ordering of queued follow-ups. Route those
                 # through the dedicated handoff path that serializes
                 # cancellation + runner response + pending drain.
                 if cmd in ("stop", "new", "reset"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4770,6 +4770,15 @@ class GatewayRunner:
                 # doesn't think an agent is still active.
                 return await self._handle_reset_command(event)
 
+            # /resume and /branch are full session-boundary operations.
+            # They must invalidate the current run before switching the
+            # session binding, otherwise the old run can finish late and
+            # leak results or queued follow-ups into the new session.
+            if _cmd_def_inner and _cmd_def_inner.name == "resume":
+                return await self._handle_resume_command(event)
+            if _cmd_def_inner and _cmd_def_inner.name == "branch":
+                return await self._handle_branch_command(event)
+
             # /queue <prompt> — queue without interrupting.
             # Semantics: each /queue invocation produces its own full agent
             # turn, processed in FIFO order after the current run (and any
@@ -9236,8 +9245,21 @@ class GatewayRunner:
         if current_entry.session_id == target_id:
             return f"📌 Already on session **{name}**."
 
+        if session_key in self._running_agents:
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason=_INTERRUPT_REASON_RESET,
+                invalidation_reason="resume_command",
+            )
+
         # Clear any running agent for this session key
         self._release_running_agent_state(session_key)
+
+        # Discard any queued follow-ups from the previous conversation.
+        _qe = getattr(self, "_queued_events", None)
+        if _qe is not None:
+            _qe.pop(session_key, None)
 
         # Switch the session entry to point at the old session
         new_entry = self.session_store.switch_session(session_key, target_id)
@@ -9339,6 +9361,22 @@ class GatewayRunner:
             self._session_db.set_session_title(new_session_id, branch_title)
         except Exception:
             pass
+
+        if session_key in self._running_agents:
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason=_INTERRUPT_REASON_RESET,
+                invalidation_reason="branch_command",
+            )
+
+        # Clear any running agent for this session key
+        self._release_running_agent_state(session_key)
+
+        # Discard any queued follow-ups from the previous conversation.
+        _qe = getattr(self, "_queued_events", None)
+        if _qe is not None:
+            _qe.pop(session_key, None)
 
         # Switch the session store entry to the new session
         new_entry = self.session_store.switch_session(session_key, new_session_id)

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -76,6 +76,23 @@ def _session_key(chat_id="12345"):
     return build_session_key(source)
 
 
+def _make_runner_for_active_command(event):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.session_store = MagicMock()
+    runner._detect_stale_code = lambda: False
+    runner._trigger_stale_code_restart = lambda: None
+    runner._update_prompt_pending = {}
+    runner._running_agents = {_session_key(chat_id=event.source.chat_id): MagicMock()}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_input_mode = "interrupt"
+    runner._draining = False
+    return runner
+
+
 # ---------------------------------------------------------------------------
 # Tests: commands bypass Level 1 when session is active
 # ---------------------------------------------------------------------------
@@ -341,6 +358,26 @@ class TestAllResolvableCommandsBypassGuard:
         assert should_bypass_active_session("") is False
         # A file path split on whitespace: '/path/to/file.py' -> 'path/to/file.py'
         assert should_bypass_active_session("path/to/file.py") is False
+
+    @pytest.mark.parametrize(
+        "command_text,handler_name,expected",
+        [
+            ("/resume yesterday", "_handle_resume_command", "handled:resume-boundary"),
+            ("/branch alt-path", "_handle_branch_command", "handled:branch-boundary"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_active_run_dispatches_session_boundary_handlers(self, command_text, handler_name, expected):
+        """Mid-run /resume and /branch must reach their real boundary handlers."""
+        event = _make_event(command_text)
+        event.internal = True
+        runner = _make_runner_for_active_command(event)
+        setattr(runner, handler_name, AsyncMock(return_value=expected))
+
+        result = await runner._handle_message(event)
+
+        getattr(runner, handler_name).assert_awaited_once_with(event)
+        assert result == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -39,6 +39,14 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     runner._voice_mode = {}
     runner._session_db = session_db
     runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._pending_messages = {}
+    runner._queued_events = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    runner._session_run_generation = {}
+    runner._agent_cache_lock = None
 
     # Compute the real session key if an event is provided
     session_key = build_session_key(event.source) if event else "agent:main:telegram:dm"
@@ -256,4 +264,36 @@ class TestHandleResumeCommand:
         await runner._handle_resume_command(event)
 
         assert real_key not in runner._agent_cache
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_interrupts_active_run_invalidates_generation_and_clears_queue(self, tmp_path):
+        """Mid-run /resume must behave like a real session boundary."""
+        from gateway.run import _INTERRUPT_REASON_RESET
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session", "telegram")
+        db.set_session_title("old_session", "Old Work")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Old Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+
+        real_key = _session_key_for_event(event)
+        running_agent = MagicMock()
+        runner._running_agents[real_key] = running_agent
+        runner._queued_events[real_key] = [MagicMock()]
+        runner._session_run_generation[real_key] = 7
+
+        await runner._handle_resume_command(event)
+
+        running_agent.interrupt.assert_called_once_with(_INTERRUPT_REASON_RESET)
+        assert real_key not in runner._running_agents
+        assert real_key not in runner._queued_events
+        assert runner._session_run_generation[real_key] == 8
         db.close()

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -205,6 +205,26 @@ async def test_branch_preserves_persisted_assistant_metadata():
     assert assistant_kwargs["codex_message_items"] == [{"id": "m1", "type": "message"}]
 
 
+@pytest.mark.asyncio
+async def test_branch_interrupts_active_run_invalidates_generation_and_clears_queue():
+    from gateway.run import _INTERRUPT_REASON_RESET
+
+    runner, session_key = _make_branch_runner()
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+    runner._pending_messages = {}
+    runner._queued_events = {session_key: [MagicMock()]}
+    runner._session_run_generation = {session_key: 11}
+
+    result = await runner._handle_branch_command(_make_event("/branch"))
+
+    assert "Branched to" in result
+    running_agent.interrupt.assert_called_once_with(_INTERRUPT_REASON_RESET)
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._queued_events
+    assert runner._session_run_generation[session_key] == 12
+
+
 def test_clear_session_boundary_security_state_is_scoped():
     """The helper must wipe only the target session's approval/yolo state.
 


### PR DESCRIPTION
## Summary

This fixes a gateway session-boundary bug where `/resume` and `/branch` could run while an agent turn was still active without fully invalidating the old run.

Before this change, those commands could switch the session binding while the previous run was still alive, which meant the old run could finish late and leak follow-up state into the new session. In practice, this risked:
- stale responses arriving after a session switch
- queued follow-up messages surviving across the boundary
- inconsistent session/run ownership during active gateway turns

## What changed

### Runtime behavior
- Treat active-run `/resume` and `/branch` as real session-boundary operations in the gateway runner.
- Interrupt the currently running agent before switching session state.
- Invalidate the session run generation so late results from the previous run are discarded.
- Clear queued follow-up overflow for the old conversation before the new session binding is installed.

### Active-command dispatch coverage
- Added regression coverage to ensure that, during an active turn, `/resume` and `/branch` reach their dedicated boundary handlers instead of falling into the generic busy-command path.

## Why this is needed

`/new` already had explicit boundary handling, but `/resume` and `/branch` did not. That asymmetry left a real gap: users could switch/fork sessions mid-run, but the old run still owned live execution state long enough to produce stale behavior.

This change aligns `/resume` and `/branch` with the same session-boundary safety expectations:
- old run stops
- old run loses ownership
- old queued state does not cross the boundary
- new session starts cleanly

## Files changed

- `gateway/run.py`
- `gateway/platforms/base.py`
- `tests/gateway/test_command_bypass_active_session.py`
- `tests/gateway/test_resume_command.py`
- `tests/gateway/test_session_boundary_security_state.py`

## Tests

Added regression coverage for:
- active-run `/resume` dispatch
- active-run `/branch` dispatch
- `/resume` interrupting the active run, invalidating generation, and clearing queued state
- `/branch` interrupting the active run, invalidating generation, and clearing queued state

Passed locally:

```text
tests/gateway/test_resume_command.py
tests/gateway/test_session_boundary_security_state.py
tests/gateway/test_command_bypass_active_session.py

59 passed in 9.10s
