### PR TITLE
feat: make profile auth inheritance opt-in

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -42,7 +42,7 @@ import httpx
 import yaml
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_constants import OPENROUTER_BASE_URL, get_default_hermes_root
 from utils import atomic_replace, atomic_yaml_write, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -746,8 +746,85 @@ def _auth_file_path() -> Path:
     return path
 
 
+def _auth_inherit_root_enabled() -> bool:
+    """Return true when this profile explicitly opts into root auth fallback."""
+    try:
+        raw_config = read_raw_config()
+    except Exception:
+        return False
+    auth_config = raw_config.get("auth") if isinstance(raw_config, dict) else None
+    if not isinstance(auth_config, dict):
+        return False
+    return is_truthy_value(auth_config.get("inherit_root"), default=False)
+
+
+def _default_root_auth_file_path() -> Optional[Path]:
+    """Return the shared root auth.json for opt-in profile fallback.
+
+    Profiles are auth-isolated by default. When a named profile sets
+    ``auth.inherit_root: true``, missing provider auth / credential-pool buckets
+    may be read from the root profile's ``auth.json``. Profile-local state still
+    wins whenever it defines the same provider or pool bucket.
+    """
+    if not _auth_inherit_root_enabled():
+        return None
+
+    current = _auth_file_path()
+    root_auth = get_default_hermes_root() / "auth.json"
+    try:
+        if root_auth.resolve(strict=False) == current.resolve(strict=False):
+            return None
+    except Exception:
+        if root_auth == current:
+            return None
+    return root_auth
+
+
 def _auth_lock_path() -> Path:
     return _auth_file_path().with_suffix(".lock")
