### PR TITLE
fix(agent): surface preflight compression status

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10623,11 +10623,11 @@ class AIAgent:
                     self.model,
                     f"{self.context_compressor.context_length:,}",
                 )
-                if not self.quiet_mode:
-                    self._safe_print(
-                        f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
-                        f">= {self.context_compressor.threshold_tokens:,} threshold"
-                    )
+                self._emit_status(
+                    f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
+                    f">= {self.context_compressor.threshold_tokens:,} threshold. "
+                    "This may take a moment."
+                )
                 # May need multiple passes for very large sessions with small
                 # context windows (each pass summarises the middle N turns).
                 for _pass in range(3):

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -432,6 +432,8 @@ class TestPreflightCompression:
 
         ok_resp = _mock_response(content="After preflight", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
 
         with (
             patch.object(agent, "_compress_context") as mock_compress,
@@ -460,6 +462,10 @@ class TestPreflightCompression:
         )
         assert result["completed"] is True
         assert result["final_response"] == "After preflight"
+        assert any(
+            ev == "lifecycle" and "Preflight compression" in msg
+            for ev, msg in status_messages
+        )
 
     def test_no_preflight_when_under_threshold(self, agent):
         """When history fits within context, no preflight compression needed."""


### PR DESCRIPTION
## Summary
- surface automatic preflight context compression through the existing lifecycle status callback
- replace the quiet-mode-only local print with `_emit_status(...)` so gateway/WebUI users get immediate feedback before synchronous compression starts
- add a regression assertion for the preflight compression path

## Why
When a loaded session is already over the context threshold, `run_conversation()` performs preflight compression before the first model call. That compression is synchronous and can take a long time on slow auxiliary models/providers. In gateway channels this looked like the inbound message disappeared: no tool progress, no streaming, and no visible status until compression finished.

Observed locally on 2026-05-03:
- inbound Telegram message at `15:15:30`
- `Auxiliary compression` started at `15:15:31`
- session split + response only at `15:19:48`
- total user-visible silence: `257.5s`

This PR does not make compression asynchronous. It makes the blocking work visible immediately using the status plumbing that gateway platforms already consume.

Related: #9231 (progress UI for explicit `/compress`; this fixes the automatic preflight path).

## Tests
- `python -m pytest -q tests/run_agent/test_413_compression.py::TestPreflightCompression::test_preflight_compresses_oversized_history` → 1 passed
- `python -m pytest -q tests/run_agent/test_413_compression.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compressor_fallback_update.py` → 38 passed, 14 warnings
