### PR TITLE
fix: harden Copilot ACP command error classification

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -25,10 +25,149 @@ from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
 
 ACP_MARKER_BASE_URL = "acp://copilot"
-_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+_DEFAULT_TIMEOUT_SECONDS = _env_float("HERMES_ACP_TIMEOUT_SECONDS", 180.0)
+_MAX_DIAGNOSTIC_CHARS = _env_int("HERMES_ACP_MAX_OUTPUT_CHARS", 4000)
+_STDERR_TAIL_LINES = 80
+_STDOUT_TAIL_LINES = 80
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
+_TIMEOUT_PATTERNS = ("timed out", "timeout")
+_HTTP_500_PATTERNS = ("api error: 500", "http 500", "500 internal server error")
+_INVALID_JSON_PATTERNS = ("unexpected token", "is not valid json", "json parse", "jsondecodeerror")
+_SSE_PATTERNS = ("event:", "data:")
+_NON_RETRYABLE_PATTERNS = (
+    "401",
+    "403",
+    "429",
+    "unauthorized",
+    "forbidden",
+    "login",
+    "not authenticated",
+    "authentication",
+    "rate limit",
+    "rate-limit",
+    "permission denied",
+    "tool denied",
+    "not allowed",
+    "access denied",
+)
+
+
+class ACPInvocationError(RuntimeError):
+    def __init__(self, message: str, *, category: str, retryable: bool):
+        super().__init__(message)
+        self.category = category
+        self.retryable = retryable
+
+
+def _truncate_diagnostic(text: str, *, limit: int = _MAX_DIAGNOSTIC_CHARS) -> str:
+    if not text:
+        return ""
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    marker = "\n[output truncated]"
+    cutoff = max(0, limit - len(marker))
+    return text[:cutoff].rstrip() + marker
+
+
+def _looks_like_sse_payload(text: str) -> bool:
+    lowered = text.lower()
+    return any(pattern in lowered for pattern in _SSE_PATTERNS)
+
+
+def _format_failure_diagnostics(stdout_text: str, stderr_text: str) -> str:
+    parts: list[str] = []
+    stdout_text = _truncate_diagnostic(stdout_text)
+    stderr_text = _truncate_diagnostic(stderr_text)
+    if stdout_text:
+        parts.append(f"stdout:\n{stdout_text}")
+    if stderr_text:
+        parts.append(f"stderr:\n{stderr_text}")
+    if not parts:
+        return ""
+    return "\n\nDiagnostics:\n" + "\n\n".join(parts)
+
+
+def classify_acp_failure(
+    *,
+    stdout_text: str = "",
+    stderr_text: str = "",
+    exception_text: str = "",
+    timed_out: bool = False,
+) -> tuple[str, bool, str]:
+    combined = "\n".join(part for part in (exception_text, stdout_text, stderr_text) if part).strip()
+    lowered = combined.lower()
+    diagnostics = _format_failure_diagnostics(stdout_text, stderr_text)
+
+    if timed_out or any(pattern in lowered for pattern in _TIMEOUT_PATTERNS):
+        return (
+            "timeout",
+            True,
+            "ACP subprocess timed out waiting for a response." + diagnostics,
+        )
+
+    if any(pattern in lowered for pattern in _NON_RETRYABLE_PATTERNS):
+        return (
+            "non_transient",
+            False,
+            "ACP subprocess returned a non-retryable authentication/permission/rate-limit failure." + diagnostics,
+        )
+
+    if any(pattern in lowered for pattern in _HTTP_500_PATTERNS):
+        return (
+            "http_500",
+            True,
+            "ACP subprocess returned an upstream HTTP 500/API Error 500." + diagnostics,
+        )
+
+    if any(pattern in lowered for pattern in _INVALID_JSON_PATTERNS):
+        if _looks_like_sse_payload(stdout_text) or _looks_like_sse_payload(stderr_text) or _looks_like_sse_payload(exception_text):
+            return (
+                "sse_json_mismatch",
+                True,
+                "Expected JSON but received SSE event stream. Likely CCR/upstream streaming-format mismatch. Retry once, shorten the prompt, reduce log output, or check CCR non-streaming mode." + diagnostics,
+            )
+        return (
+            "malformed_json",
+            True,
+            "ACP subprocess returned malformed JSON." + diagnostics,
+        )
+
+    return (
+        "process_error",
+        False,
+        "ACP subprocess failed before returning a valid response." + diagnostics,
+    )
 
 
 def _resolve_command() -> str:
