### PR TITLE
fix(auth): stop treating CLAUDE_CODE_OAUTH_TOKEN as Anthropic API key

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -279,7 +279,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Anthropic",
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
-        api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"),
         base_url_env_var="ANTHROPIC_BASE_URL",
     ),
     "alibaba": ProviderConfig(

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -90,7 +90,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "anthropic": HermesOverlay(
         transport="anthropic_messages",
-        extra_env_vars=("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        extra_env_vars=("ANTHROPIC_TOKEN",),
     ),
     "zai": HermesOverlay(
         transport="openai_chat",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1356,7 +1356,7 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
             "has_refresh_token": bool(cc_creds.get("refreshToken")),
         }
 
-    env_token = os.getenv("ANTHROPIC_TOKEN") or os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+    env_token = os.getenv("ANTHROPIC_TOKEN")
     if env_token:
         return {
             "logged_in": True,


### PR DESCRIPTION
## Summary
- Remove `CLAUDE_CODE_OAUTH_TOKEN` from Anthropic provider's `api_key_env_vars` in `auth.py`
- Remove from `extra_env_vars` in `providers.py`
- Remove from auth status fallback in `web_server.py`

## Problem
When Hermes runs alongside Claude Code (common on dev machines), it picks up `CLAUDE_CODE_OAUTH_TOKEN` and tries to use it for Anthropic API requests. The token is an OAuth token scoped to Claude Code's client ID — the Anthropic API rejects it with HTTP 400. This causes silent auth failures or crash loops.

The token is already blocked from terminal subprocesses (`local.py` line 53) and marked as implicit in `setup.py`, but the auth resolver still treats it as a valid API key.

## Fix
Remove `CLAUDE_CODE_OAUTH_TOKEN` from the three places that use it as an Anthropic credential. Users who want Anthropic access in Hermes should set `ANTHROPIC_API_KEY` explicitly.

## Test plan
- [x] Hermes no longer auto-detects Anthropic as configured when only `CLAUDE_CODE_OAUTH_TOKEN` is present
- [x] `hermes setup` still prompts for Anthropic API key correctly
- [x] Explicit `ANTHROPIC_API_KEY` still works as before
- [x] No regression on machines without Claude Code installed

Fixes #15080

🤖 Generated with [Claude Code](https://claude.com/claude-code)