### PR TITLE
feat(image-gen): add image edit tool

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -50,6 +50,7 @@ TOOL_KIND_MAP: Dict[str, ToolKind] = {
     "delegate_task": "execute",
     "vision_analyze": "read",
     "image_generate": "execute",
+    "image_edit": "execute",
     "text_to_speech": "execute",
     # Thinking / meta
     "_thinking": "think",
@@ -65,7 +66,7 @@ _POLISHED_TOOLS = {
     "skill_view", "skills_list", "skill_manage", "web_search", "web_extract",
     "browser_navigate", "browser_click", "browser_type", "browser_press", "browser_scroll",
     "browser_back", "browser_snapshot", "browser_console", "browser_get_images", "browser_vision",
-    "vision_analyze", "image_generate", "text_to_speech",
+    "vision_analyze", "image_generate", "image_edit", "text_to_speech",
     # Schedulers / platform integrations
     "cronjob", "send_message", "clarify", "discord", "discord_admin",
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
@@ -173,6 +174,9 @@ def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
     if tool_name == "image_generate":
         prompt = str(args.get("prompt") or args.get("description") or "").strip()
         return f"generate image: {prompt[:50]}" if prompt else "generate image"
+    if tool_name == "image_edit":
+        prompt = str(args.get("prompt") or args.get("description") or "").strip()
+        return f"edit image: {prompt[:50]}" if prompt else "edit image"
     if tool_name == "cronjob":
         action = str(args.get("action") or "manage").strip() or "manage"
         job_id = str(args.get("job_id") or args.get("id") or "").strip()

--- a/agent/display.py
+++ b/agent/display.py
@@ -182,7 +182,7 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         "read_file": "path", "write_file": "path", "patch": "path",
         "search_files": "pattern", "browser_navigate": "url",
         "browser_click": "ref", "browser_type": "text",
-        "image_generate": "prompt", "text_to_speech": "text",
+        "image_generate": "prompt", "image_edit": "prompt", "text_to_speech": "text",
         "vision_analyze": "question", "mixture_of_agents": "user_prompt",
         "skill_view": "name", "skills_list": "category",
         "cronjob": "action",
@@ -955,6 +955,8 @@ def get_cute_tool_message(
         return _wrap(f"┊ 📚 skill     {_trunc(args.get('name', ''), 30)}  {dur}")
     if tool_name == "image_generate":
         return _wrap(f"┊ 🎨 create    {_trunc(args.get('prompt', ''), 35)}  {dur}")
+    if tool_name == "image_edit":
+        return _wrap(f"┊ 🖼️  edit      {_trunc(args.get('prompt', ''), 35)}  {dur}")
     if tool_name == "text_to_speech":
         return _wrap(f"┊ 🔊 speak     {_trunc(args.get('text', ''), 30)}  {dur}")
     if tool_name == "vision_analyze":

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -142,6 +142,32 @@ class ImageGenProvider(abc.ABC):
         should ignore unknown keys.
         """
 
+    def supports_edit(self) -> bool:
+        """Return True when this backend supports reference-image editing."""
+        return False
+
+    def edit(
+        self,
+        prompt: str,
+        image: Any,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Edit an existing image using a prompt.
+
+        Providers that support image-to-image should override this method.
+        The default keeps older providers source-compatible while giving the
+        image_edit tool a uniform unsupported response.
+        """
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        return error_response(
+            error=f"Image editing is not supported by provider '{self.name}'",
+            error_type="unsupported",
+            provider=self.name,
+            prompt=prompt or "",
+            aspect_ratio=aspect,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -32,6 +32,7 @@ import abc
 import base64
 import datetime
 import logging
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -39,8 +40,22 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
-VALID_ASPECT_RATIOS: Tuple[str, ...] = ("landscape", "square", "portrait")
+VALID_ASPECT_RATIOS: Tuple[str, ...] = (
+    "landscape",
+    "square",
+    "portrait",
+    "16:9",
+    "5:4",
+    "4:3",
+    "3:2",
+    "1:1",
+    "2:3",
+    "3:4",
+    "4:5",
+    "9:16",
+)
 DEFAULT_ASPECT_RATIO = "landscape"
+_SIZE_RE = re.compile(r"^\s*(\d+)x(\d+)\s*$")
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +201,40 @@ def resolve_aspect_ratio(value: Optional[str]) -> str:
     if v in VALID_ASPECT_RATIOS:
         return v
     return DEFAULT_ASPECT_RATIO
+
+
+def normalize_image_size(value: Optional[str]) -> Optional[str]:
+    """Validate an explicit OpenAI gpt-image-2 ``<width>x<height>`` size.
+
+    Returns the normalized size string when valid, else ``None``. Constraints
+    mirror the documented gpt-image-2 limits.
+    """
+    if not isinstance(value, str):
+        return None
+
+    match = _SIZE_RE.match(value)
+    if not match:
+        return None
+
+    width = int(match.group(1))
+    height = int(match.group(2))
+    if width <= 0 or height <= 0:
+        return None
+    if width % 16 != 0 or height % 16 != 0:
+        return None
+
+    longest = max(width, height)
+    shortest = min(width, height)
+    if longest >= 3840:
+        return None
+    if longest > shortest * 3:
+        return None
+
+    pixels = width * height
+    if pixels < 655_360 or pixels > 8_294_400:
+        return None
+
+    return f"{width}x{height}"
 
 
 def _images_cache_dir() -> Path:

--- a/model_tools.py
+++ b/model_tools.py
@@ -222,7 +222,7 @@ _LEGACY_TOOLSET_MAP = {
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "moa_tools": ["mixture_of_agents"],
-    "image_tools": ["image_generate"],
+    "image_tools": ["image_generate", "image_edit"],
     "skills_tools": ["skills_list", "skill_view", "skill_manage"],
     "browser_tools": [
         "browser_navigate", "browser_snapshot", "browser_click",

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,8 +19,13 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import logging
+import mimetypes
+import re
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -74,9 +79,17 @@ _SIZES = {
 # done by ``API_MODEL``.
 _CODEX_CHAT_MODEL = "gpt-5.4"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+_MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024
+_ALLOWED_REFERENCE_MIME_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
+_DATA_URL_RE = re.compile(r"^data:([^;,]+)(?:;[^,]*)?,", re.IGNORECASE)
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
     "using the image_generation tool when provided."
+)
+_CODEX_EDIT_INSTRUCTIONS = (
+    "You are an assistant that must edit the provided reference image by "
+    "using the image_generation tool when provided. Preserve visual details "
+    "the user did not ask to change."
 )
 
 
@@ -163,26 +176,49 @@ def _build_codex_client():
 
 def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
+    return _collect_image_b64_from_content(
+        client,
+        content=[{"type": "input_text", "text": prompt}],
+        size=size,
+        quality=quality,
+        instructions=_CODEX_INSTRUCTIONS,
+        action=None,
+    )
+
+
+def _collect_image_b64_from_content(
+    client: Any,
+    *,
+    content: List[Dict[str, Any]],
+    size: str,
+    quality: str,
+    instructions: str,
+    action: Optional[str] = None,
+) -> Optional[str]:
+    """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
+    tool: Dict[str, Any] = {
+        "type": "image_generation",
+        "model": API_MODEL,
+        "size": size,
+        "quality": quality,
+        "output_format": "png",
+        "background": "opaque",
+        "partial_images": 1,
+    }
+    if action:
+        tool["action"] = action
 
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
         store=False,
-        instructions=_CODEX_INSTRUCTIONS,
+        instructions=instructions,
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": content,
         }],
-        tools=[{
-            "type": "image_generation",
-            "model": API_MODEL,
-            "size": size,
-            "quality": quality,
-            "output_format": "png",
-            "background": "opaque",
-            "partial_images": 1,
-        }],
+        tools=[tool],
         tool_choice={
             "type": "allowed_tools",
             "mode": "required",
@@ -212,6 +248,77 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
                 image_b64 = result
 
     return image_b64
+
+
+def _image_to_input_image_part(image: str) -> Dict[str, str]:
+    """Convert a local path, HTTP(S) URL, or data URL into Responses input_image."""
+    value = (image or "").strip()
+    if not value:
+        raise ValueError("image is required")
+
+    parsed = urlparse(value)
+    if parsed.scheme in {"http", "https"}:
+        return {"type": "input_image", "image_url": value}
+    if parsed.scheme == "data":
+        match = _DATA_URL_RE.match(value)
+        mime = match.group(1).lower() if match else ""
+        if mime not in _ALLOWED_REFERENCE_MIME_TYPES:
+            raise ValueError(f"Unsupported reference image MIME type: {mime or 'unknown'}")
+        if len(value.encode("utf-8")) > int(_MAX_REFERENCE_IMAGE_BYTES * 1.4):
+            raise ValueError("Reference image data URL is too large")
+        return {"type": "input_image", "image_url": value}
+
+    path = Path(value).expanduser()
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(f"Reference image not found: {value}")
+    if path.stat().st_size > _MAX_REFERENCE_IMAGE_BYTES:
+        raise ValueError("Reference image is too large")
+
+    raw = path.read_bytes()
+    detected = _detect_image_mime(raw)
+    if detected not in _ALLOWED_REFERENCE_MIME_TYPES:
+        raise ValueError("Reference image must be a PNG, JPEG, WEBP, or GIF image")
+    guessed = mimetypes.guess_type(str(path))[0]
+    if guessed and guessed not in _ALLOWED_REFERENCE_MIME_TYPES:
+        raise ValueError(f"Unsupported reference image MIME type: {guessed}")
+    mime = guessed or detected
+    encoded = base64.b64encode(raw).decode("ascii")
+    return {"type": "input_image", "image_url": f"data:{mime};base64,{encoded}"}
+
+
+def _detect_image_mime(raw: bytes) -> Optional[str]:
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith(b"GIF87a") or raw.startswith(b"GIF89a"):
+        return "image/gif"
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _collect_edited_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    image: str,
+    size: str,
+    quality: str,
+) -> Optional[str]:
+    """Stream a Codex Responses image edit call and return the b64 image."""
+    content = [
+        {"type": "input_text", "text": prompt},
+        _image_to_input_image_part(image),
+    ]
+    return _collect_image_b64_from_content(
+        client,
+        content=content,
+        size=size,
+        quality=quality,
+        instructions=_CODEX_EDIT_INSTRUCTIONS,
+        action="edit",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +372,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 "if you haven't already. No API key needed."
             ),
         }
+
+    def supports_edit(self) -> bool:
+        return True
 
     def generate(
         self,
@@ -365,6 +475,127 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             aspect_ratio=aspect,
             provider="openai-codex",
             extra={"size": size, "quality": meta["quality"]},
+        )
+
+    def edit(
+        self,
+        prompt: str,
+        image: Any,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="openai-codex",
+                aspect_ratio=aspect,
+            )
+        if not isinstance(image, str) or not image.strip():
+            return error_response(
+                error="A reference image path or URL is required",
+                error_type="invalid_argument",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if not _read_codex_access_token():
+            return error_response(
+                error=(
+                    "No Codex/ChatGPT OAuth credentials available. Run "
+                    "`hermes auth codex` (or `hermes setup` → Codex) to sign in."
+                ),
+                error_type="auth_required",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        try:
+            import openai  # noqa: F401
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        tier_id, meta = _resolve_model()
+        size = _SIZES.get(aspect, _SIZES["square"])
+
+        client = _build_codex_client()
+        if client is None:
+            return error_response(
+                error="Could not initialize Codex image client",
+                error_type="auth_required",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            b64 = _collect_edited_image_b64(
+                client,
+                prompt=prompt,
+                image=image,
+                size=size,
+                quality=meta["quality"],
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            logger.debug("Codex image edit failed", exc_info=True)
+            return error_response(
+                error=f"OpenAI image edit via Codex auth failed: {exc}",
+                error_type="api_error",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if not b64:
+            return error_response(
+                error="Codex response contained no image_generation_call result",
+                error_type="empty_response",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            saved_path = save_b64_image(b64, prefix=f"openai_codex_edit_{tier_id}")
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        return success_response(
+            image=str(saved_path),
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="openai-codex",
+            extra={"size": size, "quality": meta["quality"], "source_image": image},
         )
 
 

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -31,6 +31,7 @@ from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    normalize_image_size,
     resolve_aspect_ratio,
     save_b64_image,
     success_response,
@@ -69,10 +70,28 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 DEFAULT_MODEL = "gpt-image-2-medium"
 
 _SIZES = {
+    # Legacy compatibility presets.
     "landscape": "1536x1024",
     "square": "1024x1024",
     "portrait": "1024x1536",
+    # Explicit aspect-ratio presets.
+    "16:9": "1824x1024",
+    "5:4": "1280x1024",
+    "4:3": "1360x1024",
+    "3:2": "1536x1024",
+    "1:1": "1024x1024",
+    "2:3": "1024x1536",
+    "3:4": "1024x1360",
+    "4:5": "1024x1280",
+    "9:16": "1024x1824",
 }
+
+
+def _resolve_openai_size(aspect_ratio: str, requested_size: Any) -> Optional[str]:
+    explicit = normalize_image_size(requested_size)
+    if requested_size is not None:
+        return explicit
+    return _SIZES.get(aspect_ratio, _SIZES[DEFAULT_ASPECT_RATIO])
 
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
@@ -81,7 +100,7 @@ _CODEX_CHAT_MODEL = "gpt-5.4"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024
 _ALLOWED_REFERENCE_MIME_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
-_DATA_URL_RE = re.compile(r"^data:([^;,]+)(?:;[^,]*)?,", re.IGNORECASE)
+_DATA_URL_RE = re.compile(r"^data:([^;,]+)((?:;[^,]*)*),(.*)$", re.IGNORECASE | re.DOTALL)
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
     "using the image_generation tool when provided."
@@ -111,9 +130,21 @@ def _load_image_gen_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
-    """Decide which tier to use and return ``(model_id, meta)``."""
+def _resolve_model(model: Optional[str] = None, quality_tier: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    """Decide which tier to use and return ``(model_id, meta)``.
+
+    Explicit call-level overrides win over environment/config defaults.
+    """
     import os
+
+    if isinstance(model, str) and model in _MODELS:
+        return model, _MODELS[model]
+
+    if isinstance(quality_tier, str):
+        tier = quality_tier.strip().lower()
+        if tier in {"low", "medium", "high"}:
+            model_id = f"gpt-image-2-{tier}"
+            return model_id, _MODELS[model_id]
 
     env_override = os.environ.get("OPENAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
@@ -135,6 +166,22 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
         return candidate, _MODELS[candidate]
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_requested_model(kwargs: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    explicit_model = kwargs.get("model")
+    if isinstance(explicit_model, str) and explicit_model in _MODELS:
+        return explicit_model, _MODELS[explicit_model]
+
+    quality_tier = kwargs.get("quality_tier")
+    if isinstance(quality_tier, str):
+        normalized_tier = quality_tier.strip().lower()
+        if normalized_tier and normalized_tier != "auto":
+            candidate = f"gpt-image-2-{normalized_tier}"
+            if candidate in _MODELS:
+                return candidate, _MODELS[candidate]
+
+    return _resolve_model()
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -260,12 +307,7 @@ def _image_to_input_image_part(image: str) -> Dict[str, str]:
     if parsed.scheme in {"http", "https"}:
         return {"type": "input_image", "image_url": value}
     if parsed.scheme == "data":
-        match = _DATA_URL_RE.match(value)
-        mime = match.group(1).lower() if match else ""
-        if mime not in _ALLOWED_REFERENCE_MIME_TYPES:
-            raise ValueError(f"Unsupported reference image MIME type: {mime or 'unknown'}")
-        if len(value.encode("utf-8")) > int(_MAX_REFERENCE_IMAGE_BYTES * 1.4):
-            raise ValueError("Reference image data URL is too large")
+        _validate_image_data_url(value)
         return {"type": "input_image", "image_url": value}
 
     path = Path(value).expanduser()
@@ -284,6 +326,30 @@ def _image_to_input_image_part(image: str) -> Dict[str, str]:
     mime = guessed or detected
     encoded = base64.b64encode(raw).decode("ascii")
     return {"type": "input_image", "image_url": f"data:{mime};base64,{encoded}"}
+
+
+def _validate_image_data_url(value: str) -> None:
+    match = _DATA_URL_RE.match(value)
+    mime = match.group(1).lower() if match else ""
+    params = match.group(2).lower() if match else ""
+    payload = match.group(3) if match else ""
+    if mime not in _ALLOWED_REFERENCE_MIME_TYPES:
+        raise ValueError(f"Unsupported reference image MIME type: {mime or 'unknown'}")
+    if ";base64" not in params:
+        raise ValueError("Reference image data URL must be base64-encoded")
+    if len(value.encode("utf-8")) > int(_MAX_REFERENCE_IMAGE_BYTES * 1.4):
+        raise ValueError("Reference image data URL is too large")
+    try:
+        raw = base64.b64decode(payload, validate=True)
+    except Exception as exc:
+        raise ValueError("Reference image data URL contains invalid base64") from exc
+    if len(raw) > _MAX_REFERENCE_IMAGE_BYTES:
+        raise ValueError("Reference image data URL is too large")
+    detected = _detect_image_mime(raw)
+    if detected not in _ALLOWED_REFERENCE_MIME_TYPES:
+        raise ValueError("Reference image data URL must contain PNG, JPEG, WEBP, or GIF bytes")
+    if detected != mime:
+        raise ValueError("Reference image data URL MIME type does not match image bytes")
 
 
 def _detect_image_mime(raw: bytes) -> Optional[str]:
@@ -414,8 +480,22 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        tier_id, meta = _resolve_requested_model(kwargs)
+        requested_size = kwargs.get("size")
+        size = _resolve_openai_size(aspect, requested_size)
+        if requested_size is not None and size is None:
+            return error_response(
+                error=(
+                    "Invalid size. Use <width>x<height> with dimensions that are "
+                    "multiples of 16, max side < 3840, aspect ratio <= 3:1, and "
+                    "total pixels between 655,360 and 8,294,400."
+                ),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
 
         client = _build_codex_client()
         if client is None:
@@ -525,8 +605,22 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        tier_id, meta = _resolve_requested_model(kwargs)
+        requested_size = kwargs.get("size")
+        size = _resolve_openai_size(aspect, requested_size)
+        if requested_size is not None and size is None:
+            return error_response(
+                error=(
+                    "Invalid size. Use <width>x<height> with dimensions that are "
+                    "multiples of 16, max side < 3840, aspect ratio <= 3:1, and "
+                    "total pixels between 655,360 and 8,294,400."
+                ),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
 
         client = _build_codex_client()
         if client is None:

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -31,6 +31,7 @@ from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    normalize_image_size,
     resolve_aspect_ratio,
     save_b64_image,
     success_response,
@@ -73,10 +74,28 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 DEFAULT_MODEL = "gpt-image-2-medium"
 
 _SIZES = {
+    # Legacy compatibility presets.
     "landscape": "1536x1024",
     "square": "1024x1024",
     "portrait": "1024x1536",
+    # Explicit aspect-ratio presets.
+    "16:9": "1824x1024",
+    "5:4": "1280x1024",
+    "4:3": "1360x1024",
+    "3:2": "1536x1024",
+    "1:1": "1024x1024",
+    "2:3": "1024x1536",
+    "3:4": "1024x1360",
+    "4:5": "1024x1280",
+    "9:16": "1024x1824",
 }
+
+
+def _resolve_openai_size(aspect_ratio: str, requested_size: Any) -> Optional[str]:
+    explicit = normalize_image_size(requested_size)
+    if requested_size is not None:
+        return explicit
+    return _SIZES.get(aspect_ratio, _SIZES[DEFAULT_ASPECT_RATIO])
 
 
 def _load_openai_config() -> Dict[str, Any]:
@@ -210,7 +229,21 @@ class OpenAIImageGenProvider(ImageGenProvider):
             )
 
         tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        requested_size = kwargs.get("size")
+        size = _resolve_openai_size(aspect, requested_size)
+        if requested_size is not None and size is None:
+            return error_response(
+                error=(
+                    "Invalid size. Use <width>x<height> with dimensions that are "
+                    "multiples of 16, max side < 3840, aspect ratio <= 3:1, and "
+                    "total pixels between 655,360 and 8,294,400."
+                ),
+                error_type="invalid_argument",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
 
         # gpt-image-2 returns b64_json unconditionally and REJECTS
         # ``response_format`` as an unknown parameter. Don't send it.

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -28,12 +28,17 @@ class TestHermesApiServerToolset:
         expected = [
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
-            "vision_analyze", "image_generate",
+            "vision_analyze", "image_generate", "image_edit",
             "execute_code", "delegate_task",
             "todo", "memory", "session_search", "cronjob",
         ]
         for tool in expected:
             assert tool in tools, f"Missing expected tool: {tool}"
+
+    def test_safe_toolset_excludes_image_edit(self):
+        tools = resolve_toolset("safe")
+        assert "image_generate" in tools
+        assert "image_edit" not in tools
 
     def test_toolset_includes_browser_tools(self):
         tools = resolve_toolset("hermes-api-server")

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -86,6 +86,9 @@ class TestMetadata:
         assert schema["env_vars"] == []
         assert schema["badge"] == "free"
 
+    def test_supports_edit(self, provider):
+        assert provider.supports_edit() is True
+
 
 # ── Availability ────────────────────────────────────────────────────────────
 
@@ -281,6 +284,137 @@ class TestGenerate:
         assert result["success"] is False
         assert result["error_type"] == "api_error"
         assert "cloudflare 403" in result["error"]
+
+
+# ── Edit ────────────────────────────────────────────────────────────────────
+
+
+class TestEdit:
+    def test_edit_uses_input_image_content(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        source = tmp_path / "source.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_edit",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.edit("make the background blue", str(source), aspect_ratio="square")
+
+        assert result["success"] is True
+        assert result["provider"] == "openai-codex"
+        assert result["source_image"] == str(source)
+        assert Path(result["image"]).exists()
+        assert Path(result["image"]).name.startswith("openai_codex_edit_")
+
+        content = captured["input"][0]["content"]
+        assert content[0] == {"type": "input_text", "text": "make the background blue"}
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+
+        tool = captured["tools"][0]
+        assert tool["type"] == "image_generation"
+        assert tool["model"] == "gpt-image-2"
+        assert tool["action"] == "edit"
+        assert tool["size"] == "1024x1024"
+        assert tool["quality"] == "medium"
+
+    def test_edit_accepts_http_image_url(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(type="image_generation_call", result=_b64_png())
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            return _FakeStream([done_event], SimpleNamespace(output=[]))
+
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=_stream)),
+        )
+
+        result = provider.edit("add a hat", "https://example.com/cat.png")
+
+        assert result["success"] is True
+        assert captured["input"][0]["content"][1] == {
+            "type": "input_image",
+            "image_url": "https://example.com/cat.png",
+        }
+
+    def test_edit_rejects_non_image_local_file(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        source = tmp_path / "secrets.txt"
+        source.write_text("not an image")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None)),
+        )
+
+        result = provider.edit("make it blue", str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "Reference image must be" in result["error"]
+
+    def test_edit_rejects_text_data_url(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None)),
+        )
+
+        result = provider.edit("make it blue", "data:text/plain;base64,Zm9v")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "Unsupported reference image MIME type" in result["error"]
+
+    def test_edit_rejects_oversized_local_image(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        source = tmp_path / "huge.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        monkeypatch.setattr(codex_plugin, "_MAX_REFERENCE_IMAGE_BYTES", 4)
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None)),
+        )
+
+        result = provider.edit("make it blue", str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "Reference image is too large" in result["error"]
+
+    def test_edit_missing_reference_image_returns_invalid_argument(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None)),
+        )
+
+        result = provider.edit("add a hat", "/definitely/missing.png")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "Reference image not found" in result["error"]
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -202,6 +202,55 @@ class TestGenerate:
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
 
+    @pytest.mark.parametrize("aspect,expected_size", [
+        ("16:9", "1824x1024"),
+        ("9:16", "1024x1824"),
+        ("4:3", "1360x1024"),
+        ("3:4", "1024x1360"),
+    ])
+    def test_codex_aspect_ratio_mapping(self, provider, monkeypatch, aspect, expected_size):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(type="image_generation_call", result=_b64_png())
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            return _FakeStream([done_event], SimpleNamespace(output=[]))
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat", aspect_ratio=aspect)
+        assert result["success"] is True
+        assert captured["tools"][0]["size"] == expected_size
+
+    def test_codex_explicit_size_overrides_aspect_ratio(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(type="image_generation_call", result=_b64_png())
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            return _FakeStream([done_event], SimpleNamespace(output=[]))
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat", aspect_ratio="square", size="1024x1824")
+        assert result["success"] is True
+        assert result["size"] == "1024x1824"
+        assert captured["tools"][0]["size"] == "1024x1824"
+
+    def test_codex_invalid_explicit_size_returns_error(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: object())
+
+        result = provider.generate("a cat", size="1000x1000")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
     def test_partial_image_event_used_when_done_missing(self, provider, monkeypatch):
         """If the stream never emits output_item.done, fall back to the
         partial_image event so users at least get the latest preview frame."""
@@ -356,6 +405,31 @@ class TestEdit:
             "image_url": "https://example.com/cat.png",
         }
 
+    def test_edit_accepts_valid_image_data_url(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(type="image_generation_call", result=_b64_png())
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            return _FakeStream([done_event], SimpleNamespace(output=[]))
+
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=_stream)),
+        )
+        data_url = f"data:image/png;base64,{_b64_png()}"
+
+        result = provider.edit("add a hat", data_url)
+
+        assert result["success"] is True
+        assert captured["input"][0]["content"][1] == {
+            "type": "input_image",
+            "image_url": data_url,
+        }
+
     def test_edit_rejects_non_image_local_file(self, provider, monkeypatch, tmp_path):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
         source = tmp_path / "secrets.txt"
@@ -386,6 +460,34 @@ class TestEdit:
         assert result["error_type"] == "invalid_argument"
         assert "Unsupported reference image MIME type" in result["error"]
 
+    def test_edit_rejects_malformed_image_data_url(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None)),
+        )
+
+        result = provider.edit("make it blue", "data:image/png;base64,not-base64")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "invalid base64" in result["error"]
+
+    def test_edit_rejects_image_data_url_with_non_image_bytes(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=lambda **kwargs: None)),
+        )
+
+        result = provider.edit("make it blue", "data:image/png;base64,Zm9v")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "must contain PNG" in result["error"]
+
     def test_edit_rejects_oversized_local_image(self, provider, monkeypatch, tmp_path):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
         source = tmp_path / "huge.png"
@@ -402,6 +504,66 @@ class TestEdit:
         assert result["success"] is False
         assert result["error_type"] == "invalid_argument"
         assert "Reference image is too large" in result["error"]
+
+    def test_edit_model_kwarg_overrides_env_selected_tier(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-low")
+        source = tmp_path / "source.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(type="image_generation_call", result=_b64_png())
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            return _FakeStream([done_event], SimpleNamespace(output=[]))
+
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=_stream)),
+        )
+
+        result = provider.edit(
+            "add a hat",
+            str(source),
+            model="gpt-image-2-high",
+        )
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-high"
+        assert result["quality"] == "high"
+        assert captured["tools"][0]["quality"] == "high"
+
+    def test_edit_quality_tier_kwarg_overrides_env_selected_tier(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-high")
+        source = tmp_path / "source.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(type="image_generation_call", result=_b64_png())
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            return _FakeStream([done_event], SimpleNamespace(output=[]))
+
+        monkeypatch.setattr(
+            codex_plugin,
+            "_build_codex_client",
+            lambda: SimpleNamespace(responses=SimpleNamespace(stream=_stream)),
+        )
+
+        result = provider.edit(
+            "add a hat",
+            str(source),
+            quality_tier="low",
+        )
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-low"
+        assert result["quality"] == "low"
+        assert captured["tools"][0]["quality"] == "low"
 
     def test_edit_missing_reference_image_returns_invalid_argument(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -137,7 +137,6 @@ class TestGenerate:
         assert result["error_type"] == "auth_required"
 
     def test_b64_saves_to_cache(self, provider, tmp_path):
-        import base64
         png_bytes = bytes.fromhex(_PNG_HEX)
         fake_client = MagicMock()
         fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
@@ -187,6 +186,10 @@ class TestGenerate:
         ("landscape", "1536x1024"),
         ("square", "1024x1024"),
         ("portrait", "1024x1536"),
+        ("16:9", "1824x1024"),
+        ("9:16", "1024x1824"),
+        ("4:3", "1360x1024"),
+        ("3:4", "1024x1360"),
     ])
     def test_aspect_ratio_mapping(self, provider, aspect, expected_size):
         fake_client = MagicMock()
@@ -196,6 +199,27 @@ class TestGenerate:
             provider.generate("a cat", aspect_ratio=aspect)
 
         assert fake_client.images.generate.call_args.kwargs["size"] == expected_size
+
+    def test_explicit_size_overrides_aspect_ratio(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", aspect_ratio="square", size="1024x1824")
+
+        assert result["success"] is True
+        assert result["size"] == "1024x1824"
+        assert fake_client.images.generate.call_args.kwargs["size"] == "1024x1824"
+
+    def test_invalid_explicit_size_returns_error(self, provider):
+        fake_client = MagicMock()
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", size="1000x1000")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert fake_client.images.generate.call_count == 0
 
     def test_revised_prompt_passed_through(self, provider):
         fake_client = MagicMock()

--- a/tests/tools/test_image_edit_tool.py
+++ b/tests/tools/test_image_edit_tool.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from agent import image_gen_registry
+from agent.image_gen_provider import ImageGenProvider
+
+
+class _FakeEditProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        raise AssertionError("generate should not be called by image_edit")
+
+    def supports_edit(self) -> bool:
+        return True
+
+    def is_available(self) -> bool:
+        return True
+
+    def edit(self, prompt, image, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": True,
+            "image": "/tmp/edit.png",
+            "model": "gpt-image-2-medium",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "codex",
+            "source_image": image,
+        }
+
+
+class _NoEditProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "noedit"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {}
+
+
+def setup_function():
+    image_gen_registry._reset_for_tests()
+
+
+def teardown_function():
+    image_gen_registry._reset_for_tests()
+
+
+def test_image_edit_schema_requires_prompt_and_image():
+    from tools.image_edit_tool import IMAGE_EDIT_SCHEMA
+
+    assert IMAGE_EDIT_SCHEMA["name"] == "image_edit"
+    assert IMAGE_EDIT_SCHEMA["parameters"]["required"] == ["prompt", "image"]
+    assert "aspect_ratio" in IMAGE_EDIT_SCHEMA["parameters"]["properties"]
+
+
+def test_dispatch_routes_to_edit_provider(monkeypatch):
+    from tools import image_edit_tool
+    from agent import image_gen_registry as registry_module
+    from hermes_cli import plugins as plugins_module
+
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "codex")
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+    monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeEditProvider() if name == "codex" else None)
+
+    payload = json.loads(image_edit_tool._dispatch_to_plugin_provider("make it blue", "/tmp/source.png", "square"))
+
+    assert payload["success"] is True
+    assert payload["provider"] == "codex"
+    assert payload["image"] == "/tmp/edit.png"
+    assert payload["source_image"] == "/tmp/source.png"
+    assert payload["aspect_ratio"] == "square"
+
+
+def test_dispatch_reports_provider_without_edit(monkeypatch):
+    from tools import image_edit_tool
+    from agent import image_gen_registry as registry_module
+    from hermes_cli import plugins as plugins_module
+
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "noedit")
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+    monkeypatch.setattr(registry_module, "get_provider", lambda name: _NoEditProvider() if name == "noedit" else None)
+
+    payload = json.loads(image_edit_tool._dispatch_to_plugin_provider("make it blue", "/tmp/source.png", "square"))
+
+    assert payload["success"] is False
+    assert payload["error_type"] == "unsupported"
+
+
+def test_image_gen_toolset_includes_image_edit():
+    from toolsets import resolve_toolset
+
+    tools = resolve_toolset("image_gen")
+    assert "image_generate" in tools
+    assert "image_edit" in tools

--- a/tests/tools/test_image_edit_tool.py
+++ b/tests/tools/test_image_edit_tool.py
@@ -24,7 +24,9 @@ class _FakeEditProvider(ImageGenProvider):
         return {
             "success": True,
             "image": "/tmp/edit.png",
-            "model": "gpt-image-2-medium",
+            "model": kwargs.get("model", "gpt-image-2-medium"),
+            "quality_tier": kwargs.get("quality_tier"),
+            "size": kwargs.get("size"),
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
             "provider": "codex",
@@ -55,6 +57,14 @@ def test_image_edit_schema_requires_prompt_and_image():
     assert IMAGE_EDIT_SCHEMA["name"] == "image_edit"
     assert IMAGE_EDIT_SCHEMA["parameters"]["required"] == ["prompt", "image"]
     assert "aspect_ratio" in IMAGE_EDIT_SCHEMA["parameters"]["properties"]
+    assert "size" in IMAGE_EDIT_SCHEMA["parameters"]["properties"]
+    assert IMAGE_EDIT_SCHEMA["parameters"]["properties"]["quality_tier"]["enum"] == [
+        "auto",
+        "low",
+        "medium",
+        "high",
+    ]
+    assert "model" in IMAGE_EDIT_SCHEMA["parameters"]["properties"]
 
 
 def test_dispatch_routes_to_edit_provider(monkeypatch):
@@ -73,6 +83,69 @@ def test_dispatch_routes_to_edit_provider(monkeypatch):
     assert payload["image"] == "/tmp/edit.png"
     assert payload["source_image"] == "/tmp/source.png"
     assert payload["aspect_ratio"] == "square"
+
+
+def test_dispatch_forwards_optional_edit_overrides(monkeypatch):
+    from tools import image_edit_tool
+    from agent import image_gen_registry as registry_module
+    from hermes_cli import plugins as plugins_module
+
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "codex")
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+    monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeEditProvider() if name == "codex" else None)
+
+    payload = json.loads(
+        image_edit_tool._dispatch_to_plugin_provider(
+            "make it blue",
+            "/tmp/source.png",
+            "9:16",
+            size="1024x1824",
+            quality_tier="high",
+            model="gpt-image-2-low",
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["aspect_ratio"] == "9:16"
+    assert payload["size"] == "1024x1824"
+    assert payload["quality_tier"] == "high"
+    assert payload["model"] == "gpt-image-2-low"
+
+
+def test_handler_forwards_optional_edit_overrides(monkeypatch):
+    from tools import image_edit_tool
+
+    captured = {}
+
+    def _fake_dispatch(prompt, image, aspect_ratio, **kwargs):
+        captured.update({
+            "prompt": prompt,
+            "image": image,
+            "aspect_ratio": aspect_ratio,
+            **kwargs,
+        })
+        return json.dumps({"success": True, "image": "/tmp/edit.png"})
+
+    monkeypatch.setattr(image_edit_tool, "_dispatch_to_plugin_provider", _fake_dispatch)
+
+    payload = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "make it blue",
+        "image": "/tmp/source.png",
+        "aspect_ratio": "9:16",
+        "size": "1024x1824",
+        "quality_tier": "low",
+        "model": "gpt-image-2-medium",
+    }))
+
+    assert payload["success"] is True
+    assert captured == {
+        "prompt": "make it blue",
+        "image": "/tmp/source.png",
+        "aspect_ratio": "9:16",
+        "size": "1024x1824",
+        "quality_tier": "low",
+        "model": "gpt-image-2-medium",
+    }
 
 
 def test_dispatch_reports_provider_without_edit(monkeypatch):

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -33,6 +33,13 @@ def image_tool():
 class TestFalCatalog:
     """Every FAL_MODELS entry must have a consistent shape."""
 
+    def test_image_generate_schema_exposes_size_and_extended_aspect_ratios(self, image_tool):
+        props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
+        assert "size" in props
+        assert props["size"]["pattern"] == "^[0-9]+x[0-9]+$"
+        assert "9:16" in props["aspect_ratio"]["enum"]
+        assert "16:9" in props["aspect_ratio"]["enum"]
+
     def test_default_model_is_klein(self, image_tool):
         assert image_tool.DEFAULT_MODEL == "fal-ai/flux-2/klein/9b"
 
@@ -363,15 +370,21 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_prompt_aspect_ratio_and_size_to_agent(self, image_tool):
+        """The agent-facing schema stays tight: prompt + framing controls only,
+        not provider/model selection."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "size"}
 
-    def test_aspect_ratio_enum_is_three_values(self, image_tool):
+    def test_image_generate_description_routes_reference_images_to_image_edit_image_arg(self, image_tool):
+        description = image_tool.IMAGE_GENERATE_SCHEMA["description"]
+        assert "image_edit" in description
+        assert "`image` argument" in description
+        assert "reference_image" not in description
+
+    def test_aspect_ratio_enum_includes_legacy_and_explicit_ratios(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]
-        assert set(enum) == {"landscape", "square", "portrait"}
+        assert {"landscape", "square", "portrait", "16:9", "9:16", "4:3", "3:4"} <= set(enum)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -27,6 +27,7 @@ class _FakeCodexProvider(ImageGenProvider):
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
             "provider": "codex",
+            "size": kwargs.get("size"),
         }
 
 
@@ -51,6 +52,26 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+        assert payload["size"] is None
+
+    def test_dispatch_passes_explicit_size_to_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw poster", "9:16", size="1024x1824")
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert payload["aspect_ratio"] == "9:16"
+        assert payload["size"] == "1024x1824"
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -303,6 +303,7 @@ class TestBuiltinDiscovery:
             "tools.feishu_drive_tool",
             "tools.file_tools",
             "tools.homeassistant_tool",
+            "tools.image_edit_tool",
             "tools.image_generation_tool",
             "tools.kanban_tools",
             "tools.memory_tool",

--- a/tools/image_edit_tool.py
+++ b/tools/image_edit_tool.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Image editing tool.
+
+Provides a small, provider-dispatched tool for prompt-guided image-to-image
+editing. The first local implementation targets the openai-codex image_gen
+backend, which can pass reference images through the Codex Responses API.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from agent.image_gen_provider import DEFAULT_ASPECT_RATIO, VALID_ASPECT_RATIOS
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+IMAGE_EDIT_SCHEMA = {
+    "name": "image_edit",
+    "description": (
+        "Edit an existing image using a text instruction and a reference image. "
+        "The active image backend is user-configured. Currently this is intended "
+        "for backends that support image-to-image editing, such as OpenAI Codex "
+        "auth with GPT Image 2. Returns either a URL or an absolute file path in "
+        "the `image` field; display it with markdown ![description](url-or-path)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Instruction describing the edit to apply while preserving unchanged parts of the source image.",
+            },
+            "image": {
+                "type": "string",
+                "description": "Reference image as an absolute/local file path, HTTP(S) URL, or data URL.",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": list(VALID_ASPECT_RATIOS),
+                "description": "Desired output aspect ratio. 'landscape' is wide, 'portrait' is tall, 'square' is 1:1.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+        },
+        "required": ["prompt", "image"],
+    },
+}
+
+
+def _read_configured_image_provider():
+    # Reuse image_generate's provider selection logic so both tools honor the
+    # same image_gen.provider setting.
+    try:
+        from tools.image_generation_tool import _read_configured_image_provider as _reader
+
+        return _reader()
+    except Exception as exc:
+        logger.debug("Could not read configured image provider for image_edit: %s", exc)
+        return None
+
+
+def _get_active_edit_provider():
+    configured = _read_configured_image_provider()
+    if not configured or configured == "fal":
+        return None, configured
+
+    try:
+        from agent.image_gen_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        provider = get_provider(configured)
+        if provider is None:
+            _ensure_plugins_discovered(force=True)
+            provider = get_provider(configured)
+        return provider, configured
+    except Exception as exc:
+        logger.debug("image_edit provider discovery failed: %s", exc)
+        return None, configured
+
+
+def _dispatch_to_plugin_provider(prompt: str, image: str, aspect_ratio: str):
+    provider, configured = _get_active_edit_provider()
+    if configured is None or configured == "fal":
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                "image_edit requires an image_gen provider that supports editing. "
+                "Set image_gen.provider to an edit-capable backend such as 'openai-codex'."
+            ),
+            "error_type": "provider_not_configured",
+        })
+
+    if provider is None:
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                f"image_gen.provider='{configured}' is set but no plugin registered "
+                "that name. Run `hermes plugins list` to see available image gen backends."
+            ),
+            "error_type": "provider_not_registered",
+        })
+
+    if not getattr(provider, "supports_edit", lambda: False)():
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Image provider '{getattr(provider, 'name', configured)}' does not support image_edit",
+            "error_type": "unsupported",
+        })
+
+    try:
+        result = provider.edit(prompt=prompt, image=image, aspect_ratio=aspect_ratio)
+    except Exception as exc:
+        logger.warning("Image edit provider '%s' raised: %s", getattr(provider, "name", "?"), exc)
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Provider '{getattr(provider, 'name', '?')}' error: {exc}",
+            "error_type": "provider_exception",
+        })
+
+    if not isinstance(result, dict):
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": "Provider returned a non-dict result",
+            "error_type": "provider_contract",
+        })
+    return json.dumps(result)
+
+
+def check_image_edit_requirements() -> bool:
+    provider, configured = _get_active_edit_provider()
+    if not configured or provider is None:
+        return False
+    try:
+        return bool(provider.is_available() and provider.supports_edit())
+    except Exception:
+        return False
+
+
+def _handle_image_edit(args: Dict[str, Any], **kw):
+    prompt = (args.get("prompt") or "").strip()
+    if not prompt:
+        return tool_error("prompt is required for image editing")
+
+    image = args.get("image") or args.get("image_path") or args.get("image_url")
+    if not image or not isinstance(image, str):
+        return tool_error("image is required for image editing and must be a path or URL")
+
+    aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    return _dispatch_to_plugin_provider(prompt, image, aspect_ratio)
+
+
+registry.register(
+    name="image_edit",
+    toolset="image_gen",
+    schema=IMAGE_EDIT_SCHEMA,
+    handler=_handle_image_edit,
+    check_fn=check_image_edit_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🖼️",
+)

