### PR TITLE
fix(slack): open DMs for user send targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -25,6 +25,7 @@ from tools.send_message_tool import (
     _derive_forum_thread_name,
     _parse_target_ref,
     _send_discord,
+    _send_slack,
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
@@ -917,7 +918,7 @@ class TestParseTargetRefE164:
 
 
 class TestParseTargetRefSlack:
-    """_parse_target_ref recognizes Slack channel/user IDs as explicit."""
+    """_parse_target_ref recognizes Slack conversation and user targets."""
 
     def test_public_channel_id_is_explicit(self):
         chat_id, thread_id, is_explicit = _parse_target_ref("slack", "C0B0QV5434G")
@@ -931,12 +932,22 @@ class TestParseTargetRefSlack:
     def test_dm_id_is_explicit(self):
         assert _parse_target_ref("slack", "D123ABCDEF")[2] is True
 
-    def test_user_id_is_not_explicit(self):
-        """Slack user IDs (U...) and workspace IDs (W...) are NOT explicit send
-        targets. chat.postMessage rejects them — a DM must be opened first via
-        conversations.open to obtain a D... conversation ID.
-        """
-        assert _parse_target_ref("slack", "U123ABCDEF")[2] is False
+    def test_user_id_is_explicit_dm_target(self):
+        """Slack user IDs are explicit user targets that must be opened as DMs."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "U123ABCDEF")
+        assert chat_id == "user:U123ABCDEF"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_at_username_is_explicit_dm_target(self):
+        """slack:@username targets resolve to DMs through users.list + conversations.open."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "@alice")
+        assert chat_id == "user_name:alice"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_workspace_id_is_not_explicit(self):
+        """Slack workspace IDs (W...) are not sendable conversation/user targets."""
         assert _parse_target_ref("slack", "W123ABCDEF")[2] is False
 
     def test_whitespace_is_stripped(self):
@@ -952,6 +963,105 @@ class TestParseTargetRefSlack:
     def test_slack_id_not_explicit_for_other_platforms(self):
         assert _parse_target_ref("discord", "C0B0QV5434G")[2] is False
         assert _parse_target_ref("telegram", "C0B0QV5434G")[2] is False
+
+
+class TestSendSlackDmTargets:
+    """_send_slack opens user targets as DMs before posting."""
+
+    @staticmethod
+    def _mock_response(data):
+        response = MagicMock()
+        response.json = AsyncMock(return_value=data)
+        response.__aenter__ = AsyncMock(return_value=response)
+        response.__aexit__ = AsyncMock(return_value=None)
+        return response
+
+    @staticmethod
+    def _mock_session(*responses):
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=responses)
+        return session
+
+    def test_user_id_target_opens_dm_before_posting(self):
+        session = self._mock_session(
+            self._mock_response({"ok": True, "channel": {"id": "D123ABCDEF"}}),
+            self._mock_response({"ok": True, "ts": "123.456"}),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("tok", "user:U123ABCDEF", "hello"))
+
+        assert result == {
+            "success": True,
+            "platform": "slack",
+            "chat_id": "D123ABCDEF",
+            "message_id": "123.456",
+        }
+        open_payload = session.post.call_args_list[0].kwargs["json"]
+        post_payload = session.post.call_args_list[1].kwargs["json"]
+        assert open_payload == {"users": "U123ABCDEF"}
+        assert post_payload["channel"] == "D123ABCDEF"
+        assert post_payload["text"] == "hello"
+
+    def test_username_target_resolves_user_then_opens_dm(self):
+        session = self._mock_session(
+            self._mock_response({
+                "ok": True,
+                "members": [
+                    {"id": "UOTHER123", "name": "someone", "profile": {"display_name": "Other", "real_name": "Other User"}},
+                    {"id": "U123ABCDEF", "name": "alice", "profile": {"display_name": "Alice", "real_name": "Alice Example"}},
+                ],
+                "response_metadata": {},
+            }),
+            self._mock_response({"ok": True, "channel": {"id": "D123ABCDEF"}}),
+            self._mock_response({"ok": True, "ts": "123.456"}),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("tok", "user_name:alice", "hello"))
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D123ABCDEF"
+        assert session.post.call_args_list[1].kwargs["json"] == {"users": "U123ABCDEF"}
+
+    def test_username_target_does_not_match_display_or_real_name(self):
+        session = self._mock_session(
+            self._mock_response({
+                "ok": True,
+                "members": [
+                    {"id": "U123ABCDEF", "name": "notalice", "profile": {"display_name": "alice", "real_name": "alice"}},
+                ],
+                "response_metadata": {},
+            }),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("tok", "user_name:alice", "hello"))
+
+        assert "error" in result
+        assert "Could not resolve Slack user '@alice'" in result["error"]
+        assert session.post.call_count == 1
+
+    def test_ambiguous_username_returns_error_without_opening_dm(self):
+        session = self._mock_session(
+            self._mock_response({
+                "ok": True,
+                "members": [
+                    {"id": "U111AAAAA", "name": "alice", "profile": {}},
+                    {"id": "U222BBBBB", "name": "alice", "profile": {}},
+                ],
+                "response_metadata": {},
+            }),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("tok", "user_name:alice", "hello"))
+
+        assert "error" in result
+        assert "matched multiple Slack users" in result["error"]
+        assert session.post.call_count == 1
 
 
 class TestSendDiscordThreadId:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -22,12 +22,13 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 # Slack conversation IDs: C (public channel), G (private/group channel), D (DM).
