### PR TITLE
fix(approval): extend sensitive write target to cover shell RC and credential files

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -65,10 +65,20 @@ _HERMES_ENV_PATH = (
 )
 _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
+_SHELL_RC_FILES = (
+    r'(?:~|\$home|\$\{home\})/\.'
+    r'(?:bashrc|zshrc|profile|bash_profile|zprofile)\b'
+)
+_CREDENTIAL_FILES = (
+    r'(?:~|\$home|\$\{home\})/\.'
+    r'(?:netrc|pgpass|npmrc|pypirc)\b'
+)
 _SENSITIVE_WRITE_TARGET = (
     r'(?:/etc/|/dev/sd|'
     rf'{_SSH_SENSITIVE_PATH}|'
-    rf'{_HERMES_ENV_PATH})'
+    rf'{_HERMES_ENV_PATH}|'
+    rf'{_SHELL_RC_FILES}|'
+    rf'{_CREDENTIAL_FILES})'
 )
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'
 _COMMAND_TAIL = r'(?:\s*(?:&&|\|\||;).*)?$'


### PR DESCRIPTION
## Summary

Terminal commands can write to shell RC files (`~/.bashrc`, `~/.zshrc`, `~/.profile`) and credential files (`~/.netrc`, `~/.pgpass`, `~/.npmrc`, `~/.pypirc`) via shell redirection or `tee` **without triggering the approval gate**, even though `write_file` already blocks these same paths via `file_safety.py` `WRITE_DENIED_PATHS`.

This inconsistency means an agent (prompted via indirect injection) could bypass the write protection by using terminal commands instead of the `write_file` tool:

```bash
# Installs persistent alias override — no approval triggered
echo "alias sudo=\"echo password required\"" >> ~/.bashrc

# PATH injection for persistence across sessions
echo "export PATH=/tmp/evil:$PATH" >> ~/.profile

# Credential file entry for exfiltration
echo "machine evil.com login user password token" >> ~/.netrc

# tee variant — also uncaught
echo payload | tee -a ~/.bashrc
```

All four execute without approval despite being equivalent to blocked `write_file` calls.

## Fix

Extend `_SENSITIVE_WRITE_TARGET` with two new regex groups matching the same paths `file_safety.py` already covers:

- `_SHELL_RC_FILES` — `~/.bashrc`, `~/.zshrc`, `~/.profile`, `~/.bash_profile`, `~/.zprofile`
- `_CREDENTIAL_FILES` — `~/.netrc`, `~/.pgpass`, `~/.npmrc`, `~/.pypirc`

The existing `tee` and redirection patterns in `DANGEROUS_PATTERNS` pick these up automatically — no new pattern entries needed.

## Testing

- All 130 existing `test_approval.py` tests pass
- Verified the fix catches all attack vectors listed above
- Normal file writes (`>> /tmp/file`, `>> ~/regular.txt`) continue to pass through

## Consistency

Before this fix, `file_safety.py` and `tools/approval.py` had divergent protection scopes:

| Path | `write_file` (file_safety) | terminal (approval) |
|------|:-:|:-:|
| `~/.bashrc` | ✅ blocked | ❌ **gap** |
| `~/.zshrc` | ✅ blocked | ❌ **gap** |
| `~/.profile` | ✅ blocked | ❌ **gap** |
| `~/.netrc` | ✅ blocked | ❌ **gap** |
| `~/.pypirc` | ✅ blocked | ❌ **gap** |
| `~/.ssh/*` | ✅ blocked | ✅ blocked |
| `~/.hermes/.env` | ✅ blocked | ✅ blocked |
| `/etc/*` | ✅ blocked | ✅ blocked |

This PR closes the gap.