### PR TITLE
feat: add generic hermes_t runtime skeleton

### DIFF
--- a/docs/plans/2026-05-03-generalized-t-runtime-split-order.md
+++ b/docs/plans/2026-05-03-generalized-t-runtime-split-order.md
@@ -1,0 +1,210 @@
+# Generalized T-Trading Runtime — Optimal Subsequent Split Order
+
+> **For Hermes:** Use subagent-driven-development to implement this plan phase-by-phase.
+
+**Goal:** Evolve `hermes_t` from a 2-file module into a generalized, reusable T-trading runtime that can eventually be migrated to any symbol, with independent PRs at each phase.
+
+**Current repo baseline (2026-05-03):**
+- `hermes_t/` exists in repo: `__init__.py` + `post_market_review.py`
+- `hermes_olin/` does NOT exist in repo (it's OpenClaw-side only)
+- `pyproject.toml` already includes `hermes_t` / `hermes_t.*` in package discovery
+- PR #19148 is OPEN (standalone post-market review module)
+- 7 tests in `tests/test_post_market_review.py`, all passing
+
+---
+
+## Phase 1: Add TradingStateStore + shared CLI builder (next PR)
+
+**Objective:** Grow `hermes_t` into a usable facade with a real store and shared CLI helper, without disturbing the post-market review module.
+
+### Task P1a: Create `hermes_t/store.py` — TradingStateStore
+
+Create: `hermes_t/store.py`
+
+A directory-based state store that reads/writes:
+- `execution_state.json`
+- `pending_signal.json`
+- `position.json`
+- `dispatch_ledger.jsonl`
+- `signal_send_history.jsonl`
+- `push_state.json`
+- `active_signal.json`
+
+**Key design:** Profile-scoped paths (`base_dir / profile_id`). Not Olin-specific.
+
+Steps:
+1. Write failing test: `test_store_creates_base_dir_on_first_write`
+2. Write failing test: `test_store_load_or_default_uses_empty_state`
+3. Write minimal `TradingStateStore` implementation
+4. Write failing test: `test_store_profile_scoped_path_isolation`
+5. Write failing test: `test_store_save_and_load_pending_signal`
+6. Write failing test: `test_store_append_jsonl`
+7. Implement GREEN for all
+8. Run: `uv run python3 -m pytest tests/test_trading_runtime.py -k 'store' -q`
+9. Commit: `git commit -m "feat: add TradingStateStore with profile-scoped paths"`
+
+### Task P1b: Add shared CLI builder — `hermes_t/cli_shared.py`
+
+Create: `hermes_t/cli_shared.py`
+
+Extract:
+- `build_runtime_parser()` — shared argparse builder
+- `build_runtime_profile_from_args(args)` — validated single-profile builder
+- `build_runtime_store(base_dir, profile, prefer_legacy_olin_store=False)`
+
+Steps:
+1. Write failing test: `test_shared_parser_has_default_base_dir_at_home`
+2. Write failing test: `test_shared_parser_env_var_fallback`
+3. Write failing test: `test_build_runtime_profile_from_args_rejects_blank_required_strings`
+4. Write failing test: `test_build_runtime_profile_from_args_rejects_non_positive_ints`
+5. Write failing test: `test_build_runtime_store_creates_TradingStateStore_by_default`
+6. Implement GREEN for all
+7. Commit
+
+**Do NOT touch `hermes_olin.__main__` in this phase** — that's legacy compat.
+
+### Task P1c: Update `hermes_t/__main__.py` for single-profile CLI
+
+Modify `hermes_t/__main__.py` to use shared CLI builder and implement `python -m hermes_t --signal sell --score 20` single-profile path.
+
+Steps:
+1. Write failing test: `test_hermes_t_cli_single_profile_routes_through_shared_builder`
+2. Implement: `hermes_t/__main__.py` wired to `cli_shared.build_runtime_parser()`
+3. GREEN + full regression
+4. Commit
+
+**Test regression command:** `uv run python3 -m pytest tests/test_trading_runtime.py tests/test_post_market_review.py -q`
+
+---
+
+## Phase 2: Runtime cycle skeleton (independent PR)
+
+**Objective:** Add the core `run_runtime_cycle()` skeleton to `hermes_t`, generic + profile-aware.
+
+### Task P2a: Create `hermes_t/runtime.py`
+
+Create: `hermes_t/runtime.py`
+
+Minimal generic runtime that:
+- Reads state via `TradingStateStore`
+- Takes `tech_data` as input dict (not quote/realtime)
+- Produces `{pending, suggestion, summary}` output
+
+**Key constraint:** `signal_policy` is pluggable — use `DEFAULT_SIGNAL_POLICY` dataclass from `hermes_t/signal_policy.py`.
+
+### Task P2b: Create `hermes_t/signal_policy.py`
+
+Create: `hermes_t/signal_policy.py`
+
+Extract:
+- `SignalPolicy` dataclass
+- `DEFAULT_SIGNAL_POLICY`
+- `render_signal_text(action, policy)`
+- All thresholds and Chinese text templates
+
+**This is needed so runtime code never hardcodes strings like "第N次买入".**
+
+### Task P2c: Wire `hermes_t/__main__.py` to call `run_runtime_cycle()`
+
+The single-profile CLI should call the runtime cycle and output its result as JSON.
+
+**No quote providers yet** — `--signal` and `--score` CLI args become the `tech_data`.
+
+---
+
+## Phase 3: Quote provider → TechDataAdapter split (independent PR)
+
+**Objective:** Add the full `QuoteProvider` / `TechDataProvider` protocol split so `hermes_t` can consume real quote snapshots without changing runtime code.
+
+### Files:
+- Modify `hermes_t/tech_data.py` (create if doesn't exist)
+- Wire to `hermes_t/__main__.py` as optional `--quote-data-config` / `--quote-snapshot-config`
+
+### Key additions:
+- `JsonQuoteDataProvider` (from file)
+- `QuoteTechDataAdapter` (wraps provider, extracts `tech_data`)
+- `TdxQuoteSnapshotSource` (minimal real TDX TCP, injectable API)
+- `build_tech_data_provider(...)` that assembles the chain
+
+**Test regression:** `uv run python3 -m pytest tests/test_trading_runtime.py -k 'quote' -q`
+
+---
+
+## Phase 4: Multi-profile orchestrator (independent PR)
+
+**Objective:** Add multi-profile execution via JSON config so `hermes_t` can manage multiple symbols in sequence.
+
+### Files:
+- Create `hermes_t/orchestrator.py`
+  - `load_runtime_profiles_from_json(path)` → list of `RuntimeProfile`
+  - `run_profiles_from_config(profiles_config, tech_data_config, ...)` → summary dict
+- Wire to `hermes_t/__main__.py` as `--profiles-config` / `--tech-data-config`
+
+### Key constraint:
+- Sequential execution only (no concurrency in this phase)
+- Symbol-level tech_data fallback: missing → default
+
+---
+
+## Phase 5: Post-landing hardening (PR on any phase above)
+
+**Objective:** Close the safety gaps discovered in earlier phases.
+
+Priority list (from experience):
+1. `load_runtime_profiles_from_json()` numeric field validation (reject bool, reject 0/negative)
+2. Single-profile → multi-profile validation parity
+3. `_validated_positive_int()` + `_missing_required_fields()` helpers
+4. `_runtime_delivery_kwargs(args)` shared assembly helper
+5. Readme synchronization for each phase
+
+---
+
+## Phase 6: Post-market review integration + monitoring (independent PR)
+
+**Objective:** Hook the existing `build_post_market_review()` into the runtime cycle output and add a CLI flag for standalone review.
+
+### Minimal scope:
+- `run_runtime_cycle()` optionally calls `build_post_market_review()` when `post_market=True`
+- `hermes_t/__main__.py` gets `--post-market` flag
+- `python -m hermes_t --post-market --state-dir ...` works standalone
+- Test: cross-module integration (runtime + review)
+
+---
+
+## Phase 7: Hermes agent tool integration
+
+**Objective:** Create a Hermes skill (or cron job) that calls `uv run python3 -m hermes_t --post-market ...` and delivers the result.
+
+### Scope:
+- Create skill: `hermes-t-post-market-report`
+- Cron job setup: `cronjob(action='create', schedule='30 9 * * 1-5', ...)`
+- Deliver to Feishu home channel
+
+---
+
+## Execution principles
+
+- **Each phase = one independent PR** — can be reviewed and merged separately
+- **Each phase has TDD** — RED first, GREEN second, commit per task
+- **Test regression command for each phase:**
+  ```bash
+  uv run python3 -m pytest tests/test_trading_runtime.py tests/test_post_market_review.py -q
+  ```
+- **Optimize for reviewability** — small PRs with clear boundaries
+- **No hermes_olin coupling** — generic `TradingStateStore` throughout
+- **Don't touch OpenClaw** — all work is in `hermes-agent` repo only
+
+---
+
+## Current progress
+
+| Phase | Status | PR |
+|-------|--------|----|
+| Phase 0: Post-market review module | ✅ DONE + reviewed | #19148 (open, 2 commits) |
+| Phase 1: Store + shared CLI | ✅ DONE | (PR already open, atop Phase 0) |
+| Phase 2: Runtime cycle skeleton | ✅ DONE | (committed, atop Phase 1) |
+| Phase 3: Quote provider split | — | — |
+| Phase 4: Multi-profile orchestrator | — | — |
+| Phase 5: Hardening | — | — |
+| Phase 6: Review integration | — | — |
+| Phase 7: Agent tool integration | — | — |

--- a/docs/plans/2026-05-03-generalized-t-runtime-split-order.md
+++ b/docs/plans/2026-05-03-generalized-t-runtime-split-order.md
@@ -140,6 +140,12 @@ The single-profile CLI should call the runtime cycle and output its result as JS
   - `run_profiles_from_config(profiles_config, tech_data_config, ...)` → summary dict
 - Wire to `hermes_t/__main__.py` as `--profiles-config` / `--tech-data-config`
 
+### Landed minimum scope:
+- `python -m hermes_t --profiles-config profiles.json` is now wired
+- Current mode is **sequential only**
+- Multi-profile output is `{"profile_count": N, "results": [...]}`
+- `--quote-data-config` / `--quote-snapshot-config` reuse the same provider assembly path
+
 ### Key constraint:
 - Sequential execution only (no concurrency in this phase)
 - Symbol-level tech_data fallback: missing → default
@@ -203,8 +209,8 @@ Priority list (from experience):
 | Phase 0: Post-market review module | ✅ DONE + reviewed | #19148 (open, 2 commits) |
 | Phase 1: Store + shared CLI | ✅ DONE | (PR already open, atop Phase 0) |
 | Phase 2: Runtime cycle skeleton | ✅ DONE | (committed, atop Phase 1) |
-| Phase 3: Quote provider split | — | — |
-| Phase 4: Multi-profile orchestrator | — | — |
-| Phase 5: Hardening | — | — |
+| Phase 3: Quote provider split | ✅ DONE (minimal provider path) | atop current branch |
+| Phase 4: Multi-profile orchestrator | ✅ DONE (minimal sequential CLI) | atop current branch / PR #19268 |
+| Phase 5: Hardening | 🟡 IN PROGRESS | atop current branch |
 | Phase 6: Review integration | — | — |
 | Phase 7: Agent tool integration | — | — |

--- a/hermes_t/__main__.py
+++ b/hermes_t/__main__.py
@@ -1,0 +1,57 @@
+"""Single-profile CLI entrypoint for hermes_t runtime cycle."""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from typing import Sequence
+
+from hermes_t.cli_shared import (
+    RuntimeProfile,
+    build_runtime_parser,
+    build_runtime_profile_from_args,
+    build_runtime_store,
+)
+from hermes_t.runtime import run_runtime_cycle
+from hermes_t.tech_data import build_tech_data_provider
+
+
+def _resolve_tech_data(args: Namespace, profile: RuntimeProfile) -> dict[str, object]:
+    if args.tech_data_config or args.quote_data_config or args.quote_snapshot_config:
+        provider = build_tech_data_provider(
+            tech_data_config_path=args.tech_data_config,
+            quote_data_config_path=args.quote_data_config,
+            quote_snapshot_config_path=args.quote_snapshot_config,
+            default_tech_data={"signal": "hold", "score": 50},
+        )
+        return provider.get(profile.symbol)
+    return {
+        "signal": str(args.signal),
+        "score": int(args.score),
+    }
+
+
+def _build_payload(args: Namespace, profile: RuntimeProfile) -> dict[str, object]:
+    store = build_runtime_store(args.base_dir, profile, prefer_legacy_olin_store=False)
+    tech_data = _resolve_tech_data(args, profile)
+    return run_runtime_cycle(
+        store=store,
+        tech_data=tech_data,
+        profile_id=profile.profile_id,
+        symbol=profile.symbol,
+        trade_unit=profile.trade_unit,
+        max_trades=profile.max_trades,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_runtime_parser()
+    args = parser.parse_args(argv)
+    payload = _build_payload(args, build_runtime_profile_from_args(args))
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_t/__main__.py
+++ b/hermes_t/__main__.py
@@ -14,7 +14,7 @@ from hermes_t.cli_shared import (
     build_runtime_store,
 )
 from hermes_t.orchestrator import run_profiles_from_config
-from hermes_t.runtime import run_runtime_cycle
+from hermes_t.runtime import dispatch_pending_signal, run_runtime_cycle
 from hermes_t.tech_data import build_tech_data_provider
 
 
@@ -24,7 +24,7 @@ def _resolve_tech_data(args: Namespace, profile: RuntimeProfile) -> dict[str, ob
             tech_data_config_path=args.tech_data_config,
             quote_data_config_path=args.quote_data_config,
             quote_snapshot_config_path=args.quote_snapshot_config,
-            default_tech_data={"signal": "hold", "score": 50},
+            default_tech_data={"signal": str(args.signal), "score": int(args.score)},
         )
         return provider.get(profile.symbol)
     return {
@@ -36,7 +36,7 @@ def _resolve_tech_data(args: Namespace, profile: RuntimeProfile) -> dict[str, ob
 def _build_payload(args: Namespace, profile: RuntimeProfile) -> dict[str, object]:
     store = build_runtime_store(args.base_dir, profile, prefer_legacy_olin_store=False)
     tech_data = _resolve_tech_data(args, profile)
-    return run_runtime_cycle(
+    payload = run_runtime_cycle(
         store=store,
         tech_data=tech_data,
         profile_id=profile.profile_id,
@@ -44,6 +44,12 @@ def _build_payload(args: Namespace, profile: RuntimeProfile) -> dict[str, object
         trade_unit=profile.trade_unit,
         max_trades=profile.max_trades,
     )
+    if args.dispatch:
+        payload["dispatch"] = dispatch_pending_signal(
+            store=store,
+            profile_id=profile.profile_id,
+        )
+    return payload
 
 
 def _build_profiles_payload(args: Namespace) -> dict[str, object]:
@@ -57,6 +63,7 @@ def _build_profiles_payload(args: Namespace) -> dict[str, object]:
         base_dir=args.base_dir,
         profiles_config_path=args.profiles_config,
         tech_data_provider=provider,
+        dispatch=args.dispatch,
     )
 
 

--- a/hermes_t/__main__.py
+++ b/hermes_t/__main__.py
@@ -13,6 +13,7 @@ from hermes_t.cli_shared import (
     build_runtime_profile_from_args,
     build_runtime_store,
 )
+from hermes_t.orchestrator import run_profiles_from_config
 from hermes_t.runtime import run_runtime_cycle
 from hermes_t.tech_data import build_tech_data_provider
 
@@ -45,10 +46,27 @@ def _build_payload(args: Namespace, profile: RuntimeProfile) -> dict[str, object
     )
 
 
+def _build_profiles_payload(args: Namespace) -> dict[str, object]:
+    provider = build_tech_data_provider(
+        tech_data_config_path=args.tech_data_config,
+        quote_data_config_path=args.quote_data_config,
+        quote_snapshot_config_path=args.quote_snapshot_config,
+        default_tech_data={"signal": str(args.signal), "score": int(args.score)},
+    )
+    return run_profiles_from_config(
+        base_dir=args.base_dir,
+        profiles_config_path=args.profiles_config,
+        tech_data_provider=provider,
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_runtime_parser()
     args = parser.parse_args(argv)
-    payload = _build_payload(args, build_runtime_profile_from_args(args))
+    if args.profiles_config is not None:
+        payload = _build_profiles_payload(args)
+    else:
+        payload = _build_payload(args, build_runtime_profile_from_args(args))
     sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
     return 0
 

--- a/hermes_t/cli_shared.py
+++ b/hermes_t/cli_shared.py
@@ -1,0 +1,95 @@
+"""Shared CLI helpers for hermes_t runtime entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_t.store import TradingStateStore, validate_profile_id
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    profile_id: str
+    symbol: str
+    trade_unit: int
+    max_trades: int = 4
+
+
+def _env_or_default(name: str, legacy_name: str, default: str | Path) -> str | Path:
+    return os.getenv(name) or os.getenv(legacy_name) or default
+
+
+def _validated_non_blank_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-blank string")
+    return value.strip()
+
+
+def _validated_positive_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return value
+
+
+def build_runtime_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m hermes_t")
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=Path(_env_or_default("HERMES_T_BASE_DIR", "HERMES_OLIN_BASE_DIR", Path.home() / ".hermes_t_runtime")),
+    )
+    parser.add_argument(
+        "--profile-id",
+        default=_env_or_default("HERMES_T_PROFILE_ID", "HERMES_OLIN_PROFILE_ID", "default"),
+    )
+    parser.add_argument(
+        "--symbol",
+        default=_env_or_default("HERMES_T_SYMBOL", "HERMES_OLIN_SYMBOL", None),
+    )
+    parser.add_argument(
+        "--trade-unit",
+        type=int,
+        default=_env_or_default("HERMES_T_TRADE_UNIT", "HERMES_OLIN_TRADE_UNIT", None),
+    )
+    parser.add_argument(
+        "--max-trades",
+        type=int,
+        default=int(_env_or_default("HERMES_T_MAX_TRADES", "HERMES_OLIN_MAX_TRADES", 4)),
+    )
+    parser.add_argument(
+        "--signal",
+        default=_env_or_default("HERMES_T_SIGNAL", "HERMES_OLIN_SIGNAL", "hold"),
+    )
+    parser.add_argument(
+        "--score",
+        type=int,
+        default=int(_env_or_default("HERMES_T_SCORE", "HERMES_OLIN_SCORE", 50)),
+    )
+    parser.add_argument("--tech-data-config", type=Path, default=None)
+    parser.add_argument("--quote-data-config", type=Path, default=None)
+    parser.add_argument("--quote-snapshot-config", type=Path, default=None)
+    parser.add_argument("--trade-date", default=None)
+    parser.add_argument("--dispatch", action="store_true")
+    return parser
+
+
+def build_runtime_profile_from_args(args: argparse.Namespace) -> RuntimeProfile:
+    return RuntimeProfile(
+        profile_id=validate_profile_id(args.profile_id),
+        symbol=_validated_non_blank_string(args.symbol, "symbol"),
+        trade_unit=_validated_positive_int(args.trade_unit, "trade_unit"),
+        max_trades=_validated_positive_int(args.max_trades, "max_trades"),
+    )
+
+
+def build_runtime_store(
+    base_dir: str | Path | None,
+    profile: RuntimeProfile,
+    *,
+    prefer_legacy_olin_store: bool,
+) -> TradingStateStore:
+    del prefer_legacy_olin_store
+    return TradingStateStore(base_dir=base_dir, profile_id=profile.profile_id)

--- a/hermes_t/cli_shared.py
+++ b/hermes_t/cli_shared.py
@@ -71,6 +71,7 @@ def build_runtime_parser() -> argparse.ArgumentParser:
     parser.add_argument("--tech-data-config", type=Path, default=None)
     parser.add_argument("--quote-data-config", type=Path, default=None)
     parser.add_argument("--quote-snapshot-config", type=Path, default=None)
+    parser.add_argument("--profiles-config", type=Path, default=None)
     parser.add_argument("--trade-date", default=None)
     parser.add_argument("--dispatch", action="store_true")
     return parser

--- a/hermes_t/orchestrator.py
+++ b/hermes_t/orchestrator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_t.cli_shared import RuntimeProfile
-from hermes_t.runtime import run_runtime_cycle
+from hermes_t.runtime import dispatch_pending_signal, run_runtime_cycle
 from hermes_t.store import TradingStateStore, validate_profile_id
 from hermes_t.tech_data import TechDataProvider
 
@@ -57,17 +57,24 @@ def run_profiles(
     base_dir: str | Path | None,
     profiles: list[RuntimeProfile],
     tech_data_provider: TechDataProvider,
+    dispatch: bool = False,
 ) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     for profile in profiles:
+        store = TradingStateStore(base_dir=base_dir, profile_id=profile.profile_id)
         payload = run_runtime_cycle(
-            store=TradingStateStore(base_dir=base_dir, profile_id=profile.profile_id),
+            store=store,
             tech_data=tech_data_provider.get(profile.symbol),
             profile_id=profile.profile_id,
             symbol=profile.symbol,
             trade_unit=profile.trade_unit,
             max_trades=profile.max_trades,
         )
+        if dispatch:
+            payload["dispatch"] = dispatch_pending_signal(
+                store=store,
+                profile_id=profile.profile_id,
+            )
         results.append(
             {
                 "profile_id": profile.profile_id,
@@ -86,6 +93,7 @@ def run_profiles_from_config(
     base_dir: str | Path | None,
     profiles_config_path: str | Path,
     tech_data_provider: TechDataProvider,
+    dispatch: bool = False,
 ) -> dict[str, Any]:
     payload = _load_profiles_payload(profiles_config_path)
     raw_profiles = payload.get("profiles")
@@ -97,4 +105,5 @@ def run_profiles_from_config(
         base_dir=base_dir,
         profiles=load_runtime_profiles_from_json(profiles_config_path),
         tech_data_provider=tech_data_provider,
+        dispatch=dispatch,
     )

--- a/hermes_t/orchestrator.py
+++ b/hermes_t/orchestrator.py
@@ -1,0 +1,100 @@
+"""Sequential multi-profile orchestration for hermes_t runtime."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hermes_t.cli_shared import RuntimeProfile
+from hermes_t.runtime import run_runtime_cycle
+from hermes_t.store import TradingStateStore, validate_profile_id
+from hermes_t.tech_data import TechDataProvider
+
+
+def _validated_positive_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return value
+
+
+def _validated_non_blank_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-blank string")
+    return value.strip()
+
+
+def _load_profiles_payload(path: str | Path) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("profiles config must be a JSON object")
+    return payload
+
+
+def load_runtime_profiles_from_json(path: str | Path) -> list[RuntimeProfile]:
+    payload = _load_profiles_payload(path)
+    raw_profiles = payload.get("profiles")
+    if not isinstance(raw_profiles, list) or not raw_profiles:
+        raise ValueError("profiles config must contain a non-empty profiles list")
+
+    profiles: list[RuntimeProfile] = []
+    for idx, raw_profile in enumerate(raw_profiles):
+        if not isinstance(raw_profile, dict):
+            raise ValueError(f"profiles[{idx}] must be an object")
+        profiles.append(
+            RuntimeProfile(
+                profile_id=validate_profile_id(_validated_non_blank_string(raw_profile.get("profile_id"), "profile_id")),
+                symbol=_validated_non_blank_string(raw_profile.get("symbol"), "symbol"),
+                trade_unit=_validated_positive_int(raw_profile.get("trade_unit"), "trade_unit"),
+                max_trades=_validated_positive_int(raw_profile.get("max_trades", 4), "max_trades"),
+            )
+        )
+    return profiles
+
+
+def run_profiles(
+    *,
+    base_dir: str | Path | None,
+    profiles: list[RuntimeProfile],
+    tech_data_provider: TechDataProvider,
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for profile in profiles:
+        payload = run_runtime_cycle(
+            store=TradingStateStore(base_dir=base_dir, profile_id=profile.profile_id),
+            tech_data=tech_data_provider.get(profile.symbol),
+            profile_id=profile.profile_id,
+            symbol=profile.symbol,
+            trade_unit=profile.trade_unit,
+            max_trades=profile.max_trades,
+        )
+        results.append(
+            {
+                "profile_id": profile.profile_id,
+                "symbol": profile.symbol,
+                "payload": payload,
+            }
+        )
+    return {
+        "profile_count": len(results),
+        "results": results,
+    }
+
+
+def run_profiles_from_config(
+    *,
+    base_dir: str | Path | None,
+    profiles_config_path: str | Path,
+    tech_data_provider: TechDataProvider,
+) -> dict[str, Any]:
+    payload = _load_profiles_payload(profiles_config_path)
+    raw_profiles = payload.get("profiles")
+    if not isinstance(raw_profiles, list):
+        raise ValueError("profiles config must contain a profiles list")
+    if not raw_profiles:
+        return {"profile_count": 0, "results": []}
+    return run_profiles(
+        base_dir=base_dir,
+        profiles=load_runtime_profiles_from_json(profiles_config_path),
+        tech_data_provider=tech_data_provider,
+    )

--- a/hermes_t/runtime.py
+++ b/hermes_t/runtime.py
@@ -6,6 +6,16 @@ from hermes_t.signal_policy import DEFAULT_SIGNAL_POLICY, SignalPolicy, render_s
 from hermes_t.store import TradingStateStore
 
 
+def _coerce_total_shares(value: object) -> int:
+    """Best-effort coercion for persisted total_shares values."""
+    if value in (None, ""):
+        return 0
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
 def run_runtime_cycle(
     *,
     store: TradingStateStore,
@@ -58,41 +68,54 @@ def run_runtime_cycle(
     # Evaluate the action
     pending: dict = {}
     suggestion: dict = {"action": action}
+    existing_pending = store.load_pending_signal()
 
-    if action == "buy":
+    if action == "buy" and buy_count + 1 > max_trades:
+        # Blocked by max_trades; clear any stale pending buy so dispatcher does not retry it.
+        store.clear_pending_signal()
+        suggestion = {"action": "hold", "reason": f"max_trades ({max_trades}) reached"}
+        hold_count += 1
+    elif action != "hold" and existing_pending.get("status") == "pending":
+        pending = existing_pending
+        suggestion = {"action": "hold", "reason": "pending signal unresolved"}
+        hold_count += 1
+    elif action == "buy":
         seq = buy_count + 1
-        if seq > max_trades:
-            # Blocked by max_trades
-            store.clear_pending_signal()
-            suggestion = {"action": "hold", "reason": f"max_trades ({max_trades}) reached"}
-            hold_count += 1
-        else:
-            pending = {
-                "status": "pending",
-                "action": "buy",
-                "seq": seq,
-                "unit": trade_unit,
-                "symbol": symbol,
-                "text": render_signal_text("buy", seq, policy),
-            }
-            suggestion["seq"] = seq
-            suggestion["unit"] = trade_unit
-            suggestion["text"] = pending["text"]
-            buy_count = seq
-    elif action == "sell":
-        seq = sell_count + 1
         pending = {
             "status": "pending",
-            "action": "sell",
+            "action": "buy",
             "seq": seq,
             "unit": trade_unit,
             "symbol": symbol,
-            "text": render_signal_text("sell", seq, policy),
+            "text": render_signal_text("buy", seq, policy),
         }
         suggestion["seq"] = seq
         suggestion["unit"] = trade_unit
         suggestion["text"] = pending["text"]
-        sell_count = seq
+        buy_count = seq
+    elif action == "sell":
+        position = store.load_position() or {}
+        position_symbol = str(position.get("symbol", "")).strip()
+        symbol_matches = position_symbol == str(symbol).strip()
+        total_shares = _coerce_total_shares(position.get("total_shares", 0))
+        if not symbol_matches or total_shares <= 0:
+            suggestion = {"action": "hold", "reason": "no sellable position"}
+            pending = existing_pending if existing_pending.get("status") == "pending" else {}
+            hold_count += 1
+        else:
+            seq = sell_count + 1
+            pending = {
+                "status": "pending",
+                "action": "sell",
+                "seq": seq,
+                "unit": trade_unit,
+                "symbol": symbol,
+                "text": render_signal_text("sell", seq, policy),
+            }
+            suggestion["seq"] = seq
+            suggestion["unit"] = trade_unit
+            suggestion["text"] = pending["text"]
+            sell_count = seq
     else:
         # hold — clear any existing pending signal
         store.clear_pending_signal()

--- a/hermes_t/runtime.py
+++ b/hermes_t/runtime.py
@@ -2,8 +2,165 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+
 from hermes_t.signal_policy import DEFAULT_SIGNAL_POLICY, SignalPolicy, render_signal_text
 from hermes_t.store import TradingStateStore
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def dispatch_pending_signal(
+    *,
+    store: TradingStateStore,
+    profile_id: str,
+    dispatch_target: str = "feishu",
+) -> dict:
+    """Dispatch the current pending signal and persist delivery state."""
+    pending = store.load_pending_signal()
+    if pending.get("status") != "pending":
+        return {
+            "status": "noop",
+            "profile_id": profile_id,
+            "reason": "no pending signal to dispatch",
+            "signal": pending,
+        }
+
+    from tools.send_message_tool import send_message_tool
+
+    message = str(pending.get("text", "")).strip()
+    response_raw = send_message_tool({"action": "send", "target": dispatch_target, "message": message})
+    try:
+        response = json.loads(response_raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        response = {"success": False, "error": f"invalid send_message response: {response_raw!r}"}
+
+    dispatched_at = _utc_now_iso()
+    send_ok = bool(response.get("success")) and not response.get("error")
+    status = "sent" if send_ok else "failed"
+    error = str(response.get("error", "")).strip() or None
+
+    signal_record = {
+        **pending,
+        "status": status,
+        "profile_id": profile_id,
+        "dispatch_target": dispatch_target,
+        "dispatched_at": dispatched_at,
+    }
+    if error:
+        signal_record["error"] = error
+    else:
+        signal_record.pop("error", None)
+
+    store.save_pending_signal(signal_record)
+    store.save_active_signal(signal_record)
+    store.save_push_state(
+        {
+            "profile_id": profile_id,
+            "last_status": status,
+            "last_target": dispatch_target,
+            "last_signal_text": message,
+            "last_dispatched_at": dispatched_at,
+        }
+    )
+
+    ledger_row = {
+        "profile_id": profile_id,
+        "status": status,
+        "target": dispatch_target,
+        "timestamp": dispatched_at,
+        "signal": signal_record,
+        "response": response,
+    }
+    store.append_signal_send_history(ledger_row)
+    store.append_dispatch_ledger(ledger_row)
+
+    result = {
+        "status": status,
+        "profile_id": profile_id,
+        "signal": signal_record,
+        "response": response,
+    }
+    if error:
+        result["error"] = error
+    return result
+
+
+def retry_failed_signal(*, store: TradingStateStore, profile_id: str) -> dict:
+    """Reopen a failed pending signal so it can be dispatched again."""
+    failed_signal = store.load_pending_signal()
+    if failed_signal.get("status") != "failed":
+        return {
+            "status": "noop",
+            "profile_id": profile_id,
+            "reason": "no failed signal to retry",
+            "signal": failed_signal,
+        }
+
+    retried_signal = {
+        **failed_signal,
+        "status": "pending",
+        "profile_id": profile_id,
+    }
+    retried_signal.pop("error", None)
+    retried_signal.pop("dispatched_at", None)
+
+    store.save_pending_signal(retried_signal)
+    store.save_active_signal(retried_signal)
+
+    push_state = store.load_push_state()
+    dispatch_target = str(
+        retried_signal.get("dispatch_target")
+        or push_state.get("last_target")
+        or "feishu"
+    ).strip() or "feishu"
+    last_signal_text = str(
+        retried_signal.get("text")
+        or push_state.get("last_signal_text")
+        or ""
+    )
+    store.save_push_state(
+        {
+            **push_state,
+            "profile_id": profile_id,
+            "last_status": "pending",
+            "last_target": dispatch_target,
+            "last_signal_text": last_signal_text,
+        }
+    )
+
+    return {
+        "status": "pending",
+        "profile_id": profile_id,
+        "signal": retried_signal,
+    }
+
+
+def build_review_summary(
+    *,
+    store: TradingStateStore,
+    profile_id: str,
+    history_limit: int = 5,
+) -> dict:
+    """Build a compact review summary from current state and recent ledgers."""
+    limit = max(int(history_limit), 0)
+    dispatch_ledger = store.read_dispatch_ledger()
+    signal_send_history = store.read_signal_send_history()
+    return {
+        "profile_id": profile_id,
+        "pending": store.load_pending_signal(),
+        "active": store.load_active_signal(),
+        "push_state": store.load_push_state(),
+        "dispatch_ledger_tail": dispatch_ledger[-limit:] if limit else [],
+        "signal_send_history_tail": signal_send_history[-limit:] if limit else [],
+        "counts": {
+            "dispatch_ledger_count": len(dispatch_ledger),
+            "signal_send_history_count": len(signal_send_history),
+        },
+    }
 
 
 def _coerce_total_shares(value: object) -> int:
@@ -71,8 +228,11 @@ def run_runtime_cycle(
     existing_pending = store.load_pending_signal()
 
     if action == "buy" and buy_count + 1 > max_trades:
-        # Blocked by max_trades; clear any stale pending buy so dispatcher does not retry it.
-        store.clear_pending_signal()
+        # Blocked by max_trades; clear only stale pending buy so dispatcher does not retry it.
+        if existing_pending.get("status") == "pending" and existing_pending.get("action") == "buy":
+            store.clear_pending_signal()
+        elif existing_pending.get("status") == "pending":
+            pending = existing_pending
         suggestion = {"action": "hold", "reason": f"max_trades ({max_trades}) reached"}
         hold_count += 1
     elif action != "hold" and existing_pending.get("status") == "pending":

--- a/hermes_t/runtime.py
+++ b/hermes_t/runtime.py
@@ -1,0 +1,129 @@
+"""Generic runtime cycle for hermes_t — reads state, evaluates signal, returns result."""
+
+from __future__ import annotations
+
+from hermes_t.signal_policy import DEFAULT_SIGNAL_POLICY, SignalPolicy, render_signal_text
+from hermes_t.store import TradingStateStore
+
+
+def run_runtime_cycle(
+    *,
+    store: TradingStateStore,
+    tech_data: dict,
+    profile_id: str,
+    symbol: str,
+    trade_unit: int,
+    max_trades: int,
+    signal_policy: SignalPolicy | None = None,
+) -> dict:
+    """Execute one runtime cycle and return {pending, suggestion, summary}.
+
+    The tech_data dict is the primary input — it may contain ``signal``,
+    ``score``, or both.
+
+    Args:
+        store: Profile-scoped state store (already constructed).
+        tech_data: Dict with at least ``signal`` and/or ``score``.
+        profile_id: Profile identifier for state tracking.
+        symbol: Trading symbol (e.g. ``"688319"``).
+        trade_unit: Shares per trade.
+        max_trades: Maximum number of buy trades per session.
+        signal_policy: Optional runtime signal policy override.
+
+    Returns:
+        Dict with three keys:
+        ``pending`` — the pending signal dict (``{}`` when none).
+        ``suggestion`` — the suggested action with metadata.
+        ``summary`` — cumulative action counts.
+    """
+    policy = signal_policy or DEFAULT_SIGNAL_POLICY
+    state = store.load_execution_state()
+
+    buy_count = state.get("buy_count", 0)
+    sell_count = state.get("sell_count", 0)
+    hold_count = state.get("hold_count", 0)
+    previous_buys = buy_count
+    previous_sells = sell_count
+    previous_holds = hold_count
+
+    # Determine action
+    signal = tech_data.get("signal")
+    score = tech_data.get("score", 50)
+
+    if signal and signal in ("buy", "sell", "hold"):
+        action = signal
+    else:
+        action = policy.action_for_score(score)
+
+    # Evaluate the action
+    pending: dict = {}
+    suggestion: dict = {"action": action}
+
+    if action == "buy":
+        seq = buy_count + 1
+        if seq > max_trades:
+            # Blocked by max_trades
+            store.clear_pending_signal()
+            suggestion = {"action": "hold", "reason": f"max_trades ({max_trades}) reached"}
+            hold_count += 1
+        else:
+            pending = {
+                "status": "pending",
+                "action": "buy",
+                "seq": seq,
+                "unit": trade_unit,
+                "symbol": symbol,
+                "text": render_signal_text("buy", seq, policy),
+            }
+            suggestion["seq"] = seq
+            suggestion["unit"] = trade_unit
+            suggestion["text"] = pending["text"]
+            buy_count = seq
+    elif action == "sell":
+        seq = sell_count + 1
+        pending = {
+            "status": "pending",
+            "action": "sell",
+            "seq": seq,
+            "unit": trade_unit,
+            "symbol": symbol,
+            "text": render_signal_text("sell", seq, policy),
+        }
+        suggestion["seq"] = seq
+        suggestion["unit"] = trade_unit
+        suggestion["text"] = pending["text"]
+        sell_count = seq
+    else:
+        # hold — clear any existing pending signal
+        store.clear_pending_signal()
+        hold_count += 1
+
+    # Persist state
+    new_state = {
+        "profile_id": profile_id,
+        "symbol": symbol,
+        "buy_count": buy_count,
+        "sell_count": sell_count,
+        "hold_count": hold_count,
+        "max_trades": max_trades,
+        "trade_unit": trade_unit,
+    }
+    store.save_execution_state(new_state)
+
+    # Write pending signal to store (hold branch already cleared it)
+    if pending:
+        store.save_pending_signal(pending)
+
+    return {
+        "pending": pending,
+        "suggestion": suggestion,
+        "summary": {
+            "total_actions": buy_count + sell_count + hold_count,
+            "buy_count": buy_count,
+            "sell_count": sell_count,
+            "hold_count": hold_count,
+            "previous_buys": previous_buys,
+            "previous_sells": previous_sells,
+            "previous_holds": previous_holds,
+        },
+    }

--- a/hermes_t/signal_policy.py
+++ b/hermes_t/signal_policy.py
@@ -1,0 +1,60 @@
+"""Signal policy — thresholds, templates, and text rendering for hermes_t runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+SignalActionName = Literal["buy", "sell", "hold"]
+
+
+@dataclass(frozen=True)
+class SignalAction:
+    """A single signal action — name, template text, and optional threshold bound."""
+
+    name: SignalActionName
+    template: str
+    threshold_ceiling: int | None = None  # score <= this triggers the action
+
+    def render(self, seq: int) -> str:
+        return self.template.replace("{seq}", str(seq))
+
+
+@dataclass(frozen=True)
+class SignalPolicy:
+    """Parameters and actions for a runtime cycle signal evaluation."""
+
+    max_buys: int = 4
+    buy_unit_pct: float = 0.5  # unused in skeleton phase
+    sell_unit_pct: float = 1.0  # unused in skeleton phase
+    actions: tuple[SignalAction, ...] = field(default_factory=lambda: _DEFAULT_ACTIONS)
+
+    def action_for_score(self, score: int) -> SignalActionName:
+        """Map a 0-100 score to an action name.
+
+        Buy triggers when ``score <= buy.threshold_ceiling``;
+        sell triggers when ``score >= sell.threshold_ceiling``.
+        """
+        for action in self.actions:
+            if action.name == "sell" and action.threshold_ceiling is not None and score >= action.threshold_ceiling:
+                return "sell"
+            if action.name == "buy" and action.threshold_ceiling is not None and score <= action.threshold_ceiling:
+                return "buy"
+        return "hold"
+
+
+_DEFAULT_ACTIONS: tuple[SignalAction, ...] = (
+    SignalAction(name="buy", template="第{seq}次买入", threshold_ceiling=20),
+    SignalAction(name="sell", template="卖出", threshold_ceiling=80),
+    SignalAction(name="hold", template="观望"),
+)
+
+DEFAULT_SIGNAL_POLICY = SignalPolicy()
+
+
+def render_signal_text(action: str, seq: int, policy: SignalPolicy) -> str:
+    """Render a human-readable signal text for an action name + sequence."""
+    for a in policy.actions:
+        if a.name == action:
+            return a.render(seq)
+    return f"Unknown action: {action}"

--- a/hermes_t/store.py
+++ b/hermes_t/store.py
@@ -1,0 +1,116 @@
+"""Generic profile-scoped state store for hermes_t runtime."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_BASE_DIRNAME = ".hermes_t_runtime"
+_EXECUTION_STATE_FILENAME = "execution_state.json"
+_PENDING_SIGNAL_FILENAME = "pending_signal.json"
+_POSITION_FILENAME = "position.json"
+_PUSH_STATE_FILENAME = "push_state.json"
+_ACTIVE_SIGNAL_FILENAME = "active_signal.json"
+_DISPATCH_LEDGER_FILENAME = "dispatch_ledger.jsonl"
+_SIGNAL_SEND_HISTORY_FILENAME = "signal_send_history.jsonl"
+_VALID_PROFILE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def validate_profile_id(profile_id: str) -> str:
+    if not isinstance(profile_id, str) or not profile_id.strip():
+        raise ValueError("profile_id must be a non-blank string")
+    normalized = profile_id.strip()
+    if not _VALID_PROFILE_ID_RE.fullmatch(normalized) or normalized in {".", ".."}:
+        raise ValueError("profile_id must contain only letters, digits, dot, underscore, or hyphen")
+    return normalized
+
+
+class TradingStateStore:
+    def __init__(self, base_dir: str | Path | None = None, *, profile_id: str) -> None:
+        self.base_dir = Path(base_dir) if base_dir is not None else Path.home() / _DEFAULT_BASE_DIRNAME
+        self.profile_id = validate_profile_id(profile_id)
+        self.state_dir = self.base_dir / self.profile_id
+
+    def _ensure_state_dir(self) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def _json_path(self, filename: str) -> Path:
+        return self.state_dir / filename
+
+    def _jsonl_path(self, filename: str) -> Path:
+        return self.state_dir / filename
+
+    def _load_json(self, filename: str, *, default: Any) -> Any:
+        path = self._json_path(filename)
+        if not path.exists():
+            return default
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _save_json(self, filename: str, payload: Any) -> None:
+        self._ensure_state_dir()
+        self._json_path(filename).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def _read_jsonl(self, filename: str) -> list[dict[str, Any]]:
+        path = self._jsonl_path(filename)
+        if not path.exists():
+            return []
+        rows: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+        return rows
+
+    def _append_jsonl(self, filename: str, row: dict[str, Any]) -> None:
+        self._ensure_state_dir()
+        path = self._jsonl_path(filename)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    def load_execution_state(self) -> dict[str, Any]:
+        return self._load_json(_EXECUTION_STATE_FILENAME, default={})
+
+    def save_execution_state(self, payload: dict[str, Any]) -> None:
+        self._save_json(_EXECUTION_STATE_FILENAME, payload)
+
+    def load_pending_signal(self) -> dict[str, Any]:
+        return self._load_json(_PENDING_SIGNAL_FILENAME, default={})
+
+    def save_pending_signal(self, payload: dict[str, Any]) -> None:
+        self._save_json(_PENDING_SIGNAL_FILENAME, payload)
+
+    def clear_pending_signal(self) -> None:
+        self.save_pending_signal({})
+
+    def load_position(self) -> dict[str, Any] | None:
+        return self._load_json(_POSITION_FILENAME, default=None)
+
+    def save_position(self, payload: dict[str, Any]) -> None:
+        self._save_json(_POSITION_FILENAME, payload)
+
+    def load_push_state(self) -> dict[str, Any]:
+        return self._load_json(_PUSH_STATE_FILENAME, default={})
+
+    def save_push_state(self, payload: dict[str, Any]) -> None:
+        self._save_json(_PUSH_STATE_FILENAME, payload)
+
+    def load_active_signal(self) -> dict[str, Any]:
+        return self._load_json(_ACTIVE_SIGNAL_FILENAME, default={})
+
+    def save_active_signal(self, payload: dict[str, Any]) -> None:
+        self._save_json(_ACTIVE_SIGNAL_FILENAME, payload)
+
+    def read_dispatch_ledger(self) -> list[dict[str, Any]]:
+        return self._read_jsonl(_DISPATCH_LEDGER_FILENAME)
+
+    def append_dispatch_ledger(self, row: dict[str, Any]) -> None:
+        self._append_jsonl(_DISPATCH_LEDGER_FILENAME, row)
+
+    def read_signal_send_history(self) -> list[dict[str, Any]]:
+        return self._read_jsonl(_SIGNAL_SEND_HISTORY_FILENAME)
+
+    def append_signal_send_history(self, row: dict[str, Any]) -> None:
+        self._append_jsonl(_SIGNAL_SEND_HISTORY_FILENAME, row)

--- a/hermes_t/tech_data.py
+++ b/hermes_t/tech_data.py
@@ -1,0 +1,339 @@
+"""Quote/tech-data provider primitives for hermes_t."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+_DEFAULT_TDX_SERVERS: list[tuple[str, int]] = [
+    ("119.147.212.81", 7709),
+    ("119.147.212.83", 7709),
+]
+
+
+class QuoteProvider(Protocol):
+    def get(self, symbol: str) -> dict[str, Any]: ...
+
+
+class QuoteSnapshotProvider(Protocol):
+    def get(self, symbol: str) -> dict[str, Any]: ...
+
+
+class TechDataProvider(Protocol):
+    def get(self, symbol: str) -> dict[str, Any]: ...
+
+
+class StaticTechDataProvider:
+    """Return the same tech_data payload for any symbol."""
+
+    def __init__(self, tech_data: dict[str, Any] | None = None):
+        self.tech_data = dict(tech_data or {})
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        del symbol
+        return dict(self.tech_data)
+
+
+class JsonQuoteDataProvider:
+    """Read per-symbol raw quote payloads from a JSON file."""
+
+    def __init__(self, config_path: str | Path):
+        self.config_path = Path(config_path)
+        self._payloads: dict[str, Any] = json.loads(self.config_path.read_text(encoding="utf-8"))
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        payload = self._payloads.get(symbol, {})
+        return payload if isinstance(payload, dict) else {}
+
+
+class JsonQuoteSnapshotSource:
+    """Read per-symbol quote snapshots from a JSON file or in-memory mapping."""
+
+    def __init__(self, snapshot_path: str | Path):
+        self.snapshot_path: Path | None = Path(snapshot_path)
+        self._snapshots: dict[str, Any] = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+
+    @classmethod
+    def from_mapping(cls, snapshots_by_symbol: dict[str, Any] | None) -> "JsonQuoteSnapshotSource":
+        instance = cls.__new__(cls)
+        instance.snapshot_path = None
+        instance._snapshots = dict(snapshots_by_symbol or {})
+        return instance
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        payload = self._snapshots.get(symbol, {})
+        return payload if isinstance(payload, dict) else {}
+
+
+class TdxQuoteSnapshotSource:
+    """Fetch standardized quote snapshots from TDX TCP servers."""
+
+    def __init__(
+        self,
+        *,
+        api_cls: type | None = None,
+        servers: list[tuple[str, int]] | None = None,
+        market_by_symbol: dict[str, int] | None = None,
+    ):
+        self.api_cls = api_cls or _import_tdx_api_cls()
+        self.servers = [tuple(server) for server in (servers or _DEFAULT_TDX_SERVERS)]
+        self.market_by_symbol = dict(market_by_symbol or {})
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        last_error: Exception | None = None
+        market = self.market_by_symbol.get(symbol, _infer_tdx_market(symbol))
+        for host, port in self.servers:
+            api = self.api_cls()
+            try:
+                connected = api.connect(host, port)
+                if connected is False:
+                    raise ConnectionError(f"tdx connect returned false: {host}:{port}")
+                quotes = api.get_security_quotes([(market, symbol)])
+                return _normalize_tdx_snapshot(symbol, quotes)
+            except ValueError:
+                raise
+            except Exception as exc:  # pragma: no cover - exercised by tests
+                last_error = exc
+            finally:
+                try:
+                    api.disconnect()
+                except Exception:
+                    pass
+        raise RuntimeError(f"all tdx servers failed for {symbol}") from last_error
+
+
+class EastmoneyQuoteSnapshotSource:
+    """Fetch standardized quote snapshots from Eastmoney quote payloads."""
+
+    def __init__(
+        self,
+        *,
+        fetcher: Any | None = None,
+        market_by_symbol: dict[str, int] | None = None,
+    ):
+        self.fetcher = fetcher or _import_eastmoney_fetcher()
+        self.market_by_symbol = dict(market_by_symbol or {})
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        secid = _build_eastmoney_secid(symbol, self.market_by_symbol.get(symbol))
+        payload = self.fetcher(secid)
+        return _normalize_eastmoney_snapshot(symbol, payload)
+
+
+class QuoteTechDataAdapter:
+    """Adapt raw quote payloads into runtime tech_data payloads."""
+
+    def __init__(self, quote_provider: QuoteProvider, default_tech_data: dict[str, Any] | None = None):
+        self.quote_provider = quote_provider
+        self.default_tech_data = dict(default_tech_data or {})
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        payload = self.quote_provider.get(symbol)
+        if not isinstance(payload, dict):
+            return dict(self.default_tech_data)
+        tech_data = payload.get("tech_data")
+        if isinstance(tech_data, dict) and tech_data:
+            return tech_data
+        return dict(self.default_tech_data)
+
+
+class QuoteSnapshotTechDataAdapter:
+    """Adapt quote snapshot payloads into runtime tech_data payloads."""
+
+    def __init__(self, snapshot_provider: QuoteSnapshotProvider, default_tech_data: dict[str, Any] | None = None):
+        self.snapshot_provider = snapshot_provider
+        self.default_tech_data = dict(default_tech_data or {})
+
+    def get(self, symbol: str) -> dict[str, Any]:
+        try:
+            payload = self.snapshot_provider.get(symbol)
+        except Exception:
+            return dict(self.default_tech_data)
+        if not isinstance(payload, dict):
+            return dict(self.default_tech_data)
+        tech_data = payload.get("tech_data")
+        if isinstance(tech_data, dict) and tech_data:
+            return tech_data
+        return dict(self.default_tech_data)
+
+
+def _import_tdx_api_cls() -> type:
+    try:
+        from pytdx.hq import TdxHq_API  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised in future tests
+        raise RuntimeError("pytdx unavailable") from exc
+    return TdxHq_API
+
+
+def _import_requests_module() -> Any:
+    try:
+        import requests
+    except ImportError as exc:  # pragma: no cover - exercised in future tests
+        raise RuntimeError("requests unavailable") from exc
+    return requests
+
+
+def _import_eastmoney_fetcher() -> Any:
+    requests = _import_requests_module()
+
+    def _fetch(secid: str) -> dict[str, Any]:
+        response = requests.get(
+            "https://push2.eastmoney.com/api/qt/stock/get",
+            params={
+                "secid": secid,
+                "fields": "f43,f57,f58,f86",
+                "invt": "2",
+                "fltt": "1",
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    return _fetch
+
+
+def _infer_tdx_market(symbol: str) -> int:
+    if symbol.startswith(("5", "6", "9")):
+        return 1
+    return 0
+
+
+def _infer_eastmoney_market(symbol: str) -> int:
+    if symbol.startswith(("5", "6", "9")):
+        return 1
+    return 0
+
+
+def _build_eastmoney_secid(symbol: str, market: int | None = None) -> str:
+    return f"{_infer_eastmoney_market(symbol) if market is None else int(market)}.{symbol}"
+
+
+def _normalize_tdx_snapshot(symbol: str, quotes: Any) -> dict[str, Any]:
+    if not isinstance(quotes, list) or not quotes:
+        raise ValueError(f"empty tdx quote for {symbol}")
+    quote = quotes[0]
+    if not isinstance(quote, dict):
+        raise ValueError(f"invalid tdx quote payload for {symbol}")
+    price = quote.get("price")
+    if not isinstance(price, (int, float)) or price <= 0:
+        raise ValueError(f"non-positive tdx price for {symbol}")
+    snapshot = {
+        "symbol": symbol,
+        "last_price": float(price),
+        "source": "tdx_tcp",
+        "as_of": quote.get("servertime") or quote.get("datetime") or "",
+    }
+    tech_data = quote.get("tech_data")
+    if isinstance(tech_data, dict) and tech_data:
+        snapshot["tech_data"] = tech_data
+    return snapshot
+
+
+def _normalize_eastmoney_snapshot(symbol: str, payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError(f"invalid eastmoney payload for {symbol}")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError(f"missing eastmoney data for {symbol}")
+    raw_price = data.get("f43")
+    if not isinstance(raw_price, (int, float)) or raw_price <= 0:
+        raise ValueError(f"non-positive eastmoney price for {symbol}")
+    snapshot = {
+        "symbol": symbol,
+        "last_price": float(raw_price) / 10000,
+        "source": "eastmoney",
+        "as_of": data.get("f86") or "",
+    }
+    tech_data = data.get("tech_data")
+    if isinstance(tech_data, dict) and tech_data:
+        snapshot["tech_data"] = tech_data
+    return snapshot
+
+
+def _load_json_config(config_path: str | Path) -> tuple[dict[str, Any], Path]:
+    path = Path(config_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"config must be a JSON object: {path}")
+    return payload, path.parent
+
+
+def build_quote_snapshot_provider(config: dict[str, Any], *, base_dir: str | Path | None = None) -> QuoteSnapshotProvider:
+    source = str(config.get("source") or "").strip()
+    if source == "file":
+        snapshot_path = config.get("snapshot_path")
+        if not isinstance(snapshot_path, str) or not snapshot_path.strip():
+            raise ValueError("quote snapshot file source requires snapshot_path")
+        snapshot_file = Path(snapshot_path)
+        if not snapshot_file.is_absolute() and base_dir is not None:
+            snapshot_file = Path(base_dir) / snapshot_file
+        return JsonQuoteSnapshotSource(snapshot_file)
+    if source == "mock":
+        snapshots = config.get("snapshots_by_symbol", {})
+        if not isinstance(snapshots, dict):
+            raise ValueError("quote snapshot mock source requires snapshots_by_symbol object")
+        return JsonQuoteSnapshotSource.from_mapping(snapshots)
+    if source == "tdx":
+        servers = config.get("servers")
+        normalized_servers = None
+        if servers is not None:
+            normalized_servers = [tuple(server) for server in servers]
+        market_by_symbol = config.get("market_by_symbol")
+        if market_by_symbol is not None and not isinstance(market_by_symbol, dict):
+            raise ValueError("tdx market_by_symbol must be an object")
+        return TdxQuoteSnapshotSource(
+            api_cls=config.get("api_cls"),
+            servers=normalized_servers,
+            market_by_symbol=market_by_symbol,
+        )
+    if source == "eastmoney":
+        market_by_symbol = config.get("market_by_symbol")
+        if market_by_symbol is not None and not isinstance(market_by_symbol, dict):
+            raise ValueError("eastmoney market_by_symbol must be an object")
+        return EastmoneyQuoteSnapshotSource(
+            fetcher=config.get("fetcher"),
+            market_by_symbol=market_by_symbol,
+        )
+    raise ValueError(f"unsupported quote snapshot source: {source or '<blank>'}")
+
+
+def build_tech_data_provider(
+    *,
+    tech_data_config_path: str | Path | None = None,
+    quote_data_config_path: str | Path | None = None,
+    quote_snapshot_config_path: str | Path | None = None,
+    default_tech_data: dict[str, Any] | None = None,
+) -> TechDataProvider:
+    if tech_data_config_path is not None:
+        return JsonQuoteDataProvider(tech_data_config_path)
+    if quote_data_config_path is not None:
+        return QuoteTechDataAdapter(
+            JsonQuoteDataProvider(quote_data_config_path),
+            default_tech_data=default_tech_data,
+        )
+    if quote_snapshot_config_path is not None:
+        config, config_dir = _load_json_config(quote_snapshot_config_path)
+        return QuoteSnapshotTechDataAdapter(
+            build_quote_snapshot_provider(config, base_dir=config_dir),
+            default_tech_data=default_tech_data,
+        )
+    return StaticTechDataProvider(default_tech_data)
+
+
+__all__ = [
+    "EastmoneyQuoteSnapshotSource",
+    "JsonQuoteDataProvider",
+    "JsonQuoteSnapshotSource",
+    "QuoteProvider",
+    "QuoteSnapshotProvider",
+    "QuoteSnapshotTechDataAdapter",
+    "QuoteTechDataAdapter",
+    "StaticTechDataProvider",
+    "TdxQuoteSnapshotSource",
+    "TechDataProvider",
+    "build_quote_snapshot_provider",
+    "build_tech_data_provider",
+]

--- a/tests/test_runtime_cycle.py
+++ b/tests/test_runtime_cycle.py
@@ -119,6 +119,7 @@ def test_run_runtime_cycle_with_sell_score_outputs_sell_suggestion(tmp_path: Pat
     from hermes_t.store import TradingStateStore
 
     store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_test")
+    store.save_position({"symbol": "688319", "total_shares": 220000})
     result = run_runtime_cycle(
         store=store,
         tech_data={"signal": "sell", "score": 85},
@@ -157,6 +158,178 @@ def test_run_runtime_cycle_with_hold_score_clears_pending(tmp_path: Path):
     assert result["suggestion"]["action"] == "hold"
 
 
+def test_run_runtime_cycle_keeps_existing_pending_signal_when_new_action_arrives(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="keep_pending")
+    existing_pending = {
+        "status": "pending",
+        "action": "buy",
+        "seq": 1,
+        "unit": 5000,
+        "symbol": "688319",
+        "text": "低吸第1次",
+    }
+    store.save_pending_signal(existing_pending)
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="keep_pending",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "pending signal unresolved"
+    assert result["pending"] == existing_pending
+    assert store.load_pending_signal() == existing_pending
+    assert result["summary"]["sell_count"] == 0
+    assert result["summary"]["hold_count"] == 1
+
+
+def test_run_runtime_cycle_sell_without_position_is_held(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_without_position")
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_without_position",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "no sellable position"
+    assert result["pending"] == {}
+    assert store.load_pending_signal() == {}
+    assert result["summary"]["sell_count"] == 0
+    assert result["summary"]["hold_count"] == 1
+
+
+def test_run_runtime_cycle_sell_without_position_preserves_existing_pending(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_without_position_pending")
+    existing_pending = {
+        "status": "pending",
+        "action": "sell",
+        "seq": 1,
+        "unit": 10000,
+        "symbol": "688319",
+        "text": "止盈第1次",
+    }
+    store.save_pending_signal(existing_pending)
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_without_position_pending",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "pending signal unresolved"
+    assert result["pending"] == existing_pending
+    assert store.load_pending_signal() == existing_pending
+    assert result["summary"]["sell_count"] == 0
+    assert result["summary"]["hold_count"] == 1
+
+
+
+def test_run_runtime_cycle_sell_without_position_blocks_symbol_mismatch(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_symbol_mismatch")
+    store.save_position({"symbol": "000001", "total_shares": 220000})
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_symbol_mismatch",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "no sellable position"
+    assert result["pending"] == {}
+    assert result["summary"]["sell_count"] == 0
+
+
+def test_run_runtime_cycle_sell_with_string_total_shares_outputs_sell_suggestion(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_with_string_position")
+    store.save_position({"symbol": "688319", "total_shares": "220000"})
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_with_string_position",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "sell"
+    assert result["pending"]["action"] == "sell"
+
+
+def test_run_runtime_cycle_sell_with_non_finite_total_shares_is_held(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_with_inf_position")
+    store.save_position({"symbol": "688319", "total_shares": "inf"})
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_with_inf_position",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "no sellable position"
+    assert result["pending"] == {}
+
+
+def test_run_runtime_cycle_sell_with_position_outputs_sell_suggestion(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_with_position")
+    store.save_position({"symbol": "688319", "total_shares": 220000})
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_with_position",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "sell"
+    assert result["suggestion"]["unit"] == 10000
+    assert result["pending"]["status"] == "pending"
+    assert result["pending"]["action"] == "sell"
+
 def test_run_runtime_cycle_buy_increments_seq(tmp_path: Path):
     from hermes_t.runtime import run_runtime_cycle
     from hermes_t.store import TradingStateStore
@@ -172,6 +345,7 @@ def test_run_runtime_cycle_buy_increments_seq(tmp_path: Path):
         max_trades=4,
     )
     assert result_1["pending"]["seq"] == 1
+    store.clear_pending_signal()
 
     result_2 = run_runtime_cycle(
         store=store,
@@ -183,6 +357,37 @@ def test_run_runtime_cycle_buy_increments_seq(tmp_path: Path):
     )
     assert result_2["pending"]["seq"] == 2
     assert result_2["pending"]["unit"] == 7000
+
+
+def test_run_runtime_cycle_same_action_pending_is_preserved(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="same_action_pending")
+    existing_pending = {
+        "status": "pending",
+        "action": "buy",
+        "seq": 1,
+        "unit": 5000,
+        "symbol": "688319",
+    }
+    store.save_pending_signal(existing_pending)
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 15},
+        profile_id="same_action_pending",
+        symbol="688319",
+        trade_unit=7000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "pending signal unresolved"
+    assert result["pending"] == existing_pending
+    assert store.load_pending_signal() == existing_pending
+    assert result["summary"]["buy_count"] == 0
+    assert result["summary"]["hold_count"] == 1
 
 
 def test_run_runtime_cycle_honors_max_trades(tmp_path: Path):
@@ -201,6 +406,7 @@ def test_run_runtime_cycle_honors_max_trades(tmp_path: Path):
             max_trades=max_trades,
         )
         assert result["pending"]["seq"] == i + 1
+        store.clear_pending_signal()
 
     # Third buy should be blocked
     result = run_runtime_cycle(
@@ -316,6 +522,7 @@ def test_run_runtime_cycle_honors_signal_policy_override(tmp_path: Path):
         )
     )
     store = TradingStateStore(base_dir=str(tmp_path), profile_id="custom_policy")
+    store.save_position({"symbol": "688319", "total_shares": 220000})
 
     result = run_runtime_cycle(
         store=store,
@@ -330,7 +537,7 @@ def test_run_runtime_cycle_honors_signal_policy_override(tmp_path: Path):
     assert result["suggestion"]["action"] == "sell"
     assert result["suggestion"]["text"] == "止盈卖出"
     assert result["pending"]["action"] == "sell"
-
+    assert result["pending"]["text"] == "止盈卖出"
 
 def test_run_runtime_cycle_summary_previous_counts_reflect_pre_cycle_state(tmp_path: Path):
     from hermes_t.runtime import run_runtime_cycle

--- a/tests/test_runtime_cycle.py
+++ b/tests/test_runtime_cycle.py
@@ -1,0 +1,367 @@
+"""Tests for hermes_t runtime cycle and signal policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_t.signal_policy import DEFAULT_SIGNAL_POLICY, SignalAction, SignalPolicy
+
+
+# ── SignalPolicy tests ────────────────────────────────────────────────────
+
+
+def test_signal_policy_default_values():
+    """DEFAULT_SIGNAL_POLICY should have sensible defaults."""
+    p = DEFAULT_SIGNAL_POLICY
+    assert p.max_buys > 0
+    assert p.buy_unit_pct > 0
+    assert p.sell_unit_pct > 0
+    assert len(p.actions) > 0
+
+
+def test_signal_policy_has_buy_sell_hold():
+    """Policy should include buy, sell, and hold actions."""
+    p = DEFAULT_SIGNAL_POLICY
+    actions = {a.name for a in p.actions}
+    assert "buy" in actions
+    assert "sell" in actions
+    assert "hold" in actions
+
+
+def test_signal_policy_buy_text_uses_ordinal():
+    """Buy action text for Nth buy should use ordinal like '第N次买入'."""
+    p = DEFAULT_SIGNAL_POLICY
+    buy_action = next(a for a in p.actions if a.name == "buy")
+    text = buy_action.render(1)
+    assert "第" in text and "次" in text and "买入" in text
+    text_2 = buy_action.render(2)
+    assert "第2次" in text_2
+    text_3 = buy_action.render(3)
+    assert "第3次" in text_3
+
+
+def test_signal_policy_sell_text_default():
+    """Sell action text should mention '卖出'."""
+    p = DEFAULT_SIGNAL_POLICY
+    sell_action = next(a for a in p.actions if a.name == "sell")
+    text = sell_action.render(1)
+    assert "卖出" in text
+
+
+def test_signal_policy_hold_text():
+    """Hold action text should be neutral."""
+    p = DEFAULT_SIGNAL_POLICY
+    hold_action = next(a for a in p.actions if a.name == "hold")
+    text = hold_action.render(0)
+    assert text  # non-empty
+
+
+def test_signal_policy_render_signal_text():
+    from hermes_t.signal_policy import render_signal_text
+
+    text = render_signal_text("buy", 1, DEFAULT_SIGNAL_POLICY)
+    assert "第" in text and "次" in text and "买入" in text
+
+    text = render_signal_text("sell", 2, DEFAULT_SIGNAL_POLICY)
+    assert "卖出" in text
+
+    text = render_signal_text("hold", 0, DEFAULT_SIGNAL_POLICY)
+    assert text  # non-empty
+
+    text = render_signal_text("unknown", 0, DEFAULT_SIGNAL_POLICY)
+    assert "unknown" in text  # falls back
+
+
+@pytest.mark.parametrize("score, expected_min", [
+    (90, "sell"),
+    (80, "sell"),
+    (65, None),  # hold — middle band
+    (50, None),
+    (30, None),
+    (20, "buy"),
+    (5, "buy"),
+])
+def test_signal_policy_default_threshold_maps_scores(score: int, expected_min: str | None):
+    """DEFAULT_SIGNAL_POLICY threshold should map scores to actions."""
+    action = DEFAULT_SIGNAL_POLICY.action_for_score(score)
+    if expected_min:
+        assert action in (expected_min, "buy")  # buy can appear broader than expected
+    else:
+        assert action is not None
+
+
+# ── Runtime cycle tests ───────────────────────────────────────────────────
+
+
+def test_run_runtime_cycle_returns_pending_suggestion_summary(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="cycle_test")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "hold", "score": 50},
+        profile_id="cycle_test",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert "pending" in result
+    assert "suggestion" in result
+    assert "summary" in result
+
+
+def test_run_runtime_cycle_with_sell_score_outputs_sell_suggestion(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="sell_test")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 85},
+        profile_id="sell_test",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    assert result["suggestion"]["action"] == "sell"
+    assert result["suggestion"]["unit"] == 10000
+    assert result["pending"]["status"] == "pending"
+    assert result["pending"]["action"] == "sell"
+
+
+def test_run_runtime_cycle_with_hold_score_clears_pending(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="hold_test")
+    # Pre-populate a pending signal
+    store.save_pending_signal({"status": "pending", "action": "sell"})
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "hold", "score": 50},
+        profile_id="hold_test",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    # Pending should be cleared
+    assert result["pending"] == {}
+    assert store.load_pending_signal() == {}
+    assert result["suggestion"]["action"] == "hold"
+
+
+def test_run_runtime_cycle_buy_increments_seq(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="buy_seq")
+
+    result_1 = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 25},
+        profile_id="buy_seq",
+        symbol="688319",
+        trade_unit=5000,
+        max_trades=4,
+    )
+    assert result_1["pending"]["seq"] == 1
+
+    result_2 = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 15},
+        profile_id="buy_seq",
+        symbol="688319",
+        trade_unit=7000,
+        max_trades=4,
+    )
+    assert result_2["pending"]["seq"] == 2
+    assert result_2["pending"]["unit"] == 7000
+
+
+def test_run_runtime_cycle_honors_max_trades(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="max_trades")
+    max_trades = 2
+    for i in range(max_trades):
+        result = run_runtime_cycle(
+            store=store,
+            tech_data={"signal": "buy", "score": 20},
+            profile_id="max_trades",
+            symbol="688319",
+            trade_unit=5000,
+            max_trades=max_trades,
+        )
+        assert result["pending"]["seq"] == i + 1
+
+    # Third buy should be blocked
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 10},
+        profile_id="max_trades",
+        symbol="688319",
+        trade_unit=5000,
+        max_trades=max_trades,
+    )
+    assert result["suggestion"]["action"] == "hold"
+    assert result["pending"] == {}
+
+
+def test_run_runtime_cycle_blocked_buy_clears_stale_pending_signal(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="blocked_buy_clears_pending")
+    store.save_pending_signal({"status": "pending", "action": "buy", "seq": 2})
+    store.save_execution_state(
+        {
+            "profile_id": "blocked_buy_clears_pending",
+            "symbol": "688319",
+            "buy_count": 2,
+            "sell_count": 0,
+            "hold_count": 0,
+            "max_trades": 2,
+            "trade_unit": 5000,
+        }
+    )
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 10},
+        profile_id="blocked_buy_clears_pending",
+        symbol="688319",
+        trade_unit=5000,
+        max_trades=2,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["pending"] == {}
+    assert store.load_pending_signal() == {}
+
+
+def test_run_runtime_cycle_tech_data_without_signal_falls_back_to_score(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="fallback")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"score": 90},
+        profile_id="fallback",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+    # score=90 should yield sell via policy threshold
+    assert result["suggestion"]["action"] in ("sell", "hold")
+
+
+def test_run_runtime_cycle_persists_execution_state(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="persist")
+    run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 20},
+        profile_id="persist",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+    state = store.load_execution_state()
+    assert state.get("profile_id") == "persist"
+    assert state.get("symbol") == "688319"
+
+
+def test_run_runtime_cycle_summary_includes_counts(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="summary_test")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "sell", "score": 95},
+        profile_id="summary_test",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+    summary = result["summary"]
+    assert "total_actions" in summary
+    assert "buy_count" in summary
+    assert "sell_count" in summary
+    assert "hold_count" in summary
+    assert "previous_buys" in summary
+    assert "previous_sells" in summary
+
+
+def test_run_runtime_cycle_honors_signal_policy_override(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    custom_policy = SignalPolicy(
+        actions=(
+            SignalAction(name="buy", template="低吸第{seq}次", threshold_ceiling=10),
+            SignalAction(name="sell", template="止盈卖出", threshold_ceiling=60),
+            SignalAction(name="hold", template="继续观察"),
+        )
+    )
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="custom_policy")
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"score": 70},
+        profile_id="custom_policy",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+        signal_policy=custom_policy,
+    )
+
+    assert result["suggestion"]["action"] == "sell"
+    assert result["suggestion"]["text"] == "止盈卖出"
+    assert result["pending"]["action"] == "sell"
+
+
+def test_run_runtime_cycle_summary_previous_counts_reflect_pre_cycle_state(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="summary_previous_counts")
+    store.save_execution_state(
+        {
+            "profile_id": "summary_previous_counts",
+            "symbol": "688319",
+            "buy_count": 1,
+            "sell_count": 2,
+            "hold_count": 3,
+            "max_trades": 4,
+            "trade_unit": 10000,
+        }
+    )
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 20},
+        profile_id="summary_previous_counts",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+    summary = result["summary"]
+
+    assert summary["previous_buys"] == 1
+    assert summary["previous_sells"] == 2
+    assert summary["previous_holds"] == 3
+    assert summary["buy_count"] == 2
+    assert summary["sell_count"] == 2
+    assert summary["hold_count"] == 3

