### PR TITLE
fix(skills): keep personal skills out of curator

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -252,6 +252,30 @@ def test_agent_created_skips_archive_and_hub_dirs(skills_home):
     assert "old-skill" not in names
 
 
+def test_agent_created_excludes_user_personal_namespace(skills_home):
+    from tools.skill_usage import list_agent_created_skill_names
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "workflow", category="me")
+    _write_skill(skills_dir, "agent-created")
+
+    names = list_agent_created_skill_names()
+
+    assert "agent-created" in names
+    assert "workflow" not in names
+
+
+def test_personal_namespace_excluded_from_curator_report(skills_home):
+    from tools.skill_usage import agent_created_report
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "personal-workflow", category="me")
+    _write_skill(skills_dir, "scratch-skill")
+
+    names = {r["name"] for r in agent_created_report()}
+
+    assert "scratch-skill" in names
+    assert "personal-workflow" not in names
+
+
 # ---------------------------------------------------------------------------
 # Archive / restore
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -11,8 +11,9 @@ Design notes:
   - Atomic writes via tempfile + os.replace (same pattern as .bundled_manifest).
   - All counter bumps are best-effort: failures log at DEBUG and return silently.
     A broken sidecar never breaks the underlying tool call.
-  - Provenance filter: "agent-created" == not in .bundled_manifest AND not in
-    .hub/lock.json. The curator only ever mutates agent-created skills.
+  - Provenance filter: "agent-created" == not in .bundled_manifest, not in
+    .hub/lock.json, and not in the user-owned skills/me/ namespace. The
+    curator only ever mutates agent-created skills.
 
 Lifecycle states:
     active    -> default
@@ -148,12 +149,27 @@ def _read_hub_installed_names() -> Set[str]:
     return set()
 
 
+def _is_user_owned_skill_path(skill_md: Path, base: Path) -> bool:
+    """Return True for personal skills that should never enter curation.
+
+    The ``skills/me/`` namespace is the documented convention for user-authored
+    personal skills. Those skills may not appear in bundled or hub manifests, so
+    path-based protection keeps the curator from treating them as agent-created.
+    """
+    try:
+        rel = skill_md.relative_to(base)
+    except ValueError:
+        return False
+    return bool(rel.parts and rel.parts[0] == "me")
+
+
 def list_agent_created_skill_names() -> List[str]:
-    """Enumerate skills that were authored by the agent (or user), NOT by a
-    bundled or hub-installed source.
+    """Enumerate skills that were authored by the agent, NOT by a bundled,
+    hub-installed, or user-owned personal source.
 
     The curator operates exclusively on this set. Bundled / hub skills are
-    maintained by their upstream sources and must never be pruned here.
+    maintained by their upstream sources and personal skills are maintained by
+    the user; neither class should be pruned here.
     """
     base = _skills_dir()
     if not base.exists():
@@ -172,6 +188,8 @@ def list_agent_created_skill_names() -> List[str]:
             continue
         parts = rel.parts
         if parts and (parts[0].startswith(".") or parts[0] == "node_modules"):
+            continue
+        if _is_user_owned_skill_path(skill_md, base):
             continue
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
         if name in off_limits:


### PR DESCRIPTION
## Summary
- exclude the user-owned skills/me/ namespace from curator candidate discovery
- keep personal slash-command skills out of agent_created_report() while preserving ordinary agent-created skill handling
- add regression coverage for the personal namespace filter

Closes #19040

## Verification
- scripts/run_tests.sh tests/tools/test_skill_usage.py -> 40 passed, 4 warnings
- git diff --check -> clean

## Non-goals
- Does not restore skills that were already consolidated or archived; this prevents future curator passes from treating personal skills as agent-created candidates.