+
+
+def _merge_auth_store_fallback(primary: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[str, Any]:
+    """Overlay missing providers/pool entries from a shared root auth store.
+
+    Primary profile state wins.  Missing provider records, missing pool buckets,
+    and an absent active_provider inherit from the root auth store.
+    """
+    if not isinstance(primary, dict):
+        primary = {"version": AUTH_STORE_VERSION, "providers": {}}
+    if not isinstance(fallback, dict):
+        return primary
+
+    merged = dict(primary)
+
+    primary_providers = primary.get("providers")
+    if not isinstance(primary_providers, dict):
+        primary_providers = {}
+    fallback_providers = fallback.get("providers")
+    if isinstance(fallback_providers, dict) and fallback_providers:
+        merged_providers = dict(fallback_providers)
+        merged_providers.update(primary_providers)
+        merged["providers"] = merged_providers
+    else:
+        merged["providers"] = dict(primary_providers)
+
+    primary_pool = primary.get("credential_pool")
+    if isinstance(primary_pool, dict):
+        merged_pool = dict(primary_pool)
+    else:
+        merged_pool = {}
+    fallback_pool = fallback.get("credential_pool")
+    if isinstance(fallback_pool, dict):
+        for provider_id, entries in fallback_pool.items():
+            if provider_id not in merged_pool:
+                merged_pool[provider_id] = entries
+    if merged_pool:
+        merged["credential_pool"] = merged_pool
+
+    if not merged.get("active_provider") and fallback.get("active_provider"):
+        merged["active_provider"] = fallback.get("active_provider")
+
+    return merged
 
 
 _auth_lock_holder = threading.local()
@@ -812,42 +889,52 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
 
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
+    should_merge_root_fallback = auth_file == _auth_file_path()
     if not auth_file.exists():
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
-
-    try:
-        raw = json.loads(auth_file.read_text())
-    except Exception as exc:
-        corrupt_path = auth_file.with_suffix(".json.corrupt")
+        primary = {"version": AUTH_STORE_VERSION, "providers": {}}
+    else:
         try:
-            import shutil
-            shutil.copy2(auth_file, corrupt_path)
-        except Exception:
-            pass
-        logger.warning(
-            "auth: failed to parse %s (%s) — starting with empty store. "
-            "Corrupt file preserved at %s",
-            auth_file, exc, corrupt_path,
-        )
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+            raw = json.loads(auth_file.read_text())
+        except Exception as exc:
+            corrupt_path = auth_file.with_suffix(".json.corrupt")
+            try:
+                import shutil
+                shutil.copy2(auth_file, corrupt_path)
+            except Exception:
+                pass
+            logger.warning(
+                "auth: failed to parse %s (%s) — starting with empty store. "
+                "Corrupt file preserved at %s",
+                auth_file, exc, corrupt_path,
+            )
+            primary = {"version": AUTH_STORE_VERSION, "providers": {}}
+        else:
+            if isinstance(raw, dict) and (
+                isinstance(raw.get("providers"), dict)
+                or isinstance(raw.get("credential_pool"), dict)
+            ):
+                raw.setdefault("providers", {})
+                primary = raw
+            # Migrate from PR's "systems" format if present
+            elif isinstance(raw, dict) and isinstance(raw.get("systems"), dict):
+                systems = raw["systems"]
+                providers = {}
+                if "nous_portal" in systems:
+                    providers["nous"] = systems["nous_portal"]
+                primary = {"version": AUTH_STORE_VERSION, "providers": providers,
+                           "active_provider": "nous" if providers else None}
+            else:
+                primary = {"version": AUTH_STORE_VERSION, "providers": {}}
 
-    if isinstance(raw, dict) and (
-        isinstance(raw.get("providers"), dict)
-        or isinstance(raw.get("credential_pool"), dict)
-    ):
-        raw.setdefault("providers", {})
-        return raw
+    if not should_merge_root_fallback:
+        return primary
 
-    # Migrate from PR's "systems" format if present
-    if isinstance(raw, dict) and isinstance(raw.get("systems"), dict):
-        systems = raw["systems"]
-        providers = {}
-        if "nous_portal" in systems:
-            providers["nous"] = systems["nous_portal"]
-        return {"version": AUTH_STORE_VERSION, "providers": providers,
-                "active_provider": "nous" if providers else None}
+    fallback_path = _default_root_auth_file_path()
+    if not fallback_path or not fallback_path.exists():
+        return primary
 
-    return {"version": AUTH_STORE_VERSION, "providers": {}}
+    fallback = _load_auth_store(fallback_path)
+    return _merge_auth_store_fallback(primary, fallback)
 
 
 def _save_auth_store(auth_store: Dict[str, Any]) -> Path:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -388,6 +388,12 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "auth": {
+        # Profiles are auth-isolated by default. Set true inside a named
+        # profile to inherit missing provider auth / credential-pool buckets
+        # from the root ~/.hermes/auth.json while preserving local overrides.
+        "inherit_root": False,
+    },
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
@@ -2792,7 +2798,7 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "credential_pool_strategies", "auth", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",

--- a/tests/hermes_cli/test_auth_profile_inheritance.py
+++ b/tests/hermes_cli/test_auth_profile_inheritance.py
@@ -1,0 +1,126 @@
+import json
+
+import pytest
+
+from hermes_cli.auth import AuthError, _read_codex_tokens, read_credential_pool
+
+
+def _write_auth(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def _write_inherit_root_config(profile):
+    profile.mkdir(parents=True, exist_ok=True)
+    (profile / "config.yaml").write_text("auth:\n  inherit_root: true\n")
+
+
+def _root_auth_payload():
+    return {
+        "version": 1,
+        "active_provider": "openai-codex",
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": "root-access",
+                    "refresh_token": "root-refresh",
+                },
+                "last_refresh": "2026-05-03T00:00:00Z",
+            }
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "root1",
+                    "label": "device_code",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "device_code",
+                    "access_token": "root-access",
+                    "refresh_token": "root-refresh",
+                }
+            ]
+        },
+    }
+
+
+def test_named_profile_does_not_inherit_root_codex_auth_by_default(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "planchet"
+
+    _write_auth(root / "auth.json", _root_auth_payload())
+    _write_auth(
+        profile / "auth.json",
+        {"version": 1, "providers": {}, "credential_pool": {"openrouter": []}},
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+
+    with pytest.raises(AuthError, match="No Codex credentials"):
+        _read_codex_tokens(_lock=False)
+    assert read_credential_pool("openai-codex") == []
+
+
+def test_named_profile_inherits_root_codex_auth_when_enabled(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "planchet"
+
+    _write_auth(root / "auth.json", _root_auth_payload())
+    _write_auth(
+        profile / "auth.json",
+        {"version": 1, "providers": {}, "credential_pool": {"openrouter": []}},
+    )
+    _write_inherit_root_config(profile)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+
+    tokens = _read_codex_tokens(_lock=False)
+    assert tokens["tokens"]["access_token"] == "root-access"
+
+    pool = read_credential_pool("openai-codex")
+    assert len(pool) == 1
+    assert pool[0]["access_token"] == "root-access"
+
+
+def test_profile_local_auth_overrides_root_fallback_when_enabled(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "planchet"
+
+    _write_auth(root / "auth.json", _root_auth_payload())
+    _write_auth(
+        profile / "auth.json",
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "profile-access",
+                        "refresh_token": "profile-refresh",
+                    }
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "local1",
+                        "label": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "profile-access",
+                        "refresh_token": "profile-refresh",
+                    }
+                ]
+            },
+        },
+    )
+    _write_inherit_root_config(profile)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+
+    tokens = _read_codex_tokens(_lock=False)
+    assert tokens["tokens"]["access_token"] == "profile-access"
+
+    pool = read_credential_pool("openai-codex")
+    assert len(pool) == 1
+    assert pool[0]["access_token"] == "profile-access"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -760,6 +760,17 @@ credential_pool_strategies:
 
 Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/docs/user-guide/features/credential-pools) for full documentation.
 
