### PR TITLE
fix(windows): terminal drain and cwd path conversion

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -488,6 +488,26 @@ class BaseEnvironment(ABC):
 
         def _drain():
             fd = proc.stdout.fileno()
+            # select.select does NOT work on pipe fds on Windows (only sockets).
+            # Use blocking os.read in a daemon thread instead — safe because
+            # EOF arrives promptly when bash exits.
+            if os.name == "nt":
+                try:
+                    while True:
+                        chunk = os.read(fd, 4096)
+                        if not chunk:
+                            break
+                        output_chunks.append(decoder.decode(chunk))
+                except (ValueError, OSError):
+                    pass
+                finally:
+                    try:
+                        tail = decoder.decode(b"", final=True)
+                        if tail:
+                            output_chunks.append(tail)
+                    except Exception:
+                        pass
+                return
             idle_after_exit = 0
             try:
                 while True:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -358,6 +359,12 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # On Windows, self.cwd may be a Git Bash-style path (/c/Users/...)
+        # from pwd output. subprocess.Popen needs a native Windows path.
+        _popen_cwd = self.cwd
+        if _IS_WINDOWS and _popen_cwd and re.match(r'^/[a-zA-Z]/', _popen_cwd):
+            _popen_cwd = _popen_cwd[1].upper() + ':' + _popen_cwd[2:].replace('/', '\\')
+
         proc = subprocess.Popen(
             args,
             text=True,
@@ -368,7 +375,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            cwd=self.cwd,
+            cwd=_popen_cwd,
         )
         if not _IS_WINDOWS:
             try:


### PR DESCRIPTION
## Summary
- `_drain()` in `base.py`: `select.select()` only works on sockets on Windows, not pipe fds. Added a Windows branch using blocking `os.read()` in the daemon thread instead. EOF arrives promptly when bash exits.
- `_run_bash()` in `local.py`: `self.cwd` from `pwd` output uses Git Bash paths (`/c/Users/...`), but `subprocess.Popen(cwd=...)` needs native Windows paths (`C:\Users\...`). Added conversion before Popen.

Without these, all `terminal()` calls on Windows return empty output with exit 126, and cwd tracking breaks completely.

## Test plan
- [x] Tested on Windows 11 + Git for Windows + Python 3.13
- [x] `terminal("echo hello")` returns correct output (was empty before)
- [x] `__HERMES_CWD__` marker correctly parsed after fix
- [x] No regression on Unix (Windows branch is gated on `os.name == "nt"`)

Fixes #14638

🤖 Generated with [Claude Code](https://claude.com/claude-code)