### PR TITLE
fix(agent): recover Harmony tool calls from chat content

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,8 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import json
+import re
 from typing import Any, Dict, List, Optional
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -17,6 +19,88 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+
+_HARMONY_TOOL_CALL_RE = re.compile(
+    r"(?:<\|start\|>assistant)?"
+    r"<\|channel\|>[A-Za-z0-9_-]+"
+    r"\s+to=(?P<name>[A-Za-z0-9_.-]+)"
+    r"(?:\s+(?:code|json|python|text))?"
+    r"(?:\s*<\|constrain\|>[A-Za-z0-9_-]+)?"
+    r"\s*<\|message\|>"
+    r"(?P<args>.*?)(?=<\|(?:end|call|start|channel)\|>|$)",
+    re.DOTALL,
+)
+
+
+def _sanitize_harmony_tool_name(name: str) -> str:
+    """Return an OpenAI-tool-name-safe version of a Harmony target."""
+    cleaned = (name or "").strip()
+    if cleaned.startswith("functions."):
+        cleaned = cleaned[len("functions."):]
+    cleaned = re.sub(r"[^A-Za-z0-9_-]+", "_", cleaned).strip("_")
+    return cleaned or "unknown_tool"
+
+
+def _parse_harmony_args(raw_args: str) -> Optional[str]:
+    """Normalize a complete Harmony argument JSON payload to a JSON string."""
+    text = (raw_args or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json|javascript|js)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text).strip()
+    try:
+        parsed = json.loads(text or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return json.dumps(parsed, ensure_ascii=False)
+
+
+def _extract_harmony_tool_calls(content: Any) -> tuple[Optional[List[ToolCall]], Any]:
+    """Recover complete Harmony/Codex-style tool calls leaked as text.
+
+    Some OpenAI-compatible local backends return strings such as
+    ``<|channel|>commentary to=terminal code<|message|>{"command":"pwd"}``
+    in ``message.content`` instead of populating ``message.tool_calls``.
+    Treat complete JSON payloads as real tool calls so the normal validation,
+    repair, and execution loop can handle them instead of sending raw markup
+    to chat clients.
+    """
+    if not isinstance(content, str) or "<|channel|>" not in content or "<|message|>" not in content:
+        return None, content
+
+    tool_calls: List[ToolCall] = []
+    consumed_spans: List[tuple[int, int]] = []
+    for match in _HARMONY_TOOL_CALL_RE.finditer(content):
+        arguments = _parse_harmony_args(match.group("args"))
+        if arguments is None:
+            continue
+
+        raw_name = match.group("name")
+        name = _sanitize_harmony_tool_name(raw_name)
+        provider_data = {"raw_harmony_name": raw_name} if raw_name != name else None
+        tool_calls.append(ToolCall(
+            id=f"call_harmony_{len(tool_calls) + 1}",
+            name=name,
+            arguments=arguments,
+            provider_data=provider_data,
+        ))
+        consumed_spans.append((match.start(), match.end()))
+
+    if not tool_calls:
+        return None, content
+
+    parts: List[str] = []
+    cursor = 0
+    for start, end in consumed_spans:
+        if cursor < start:
+            parts.append(content[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(content):
+        parts.append(content[cursor:])
+    cleaned = "\n".join(part.strip() for part in parts if part and part.strip()).strip()
+    cleaned = re.sub(r"<\|(?:call|end)\|>", "", cleaned).strip()
+    return tool_calls, cleaned
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -435,6 +519,7 @@ class ChatCompletionsTransport(ProviderTransport):
         choice = response.choices[0]
         msg = choice.message
         finish_reason = choice.finish_reason or "stop"
+        content = msg.content
 
         tool_calls = None
         if msg.tool_calls:
@@ -461,6 +546,12 @@ class ChatCompletionsTransport(ProviderTransport):
                     arguments=tc.function.arguments,
                     provider_data=tc_provider_data or None,
                 ))
+        else:
+            recovered_tool_calls, cleaned_content = _extract_harmony_tool_calls(content)
+            if recovered_tool_calls:
+                tool_calls = recovered_tool_calls
+                content = cleaned_content
+                finish_reason = "tool_calls"
 
         usage = None
         if hasattr(response, "usage") and response.usage:
@@ -490,7 +581,7 @@ class ChatCompletionsTransport(ProviderTransport):
             provider_data["reasoning_details"] = rd
 
         return NormalizedResponse(
-            content=msg.content,
+            content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -655,6 +655,84 @@ class TestChatCompletionsNormalize:
         nr = transport.normalize_response(r)
         assert nr.provider_data == {"reasoning_content": "model-extra scratchpad"}
 
+    def test_recovers_harmony_tool_call_leaked_as_content(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content='<|channel|>commentary to=terminal code<|message|>{"command": "pwd"}',
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == ""
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].id == "call_harmony_1"
+        assert nr.tool_calls[0].name == "terminal"
+        assert nr.tool_calls[0].arguments == '{"command": "pwd"}'
+
+    def test_recovers_harmony_tool_call_and_preserves_visible_text(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=(
+                        "I will inspect that.\n"
+                        '<|channel|>commentary to=functions.read_file code<|message|>{"path": "/tmp/a"}'
+                        "<|call|>"
+                    ),
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == "I will inspect that."
+        assert nr.finish_reason == "tool_calls"
+        assert nr.tool_calls[0].name == "read_file"
+        assert nr.tool_calls[0].arguments == '{"path": "/tmp/a"}'
+
+    def test_recovers_harmony_namespaced_tool_as_safe_invalid_name(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=(
+                        '<|channel|>commentary to=repo_browser.print_tree code'
+                        '<|message|>{"path": "/root/hermes-wiki", "depth": 2}'
+                    ),
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "tool_calls"
+        assert nr.tool_calls[0].name == "repo_browser_print_tree"
+        assert nr.tool_calls[0].provider_data == {
+            "raw_harmony_name": "repo_browser.print_tree",
+        }
+
+    def test_ignores_incomplete_harmony_tool_call_json(self, transport):
+        raw = '<|channel|>commentary to=terminal code<|message|>{"command": '
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=raw, tool_calls=None, reasoning_content=None),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == raw
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None
+
 
 class TestChatCompletionsCacheStats:
 


### PR DESCRIPTION
## What does this PR do?

This patch addresses tool call failures I noticed when running Hermes using my own local models. This is a compatibility patch so Hermes can recover Harmony/Codex-style tool calls that leak into chat-completions message content. 

Fixes #

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/chat_completions.py`
  - parse complete Harmony tool-call snippets from content only when `message.tool_calls` is absent
  - normalize safe tool names, preserving the raw name in provider data only when sanitization changed it
  - set `finish_reason` to `tool_calls` after successful recovery
  - keep invalid/incomplete Harmony JSON as original content
- `tests/agent/transports/test_chat_completions.py`
  - add coverage for plain leaked calls
  - add coverage for preserving visible assistant text
  - add coverage for namespaced tool name sanitization
  - add coverage for leaving incomplete JSON untouched
  
## Related:
- #15347 fixed the same Harmony-style tool-call leak class for the Codex Responses API path by marking the response incomplete and relying on continuation/retry.
- This PR applies the corresponding normalization to the `chat_completions` transport, where there is no Codex incomplete-continuation path. Complete leaked JSON payloads are recovered directly into `ToolCall` objects so the existing chat-completions tool loop can execute them.

## How to Test

 `/root/.venv-1/bin/python -m pytest tests/agent/transports/test_chat_completions.py -q`

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Ubuntu 25.04 (Proxmox container)

### Documentation & Housekeeping

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- N/A I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- N/A I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- N/A I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- N/A I've updated tool descriptions/schemas if I changed tool behavior — or N/A


