### PR TITLE
fix(approval): extend sensitive write target to cover shell RC and credential files

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -94,10 +94,20 @@ _HERMES_ENV_PATH = (
 )
 _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
+_SHELL_RC_FILES = (
+    r'(?:~|\$home|\$\{home\})/\.'
+    r'(?:bashrc|zshrc|profile|bash_profile|zprofile)\b'
+)
+_CREDENTIAL_FILES = (
+    r'(?:~|\$home|\$\{home\})/\.'
+    r'(?:netrc|pgpass|npmrc|pypirc)\b'
+)
 _SENSITIVE_WRITE_TARGET = (
     r'(?:/etc/|/dev/sd|'
     rf'{_SSH_SENSITIVE_PATH}|'
-    rf'{_HERMES_ENV_PATH})'
+    rf'{_HERMES_ENV_PATH}|'
+    rf'{_SHELL_RC_FILES}|'
+    rf'{_CREDENTIAL_FILES})'
 )
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'
 _COMMAND_TAIL = r'(?:\s*(?:&&|\|\||;).*)?$'


### PR DESCRIPTION
Salvage of #19240 by @JasonOA888 onto current main. Closes the terminal-vs-write_file inconsistency where `echo >> ~/.bashrc`, `tee -a ~/.netrc`, etc. bypassed the approval gate even though `write_file` blocks those exact paths via `file_safety.py`.

## Changes
- `tools/approval.py`: add `_SHELL_RC_FILES` and `_CREDENTIAL_FILES` alternatives to `_SENSITIVE_WRITE_TARGET` (+11/-1)

## Validation
- tests/tools/test_approval.py: 132/132 pass
- E2E: 8 attack vectors (`~/.bashrc`, `~/.zshrc`, `~/.profile`, `~/.bash_profile`, `~/.netrc`, `~/.pgpass`, `~/.npmrc`, `~/.pypirc`) now trigger approval; 3 normal writes (`/tmp/`, `~/regular.txt`, `~/notes/`) still pass through.

Closes #19240. Authorship preserved via cherry-pick.