@@ -414,6 +553,27 @@ class CopilotACPClient:
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        max_attempts = 2
+        last_error: ACPInvocationError | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return self._run_prompt_once(prompt_text, timeout_seconds=timeout_seconds)
+            except ACPInvocationError as exc:
+                last_error = exc
+                if exc.retryable and attempt < max_attempts:
+                    continue
+                if exc.retryable and attempt == max_attempts:
+                    raise ACPInvocationError(
+                        f"{exc}\n\nRetried once and still failed.",
+                        category=exc.category,
+                        retryable=False,
+                    ) from exc
+                raise
+
+        assert last_error is not None
+        raise last_error
+
+    def _run_prompt_once(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -440,7 +600,8 @@ class CopilotACPClient:
             self._active_process = proc
 
         inbox: queue.Queue[dict[str, Any]] = queue.Queue()
-        stderr_tail: deque[str] = deque(maxlen=40)
+        stderr_tail: deque[str] = deque(maxlen=_STDERR_TAIL_LINES)
+        stdout_tail: deque[str] = deque(maxlen=_STDOUT_TAIL_LINES)
 
         def _stdout_reader() -> None:
             if proc.stdout is None:
@@ -449,7 +610,10 @@ class CopilotACPClient:
                 try:
                     inbox.put(json.loads(line))
                 except Exception:
-                    inbox.put({"raw": line.rstrip("\n")})
+                    raw_line = line.rstrip("\n")
+                    if raw_line:
+                        stdout_tail.append(raw_line)
+                    inbox.put({"raw": raw_line})
 
         def _stderr_reader() -> None:
             if proc.stderr is None:
@@ -499,15 +663,42 @@ class CopilotACPClient:
                     continue
                 if "error" in msg:
                     err = msg.get("error") or {}
-                    raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
+                    category, retryable, failure_message = classify_acp_failure(
+                        stdout_text="\n".join(stdout_tail).strip(),
+                        stderr_text="\n".join(stderr_tail).strip(),
+                        exception_text=f"ACP method {method} failed: {err.get('message') or err}",
+                    )
+                    raise ACPInvocationError(
+                        failure_message,
+                        category=category,
+                        retryable=retryable,
                     )
                 return msg.get("result")
 
+            stdout_text = "\n".join(stdout_tail).strip()
             stderr_text = "\n".join(stderr_tail).strip()
-            if proc.poll() is not None and stderr_text:
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+            if proc.poll() is not None:
+                category, retryable, failure_message = classify_acp_failure(
+                    stdout_text=stdout_text,
+                    stderr_text=stderr_text,
+                    exception_text=f"ACP process exited early while waiting for {method}.",
+                )
+                raise ACPInvocationError(
+                    failure_message,
+                    category=category,
+                    retryable=retryable,
+                )
+            category, retryable, failure_message = classify_acp_failure(
+                stdout_text=stdout_text,
+                stderr_text=stderr_text,
+                exception_text=f"Timed out waiting for ACP response to {method} after {timeout_seconds:.1f}s.",
+                timed_out=True,
+            )
+            raise ACPInvocationError(
+                failure_message,
+                category=category,
+                retryable=retryable,
+            )
 
         try:
             _request(

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -60,6 +60,13 @@ _STDOUT_TAIL_LINES = 80
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
+CLAUDE_RESPONSE_FORMAT_MISMATCH = "CLAUDE_RESPONSE_FORMAT_MISMATCH"
+_CLAUDE_RESPONSE_FORMAT_MISMATCH_MESSAGE = (
+    "CLAUDE_RESPONSE_FORMAT_MISMATCH: Expected JSON but received SSE/event-stream style response. "
+    "Likely CCR/upstream transformer returned streaming output to a non-streaming caller. "
+    "This is usually a proxy/adapter/upstream response-format problem, not a Bash/Read tool permission problem."
+)
+
 _TIMEOUT_PATTERNS = ("timed out", "timeout")
 _HTTP_500_PATTERNS = ("api error: 500", "http 500", "500 internal server error")
 _INVALID_JSON_PATTERNS = ("unexpected token", "is not valid json", "json parse", "jsondecodeerror")
@@ -143,6 +150,19 @@ def classify_acp_failure(
             "ACP subprocess returned a non-retryable authentication/permission/rate-limit failure." + diagnostics,
         )
 
+    has_invalid_json = any(pattern in lowered for pattern in _INVALID_JSON_PATTERNS)
+    has_sse_payload = (
+        _looks_like_sse_payload(stdout_text)
+        or _looks_like_sse_payload(stderr_text)
+        or _looks_like_sse_payload(exception_text)
+    )
+    if has_invalid_json and has_sse_payload:
+        return (
+            CLAUDE_RESPONSE_FORMAT_MISMATCH,
+            True,
+            _CLAUDE_RESPONSE_FORMAT_MISMATCH_MESSAGE + diagnostics,
+        )
+
     if any(pattern in lowered for pattern in _HTTP_500_PATTERNS):
         return (
             "http_500",
@@ -150,13 +170,7 @@ def classify_acp_failure(
             "ACP subprocess returned an upstream HTTP 500/API Error 500." + diagnostics,
         )
 
-    if any(pattern in lowered for pattern in _INVALID_JSON_PATTERNS):
-        if _looks_like_sse_payload(stdout_text) or _looks_like_sse_payload(stderr_text) or _looks_like_sse_payload(exception_text):
-            return (
-                "sse_json_mismatch",
-                True,
-                "Expected JSON but received SSE event stream. Likely CCR/upstream streaming-format mismatch. Retry once, shorten the prompt, reduce log output, or check CCR non-streaming mode." + diagnostics,
-            )
+    if has_invalid_json:
         return (
             "malformed_json",
             True,

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -71,6 +71,13 @@ _TIMEOUT_PATTERNS = ("timed out", "timeout")
 _HTTP_500_PATTERNS = ("api error: 500", "http 500", "500 internal server error")
 _INVALID_JSON_PATTERNS = ("unexpected token", "is not valid json", "json parse", "jsondecodeerror")
 _SSE_PATTERNS = ("event:", "data:")
+_UNSUPPORTED_ARGS_PATTERNS = (
+    "unknown option",
+    "unrecognized option",
+    "unsupported option",
+    "invalid option",
+    "no such option",
+)
 _NON_RETRYABLE_PATTERNS = (
     "401",
     "403",
@@ -125,12 +132,51 @@ def _format_failure_diagnostics(stdout_text: str, stderr_text: str) -> str:
     return "\n\nDiagnostics:\n" + "\n\n".join(parts)
 
 
+def _extract_unsupported_option(text: str) -> str | None:
+    match = re.search(
+        r"(?:unknown|unrecognized|unsupported|invalid|no such)\s+option\s+['\"]?(--[A-Za-z0-9][A-Za-z0-9-]*)",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _format_unsupported_args_message(
+    *,
+    combined_text: str,
+    diagnostics: str,
+    command_text: str,
+    command_args: tuple[str, ...],
+) -> str:
+    command_name = Path(command_text or "").name or "configured command"
+    unsupported_option = _extract_unsupported_option(combined_text)
+    lines = [
+        "ACP subprocess failed before protocol startup.",
+        "The configured command does not support the requested ACP args.",
+    ]
+    if unsupported_option and command_name == "claude" and unsupported_option == "--acp":
+        lines.append("Current claude CLI does not expose --acp.")
+    elif unsupported_option:
+        lines.append(f"Current {command_name} CLI does not expose {unsupported_option}.")
+    elif command_args:
+        lines.append(
+            f"Current {command_name} CLI does not support the configured ACP arguments: {' '.join(command_args)}."
+        )
+    else:
+        lines.append(f"Current {command_name} CLI does not support the configured ACP arguments.")
+    return "\n".join(lines) + diagnostics
+
+
 def classify_acp_failure(
     *,
     stdout_text: str = "",
     stderr_text: str = "",
     exception_text: str = "",
     timed_out: bool = False,
+    command_text: str = "",
+    command_args: tuple[str, ...] = (),
 ) -> tuple[str, bool, str]:
     combined = "\n".join(part for part in (exception_text, stdout_text, stderr_text) if part).strip()
     lowered = combined.lower()
@@ -141,6 +187,18 @@ def classify_acp_failure(
             "timeout",
             True,
             "ACP subprocess timed out waiting for a response." + diagnostics,
+        )
+
+    if any(pattern in lowered for pattern in _UNSUPPORTED_ARGS_PATTERNS):
+        return (
+            "unsupported_cli_args",
+            False,
+            _format_unsupported_args_message(
+                combined_text=combined,
+                diagnostics=diagnostics,
+                command_text=command_text,
+                command_args=command_args,
+            ),
         )
 
     if any(pattern in lowered for pattern in _NON_RETRYABLE_PATTERNS):
@@ -681,6 +739,8 @@ class CopilotACPClient:
                         stdout_text="\n".join(stdout_tail).strip(),
                         stderr_text="\n".join(stderr_tail).strip(),
                         exception_text=f"ACP method {method} failed: {err.get('message') or err}",
+                        command_text=self._acp_command,
+                        command_args=tuple(self._acp_args),
                     )
                     raise ACPInvocationError(
                         failure_message,
@@ -696,6 +756,8 @@ class CopilotACPClient:
                     stdout_text=stdout_text,
                     stderr_text=stderr_text,
                     exception_text=f"ACP process exited early while waiting for {method}.",
+                    command_text=self._acp_command,
+                    command_args=tuple(self._acp_args),
                 )
                 raise ACPInvocationError(
                     failure_message,
@@ -707,6 +769,8 @@ class CopilotACPClient:
                 stderr_text=stderr_text,
                 exception_text=f"Timed out waiting for ACP response to {method} after {timeout_seconds:.1f}s.",
                 timed_out=True,
+                command_text=self._acp_command,
+                command_args=tuple(self._acp_args),
             )
             raise ACPInvocationError(
                 failure_message,

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from agent.copilot_acp_client import (
     ACPInvocationError,
+    CLAUDE_RESPONSE_FORMAT_MISMATCH,
     CopilotACPClient,
     _DEFAULT_TIMEOUT_SECONDS,
     _truncate_diagnostic,
@@ -266,15 +267,17 @@ def test_classify_http_500_failure_retryable():
     assert "500" in message
 
 
-def test_classify_sse_json_mismatch_retryable():
+def test_classify_claude_response_format_mismatch_retryable():
     category, retryable, message = classify_acp_failure(
         stdout_text='event: message\ndata: {"type":"chunk"}',
-        stderr_text='Unexpected token \'e\', "event: mes"... is not valid JSON',
+        stderr_text='API Error: 500 Unexpected token \'e\', "event: mes"... is not valid JSON',
     )
 
-    assert category == "sse_json_mismatch"
+    assert category == CLAUDE_RESPONSE_FORMAT_MISMATCH
     assert retryable is True
-    assert "Expected JSON but received SSE event stream" in message
+    assert "Expected JSON but received SSE/event-stream style response" in message
+    assert "streaming output to a non-streaming caller" in message
+    assert "not a Bash/Read tool permission problem" in message
 
 
 def test_classify_non_retryable_permission_failure():

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -10,7 +10,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import (
+    ACPInvocationError,
+    CopilotACPClient,
+    _DEFAULT_TIMEOUT_SECONDS,
+    _truncate_diagnostic,
+    classify_acp_failure,
+)
 
 
 class _FakeProcess:
@@ -205,3 +211,142 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+def test_create_chat_completion_uses_default_timeout(monkeypatch, tmp_path):
+    client = _make_home_client(tmp_path)
+    seen = {}
+
+    def _fake_run(prompt_text, *, timeout_seconds):
+        seen["timeout_seconds"] = timeout_seconds
+        return ("ok", "")
+
+    monkeypatch.setattr(client, "_run_prompt", _fake_run)
+    response = client._create_chat_completion(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.choices[0].message.content == "ok"
+    assert seen["timeout_seconds"] == _DEFAULT_TIMEOUT_SECONDS
+
+
+def test_create_chat_completion_respects_explicit_timeout(monkeypatch, tmp_path):
+    client = _make_home_client(tmp_path)
+    seen = {}
+
+    def _fake_run(prompt_text, *, timeout_seconds):
+        seen["timeout_seconds"] = timeout_seconds
+        return ("ok", "")
+
+    monkeypatch.setattr(client, "_run_prompt", _fake_run)
+    client._create_chat_completion(
+        messages=[{"role": "user", "content": "hello"}],
+        timeout=45.0,
+    )
+
+    assert seen["timeout_seconds"] == 45.0
+
+
+def test_classify_timeout_failure_retryable():
+    category, retryable, message = classify_acp_failure(
+        exception_text="Timed out waiting for ACP response to session/prompt after 45.0s.",
+        timed_out=True,
+    )
+
+    assert category == "timeout"
+    assert retryable is True
+    assert "timed out" in message.lower()
+
+
+def test_classify_http_500_failure_retryable():
+    category, retryable, message = classify_acp_failure(
+        stderr_text="API Error: 500 upstream exploded",
+    )
+
+    assert category == "http_500"
+    assert retryable is True
+    assert "500" in message
+
+
+def test_classify_sse_json_mismatch_retryable():
+    category, retryable, message = classify_acp_failure(
+        stdout_text='event: message\ndata: {"type":"chunk"}',
+        stderr_text='Unexpected token \'e\', "event: mes"... is not valid JSON',
+    )
+
+    assert category == "sse_json_mismatch"
+    assert retryable is True
+    assert "Expected JSON but received SSE event stream" in message
+
+
+def test_classify_non_retryable_permission_failure():
+    category, retryable, message = classify_acp_failure(
+        stderr_text="Permission denied while starting tool",
+    )
+
+    assert category == "non_transient"
+    assert retryable is False
+    assert "non-retryable" in message
+
+
+def test_run_prompt_retries_once_on_transient_failure(monkeypatch, tmp_path):
+    client = _make_home_client(tmp_path)
+    calls = {"count": 0}
+
+    def _fake_once(prompt_text, *, timeout_seconds):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise ACPInvocationError(
+                "ACP subprocess timed out waiting for a response.",
+                category="timeout",
+                retryable=True,
+            )
+        return ("ok", "")
+
+    monkeypatch.setattr(client, "_run_prompt_once", _fake_once)
+    result = client._run_prompt("hello", timeout_seconds=30.0)
+
+    assert result == ("ok", "")
+    assert calls["count"] == 2
+
+
+def test_run_prompt_does_not_retry_non_transient_failure(monkeypatch, tmp_path):
+    client = _make_home_client(tmp_path)
+    calls = {"count": 0}
+
+    def _fake_once(prompt_text, *, timeout_seconds):
+        calls["count"] += 1
+        raise ACPInvocationError(
+            "Permission denied",
+            category="non_transient",
+            retryable=False,
+        )
+
+    monkeypatch.setattr(client, "_run_prompt_once", _fake_once)
+
+    with pytest.raises(ACPInvocationError, match="Permission denied"):
+        client._run_prompt("hello", timeout_seconds=30.0)
+
+    assert calls["count"] == 1
+
+
+def test_run_prompt_reports_retry_exhaustion(monkeypatch, tmp_path):
+    client = _make_home_client(tmp_path)
+
+    def _fake_once(prompt_text, *, timeout_seconds):
+        raise ACPInvocationError(
+            "ACP subprocess returned malformed JSON.",
+            category="malformed_json",
+            retryable=True,
+        )
+
+    monkeypatch.setattr(client, "_run_prompt_once", _fake_once)
+
+    with pytest.raises(ACPInvocationError, match="Retried once and still failed"):
+        client._run_prompt("hello", timeout_seconds=30.0)
+
+
+def test_truncate_diagnostic_marks_output_truncated():
+    text = "x" * 5000
+    truncated = _truncate_diagnostic(text, limit=120)
+
+    assert truncated.endswith("[output truncated]")
+    assert len(truncated) <= 120

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -280,6 +280,21 @@ def test_classify_claude_response_format_mismatch_retryable():
     assert "not a Bash/Read tool permission problem" in message
 
 
+def test_classify_unsupported_claude_acp_args_non_retryable():
+    category, retryable, message = classify_acp_failure(
+        stderr_text="error: unknown option '--acp'",
+        exception_text="ACP process exited early while waiting for initialize.",
+        command_text="claude",
+        command_args=("--acp", "--stdio"),
+    )
+
+    assert category == "unsupported_cli_args"
+    assert retryable is False
+    assert "ACP subprocess failed before protocol startup." in message
+    assert "does not support the requested ACP args" in message
+    assert "Current claude CLI does not expose --acp." in message
+
+
 def test_classify_non_retryable_permission_failure():
     category, retryable, message = classify_acp_failure(
         stderr_text="Permission denied while starting tool",
@@ -327,6 +342,27 @@ def test_run_prompt_does_not_retry_non_transient_failure(monkeypatch, tmp_path):
 
     with pytest.raises(ACPInvocationError, match="Permission denied"):
         client._run_prompt("hello", timeout_seconds=30.0)
+
+    assert calls["count"] == 1
+
+
+def test_run_prompt_does_not_retry_unsupported_cli_args(monkeypatch, tmp_path):
+    client = _make_home_client(tmp_path)
+    calls = {"count": 0}
+
+    def _fake_once(prompt_text, *, timeout_seconds):
+        calls["count"] += 1
+        raise ACPInvocationError(
+            "ACP subprocess failed before protocol startup.\n"
+            "The configured command does not support the requested ACP args.\n"
+            "Current claude CLI does not expose --acp.",
+            category="unsupported_cli_args",
+            retryable=False,
+        )
+
+    monkeypatch.setattr(client, "_run_prompt_once", _fake_once)
+    with pytest.raises(ACPInvocationError, match="Current claude CLI does not expose --acp."):
+        client._run_prompt("hello", timeout_seconds=1)
 
     assert calls["count"] == 1
 


### PR DESCRIPTION
## Summary
- harden Copilot ACP client error handling around unsupported or malformed ACP command responses
- improve Claude invocation robustness in the Copilot ACP flow
- add focused regression coverage for unsupported-command and malformed-response paths

## Scope
- `agent/copilot_acp_client.py`
- `tests/agent/test_copilot_acp_client.py`

## Test evidence
- 19 passed

## Notes
- targeted robustness fix only
- no remote/config changes required for review