### PR TITLE
feat: store working directory (cwd) per session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4857,6 +4857,7 @@ class HermesCLI:
                             "max_iterations": self.max_turns,
                             "reasoning_config": self.reasoning_config,
                         },
+                        cwd=os.getcwd(),
                     )
                 except Exception:
                     pass
@@ -5015,6 +5016,7 @@ class HermesCLI:
                     "reasoning_config": self.reasoning_config,
                 },
                 parent_session_id=parent_session_id,
+                cwd=os.getcwd(),
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -399,6 +399,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                 or q in (s.get("preview") or "").lower()
                 or q in s.get("id", "").lower()
                 or q in (s.get("source") or "").lower()
+                or q in (s.get("cwd") or "").lower()
             )
 
         def _curses_browse(stdscr):
@@ -9470,26 +9471,53 @@ Examples:
                 print("No sessions found.")
                 return
             has_titles = any(s.get("title") for s in sessions)
+            has_cwds = any(s.get("cwd") for s in sessions)
+
+            def _short_cwd(cwd_path, max_len=20):
+                """Shorten a cwd path for display (~/... form)."""
+                if not cwd_path:
+                    return ""
+                home = os.path.expanduser("~")
+                if cwd_path.startswith(home):
+                    cwd_path = "~" + cwd_path[len(home):]
+                if len(cwd_path) > max_len:
+                    return "…" + cwd_path[-(max_len - 1):]
+                return cwd_path
+
             if has_titles:
-                print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-                print("─" * 110)
+                if has_cwds:
+                    print(f"{'Title':<28} {'Directory':<22} {'Preview':<28} {'Last Active':<13} {'ID'}")
+                    print("─" * 120)
+                else:
+                    print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+                    print("─" * 110)
             else:
-                print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
-                print("─" * 95)
+                if has_cwds:
+                    print(f"{'Preview':<38} {'Directory':<22} {'Last Active':<13} {'Src':<6} {'ID'}")
+                    print("─" * 105)
+                else:
+                    print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
+                    print("─" * 95)
             for s in sessions:
                 last_active = _relative_time(s.get("last_active"))
-                preview = (
-                    s.get("preview", "")[:38]
-                    if has_titles
-                    else s.get("preview", "")[:48]
-                )
+                cwd_display = _short_cwd(s.get("cwd")) if has_cwds else ""
                 if has_titles:
-                    title = (s.get("title") or "—")[:30]
+                    title = (s.get("title") or "—")[:26]
                     sid = s["id"]
-                    print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+                    if has_cwds:
+                        preview = s.get("preview", "")[:26]
+                        print(f"{title:<28} {cwd_display:<22} {preview:<28} {last_active:<13} {sid}")
+                    else:
+                        preview = s.get("preview", "")[:38]
+                        print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
                 else:
                     sid = s["id"]
-                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                    if has_cwds:
+                        preview = s.get("preview", "")[:36]
+                        print(f"{preview:<38} {cwd_display:<22} {last_active:<13} {s['source']:<6} {sid}")
+                    else:
+                        preview = s.get("preview", "")[:48]
+                        print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
 
         elif action == "export":
             if args.session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     pricing_version TEXT,
     title TEXT,
     api_call_count INTEGER DEFAULT 0,
+    cwd TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -444,13 +445,14 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        cwd: str = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, cwd)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -460,6 +462,7 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    cwd,
                 ),
             )
         self._execute_write(_do)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1575,6 +1575,7 @@ class AIAgent:
                     },
                     user_id=None,
                     parent_session_id=self._parent_session_id,
+                    cwd=os.getcwd(),
                 )
             except Exception as e:
                 # Transient SQLite lock contention (e.g. CLI and gateway writing
@@ -8485,6 +8486,7 @@ class AIAgent:
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
+                    cwd=os.getcwd(),
                 )
                 # Auto-number the title for the continuation session
                 if old_title:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1626,7 +1626,7 @@ def _(rid, params: dict) -> dict:
 
             db = _get_db()
             if db is not None:
-                db.create_session(key, source="tui", model=_resolve_model())
+                db.create_session(key, source="tui", model=_resolve_model(), cwd=os.getcwd())
                 pending_title = (session.get("pending_title") or "").strip()
                 if pending_title:
                     try:
@@ -2052,7 +2052,8 @@ def _(rid, params: dict) -> dict:
                 else f"{current} (branch)"
             )
         db.create_session(
-            new_key, source="tui", model=_resolve_model(), parent_session_id=old_key
+            new_key, source="tui", model=_resolve_model(), parent_session_id=old_key,
+            cwd=os.getcwd(),
         )
         for msg in history:
             db.append_message(


### PR DESCRIPTION
## Summary

Record `os.getcwd()` when creating session rows so `hermes sessions list`, `hermes sessions browse`, and external tools (e.g. [agf](https://github.com/subinium/agf)) can identify which project directory a session was launched from.

See also #19154 which addresses the same gap — this PR takes a simpler approach (single `cwd` column, no schema version bump) and adds TUI session creation, `sessions list` display, and `sessions browse` search support.

## Changes

| File | Change |
|------|--------|
| `hermes_state.py` | Add `cwd TEXT` column to sessions schema (auto-migrated via `_reconcile_columns` — no version bump needed) |
| `hermes_state.py` | Accept `cwd` param in `create_session()` |
| `run_agent.py` | Pass `cwd=os.getcwd()` at session creation (initial + compression-continuation paths) |
| `cli.py` | Pass `cwd=os.getcwd()` for `/new` and `/branch` sessions |
| `tui_gateway/server.py` | Pass `cwd=os.getcwd()` for TUI sessions (both new and branch) |
| `hermes_cli/main.py` | Display `cwd` column in `sessions list` when any session has one; include `cwd` in `sessions browse` search matching |

## Design decisions

- **Single column (`cwd`)** rather than two (`workspace_path` + `last_cwd`). The initial working directory is the meaningful identifier for "which project was this session about." Mid-session directory changes via `cd` in the terminal tool don't change the project context.
- **No schema version bump.** The existing `_reconcile_columns()` mechanism (lines 339-381 of hermes_state.py) automatically detects the new column in `SCHEMA_SQL` and runs `ALTER TABLE ADD COLUMN` on next startup. Version-gated migrations are only needed for non-declarative changes (FTS rebuilds, data transforms).
- **Graceful display.** `sessions list` only adds the Directory column when at least one session has a `cwd` value, so the output is unchanged for existing sessions until new ones are created.
- **Browse search.** The curses `_match()` function now includes `cwd` in its search text, so users can type a project directory name to filter sessions.

## Motivation

Hermes sessions currently have no record of which directory they were launched from. This means:
- `hermes sessions list` can't show project context
- `hermes sessions browse` can't filter by project
- External session finders (agf, agent-archives) show all Hermes sessions as `~/.hermes` instead of the actual project path
- The ACP adapter already stores cwd in `model_config` JSON for IDE sessions — this extends the same concept to CLI/TUI with a proper column