### PR TITLE
Harden local runtime compression, Honcho, quick commands, and delegation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3174,6 +3174,36 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
     return {}
 
 
+def _get_task_max_retries(task: str) -> Optional[int]:
+    """Read auxiliary.<task>.max_retries when explicitly configured."""
+    if not task:
+        return None
+    task_config = _get_auxiliary_task_config(task)
+    raw = task_config.get("max_retries")
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        return None
+    return max(0, value)
+
+
+def _apply_task_client_options(client: Any, task: str) -> Any:
+    """Apply per-task OpenAI-SDK options such as max_retries when supported."""
+    max_retries = _get_task_max_retries(task)
+    if max_retries is None:
+        return client
+    with_options = getattr(client, "with_options", None)
+    if not callable(with_options):
+        return client
+    try:
+        return with_options(max_retries=max_retries)
+    except TypeError:
+        # Non-OpenAI adapters may expose a partial with_options signature.
+        return client
+
+
 # ---------------------------------------------------------------------------
 # Anthropic-compatible endpoint detection + image block conversion
 # ---------------------------------------------------------------------------
@@ -3457,6 +3487,7 @@ def call_llm(
                 f"Run: hermes setup")
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    client = _apply_task_client_options(client, task)
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
@@ -3547,6 +3578,7 @@ def call_llm(
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
+                refreshed_client = _apply_task_client_options(refreshed_client, task)
                 logger.info("Auxiliary %s: refreshed Nous runtime credentials after 401, retrying",
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
@@ -3580,6 +3612,7 @@ def call_llm(
                     )
                 )
                 if retry_client is not None:
+                    retry_client = _apply_task_client_options(retry_client, task)
                     retry_kwargs = _build_call_kwargs(
                         resolved_provider,
                         retry_model or final_model,
@@ -3621,6 +3654,7 @@ def call_llm(
             fb_client, fb_model, fb_label = _try_payment_fallback(
                 resolved_provider, task, reason=reason)
             if fb_client is not None:
+                fb_client = _apply_task_client_options(fb_client, task)
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
@@ -3762,6 +3796,7 @@ async def async_call_llm(
                 f"Run: hermes setup")
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    client = _apply_task_client_options(client, task)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish
@@ -3838,6 +3873,7 @@ async def async_call_llm(
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
+                refreshed_client = _apply_task_client_options(refreshed_client, task)
                 logger.info("Auxiliary %s (async): refreshed Nous runtime credentials after 401, retrying",
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
@@ -3870,6 +3906,7 @@ async def async_call_llm(
                         api_mode=resolved_api_mode,
                     )
                 if retry_client is not None:
+                    retry_client = _apply_task_client_options(retry_client, task)
                     retry_kwargs = _build_call_kwargs(
                         resolved_provider,
                         retry_model or final_model,
@@ -3897,6 +3934,7 @@ async def async_call_llm(
             fb_client, fb_model, fb_label = _try_payment_fallback(
                 resolved_provider, task, reason=reason)
             if fb_client is not None:
+                fb_client = _apply_task_client_options(fb_client, task)
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
@@ -3907,6 +3945,7 @@ async def async_call_llm(
                 async_fb, async_fb_model = _to_async_client(
                     fb_client, fb_model or "", is_vision=(task == "vision")
                 )
+                async_fb = _apply_task_client_options(async_fb, task)
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model
                 return _validate_llm_response(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -130,6 +130,42 @@ def _content_text_for_contains(content: Any) -> str:
     return str(content)
 
 
+def _responses_payload_for_budget(msg: Dict[str, Any]) -> Any:
+    """Return the primary text payload for Responses API history entries.
+
+    Codex/OpenAI Responses mode stores tool history as typed input entries
+    instead of ChatCompletions `role=tool` messages.  Treating those entries
+    as empty lets 50-100KB tool outputs hide inside the protected tail and
+    survive compression.  This helper gives pruning/tail budgeting a single
+    view over both shapes without mutating the entry.
+    """
+    mtype = msg.get("type")
+    if mtype == "function_call_output":
+        return msg.get("output") or ""
+    if mtype == "function_call":
+        return msg.get("arguments") or ""
+    if mtype == "reasoning":
+        return msg.get("summary") or msg.get("content") or msg.get("text") or ""
+    return msg.get("content") or ""
+
+
+def _message_length_for_budget(msg: Dict[str, Any]) -> int:
+    """Effective char length for compression token budgeting.
+
+    Includes both ChatCompletions (`content`, `tool_calls[].arguments`) and
+    Responses API (`function_call.arguments`, `function_call_output.output`,
+    `reasoning.summary`) payloads.
+    """
+    total = _content_length_for_budget(_responses_payload_for_budget(msg))
+    if msg.get("type") == "function_call":
+        total += len(str(msg.get("name") or "")) + len(str(msg.get("call_id") or ""))
+    for tc in msg.get("tool_calls") or []:
+        if isinstance(tc, dict):
+            args = tc.get("function", {}).get("arguments", "")
+            total += len(args)
+    return total
+
+
 def _append_text_to_content(content: Any, text: str, *, prepend: bool = False) -> Any:
     """Append or prepend plain text to message content safely.
 
@@ -517,9 +553,15 @@ class ContextCompressor(ContextEngine):
         result = [m.copy() for m in messages]
         pruned = 0
 
-        # Build index: tool_call_id -> (tool_name, arguments_json)
+        # Build index: tool_call_id -> (tool_name, arguments_json).  Support
+        # both ChatCompletions assistant.tool_calls and Responses API typed
+        # function_call entries.
         call_id_to_tool: Dict[str, tuple] = {}
         for msg in result:
+            if msg.get("type") == "function_call":
+                cid = msg.get("call_id", "")
+                if cid:
+                    call_id_to_tool[cid] = (msg.get("name", "unknown"), msg.get("arguments", ""))
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
@@ -533,21 +575,26 @@ class ContextCompressor(ContextEngine):
                         args_str = getattr(fn, "arguments", "") if fn else ""
                         call_id_to_tool[cid] = (name, args_str)
 
+        def _tool_result_payload(msg: Dict[str, Any]) -> tuple[Optional[str], str, str]:
+            """Return (payload_field, call_id, text) for tool result shapes."""
+            if msg.get("role") == "tool":
+                raw = msg.get("content") or ""
+                return "content", msg.get("tool_call_id", ""), _content_text_for_contains(raw)
+            if msg.get("type") == "function_call_output":
+                raw = msg.get("output") or ""
+                return "output", msg.get("call_id", ""), _content_text_for_contains(raw)
+            return None, "", ""
+
         # Determine the prune boundary
         if protect_tail_tokens is not None and protect_tail_tokens > 0:
-            # Token-budget approach: walk backward accumulating tokens
+            # Token-budget approach: walk backward accumulating tokens.  Count
+            # Responses API output/arguments as real payload, not as zero-sized
+            # metadata; otherwise huge function_call_output entries survive.
             accumulated = 0
             boundary = len(result)
             min_protect = min(protect_tail_count, len(result))
             for i in range(len(result) - 1, -1, -1):
-                msg = result[i]
-                raw_content = msg.get("content") or ""
-                content_len = _content_length_for_budget(raw_content)
-                msg_tokens = content_len // _CHARS_PER_TOKEN + 10
-                for tc in msg.get("tool_calls") or []:
-                    if isinstance(tc, dict):
-                        args = tc.get("function", {}).get("arguments", "")
-                        msg_tokens += len(args) // _CHARS_PER_TOKEN
+                msg_tokens = _message_length_for_budget(result[i]) // _CHARS_PER_TOKEN + 10
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
                     break
@@ -558,59 +605,64 @@ class ContextCompressor(ContextEngine):
             prune_boundary = len(result) - protect_tail_count
 
         # Pass 1: Deduplicate identical tool results.
-        # When the same file is read multiple times, keep only the most recent
-        # full copy and replace older duplicates with a back-reference.
+        # When the same file/skill output is read multiple times, keep only the
+        # most recent full copy and replace older duplicates with a back-reference.
         content_hashes: dict = {}  # hash -> (index, tool_call_id)
         for i in range(len(result) - 1, -1, -1):
             msg = result[i]
-            if msg.get("role") != "tool":
-                continue
-            content = msg.get("content") or ""
-            # Skip multimodal content (list of content blocks)
-            if isinstance(content, list):
-                continue
-            if len(content) < 200:
+            field, call_id, content = _tool_result_payload(msg)
+            if not field or len(content) < 200:
                 continue
             h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
             if h in content_hashes:
-                # This is an older duplicate — replace with back-reference
-                result[i] = {**msg, "content": "[Duplicate tool output — same content as a more recent call]"}
+                result[i] = {**msg, field: "[Duplicate tool output — same content as a more recent call]"}
                 pruned += 1
             else:
-                content_hashes[h] = (i, msg.get("tool_call_id", "?"))
+                content_hashes[h] = (i, call_id or "?")
 
-        # Pass 2: Replace old tool results with informative summaries
-        for i in range(prune_boundary):
+        def _replace_tool_output_with_summary(i: int, *, protected_tail: bool = False) -> bool:
             msg = result[i]
-            if msg.get("role") != "tool":
-                continue
-            content = msg.get("content", "")
-            # Skip multimodal content (list of content blocks)
-            if isinstance(content, list):
-                continue
-            if not content or content == _PRUNED_TOOL_PLACEHOLDER:
-                continue
-            # Skip already-deduplicated or previously-summarized results
+            field, call_id, content = _tool_result_payload(msg)
+            if not field or not content or content == _PRUNED_TOOL_PLACEHOLDER:
+                return False
             if content.startswith("[Duplicate tool output"):
-                continue
-            # Only prune if the content is substantial (>200 chars)
-            if len(content) > 200:
-                call_id = msg.get("tool_call_id", "")
-                tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
-                summary = _summarize_tool_result(tool_name, tool_args, content)
-                result[i] = {**msg, "content": summary}
+                return False
+            threshold = self._PROTECTED_TOOL_OUTPUT_MAX if protected_tail else 200
+            if len(content) <= threshold:
+                return False
+            tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
+            summary = _summarize_tool_result(tool_name, tool_args, content)
+            if protected_tail:
+                summary = f"{summary} [protected-tail output clipped from {len(content):,} chars]"
+            result[i] = {**msg, field: summary}
+            return True
+
+        # Pass 2: Replace old tool results with informative summaries.
+        for i in range(max(0, prune_boundary)):
+            if _replace_tool_output_with_summary(i):
                 pruned += 1
 
-        # Pass 3: Truncate large tool_call arguments in assistant messages
-        # outside the protected tail. write_file with 50KB content, for
-        # example, survives pruning entirely without this.
-        #
-        # The shrinking is done inside the parsed JSON structure so the
-        # result remains valid JSON — otherwise downstream providers 400
-        # on every subsequent turn until the broken call falls out of
-        # the window. See ``_truncate_tool_call_args_json`` docstring.
-        for i in range(prune_boundary):
+        # Pass 2b: Even protected-tail tool outputs cannot be unbounded.  A
+        # single recent `skill_view hermes-agent` result can be 90KB+ and make
+        # the post-compression Responses request 100K+ tokens.  Keep the
+        # call/output entry and call_id, but shrink the payload.
+        for i in range(max(0, prune_boundary), len(result)):
+            if _replace_tool_output_with_summary(i, protected_tail=True):
+                pruned += 1
+
+        # Pass 3: Truncate large tool-call arguments.  Historical arguments are
+        # provider payload, not executable state; shrinking string leaves keeps
+        # JSON valid while preventing write_file/execute_code args from bloating
+        # every future request.  Support ChatCompletions and Responses entries.
+        for i in range(len(result)):
             msg = result[i]
+            if msg.get("type") == "function_call":
+                args = msg.get("arguments", "") or ""
+                if len(args) > 500:
+                    new_args = _truncate_tool_call_args_json(args)
+                    if new_args != args:
+                        result[i] = {**msg, "arguments": new_args}
+                continue
             if msg.get("role") != "assistant" or not msg.get("tool_calls"):
                 continue
             new_tcs = []
@@ -652,6 +704,7 @@ class ContextCompressor(ContextEngine):
     _CONTENT_TAIL = 1500      # chars kept from the end
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
+    _PROTECTED_TOOL_OUTPUT_MAX = 12000  # cap huge recent tool outputs too
 
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
@@ -667,7 +720,34 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = redact_sensitive_text(msg.get("content") or "")
+            mtype = msg.get("type")
+
+            # Responses API typed history entries (Codex/Responses mode).  If
+            # these are serialized as unknown empty messages, the summarizer
+            # loses exactly the tool details compression is supposed to retain.
+            if mtype == "function_call":
+                name = msg.get("name", "?")
+                call_id = msg.get("call_id", "")
+                args = redact_sensitive_text(_content_text_for_contains(msg.get("arguments") or ""))
+                if len(args) > self._TOOL_ARGS_MAX:
+                    args = args[:self._TOOL_ARGS_HEAD] + "..."
+                parts.append(f"[FUNCTION CALL {call_id}]: {name}({args})")
+                continue
+            if mtype == "function_call_output":
+                call_id = msg.get("call_id", "")
+                output = redact_sensitive_text(_content_text_for_contains(msg.get("output") or ""))
+                if len(output) > self._CONTENT_MAX:
+                    output = output[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + output[-self._CONTENT_TAIL:]
+                parts.append(f"[FUNCTION CALL OUTPUT {call_id}]: {output}")
+                continue
+            if mtype == "reasoning":
+                reasoning = redact_sensitive_text(_content_text_for_contains(_responses_payload_for_budget(msg)))
+                if len(reasoning) > self._CONTENT_MAX:
+                    reasoning = reasoning[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + reasoning[-self._CONTENT_TAIL:]
+                parts.append(f"[REASONING]: {reasoning}" if reasoning else "[REASONING]: [summary omitted]")
+                continue
+
+            content = redact_sensitive_text(_content_text_for_contains(msg.get("content") or ""))
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":
@@ -708,6 +788,179 @@ class ContextCompressor(ContextEngine):
 
         return "\n\n".join(parts)
 
+    _FALLBACK_EXTRACT_MAX_MESSAGES = 28
+    _FALLBACK_EXTRACT_HEAD_MESSAGES = 6
+    _FALLBACK_EXTRACT_TAIL_MESSAGES = 22
+    _FALLBACK_EXTRACT_MESSAGE_CHARS = 900
+    _FALLBACK_PREVIOUS_SUMMARY_CHARS = 4000
+
+    @staticmethod
+    def _clip_fallback_text(text: Any, limit: int) -> str:
+        """Redact and bound text included in deterministic fallback summaries."""
+        rendered = redact_sensitive_text(_content_text_for_contains(text))
+        rendered = re.sub(r"\n{3,}", "\n\n", rendered).strip()
+        if len(rendered) <= limit:
+            return rendered
+        head = max(0, int(limit * 0.65))
+        tail = max(0, limit - head - 40)
+        clipped = rendered[:head].rstrip()
+        if tail:
+            clipped += "\n...[truncated]...\n" + rendered[-tail:].lstrip()
+        else:
+            clipped += "\n...[truncated]"
+        return clipped
+
+    def _fallback_message_excerpt(self, msg: Dict[str, Any], ordinal: int) -> str:
+        """Render one compact, redacted message/tool-call excerpt for local fallback."""
+        role = msg.get("role", "unknown")
+        mtype = msg.get("type")
+        chunks: list[str] = []
+        if mtype == "function_call":
+            role = "function_call"
+            name = msg.get("name", "?")
+            args = self._clip_fallback_text(msg.get("arguments") or "", 260)
+            chunks.append(f"{name}({args})" if args else f"{name}(...)")
+        elif mtype == "function_call_output":
+            role = "function_call_output"
+            chunks.append(self._clip_fallback_text(msg.get("output") or "", self._FALLBACK_EXTRACT_MESSAGE_CHARS))
+        elif mtype == "reasoning":
+            role = "reasoning"
+            chunks.append(self._clip_fallback_text(_responses_payload_for_budget(msg), self._FALLBACK_EXTRACT_MESSAGE_CHARS))
+        else:
+            content = self._clip_fallback_text(msg.get("content") or "", self._FALLBACK_EXTRACT_MESSAGE_CHARS)
+
+            if content:
+                chunks.append(content)
+
+        tool_calls = msg.get("tool_calls") or []
+        if tool_calls:
+            tc_parts: list[str] = []
+            for tc in tool_calls[:8]:
+                if isinstance(tc, dict):
+                    fn = tc.get("function", {}) if isinstance(tc.get("function"), dict) else {}
+                    name = fn.get("name", "?")
+                    args = self._clip_fallback_text(fn.get("arguments", ""), 220)
+                    tc_parts.append(f"{name}({args})" if args else f"{name}(...)")
+                else:
+                    fn = getattr(tc, "function", None)
+                    name = getattr(fn, "name", "?") if fn else "?"
+                    tc_parts.append(f"{name}(...)")
+            if len(tool_calls) > 8:
+                tc_parts.append(f"... +{len(tool_calls) - 8} more tool call(s)")
+            chunks.append("Tool calls: " + "; ".join(tc_parts))
+
+        if role == "tool":
+            tool_id = msg.get("tool_call_id", "")
+            prefix = f"{ordinal}. [tool result {tool_id}]"
+        else:
+            prefix = f"{ordinal}. [{role}]"
+        body = " | ".join(chunk for chunk in chunks if chunk) or "[no text content]"
+        return f"{prefix} {body}"
+
+    def _generate_extractive_fallback_summary(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        *,
+        focus_topic: str = None,
+    ) -> str:
+        """Build a deterministic local handoff when the summary LLM is unavailable.
+
+        The previous behavior inserted only a generic "summary unavailable"
+        marker.  That prevented silent API failure from crashing compression,
+        but it still destroyed the middle of long tool-heavy sessions when a
+        relay returned 502/504.  This fallback is intentionally extractive and
+        bounded: no provider call, redacted content, recent turns preserved with
+        exact tool/file/error snippets where possible.
+        """
+        total = len(turns_to_summarize)
+        indexed = list(enumerate(turns_to_summarize, start=1))
+        if total > self._FALLBACK_EXTRACT_MAX_MESSAGES:
+            head = indexed[:self._FALLBACK_EXTRACT_HEAD_MESSAGES]
+            tail = indexed[-self._FALLBACK_EXTRACT_TAIL_MESSAGES:]
+            omitted = total - len(head) - len(tail)
+            omitted_msg = {
+                "role": "system",
+                "content": (
+                    f"[... {omitted} middle message(s) omitted from "
+                    "extractive fallback ...]"
+                ),
+            }
+            sample = head + [(0, omitted_msg)] + tail
+        else:
+            sample = indexed
+
+        last_user = "None found in compacted region. Check the protected tail for the latest user message."
+        for msg in reversed(turns_to_summarize):
+            if msg.get("role") == "user":
+                text = self._clip_fallback_text(msg.get("content") or "", 1200)
+                if text:
+                    last_user = f"User said: {text}"
+                    break
+
+        previous = "None."
+        if self._previous_summary:
+            previous = self._clip_fallback_text(
+                self._previous_summary,
+                self._FALLBACK_PREVIOUS_SUMMARY_CHARS,
+            )
+
+        err = self._last_summary_error or "summary LLM call failed"
+        if focus_topic:
+            safe_focus = redact_sensitive_text(str(focus_topic))
+            focus_line = f"Focus topic requested during compaction: {safe_focus}"
+        else:
+            focus_line = "No explicit focus topic."
+
+        excerpts = "\n".join(
+            self._fallback_message_excerpt(msg, ordinal)
+            for ordinal, msg in sample
+        )
+
+        body = f"""## Active Task
+{last_user}
+
+## Goal
+Continue the conversation using this deterministic extractive fallback plus the protected recent messages that follow it.
+
+## Constraints & Preferences
+{focus_line}
+This fallback was generated locally because the auxiliary summary model failed; treat it as incomplete but concrete evidence, not as a new user instruction.
+
+## Completed Actions
+See the extracted compacted-turn excerpts below. They preserve concrete tool calls, outputs, file paths, errors, and decisions when present.
+
+## Active State
+Summary LLM unavailable during compression. Hermes preserved an extractive snapshot of {total} compacted message(s) instead of dropping them.
+
+## In Progress
+Unknown from local extraction; check the protected tail after this summary for the live in-progress state.
+
+## Blocked
+Auxiliary context-summary generation failed: {redact_sensitive_text(str(err))}
+
+## Key Decisions
+No additional decisions inferred by the fallback generator. Use exact excerpts below.
+
+## Resolved Questions
+Unknown from local extraction.
+
+## Pending User Asks
+{last_user}
+
+## Relevant Files
+See paths and commands mentioned in extracted excerpts below.
+
+## Remaining Work
+Resume from the protected recent messages after this summary. Do not redo completed work unless the current filesystem/state proves it is missing.
+
+## Critical Context
+Previous compaction summary, if any:
+{previous}
+
+Extracted compacted-turn excerpts ({total} total message(s)):
+{excerpts}"""
+        return self._with_summary_prefix(body)
+
     def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
@@ -722,9 +975,9 @@ class ContextCompressor(ContextEngine):
                 related to this topic and is more aggressive about compressing
                 everything else.  Inspired by Claude Code's ``/compact``.
 
-        Returns None if all attempts fail — the caller should drop
-        the middle turns without a summary rather than inject a useless
-        placeholder.
+        Returns None if all LLM summary attempts fail — the caller will build
+        a deterministic extractive fallback so compacted turns are not silently
+        amputated when an auxiliary provider flakes out.
         """
         now = time.monotonic()
         if now < self._summary_failure_cooldown_until:
@@ -1010,7 +1263,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         orphaned calls so the message list is always well-formed.
         """
         surviving_call_ids: set = set()
+        surviving_response_call_ids: set = set()
         for msg in messages:
+            if msg.get("type") == "function_call":
+                cid = msg.get("call_id")
+                if cid:
+                    surviving_response_call_ids.add(cid)
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
                     cid = self._get_tool_call_id(tc)
@@ -1018,28 +1276,49 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                         surviving_call_ids.add(cid)
 
         result_call_ids: set = set()
+        response_result_call_ids: set = set()
         for msg in messages:
+            if msg.get("type") == "function_call_output":
+                cid = msg.get("call_id")
+                if cid:
+                    response_result_call_ids.add(cid)
             if msg.get("role") == "tool":
                 cid = msg.get("tool_call_id")
                 if cid:
                     result_call_ids.add(cid)
 
-        # 1. Remove tool results whose call_id has no matching assistant tool_call
+        # 1. Remove tool results whose call_id has no matching tool call.
         orphaned_results = result_call_ids - surviving_call_ids
-        if orphaned_results:
+        orphaned_response_results = response_result_call_ids - surviving_response_call_ids
+        if orphaned_results or orphaned_response_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (
+                    (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                    or (m.get("type") == "function_call_output" and m.get("call_id") in orphaned_response_results)
+                )
             ]
             if not self.quiet_mode:
-                logger.info("Compression sanitizer: removed %d orphaned tool result(s)", len(orphaned_results))
+                logger.info(
+                    "Compression sanitizer: removed %d orphaned tool result(s), %d orphaned Responses output(s)",
+                    len(orphaned_results), len(orphaned_response_results),
+                )
 
-        # 2. Add stub results for assistant tool_calls whose results were dropped
+        # 2. Add stub results for tool calls whose results were dropped.
         missing_results = surviving_call_ids - result_call_ids
-        if missing_results:
+        missing_response_results = surviving_response_call_ids - response_result_call_ids
+        if missing_results or missing_response_results:
             patched: List[Dict[str, Any]] = []
             for msg in messages:
                 patched.append(msg)
+                if msg.get("type") == "function_call":
+                    cid = msg.get("call_id")
+                    if cid in missing_response_results:
+                        patched.append({
+                            "type": "function_call_output",
+                            "call_id": cid,
+                            "output": "[Result from earlier conversation — see context summary above]",
+                        })
                 if msg.get("role") == "assistant":
                     for tc in msg.get("tool_calls") or []:
                         cid = self._get_tool_call_id(tc)
@@ -1051,7 +1330,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                             })
             messages = patched
             if not self.quiet_mode:
-                logger.info("Compression sanitizer: added %d stub tool result(s)", len(missing_results))
+                logger.info(
+                    "Compression sanitizer: added %d stub tool result(s), %d stub Responses output(s)",
+                    len(missing_results), len(missing_response_results),
+                )
 
         return messages
 
@@ -1088,6 +1370,32 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         if check >= 0 and messages[check].get("role") == "assistant" and messages[check].get("tool_calls"):
             idx = check
         return idx
+
+    def _align_responses_boundary_backward(
+        self,
+        messages: List[Dict[str, Any]],
+        idx: int,
+        head_end: int,
+    ) -> int:
+        """Avoid leaving Responses function_call_output entries orphaned in tail."""
+        if idx <= 0 or idx >= len(messages):
+            return idx
+        call_index: dict[str, int] = {}
+        for i, msg in enumerate(messages):
+            if msg.get("type") == "function_call":
+                cid = msg.get("call_id")
+                if cid:
+                    call_index[cid] = i
+        adjusted = idx
+        for j in range(idx, len(messages)):
+            msg = messages[j]
+            if msg.get("type") != "function_call_output":
+                continue
+            cid = msg.get("call_id")
+            call_idx = call_index.get(cid or "")
+            if call_idx is not None and head_end <= call_idx < adjusted:
+                adjusted = call_idx
+        return adjusted
 
     # ------------------------------------------------------------------
     # Tail protection by token budget
@@ -1179,15 +1487,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         cut_idx = n  # start from beyond the end
 
         for i in range(n - 1, head_end - 1, -1):
-            msg = messages[i]
-            raw_content = msg.get("content") or ""
-            content_len = _content_length_for_budget(raw_content)
-            msg_tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
-            # Include tool call arguments in estimate
-            for tc in msg.get("tool_calls") or []:
-                if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
-                    msg_tokens += len(args) // _CHARS_PER_TOKEN
+            msg_tokens = _message_length_for_budget(messages[i]) // _CHARS_PER_TOKEN + 10
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
                 break
@@ -1206,10 +1506,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         # Align to avoid splitting tool groups
         cut_idx = self._align_boundary_backward(messages, cut_idx)
+        cut_idx = self._align_responses_boundary_backward(messages, cut_idx, head_end)
 
         # Ensure the most recent user message is always in the tail so the
         # active task is never lost to compression (fixes #10896).
         cut_idx = self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
+        cut_idx = self._align_responses_boundary_backward(messages, cut_idx, head_end)
 
         return max(cut_idx, head_end + 1)
 
@@ -1330,20 +1632,18 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     )
             compressed.append(msg)
 
-        # If LLM summary failed, insert a static fallback so the model
-        # knows context was lost rather than silently dropping everything.
+        # If LLM summary failed, insert a deterministic extractive fallback so
+        # transient provider failures (502/504, timeouts, bad relays) do not
+        # turn compaction into blind context amputation.
         if not summary:
             if not self.quiet_mode:
-                logger.warning("Summary generation failed — inserting static fallback context marker")
+                logger.warning("Summary generation failed — inserting extractive fallback context summary")
             n_dropped = compress_end - compress_start
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
-            summary = (
-                f"{SUMMARY_PREFIX}\n"
-                f"Summary generation was unavailable. {n_dropped} message(s) were "
-                f"removed to free context space but could not be summarized. The removed "
-                f"messages contained earlier work in this session. Continue based on the "
-                f"recent messages below and the current state of any files or resources."
+            summary = self._generate_extractive_fallback_summary(
+                turns_to_summarize,
+                focus_topic=focus_topic,
             )
 
         _merge_summary_into_tail = False

--- a/cli.py
+++ b/cli.py
@@ -600,6 +600,29 @@ def load_cli_config() -> Dict[str, Any]:
 CLI_CONFIG = load_cli_config()
 
 
+def _load_live_quick_commands(fallback: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Return quick commands with on-disk config merged over in-memory state.
+
+    Long-lived CLI/gateway processes can keep a stale config snapshot after
+    `~/.hermes/config.yaml` is edited. Quick commands are intentionally cheap
+    local dispatch, so reload just this small mapping at dispatch time instead
+    of forcing a full process restart for every alias addition.
+    """
+    merged: Dict[str, Any] = {}
+    if isinstance(fallback, dict):
+        merged.update(fallback)
+    try:
+        cfg_path = get_hermes_home() / "config.yaml"
+        if cfg_path.exists():
+            data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+            live = data.get("quick_commands")
+            if isinstance(live, dict):
+                merged.update(live)
+    except Exception as exc:
+        logger.debug("Could not reload live quick_commands: %s", exc)
+    return merged
+
+
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
 try:
@@ -6578,7 +6601,7 @@ class HermesCLI:
         else:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
-            quick_commands = self.config.get("quick_commands", {})
+            quick_commands = _load_live_quick_commands(self.config.get("quick_commands", {}))
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
                 if qcmd.get("type") == "exec":

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1888,26 +1888,56 @@ class BasePlatformAdapter(ABC):
         media = []
         cleaned = content
         
-        # Check for [[audio_as_voice]] directive
+        # Check for [[audio_as_voice]] directive. Remove it after MEDIA span
+        # removal so match offsets still refer to the original content string.
         has_voice_tag = "[[audio_as_voice]]" in content
-        cleaned = cleaned.replace("[[audio_as_voice]]", "")
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        #
+        # SECURITY / UX NOTE:
+        # Only honor MEDIA as a real outbound directive when it starts a logical
+        # line. Explanatory prose like "use `MEDIA:/tmp/foo.txt`" must remain
+        # plain text; otherwise the gateway tries to upload documentation
+        # examples as real files. Fenced code blocks are never directives.
         media_pattern = re.compile(
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
+
+        fenced_spans = [m.span() for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL)]
+
+        def _in_fenced_code(pos: int) -> bool:
+            return any(start <= pos < end for start, end in fenced_spans)
+
+        def _is_standalone_directive(match: re.Match) -> bool:
+            line_start = content.rfind('\n', 0, match.start()) + 1
+            return content[line_start:match.start()].strip() == ""
+
+        accepted_matches = []
         for match in media_pattern.finditer(content):
+            if _in_fenced_code(match.start()) or not _is_standalone_directive(match):
+                continue
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
+                accepted_matches.append(match)
                 media.append((os.path.expanduser(path), has_voice_tag))
 
-        # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
-        if media:
-            cleaned = media_pattern.sub('', cleaned)
+        # Remove only accepted MEDIA directives from content. Do not run a global
+        # regex substitution, because skipped inline examples must survive.
+        if accepted_matches:
+            parts = []
+            last = 0
+            for match in accepted_matches:
+                parts.append(cleaned[last:match.start()])
+                last = match.end()
+            parts.append(cleaned[last:])
+            cleaned = ''.join(parts)
+
+        if accepted_matches or has_voice_tag:
+            cleaned = cleaned.replace("[[audio_as_voice]]", "")
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -589,6 +589,38 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _quick_commands_from_config(config: Any) -> Dict[str, Any]:
+    """Extract a quick_commands mapping from dict or GatewayConfig-like objects."""
+    if isinstance(config, dict):
+        quick_commands = config.get("quick_commands", {}) or {}
+    else:
+        quick_commands = getattr(config, "quick_commands", {}) or {}
+    return dict(quick_commands) if isinstance(quick_commands, dict) else {}
+
+
+def _load_live_quick_commands(fallback: Any = None) -> Dict[str, Any]:
+    """Return quick commands with live config.yaml merged over fallback state.
+
+    Gateway processes are long-lived. If a model-switch alias is added to
+    config.yaml after boot, relying only on self.config makes Weixin/Telegram
+    keep saying "unknown command" until restart. Reloading just this tiny
+    mapping at dispatch time keeps synthetic tests/fallback config intact while
+    making real config edits visible immediately.
+    """
+    merged = _quick_commands_from_config(fallback)
+    try:
+        import yaml as _yaml
+        cfg_path = _hermes_home / "config.yaml"
+        if cfg_path.exists():
+            data = _yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+            live = data.get("quick_commands")
+            if isinstance(live, dict):
+                merged.update(live)
+    except Exception as exc:
+        logger.debug("Could not reload live quick_commands: %s", exc)
+    return merged
+
+
 def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -4420,6 +4452,56 @@ class GatewayRunner:
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    async def _dispatch_quick_command(
+        self,
+        event: MessageEvent,
+        command: str,
+        quick_commands: Dict[str, Any],
+    ) -> str:
+        """Execute a user-defined quick command or alias chain."""
+        seen_quick_commands: set[str] = set()
+        for _ in range(8):
+            if command not in quick_commands:
+                break
+            if command in seen_quick_commands:
+                return f"Quick command '/{command}' alias loop detected."
+            seen_quick_commands.add(command)
+
+            qcmd = quick_commands[command]
+            if qcmd.get("type") == "exec":
+                exec_cmd = qcmd.get("command", "")
+                if exec_cmd:
+                    try:
+                        proc = await asyncio.create_subprocess_shell(
+                            exec_cmd,
+                            stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.PIPE,
+                        )
+                        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+                        output = (stdout or stderr).decode().strip()
+                        return output if output else "Command returned no output."
+                    except asyncio.TimeoutError:
+                        return "Quick command timed out (30s)."
+                    except Exception as e:
+                        return f"Quick command error: {e}"
+                return f"Quick command '/{command}' has no command defined."
+
+            if qcmd.get("type") == "alias":
+                target = qcmd.get("target", "").strip()
+                if not target:
+                    return f"Quick command '/{command}' has no target defined."
+                target = target if target.startswith("/") else f"/{target}"
+                target_command = target.lstrip("/").split(maxsplit=1)[0]
+                target_args = target[len(target.split(maxsplit=1)[0]):].strip()
+                user_args = event.get_command_args().strip()
+                combined_args = " ".join(part for part in (target_args, user_args) if part)
+                event.text = f"/{target_command} {combined_args}".strip()
+                command = target_command
+                continue
+
+            return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
+        return "Quick command alias chain is too deep."
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -4732,6 +4814,16 @@ class GatewayRunner:
             )
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
+
+            # User-defined quick commands must also work while a previous
+            # agent turn is still unwinding. Otherwise `/tk1` is treated as
+            # plain text/interrupt or falls through to "Unknown command"
+            # whenever the session lock is present, even though it is a
+            # config-level control command.
+            if _evt_cmd:
+                _quick_commands = _load_live_quick_commands(self.config)
+                if _evt_cmd in _quick_commands:
+                    return await self._dispatch_quick_command(event, _evt_cmd, _quick_commands)
 
             if _cmd_def_inner and _cmd_def_inner.name == "restart":
                 return await self._handle_restart_command(event)
@@ -5209,45 +5301,9 @@ class GatewayRunner:
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if not isinstance(quick_commands, dict):
-                quick_commands = {}
+            quick_commands = _load_live_quick_commands(self.config)
             if command in quick_commands:
-                qcmd = quick_commands[command]
-                if qcmd.get("type") == "exec":
-                    exec_cmd = qcmd.get("command", "")
-                    if exec_cmd:
-                        try:
-                            proc = await asyncio.create_subprocess_shell(
-                                exec_cmd,
-                                stdout=asyncio.subprocess.PIPE,
-                                stderr=asyncio.subprocess.PIPE,
-                            )
-                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-                            output = (stdout or stderr).decode().strip()
-                            return output if output else "Command returned no output."
-                        except asyncio.TimeoutError:
-                            return "Quick command timed out (30s)."
-                        except Exception as e:
-                            return f"Quick command error: {e}"
-                    else:
-                        return f"Quick command '/{command}' has no command defined."
-                elif qcmd.get("type") == "alias":
-                    target = qcmd.get("target", "").strip()
-                    if target:
-                        target = target if target.startswith("/") else f"/{target}"
-                        target_command = target.lstrip("/")
-                        user_args = event.get_command_args().strip()
-                        event.text = f"{target} {user_args}".strip()
-                        command = target_command
-                        # Fall through to normal command dispatch below
-                    else:
-                        return f"Quick command '/{command}' has no target defined."
-                else:
-                    return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
+                return await self._dispatch_quick_command(event, command, quick_commands)
 
         # Plugin-registered slash commands
         if command:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1262,7 +1262,8 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_context":
                 peer = args.get("peer", "user")
-                ctx = self._manager.get_session_context(self._session_key, peer=peer)
+                query = args.get("query")
+                ctx = self._manager.get_session_context(self._session_key, peer=peer, query=query)
                 if not ctx:
                     return json.dumps({"result": "No context available yet."})
                 parts = []

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -5,9 +5,11 @@ Handles: hermes honcho setup | status | sessions | map | peer
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -699,6 +701,13 @@ def cmd_status(args) -> None:
         try:
             client = get_honcho_client(hcfg)
             _show_peer_cards(hcfg, client)
+            if getattr(args, "drift_audit", False) or getattr(args, "write_audit", False):
+                _run_status_audits(
+                    hcfg,
+                    client,
+                    drift_query=getattr(args, "drift_query", None) or "billing risk",
+                    write_audit=getattr(args, "write_audit", False),
+                )
             print("OK")
         except Exception as e:
             print(f"FAILED ({e})\n")
@@ -744,6 +753,133 @@ def _show_peer_cards(hcfg, client) -> None:
         print()
     except Exception as e:
         print(f"\n  Peer data unavailable: {e}\n")
+
+
+def _audit_digest(obj) -> str:
+    """Short stable digest for status drift-audit payload comparisons."""
+    try:
+        text = json.dumps(obj, ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        text = str(obj)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+
+
+def _audit_context_payload(ctx) -> dict:
+    summary = getattr(ctx, "summary", None)
+    messages = getattr(ctx, "messages", None) or []
+    return {
+        "summary": getattr(summary, "content", None) if summary else None,
+        "representation": getattr(ctx, "peer_representation", None) or getattr(ctx, "representation", None),
+        "card": getattr(ctx, "peer_card", None),
+        "messages": [
+            {
+                "peer_id": getattr(m, "peer_id", "unknown"),
+                "content": (getattr(m, "content", "") or "")[:500],
+            }
+            for m in messages[-10:]
+        ],
+    }
+
+
+def _audit_term_counts(text: str, query: str) -> dict[str, int]:
+    terms = {t.lower() for t in query.split() if t.strip()}
+    if "billing" in terms or "risk" in terms:
+        terms.update({"billing", "risk", "invoice", "cashflow", "财务", "商务", "风险", "发票", "账单"})
+    lowered = text.lower()
+    return {term: lowered.count(term) for term in sorted(terms) if lowered.count(term)}
+
+
+def _run_status_audits(hcfg, client, *, drift_query: str, write_audit: bool) -> None:
+    """Print live Honcho drift/search/write audit lines for cron smoke checks."""
+    from plugins.memory.honcho.session import HonchoSessionManager
+
+    mgr = HonchoSessionManager(honcho=client, config=hcfg)
+    session_key = hcfg.resolve_session_name()
+    session = mgr.get_or_create(session_key)
+    noise_query = "完全无关词 柴犬火箭"
+
+    print("\n  Drift/search audit")
+
+    def manager_payload(query: str | None) -> dict:
+        return mgr.get_session_context(session_key, peer="user", query=query)
+
+    mgr_base = manager_payload(None)
+    mgr_focus = manager_payload(drift_query)
+    mgr_noise = manager_payload(noise_query)
+    mgr_hashes = [_audit_digest(x) for x in (mgr_base, mgr_focus, mgr_noise)]
+    mitigation_ok = len(set(mgr_hashes)) > 1 and mgr_hashes[1] != mgr_hashes[2]
+
+    raw_hashes: list[str] = []
+    raw_ok = False
+    try:
+        honcho_session = mgr._sessions_cache.get(session.honcho_session_id)
+        target_peer_id = session.user_peer_id
+        observer_peer_id = session.assistant_peer_id if mgr._ai_observe_others else target_peer_id
+        raw_payloads = []
+        for query in (None, drift_query, noise_query):
+            kwargs = {
+                "summary": True,
+                "tokens": hcfg.context_tokens,
+                "peer_target": target_peer_id,
+                "peer_perspective": observer_peer_id,
+            }
+            if query:
+                kwargs.update({"search_query": query, "search_top_k": 8, "max_conclusions": 8})
+            try:
+                ctx = honcho_session.context(**kwargs)
+            except TypeError:
+                kwargs.pop("search_top_k", None)
+                kwargs.pop("max_conclusions", None)
+                ctx = honcho_session.context(**kwargs)
+            raw_payloads.append(_audit_context_payload(ctx))
+        raw_hashes = [_audit_digest(x) for x in raw_payloads]
+        raw_ok = len(set(raw_hashes)) > 1 and raw_hashes[1] != raw_hashes[2]
+    except Exception as e:
+        print(f"  Raw drift audit: WARN error={type(e).__name__}: {e}")
+    else:
+        print(
+            "  Raw drift audit: "
+            f"{'PASS' if raw_ok else 'WARN'} baseline={raw_hashes[0]} focused={raw_hashes[1]} noise={raw_hashes[2]}"
+        )
+
+    print(
+        "  Hermes mitigation: "
+        f"{'PASS' if mitigation_ok else 'WARN'} baseline={mgr_hashes[0]} focused={mgr_hashes[1]} noise={mgr_hashes[2]}"
+    )
+
+    search = mgr.search_context(session_key, drift_query, max_tokens=800, peer="user")
+    terms = _audit_term_counts(search, drift_query)
+    search_status = "PASS" if search.strip() and terms else ("WARN" if search.strip() else "FAIL")
+    print(
+        "  Search evidence: "
+        f"{search_status} len={len(search)} terms={terms}"
+    )
+
+    if not write_audit:
+        return
+
+    marker = f"HERMES_HONCHO_STATUS_WRITE_AUDIT_TEMP_{int(time.time())}"
+    created_ids: list[str] = []
+    try:
+        scope = mgr._conclusions_scope_for(session, "user")
+        created = scope.create([{"content": marker, "session_id": session.honcho_session_id}])
+        created_ids = [getattr(item, "id", "") for item in created if getattr(item, "id", "")]
+        found = bool(created_ids)
+        deleted = False
+        for conclusion_id in created_ids:
+            scope.delete(conclusion_id)
+            deleted = True
+        print(
+            "  Write audit: "
+            f"{'PASS' if found and deleted else 'WARN'} created={found} deleted={deleted} ids={len(created_ids)}"
+        )
+    except Exception as e:
+        print(f"  Write audit: FAIL error={type(e).__name__}: {e}")
+        for conclusion_id in created_ids:
+            try:
+                scope.delete(conclusion_id)
+            except Exception:
+                pass
 
 
 def _cmd_status_all() -> None:
@@ -1374,6 +1510,18 @@ def register_cli(subparser) -> None:
     )
     status_parser.add_argument(
         "--all", action="store_true", help="Show config overview across all profiles",
+    )
+    status_parser.add_argument(
+        "--drift-audit", action="store_true",
+        help="Compare raw and Hermes-mitigated context for focused/noise query drift",
+    )
+    status_parser.add_argument(
+        "--drift-query", default="billing risk",
+        help="Focused query to use with --drift-audit (default: billing risk)",
+    )
+    status_parser.add_argument(
+        "--write-audit", action="store_true",
+        help="Create and delete a temporary conclusion to verify write-path health",
     )
 
     subs.add_parser("peers", help="Show peer identities across all profiles")

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -556,9 +556,8 @@ class HonchoSessionManager:
         if target_peer_id is None:
             return ""
 
-        # Guard: truncate query to Honcho's dialectic input limit
-        if len(query) > self._dialectic_max_input_chars:
-            query = query[:self._dialectic_max_input_chars].rsplit(" ", 1)[0]
+        # Guard: truncate query to Honcho's dialectic input limit.
+        query = self._truncate_with_suffix(query, self._dialectic_max_input_chars, suffix="")
 
         if self._dialectic_dynamic and reasoning_level:
             level = reasoning_level
@@ -582,13 +581,14 @@ class HonchoSessionManager:
                 target_peer = self._get_or_create_peer(target_peer_id)
                 result = target_peer.chat(query, reasoning_level=level) or ""
 
-            # Apply Hermes-side char cap before caching
-            if result and self._dialectic_max_chars and len(result) > self._dialectic_max_chars:
-                result = result[:self._dialectic_max_chars].rsplit(" ", 1)[0] + " …"
+            # Apply Hermes-side char cap before caching.
+            result = self._truncate_with_suffix(result, self._dialectic_max_chars, suffix=" …")
             return result
         except Exception as e:
             logger.warning("Honcho dialectic query failed: %s", e)
-            return ""
+            fallback = self._fetch_conclusion_context(session, peer=peer, query=query)
+            result = fallback.get("representation") or "\n".join(fallback.get("card") or [])
+            return self._truncate_with_suffix(result, self._dialectic_max_chars, suffix=" …")
 
     def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:
         """
@@ -659,17 +659,27 @@ class HonchoSessionManager:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
         try:
-            user_ctx = self._fetch_peer_context(session.user_peer_id, target=session.user_peer_id)
+            observer_peer_id, target_peer_id = self._resolve_observer_target(session, "user")
+            user_ctx = self._fetch_peer_context(observer_peer_id, target=target_peer_id)
+            user_ctx = self._merge_context_backfill(
+                user_ctx,
+                self._fetch_conclusion_context(session, peer="user"),
+            )
             result["representation"] = user_ctx["representation"]
-            result["card"] = "\n".join(user_ctx["card"])
+            result["card"] = "\n".join(user_ctx["card"]) if isinstance(user_ctx["card"], list) else str(user_ctx["card"])
         except Exception as e:
             logger.warning("Failed to fetch user context from Honcho: %s", e)
 
         # Also fetch AI peer's own representation so Hermes knows itself.
         try:
-            ai_ctx = self._fetch_peer_context(session.assistant_peer_id, target=session.assistant_peer_id)
+            ai_observer_peer_id, ai_target_peer_id = self._resolve_observer_target(session, "ai")
+            ai_ctx = self._fetch_peer_context(ai_observer_peer_id, target=ai_target_peer_id)
+            ai_ctx = self._merge_context_backfill(
+                ai_ctx,
+                self._fetch_conclusion_context(session, peer="ai"),
+            )
             result["ai_representation"] = ai_ctx["representation"]
-            result["ai_card"] = "\n".join(ai_ctx["card"])
+            result["ai_card"] = "\n".join(ai_ctx["card"]) if isinstance(ai_ctx["card"], list) else str(ai_ctx["card"])
         except Exception as e:
             logger.debug("Failed to fetch AI peer context from Honcho: %s", e)
 
@@ -855,6 +865,143 @@ class HonchoSessionManager:
             return [str(item) for item in card if item]
         return [str(card)]
 
+    @staticmethod
+    def _truncate_with_suffix(text: str, limit: int, suffix: str = " …") -> str:
+        """Truncate text while keeping any suffix inside the configured cap."""
+        if not text or not limit or len(text) <= limit:
+            return text
+        if suffix and limit > len(suffix):
+            head = text[: limit - len(suffix)].rstrip()
+            # Prefer not to cut a western word in half when possible, but never
+            # let that preference erase the whole string for CJK / long tokens.
+            if " " in head:
+                head = head.rsplit(" ", 1)[0] or head
+            return (head + suffix)[:limit]
+        return text[:limit]
+
+    @staticmethod
+    def _conclusion_contents(items: Any) -> list[str]:
+        """Extract unique conclusion contents from SDK pages/lists/objects."""
+        if not items:
+            return []
+        if hasattr(items, "items"):
+            iterable = getattr(items, "items") or []
+        elif isinstance(items, (list, tuple, set)):
+            iterable = items
+        else:
+            try:
+                iterable = list(items)
+            except TypeError:
+                iterable = [items]
+
+        contents: list[str] = []
+        seen: set[str] = set()
+        for item in iterable:
+            content = getattr(item, "content", None)
+            if content is None and isinstance(item, dict):
+                content = item.get("content")
+            if content is None:
+                content = str(item) if item else ""
+            content = str(content).strip()
+            if content and content not in seen:
+                seen.add(content)
+                contents.append(content)
+        return contents
+
+    @staticmethod
+    def _context_payload_digest(result: dict[str, Any]) -> tuple[Any, ...]:
+        """Stable-ish digest for detecting ignored query filters."""
+        card = result.get("card") or ""
+        if isinstance(card, list):
+            card = "\n".join(str(x) for x in card)
+        recent = result.get("recent_messages") or []
+        recent_digest = tuple(
+            (
+                str(m.get("role", "")) if isinstance(m, dict) else "",
+                str(m.get("content", "")) if isinstance(m, dict) else str(m),
+            )
+            for m in recent
+        )
+        return (
+            str(result.get("summary") or ""),
+            str(result.get("representation") or ""),
+            str(card),
+            recent_digest,
+        )
+
+    def _conclusions_scope_for(self, session: HonchoSession, peer: str = "user") -> Any | None:
+        """Return the observer→target conclusions scope for a requested peer."""
+        target_peer_id = self._resolve_peer_id(session, peer)
+        try:
+            if target_peer_id == session.assistant_peer_id:
+                observer = self._get_or_create_peer(session.assistant_peer_id)
+                return observer.conclusions_of(session.assistant_peer_id)
+            if self._ai_observe_others:
+                observer = self._get_or_create_peer(session.assistant_peer_id)
+                return observer.conclusions_of(target_peer_id)
+            target_peer = self._get_or_create_peer(target_peer_id)
+            return target_peer.conclusions_of(target_peer_id)
+        except Exception as e:
+            logger.debug("Failed to resolve conclusions scope for peer '%s': %s", peer, e)
+            return None
+
+    def _fetch_conclusion_context(
+        self,
+        session: HonchoSession,
+        peer: str = "user",
+        query: str | None = None,
+        *,
+        size: int = 10,
+    ) -> dict[str, Any]:
+        """Fetch representation/card-like facts from the conclusions layer.
+
+        This is the durable fallback when peer-card/session-context synthesis is
+        empty or when the session.context(search_query=...) surface ignores a
+        focused query.
+        """
+        scope = self._conclusions_scope_for(session, peer)
+        if scope is None:
+            return {"representation": "", "card": []}
+
+        representation = ""
+        try:
+            if query:
+                representation = scope.representation(
+                    search_query=query,
+                    search_top_k=8,
+                    max_conclusions=8,
+                ) or ""
+            else:
+                representation = scope.representation(max_conclusions=max(size, 10)) or ""
+        except TypeError:
+            try:
+                representation = scope.representation(search_query=query) if query else scope.representation()
+            except Exception as e:
+                logger.debug("Conclusion representation fallback failed: %s", e)
+        except Exception as e:
+            logger.debug("Conclusion representation fallback failed: %s", e)
+
+        contents: list[str] = []
+        try:
+            if query:
+                contents = self._conclusion_contents(scope.query(query, top_k=min(max(size, 1), 20)))
+            else:
+                contents = self._conclusion_contents(scope.list(size=min(max(size, 1), 100), reverse=True))
+        except Exception as e:
+            logger.debug("Conclusion list/query fallback failed: %s", e)
+
+        return {"representation": representation, "card": contents}
+
+    @staticmethod
+    def _merge_context_backfill(result: dict[str, Any], fallback: dict[str, Any]) -> dict[str, Any]:
+        """Backfill missing representation/card fields without discarding summary/messages."""
+        if not result.get("representation") and fallback.get("representation"):
+            result["representation"] = fallback["representation"]
+        if not result.get("card") and fallback.get("card"):
+            card = fallback["card"]
+            result["card"] = "\n".join(card) if isinstance(card, list) else str(card)
+        return result
+
     def _fetch_peer_card(self, peer_id: str, *, target: str | None = None) -> list[str]:
         """Fetch a peer card directly from the peer object.
 
@@ -917,56 +1064,120 @@ class HonchoSessionManager:
 
         return {"representation": representation, "card": card}
 
-    def get_session_context(self, session_key: str, peer: str = "user") -> dict[str, Any]:
+    def get_session_context(
+        self,
+        session_key: str,
+        peer: str = "user",
+        query: str | None = None,
+    ) -> dict[str, Any]:
         """Fetch full session context from Honcho including summary.
 
-        Uses the session-level context() API which returns summary,
-        peer_representation, peer_card, and messages.
+        Uses the session-level context() API, routing user reads through the
+        assistant→user observer-target view when AI observation of others is
+        enabled. Optional ``query`` is forwarded as ``search_query`` and guarded
+        with peer/conclusion fallback if the downstream API returns an unfocused
+        snapshot.
         """
         session = self._cache.get(session_key)
         if not session:
             return {}
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
-            # Fall back to peer-level context, respecting the requested peer
-            peer_id = self._resolve_peer_id(session, peer)
-            if peer_id is None:
-                peer_id = session.user_peer_id
-            return self._fetch_peer_context(peer_id, target=peer_id)
+        target_peer_id = self._resolve_peer_id(session, peer)
+        observer_peer_id, observer_target = self._resolve_observer_target(session, peer)
+        perspective_peer_id = observer_peer_id if observer_target is not None else target_peer_id
 
-        try:
-            peer_id = self._resolve_peer_id(session, peer)
-            ctx = honcho_session.context(
-                summary=True,
-                peer_target=peer_id,
-                peer_perspective=session.user_peer_id if peer == "user" else session.assistant_peer_id,
-            )
+        def _fetch_session_payload(search_query: str | None) -> dict[str, Any]:
+            honcho_session = self._sessions_cache.get(session.honcho_session_id)
+            if not honcho_session:
+                peer_ctx = self._fetch_peer_context(
+                    observer_peer_id,
+                    search_query=search_query,
+                    target=observer_target,
+                )
+                return self._merge_context_backfill(
+                    {"representation": peer_ctx.get("representation", ""), "card": peer_ctx.get("card", [])},
+                    self._fetch_conclusion_context(session, peer=peer, query=search_query),
+                )
+
+            kwargs: dict[str, Any] = {
+                "summary": True,
+                "peer_target": target_peer_id,
+                "peer_perspective": perspective_peer_id,
+            }
+            if self._context_tokens:
+                kwargs["tokens"] = self._context_tokens
+            if search_query:
+                kwargs.update({
+                    "search_query": search_query,
+                    "search_top_k": 8,
+                    "max_conclusions": 8,
+                })
+
+            try:
+                ctx = honcho_session.context(**kwargs)
+            except TypeError:
+                # Older SDK/server builds may not accept the narrowing params.
+                kwargs.pop("search_top_k", None)
+                kwargs.pop("max_conclusions", None)
+                ctx = honcho_session.context(**kwargs)
 
             result: dict[str, Any] = {}
 
-            # Summary
-            if ctx.summary:
-                result["summary"] = ctx.summary.content
+            summary = getattr(ctx, "summary", None)
+            summary_content = getattr(summary, "content", None) if summary else None
+            if summary_content:
+                result["summary"] = summary_content
 
-            # Peer representation and card
-            if ctx.peer_representation:
-                result["representation"] = ctx.peer_representation
-            if ctx.peer_card:
-                result["card"] = "\n".join(ctx.peer_card)
+            representation = getattr(ctx, "peer_representation", None) or getattr(ctx, "representation", None)
+            if representation:
+                result["representation"] = representation
 
-            # Messages (last N for context)
-            if ctx.messages:
-                recent = ctx.messages[-10:]  # last 10 messages
+            card = self._normalize_card(getattr(ctx, "peer_card", None))
+            if card:
+                result["card"] = "\n".join(card)
+
+            messages = getattr(ctx, "messages", None)
+            if messages:
+                recent = messages[-10:]
                 result["recent_messages"] = [
-                    {"role": getattr(m, "peer_id", "unknown"), "content": (m.content or "")[:500]}
+                    {"role": getattr(m, "peer_id", "unknown"), "content": (getattr(m, "content", "") or "")[:500]}
                     for m in recent
                 ]
 
+            peer_ctx = self._fetch_peer_context(
+                observer_peer_id,
+                search_query=search_query,
+                target=observer_target,
+            )
+            result = self._merge_context_backfill(result, peer_ctx)
+            result = self._merge_context_backfill(
+                result,
+                self._fetch_conclusion_context(session, peer=peer, query=search_query),
+            )
+            return result
+
+        try:
+            result = _fetch_session_payload(query)
+            if query:
+                baseline = _fetch_session_payload(None)
+                if self._context_payload_digest(result) == self._context_payload_digest(baseline):
+                    # Downstream session.context(search_query=...) ignored the
+                    # query. Overlay focused peer-level context, then conclusions.
+                    focused_peer_ctx = self._fetch_peer_context(
+                        observer_peer_id,
+                        search_query=query,
+                        target=observer_target,
+                    )
+                    result = self._merge_context_backfill({}, focused_peer_ctx)
+                    result = self._merge_context_backfill(
+                        result,
+                        self._fetch_conclusion_context(session, peer=peer, query=query),
+                    )
             return result
         except Exception as e:
             logger.debug("Session context fetch failed: %s", e)
-            return {}
+            fallback = self._fetch_conclusion_context(session, peer=peer, query=query)
+            return self._merge_context_backfill({}, fallback)
 
     def _resolve_peer_id(self, session: HonchoSession, peer: str | None) -> str:
         """Resolve a peer alias or explicit peer ID to a concrete Honcho peer ID.
@@ -1016,7 +1227,16 @@ class HonchoSessionManager:
 
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
-            return self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            card = self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            if card:
+                return card
+            fallback = self._fetch_conclusion_context(session, peer=peer)
+            if fallback.get("card"):
+                return self._normalize_card(fallback.get("card"))
+            representation = (fallback.get("representation") or "").strip()
+            if representation:
+                return [line.strip("-• ") for line in representation.splitlines() if line.strip()][:10]
+            return []
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []
@@ -1051,18 +1271,27 @@ class HonchoSessionManager:
         try:
             observer_peer_id, target = self._resolve_observer_target(session, peer)
 
-            ctx = self._fetch_peer_context(
+            peer_ctx = self._fetch_peer_context(
                 observer_peer_id,
                 search_query=query,
                 target=target,
             )
+            conclusion_ctx = self._fetch_conclusion_context(session, peer=peer, query=query)
+            if query and (conclusion_ctx.get("representation") or conclusion_ctx.get("card")):
+                ctx = self._merge_context_backfill(conclusion_ctx, peer_ctx)
+            else:
+                ctx = self._merge_context_backfill(peer_ctx, conclusion_ctx)
             parts = []
             if ctx["representation"]:
                 parts.append(ctx["representation"])
             card = ctx["card"] or []
             if card:
-                parts.append("\n".join(f"- {f}" for f in card))
-            return "\n\n".join(parts)
+                if isinstance(card, list):
+                    parts.append("\n".join(f"- {f}" for f in card))
+                else:
+                    parts.append(str(card))
+            result = "\n\n".join(parts)
+            return self._truncate_with_suffix(result, max_tokens * 4, suffix=" …")
         except Exception as e:
             logger.debug("Honcho search_context failed: %s", e)
             return ""

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -715,6 +715,54 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 10. **Start new sessions for distinct tasks** — sessions last 5 hours; fresh context is more efficient.
 11. **Use `--no-session-persistence`** in CI to avoid accumulating saved sessions on disk.
 
+## GStack methodology policy for this user
+
+Adopted on 2026-05-01: **GStack is a Claude Code methodology layer, not a Hermes main-runtime skill bundle.**
+
+Operational rules:
+
+- Do not install `garrytan/gstack/*` into `~/.hermes/skills` or make Hermes load the full GStack bundle.
+- Prefer the safe wrapper with distilled GStack methodology in the prompt (`claude_code_safe.py --mode ask|review|code`) for review/debug/QA/plan tasks.
+- Use real `/gstack-*` slash skills only inside an isolated Claude Code session when the user explicitly wants real GStack behavior.
+- If real GStack is installed for Claude Code, keep namespaced skills (`/gstack-review`, not `/review`), telemetry off, auto-upgrade/team mode off.
+- Never run high-side-effect GStack skills (`/gstack-ship`, `/gstack-land-and-deploy`, `/gstack-setup-gbrain`, `/gstack-setup-browser-cookies`, `/gstack-pair-agent`, `/gstack-skillify`, `/gstack-gstack-upgrade`) without separate explicit approval.
+
+Detailed policy and prompt templates: `references/gstack-methodology-policy.md`.
+
+## Hermes local reliability wrapper / no-response timeout fix
+
+On this Mac, direct Claude Code calls can look like they “timeout” or “give no answer” for two main reasons:
+
+1. Non-bare `claude -p` loads user settings, plugins/hooks/CLAUDE.md discovery and starts with a large prompt surface. A simple `只回复 OK` measured ~23k input tokens and ~6s, while `--bare` measured ~854 input tokens and ~2-4s.
+2. Coding runs that hit `error_max_turns` often stop with `stop_reason=tool_use` and an empty `result`, so Hermes sees “no answer” even though Claude changed files. This is not a transport failure; it is a closeout failure.
+
+Use the local wrapper for Hermes-driven Claude Code work:
+
+```bash
+~/.hermes/scripts/claude_code_safe.py --mode ask \
+  --prompt '只回复 OK，不要解释。' \
+  --turns 1 --timeout 120
+
+~/.hermes/scripts/claude_code_safe.py --mode code \
+  --workdir /path/to/project \
+  --prompt 'Fix the bug, run focused tests, then summarize.' \
+  --turns 8 --segments 3 --timeout 900
+```
+
+Wrapper behavior:
+- always uses `claude --bare -p --output-format json`
+- defaults to max effort unless explicitly overridden
+- disables tools for ask/closeout mode
+- restricts common tools for code/review mode
+- parses JSON leniently when shell output contains control characters
+- if a work segment returns `error_max_turns`, automatically resumes with tools disabled to create a checkpoint summary, then resumes the same Claude Code session with tools enabled and continues from current state; repeats up to `--segments` before a final closeout
+
+Practical rule for Hermes:
+- For one-shot answers/reviews, use wrapper `--mode ask|review` or raw `claude --bare -p ... --effort max --output-format json --no-session-persistence`.
+- For code edits, use wrapper `--mode code` with `--workdir`, `--turns 8-12`, `--segments 3` or more for large tasks, and a foreground timeout of 600-900s or a Hermes background process with `notify_on_complete=true`.
+- Avoid calling interactive `claude` directly from a non-PTY terminal. Use tmux only when a true multi-turn Claude TUI is required.
+- Do not call a plain Hermes `delegate_task` “Claude”; only `acp_command='claude'` or launching `claude` CLI is actually Claude Code.
+
 ## Pitfalls & Gotchas
 
 1. **Interactive mode REQUIRES tmux** — Claude Code is a full TUI app. Using `pty=true` alone in Hermes terminal works but tmux gives you `capture-pane` for monitoring and `send-keys` for input, which is essential for orchestration.

--- a/skills/autonomous-ai-agents/claude-code/references/gstack-methodology-policy.md
+++ b/skills/autonomous-ai-agents/claude-code/references/gstack-methodology-policy.md
@@ -1,0 +1,122 @@
+# GStack Methodology Policy for Hermes → Claude Code
+
+Date adopted: 2026-05-01
+
+## Position
+
+GStack is valuable as a Claude Code engineering-methodology pack, not as a Hermes main-runtime skill pack.
+
+Do not install `garrytan/gstack/*` into `~/.hermes/skills` or make Hermes load the full GStack bundle. It is Claude Code-first, references `~/.claude/skills/gstack`, `CLAUDE_SKILL_DIR`, and Claude-style hooks. Direct Hermes installation creates half-working skills and confusing triggers.
+
+## Preferred Use
+
+Use GStack through Claude Code subprocesses when the task is coding/product/QA/review work:
+
+- product / founder planning → GStack-style office-hours / CEO review
+- implementation plan review → GStack-style eng review
+- code review → GStack-style review
+- root cause debugging → GStack-style investigate
+- browser QA report → GStack-style qa-only
+- weekly project reflection → GStack-style retro
+
+Hermes remains the cockpit. Claude Code is the coding worker. GStack is the worker's methodology layer.
+
+## Two Execution Modes
+
+### Mode A — Distilled methodology prompt, safest default
+
+Use `~/.hermes/scripts/claude_code_safe.py` in `--mode ask|review|code` and put the relevant GStack methodology into the prompt explicitly.
+
+This keeps the safe Hermes wrapper (`--bare`) and avoids loading unknown Claude hooks/plugins.
+
+Example:
+
+```bash
+~/.hermes/scripts/claude_code_safe.py --mode review --workdir /repo --turns 3 --timeout 600 --prompt '
+Use GStack-style review methodology, but do not run GStack slash commands.
+Review current diff for production bugs, trust-boundary issues, data loss, missing tests, and operational risks.
+Return: BLOCKERS, SHOULD_FIX, NICE_TO_HAVE, TESTS_RUN, VERDICT.
+'
+```
+
+### Mode B — Real `/gstack-*` slash skills, isolated only
+
+Only use this when the user explicitly wants real GStack slash skills.
+
+Requirements:
+
+1. GStack installed under Claude Code, not Hermes.
+2. Namespaced skills enabled (`/gstack-qa`, `/gstack-review`, not `/qa`).
+3. Telemetry off.
+4. Auto-upgrade/team mode off.
+5. Run in an isolated Claude Code session/worktree when edits are possible.
+6. Never run deploy/ship skills without separate explicit approval.
+
+If installing, prefer this guarded shape after checking `bun` exists:
+
+```bash
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+cd ~/.claude/skills/gstack
+bin/gstack-config set telemetry off
+bin/gstack-config set auto_upgrade false
+bin/gstack-config set update_check false
+bin/gstack-config set skill_prefix true
+./setup --host claude --prefix --no-team --quiet
+```
+
+Do not install GStack just because a task mentions review/QA. Use Mode A unless real slash-skill behavior is required.
+
+## Allowed / Preferred GStack Subset
+
+Good candidates:
+
+- `/gstack-plan-ceo-review`
+- `/gstack-plan-eng-review`
+- `/gstack-review`
+- `/gstack-investigate`
+- `/gstack-qa-only`
+- `/gstack-retro`
+- `/gstack-cso` for explicit security audits
+
+High-side-effect skills require explicit user approval and usually a worktree:
+
+- `/gstack-ship`
+- `/gstack-land-and-deploy`
+- `/gstack-setup-gbrain`
+- `/gstack-setup-browser-cookies`
+- `/gstack-pair-agent`
+- `/gstack-skillify`
+- `/gstack-gstack-upgrade`
+
+## Safety Notes
+
+- The GStack hub skills are community source. Hermes security scan flagged GStack `guard` as `CAUTION` because it declares privileged tool surfaces.
+- Direct single-skill install can be broken: e.g. `guard` references sibling `careful` and `freeze` hook scripts that are not present when installed alone.
+- GStack has local analytics and optional Supabase telemetry. Keep telemetry off unless the user explicitly chooses otherwise.
+- Full setup may require Bun and Playwright Chromium; that is a supply-chain/system side effect and should not be hidden inside an unrelated task.
+
+## Prompt Patterns
+
+### Review
+
+```text
+Use GStack-style review methodology without loading slash skills. Inspect the diff as a production reviewer. Check: data loss, auth/trust boundaries, concurrency/races, migration safety, missing tests, observability, rollback. Return blockers first.
+```
+
+### Investigate
+
+```text
+Use GStack-style investigate methodology: reproduce/observe, collect evidence, form hypotheses, verify root cause before fixing. Do not implement until root cause is stated with evidence.
+```
+
+### QA-only
+
+```text
+Use GStack-style QA-only methodology. Produce a report only, no code changes. Include tested flows, evidence, screenshots/log references if available, severity, repro steps, and ship-readiness verdict.
+```
+
+### Plan review
+
+```text
+Use GStack-style CEO + eng review: challenge the product premise, then lock architecture/data flow/test matrix. Return plan gaps and concrete revisions before implementation.
+```

--- a/skills/software-development/subagent-driven-development/SKILL.md
+++ b/skills/software-development/subagent-driven-development/SKILL.md
@@ -32,6 +32,13 @@ Use this skill when:
 - Consistent quality checks across all tasks
 - Subagents can ask questions before starting work
 
+## Operator Defaults on This Mac
+
+- Child subagents do **not** automatically inherit the parent conversation memory or user preferences. The controller must pass important constraints explicitly in `context` every time.
+- The user prefers Chinese output unless a task says otherwise; include that in child context when user-facing summaries matter.
+- RTK discipline is mandatory for terminal-heavy subtasks: tell child agents to prefer `rtk` for noisy terminal output (`rtk git diff`, `rtk git status`, `rtk log`, `rtk test ...`, `rtk err ...`, `rtk grep`, `rtk tree`) and to use raw commands only for tiny or exact-output cases.
+- Production/remote repair discipline still belongs to the parent/controller: subagents may analyze or produce candidate patches, but Hermes applies changes, reviews diff, restarts services, and verifies health.
+
 ## The Process
 
 ### 1. Read and Parse Plan

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -657,6 +657,30 @@ class TestAuxiliaryPoolAwareness:
         assert client is not None
         assert model == "google/gemini-3-flash-preview"
 
+    def test_call_llm_applies_task_max_retries_with_client_options(self):
+        base_client = MagicMock()
+        base_client.base_url = "http://127.0.0.1:18901/v1"
+        tuned_client = MagicMock()
+        tuned_client.base_url = "http://127.0.0.1:18901/v1"
+        tuned_client.chat.completions.create.return_value = {"ok": True}
+        base_client.with_options.return_value = tuned_client
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("custom", "gpt-5.4", "http://127.0.0.1:18901/v1", "key", None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(base_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={"max_retries": 0}),
+            patch("agent.auxiliary_client._validate_llm_response", side_effect=lambda resp, _task: resp),
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == {"ok": True}
+        base_client.with_options.assert_called_once_with(max_retries=0)
+        tuned_client.chat.completions.create.assert_called_once()
+        base_client.chat.completions.create.assert_not_called()
+
     def test_call_llm_retries_nous_after_401(self):
         class _Auth401(Exception):
             status_code = 401

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -481,9 +481,9 @@ class TestSummaryFailureTrackingForGatewayWarning:
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "msg 1"},
             {"role": "assistant", "content": "msg 2"},
-            {"role": "user", "content": "msg 3"},
-            {"role": "assistant", "content": "msg 4"},
-            {"role": "user", "content": "msg 5"},
+            {"role": "user", "content": "msg 3 CRITICAL_DATA=/tmp/important.py"},
+            {"role": "assistant", "content": "msg 4 ran pytest -q"},
+            {"role": "user", "content": "msg 5 fix the context compression 502 issue"},
             {"role": "assistant", "content": "msg 6"},
             {"role": "user", "content": "msg 7"},
         ]
@@ -496,11 +496,19 @@ class TestSummaryFailureTrackingForGatewayWarning:
         assert c._last_summary_fallback_used is True
         assert c._last_summary_dropped_count > 0
         assert c._last_summary_error is not None
-        # Result must still be well-formed (fallback summary present).
-        assert any(
-            isinstance(m.get("content"), str) and "Summary generation was unavailable" in m["content"]
+        # Result must still be well-formed and must preserve concrete details
+        # from the compressed middle instead of inserting a content-free marker.
+        fallback_contents = [
+            m.get("content", "")
             for m in result
-        )
+            if isinstance(m.get("content"), str) and m["content"].startswith(SUMMARY_PREFIX)
+        ]
+        assert fallback_contents
+        fallback = "\n".join(fallback_contents)
+        assert "deterministic extractive fallback" in fallback
+        assert "CRITICAL_DATA=/tmp/important.py" in fallback
+        assert "ran pytest -q" in fallback
+        assert "Summary generation was unavailable" not in fallback
 
     def test_compress_clears_fallback_flag_on_subsequent_success(self):
         mock_response = MagicMock()
@@ -1430,3 +1438,122 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestResponsesApiCompression:
+    """Regression coverage for Codex/OpenAI Responses API history entries."""
+
+    def _compressor(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            return ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=1,
+                protect_last_n=1,
+                quiet_mode=True,
+            )
+
+    def test_prune_responses_function_call_output_preserves_pair(self):
+        c = self._compressor()
+        messages = [
+            {"role": "user", "content": "start"},
+            {"type": "function_call", "call_id": "call_1", "name": "skill_view", "arguments": '{"name":"hermes-agent"}'},
+            {"type": "function_call_output", "call_id": "call_1", "output": "X" * 90000},
+            {"role": "user", "content": "latest"},
+        ]
+
+        result, pruned = c._prune_old_tool_results(messages, protect_tail_count=1, protect_tail_tokens=1000)
+
+        assert pruned >= 1
+        assert result[1]["type"] == "function_call"
+        assert result[2]["type"] == "function_call_output"
+        assert result[1]["call_id"] == result[2]["call_id"] == "call_1"
+        assert len(result[2]["output"]) < 2000
+        assert "skill_view" in result[2]["output"]
+
+    def test_prune_responses_protected_tail_large_output_is_clipped(self):
+        c = self._compressor()
+        messages = [
+            {"role": "user", "content": "start"},
+            {"type": "function_call", "call_id": "call_tail", "name": "skill_view", "arguments": '{"name":"claude-code"}'},
+            {"type": "function_call_output", "call_id": "call_tail", "output": "Y" * 50000},
+            {"role": "user", "content": "latest"},
+        ]
+
+        result, pruned = c._prune_old_tool_results(messages, protect_tail_count=4)
+
+        assert pruned >= 1
+        assert result[2]["type"] == "function_call_output"
+        assert result[2]["call_id"] == "call_tail"
+        assert len(result[2]["output"]) < 2000
+        assert "protected-tail output clipped" in result[2]["output"]
+
+    def test_prune_responses_function_call_arguments_keeps_valid_json(self):
+        import json as _json
+        c = self._compressor()
+        args_payload = _json.dumps({"path": "x.md", "content": "A" * 50000})
+        messages = [
+            {"type": "function_call", "call_id": "call_1", "name": "write_file", "arguments": args_payload},
+            {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+            {"role": "user", "content": "tail"},
+        ]
+
+        result, _ = c._prune_old_tool_results(messages, protect_tail_count=1)
+        parsed = _json.loads(result[0]["arguments"])
+
+        assert result[0]["call_id"] == "call_1"
+        assert result[0]["name"] == "write_file"
+        assert parsed["path"] == "x.md"
+        assert parsed["content"].endswith("...[truncated]")
+        assert len(result[0]["arguments"]) < len(args_payload)
+
+    def test_tail_budget_counts_responses_function_call_output(self):
+        c = self._compressor()
+        c.tail_token_budget = 80  # soft ceiling = 120 tokens
+        messages = [
+            {"role": "user", "content": "head"},
+            {"type": "function_call_output", "call_id": "orphan", "output": "Z" * 80000},
+            {"role": "assistant", "content": "tail1"},
+            {"role": "user", "content": "tail2"},
+            {"role": "assistant", "content": "tail3"},
+        ]
+
+        cut = c._find_tail_cut_by_tokens(messages, head_end=0)
+
+        assert cut == 2
+        assert messages[cut]["content"] == "tail1"
+
+    def test_serialize_for_summary_includes_responses_entries(self):
+        c = self._compressor()
+        rendered = c._serialize_for_summary([
+            {"type": "function_call", "call_id": "call_1", "name": "skill_view", "arguments": '{"name":"hermes-agent"}'},
+            {"type": "function_call_output", "call_id": "call_1", "output": "tool output detail"},
+            {"type": "reasoning", "summary": [{"type": "summary_text", "text": "reasoning summary"}]},
+        ])
+
+        assert "[FUNCTION CALL call_1]: skill_view" in rendered
+        assert "[FUNCTION CALL OUTPUT call_1]: tool output detail" in rendered
+        assert "[REASONING]: reasoning summary" in rendered
+
+    def test_sanitize_responses_pairs_adds_stub_and_removes_orphan(self):
+        c = self._compressor()
+        result = c._sanitize_tool_pairs([
+            {"type": "function_call", "call_id": "missing", "name": "read_file", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "orphan", "output": "bad"},
+        ])
+
+        call_ids = [m.get("call_id") for m in result]
+        assert "orphan" not in call_ids
+        assert result[0]["type"] == "function_call"
+        assert result[1]["type"] == "function_call_output"
+        assert result[1]["call_id"] == "missing"
+
+    def test_estimate_messages_tokens_rough_counts_responses_entries(self):
+        from agent.model_metadata import estimate_messages_tokens_rough
+        messages = [
+            {"type": "function_call", "call_id": "c1", "name": "x", "arguments": "A" * 4000},
+            {"type": "function_call_output", "call_id": "c1", "output": "B" * 40000},
+            {"type": "reasoning", "summary": [{"text": "C" * 8000}]},
+        ]
+
+        assert estimate_messages_tokens_rough(messages) > 10000

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -119,6 +119,22 @@ class TestCLIQuickCommands:
             printed = " ".join(str(c) for c in mock_cprint.call_args_list)
             assert "unknown command" in printed.lower()
 
+    def test_loads_live_quick_command_when_config_snapshot_is_stale(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "quick_commands:\n"
+            "  live:\n"
+            "    type: exec\n"
+            "    command: echo live-ok\n",
+            encoding="utf-8",
+        )
+        cli = self._make_cli({})
+        with patch("cli.get_hermes_home", return_value=tmp_path):
+            result = cli.process_command("/live")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "live-ok"
+
     def test_timeout_shows_error(self):
         cli = self._make_cli({"slow": {"type": "exec", "command": "sleep 100"}})
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("sleep", 30)):
@@ -189,6 +205,24 @@ class TestGatewayQuickCommands:
         assert result is not None
         assert "timed out" in result.lower()
 
+
+    @pytest.mark.asyncio
+    async def test_gateway_quick_command_runs_while_session_has_running_agent(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"tk1": {"type": "exec", "command": "echo midrun-ok"}}}
+        runner._running_agents = {"telegram:123": object()}
+        runner._running_agents_ts = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._session_key_for_source = MagicMock(return_value="telegram:123")
+        runner._draining = False
+
+        event = self._make_event("tk1")
+        result = await runner._handle_message(event)
+        assert result == "midrun-ok"
+
     @pytest.mark.asyncio
     async def test_gateway_config_object_supports_quick_commands(self):
         from gateway.config import GatewayConfig
@@ -205,3 +239,25 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_gateway_loads_live_quick_command_when_config_snapshot_is_stale(self, tmp_path):
+        from gateway.run import GatewayRunner
+
+        (tmp_path / "config.yaml").write_text(
+            "quick_commands:\n"
+            "  livegw:\n"
+            "    type: exec\n"
+            "    command: echo live-gw-ok\n",
+            encoding="utf-8",
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("livegw")
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_message(event)
+        assert result == "live-gw-ok"

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -295,6 +295,30 @@ class TestExtractMedia:
         assert len(media) == 1
         assert "Here is your audio" in cleaned
 
+    def test_inline_media_example_is_not_extracted(self):
+        content = "解释里提到 `MEDIA:/tmp/foo.txt` 这种写法，不是真附件。"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert "MEDIA:/tmp/foo.txt" in cleaned
+
+    def test_prose_media_example_is_not_extracted(self):
+        content = "如果要发文件，写 MEDIA:/tmp/foo.txt；这里只是在解释。"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert "MEDIA:/tmp/foo.txt" in cleaned
+
+    def test_fenced_media_example_is_not_extracted(self):
+        content = "```text\nMEDIA:/tmp/foo.txt\n```\n普通解释"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert "MEDIA:/tmp/foo.txt" in cleaned
+
+    def test_standalone_backticked_media_directive_still_extracts(self):
+        content = "`MEDIA:/tmp/real.ogg`"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/real.ogg", False)]
+        assert cleaned == ""
+
     def test_cleaned_content_trims_excess_newlines(self):
         content = "Before\n\nMEDIA:/audio.ogg\n\n\n\nAfter"
         _, cleaned = BasePlatformAdapter.extract_media(content)

--- a/tests/gateway/test_quick_command_aliases.py
+++ b/tests/gateway/test_quick_command_aliases.py
@@ -1,0 +1,66 @@
+"""Regression tests for gateway quick-command aliases."""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _Source:
+    user_id = "test_user"
+    user_name = "Test User"
+    chat_type = "dm"
+    chat_id = "123"
+    thread_id = None
+    platform = type("P", (), {"value": "weixin"})()
+
+
+class _Event:
+    def __init__(self, command, args=""):
+        self._command = command
+        self._args = args
+        self.text = f"/{command} {args}".strip()
+        self.source = _Source()
+
+    def get_command(self):
+        return self._command
+
+    def get_command_args(self):
+        return self._args
+
+
+class TestGatewayQuickCommandAliases:
+    @pytest.mark.asyncio
+    async def test_alias_to_exec_quick_command_executes_target(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "quick_commands": {
+                "tk1": {"type": "exec", "command": "echo switched-tk1"},
+                "tokenx24": {"type": "alias", "target": "/tk1"},
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        result = await runner._handle_message(_Event("tokenx24"))
+        assert result == "switched-tk1"
+
+    @pytest.mark.asyncio
+    async def test_alias_loop_returns_error(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "quick_commands": {
+                "a": {"type": "alias", "target": "/b"},
+                "b": {"type": "alias", "target": "/a"},
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        result = await runner._handle_message(_Event("a"))
+        assert result is not None
+        assert "alias loop" in result.lower()

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/honcho/cli.py."""
 
 from types import SimpleNamespace
+import argparse
 
 
 class TestResolveApiKey:
@@ -154,3 +155,82 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         assert "FAILED (Invalid API key)" in out
         assert "Connection... OK" not in out
+
+    def test_status_parser_accepts_drift_and_write_audit_flags(self):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        parser = argparse.ArgumentParser()
+        subs = parser.add_subparsers(dest="command")
+        honcho_parser = subs.add_parser("honcho")
+        honcho_cli.register_cli(honcho_parser)
+
+        args = parser.parse_args([
+            "honcho",
+            "status",
+            "--drift-audit",
+            "--drift-query",
+            "billing risk",
+            "--write-audit",
+        ])
+
+        assert args.honcho_command == "status"
+        assert args.drift_audit is True
+        assert args.drift_query == "billing risk"
+        assert args.write_audit is True
+
+    def test_cmd_status_runs_audits_when_requested(self, monkeypatch, capsys, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{}")
+
+        class FakeConfig:
+            enabled = True
+            api_key = "root-key"
+            workspace_id = "hermes"
+            host = "hermes"
+            base_url = None
+            ai_peer = "hermes"
+            peer_name = "eri"
+            recall_mode = "tools"
+            user_observe_me = True
+            user_observe_others = True
+            ai_observe_me = True
+            ai_observe_others = True
+            write_frequency = "async"
+            session_strategy = "global"
+            context_tokens = 2000
+            dialectic_reasoning_level = "minimal"
+            reasoning_level_cap = "minimal"
+            reasoning_heuristic = False
+            raw = {"dialecticCadence": 999999}
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        audit_calls = []
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {"apiKey": "***"})
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_active_profile_name", lambda: "default")
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: FakeConfig(),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.get_honcho_client",
+            lambda cfg: object(),
+        )
+        monkeypatch.setattr(honcho_cli, "_show_peer_cards", lambda hcfg, client: None)
+        monkeypatch.setattr(
+            honcho_cli,
+            "_run_status_audits",
+            lambda hcfg, client, *, drift_query, write_audit: audit_calls.append((drift_query, write_audit)),
+        )
+        monkeypatch.setitem(__import__("sys").modules, "honcho", SimpleNamespace())
+
+        honcho_cli.cmd_status(SimpleNamespace(all=False, drift_audit=True, drift_query="billing risk", write_audit=True))
+
+        out = capsys.readouterr().out
+        assert "Connection... OK" in out
+        assert audit_calls == [("billing risk", True)]

--- a/tests/honcho_plugin/test_session_context_query.py
+++ b/tests/honcho_plugin/test_session_context_query.py
@@ -1,0 +1,123 @@
+import json
+from types import SimpleNamespace
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class FakeHonchoSession:
+    def __init__(self, same_payload=False):
+        self.calls = []
+        self.same_payload = same_payload
+
+    def context(self, **kwargs):
+        self.calls.append(kwargs)
+        query = kwargs.get("search_query")
+        suffix = "same" if self.same_payload else (query or "baseline")
+        return SimpleNamespace(
+            summary=SimpleNamespace(content=f"summary {suffix}"),
+            peer_representation=f"representation {suffix}",
+            peer_card=[f"card {suffix}"],
+            messages=[],
+        )
+
+
+def make_manager(fake_session, *, ai_observe_others=True):
+    mgr = HonchoSessionManager(config=None)
+    mgr._ai_observe_others = ai_observe_others
+    mgr._context_tokens = 2000
+    session = HonchoSession(
+        key="hermes",
+        user_peer_id="maoge",
+        assistant_peer_id="hermes",
+        honcho_session_id="hermes",
+    )
+    mgr._cache["hermes"] = session
+    mgr._sessions_cache["hermes"] = fake_session
+    return mgr
+
+
+def test_honcho_context_tool_forwards_query_to_session_manager():
+    class Manager:
+        def __init__(self):
+            self.calls = []
+
+        def get_session_context(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return {"representation": "focused billing risk"}
+
+    manager = Manager()
+    provider = HonchoMemoryProvider()
+    provider._manager = manager
+    provider._session_key = "hermes"
+    provider._session_initialized = True
+
+    raw = provider.handle_tool_call(
+        "honcho_context",
+        {"peer": "user", "query": "billing risk"},
+    )
+
+    payload = json.loads(raw)
+    assert "focused billing risk" in payload["result"]
+    assert manager.calls == [((), {"peer": "user", "query": "billing risk"})] or manager.calls == [(("hermes",), {"peer": "user", "query": "billing risk"})]
+
+
+def test_get_session_context_forwards_query_and_observer_target(monkeypatch):
+    fake = FakeHonchoSession()
+    mgr = make_manager(fake)
+    monkeypatch.setattr(mgr, "_fetch_peer_context", lambda *a, **k: {"representation": "", "card": []})
+    monkeypatch.setattr(mgr, "_fetch_conclusion_context", lambda *a, **k: {"representation": "", "card": []})
+
+    result = mgr.get_session_context("hermes", peer="user", query="billing risk")
+
+    focused_call = fake.calls[0]
+    assert focused_call["peer_target"] == "maoge"
+    assert focused_call["peer_perspective"] == "hermes"
+    assert focused_call["search_query"] == "billing risk"
+    assert focused_call["search_top_k"] == 8
+    assert focused_call["max_conclusions"] == 8
+    assert focused_call["tokens"] == 2000
+    assert fake.calls[1].get("search_query") is None
+    assert result["representation"] == "representation billing risk"
+
+
+def test_get_session_context_uses_self_perspective_when_ai_does_not_observe_others(monkeypatch):
+    fake = FakeHonchoSession()
+    mgr = make_manager(fake, ai_observe_others=False)
+    monkeypatch.setattr(mgr, "_fetch_peer_context", lambda *a, **k: {"representation": "", "card": []})
+    monkeypatch.setattr(mgr, "_fetch_conclusion_context", lambda *a, **k: {"representation": "", "card": []})
+
+    mgr.get_session_context("hermes", peer="user", query="billing risk")
+
+    focused_call = fake.calls[0]
+    assert focused_call["peer_target"] == "maoge"
+    assert focused_call["peer_perspective"] == "maoge"
+
+
+def test_query_ignored_by_session_context_falls_back_to_peer_search_context(monkeypatch):
+    fake = FakeHonchoSession(same_payload=True)
+    mgr = make_manager(fake)
+
+    def fake_peer_context(peer_id, search_query=None, target=None):
+        if search_query:
+            return {"representation": f"focused peer {search_query}", "card": ["peer card"]}
+        return {"representation": "baseline peer", "card": ["baseline card"]}
+
+    monkeypatch.setattr(mgr, "_fetch_peer_context", fake_peer_context)
+    monkeypatch.setattr(
+        mgr,
+        "_fetch_conclusion_context",
+        lambda *a, **k: {"representation": "focused conclusion", "card": ["conclusion card"]},
+    )
+
+    result = mgr.get_session_context("hermes", peer="user", query="billing risk")
+
+    assert result["representation"] == "focused peer billing risk"
+    assert result["card"] == "peer card"
+
+
+def test_truncate_with_suffix_keeps_suffix_inside_cap():
+    text = "x" * 100
+    truncated = HonchoSessionManager._truncate_with_suffix(text, 20, suffix=" …")
+    assert len(truncated) <= 20
+    assert truncated.endswith(" …")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -48,6 +48,15 @@ def _make_mock_parent(depth=0):
     parent.providers_ignored = None
     parent.providers_order = None
     parent.provider_sort = None
+    parent.provider_require_parameters = False
+    parent.provider_data_collection = None
+    parent.max_tokens = None
+    parent.reasoning_config = None
+    parent.service_tier = None
+    parent.request_overrides = {}
+    parent.prefill_messages = []
+    parent._fallback_chain = []
+    parent._fallback_model = None
     parent._session_db = None
     parent._delegate_depth = depth
     parent._active_children = []
@@ -241,12 +250,30 @@ class TestDelegateTask(unittest.TestCase):
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)
+        # Simulate a live /model switch in the parent. Subagents must inherit
+        # the runtime state, not stale config.yaml defaults.
+        parent.model = "gpt-5.5-switched"
         parent.base_url = "https://chatgpt.com/backend-api/codex"
         parent.api_key="***"
         parent.provider = "openai-codex"
         parent.api_mode = "codex_responses"
+        parent.max_tokens = 8192
+        parent.reasoning_config = {"effort": "high"}
+        parent.service_tier = "priority"
+        parent.request_overrides = {"extra_body": {"reasoning_effort": "high"}}
+        parent.prefill_messages = [{"role": "user", "content": "prime"}]
+        parent.providers_allowed = ["provider-a"]
+        parent.providers_ignored = ["provider-b"]
+        parent.providers_order = ["provider-a", "provider-c"]
+        parent.provider_sort = "throughput"
+        parent.provider_require_parameters = True
+        parent.provider_data_collection = "deny"
+        parent._fallback_chain = [
+            {"provider": "fallback-a", "model": "model-a"},
+            {"provider": "fallback-b", "model": "model-b"},
+        ]
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with patch("tools.delegate_tool._load_config", return_value={}), patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
             mock_child.run_conversation.return_value = {
                 "final_response": "ok",
@@ -258,10 +285,24 @@ class TestDelegateTask(unittest.TestCase):
             delegate_task(goal="Test runtime inheritance", parent_agent=parent)
 
             _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], parent.model)
             self.assertEqual(kwargs["base_url"], parent.base_url)
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+            self.assertEqual(kwargs["max_tokens"], parent.max_tokens)
+            self.assertEqual(kwargs["reasoning_config"], parent.reasoning_config)
+            self.assertEqual(kwargs["service_tier"], parent.service_tier)
+            self.assertEqual(kwargs["request_overrides"], parent.request_overrides)
+            self.assertEqual(kwargs["prefill_messages"], parent.prefill_messages)
+            self.assertEqual(kwargs["providers_allowed"], parent.providers_allowed)
+            self.assertEqual(kwargs["providers_ignored"], parent.providers_ignored)
+            self.assertEqual(kwargs["providers_order"], parent.providers_order)
+            self.assertEqual(kwargs["provider_sort"], parent.provider_sort)
+            self.assertEqual(kwargs["provider_require_parameters"], parent.provider_require_parameters)
+            self.assertEqual(kwargs["provider_data_collection"], parent.provider_data_collection)
+            self.assertEqual(kwargs["fallback_model"], parent._fallback_chain)
+            self.assertIsNot(kwargs["fallback_model"], parent._fallback_chain)
 
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)
@@ -1478,7 +1519,9 @@ class TestDelegateHeartbeat(unittest.TestCase):
         }
 
         def slow_run(**kwargs):
-            time.sleep(0.15)
+            deadline = time.monotonic() + 0.6
+            while not touch_calls and time.monotonic() < deadline:
+                time.sleep(0.01)
             return {"final_response": "done", "completed": True, "api_calls": 5}
 
         child.run_conversation.side_effect = slow_run
@@ -1524,10 +1567,11 @@ class TestDelegateHeartbeat(unittest.TestCase):
         }
 
         def slow_run(**kwargs):
-            # Long enough to exceed the OLD idle threshold (5 cycles) at
-            # the patched interval, but shorter than the new in-tool
-            # threshold.
-            time.sleep(0.4)
+            # Wait until the heartbeat proves it stayed alive past the old
+            # idle threshold, or time out if the old stale-stop bug regresses.
+            deadline = time.monotonic() + 1.2
+            while len(touch_calls) <= 6 and time.monotonic() < deadline:
+                time.sleep(0.01)
             return {"final_response": "done", "completed": True, "api_calls": 1}
 
         child.run_conversation.side_effect = slow_run
@@ -1548,7 +1592,7 @@ class TestDelegateHeartbeat(unittest.TestCase):
         # With the old idle threshold (5 cycles = 0.25s), touch_calls
         # would cap at ~5. With the in-tool threshold (20 cycles = 1.0s),
         # we should see substantially more heartbeats over 0.4s.
-        self.assertGreater(
+        self.assertGreaterEqual(
             len(touch_calls), 6,
             f"Heartbeat stopped too early while child was inside a tool; "
             f"got {len(touch_calls)} touches over 0.4s at 0.05s interval",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1026,6 +1026,15 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
+    # Inherit the parent's *runtime* model configuration, not just the static
+    # config.yaml defaults. This is what keeps subagents aligned after live
+    # /model switches, fallback-chain pruning, service-tier changes, or
+    # provider-routing tweaks in the already-running parent session. Explicit
+    # delegation.provider/base_url/model config still wins via override_* above.
+    parent_fallback_chain = getattr(parent_agent, "_fallback_chain", [])
+    if not isinstance(parent_fallback_chain, list):
+        parent_fallback_chain = []
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -1037,6 +1046,8 @@ def _build_child_agent(
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
+        service_tier=getattr(parent_agent, "service_tier", None),
+        request_overrides=getattr(parent_agent, "request_overrides", None),
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
@@ -1053,6 +1064,9 @@ def _build_child_agent(
         providers_ignored=parent_agent.providers_ignored,
         providers_order=parent_agent.providers_order,
         provider_sort=parent_agent.provider_sort,
+        provider_require_parameters=getattr(parent_agent, "provider_require_parameters", False),
+        provider_data_collection=getattr(parent_agent, "provider_data_collection", None),
+        fallback_model=list(parent_fallback_chain),
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
     )


### PR DESCRIPTION
## Summary
- Harden Responses API context compression for typed function_call/function_call_output history and add extractive fallback summaries.
- Add auxiliary task retry overrides via `auxiliary.<task>.max_retries`.
- Make Honcho context/search query-aware and add drift/write audit CLI coverage.
- Reload quick commands from live config and fix alias resolution during running-agent sessions.
- Avoid false-positive `MEDIA:` directive extraction from prose/code examples.
- Inherit runtime provider/model/reasoning settings in delegated agents.
- Document local GStack/Claude Code and subagent operating policy.

## Test Plan
- `rtk pytest tests/agent/test_context_compressor.py -q` → 73 passed
- `rtk pytest tests/agent/test_auxiliary_client.py -q` → 118 passed
- `rtk pytest tests/honcho_plugin/test_cli.py tests/honcho_plugin/test_session_context_query.py -q` → 17 passed
- `rtk pytest tests/cli/test_quick_commands.py tests/gateway/test_quick_command_aliases.py -q` → 21 passed
- `rtk pytest tests/gateway/test_platform_base.py -q` → 89 passed
- `rtk pytest tests/tools/test_delegate.py -q` → 121 passed
- Combined related suite → 439 passed
- `git diff --check HEAD --` → passed
