### PR TITLE
fix(config): support api key files

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -45,8 +45,9 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
-    "OPENAI_API_KEY", "OPENAI_BASE_URL",
-    "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    "OPENAI_API_KEY", "OPENAI_API_KEY_FILE", "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_FILE", "ANTHROPIC_TOKEN",
+    "GEMINI_API_KEY_FILE", "GOOGLE_API_KEY_FILE", "OPENROUTER_API_KEY_FILE",
     "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_NAME",
     "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_NAME",
     "SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_NAME",
@@ -242,6 +243,31 @@ def get_container_exec_info() -> Optional[dict]:
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home  # noqa: F811,E402
 from utils import atomic_replace
+
+
+def read_api_key_file(path_value: Any, *, label: str = "api_key_file") -> str:
+    """Read an API key from a user-configured secret file path.
+
+    The returned value is stripped of surrounding whitespace so Docker,
+    Kubernetes, and systemd secret files with a trailing newline work as
+    expected. Failures are logged without exposing file contents.
+    """
+    if not isinstance(path_value, str) or not path_value.strip():
+        return ""
+
+    raw_path = os.path.expandvars(os.path.expanduser(path_value.strip()))
+    path = Path(raw_path)
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger.warning("%s: could not read API key file %s: %s", label, path, exc)
+        return ""
+    except UnicodeDecodeError as exc:
+        logger.warning("%s: API key file %s is not valid UTF-8: %s", label, path, exc)
+        return ""
+    if not value:
+        logger.warning("%s: API key file %s is empty", label, path)
+    return value
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -2547,7 +2573,8 @@ def _normalize_custom_provider_entry(
     if "api_key_env" in entry and "key_env" not in entry:
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+        "name", "api", "url", "base_url", "api_key", "api_key_file",
+        "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
@@ -2608,6 +2635,10 @@ def _normalize_custom_provider_entry(
     api_key = entry.get("api_key")
     if isinstance(api_key, str) and api_key.strip():
         normalized["api_key"] = api_key.strip()
+
+    api_key_file = entry.get("api_key_file")
+    if isinstance(api_key_file, str) and api_key_file.strip():
+        normalized["api_key_file"] = api_key_file.strip()
 
     key_env = entry.get("key_env")
     if isinstance(key_env, str) and key_env.strip():
@@ -2800,7 +2831,7 @@ _KNOWN_ROOT_KEYS = {
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
+    "name", "base_url", "api_key", "api_key_file", "api_mode", "model", "models",
     "context_length", "rate_limit_delay",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -22,6 +22,38 @@ _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 _WARNED_KEYS: set[str] = set()
 
 
+def _resolve_api_key_file_env_vars() -> None:
+    """Resolve ``*_API_KEY_FILE`` variables into in-process API key env vars.
+
+    Direct ``*_API_KEY`` values keep precedence. This mirrors common Docker,
+    Kubernetes, and systemd secret-file conventions without persisting the
+    secret back to ``.env`` or ``config.yaml``.
+    """
+    for file_key, file_path in list(os.environ.items()):
+        if not file_key.endswith("_API_KEY_FILE") or not file_path.strip():
+            continue
+        target_key = file_key[: -len("_FILE")]
+        if os.environ.get(target_key, "").strip():
+            continue
+        expanded_path = os.path.expandvars(os.path.expanduser(file_path.strip()))
+        try:
+            secret = Path(expanded_path).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            print(
+                f"  Warning: {file_key} points to an unreadable file: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        except UnicodeDecodeError as exc:
+            print(
+                f"  Warning: {file_key} points to a non-UTF-8 file: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if secret:
+            os.environ[target_key] = secret
+
+
 def _format_offending_chars(value: str, limit: int = 3) -> str:
     """Return a compact 'U+XXXX ('c'), ...' summary of non-ASCII codepoints."""
     seen: list[str] = []
@@ -91,6 +123,8 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars
     # typically come from copy-pasting keys from PDFs or rich-text editors
     # that substitute Unicode lookalike glyphs (e.g. ʋ U+028B for v).
+    _sanitize_loaded_credentials()
+    _resolve_api_key_file_env_vars()
     _sanitize_loaded_credentials()
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -27,7 +27,11 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import (
+    get_compatible_custom_providers,
+    load_config,
+    read_api_key_file,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname
 
@@ -112,6 +116,13 @@ def _get_model_config() -> Dict[str, Any]:
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
         cfg = dict(model_cfg)
+        if not str(cfg.get("api_key") or "").strip():
+            secret = read_api_key_file(
+                cfg.get("api_key_file"),
+                label="model.api_key_file",
+            )
+            if secret:
+                cfg["api_key"] = secret
         # Accept "model" as alias for "default" (users intuitively write model.model)
         if not cfg.get("default") and cfg.get("model"):
             cfg["default"] = cfg["model"]
@@ -374,7 +385,16 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 return None
 
     config = load_config()
-    
+
+    def _resolve_entry_api_key(entry: Dict[str, Any], *, label: str) -> str:
+        key_env = str(entry.get("key_env", "") or "").strip()
+        resolved = os.getenv(key_env, "").strip() if key_env else ""
+        if not resolved:
+            resolved = str(entry.get("api_key", "") or "").strip()
+        if not resolved:
+            resolved = read_api_key_file(entry.get("api_key_file"), label=label)
+        return resolved
+
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
     if isinstance(providers, dict):
@@ -383,14 +403,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
-            # Fall back to inline api_key when key_env is absent or unresolvable
-            if not resolved_api_key:
-                resolved_api_key = str(entry.get("api_key", "") or "").strip()
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
+                resolved_api_key = _resolve_entry_api_key(
+                    entry,
+                    label=f"providers.{ep_name}.api_key_file",
+                )
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
@@ -416,6 +434,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             if display_name:
                 display_norm = _normalize_custom_provider_name(display_name)
                 if requested_norm in {display_name, display_norm, f"custom:{display_norm}"}:
+                    resolved_api_key = _resolve_entry_api_key(
+                        entry,
+                        label=f"providers.{ep_name}.api_key_file",
+                    )
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
@@ -461,7 +483,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
-            "api_key": str(entry.get("api_key", "") or "").strip(),
+            "api_key": str(entry.get("api_key", "") or "").strip()
+            or read_api_key_file(
+                entry.get("api_key_file"),
+                label=f"custom_providers.{name}.api_key_file",
+            ),
         }
         key_env = str(entry.get("key_env", "") or "").strip()
         if key_env:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -70,6 +70,43 @@ def test_user_env_takes_precedence_over_project_env(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_API_KEY") == "project-key"
 
 
+def test_api_key_file_env_var_populates_missing_api_key(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    secret_file = tmp_path / "openai.key"
+    secret_file.write_text("sk-file-secret\n", encoding="utf-8")
+    env_file = home / ".env"
+    env_file.write_text(f"OPENAI_API_KEY_FILE={secret_file}\n", encoding="utf-8")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_FILE", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("OPENAI_API_KEY") == "sk-file-secret"
+
+
+def test_api_key_file_env_var_does_not_override_direct_api_key(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    secret_file = tmp_path / "openai.key"
+    secret_file.write_text("sk-file-secret\n", encoding="utf-8")
+    env_file = home / ".env"
+    env_file.write_text(
+        f"OPENAI_API_KEY=sk-direct-secret\nOPENAI_API_KEY_FILE={secret_file}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY_FILE", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("OPENAI_API_KEY") == "sk-direct-secret"
+
+
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -832,6 +832,80 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_uses_api_key_file_from_providers_dict(tmp_path, monkeypatch):
+    """providers dict entries with api_key_file should resolve from secret files."""
+    key_file = tmp_path / "mycorp.key"
+    key_file.write_text("file-secret\n", encoding="utf-8")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "api_key_file": str(key_file),
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "file-secret"
+    assert resolved["model"] == "acme-large"
+
+
+def test_named_custom_provider_uses_api_key_file_from_custom_providers(tmp_path, monkeypatch):
+    """legacy custom_providers entries with api_key_file should also work."""
+    key_file = tmp_path / "legacy.key"
+    key_file.write_text("legacy-file-secret\n", encoding="utf-8")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Legacy Proxy",
+                    "base_url": "https://legacy.example.com/v1",
+                    "api_key_file": str(key_file),
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="legacy-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://legacy.example.com/v1"
+    assert resolved["api_key"] == "legacy-file-secret"
+
+
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- recognize `api_key_file` as a supported provider/custom-provider config field
- resolve `providers.<name>.api_key_file`, `custom_providers[].api_key_file`, and `model.api_key_file` at runtime without writing secrets back to config
- support `*_API_KEY_FILE` env vars when the direct `*_API_KEY` is unset

Fixes #18709.
Also addresses duplicate signal from #19203.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_api_key_file_from_providers_dict tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_api_key_file_from_custom_providers` -> 9 passed, 4 warnings
- `git diff --check`