-# Must be uppercase alphanumeric, 9+ chars. User IDs (U...) and workspace IDs
-# (W...) are NOT valid chat.postMessage channel values — posting to them fails
-# because the API requires a conversation ID. To DM a user you must first call
-# conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
-# through to channel-name resolution, which only matches by name and fails.
+# Must be uppercase alphanumeric, 9+ chars. User IDs (U...) are parsed as
+# explicit user targets but are converted to D... conversations via
+# conversations.open before chat.postMessage.
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
+_SLACK_USER_ID_RE = re.compile(r"^\s*(U[A-Z0-9]{8,})\s*$")
+_SLACK_USER_NAME_RE = re.compile(r"^\s*@([A-Za-z0-9._-]{1,80})\s*$")
+_SLACK_MENTION_RE = re.compile(r"^\s*<@(U[A-Z0-9]{8,})(?:\|[^>]+)?>\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -333,6 +334,12 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+        match = _SLACK_USER_ID_RE.fullmatch(target_ref) or _SLACK_MENTION_RE.fullmatch(target_ref)
+        if match:
+            return f"user:{match.group(1)}", None, True
+        match = _SLACK_USER_NAME_RE.fullmatch(target_ref)
+        if match:
+            return f"user_name:{match.group(1)}", None, True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -1121,7 +1128,12 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
 
 
 async def _send_slack(token, chat_id, message):
-    """Send via Slack Web API."""
+    """Send via Slack Web API.
+
+    ``chat_id`` may be a Slack conversation ID (C/G/D...) or an internal user
+    target (``user:U...`` / ``user_name:...``). User targets are opened as DMs
+    before posting because Slack chat.postMessage requires a conversation ID.
+    """
     try:
         import aiohttp
     except ImportError:
@@ -1130,15 +1142,62 @@ async def _send_slack(token, chat_id, message):
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
         _proxy = resolve_proxy_url()
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
-        url = "https://slack.com/api/chat.postMessage"
+        base_url = "https://slack.com/api"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+        async def post_api(session, method, payload):
+            async with session.post(f"{base_url}/{method}", headers=headers, json=payload, **_req_kw) as resp:
+                return await resp.json()
+
+        async def resolve_user_name(session, name):
+            query = name.strip().lstrip("@").lower()
+            matches = []
+            cursor = None
+            for _page in range(20):
+                payload = {"limit": 200}
+                if cursor:
+                    payload["cursor"] = cursor
+                data = await post_api(session, "users.list", payload)
+                if not data.get("ok"):
+                    return None, f"Slack users.list error: {data.get('error', 'unknown')}"
+                for member in data.get("members", []):
+                    if member.get("deleted") or member.get("is_bot"):
+                        continue
+                    # ``@name`` should match the stable Slack handle only. Display
+                    # and real names are mutable/non-unique enough that using them
+                    # could DM the wrong person with sensitive content.
+                    if str(member.get("name", "")).strip().lower() == query:
+                        matches.append(member)
+                cursor = (data.get("response_metadata") or {}).get("next_cursor")
+                if not cursor:
+                    break
+            if not matches:
+                return None, f"Could not resolve Slack user '@{name}'."
+            if len(matches) > 1:
+                return None, f"Slack user '@{name}' matched multiple Slack users. Use a Slack user ID instead."
+            return matches[0].get("id"), None
+
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
+            if chat_id.startswith("user_name:"):
+                user_id, error = await resolve_user_name(session, chat_id[len("user_name:"):])
+                if error:
+                    return _error(error)
+                chat_id = f"user:{user_id}"
+
+            if chat_id.startswith("user:"):
+                user_id = chat_id[len("user:"):]
+                opened = await post_api(session, "conversations.open", {"users": user_id})
+                if not opened.get("ok"):
+                    return _error(f"Slack conversations.open error: {opened.get('error', 'unknown')}")
+                chat_id = (opened.get("channel") or {}).get("id")
+                if not chat_id:
+                    return _error("Slack conversations.open did not return a DM channel ID")
+
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
-            async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
-                data = await resp.json()
-                if data.get("ok"):
-                    return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}
-                return _error(f"Slack API error: {data.get('error', 'unknown')}")
+            data = await post_api(session, "chat.postMessage", payload)
+            if data.get("ok"):
+                return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}
+            return _error(f"Slack API error: {data.get('error', 'unknown')}")
     except Exception as e:
         return _error(f"Slack send failed: {e}")
 


