### PR TITLE
fix(discord): render clarify choices as buttons

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1593,6 +1593,18 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: List[str],
+        session_key: str,
+        on_answer: Callable[[str], None],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive clarify prompt when the platform supports it."""
+        return SendResult(success=False, error="Not supported")
+
     async def send_private_notice(
         self,
         chat_id: str,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3451,6 +3451,65 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: List[str],
+        session_key: str,
+        on_answer: Callable[[str], None],
+        metadata: Optional[dict] = None,
+    ) -> SendResult:
+        """Send a Discord button prompt for the clarify tool."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            target_id = chat_id
+            if metadata and metadata.get("thread_id"):
+                target_id = metadata["thread_id"]
+
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            clean_choices = [str(choice).strip() for choice in (choices or []) if str(choice).strip()]
+            clean_choices = clean_choices[:4]
+
+            body = str(question or "").strip()
+            max_desc = 4088
+            if len(body) > max_desc:
+                body = body[: max_desc - 3] + "..."
+
+            embed = discord.Embed(
+                title="Hermes needs your input",
+                description=body,
+                color=discord.Color.orange(),
+            )
+            if clean_choices:
+                embed.add_field(
+                    name="Choices",
+                    value="Pick one below, or reply with a custom answer.",
+                    inline=False,
+                )
+            else:
+                embed.add_field(
+                    name="Reply",
+                    value="Reply with your answer.",
+                    inline=False,
+                )
+
+            view = ClarifyChoiceView(
+                choices=clean_choices,
+                on_answer=on_answer,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+            msg = await channel.send(embed=embed, view=view if clean_choices else None)
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
@@ -4358,6 +4417,75 @@ if DISCORD_AVAILABLE:
             self, interaction: discord.Interaction, button: discord.ui.Button,
         ):
             await self._resolve(interaction, "cancel", discord.Color.greyple(), "Cancelled")