--- a/tools/image_edit_tool.py
+++ b/tools/image_edit_tool.py
@@ -22,10 +22,13 @@ IMAGE_EDIT_SCHEMA = {
     "name": "image_edit",
     "description": (
         "Edit an existing image using a text instruction and a reference image. "
-        "The active image backend is user-configured. Currently this is intended "
-        "for backends that support image-to-image editing, such as OpenAI Codex "
-        "auth with GPT Image 2. Returns either a URL or an absolute file path in "
-        "the `image` field; display it with markdown ![description](url-or-path)."
+        "Mandatory: when the user provides, uploads, links, or names any "
+        "reference/source/product/person image, use this image-to-image tool "
+        "rather than image_generate/text-to-image. The active image backend is "
+        "user-configured. Currently this is intended for backends that support "
+        "image-to-image editing, such as OpenAI Codex auth with GPT Image 2. "
+        "Returns either a URL or an absolute file path in the `image` field; "
+        "display it with markdown ![description](url-or-path)."
     ),
     "parameters": {
         "type": "object",
@@ -41,8 +44,36 @@ IMAGE_EDIT_SCHEMA = {
             "aspect_ratio": {
                 "type": "string",
                 "enum": list(VALID_ASPECT_RATIOS),
-                "description": "Desired output aspect ratio. 'landscape' is wide, 'portrait' is tall, 'square' is 1:1.",
+                "description": (
+                    "Desired output aspect ratio. Use '9:16' for exact vertical "
+                    "TikTok/Reels-style images; legacy 'portrait' is 2:3 tall."
+                ),
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "size": {
+                "type": "string",
+                "pattern": "^[0-9]+x[0-9]+$",
+                "description": (
+                    "Optional exact output size for OpenAI/OpenAI-Codex GPT Image 2, "
+                    "formatted WIDTHxHEIGHT (e.g. 1024x1824 for 9:16). Overrides "
+                    "aspect_ratio when supported. Dimensions must be multiples of 16, "
+                    "max side < 3840, aspect ratio <= 3:1, and total pixels between "
+                    "655,360 and 8,294,400."
+                ),
+            },
+            "quality_tier": {
+                "type": "string",
+                "enum": ["auto", "low", "medium", "high"],
+                "description": (
+                    "Optional quality tier override for providers that support GPT Image 2 "
+                    "tiering. 'auto' preserves provider defaults/router heuristics."
+                ),
+                "default": "auto",
+            },
+            "model": {
+                "type": "string",
+                "enum": ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"],
+                "description": "Optional explicit model override. Takes precedence over quality_tier when both are provided.",
             },
         },
         "required": ["prompt", "image"],
@@ -82,7 +113,15 @@ def _get_active_edit_provider():
         return None, configured
 
 
-def _dispatch_to_plugin_provider(prompt: str, image: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    image: str,
+    aspect_ratio: str,
+    *,
+    size: Any = None,
+    quality_tier: Any = None,
+    model: Any = None,
+):
     provider, configured = _get_active_edit_provider()
     if configured is None or configured == "fal":
         return json.dumps({
@@ -115,7 +154,21 @@ def _dispatch_to_plugin_provider(prompt: str, image: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.edit(prompt=prompt, image=image, aspect_ratio=aspect_ratio)
+        provider_kwargs = {
+            key: value
+            for key, value in {
+                "size": size,
+                "quality_tier": quality_tier,
+                "model": model,
+            }.items()
+            if value is not None
+        }
+        result = provider.edit(
+            prompt=prompt,
+            image=image,
+            aspect_ratio=aspect_ratio,
+            **provider_kwargs,
+        )
     except Exception as exc:
         logger.warning("Image edit provider '%s' raised: %s", getattr(provider, "name", "?"), exc)
         return json.dumps({
@@ -155,7 +208,14 @@ def _handle_image_edit(args: Dict[str, Any], **kw):
         return tool_error("image is required for image editing and must be a path or URL")
 
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
-    return _dispatch_to_plugin_provider(prompt, image, aspect_ratio)
+    return _dispatch_to_plugin_provider(
+        prompt,
+        image,
+        aspect_ratio,
+        size=args.get("size"),
+        quality_tier=args.get("quality_tier"),
+        model=args.get("model"),
+    )
 
 
 registry.register(

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -293,7 +293,31 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
 DEFAULT_MODEL = "fal-ai/flux-2/klein/9b"
 
 DEFAULT_ASPECT_RATIO = "landscape"
-VALID_ASPECT_RATIOS = ("landscape", "square", "portrait")
+VALID_ASPECT_RATIOS = (
+    "landscape",
+    "square",
+    "portrait",
+    "16:9",
+    "5:4",
+    "4:3",
+    "3:2",
+    "1:1",
+    "2:3",
+    "3:4",
+    "4:5",
+    "9:16",
+)
+_ASPECT_RATIO_FALLBACKS = {
+    "16:9": "landscape",
+    "5:4": "landscape",
+    "4:3": "landscape",
+    "3:2": "landscape",
+    "1:1": "square",
+    "2:3": "portrait",
+    "3:4": "portrait",
+    "4:5": "portrait",
+    "9:16": "portrait",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -539,7 +563,7 @@ def _build_fal_payload(
 
     aspect = (aspect_ratio or DEFAULT_ASPECT_RATIO).lower().strip()
     if aspect not in sizes:
-        aspect = DEFAULT_ASPECT_RATIO
+        aspect = _ASPECT_RATIO_FALLBACKS.get(aspect, DEFAULT_ASPECT_RATIO)
 
     payload: Dict[str, Any] = dict(meta.get("defaults", {}))
     payload["prompt"] = (prompt or "").strip()
@@ -623,6 +647,7 @@ def image_generate_tool(
     num_images: Optional[int] = None,
     output_format: Optional[str] = None,
     seed: Optional[int] = None,
+    size: Optional[str] = None,
 ) -> str:
     """Generate an image from a text prompt using the configured FAL model.
 
@@ -646,6 +671,7 @@ def image_generate_tool(
             "num_images": num_images,
             "output_format": output_format,
             "seed": seed,
+            "size": size,
         },
         "error": None,
         "success": False,
@@ -683,6 +709,10 @@ def image_generate_tool(
         if output_format is not None:
             overrides["output_format"] = output_format
 
+        # Explicit pixel sizes are intentionally handled only by plugin-backed
+        # providers (OpenAI / Codex OAuth). The in-tree FAL path keeps its
+        # existing preset behavior to avoid sending unsupported literals to
+        # non-OpenAI models.
         arguments = _build_fal_payload(
             model_id, prompt, aspect_lc, seed=seed, overrides=overrides,
         )
@@ -854,7 +884,9 @@ from tools.registry import registry, tool_error
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
     "description": (
-        "Generate high-quality images from text prompts. The underlying "
+        "Generate high-quality images from text prompts only when no reference image is provided. "
+        "Mandatory: if the user provides, uploads, links, or names any reference/source/product/person image, "
+        "do NOT use this tool; use image_edit with that file passed as the `image` argument instead. The underlying "
         "backend (FAL, OpenAI, etc.) and model are user-configured and not "
         "selectable by the agent. Returns either a URL or an absolute file "
         "path in the `image` field; display it with markdown "
@@ -870,8 +902,22 @@ IMAGE_GENERATE_SCHEMA = {
             "aspect_ratio": {
                 "type": "string",
                 "enum": list(VALID_ASPECT_RATIOS),
-                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "description": (
+                    "Preferred aspect ratio. Legacy presets landscape/square/portrait "
+                    "keep their historical sizes; explicit ratios like 16:9, 4:3, 3:2, "
+                    "1:1, 2:3, 3:4, 4:5, 5:4, and 9:16 are also accepted."
+                ),
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "size": {
+                "type": "string",
+                "pattern": "^[0-9]+x[0-9]+$",
+                "description": (
+                    "Optional explicit output size in pixels, e.g. 1024x1824 for 9:16. "
+                    "When supported by the active provider, this overrides aspect_ratio. "
+                    "For gpt-image-2 sizes, both sides must be multiples of 16 and stay "
+                    "within the model's documented limits."
+                ),
             },
         },
         "required": ["prompt"],
@@ -900,7 +946,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, size: Optional[str] = None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -950,7 +996,7 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio, size=size)
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
@@ -977,16 +1023,18 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    size = args.get("size")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, size=size)
     if dispatched is not None:
         return dispatched
 
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=aspect_ratio,
+        size=size,
     )
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -36,7 +36,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "image_generate", "image_edit",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -98,7 +98,7 @@ TOOLSETS = {
     
     "image_gen": {
         "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "tools": ["image_generate", "image_edit"],
         "includes": []
     },
     
@@ -290,8 +290,8 @@ TOOLSETS = {
     
     "safe": {
         "description": "Safe toolkit without terminal access",
-        "tools": [],
-        "includes": ["web", "vision", "image_gen"]
+        "tools": ["image_generate"],
+        "includes": ["web", "vision"]
     },
     
     # ==========================================================================
@@ -330,7 +330,7 @@ TOOLSETS = {
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation
-            "vision_analyze", "image_generate",
+            "vision_analyze", "image_generate", "image_edit",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -10,18 +10,10 @@ Sometimes you already know exactly what message you want to send. You don't need
 
 Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 
-```
-   ┌──────────────────┐          ┌──────────────────┐
-   │ scheduler tick   │  every   │ run script       │
-   │ (every N minutes)│ ──────▶ │ (bash or python) │
-   └──────────────────┘          └──────────────────┘
-                                          │
-                                          │ stdout
-                                          ▼
-                                 ┌──────────────────┐
-                                 │ delivery router  │
-                                 │ (telegram/disc…) │
-                                 └──────────────────┘
+```mermaid
+flowchart TD
+    A[Scheduler tick<br/>every N minutes] --> B[Run script<br/>bash or python]
+    B -->|stdout| C[Delivery router<br/>Telegram / Discord / Slack / Signal]
 ```
 
 - **No LLM call.** Zero tokens, zero agent loop, zero model spend.

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -107,7 +107,8 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `image_generate` | Generate high-quality images from text prompts using FAL.ai. The underlying model is user-configured (default: FLUX 2 Klein 9B, sub-1s generation) and is not selectable by the agent. Returns a single image URL. Display it using… | FAL_KEY |
+| `image_generate` | Generate high-quality images from text prompts using the configured image backend. The underlying provider and model are user-configured and are not selected by the agent. Returns either a URL or an absolute file path in the `image` field. | Provider-specific |
+| `image_edit` | Edit an existing image using a text instruction and a reference image path, HTTP(S) URL, or data URL. Requires an image backend that supports image-to-image editing, such as the OpenAI Codex GPT Image 2 backend. Returns either a URL or an absolute file path in the `image` field. | Provider-specific |
 
 ## `memory` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -64,12 +64,12 @@ Or in-session:
 | `feishu_drive` | `feishu_drive_add_comment`, `feishu_drive_list_comments`, `feishu_drive_list_comment_replies`, `feishu_drive_reply_comment` | Feishu/Lark drive comment operations. Scoped to the comment agent; not exposed on `hermes-cli` or other messaging toolsets. |
 | `file` | `patch`, `read_file`, `search_files`, `write_file` | File reading, writing, searching, and editing. |
 | `homeassistant` | `ha_call_service`, `ha_get_state`, `ha_list_entities`, `ha_list_services` | Smart home control via Home Assistant. Only available when `HASS_TOKEN` is set. |
-| `image_gen` | `image_generate` | Text-to-image generation via FAL.ai (with opt-in OpenAI / xAI backends). |
+| `image_gen` | `image_edit`, `image_generate` | Image generation and prompt-guided reference-image editing via the configured image backend. |
 | `memory` | `memory` | Persistent cross-session memory management. |
 | `messaging` | `send_message` | Send messages to other platforms (Telegram, Discord, etc.) from within a session. |
 | `moa` | `mixture_of_agents` | Multi-model consensus via Mixture of Agents. |
 | `rl` | `rl_check_status`, `rl_edit_config`, `rl_get_current_config`, `rl_get_results`, `rl_list_environments`, `rl_list_runs`, `rl_select_environment`, `rl_start_training`, `rl_stop_training`, `rl_test_inference` | RL training environment management (Atropos). |
-| `safe` | `image_generate`, `vision_analyze`, `web_extract`, `web_search` (via `includes`) | Read-only research + media generation. No file writes, no terminal, no code execution. |
+| `safe` | `image_generate`, `vision_analyze`, `web_extract`, `web_search` (via `includes`) | Read-only research + media generation. Excludes `image_edit` because image editing can read and upload local reference images. No file writes, no terminal, no code execution. |
 | `search` | `web_search` | Web search only (without extract). |
 | `session_search` | `session_search` | Search past conversation sessions. |
 | `skills` | `skill_manage`, `skill_view`, `skills_list` | Skill CRUD and browsing. |
@@ -87,8 +87,8 @@ Platform toolsets define the complete tool configuration for a deployment target
 
 | Toolset | Differences from `hermes-cli` |
 |---------|-------------------------------|
-| `hermes-cli` | Full toolset — 38 tools. The default for interactive CLI sessions. |
-| `hermes-acp` | Drops `clarify`, `cronjob`, `image_generate`, `send_message`, `text_to_speech`, and all four Home Assistant tools. Focused on coding tasks in IDE context. |
+| `hermes-cli` | Full toolset — 46 tools. The default for interactive CLI sessions. |
+| `hermes-acp` | Drops `clarify`, `cronjob`, `image_edit`, `image_generate`, `send_message`, `text_to_speech`, and all four Home Assistant tools. Focused on coding tasks in IDE context. |
 | `hermes-api-server` | Drops `clarify`, `send_message`, and `text_to_speech`. Keeps everything else — suitable for programmatic access where user interaction isn't possible. |
 | `hermes-cron` | Same as `hermes-cli`. |
 | `hermes-telegram` | Same as `hermes-cli`. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -414,24 +414,26 @@ Visually the target is the familiar Linear / Fusion layout: dark theme, column h
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
 ```
-┌────────────────────────┐      WebSocket (tails task_events)
-│   React SPA (plugin)   │ ◀──────────────────────────────────┐
-│   HTML5 drag-and-drop  │                                    │
-└──────────┬─────────────┘                                    │
-           │ REST over fetchJSON                              │
-           ▼                                                  │
-┌────────────────────────┐     writes call kanban_db.*        │
-│  FastAPI router        │     directly — same code path      │
-│  plugins/kanban/       │     the CLI /kanban verbs use      │
-│  dashboard/plugin_api.py                                    │
-└──────────┬─────────────┘                                    │
-           │                                                  │
-           ▼                                                  │
-┌────────────────────────┐                                    │
-│  ~/.hermes/kanban.db   │ ───── append task_events ──────────┘
+┌────────────────────────┐
+│   React SPA (plugin)   │
+│   HTML5 drag-and-drop  │
+└──────────┬─────────────┘
+           │ REST over fetchJSON
+           ▼
+┌────────────────────────┐
+│  FastAPI router        │
+│  plugins/kanban/       │
+│  dashboard/plugin_api  │
+└──────────┬─────────────┘
+           │ writes call kanban_db.*
+           ▼
+┌────────────────────────┐
+│  ~/.hermes/kanban.db   │
 │  (WAL, shared)         │
 └────────────────────────┘
 ```
+
+The SPA also opens a WebSocket that tails `task_events`; router writes go through the same `kanban_db` code path used by the CLI `/kanban` verbs.
 
 ### REST surface
 


### PR DESCRIPTION
## Summary

Adds a first-class `image_edit` tool for prompt-guided image-to-image editing through configured image-generation backends, with OpenAI Codex / GPT Image 2 as the initial backend implementation.

## What changed

- Add `ImageGenProvider.supports_edit()` and default `edit()` fallback for backwards-compatible provider capability detection.
- Add `tools/image_edit_tool.py` and expose it through the `image_gen`, CLI, messaging, and API-server toolsets.
- Implement OpenAI Codex / GPT Image 2 edit calls using the Responses `image_generation` tool with `action: edit` and an `input_image` content part.
- Accept local image paths, HTTP(S) URLs, and image data URLs as reference images.
- Guard local/data image inputs:
  - local files must be PNG/JPEG/WEBP/GIF by magic bytes / MIME;
  - local files and data URLs have a size cap;
  - `safe` toolset intentionally excludes `image_edit` because it can read/upload local reference images.
- Harden image size / aspect-ratio / model-quality override dispatch for both generation and edit paths.
- Add tests for tool dispatch, Codex edit payloads, validation failures, toolset exposure, and docs references.

## Testing

- `python -m py_compile tools/image_edit_tool.py agent/image_gen_provider.py plugins/image_gen/openai-codex/__init__.py acp_adapter/tools.py toolsets.py tests/plugins/image_gen/test_openai_codex_provider.py tests/gateway/test_api_server_toolset.py`
- `python -m pytest tests/plugins/image_gen tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_image_edit_tool.py tests/tools/test_registry.py tests/gateway/test_api_server_toolset.py -q -o 'addopts='`
  - 196 passed
- `cd website && npm run lint:diagrams`
  - 290 files checked, 22 boxes found, 0 errors
- `ruff check agent/image_gen_provider.py tools/image_edit_tool.py plugins/image_gen/openai/__init__.py plugins/image_gen/openai-codex/__init__.py tests/plugins/image_gen/test_openai_provider.py`

## CI compatibility notes

- Kept the branch-only docs diagram cleanup so `docs-site-checks` passes on current `main`.
- This docs change only removes/rewrites ASCII box diagrams that the repository's `ascii-guard` job rejects; it is not part of the image-edit feature and can be split or dropped if maintainers prefer a separate docs PR.

## Notes

This PR keeps scope narrow: it adds the edit capability abstraction, one tool, and one backend implementation. Other image providers keep working through the default unsupported-edit fallback until they opt in.