### PR TITLE
fix: use max_completion_tokens for GitHub Copilot

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2757,10 +2757,11 @@ def auxiliary_max_tokens_param(value: int) -> dict:
     """
     custom_base = _current_custom_base_url()
     or_key = os.getenv("OPENROUTER_API_KEY")
-    # Only use max_completion_tokens for direct OpenAI custom endpoints
+    # Use max_completion_tokens for direct OpenAI-compatible providers that reject
+    # max_tokens on newer GPT-4o/o-series/GPT-5-style models.
     if (not or_key
             and _read_nous_auth() is None
-            and base_url_hostname(custom_base) == "api.openai.com"):
+            and base_url_hostname(custom_base) in {"api.openai.com", "api.githubcopilot.com"}):
         return {"max_completion_tokens": value}
     return {"max_tokens": value}
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2808,6 +2808,16 @@ class AIAgent:
             url = getattr(self, "_base_url_lower", "") or ""
         return "openai.azure.com" in url
 
+    def _is_github_copilot_url(self, base_url: str = None) -> bool:
+        """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""
+        if base_url is not None:
+            hostname = base_url_hostname(base_url)
+        else:
+            hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
+                getattr(self, "_base_url_lower", "")
+            )
+        return hostname == "api.githubcopilot.com"
+
     def _resolved_api_call_timeout(self) -> float:
         """Resolve the effective per-call request timeout in seconds.
 
@@ -3003,7 +3013,7 @@ class AIAgent:
         OpenAI-compatible endpoint. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
         """
-        if self._is_direct_openai_url() or self._is_azure_openai_url():
+        if self._is_direct_openai_url() or self._is_azure_openai_url() or self._is_github_copilot_url():
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -56,6 +56,18 @@ def codex_auth_dir(tmp_path, monkeypatch):
     return codex_dir
 
 
+class TestAuxiliaryMaxTokensParam:
+    def test_uses_max_completion_tokens_for_github_copilot_custom_base(self):
+        with patch("agent.auxiliary_client._resolve_custom_runtime", return_value=("https://api.githubcopilot.com", "key", None)), \
+             patch("agent.auxiliary_client._read_nous_auth", return_value=None):
+            assert auxiliary_max_tokens_param(2048) == {"max_completion_tokens": 2048}
+
+    def test_uses_max_completion_tokens_for_github_copilot_custom_base_path(self):
+        with patch("agent.auxiliary_client._resolve_custom_runtime", return_value=("https://api.githubcopilot.com/chat/completions", "key", None)), \
+             patch("agent.auxiliary_client._read_nous_auth", return_value=None):
+            assert auxiliary_max_tokens_param(2048) == {"max_completion_tokens": 2048}
+
+
 class TestNormalizeAuxProvider:
     def test_maps_github_copilot_aliases(self):
         assert _normalize_aux_provider("github") == "copilot"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3553,6 +3553,18 @@ class TestMaxTokensParam:
         result = agent._max_tokens_param(4096)
         assert result == {"max_completion_tokens": 4096}
 
+    def test_returns_max_completion_tokens_for_github_copilot(self, agent):
+        """GitHub Copilot's OpenAI-compatible API rejects max_tokens for newer models."""
+        agent.base_url = "https://api.githubcopilot.com"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_completion_tokens": 4096}
+
+    def test_returns_max_completion_tokens_for_github_copilot_path(self, agent):
+        """Detect Copilot by hostname even when the configured URL includes a path."""
+        agent.base_url = "https://api.githubcopilot.com/chat/completions"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_completion_tokens": 4096}
+
 
 class TestAzureOpenAIRouting:
     """Verify Azure OpenAI endpoints stay on chat_completions for gpt-5.x."""


### PR DESCRIPTION
## Summary

- detect GitHub Copilot's OpenAI-compatible API host (`api.githubcopilot.com`)
- send `max_completion_tokens` instead of `max_tokens` for Copilot-hosted newer GPT-style models
- extend the auxiliary client token-parameter handling for Copilot custom base URLs
- add targeted regression coverage for the main agent and auxiliary client paths

## Why

We run Hermes with GitHub Copilot Enterprise as an important provider/fallback lane. Copilot Enterprise exposes newer models through `https://api.githubcopilot.com`, but those models can reject `max_tokens` with:

```text
HTTP 400: Unsupported parameter: 'max_tokens' is not supported with this model
```

In practice this meant Hermes could fail the Copilot request or silently fall back to another provider instead of using the configured Copilot Enterprise token/provider.

Direct OpenAI and Azure OpenAI already use `max_completion_tokens` for these newer model families. This PR applies the same parameter selection to GitHub Copilot's OpenAI-compatible endpoint, based on the endpoint hostname.

## Verification

- `python3 -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryMaxTokensParam -o 'addopts=' -q`
  - `2 passed, 6 warnings in 0.74s`
- direct local assertions confirmed:
  - `https://api.githubcopilot.com` -> `{"max_completion_tokens": 4096}`
  - `https://api.githubcopilot.com/chat/completions` -> `{"max_completion_tokens": 4096}`
  - non-Copilot OpenRouter URL still uses `{"max_tokens": 4096}`
  - auxiliary client returns `max_completion_tokens` for Copilot custom base URLs
- live local verification against GitHub Copilot Enterprise `gpt-5.4` succeeded:
  - provider: `copilot`
  - base URL: `https://api.githubcopilot.com`
  - model: `gpt-5.4`
  - one successful API call
  - no fallback
  - response matched the requested sentinel text

Note: on this local machine, `tests/run_agent/test_run_agent.py::TestMaxTokensParam` currently hangs under pytest before producing output. The same behavior was observed before this PR work. The new `AIAgent._max_tokens_param()` behavior was therefore also verified with direct assertions.