### PR TITLE
fix(windows): enforce UTF-8 to prevent UnicodeEncodeError crash on startup

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -5,11 +5,43 @@ Provides subcommands for:
 - hermes chat          - Interactive chat (same as ./hermes)
 - hermes gateway       - Run gateway in foreground
 - hermes gateway start - Start gateway service
-- hermes gateway stop  - Stop gateway service  
+- hermes gateway stop  - Stop gateway service
 - hermes setup         - Interactive setup wizard
 - hermes status        - Show status of all components
 - hermes cron          - Manage cron jobs
 """
 
+import os
+import sys
+
 __version__ = "0.12.0"
 __release_date__ = "2026.4.30"
+
+
+def _ensure_utf8():
+    """Force UTF-8 stdout/stderr on Windows to prevent UnicodeEncodeError.
+
+    Windows services and terminals default to cp1252, which cannot encode
+    box-drawing characters used in CLI output. This causes unhandled
+    UnicodeEncodeError crashes on gateway startup.
+    """
+    if sys.platform != "win32":
+        return
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if stream is None:
+            continue
+        try:
+            if getattr(stream, "encoding", "").lower().replace("-", "") != "utf8":
+                new_stream = open(
+                    stream.fileno(), "w", encoding="utf-8",
+                    buffering=1, closefd=False,
+                )
+                setattr(sys, stream_name, new_stream)
+        except (AttributeError, OSError):
+            pass
+
+
+_ensure_utf8()


### PR DESCRIPTION
## Summary
- Early UTF-8 enforcement in `hermes_cli/__init__.py` — sets `PYTHONUTF8=1`, `PYTHONIOENCODING=utf-8`, and re-opens stdout/stderr with UTF-8 encoding
- Prevents `UnicodeEncodeError` crash when CLI prints box-drawing characters (┌│├└─) under Windows cp1252 default encoding
- Gateway crashes in a restart loop on Windows services where encoding is cp1252

## Root cause
Windows services (and many terminal configs) default to cp1252. The CLI banner, `hermes doctor`, `hermes status`, and 10+ other files use Unicode box-drawing characters in `print()`. cp1252 can't encode them → unhandled exception → process crash → restart loop.

## Test plan
- [x] Tested on Windows 11 with cp1252 locale — no crash
- [x] `hermes gateway start` runs without UnicodeEncodeError
- [x] `hermes doctor` output renders correctly
- [x] No effect on Unix (gated on `sys.platform == "win32"`)
- [x] No effect on systems already using UTF-8 (no-op)

Fixes #10956

🤖 Generated with [Claude Code](https://claude.com/claude-code)