+
+        async def on_timeout(self):
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+
+    class ClarifyChoiceView(discord.ui.View):
+        """Button view for clarify tool choices."""
+
+        def __init__(
+            self,
+            choices: List[str],
+            on_answer: Callable[[str], None],
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            super().__init__(timeout=300)
+            self.choices = choices[:4]
+            self.on_answer = on_answer
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+
+            for index, choice in enumerate(self.choices, start=1):
+                label = choice if len(choice) <= 80 else choice[:77] + "..."
+                button = discord.ui.Button(
+                    label=label,
+                    style=discord.ButtonStyle.primary,
+                    custom_id=f"clarify_choice_{index}",
+                )
+                button.callback = self._choice_callback(choice)
+                self.add_item(button)
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        def _choice_callback(self, choice: str):
+            async def _callback(interaction: discord.Interaction):
+                await self._resolve(interaction, choice)
+
+            return _callback
+
+        async def _resolve(self, interaction: discord.Interaction, choice: str):
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+
+            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            if embed:
+                user = getattr(interaction, "user", None)
+                display_name = getattr(user, "display_name", "user")
+                embed.color = discord.Color.green()
+                embed.set_footer(text=f"Answered by {display_name}")
+
+            await interaction.response.edit_message(embed=embed, view=self)
+            self.on_answer(choice)
 
         async def on_timeout(self):
             self.resolved = True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -961,6 +961,7 @@ class GatewayRunner:
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+    _pending_clarify_responses: Dict[str, Any] = {}
     # Stale-code self-check defaults (see _detect_stale_code()).  Class-level
     # so tests that construct GatewayRunner via ``object.__new__`` without
     # running __init__ don't crash when _handle_message reads these.
@@ -1065,6 +1066,9 @@ class GatewayRunner:
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+        # Track live clarify prompts per session. The value is a thread-safe
+        # callback that accepts the user's answer and unblocks the agent thread.
+        self._pending_clarify_responses: Dict[str, Any] = {}
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
@@ -2075,6 +2079,20 @@ class GatewayRunner:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return False  # let default path handle it
+
+        clarify_responder = getattr(self, "_pending_clarify_responses", {}).get(session_key)
+        if clarify_responder:
+            answer = (event.text or "").strip()
+            if answer:
+                try:
+                    clarify_responder(answer)
+                except Exception as exc:
+                    logger.warning(
+                        "Gateway clarify text response failed for session %s: %s",
+                        session_key,
+                        exc,
+                    )
+                return True
 
         running_agent = self._running_agents.get(session_key)
 
@@ -12214,6 +12232,63 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        def _discord_clarify_callback(question, choices):
+            """Block the agent thread while Discord collects a clarify answer."""
+            if source.platform != Platform.DISCORD:
+                raise RuntimeError("Clarify tool is not available on this platform.")
+
+            adapter = self.adapters.get(source.platform)
+            send_prompt = getattr(adapter, "send_clarify_prompt", None)
+            if not adapter or not callable(send_prompt):
+                raise RuntimeError("Discord clarify prompts are not supported by this adapter.")
+
+            response_queue = queue.Queue(maxsize=1)
+            resolved = threading.Event()
+
+            def _answer_callback(answer: str) -> None:
+                if resolved.is_set():
+                    return
+                resolved.set()
+                try:
+                    response_queue.put_nowait(str(answer).strip())
+                except queue.Full:
+                    pass
+
+            if session_key:
+                self._pending_clarify_responses[session_key] = _answer_callback
+
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    send_prompt(
+                        chat_id=source.chat_id,
+                        question=question,
+                        choices=choices or [],
+                        session_key=session_key or "",
+                        on_answer=_answer_callback,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                )
+                send_result = future.result(timeout=10)
+                if not getattr(send_result, "success", False):
+                    error = getattr(send_result, "error", None) or "unknown error"
+                    raise RuntimeError(f"Failed to send Discord clarify prompt: {error}")
+
+                clarify_cfg = user_config.get("clarify") if isinstance(user_config, dict) else {}
+                try:
+                    timeout = int((clarify_cfg or {}).get("timeout", 120))
+                except (TypeError, ValueError):
+                    timeout = 120
+                try:
+                    return response_queue.get(timeout=max(1, timeout))
+                except queue.Empty:
+                    return "No response; clarify timed out."
+            finally:
+                if session_key:
+                    current = self._pending_clarify_responses.get(session_key)
+                    if current is _answer_callback:
+                        self._pending_clarify_responses.pop(session_key, None)
+
         def run_sync():
             # The conditional re-assignment of `message` further below
             # (prepending model-switch notes) makes Python treat it as a
@@ -12455,6 +12530,9 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            agent.clarify_callback = (
+                _discord_clarify_callback if source.platform == Platform.DISCORD else None
+            )
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -1,0 +1,155 @@
+"""Tests for Discord clarify prompts rendered as buttons."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+class _FakeView:
+    def __init__(self, timeout=None):
+        self.timeout = timeout
+        self.children = []
+
+    def add_item(self, item):
+        self.children.append(item)
+
+
+class _FakeButton:
+    def __init__(self, *, label=None, style=None, custom_id=None):
+        self.label = label
+        self.style = style
+        self.custom_id = custom_id
+        self.callback = None
+        self.disabled = False
+
+
+class _FakeEmbed:
+    def __init__(self, *, title=None, description=None, color=None):
+        self.title = title
+        self.description = description
+        self.color = color
+        self.fields = []
+        self.footer = None
+
+    def add_field(self, *, name, value, inline=False):
+        self.fields.append(SimpleNamespace(name=name, value=value, inline=inline))
+
+    def set_footer(self, *, text):
+        self.footer = text
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(
+        View=_FakeView,
+        Button=_FakeButton,
+        button=lambda *a, **k: (lambda fn: fn),
+    )
+    discord_mod.ButtonStyle = SimpleNamespace(
+        primary=1,
+        green=2,
+        grey=3,
+        blurple=4,
+        red=5,
+    )
+    discord_mod.Color = SimpleNamespace(
+        orange=lambda: "orange",
+        green=lambda: "green",
+        blue=lambda: "blue",
+        purple=lambda: "purple",
+        red=lambda: "red",
+        greyple=lambda: "greyple",
+    )
+    discord_mod.Interaction = object
+    discord_mod.Embed = _FakeEmbed
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules["discord"] = discord_mod
+    sys.modules["discord.ext"] = ext_mod
+    sys.modules["discord.ext.commands"] = commands_mod
+
+
+_ensure_discord_mock()
+
+from gateway.platforms.discord import ClarifyChoiceView, DiscordAdapter  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_send_clarify_prompt_renders_choice_buttons():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    channel = AsyncMock()
+    sent_msg = MagicMock()
+    sent_msg.id = 42
+    channel.send = AsyncMock(return_value=sent_msg)
+
+    client = MagicMock()
+    client.get_channel.return_value = channel
+    adapter._client = client
+
+    answers = []
+    result = await adapter.send_clarify_prompt(
+        chat_id="123",
+        question="Pick a path",
+        choices=["Fast", "Careful"],
+        session_key="session",
+        on_answer=answers.append,
+    )
+
+    assert result.success is True
+    _, kwargs = channel.send.call_args
+    assert kwargs["embed"].title == "Hermes needs your input"
+    assert kwargs["embed"].description == "Pick a path"
+    view = kwargs["view"]
+    assert [button.label for button in view.children] == ["Fast", "Careful"]
+    assert all(button.callback for button in view.children)
+
+
+@pytest.mark.asyncio
+async def test_clarify_choice_button_resolves_answer():
+    answers = []
+    view = ClarifyChoiceView(
+        choices=["Fast", "Careful"],
+        on_answer=answers.append,
+        allowed_user_ids={"123"},
+    )
+
+    embed = _FakeEmbed(title="Hermes needs your input", description="Pick")
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id="123", display_name="Leon"),
+        message=SimpleNamespace(embeds=[embed]),
+        response=SimpleNamespace(
+            edit_message=AsyncMock(),
+            send_message=AsyncMock(),
+        ),
+    )
+
+    await view.children[1].callback(interaction)
+
+    assert answers == ["Careful"]
+    assert all(button.disabled for button in view.children)
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.response.send_message.assert_not_awaited()
+    assert embed.footer == "Answered by Leon"


### PR DESCRIPTION
Fixes #19111

## Summary
- wire a Discord clarify callback into gateway agent turns so the clarify tool is available in Discord sessions
- render clarify choices with Discord buttons using the same component auth boundary as approval prompts
- capture custom text replies while a clarify prompt is pending so users can still answer outside the predefined choices

## Tests
- scripts/run_tests.sh tests/gateway/test_discord_clarify_buttons.py
- scripts/run_tests.sh tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_discord_allowed_mentions.py
- git diff --check