### PR TITLE
fix(weixin): wrap long copy-unfriendly lines

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -23,6 +23,7 @@ import re
 import secrets
 import struct
 import tempfile
+import textwrap
 import time
 import uuid
 from datetime import datetime
@@ -31,6 +32,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, urlparse
 
 logger = logging.getLogger(__name__)
+
+WEIXIN_COPY_LINE_WIDTH = 120
 
 try:
     import aiohttp
@@ -722,6 +725,46 @@ def _normalize_markdown_blocks(content: str) -> str:
         result.append(line)
 
     return "\n".join(result).strip()
+
+
+def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
+    """Wrap long display lines that are hard to copy in WeChat clients."""
+    if not content:
+        return content
+
+    wrapped: List[str] = []
+    in_code_block = False
+
+    for raw_line in content.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+
+        if _FENCE_RE.match(stripped):
+            in_code_block = not in_code_block
+            wrapped.append(line)
+            continue
+
+        if (
+            in_code_block
+            or len(line) <= WEIXIN_COPY_LINE_WIDTH
+            or not stripped
+            or stripped.startswith("|")
+            or _TABLE_RULE_RE.match(stripped)
+        ):
+            wrapped.append(line)
+            continue
+
+        wrapped_lines = textwrap.wrap(
+            line,
+            width=WEIXIN_COPY_LINE_WIDTH,
+            break_long_words=False,
+            break_on_hyphens=False,
+            replace_whitespace=False,
+            drop_whitespace=True,
+        )
+        wrapped.extend(wrapped_lines or [line])
+
+    return "\n".join(wrapped).strip()
 
 
 def _split_markdown_blocks(content: str) -> List[str]:
@@ -1999,7 +2042,7 @@ class WeixinAdapter(BasePlatformAdapter):
     def format_message(self, content: Optional[str]) -> str:
         if content is None:
             return ""
-        return _normalize_markdown_blocks(content)
+        return _wrap_copy_friendly_lines_for_weixin(_normalize_markdown_blocks(content))
 
 
 async def send_weixin_direct(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -52,6 +52,28 @@ class TestWeixinFormatting:
 
         assert adapter.format_message(content) == content
 
+    def test_format_message_wraps_long_plain_lines_for_copying(self):
+        adapter = _make_adapter()
+
+        content = (
+            "Here is a long issue template line with many copyable fields "
+            + " ".join(f"field_{idx}=value_{idx}" for idx in range(24))
+        )
+
+        formatted = adapter.format_message(content)
+
+        assert "\n" in formatted
+        assert all(len(line) <= weixin.WEIXIN_COPY_LINE_WIDTH for line in formatted.splitlines())
+        assert " ".join(formatted.split()) == " ".join(content.split())
+
+    def test_format_message_does_not_wrap_long_code_block_lines(self):
+        adapter = _make_adapter()
+
+        command = "hermes " + " ".join(f"--option-{idx}=value" for idx in range(30))
+        content = f"```bash\n{command}\n```"
+
+        assert adapter.format_message(content) == content
+
     def test_format_message_returns_empty_string_for_none(self):
         adapter = _make_adapter()
 


### PR DESCRIPTION
## Summary

- Wraps long non-code, non-table Weixin text lines at a copy-friendly display width.
- Leaves fenced code blocks and Markdown tables untouched so commands/code and table structure are not damaged.
- Adds focused Weixin formatting regressions for long line wrapping and code-block preservation.

## Why

Fixes #19161. WeChat clients can make very long single-line Hermes replies difficult to copy, especially issue-template or log-style prose. Breaking long display text at natural whitespace keeps the full content while making it easier to select and copy.

## Scope

This only changes outbound Weixin formatting before the existing message chunking path. It does not alter Weixin delivery, message limits, media handling, or other gateway platforms.

## Verification

- `scripts/run_tests.sh tests/gateway/test_weixin.py` -> 51 passed, 4 warnings
- `git diff --check`