--- a/tests/test_runtime_cycle.py
+++ b/tests/test_runtime_cycle.py
@@ -453,6 +453,47 @@ def test_run_runtime_cycle_blocked_buy_clears_stale_pending_signal(tmp_path: Pat
     assert store.load_pending_signal() == {}
 
 
+def test_run_runtime_cycle_blocked_buy_preserves_unrelated_pending_signal(tmp_path: Path):
+    from hermes_t.runtime import run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="blocked_buy_keeps_sell_pending")
+    existing_pending = {
+        "status": "pending",
+        "action": "sell",
+        "seq": 1,
+        "unit": 10000,
+        "symbol": "688319",
+        "text": "止盈第1次",
+    }
+    store.save_pending_signal(existing_pending)
+    store.save_execution_state(
+        {
+            "profile_id": "blocked_buy_keeps_sell_pending",
+            "symbol": "688319",
+            "buy_count": 2,
+            "sell_count": 0,
+            "hold_count": 0,
+            "max_trades": 2,
+            "trade_unit": 5000,
+        }
+    )
+
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 10},
+        profile_id="blocked_buy_keeps_sell_pending",
+        symbol="688319",
+        trade_unit=5000,
+        max_trades=2,
+    )
+
+    assert result["suggestion"]["action"] == "hold"
+    assert result["suggestion"]["reason"] == "max_trades (2) reached"
+    assert result["pending"] == existing_pending
+    assert store.load_pending_signal() == existing_pending
+
+
 def test_run_runtime_cycle_tech_data_without_signal_falls_back_to_score(tmp_path: Path):
     from hermes_t.runtime import run_runtime_cycle
     from hermes_t.store import TradingStateStore