+## Auth Settings
+
+OAuth credentials and credential pools live in each profile's `auth.json`. Profiles are isolated by default. To let a named profile read missing providers or credential-pool buckets from the root `~/.hermes/auth.json`, opt in explicitly:
+
+```yaml
+auth:
+  inherit_root: true   # default: false
+```
+
+Profile-local auth entries always override root entries, and writes still go to the profile-local `auth.json`. See [Profiles: Optional root auth inheritance](./profiles.md#optional-root-auth-inheritance) for details.
+
 ## Auxiliary Models
 
 Hermes uses "auxiliary" models for side tasks like image analysis, web page summarization, browser screenshot analysis, session-title generation, and context compression. By default (`auxiliary.*.provider: "auto"`), Hermes routes every auxiliary task to your **main chat model** — the same provider/model you picked in `hermes model`. You don't need to configure anything to get started, but be aware that on expensive reasoning models (Opus, MiniMax M2.7, etc.) auxiliary tasks add meaningful cost. If you want cheap-and-fast side tasks regardless of your main model, set `auxiliary.<task>.provider` and `auxiliary.<task>.model` explicitly (for example, Gemini Flash on OpenRouter for vision and web extraction).

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -183,6 +183,28 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+### Optional root auth inheritance
+
+Profiles are isolated by default, including OAuth credentials and credential pools in `auth.json`. A new profile does **not** automatically reuse the default profile's Codex, Nous, MiniMax, Qwen, Copilot, or other stored auth state.
+
+If you intentionally want a named profile to reuse missing credentials from the root `~/.hermes/auth.json`, enable explicit inheritance in that profile's `config.yaml`:
+
+```bash
+coder config set auth.inherit_root true
+```
+
+With inheritance enabled:
+
+- Profile-local credentials still win when the same provider exists in `~/.hermes/profiles/<name>/auth.json`.
+- Missing provider entries and missing credential-pool buckets fall back to the root auth store.
+- Writes still go to the profile's own `auth.json`; the root file is only a read fallback.
+
+Disable it again with:
+
+```bash
+coder config set auth.inherit_root false
+```
+
 ## Updating
 
 `hermes update` pulls code once (shared) and syncs new bundled skills to **all** profiles automatically:


### PR DESCRIPTION
## Summary
- Adds `auth.inherit_root` as an explicit opt-in for named profiles to read missing providers and credential-pool buckets from root `~/.hermes/auth.json`.
- Keeps profile-local auth isolated by default and lets local provider/pool entries override inherited root entries.
- Documents the setting in profile and configuration docs.

## Test Plan
- `python -m pytest tests/hermes_cli/test_auth*.py tests/hermes_cli/test_config*.py tests/hermes_cli/test_profile*.py -q -o 'addopts='`
