### PR TITLE
fix(mcp): reconnect on terminated sessions

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -46,6 +46,13 @@ def test_is_session_expired_detects_session_not_found():
     assert _is_session_expired_error(RuntimeError("Unknown session: abc123")) is True
 
 
+def test_is_session_expired_detects_session_terminated():
+    """Remote Playwright MCP reports transport loss as ``Session terminated``."""
+    from tools.mcp_tool import _is_session_expired_error
+
+    assert _is_session_expired_error(RuntimeError("Session terminated")) is True
+
+
 def test_is_session_expired_is_case_insensitive():
     """Match uses lower-cased comparison so servers that emit the
     message in different cases (SDK formatter quirks) still trigger."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1667,6 +1667,7 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "session expired",
     "session not found",
     "unknown session",
+    "session terminated",
 )
 
 


### PR DESCRIPTION
Fixes #18790\n\n## Summary\n- Treat MCP `Session terminated` errors as transport-session expiry signals.\n- Reuse the existing reconnect-and-retry path instead of surfacing a hard tool failure.\n- Add a focused regression assertion for the Playwright MCP wording reported by gateway users.\n\n## Verification\n- `scripts/run_tests.sh tests/tools/test_mcp_tool_session_expired.py` (17 passed, 4 warnings)\n- `git diff --check`