### PR TITLE
fix(codex-transport): preserve extra_headers for xai responses requests

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -143,7 +143,18 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["max_output_tokens"] = max_tokens
 
         if is_xai_responses and session_id:
-            kwargs["extra_headers"] = {"x-grok-conv-id": session_id}
+            existing_extra_headers = kwargs.get("extra_headers")
+            merged_extra_headers: Dict[str, str] = {}
+            if isinstance(existing_extra_headers, dict):
+                merged_extra_headers.update(
+                    {
+                        str(key): str(value)
+                        for key, value in existing_extra_headers.items()
+                        if key and value is not None
+                    }
+                )
+            merged_extra_headers["x-grok-conv-id"] = session_id
+            kwargs["extra_headers"] = merged_extra_headers
 
         return kwargs
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -126,6 +126,20 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("extra_headers", {}).get("x-grok-conv-id") == "conv-123"
 
+    def test_xai_headers_preserve_request_override_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-3", messages=messages, tools=[],
+            session_id="conv-123",
+            is_xai_responses=True,
+            request_overrides={"extra_headers": {"X-Test": "1", "X-Trace": "abc"}},
+        )
+        assert kw.get("extra_headers") == {
+            "X-Test": "1",
+            "X-Trace": "abc",
+            "x-grok-conv-id": "conv-123",
+        }
+
     def test_minimal_effort_clamped(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary

Preserve existing `extra_headers` when building xAI Responses API requests in `ResponsesApiTransport`.

Before this change, the xAI-specific `x-grok-conv-id` header replaced any `extra_headers` provided through `request_overrides`, which silently dropped caller-supplied headers. This change merges the conversation header into the existing header map instead of overwriting it.

## What changed

- Merge `x-grok-conv-id` into existing `extra_headers` for `is_xai_responses` requests
- Keep the existing normalization behavior for header keys and values
- Add a regression test covering `request_overrides={"extra_headers": ...}` on the xAI path

## Why

`request_overrides` is intended to be the final request-shaping layer. Overwriting `extra_headers` in the xAI branch made the Responses transport behave inconsistently with other backend-specific branches and could break custom routing, tracing, or provider-specific headers added by callers.

## Reproduction

Before:
- Call `ResponsesApiTransport.build_kwargs(...)` with:
  - `is_xai_responses=True`
  - `session_id="conv-123"`
  - `request_overrides={"extra_headers": {"X-Test": "1"}}`
- Result:
  - `extra_headers == {"x-grok-conv-id": "conv-123"}`
  - `X-Test` is lost

After:
- Result:
  - `extra_headers == {"X-Test": "1", "x-grok-conv-id": "conv-123"}`

## Testing

Passed:

- `tests/agent/transports/test_codex_transport.py`
