### PR TITLE
feat: add provider retry and proxy config handling

### DIFF
--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -11,10 +11,29 @@ def _coerce_timeout(raw: object) -> float | None:
     return timeout
 
 
-def get_provider_request_timeout(
-    provider_id: str, model: str | None = None
-) -> float | None:
-    """Return a configured provider request timeout in seconds, if any."""
+def _coerce_int(raw: object) -> int | None:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _coerce_bool(raw: object) -> bool | None:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        value = raw.strip().lower()
+        if value in {"1", "true", "yes", "on"}:
+            return True
+        if value in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _load_provider_config(provider_id: str) -> dict[str, object] | None:
     if not provider_id:
         return None
 
@@ -28,7 +47,17 @@ def get_provider_request_timeout(
     provider_config = (
         providers.get(provider_id, {}) if isinstance(providers, dict) else {}
     )
-    if not isinstance(provider_config, dict):
+    if isinstance(provider_config, dict):
+        return provider_config
+    return None
+
+
+def get_provider_request_timeout(
+    provider_id: str, model: str | None = None
+) -> float | None:
+    """Return a configured provider request timeout in seconds, if any."""
+    provider_config = _load_provider_config(provider_id)
+    if provider_config is None:
         return None
 
     model_config = _get_model_config(provider_config, model)
@@ -44,20 +73,8 @@ def get_provider_stale_timeout(
     provider_id: str, model: str | None = None
 ) -> float | None:
     """Return a configured non-stream stale timeout in seconds, if any."""
-    if not provider_id:
-        return None
-
-    try:
-        from hermes_cli.config import load_config
-        config = load_config()
-    except Exception:
-        return None
-
-    providers = config.get("providers", {}) if isinstance(config, dict) else {}
-    provider_config = (
-        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
-    )
-    if not isinstance(provider_config, dict):
+    provider_config = _load_provider_config(provider_id)
+    if provider_config is None:
         return None
 
     model_config = _get_model_config(provider_config, model)
@@ -67,6 +84,66 @@ def get_provider_stale_timeout(
             return timeout
 
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
+
+
+def get_provider_retry_attempts(
+    provider_id: str, model: str | None = None
+) -> int | None:
+    """Return a configured API retry count, if any."""
+    provider_config = _load_provider_config(provider_id)
+    if provider_config is None:
+        return None
+
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        attempts = _coerce_int(model_config.get("retry_attempts"))
+        if attempts is not None:
+            return attempts
+
+    return _coerce_int(provider_config.get("retry_attempts"))
+
+
+def get_provider_retry_backoff_seconds(
+    provider_id: str, model: str | None = None
+) -> tuple[float, float] | None:
+    """Return configured retry backoff ``(base_seconds, max_seconds)``, if any."""
+    provider_config = _load_provider_config(provider_id)
+    if provider_config is None:
+        return None
+
+    model_config = _get_model_config(provider_config, model)
+    candidates = [model_config, provider_config]
+    for cfg in candidates:
+        if not isinstance(cfg, dict):
+            continue
+        base = _coerce_timeout(cfg.get("retry_backoff_seconds"))
+        max_delay = _coerce_timeout(cfg.get("retry_backoff_max_seconds"))
+        if base is None and max_delay is None:
+            continue
+        resolved_base = base if base is not None else 2.0
+        resolved_max = max_delay if max_delay is not None else 60.0
+        if resolved_max < resolved_base:
+            resolved_max = resolved_base
+        return resolved_base, resolved_max
+
+    return None
+
+
+def get_provider_ignore_env_proxy(
+    provider_id: str, model: str | None = None
+) -> bool | None:
+    """Return whether env proxy vars should be ignored for this provider/model."""
+    provider_config = _load_provider_config(provider_id)
+    if provider_config is None:
+        return None
+
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        ignore = _coerce_bool(model_config.get("ignore_env_proxy"))
+        if ignore is not None:
+            return ignore
+
+    return _coerce_bool(provider_config.get("ignore_env_proxy"))
 
 
 def _get_model_config(

--- a/run_agent.py
+++ b/run_agent.py
@@ -93,7 +93,10 @@ OpenAI = _OpenAIProxy()
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_cli.timeouts import (
+    get_provider_ignore_env_proxy,
     get_provider_request_timeout,
+    get_provider_retry_attempts,
+    get_provider_retry_backoff_seconds,
     get_provider_stale_timeout,
 )
 
@@ -241,8 +244,15 @@ def _get_proxy_from_env() -> Optional[str]:
     return None
 
 
-def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
+def _get_proxy_for_base_url(
+    base_url: Optional[str],
+    *,
+    provider_id: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Optional[str]:
     """Return an env-configured proxy unless NO_PROXY excludes this base URL."""
+    if provider_id and get_provider_ignore_env_proxy(provider_id, model) is True:
+        return None
     proxy = _get_proxy_from_env()
     if not proxy or not base_url:
         return proxy
@@ -4064,6 +4074,44 @@ class AIAgent:
         prefix = f"HTTP {status_code}: " if status_code else ""
         return f"{prefix}{raw[:500]}"
 
+    def _timeout_diagnostic_hint(self, error: Exception) -> str:
+        error_type = type(error).__name__
+        if error_type not in {"APITimeoutError", "ReadTimeout", "ConnectTimeout", "PoolTimeout"}:
+            return ""
+
+        provider = (self.provider or "").strip().lower()
+        if provider != "openai-codex":
+            return ""
+
+        hints: list[str] = []
+        proxy = _get_proxy_from_env()
+        if proxy:
+            if get_provider_ignore_env_proxy(provider, self.model) is True:
+                hints.append("provider config is bypassing HTTP(S)_PROXY for Codex")
+            else:
+                hints.append("Codex is using HTTP(S)_PROXY/ALL_PROXY from the environment")
+        else:
+            hints.append("Codex is connecting directly without HTTP(S)_PROXY")
+
+        hints.append(
+            "check chatgpt.com/backend-api/codex reachability and refresh `hermes auth login openai-codex` if the ChatGPT session expired"
+        )
+
+        timeout_cfg = get_provider_request_timeout(provider, self.model)
+        if timeout_cfg is not None:
+            hints.append(f"configured request timeout is {timeout_cfg:.0f}s")
+        else:
+            hints.append("set `providers.openai-codex.request_timeout_seconds` in config.yaml to raise the timeout")
+
+        return " | ".join(hints)
+
+    def _summarize_api_error_with_hint(self, error: Exception) -> str:
+        summary = self._summarize_api_error(error)
+        hint = self._timeout_diagnostic_hint(error)
+        if not hint:
+            return summary
+        return f"{summary} | {hint}"
+
     def _mask_api_key_for_logs(self, key: Optional[str]) -> Optional[str]:
         if not key:
             return None
@@ -5449,8 +5497,7 @@ class AIAgent:
             return bool(getattr(http_client, "is_closed", False))
         return False
 
-    @staticmethod
-    def _build_keepalive_http_client(base_url: str = "") -> Any:
+    def _build_keepalive_http_client(self, base_url: str = "") -> Any:
         try:
             import httpx as _httpx
             import socket as _socket
@@ -5466,7 +5513,11 @@ class AIAgent:
             # from env vars (allow_env_proxies = trust_env and transport is None).
             # Explicitly read proxy settings while still honoring NO_PROXY for
             # loopback / local endpoints such as a locally hosted sub2api.
-            _proxy = _get_proxy_for_base_url(base_url)
+            _proxy = _get_proxy_for_base_url(
+                base_url,
+                provider_id=getattr(self, "provider", None),
+                model=getattr(self, "model", None),
+            )
             return _httpx.Client(
                 transport=_httpx.HTTPTransport(socket_options=_sock_opts),
                 proxy=_proxy,
@@ -11021,7 +11072,11 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = self._api_max_retries
+            max_retries = get_provider_retry_attempts(self.provider, self.model)
+            if max_retries is None:
+                max_retries = self._api_max_retries
+            if max_retries < 1:
+                max_retries = 1
             primary_recovery_attempted = False
             max_compression_attempts = 3
             codex_auth_retry_attempted=False
@@ -12673,7 +12728,7 @@ class AIAgent:
                             compression_attempts = 0
                             primary_recovery_attempted = False
                             continue
-                        _final_summary = self._summarize_api_error(api_error)
+                        _final_summary = self._summarize_api_error_with_hint(api_error)
                         if is_rate_limited:
                             self._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
                         else:
@@ -12749,7 +12804,20 @@ class AIAgent:
                                     _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
-                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                    if _retry_after:
+                        wait_time = _retry_after
+                    else:
+                        _backoff = get_provider_retry_backoff_seconds(self.provider, self.model)
+                        if _backoff is None:
+                            wait_time = jittered_backoff(
+                                retry_count, base_delay=2.0, max_delay=60.0,
+                            )
+                        else:
+                            wait_time = jittered_backoff(
+                                retry_count,
+                                base_delay=_backoff[0],
+                                max_delay=_backoff[1],
+                            )
                     if is_rate_limited:
                         self._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                     else:

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import textwrap
 
 from hermes_cli.timeouts import (
+    get_provider_ignore_env_proxy,
     get_provider_request_timeout,
+    get_provider_retry_attempts,
+    get_provider_retry_backoff_seconds,
     get_provider_stale_timeout,
 )
 
@@ -74,6 +77,48 @@ def test_provider_stale_timeout_used_when_no_model_override(monkeypatch, tmp_pat
     assert get_provider_stale_timeout("openai-codex", "gpt-5.4") == 900.0
 
 
+def test_provider_retry_settings_support_model_overrides(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          openai-codex:
+            retry_attempts: 5
+            retry_backoff_seconds: 4
+            retry_backoff_max_seconds: 45
+            models:
+              gpt-5.5:
+                retry_attempts: 7
+                retry_backoff_seconds: 6
+                retry_backoff_max_seconds: 30
+        """,
+    )
+
+    assert get_provider_retry_attempts("openai-codex", "gpt-5.5") == 7
+    assert get_provider_retry_backoff_seconds("openai-codex", "gpt-5.5") == (6.0, 30.0)
+    assert get_provider_retry_attempts("openai-codex", "gpt-5.4") == 5
+    assert get_provider_retry_backoff_seconds("openai-codex", "gpt-5.4") == (4.0, 45.0)
+
+
+def test_provider_ignore_env_proxy_supports_model_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          openai-codex:
+            ignore_env_proxy: false
+            models:
+              gpt-5.5:
+                ignore_env_proxy: true
+        """,
+    )
+
+    assert get_provider_ignore_env_proxy("openai-codex", "gpt-5.5") is True
+    assert get_provider_ignore_env_proxy("openai-codex", "gpt-5.4") is False
+
+
 def test_missing_timeout_returns_none(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _write_config(
@@ -128,6 +173,30 @@ def test_invalid_stale_timeout_values_return_none(monkeypatch, tmp_path):
 
     assert get_provider_stale_timeout("openai-codex", "gpt-5.4") is None
     assert get_provider_stale_timeout("openai-codex", "gpt-5.5") is None
+
+
+def test_invalid_retry_and_proxy_values_return_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          openai-codex:
+            retry_attempts: invalid
+            retry_backoff_seconds: slow
+            retry_backoff_max_seconds: -1
+            ignore_env_proxy: maybe
+            models:
+              gpt-5.5:
+                retry_attempts: -5
+                retry_backoff_seconds: -2
+                ignore_env_proxy: not-sure
+        """,
+    )
+
+    assert get_provider_retry_attempts("openai-codex", "gpt-5.5") is None
+    assert get_provider_retry_backoff_seconds("openai-codex", "gpt-5.5") is None
+    assert get_provider_ignore_env_proxy("openai-codex", "gpt-5.5") is None
 
 
 def test_anthropic_adapter_honors_timeout_kwarg():

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -18,6 +18,7 @@ This test pins that the constructed ``httpx.Client`` mounts an ``HTTPProxy``
 pool when a proxy env var is set, AND that the socket-level keepalive
 transport is still installed on the no-proxy default path.
 """
+import textwrap
 from unittest.mock import patch
 
 import httpx
@@ -40,6 +41,10 @@ def _make_agent():
 def _extract_http_client(client_kwargs: dict):
     """_create_openai_client calls ``OpenAI(**client_kwargs)``; grab the injected client."""
     return client_kwargs.get("http_client")
+
+
+def _write_config(tmp_path, body: str) -> None:
+    (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
 
 
 def test_get_proxy_from_env_prefers_https_then_http_then_all(monkeypatch):
@@ -186,6 +191,47 @@ def test_get_proxy_for_base_url_returns_none_when_proxy_unset(monkeypatch):
     monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1")
     assert _get_proxy_for_base_url("http://127.0.0.1:11434/v1") is None
     assert _get_proxy_for_base_url("https://api.openai.com/v1") is None
+
+
+def test_get_proxy_for_base_url_can_ignore_env_proxy_per_provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          openai-codex:
+            ignore_env_proxy: true
+        """,
+    )
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://corp:8080")
+
+    assert _get_proxy_for_base_url(
+        "https://chatgpt.com/backend-api/codex",
+        provider_id="openai-codex",
+        model="gpt-5.5",
+    ) is None
+
+
+def test_codex_timeout_summary_includes_proxy_hint(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+
+    agent = _make_agent()
+    agent.model = "gpt-5.5"
+
+    class APITimeoutError(Exception):
+        pass
+
+    summary = agent._summarize_api_error_with_hint(APITimeoutError("request timed out"))
+    assert "request timed out" in summary
+    assert "HTTP(S)_PROXY/ALL_PROXY" in summary
+    assert "hermes auth login openai-codex" in summary
 
 
 @patch("run_agent.OpenAI")


### PR DESCRIPTION
## Summary
- add retry handling for provider startup and timeout-sensitive execution paths
- improve proxy config/environment handling in OpenAI client creation
- add regression coverage for timeout behavior and proxy environment wiring

## Scope
- `hermes_cli/timeouts.py`
- `run_agent.py`
- `tests/hermes_cli/test_timeouts.py`
- `tests/run_agent/test_create_openai_client_proxy_env.py`

## Test evidence
- 26 passed

## Notes
- standalone PR
- PR 3 stacks on top of this branch