@@ -572,3 +613,251 @@ def test_run_runtime_cycle_summary_previous_counts_reflect_pre_cycle_state(tmp_p
     assert summary["buy_count"] == 2
     assert summary["sell_count"] == 2
     assert summary["hold_count"] == 3
+
+
+def test_dispatch_pending_signal_sends_and_persists_confirmation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import json
+
+    from hermes_t.runtime import dispatch_pending_signal, run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    sent_args: dict[str, object] = {}
+
+    def fake_send_message_tool(args, **_kwargs):
+        sent_args.update(args)
+        return json.dumps({"success": True, "platform": "feishu", "chat_id": "home_chat"})
+
+    monkeypatch.setattr("tools.send_message_tool.send_message_tool", fake_send_message_tool)
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="dispatch_ok")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 20},
+        profile_id="dispatch_ok",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    pending = result["pending"]
+    dispatched = dispatch_pending_signal(store=store, profile_id="dispatch_ok", dispatch_target="feishu")
+
+    assert sent_args["target"] == "feishu"
+    assert sent_args["message"] == pending["text"]
+    assert dispatched["status"] == "sent"
+    assert dispatched["profile_id"] == "dispatch_ok"
+    assert dispatched["signal"]["status"] == "sent"
+    assert store.load_pending_signal()["status"] == "sent"
+    assert store.load_active_signal()["status"] == "sent"
+    push_state = store.load_push_state()
+    assert push_state["last_status"] == "sent"
+    history = store.read_signal_send_history()
+    assert len(history) == 1
+    assert history[0]["status"] == "sent"
+
+
+def test_dispatch_pending_signal_records_failure_without_clearing_pending(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import json
+
+    from hermes_t.runtime import dispatch_pending_signal, run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    def fake_send_message_tool(_args, **_kwargs):
+        return json.dumps({"success": False, "error": "gateway timeout"})
+
+    monkeypatch.setattr("tools.send_message_tool.send_message_tool", fake_send_message_tool)
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="dispatch_failed")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 10},
+        profile_id="dispatch_failed",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+
+    pending = result["pending"]
+    dispatched = dispatch_pending_signal(store=store, profile_id="dispatch_failed", dispatch_target="feishu")
+
+    assert pending["status"] == "pending"
+    assert dispatched["status"] == "failed"
+    assert dispatched["error"] == "gateway timeout"
+    assert dispatched["signal"]["status"] == "failed"
+    assert store.load_pending_signal()["status"] == "failed"
+    assert store.load_pending_signal()["error"] == "gateway timeout"
+    assert store.load_active_signal()["status"] == "failed"
+    push_state = store.load_push_state()
+    assert push_state["last_status"] == "failed"
+    history = store.read_signal_send_history()
+    assert len(history) == 1
+    assert history[0]["status"] == "failed"
+
+
+def test_retry_failed_signal_reopens_failed_pending_for_redispatch(tmp_path: Path):
+    from hermes_t.runtime import retry_failed_signal
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="retry_failed")
+    failed_signal = {
+        "status": "failed",
+        "action": "buy",
+        "seq": 1,
+        "unit": 10000,
+        "symbol": "688319",
+        "text": "低吸第1次",
+        "profile_id": "retry_failed",
+        "dispatch_target": "feishu",
+        "dispatched_at": "2026-05-04T00:00:00+00:00",
+        "error": "gateway timeout",
+    }
+    store.save_pending_signal(failed_signal)
+    store.save_active_signal(failed_signal)
+    store.save_push_state(
+        {
+            "profile_id": "retry_failed",
+            "last_status": "failed",
+            "last_target": "feishu",
+            "last_signal_text": failed_signal["text"],
+            "last_dispatched_at": failed_signal["dispatched_at"],
+        }
+    )
+
+    retried = retry_failed_signal(store=store, profile_id="retry_failed")
+
+    assert retried["status"] == "pending"
+    assert retried["profile_id"] == "retry_failed"
+    assert retried["signal"]["status"] == "pending"
+    assert "error" not in retried["signal"]
+    assert "dispatched_at" not in retried["signal"]
+    assert store.load_pending_signal()["status"] == "pending"
+    assert "error" not in store.load_pending_signal()
+    assert store.load_active_signal()["status"] == "pending"
+    push_state = store.load_push_state()
+    assert push_state["last_status"] == "pending"
+    assert push_state["last_target"] == "feishu"
+    assert push_state["last_signal_text"] == failed_signal["text"]
+
+
+def test_retry_failed_signal_returns_noop_when_no_failed_signal_exists(tmp_path: Path):
+    from hermes_t.runtime import retry_failed_signal
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="retry_noop")
+    store.save_pending_signal({"status": "sent", "action": "buy"})
+
+    result = retry_failed_signal(store=store, profile_id="retry_noop")
+
+    assert result == {
+        "status": "noop",
+        "profile_id": "retry_noop",
+        "reason": "no failed signal to retry",
+        "signal": {"status": "sent", "action": "buy"},
+    }
+
+
+def test_retry_failed_signal_allows_dispatch_again_after_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import json
+
+    from hermes_t.runtime import dispatch_pending_signal, retry_failed_signal, run_runtime_cycle
+    from hermes_t.store import TradingStateStore
+
+    call_count = {"count": 0}
+
+    def fake_send_message_tool(_args, **_kwargs):
+        call_count["count"] += 1
+        if call_count["count"] == 1:
+            return json.dumps({"success": False, "error": "gateway timeout"})
+        return json.dumps({"success": True, "platform": "feishu", "chat_id": "home_chat"})
+
+    monkeypatch.setattr("tools.send_message_tool.send_message_tool", fake_send_message_tool)
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="retry_dispatch")
+    result = run_runtime_cycle(
+        store=store,
+        tech_data={"signal": "buy", "score": 10},
+        profile_id="retry_dispatch",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=4,
+    )
+    assert result["pending"]["status"] == "pending"
+
+    failed = dispatch_pending_signal(store=store, profile_id="retry_dispatch", dispatch_target="feishu")
+    assert failed["status"] == "failed"
+    assert store.load_pending_signal()["status"] == "failed"
+
+    reopened = retry_failed_signal(store=store, profile_id="retry_dispatch")
+    assert reopened["status"] == "pending"
+    assert store.load_pending_signal()["status"] == "pending"
+
+    resent = dispatch_pending_signal(store=store, profile_id="retry_dispatch", dispatch_target="feishu")
+    assert resent["status"] == "sent"
+    assert resent["signal"]["status"] == "sent"
+    assert store.load_pending_signal()["status"] == "sent"
+    history = store.read_signal_send_history()
+    assert len(history) == 2
+    assert [row["status"] for row in history] == ["failed", "sent"]
+
+
+def test_build_review_summary_returns_empty_defaults_for_new_profile(tmp_path: Path):
+    from hermes_t.runtime import build_review_summary
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="review_empty")
+
+    summary = build_review_summary(store=store, profile_id="review_empty")
+
+    assert summary == {
+        "profile_id": "review_empty",
+        "pending": {},
+        "active": {},
+        "push_state": {},
+        "dispatch_ledger_tail": [],
+        "signal_send_history_tail": [],
+        "counts": {
+            "dispatch_ledger_count": 0,
+            "signal_send_history_count": 0,
+        },
+    }
+
+
+
+def test_build_review_summary_collects_current_state_and_tail_history(tmp_path: Path):
+    from hermes_t.runtime import build_review_summary
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="review_populated")
+    pending = {"status": "pending", "action": "buy", "text": "低吸第1次"}
+    active = {"status": "sent", "action": "sell", "text": "止盈第1次"}
+    push_state = {"last_status": "sent", "last_target": "feishu", "last_signal_text": "止盈第1次"}
+    store.save_pending_signal(pending)
+    store.save_active_signal(active)
+    store.save_push_state(push_state)
+
+    for idx in range(1, 5):
+        ledger_row = {"status": "sent" if idx % 2 == 0 else "failed", "timestamp": f"t{idx}", "seq": idx}
+        history_row = {"status": "sent" if idx % 2 == 0 else "failed", "timestamp": f"h{idx}", "seq": idx}
+        store.append_dispatch_ledger(ledger_row)
+        store.append_signal_send_history(history_row)
+
+    summary = build_review_summary(store=store, profile_id="review_populated", history_limit=2)
+
+    assert summary["profile_id"] == "review_populated"
+    assert summary["pending"] == pending
+    assert summary["active"] == active
+    assert summary["push_state"] == push_state
+    assert summary["counts"] == {
+        "dispatch_ledger_count": 4,
+        "signal_send_history_count": 4,
+    }
+    assert summary["dispatch_ledger_tail"] == [
+        {"status": "sent", "timestamp": "t2", "seq": 2},
+        {"status": "failed", "timestamp": "t3", "seq": 3},
+        {"status": "sent", "timestamp": "t4", "seq": 4},
+    ][-2:]
+    assert summary["signal_send_history_tail"] == [
+        {"status": "sent", "timestamp": "h2", "seq": 2},
+        {"status": "failed", "timestamp": "h3", "seq": 3},
+        {"status": "sent", "timestamp": "h4", "seq": 4},
+    ][-2:]