### PR DESCRIPTION
## What does this PR do?

Adds Slack `send_message` support for direct-message user targets. Hermes already supports Slack conversation IDs (`C...`, `G...`, `D...`), but user-oriented targets require opening a DM first because Slack `chat.postMessage` only accepts conversation IDs.

This PR makes these target forms work:

- `slack:U123ABCDEF`
- `slack:@alice`
- `slack:<@U123ABCDEF>`

For user targets, Hermes now calls `conversations.open` to get a `D...` DM conversation before posting.

## Related Issue

Fixes #19236

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`
  - Parse Slack user IDs (`U...`) as explicit internal user targets.
  - Parse Slack `@username` targets as explicit internal username targets.
  - Parse Slack mention form (`<@U...>`) as an explicit user target.
  - Resolve username targets with `users.list`.
  - Open user targets with `conversations.open` before `chat.postMessage`.
  - Return a clear error when a username target is missing or ambiguous.
- `tests/tools/test_send_message_tool.py`
  - Add parser regression tests for Slack user targets.
  - Add `_send_slack` tests for user-ID DM opening, username resolution, and ambiguous username handling.

## How to Test

1. Run targeted tests:

   ```shell
   venv/bin/python -m pytest tests/tools/test_send_message_tool.py tests/gateway/test_channel_directory.py -q -o 'addopts='
   ```

2. Verify targeted result:

   ```text
   133 passed
   ```

3. Optional live Slack validation with a configured app that has `chat:write`, `im:write`, and `users:read`:

   ```text
   send_message(action="send", target="slack:@alice", message="hello")
   ```

   Expected: Hermes resolves the user, opens a DM, and sends successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test output:

```text
133 passed, 2 warnings
```

Full-suite note:

A local full `pytest tests/ -q -o 'addopts='` run was attempted but did not complete within 10 minutes in this development environment. The targeted tool/gateway regression tests for this change pass.