### PR TITLE
fix(tui): avoid main-screen scrollback reset loops

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -30,10 +30,10 @@ const paint = (screen: Screen, y: number, text: string) => {
   }
 }
 
-const mkFrame = (screen: Screen, viewportW: number, viewportH: number): Frame => ({
+const mkFrame = (screen: Screen, viewportW: number, viewportH: number, cursorY = 0): Frame => ({
   screen,
   viewport: { width: viewportW, height: viewportH },
-  cursor: { x: 0, y: 0, visible: true }
+  cursor: { x: 0, y: cursorY, visible: true }
 })
 
 const stdoutOnly = (diff: ReturnType<LogUpdate['render']>) =>
@@ -111,5 +111,47 @@ describe('LogUpdate.render diff contract', () => {
 
     expect(stdoutOnly(diff)).toBe('')
     expect(diff.some(p => p.type === 'clearTerminal')).toBe(false)
+  })
+
+  it('ignores main-screen scrollback-only changes instead of resetting repeatedly', () => {
+    const w = 20
+    const viewportH = 5
+    const h = 8
+
+    const prev = mkScreen(w, h)
+    paint(prev, 0, 'timer 1s')
+    paint(prev, 6, 'visible prompt')
+
+    const next = mkScreen(w, h)
+    paint(next, 0, 'timer 2s')
+    paint(next, 6, 'visible prompt')
+    next.damage = { x: 0, y: 0, width: w, height: h }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const diff = log.render(mkFrame(prev, w, viewportH, h), mkFrame(next, w, viewportH, h), false, false)
+
+    expect(diff.some(p => p.type === 'clearTerminal')).toBe(false)
+    expect(stdoutOnly(diff)).not.toContain('timer2s')
+  })
+
+  it('keeps alt-screen full reset for unreachable scrollback row changes', () => {
+    const w = 20
+    const viewportH = 5
+    const h = 8
+
+    const prev = mkScreen(w, h)
+    paint(prev, 0, 'timer 1s')
+    paint(prev, 6, 'visible prompt')
+
+    const next = mkScreen(w, h)
+    paint(next, 0, 'timer 2s')
+    paint(next, 6, 'visible prompt')
+    next.damage = { x: 0, y: 0, width: w, height: h }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const diff = log.render(mkFrame(prev, w, viewportH, h), mkFrame(next, w, viewportH, h), true, false)
+
+    expect(diff.some(p => p.type === 'clearTerminal')).toBe(true)
+    expect(stdoutOnly(diff)).toContain('timer2s')
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.ts
@@ -226,7 +226,13 @@ export class LogUpdate {
       return fullResetSequence_CAUSES_FLICKER(next, 'offscreen', stylePool)
     }
 
-    if (prev.screen.height >= prev.viewport.height && prev.screen.height > 0 && cursorAtBottom && !isGrowing) {
+    if (
+      altScreen &&
+      prev.screen.height >= prev.viewport.height &&
+      prev.screen.height > 0 &&
+      cursorAtBottom &&
+      !isGrowing
+    ) {
       // viewportY = rows in scrollback from content overflow
       // +1 for the row pushed by cursor-restore scroll
       const viewportY = prev.screen.height - prev.viewport.height
@@ -330,8 +336,15 @@ export class LogUpdate {
       }
 
       // If the cell outside the viewport range has changed, we need to reset
-      // because we can't move the cursor there to draw.
+      // because we can't move the cursor there to draw. In main-screen mode,
+      // those rows are already in terminal scrollback and invisible; resetting
+      // on every scrollback-only update can loop when a resize changes the
+      // physical buffer. Shrink-to-visible cases are handled above.
       if (y < viewportY) {
+        if (!altScreen) {
+          return
+        }
+
         needsFullReset = true
         resetTriggerY = y
 


### PR DESCRIPTION
## Summary

- Stops main-screen scrollback-only row changes from triggering `fullReset(offscreen)` in `LogUpdate.render`.
- Keeps the existing alt-screen reset behavior for unreachable rows.
- Adds focused renderer regression coverage for the resize/status-bar loop described in #19216.

## Why

Fixes #19216. After a terminal resize, dynamic rows that have already moved into main-screen scrollback can differ from the virtual frame. Resetting the whole terminal for those invisible rows can immediately perturb scrollback again, causing repeated repaint/flicker and duplicated status-bar lines.

## Scope

This is limited to the Hermes Ink diff renderer. It does not change resize handling in the classic CLI or the alt-screen repaint path.

## Verification

- `cd ui-tui && npm test -- --run packages/hermes-ink/src/ink/log-update.test.ts` -> 5 passed
- `cd ui-tui && npm run type-check`
- `git diff --check`