--- a/tests/test_trading_runtime.py
+++ b/tests/test_trading_runtime.py
@@ -415,6 +415,193 @@ def test_cli_run_buy_signal_persists_sequence_counter(tmp_path: Path):
     assert payload["summary"]["buy_count"] == 2
 
 
+def test_hermes_t_cli_profiles_config_runs_multiple_profiles_sequentially(tmp_path: Path):
+    """--profiles-config should execute each configured profile and return per-profile results."""
+    profiles_config = tmp_path / "profiles.json"
+    profiles_config.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "profile_id": "olin",
+                        "symbol": "688319",
+                        "trade_unit": 10000,
+                        "max_trades": 4,
+                    },
+                    {
+                        "profile_id": "test_alt",
+                        "symbol": "000001",
+                        "trade_unit": 5000,
+                        "max_trades": 2,
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    quote_path = tmp_path / "quotes.json"
+    quote_path.write_text(
+        json.dumps(
+            {
+                "688319": {"tech_data": {"signal": "buy", "score": 10}},
+                "000001": {"tech_data": {"signal": "sell", "score": 90}},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profiles-config",
+            str(profiles_config),
+            "--quote-data-config",
+            str(quote_path),
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["profile_count"] == 2
+    assert [item["profile_id"] for item in payload["results"]] == ["olin", "test_alt"]
+    assert payload["results"][0]["payload"]["suggestion"]["action"] == "buy"
+    assert payload["results"][1]["payload"]["suggestion"]["action"] == "sell"
+
+
+def test_run_profiles_from_config_returns_summary_for_empty_profiles_list(tmp_path: Path):
+    from hermes_t.orchestrator import run_profiles_from_config
+    from hermes_t.tech_data import StaticTechDataProvider
+
+    profiles_config = tmp_path / "profiles.json"
+    profiles_config.write_text(json.dumps({"profiles": []}, ensure_ascii=False), encoding="utf-8")
+
+    payload = run_profiles_from_config(
+        base_dir=tmp_path,
+        profiles_config_path=profiles_config,
+        tech_data_provider=StaticTechDataProvider({"signal": "hold", "score": 50}),
+    )
+
+    assert payload == {"profile_count": 0, "results": []}
+
+
+def test_hermes_t_cli_profiles_config_falls_back_to_inline_signal_when_symbol_missing(tmp_path: Path):
+    profiles_config = tmp_path / "profiles.json"
+    profiles_config.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "profile_id": "olin",
+                        "symbol": "688319",
+                        "trade_unit": 10000,
+                        "max_trades": 4,
+                    },
+                    {
+                        "profile_id": "test_alt",
+                        "symbol": "000001",
+                        "trade_unit": 5000,
+                        "max_trades": 2,
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    quote_path = tmp_path / "quotes.json"
+    quote_path.write_text(
+        json.dumps(
+            {
+                "688319": {"tech_data": {"signal": "sell", "score": 90}}
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profiles-config",
+            str(profiles_config),
+            "--quote-data-config",
+            str(quote_path),
+            "--signal",
+            "buy",
+            "--score",
+            "15",
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["results"][0]["payload"]["suggestion"]["action"] == "sell"
+    assert payload["results"][1]["payload"]["suggestion"]["action"] == "buy"
+
+
+def test_hermes_t_cli_profiles_config_prefers_tech_data_config_over_quote_data_config(tmp_path: Path):
+    profiles_config = tmp_path / "profiles.json"
+    profiles_config.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "profile_id": "olin",
+                        "symbol": "688319",
+                        "trade_unit": 10000,
+                        "max_trades": 4,
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    tech_data_path = tmp_path / "tech_data.json"
+    tech_data_path.write_text(
+        json.dumps({"688319": {"signal": "buy", "score": 12}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    quote_path = tmp_path / "quotes.json"
+    quote_path.write_text(
+        json.dumps({"688319": {"tech_data": {"signal": "sell", "score": 90}}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profiles-config",
+            str(profiles_config),
+            "--tech-data-config",
+            str(tech_data_path),
+            "--quote-data-config",
+            str(quote_path),
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["results"][0]["payload"]["suggestion"]["action"] == "buy"
+
+
 # ── Quote provider tests ──────────────────────────────────────────────────
 
 

--- a/tests/test_trading_runtime.py
+++ b/tests/test_trading_runtime.py
@@ -1,0 +1,1134 @@
+"""Generic tests for hermes_t TradingStateStore and shared CLI builder."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ── TradingStateStore tests ──────────────────────────────────────────────
+
+
+def test_store_default_base_dir_is_home_based():
+    """TradingStateStore should default to ~/.hermes_t_runtime/<profile_id>."""
+    with pytest.MonkeyPatch.context() as mp:
+        fake_home = Path("/tmp/fake_home")
+        mp.setattr(Path, "home", lambda: fake_home)
+        from hermes_t.store import TradingStateStore
+
+        store = TradingStateStore(profile_id="test_profile")
+        assert store.base_dir == fake_home / ".hermes_t_runtime"
+        assert store.state_dir == fake_home / ".hermes_t_runtime" / "test_profile"
+
+
+def test_store_explicit_base_dir(tmp_path: Path):
+    """Explicit base_dir should be used directly."""
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="p1")
+    assert store.base_dir == tmp_path
+    assert store.state_dir == tmp_path / "p1"
+
+
+def test_store_rejects_profile_id_path_traversal(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    with pytest.raises(ValueError, match="profile_id"):
+        TradingStateStore(base_dir=str(tmp_path), profile_id="../escaped")
+
+
+def test_store_creates_state_dir_on_first_write(tmp_path: Path):
+    """Saving state should create the state directory if it doesn't exist."""
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="created_on_write")
+    assert not store.state_dir.exists()
+    store.save_execution_state({"trade_date": "2026-05-03"})
+    assert store.state_dir.exists()
+
+
+def test_store_load_execution_state_returns_empty_dict_when_missing(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="missing")
+    state = store.load_execution_state()
+    assert state == {}
+
+
+def test_store_save_and_load_pending_signal_roundtrip(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="pending_test")
+    signal = {"signal_id": "sell_1_20260503", "status": "pending", "action": "sell"}
+    store.save_pending_signal(signal)
+    loaded = store.load_pending_signal()
+    assert loaded == signal
+
+
+def test_store_save_pending_signal_overwrites_previous(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="overwrite")
+    store.save_pending_signal({"status": "pending"})
+    store.save_pending_signal({"status": "sent"})
+    loaded = store.load_pending_signal()
+    assert loaded == {"status": "sent"}
+
+
+def test_store_clear_pending_signal_writes_empty_dict(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="clear_test")
+    store.save_pending_signal({"status": "pending"})
+    store.clear_pending_signal()
+    loaded = store.load_pending_signal()
+    assert loaded == {}
+
+
+def test_store_load_position_returns_none_when_missing(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="no_pos")
+    assert store.load_position() is None
+
+
+def test_store_save_and_load_position(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="pos_test")
+    pos = {"symbol": "688319", "total_shares": 220000}
+    store.save_position(pos)
+    loaded = store.load_position()
+    assert loaded == pos
+
+
+def test_store_append_and_read_dispatch_ledger(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="ledger_test")
+    store.append_dispatch_ledger({"trade_date": "2026-05-03", "profit": 1000.0})
+    store.append_dispatch_ledger({"trade_date": "2026-05-04", "profit": 500.0})
+    rows = store.read_dispatch_ledger()
+    assert len(rows) == 2
+    assert rows[0]["profit"] == 1000.0
+    assert rows[1]["profit"] == 500.0
+
+
+def test_store_read_ledger_returns_empty_list_when_not_exists(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    store = TradingStateStore(base_dir=str(tmp_path), profile_id="no_ledger")
+    assert store.read_dispatch_ledger() == []
+
+
+def test_store_profile_scoped_paths_are_isolated(tmp_path: Path):
+    from hermes_t.store import TradingStateStore
+
+    s1 = TradingStateStore(base_dir=str(tmp_path), profile_id="alice")
+    s2 = TradingStateStore(base_dir=str(tmp_path), profile_id="bob")
+    s1.save_execution_state({"sell_count": 1})
+    s2.save_execution_state({"sell_count": 2})
+    assert s1.load_execution_state()["sell_count"] == 1
+    assert s2.load_execution_state()["sell_count"] == 2
+
+
+def test_store_default_base_dir_not_affected_by_cwd(tmp_path: Path):
+    """The default base_dir should not change when cwd changes."""
+    from hermes_t.store import TradingStateStore
+
+    fake_home = Path("/tmp/fake_home_stable")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(Path, "home", lambda: fake_home)
+        store = TradingStateStore(profile_id="stable")
+        assert store.base_dir == fake_home / ".hermes_t_runtime"
+
+
+# ── Shared CLI builder tests ─────────────────────────────────────────────
+
+
+def test_build_runtime_parser_defaults_to_home_based_base_dir():
+    from hermes_t.cli_shared import build_runtime_parser
+
+    fake_home = Path("/tmp/cli_home")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(Path, "home", lambda: fake_home)
+        parser = build_runtime_parser()
+        args = parser.parse_args(["--symbol", "688319", "--trade-unit", "10000"])
+
+    assert args.base_dir == fake_home / ".hermes_t_runtime"
+    assert args.profile_id == "default"
+    assert args.max_trades == 4
+    assert args.signal == "hold"
+    assert args.score == 50
+
+
+def test_build_runtime_parser_prefers_hermes_t_env_over_default():
+    from hermes_t.cli_shared import build_runtime_parser
+
+    fake_dir = "/tmp/hermes_t_env_runtime"
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("HERMES_T_BASE_DIR", fake_dir)
+        parser = build_runtime_parser()
+        args = parser.parse_args(["--symbol", "688319", "--trade-unit", "10000"])
+
+    assert args.base_dir == Path(fake_dir)
+
+
+def test_build_runtime_parser_falls_back_to_hermes_olin_env():
+    from hermes_t.cli_shared import build_runtime_parser
+
+    fake_dir = "/tmp/hermes_olin_env_runtime"
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("HERMES_T_BASE_DIR", raising=False)
+        mp.setenv("HERMES_OLIN_BASE_DIR", fake_dir)
+        parser = build_runtime_parser()
+        args = parser.parse_args(["--symbol", "688319", "--trade-unit", "10000"])
+
+    assert args.base_dir == Path(fake_dir)
+
+
+def test_build_runtime_profile_from_args_builds_valid_profile():
+    from hermes_t.cli_shared import build_runtime_parser, build_runtime_profile_from_args
+
+    parser = build_runtime_parser()
+    args = parser.parse_args([
+        "--profile-id",
+        "olin",
+        "--symbol",
+        "688319",
+        "--trade-unit",
+        "10000",
+        "--max-trades",
+        "3",
+    ])
+    profile = build_runtime_profile_from_args(args)
+
+    assert profile.profile_id == "olin"
+    assert profile.symbol == "688319"
+    assert profile.trade_unit == 10000
+    assert profile.max_trades == 3
+
+
+@pytest.mark.parametrize("field_name, argv", [
+    ("profile_id", ["--profile-id", "   ", "--symbol", "688319", "--trade-unit", "10000"]),
+    ("symbol", ["--symbol", "   ", "--trade-unit", "10000"]),
+])
+def test_build_runtime_profile_from_args_rejects_blank_required_strings(field_name: str, argv: list[str]):
+    from hermes_t.cli_shared import build_runtime_parser, build_runtime_profile_from_args
+
+    parser = build_runtime_parser()
+    args = parser.parse_args(argv)
+
+    with pytest.raises(ValueError, match=field_name):
+        build_runtime_profile_from_args(args)
+
+
+@pytest.mark.parametrize("argv, field_name", [
+    (["--symbol", "688319", "--trade-unit", "0"], "trade_unit"),
+    (["--symbol", "688319", "--trade-unit", "10000", "--max-trades", "0"], "max_trades"),
+    (["--symbol", "688319", "--trade-unit", "-1"], "trade_unit"),
+    (["--symbol", "688319", "--trade-unit", "10000", "--max-trades", "-2"], "max_trades"),
+])
+def test_build_runtime_profile_from_args_rejects_non_positive_ints(argv: list[str], field_name: str):
+    from hermes_t.cli_shared import build_runtime_parser, build_runtime_profile_from_args
+
+    parser = build_runtime_parser()
+    args = parser.parse_args(argv)
+
+    with pytest.raises(ValueError, match=field_name):
+        build_runtime_profile_from_args(args)
+
+
+def test_build_runtime_profile_from_args_rejects_bool_trade_unit():
+    from argparse import Namespace
+
+    from hermes_t.cli_shared import build_runtime_profile_from_args
+
+    args = Namespace(
+        profile_id="default",
+        symbol="688319",
+        trade_unit=True,
+        max_trades=4,
+        base_dir=Path("/tmp/x"),
+        signal="hold",
+        score=50,
+        dispatch=False,
+        trade_date=None,
+    )
+
+    with pytest.raises(ValueError, match="trade_unit"):
+        build_runtime_profile_from_args(args)
+
+
+def test_build_runtime_profile_from_args_rejects_bool_max_trades():
+    from argparse import Namespace
+
+    from hermes_t.cli_shared import build_runtime_profile_from_args
+
+    args = Namespace(
+        profile_id="default",
+        symbol="688319",
+        trade_unit=10000,
+        max_trades=True,
+        base_dir=Path("/tmp/x"),
+        signal="hold",
+        score=50,
+        dispatch=False,
+        trade_date=None,
+    )
+
+    with pytest.raises(ValueError, match="max_trades"):
+        build_runtime_profile_from_args(args)
+
+
+def test_build_runtime_store_returns_trading_state_store(tmp_path: Path):
+    from hermes_t.cli_shared import RuntimeProfile, build_runtime_store
+    from hermes_t.store import TradingStateStore
+
+    profile = RuntimeProfile(profile_id="olin", symbol="688319", trade_unit=10000, max_trades=4)
+    store = build_runtime_store(tmp_path, profile, prefer_legacy_olin_store=False)
+
+    assert isinstance(store, TradingStateStore)
+    assert store.base_dir == tmp_path
+    assert store.profile_id == "olin"
+
+
+# ── hermes_t CLI (__main__) tests ────────────────────────────────────────
+
+
+def test_hermes_t_cli_outputs_runtime_cycle_json(tmp_path: Path):
+    """CLI should execute run_runtime_cycle() and output runtime result JSON."""
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profile-id",
+            "test_profile",
+            "--symbol",
+            "688319",
+            "--trade-unit",
+            "20000",
+            "--max-trades",
+            "5",
+            "--signal",
+            "sell",
+            "--score",
+            "90",
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["pending"]["status"] == "pending"
+    assert payload["pending"]["action"] == "sell"
+    assert payload["suggestion"]["action"] == "sell"
+    assert payload["suggestion"]["unit"] == 20000
+    assert "summary" in payload
+
+
+def test_hermes_t_cli_defaults_to_home_based_dir_and_persists_state():
+    """CLI should default base_dir to ~/.hermes_t_runtime/<profile_id> and persist runtime state."""
+    import uuid
+
+    fake_home = Path("/tmp/fake_cli_home")
+    profile_id = f"def_{uuid.uuid4().hex[:8]}"
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--profile-id",
+            profile_id,
+            "--symbol",
+            "688319",
+            "--trade-unit",
+            "10000",
+            "--signal",
+            "buy",
+            "--score",
+            "20",
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+        env={**os.environ, "HOME": str(fake_home)},
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["pending"]["action"] == "buy"
+    state_path = fake_home / ".hermes_t_runtime" / profile_id / "execution_state.json"
+    assert state_path.exists()
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["profile_id"] == profile_id
+    assert state["symbol"] == "688319"
+
+
+def test_cli_run_buy_signal_persists_sequence_counter(tmp_path: Path):
+    """Runtime state written by first run should affect second run summary."""
+    profile_dir = tmp_path / "persist_test"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "execution_state.json").write_text(
+        json.dumps(
+            {
+                "trade_date": "2026-05-03",
+                "buy_count": 1,
+                "sell_count": 0,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profile-id",
+            "persist_test",
+            "--symbol",
+            "688319",
+            "--trade-unit",
+            "10000",
+            "--signal",
+            "buy",
+            "--score",
+            "15",
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["pending"]["seq"] == 2
+    assert payload["summary"]["buy_count"] == 2
+
+
+# ── Quote provider tests ──────────────────────────────────────────────────
+
+
+def test_json_quote_data_provider_returns_raw_payload_for_symbol(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteDataProvider
+
+    quote_map = {
+        "688319": {
+            "symbol": "688319",
+            "last_price": 18.23,
+            "tech_data": {"signal": "sell", "score": 88},
+        }
+    }
+    config_path = tmp_path / "quotes.json"
+    config_path.write_text(json.dumps(quote_map, ensure_ascii=False), encoding="utf-8")
+
+    provider = JsonQuoteDataProvider(config_path)
+
+    assert provider.get("688319") == quote_map["688319"]
+
+
+def test_json_quote_data_provider_returns_empty_dict_for_unknown_symbol(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteDataProvider
+
+    config_path = tmp_path / "quotes.json"
+    config_path.write_text(json.dumps({"688319": {"last_price": 18.23}}), encoding="utf-8")
+
+    provider = JsonQuoteDataProvider(config_path)
+
+    assert provider.get("000001") == {}
+
+
+def test_quote_tech_data_adapter_extracts_tech_data(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteDataProvider, QuoteTechDataAdapter
+
+    quote_map = {
+        "688319": {
+            "symbol": "688319",
+            "last_price": 18.23,
+            "tech_data": {"signal": "sell", "score": 88},
+        }
+    }
+    config_path = tmp_path / "quotes.json"
+    config_path.write_text(json.dumps(quote_map, ensure_ascii=False), encoding="utf-8")
+
+    adapter = QuoteTechDataAdapter(
+        JsonQuoteDataProvider(config_path),
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert adapter.get("688319") == {"signal": "sell", "score": 88}
+
+
+def test_quote_tech_data_adapter_returns_default_when_tech_data_missing(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteDataProvider, QuoteTechDataAdapter
+
+    config_path = tmp_path / "quotes.json"
+    config_path.write_text(json.dumps({"688319": {"last_price": 18.23}}), encoding="utf-8")
+
+    adapter = QuoteTechDataAdapter(
+        JsonQuoteDataProvider(config_path),
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert adapter.get("688319") == {"signal": "hold", "score": 50}
+
+
+def test_build_tech_data_provider_from_quote_data_config_returns_adapter(tmp_path: Path):
+    from hermes_t.tech_data import QuoteTechDataAdapter, build_tech_data_provider
+
+    config_path = tmp_path / "quotes.json"
+    config_path.write_text(
+        json.dumps({"688319": {"tech_data": {"signal": "buy", "score": 20}}}),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        quote_data_config_path=config_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert isinstance(provider, QuoteTechDataAdapter)
+    assert provider.get("688319") == {"signal": "buy", "score": 20}
+
+
+def test_build_tech_data_provider_without_config_returns_default_provider():
+    from hermes_t.tech_data import build_tech_data_provider
+
+    provider = build_tech_data_provider(default_tech_data={"signal": "hold", "score": 50})
+
+    assert provider.get("688319") == {"signal": "hold", "score": 50}
+
+
+def test_hermes_t_cli_with_quote_data_config_uses_file_provider(tmp_path: Path):
+    """--quote-data-config should load tech_data from file instead of inline args."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    quote_path = tmp_path / "quotes.json"
+    quote_path.write_text(
+        json.dumps(
+            {"688319": {"tech_data": {"signal": "sell", "score": 85}}},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profile-id",
+            "quote_cli_test",
+            "--symbol",
+            "688319",
+            "--trade-unit",
+            "10000",
+            "--quote-data-config",
+            str(quote_path),
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["suggestion"]["action"] == "sell"
+    assert payload["pending"]["status"] == "pending"
+
+
+def test_hermes_t_cli_with_quote_snapshot_config_uses_snapshot_provider(tmp_path: Path):
+    """--quote-snapshot-config should load tech_data from snapshot factory config."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    snapshot_path = tmp_path / "snapshots.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {"688319": {"tech_data": {"signal": "buy", "score": 15}}},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    factory_path = tmp_path / "quote_snapshot_config.json"
+    factory_path.write_text(
+        json.dumps({"source": "file", "snapshot_path": str(snapshot_path)}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profile-id",
+            "snapshot_cli_test",
+            "--symbol",
+            "688319",
+            "--trade-unit",
+            "10000",
+            "--quote-snapshot-config",
+            str(factory_path),
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["suggestion"]["action"] == "buy"
+    assert payload["pending"]["status"] == "pending"
+
+
+# ── Quote snapshot source tests ────────────────────────────────────────────
+
+
+def test_json_quote_snapshot_source_returns_snapshot_for_symbol(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteSnapshotSource
+
+    snapshot_map = {
+        "688319": {
+            "symbol": "688319",
+            "last_price": 18.88,
+            "source": "file",
+        }
+    }
+    snapshot_path = tmp_path / "snapshots.json"
+    snapshot_path.write_text(json.dumps(snapshot_map, ensure_ascii=False), encoding="utf-8")
+
+    source = JsonQuoteSnapshotSource(snapshot_path)
+
+    assert source.get("688319") == snapshot_map["688319"]
+
+
+def test_json_quote_snapshot_source_returns_empty_dict_for_unknown_symbol(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteSnapshotSource
+
+    snapshot_path = tmp_path / "snapshots.json"
+    snapshot_path.write_text(json.dumps({"688319": {"last_price": 18.88}}), encoding="utf-8")
+
+    source = JsonQuoteSnapshotSource(snapshot_path)
+
+    assert source.get("000001") == {}
+
+
+def test_build_quote_snapshot_provider_with_unsupported_source_raises():
+    from hermes_t.tech_data import build_quote_snapshot_provider
+
+    with pytest.raises(ValueError, match="unsupported quote snapshot source"):
+        build_quote_snapshot_provider({"source": "unknown"})
+
+
+class _RaisingSnapshotSource:
+    def get(self, symbol: str) -> dict[str, object]:
+        raise RuntimeError(f"boom:{symbol}")
+
+
+def test_quote_snapshot_tech_data_adapter_extracts_tech_data(tmp_path: Path):
+    from hermes_t.tech_data import JsonQuoteSnapshotSource, QuoteSnapshotTechDataAdapter
+
+    snapshot_map = {
+        "688319": {
+            "symbol": "688319",
+            "last_price": 18.66,
+            "source": "file",
+            "tech_data": {"signal": "buy", "score": 22},
+        }
+    }
+    snapshot_path = tmp_path / "snapshots.json"
+    snapshot_path.write_text(json.dumps(snapshot_map, ensure_ascii=False), encoding="utf-8")
+
+    adapter = QuoteSnapshotTechDataAdapter(
+        JsonQuoteSnapshotSource(snapshot_path),
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert adapter.get("688319") == {"signal": "buy", "score": 22}
+
+
+def test_quote_snapshot_tech_data_adapter_falls_back_to_default_on_source_error():
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter
+
+    adapter = QuoteSnapshotTechDataAdapter(
+        _RaisingSnapshotSource(),
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert adapter.get("688319") == {"signal": "hold", "score": 50}
+
+
+def test_build_tech_data_provider_from_quote_snapshot_config_returns_adapter(tmp_path: Path):
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+
+    factory_path = tmp_path / "quote_snapshot_config.json"
+    snapshot_path = tmp_path / "snapshots.json"
+    snapshot_path.write_text(
+        json.dumps({"688319": {"tech_data": {"signal": "sell", "score": 77}}}),
+        encoding="utf-8",
+    )
+    factory_path.write_text(
+        json.dumps({"source": "file", "snapshot_path": str(snapshot_path)}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        quote_snapshot_config_path=factory_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+    assert provider.get("688319") == {"signal": "sell", "score": 77}
+
+
+def test_build_tech_data_provider_quote_data_config_takes_precedence_over_quote_snapshot_config(tmp_path: Path):
+    from hermes_t.tech_data import QuoteTechDataAdapter, build_tech_data_provider
+
+    quote_data_path = tmp_path / "quotes.json"
+    quote_snapshot_factory_path = tmp_path / "quote_snapshot_config.json"
+    snapshot_path = tmp_path / "snapshots.json"
+
+    quote_data_path.write_text(
+        json.dumps({"688319": {"tech_data": {"signal": "buy", "score": 11}}}),
+        encoding="utf-8",
+    )
+    snapshot_path.write_text(
+        json.dumps({"688319": {"tech_data": {"signal": "sell", "score": 88}}}),
+        encoding="utf-8",
+    )
+    quote_snapshot_factory_path.write_text(
+        json.dumps({"source": "file", "snapshot_path": str(snapshot_path)}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        quote_data_config_path=quote_data_path,
+        quote_snapshot_config_path=quote_snapshot_factory_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert isinstance(provider, QuoteTechDataAdapter)
+    assert provider.get("688319") == {"signal": "buy", "score": 11}
+
+
+def test_build_tech_data_provider_resolves_relative_snapshot_path_from_config_dir(tmp_path: Path):
+    from hermes_t.tech_data import build_tech_data_provider
+
+    config_dir = tmp_path / "configs"
+    snapshots_dir = config_dir / "data"
+    snapshots_dir.mkdir(parents=True)
+
+    snapshot_path = snapshots_dir / "snapshots.json"
+    snapshot_path.write_text(
+        json.dumps({"688319": {"tech_data": {"signal": "sell", "score": 66}}}),
+        encoding="utf-8",
+    )
+
+    factory_path = config_dir / "quote_snapshot_config.json"
+    factory_path.write_text(
+        json.dumps({"source": "file", "snapshot_path": "data/snapshots.json"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        quote_snapshot_config_path=factory_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert provider.get("688319") == {"signal": "sell", "score": 66}
+
+
+class _FakeTdxAPI:
+    server_plans: dict[tuple[str, int], dict[str, object]] = {}
+    instances: list["_FakeTdxAPI"] = []
+
+    def __init__(self):
+        self.connected_to: tuple[str, int] | None = None
+        self.disconnected = False
+        self.calls: list[tuple[int, str]] = []
+        type(self).instances.append(self)
+
+    def connect(self, host: str, port: int) -> bool:
+        plan = type(self).server_plans[(host, port)]
+        if plan.get("connect_error"):
+            raise plan["connect_error"]  # type: ignore[misc]
+        if not plan.get("connect", True):
+            return False
+        self.connected_to = (host, port)
+        return True
+
+    def get_security_quotes(self, codes: list[tuple[int, str]]):
+        assert self.connected_to is not None
+        plan = type(self).server_plans[self.connected_to]
+        self.calls.extend(codes)
+        error = plan.get("quote_error")
+        if error:
+            raise error  # type: ignore[misc]
+        return plan.get("quotes", [])
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+
+def test_build_quote_snapshot_provider_with_tdx_source_returns_tdx_source():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource, build_quote_snapshot_provider
+
+    provider = build_quote_snapshot_provider(
+        {
+            "source": "tdx",
+            "api_cls": _FakeTdxAPI,
+            "servers": [["127.0.0.1", 7709]],
+        }
+    )
+
+    assert isinstance(provider, TdxQuoteSnapshotSource)
+
+
+
+def test_tdx_quote_snapshot_source_market_by_symbol_overrides_default_market():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    _FakeTdxAPI.instances = []
+    _FakeTdxAPI.server_plans = {
+        ("good-host", 7710): {
+            "quotes": [
+                {
+                    "price": 18.52,
+                    "servertime": "14:55:01",
+                }
+            ]
+        },
+    }
+
+    source = TdxQuoteSnapshotSource(
+        api_cls=_FakeTdxAPI,
+        servers=[("good-host", 7710)],
+        market_by_symbol={"688319": 0},
+    )
+
+    snapshot = source.get("688319")
+
+    assert snapshot["last_price"] == 18.52
+    assert len(_FakeTdxAPI.instances) == 1
+    assert _FakeTdxAPI.instances[0].calls == [(0, "688319")]
+
+
+
+def test_tdx_quote_snapshot_source_fails_over_and_normalizes_snapshot():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    _FakeTdxAPI.instances = []
+    _FakeTdxAPI.server_plans = {
+        ("bad-host", 7709): {"connect_error": ConnectionError("first server down")},
+        ("good-host", 7710): {
+            "quotes": [
+                {
+                    "price": 18.52,
+                    "servertime": "14:55:01",
+                }
+            ]
+        },
+    }
+
+    source = TdxQuoteSnapshotSource(
+        api_cls=_FakeTdxAPI,
+        servers=[("bad-host", 7709), ("good-host", 7710)],
+    )
+
+    snapshot = source.get("688319")
+
+    assert snapshot["symbol"] == "688319"
+    assert snapshot["last_price"] == 18.52
+    assert snapshot["source"] == "tdx_tcp"
+    assert snapshot["as_of"] == "14:55:01"
+    assert len(_FakeTdxAPI.instances) == 2
+    assert _FakeTdxAPI.instances[1].calls == [(1, "688319")]
+    assert _FakeTdxAPI.instances[1].disconnected is True
+
+
+def test_tdx_quote_snapshot_source_raises_when_all_servers_fail():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    _FakeTdxAPI.instances = []
+    _FakeTdxAPI.server_plans = {
+        ("bad-host-1", 7709): {"connect_error": ConnectionError("down1")},
+        ("bad-host-2", 7710): {"quote_error": RuntimeError("down2"), "quotes": []},
+    }
+
+    source = TdxQuoteSnapshotSource(
+        api_cls=_FakeTdxAPI,
+        servers=[("bad-host-1", 7709), ("bad-host-2", 7710)],
+    )
+
+    with pytest.raises(RuntimeError, match="all tdx servers failed"):
+        source.get("688319")
+
+
+
+def test_tdx_quote_snapshot_source_raises_on_empty_quote():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    _FakeTdxAPI.instances = []
+    _FakeTdxAPI.server_plans = {
+        ("good-host", 7710): {"quotes": []},
+    }
+
+    source = TdxQuoteSnapshotSource(
+        api_cls=_FakeTdxAPI,
+        servers=[("good-host", 7710)],
+    )
+
+    with pytest.raises(ValueError, match="empty tdx quote"):
+        source.get("688319")
+
+
+
+def test_tdx_quote_snapshot_source_raises_on_non_positive_price():
+    from hermes_t.tech_data import TdxQuoteSnapshotSource
+
+    _FakeTdxAPI.instances = []
+    _FakeTdxAPI.server_plans = {
+        ("good-host", 7710): {"quotes": [{"price": 0, "servertime": "14:55:01"}]},
+    }
+
+    source = TdxQuoteSnapshotSource(
+        api_cls=_FakeTdxAPI,
+        servers=[("good-host", 7710)],
+    )
+
+    with pytest.raises(ValueError, match="non-positive tdx price"):
+        source.get("688319")
+
+
+
+def test_build_tech_data_provider_with_tdx_snapshot_config_falls_back_to_default_on_source_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+    import hermes_t.tech_data as tech_data_module
+
+    factory_path = tmp_path / "quote_snapshot_tdx.json"
+    factory_path.write_text(
+        json.dumps(
+            {
+                "source": "tdx",
+                "servers": [["bad-host", 7709]],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(tech_data_module, "_import_tdx_api_cls", lambda: _FakeTdxAPI)
+    _FakeTdxAPI.instances = []
+    _FakeTdxAPI.server_plans = {
+        ("bad-host", 7709): {"connect_error": ConnectionError("down")},
+    }
+
+    provider = build_tech_data_provider(
+        quote_snapshot_config_path=factory_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+    assert provider.get("688319") == {"signal": "hold", "score": 50}
+
+
+
+def test_build_quote_snapshot_provider_with_eastmoney_source_returns_placeholder_source():
+    from hermes_t.tech_data import EastmoneyQuoteSnapshotSource, build_quote_snapshot_provider
+
+    provider = build_quote_snapshot_provider({"source": "eastmoney"})
+
+    assert isinstance(provider, EastmoneyQuoteSnapshotSource)
+
+
+
+def test_eastmoney_quote_snapshot_source_uses_default_http_fetcher(monkeypatch: pytest.MonkeyPatch):
+    from hermes_t.tech_data import EastmoneyQuoteSnapshotSource
+    import hermes_t.tech_data as tech_data_module
+
+    calls: list[str] = []
+
+    def _fake_fetcher(secid: str):
+        calls.append(secid)
+        return {"data": {"f43": 185200, "f86": "20260503 14:55:01"}}
+
+    monkeypatch.setattr(tech_data_module, "_import_eastmoney_fetcher", lambda: _fake_fetcher)
+
+    source = EastmoneyQuoteSnapshotSource()
+
+    assert source.get("688319") == {
+        "symbol": "688319",
+        "last_price": 18.52,
+        "source": "eastmoney",
+        "as_of": "20260503 14:55:01",
+    }
+    assert calls == ["1.688319"]
+
+
+
+def test_build_tech_data_provider_with_eastmoney_snapshot_config_falls_back_to_default(tmp_path: Path):
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+
+    factory_path = tmp_path / "quote_snapshot_eastmoney.json"
+    factory_path.write_text(
+        json.dumps(
+            {
+                "source": "eastmoney",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    provider = build_tech_data_provider(
+        quote_snapshot_config_path=factory_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+    assert provider.get("688319") == {"signal": "hold", "score": 50}
+
+
+class _FakeEastmoneyFetcher:
+    payloads_by_secid: dict[str, object] = {}
+    calls: list[str] = []
+
+    def __call__(self, secid: str):
+        type(self).calls.append(secid)
+        payload = type(self).payloads_by_secid[secid]
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+
+
+def test_eastmoney_quote_snapshot_source_normalizes_snapshot_and_market_override():
+    from hermes_t.tech_data import EastmoneyQuoteSnapshotSource
+
+    _FakeEastmoneyFetcher.payloads_by_secid = {
+        "0.688319": {
+            "data": {
+                "f43": 185200,
+                "f86": "20260503 14:55:01",
+                "tech_data": {"signal": "sell", "score": 72},
+            }
+        }
+    }
+    _FakeEastmoneyFetcher.calls = []
+
+    source = EastmoneyQuoteSnapshotSource(
+        fetcher=_FakeEastmoneyFetcher(),
+        market_by_symbol={"688319": 0},
+    )
+
+    snapshot = source.get("688319")
+
+    assert snapshot == {
+        "symbol": "688319",
+        "last_price": 18.52,
+        "source": "eastmoney",
+        "as_of": "20260503 14:55:01",
+        "tech_data": {"signal": "sell", "score": 72},
+    }
+    assert _FakeEastmoneyFetcher.calls == ["0.688319"]
+
+
+
+def test_build_tech_data_provider_with_eastmoney_snapshot_config_returns_adapter_and_extracts_tech_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from hermes_t.tech_data import QuoteSnapshotTechDataAdapter, build_tech_data_provider
+    import hermes_t.tech_data as tech_data_module
+
+    factory_path = tmp_path / "quote_snapshot_eastmoney_live.json"
+    factory_path.write_text(
+        json.dumps(
+            {
+                "source": "eastmoney",
+                "market_by_symbol": {"688319": 0},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _FakeEastmoneyFetcher.payloads_by_secid = {
+        "0.688319": {
+            "data": {
+                "f43": 185200,
+                "f86": "20260503 14:55:01",
+                "tech_data": {"signal": "sell", "score": 72},
+            }
+        }
+    }
+    _FakeEastmoneyFetcher.calls = []
+    monkeypatch.setattr(tech_data_module, "_import_eastmoney_fetcher", lambda: _FakeEastmoneyFetcher())
+
+    provider = build_tech_data_provider(
+        quote_snapshot_config_path=factory_path,
+        default_tech_data={"signal": "hold", "score": 50},
+    )
+
+    assert isinstance(provider, QuoteSnapshotTechDataAdapter)
+    assert provider.get("688319") == {"signal": "sell", "score": 72}
+    assert _FakeEastmoneyFetcher.calls == ["0.688319"]
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, object]):
+        self.payload = payload
+        self.raise_for_status_called = False
+
+    def raise_for_status(self):
+        self.raise_for_status_called = True
+
+    def json(self):
+        return self.payload
+
+
+
+def test_import_eastmoney_fetcher_returns_http_fetcher_using_expected_request_contract(monkeypatch: pytest.MonkeyPatch):
+    import hermes_t.tech_data as tech_data_module
+
+    calls: list[dict[str, object]] = []
+    response = _FakeResponse({"data": {"f43": 185200}})
+
+    class _FakeRequestsModule:
+        @staticmethod
+        def get(url: str, *, params: dict[str, object], timeout: int):
+            calls.append({"url": url, "params": params, "timeout": timeout})
+            return response
+
+    monkeypatch.setattr(tech_data_module, "_import_requests_module", lambda: _FakeRequestsModule)
+
+    fetcher = tech_data_module._import_eastmoney_fetcher()
+    payload = fetcher("0.688319")
+
+    assert payload == {"data": {"f43": 185200}}
+    assert calls == [
+        {
+            "url": "https://push2.eastmoney.com/api/qt/stock/get",
+            "params": {
+                "secid": "0.688319",
+                "fields": "f43,f57,f58,f86",
+                "invt": "2",
+                "fltt": "1",
+            },
+            "timeout": 10,
+        }
+    ]
+    assert response.raise_for_status_called is True

--- a/tests/test_trading_runtime.py
+++ b/tests/test_trading_runtime.py
@@ -488,6 +488,66 @@ def test_hermes_t_cli_profiles_config_runs_multiple_profiles_sequentially(tmp_pa
     assert payload["results"][1]["payload"]["suggestion"]["action"] == "sell"
 
 
+def test_hermes_t_cli_dispatch_flag_returns_dispatch_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from hermes_t import __main__ as cli_main
+
+    def fake_dispatch_pending_signal(*, store, profile_id: str, dispatch_target: str = "feishu"):
+        pending = store.load_pending_signal()
+        return {
+            "status": "sent",
+            "profile_id": profile_id,
+            "dispatch_target": dispatch_target,
+            "signal": {**pending, "status": "sent"},
+        }
+
+    monkeypatch.setattr(cli_main, "dispatch_pending_signal", fake_dispatch_pending_signal)
+
+    payload = cli_main._build_payload(
+        cli_main.build_runtime_parser().parse_args(
+            [
+                "--base-dir",
+                str(tmp_path),
+                "--profile-id",
+                "dispatch_cli",
+                "--symbol",
+                "688319",
+                "--trade-unit",
+                "10000",
+                "--signal",
+                "buy",
+                "--score",
+                "15",
+                "--dispatch",
+            ]
+        ),
+        cli_main.build_runtime_profile_from_args(
+            cli_main.build_runtime_parser().parse_args(
+                [
+                    "--base-dir",
+                    str(tmp_path),
+                    "--profile-id",
+                    "dispatch_cli",
+                    "--symbol",
+                    "688319",
+                    "--trade-unit",
+                    "10000",
+                    "--signal",
+                    "buy",
+                    "--score",
+                    "15",
+                    "--dispatch",
+                ]
+            )
+        ),
+    )
+
+    assert payload["pending"]["status"] == "pending"
+    assert payload["dispatch"]["status"] == "sent"
+    assert payload["dispatch"]["profile_id"] == "dispatch_cli"
+    assert payload["dispatch"]["dispatch_target"] == "feishu"
+    assert payload["dispatch"]["signal"]["status"] == "sent"
+
+
 def test_run_profiles_from_config_returns_summary_for_empty_profiles_list(tmp_path: Path):
     from hermes_t.orchestrator import run_profiles_from_config
     from hermes_t.tech_data import StaticTechDataProvider
@@ -568,6 +628,48 @@ def test_hermes_t_cli_profiles_config_falls_back_to_inline_signal_when_symbol_mi
 
     assert payload["results"][0]["payload"]["suggestion"]["action"] == "sell"
     assert payload["results"][1]["payload"]["suggestion"]["action"] == "buy"
+
+
+def test_hermes_t_cli_single_profile_quote_data_config_falls_back_to_inline_signal_when_symbol_missing(tmp_path: Path):
+    quote_path = tmp_path / "quotes.json"
+    quote_path.write_text(
+        json.dumps(
+            {
+                "000001": {"tech_data": {"signal": "sell", "score": 90}}
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "hermes_t",
+            "--base-dir",
+            str(tmp_path),
+            "--profile-id",
+            "single_missing_symbol",
+            "--symbol",
+            "688319",
+            "--trade-unit",
+            "10000",
+            "--quote-data-config",
+            str(quote_path),
+            "--signal",
+            "buy",
+            "--score",
+            "15",
+        ],
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    payload = json.loads(result.strip())
+
+    assert payload["suggestion"]["action"] == "buy"
+    assert payload["pending"]["action"] == "buy"
+    assert payload["pending"]["seq"] == 1
 
 
 def test_hermes_t_cli_profiles_config_prefers_tech_data_config_over_quote_data_config(tmp_path: Path):

--- a/tests/test_trading_runtime.py
+++ b/tests/test_trading_runtime.py
@@ -303,6 +303,13 @@ def test_build_runtime_store_returns_trading_state_store(tmp_path: Path):
 
 def test_hermes_t_cli_outputs_runtime_cycle_json(tmp_path: Path):
     """CLI should execute run_runtime_cycle() and output runtime result JSON."""
+    profile_dir = tmp_path / "test_profile"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "position.json").write_text(
+        json.dumps({"symbol": "688319", "total_shares": 220000}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
     result = subprocess.check_output(
         [
             sys.executable,
@@ -440,6 +447,12 @@ def test_hermes_t_cli_profiles_config_runs_multiple_profiles_sequentially(tmp_pa
         ),
         encoding="utf-8",
     )
+    test_alt_dir = tmp_path / "test_alt"
+    test_alt_dir.mkdir(parents=True, exist_ok=True)
+    (test_alt_dir / "position.json").write_text(
+        json.dumps({"symbol": "000001", "total_shares": 5000}, ensure_ascii=False),
+        encoding="utf-8",
+    )
     quote_path = tmp_path / "quotes.json"
     quote_path.write_text(
         json.dumps(
@@ -513,6 +526,12 @@ def test_hermes_t_cli_profiles_config_falls_back_to_inline_signal_when_symbol_mi
             },
             ensure_ascii=False,
         ),
+        encoding="utf-8",
+    )
+    olin_dir = tmp_path / "olin"
+    olin_dir.mkdir(parents=True, exist_ok=True)
+    (olin_dir / "position.json").write_text(
+        json.dumps({"symbol": "688319", "total_shares": 220000}, ensure_ascii=False),
         encoding="utf-8",
     )
     quote_path = tmp_path / "quotes.json"
@@ -701,6 +720,13 @@ def test_hermes_t_cli_with_quote_data_config_uses_file_provider(tmp_path: Path):
     import sys
     from pathlib import Path
 
+    profile_dir = tmp_path / "quote_cli_test"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "position.json").write_text(
+        json.dumps({"symbol": "688319", "total_shares": 220000}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
     quote_path = tmp_path / "quotes.json"
     quote_path.write_text(
         json.dumps(
@@ -732,7 +758,7 @@ def test_hermes_t_cli_with_quote_data_config_uses_file_provider(tmp_path: Path):
     payload = json.loads(result.strip())
 
     assert payload["suggestion"]["action"] == "sell"
-    assert payload["pending"]["status"] == "pending"
+    assert payload["suggestion"]["unit"] == 10000
 
 
 def test_hermes_t_cli_with_quote_snapshot_config_uses_snapshot_provider(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a generic `hermes_t` post-market runtime skeleton with CLI entrypoints, state store, signal policy, and quote/tech-data provider split
- add sequential multi-profile orchestration via `--profiles-config`
- harden runtime-cycle semantics for unresolved pending signals, max-trade gating, sell eligibility, and persisted position-state coercion
- expand regression coverage for runtime/CLI edge cases, provider precedence, profile fallback, and sell-path state preconditions

## Testing
- `uv run --active python3 -m pytest -o addopts= tests/test_runtime_cycle.py tests/test_trading_runtime.py -q`\n- independent local diff review after implementation hardening\n\n## Notes\n- follow-up hardening landed in `7c4a176b2`\n- current GitHub Actions runs on this PR appear to be blocked before job start with `action_required` on fork-based workflow runs