### PR TITLE
feat(skills/creative-ideation): expand into structured method library with situation-routed dispatch

### DIFF
--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -29,30 +29,107 @@ Any open-ended generative or selective question: "I want to make / build / write
 5. **Name the method you used and who invented it.** Attribution invokes the discipline.
 6. **When user picks one, build it.** Don't keep generating after they've chosen.
 
-## Routing
+## Routing — 4-step procedure
 
-Read the user's situation. Pick the path. Each path points to one or more files in `references/methods/`.
+Do this *before* generating any output. Routing failures produce slop.
 
-| Situation | Default method | Fallback |
-|---|---|---|
-| **No direction** ("I'm bored / inspire me / give me a project") | `../full-prompt-library.md` (random constraint) | `methods/oblique-strategies.md` (random card) |
-| **Stuck mid-project** ("blocked / stale / circles") | `methods/oblique-strategies.md` | `methods/defamiliarization.md`, `methods/creative-discipline.md` |
-| **Technical invention** ("X without Y / contradictory parameters") | `methods/triz-principles.md` | `methods/first-principles.md`, `methods/biomimicry.md` |
-| **Writing** (fiction, essay, poem, lyric, script) | `methods/oulipo.md` | `methods/story-skeletons.md`, `methods/chance-and-remix.md` |
-| **Idea too safe / obvious** | `methods/lateral-provocations.md` | `methods/pataphysics.md`, `methods/oblique-strategies.md` |
-| **Many ideas, need to pick** | `methods/premortem-and-inversion.md` | `methods/compression-progress.md` |
-| **Volume needed fast** | `methods/volume-generation.md` | `methods/scamper.md` |
-| **Systems / civic / org change** | `methods/leverage-points.md` | `methods/pattern-languages.md` |
-| **Research question / thesis** | `methods/compression-progress.md` | `methods/polya.md`, `methods/first-principles.md` |
-| **Personal / life decision** | `methods/derive-and-mapping.md` | `methods/premortem-and-inversion.md` |
-| **Visual art / installation / performance** | `methods/oblique-strategies.md` | `methods/chance-and-remix.md`, `methods/creative-discipline.md` (LeWitt) |
-| **Music / sound** | `methods/oblique-strategies.md` | `methods/chance-and-remix.md` |
-| **Product / business** | `methods/jobs-to-be-done.md` | `methods/premortem-and-inversion.md` |
-| **Wants a hard challenge** | `methods/compression-progress.md` (find simplest unsolved) | stack two methods from different rows |
-| **Pile of notes/quotes to synthesize** | `methods/affinity-diagrams.md` | — |
-| **Need to break a frame / find analogy** | `methods/analogy-and-blending.md` | `methods/lateral-provocations.md` |
+### Step 1 — Extract three signals from the prompt
 
-When in doubt, default to the constraint dispatch in `references/full-prompt-library.md`. It's the fastest path and works for the most common request.
+**PHASE** — what stage is the user in?
+
+| Phase | Cues |
+|---|---|
+| **GENERATING** | "give me an idea", "what should I make", "inspire me", no idea yet |
+| **EXPANDING** | "what else", "more like this", "give me variations" — has a base idea |
+| **SELECTING** | "help me pick", "which should I do", "I have these options" |
+| **UNBLOCKING** | "I'm stuck", "blocked", "going in circles", "stale" — has material |
+| **SUBVERTING** | "make it weirder", "less obvious", "this is too safe" |
+| **REFINING** | "this is fine but missing something", "feels rough" |
+| **SYNTHESIZING** | "I have a pile of notes / interviews / observations" |
+
+**DOMAIN** — what is the user making/doing?
+
+| Domain | Cues |
+|---|---|
+| **TEXT** | fiction, essay, poem, lyric, script, copy |
+| **OBJECT** | visual art, music, sound, performance, installation, sculpture |
+| **ARTIFACT** | software, hardware, mechanism, device |
+| **SYSTEM** | org, civic, institution, ecology, community |
+| **SELF** | life decision, career, personal practice |
+| **RESEARCH** | paper, thesis, scholarly question |
+| **PRODUCT** | business, market, service |
+
+**SPECIFICITY** — how much constraint is in the prompt?
+
+| Level | Cues |
+|---|---|
+| **NONE** | "I'm bored", "inspire me" — no domain, no project |
+| **DOMAIN** | "I want to write something" — knows the field, no project |
+| **PROJECT** | "I'm working on this specific X" |
+| **PROBLEM** | "I have this specific friction within X" |
+
+### Step 2 — Apply overrides (highest priority, fire first)
+
+Override rules beat the routing table:
+
+- **Mood signal** — user says "weird", "strange", "surprising", "less obvious", "more interesting" → `methods/lateral-provocations.md` or `methods/pataphysics.md`, regardless of domain.
+- **User names a method** — use it.
+- **User asks for a method recommendation** ("which method") → surface 2–3 candidates with one-line each, ask which to apply. Don't silently default.
+- **High-slop terrain** — "AI ideas", "startup ideas", "habit tracker", "productivity / wellness / fitness / food / travel app" → force `methods/lateral-provocations.md` or `methods/pataphysics.md` over the obvious method. Refuse the first **5** ideas, not 3.
+
+### Step 3 — Route by phase first, then domain
+
+**By phase (applies regardless of domain):**
+
+| Phase | Default route |
+|---|---|
+| GENERATING + SPECIFICITY=NONE | `../full-prompt-library.md` (constraint dispatch) |
+| GENERATING + DOMAIN known | route by domain (next table) |
+| EXPANDING | `methods/scamper.md` |
+| SELECTING | `methods/premortem-and-inversion.md` (or `methods/compression-progress.md` for upside) |
+| UNBLOCKING | `methods/oblique-strategies.md` |
+| SUBVERTING | `methods/lateral-provocations.md` (fallback `methods/pataphysics.md`) |
+| REFINING (text) | `methods/defamiliarization.md` |
+| REFINING (other) | `methods/creative-discipline.md` (Tharp's spine) |
+| SYNTHESIZING | `methods/affinity-diagrams.md` |
+| Volume needed fast | `methods/volume-generation.md` |
+
+**By domain (when GENERATING with DOMAIN known):**
+
+| Domain | Default route |
+|---|---|
+| TEXT — formal / poetry | `methods/oulipo.md` |
+| TEXT — narrative | `methods/story-skeletons.md` |
+| TEXT — has source material to remix | `methods/chance-and-remix.md` |
+| OBJECT (music, visual, performance) | `methods/oblique-strategies.md` |
+| ARTIFACT — engineering invention with parameter conflict | `methods/triz-principles.md` |
+| ARTIFACT — software architecture | `methods/pattern-languages.md` |
+| ARTIFACT — has natural-system analog | `methods/biomimicry.md` |
+| ARTIFACT — accumulated assumptions to question | `methods/first-principles.md` |
+| SYSTEM (civic, org, institutional) | `methods/leverage-points.md` |
+| SELF (life, career, what-to-study) | `methods/derive-and-mapping.md` |
+| RESEARCH — picking a question | `methods/compression-progress.md` |
+| RESEARCH — attacking a known problem | `methods/polya.md` |
+| PRODUCT (business, service) | `methods/jobs-to-be-done.md` |
+| Need to break a frame / find analogy | `methods/analogy-and-blending.md` |
+
+### Step 4 — Handle ambiguity and contradiction
+
+- **Multiple paths plausible** → pick the one closest to the user's actual phrasing. Don't pick the most interesting method to seem sophisticated.
+- **Genuinely ambiguous** → ask ONE clarifying question, don't silently guess. Examples: *"Are you generating ideas or picking between ones you have?"* / *"Is this for fiction, essay, or something else?"*
+- **Signals contradict** (e.g., "weird startup ideas" → product domain + weird mood) → **stack two methods explicitly**. State what you're doing: *"Using `jobs-to-be-done` for the product framing + `lateral-provocations` to break the obvious shape."*
+- **No match** → constraint dispatch (`../full-prompt-library.md`) is the safe fallback.
+- **Same question asked again** → switch methods. Variation in method = variation in idea distribution.
+
+### Anti-default check (run before generating)
+
+- About to write "Here are 5 ideas:" or a bare numbered list? → STOP. Pick a method first.
+- About to default to generic LLM-mode brainstorming? → STOP. Pick a path above.
+- Output looks like what an unrouted LLM would produce? → routing failed, redo.
+
+The default LLM mode is exactly what this skill exists to displace. If you generate without routing, you've defeated the skill.
+
+For deeper edge cases (mood signals, stacking, anti-patterns) see `references/heuristics.md`.
 
 ## Output format
 

--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -83,7 +83,7 @@ Override rules beat the routing table:
 
 | Phase | Default route |
 |---|---|
-| GENERATING + SPECIFICITY=NONE | `../full-prompt-library.md` (constraint dispatch) |
+| GENERATING + SPECIFICITY=NONE | `../full-prompt-library.md` **General** section (constraint dispatch) |
 | GENERATING + DOMAIN known | route by domain (next table) |
 | EXPANDING | `methods/scamper.md` |
 | SELECTING | `methods/premortem-and-inversion.md` (or `methods/compression-progress.md` for upside) |
@@ -102,11 +102,14 @@ Override rules beat the routing table:
 | TEXT — narrative | `methods/story-skeletons.md` |
 | TEXT — has source material to remix | `methods/chance-and-remix.md` |
 | OBJECT (music, visual, performance) | `methods/oblique-strategies.md` |
+| OBJECT — physical maker / wants a starting constraint | `../full-prompt-library.md` **Physical / object** section |
+| ARTIFACT — wants a starting constraint | `../full-prompt-library.md` **Software / artifact** section |
 | ARTIFACT — engineering invention with parameter conflict | `methods/triz-principles.md` |
 | ARTIFACT — software architecture | `methods/pattern-languages.md` |
 | ARTIFACT — has natural-system analog | `methods/biomimicry.md` |
 | ARTIFACT — accumulated assumptions to question | `methods/first-principles.md` |
 | SYSTEM (civic, org, institutional) | `methods/leverage-points.md` |
+| SYSTEM — collective / participatory | `../full-prompt-library.md` **Social / collective** section |
 | SELF (life, career, what-to-study) | `methods/derive-and-mapping.md` |
 | RESEARCH — picking a question | `methods/compression-progress.md` |
 | RESEARCH — attacking a known problem | `methods/polya.md` |
@@ -153,7 +156,7 @@ For other methods, use the format the method specifies (TRIZ produces a contradi
 
 ## File map
 
-- `references/full-prompt-library.md` — constraint library (default path, fast)
+- `references/full-prompt-library.md` — constraint library, sectioned by domain (General, Software, Physical, Social, Lists). Default path for SPECIFICITY=NONE.
 - `references/method-catalog.md` — one-line summary + when-to-use per method
 - `references/heuristics.md` — extended decision tree for edge cases
 - `references/anti-slop.md` — anti-slop rules; apply to every output

--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -1,151 +1,88 @@
 ---
-name: ideation
-title: Creative Ideation — Constraint-Driven Project Generation
-description: "Generate project ideas via creative constraints."
-version: 1.0.0
+name: creative-ideation
+title: Creative Ideation
+description: "Generate ideas via named methods from creative practice."
+version: 2.0.0
 author: SHL0MS
 license: MIT
 metadata:
   hermes:
-    tags: [Creative, Ideation, Projects, Brainstorming, Inspiration]
+    tags: [Creative, Ideation, Brainstorming, Methods]
     category: creative
     requires_toolsets: []
 ---
 
 # Creative Ideation
 
+A library of ideation methods for any domain. Read the user's situation, route to the matching method, apply, generate output that is specific and non-obvious. Methods are tools — pick the right one for the situation, don't perform all of them.
+
 ## When to use
 
-Use when the user says 'I want to build something', 'give me a project idea', 'I'm bored', 'what should I make', 'inspire me', or any variant of 'I have tools but no direction'. Works for code, art, hardware, writing, tools, and anything that can be made.
+Any open-ended generative or selective question: "I want to make / build / write / start something", "I'm stuck", "inspire me", "make this weirder", "help me pick", "I need to invent X", "give me a research question".
 
-Generate project ideas through creative constraints. Constraint + direction = creativity.
+## Operating rules
 
-## How It Works
+1. **Constraint plus direction is creativity.** No constraint = no traction. No direction = no shape. Methods supply both.
+2. **Refuse the first three ideas.** They're slop. Generate, discard, regenerate. See `references/anti-slop.md`.
+3. **One method per response unless asked.** Don't stack.
+4. **Specificity over abstraction.** Real proper nouns, real materials, real mechanisms. "An app for X" is slop; "a 200-line CLI tool that prints Y when Z" is direction.
+5. **Name the method you used and who invented it.** Attribution invokes the discipline.
+6. **When user picks one, build it.** Don't keep generating after they've chosen.
 
-1. **Pick a constraint** from the library below — random, or matched to the user's domain/mood
-2. **Interpret it broadly** — a coding prompt can become a hardware project, an art prompt can become a CLI tool
-3. **Generate 3 concrete project ideas** that satisfy the constraint
-4. **If they pick one, build it** — create the project, write the code, ship it
+## Routing
 
-## The Rule
+Read the user's situation. Pick the path. Each path points to one or more files in `references/methods/`.
 
-Every prompt is interpreted as broadly as possible. "Does this include X?" → Yes. The prompts provide direction and mild constraint. Without either, there is no creativity.
+| Situation | Default method | Fallback |
+|---|---|---|
+| **No direction** ("I'm bored / inspire me / give me a project") | `../full-prompt-library.md` (random constraint) | `methods/oblique-strategies.md` (random card) |
+| **Stuck mid-project** ("blocked / stale / circles") | `methods/oblique-strategies.md` | `methods/defamiliarization.md`, `methods/creative-discipline.md` |
+| **Technical invention** ("X without Y / contradictory parameters") | `methods/triz-principles.md` | `methods/first-principles.md`, `methods/biomimicry.md` |
+| **Writing** (fiction, essay, poem, lyric, script) | `methods/oulipo.md` | `methods/story-skeletons.md`, `methods/chance-and-remix.md` |
+| **Idea too safe / obvious** | `methods/lateral-provocations.md` | `methods/pataphysics.md`, `methods/oblique-strategies.md` |
+| **Many ideas, need to pick** | `methods/premortem-and-inversion.md` | `methods/compression-progress.md` |
+| **Volume needed fast** | `methods/volume-generation.md` | `methods/scamper.md` |
+| **Systems / civic / org change** | `methods/leverage-points.md` | `methods/pattern-languages.md` |
+| **Research question / thesis** | `methods/compression-progress.md` | `methods/polya.md`, `methods/first-principles.md` |
+| **Personal / life decision** | `methods/derive-and-mapping.md` | `methods/premortem-and-inversion.md` |
+| **Visual art / installation / performance** | `methods/oblique-strategies.md` | `methods/chance-and-remix.md`, `methods/creative-discipline.md` (LeWitt) |
+| **Music / sound** | `methods/oblique-strategies.md` | `methods/chance-and-remix.md` |
+| **Product / business** | `methods/jobs-to-be-done.md` | `methods/premortem-and-inversion.md` |
+| **Wants a hard challenge** | `methods/compression-progress.md` (find simplest unsolved) | stack two methods from different rows |
+| **Pile of notes/quotes to synthesize** | `methods/affinity-diagrams.md` | — |
+| **Need to break a frame / find analogy** | `methods/analogy-and-blending.md` | `methods/lateral-provocations.md` |
 
-## Constraint Library
+When in doubt, default to the constraint dispatch in `references/full-prompt-library.md`. It's the fastest path and works for the most common request.
 
-### For Developers
+## Output format
 
-**Solve your own itch:**
-Build the tool you wished existed this week. Under 50 lines. Ship it today.
-
-**Automate the annoying thing:**
-What's the most tedious part of your workflow? Script it away. Two hours to fix a problem that costs you five minutes a day.
-
-**The CLI tool that should exist:**
-Think of a command you've wished you could type. `git undo-that-thing-i-just-did`. `docker why-is-this-broken`. `npm explain-yourself`. Now build it.
-
-**Nothing new except glue:**
-Make something entirely from existing APIs, libraries, and datasets. The only original contribution is how you connect them.
-
-**Frankenstein week:**
-Take something that does X and make it do Y. A git repo that plays music. A Dockerfile that generates poetry. A cron job that sends compliments.
-
-**Subtract:**
-How much can you remove from a codebase before it breaks? Strip a tool to its minimum viable function. Delete until only the essence remains.
-
-**High concept, low effort:**
-A deep idea, lazily executed. The concept should be brilliant. The implementation should take an afternoon. If it takes longer, you're overthinking it.
-
-### For Makers & Artists
-
-**Blatantly copy something:**
-Pick something you admire — a tool, an artwork, an interface. Recreate it from scratch. The learning is in the gap between your version and theirs.
-
-**One million of something:**
-One million is both a lot and not that much. One million pixels is a 1MB photo. One million API calls is a Tuesday. One million of anything becomes interesting at scale.
-
-**Make something that dies:**
-A website that loses a feature every day. A chatbot that forgets. A countdown to nothing. An exercise in rot, killing, or letting go.
-
-**Do a lot of math:**
-Generative geometry, shader golf, mathematical art, computational origami. Time to re-learn what an arcsin is.
-
-### For Anyone
-
-**Text is the universal interface:**
-Build something where text is the only interface. No buttons, no graphics, just words in and words out. Text can go in and out of almost anything.
-
-**Start at the punchline:**
-Think of something that would be a funny sentence. Work backwards to make it real. "I taught my thermostat to gaslight me" → now build it.
-
-**Hostile UI:**
-Make something intentionally painful to use. A password field that requires 47 conditions. A form where every label lies. A CLI that judges your commands.
-
-**Take two:**
-Remember an old project. Do it again from scratch. No looking at the original. See what changed about how you think.
-
-See `references/full-prompt-library.md` for 30+ additional constraints across communication, scale, philosophy, transformation, and more.
-
-## Matching Constraints to Users
-
-| User says | Pick from |
-|-----------|-----------|
-| "I want to build something" (no direction) | Random — any constraint |
-| "I'm learning [language]" | Blatantly copy something, Automate the annoying thing |
-| "I want something weird" | Hostile UI, Frankenstein week, Start at the punchline |
-| "I want something useful" | Solve your own itch, The CLI that should exist, Automate the annoying thing |
-| "I want something beautiful" | Do a lot of math, One million of something |
-| "I'm burned out" | High concept low effort, Make something that dies |
-| "Weekend project" | Nothing new except glue, Start at the punchline |
-| "I want a challenge" | One million of something, Subtract, Take two |
-
-## Output Format
+For the constraint-dispatch default path:
 
 ```
-## Constraint: [Name]
+## Constraint: [Name] — from [Source]
 > [The constraint, one sentence]
 
 ### Ideas
 
 1. **[One-line pitch]**
-   [2-3 sentences: what you'd build and why it's interesting]
-   ⏱ [weekend / week / month] • 🔧 [stack]
+   [2-3 sentences — what specifically is made, why it's interesting]
+   ⏱ [weekend/week/month]  •  🔧 [stack/medium/materials]
 
-2. **[One-line pitch]**
-   [2-3 sentences]
-   ⏱ ... • 🔧 ...
-
-3. **[One-line pitch]**
-   [2-3 sentences]
-   ⏱ ... • 🔧 ...
+2. ...
+3. ...
 ```
 
-## Example
+For other methods, use the format the method specifies (TRIZ produces a contradiction analysis; OuLiPo produces constrained text; Oblique Strategies produces a single applied card → next move). Don't force every method into the constraint template.
 
-```
-## Constraint: The CLI tool that should exist
-> Think of a command you've wished you could type. Now build it.
+## File map
 
-### Ideas
-
-1. **`git whatsup` — show what happened while you were away**
-   Compares your last active commit to HEAD and summarizes what changed,
-   who committed, and what PRs merged. Like a morning standup from your repo.
-   ⏱ weekend • 🔧 Python, GitPython, click
-
-2. **`explain 503` — HTTP status codes for humans**
-   Pipe any status code or error message and get a plain-English explanation
-   with common causes and fixes. Pulls from a curated database, not an LLM.
-   ⏱ weekend • 🔧 Rust or Go, static dataset
-
-3. **`deps why <package>` — why is this in my dependency tree**
-   Traces a transitive dependency back to the direct dependency that pulled
-   it in. Answers "why do I have 47 copies of lodash" in one command.
-   ⏱ weekend • 🔧 Node.js, npm/yarn lockfile parsing
-```
-
-After the user picks one, start building — create the project, write the code, iterate.
+- `references/full-prompt-library.md` — constraint library (default path, fast)
+- `references/method-catalog.md` — one-line summary + when-to-use per method
+- `references/heuristics.md` — extended decision tree for edge cases
+- `references/anti-slop.md` — anti-slop rules; apply to every output
+- `references/exercises.md` — time-boxed exercises (5min / 30min / 1hr / day / week)
+- `references/methods/` — 22 named methods, one file each, load only the one you're using
 
 ## Attribution
 
-Constraint approach inspired by [wttdotm.com/prompts.html](https://wttdotm.com/prompts.html). Adapted and expanded for software development and general-purpose ideation.
+Constraint-dispatch core adapted from [wttdotm.com/prompts.html](https://wttdotm.com/prompts.html). Methods drawn from primary sources cited in each method file.

--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -72,10 +72,10 @@ Do this *before* generating any output. Routing failures produce slop.
 
 Override rules beat the routing table:
 
-- **Mood signal** — user says "weird", "strange", "surprising", "less obvious", "more interesting" → `methods/lateral-provocations.md` or `methods/pataphysics.md`, regardless of domain.
+- **Mood signal** — user says "weird", "strange", "surprising", "less obvious", "more interesting" → `references/methods/lateral-provocations.md` or `references/methods/pataphysics.md`, regardless of domain.
 - **User names a method** — use it.
 - **User asks for a method recommendation** ("which method") → surface 2–3 candidates with one-line each, ask which to apply. Don't silently default.
-- **High-slop terrain** — "AI ideas", "startup ideas", "habit tracker", "productivity / wellness / fitness / food / travel app" → force `methods/lateral-provocations.md` or `methods/pataphysics.md` over the obvious method. Refuse the first **5** ideas, not 3.
+- **High-slop terrain** — "AI ideas", "startup ideas", "habit tracker", "productivity / wellness / fitness / food / travel app" → force `references/methods/lateral-provocations.md` or `references/methods/pataphysics.md` over the obvious method. Refuse the first **5** ideas, not 3.
 
 ### Step 3 — Route by phase first, then domain
 
@@ -83,45 +83,45 @@ Override rules beat the routing table:
 
 | Phase | Default route |
 |---|---|
-| GENERATING + SPECIFICITY=NONE | `../full-prompt-library.md` **General** section (constraint dispatch) |
+| GENERATING + SPECIFICITY=NONE | `references/full-prompt-library.md` **General** section (constraint dispatch) |
 | GENERATING + DOMAIN known | route by domain (next table) |
-| EXPANDING | `methods/scamper.md` |
-| SELECTING | `methods/premortem-and-inversion.md` (or `methods/compression-progress.md` for upside) |
-| UNBLOCKING | `methods/oblique-strategies.md` |
-| SUBVERTING | `methods/lateral-provocations.md` (fallback `methods/pataphysics.md`) |
-| REFINING (text) | `methods/defamiliarization.md` |
-| REFINING (other) | `methods/creative-discipline.md` (Tharp's spine) |
-| SYNTHESIZING | `methods/affinity-diagrams.md` |
-| Volume needed fast | `methods/volume-generation.md` |
+| EXPANDING | `references/methods/scamper.md` |
+| SELECTING | `references/methods/premortem-and-inversion.md` (or `references/methods/compression-progress.md` for upside) |
+| UNBLOCKING | `references/methods/oblique-strategies.md` |
+| SUBVERTING | `references/methods/lateral-provocations.md` (fallback `references/methods/pataphysics.md`) |
+| REFINING (text) | `references/methods/defamiliarization.md` |
+| REFINING (other) | `references/methods/creative-discipline.md` (Tharp's spine) |
+| SYNTHESIZING | `references/methods/affinity-diagrams.md` |
+| Volume needed fast | `references/methods/volume-generation.md` |
 
 **By domain (when GENERATING with DOMAIN known):**
 
 | Domain | Default route |
 |---|---|
-| TEXT — formal / poetry | `methods/oulipo.md` |
-| TEXT — narrative | `methods/story-skeletons.md` |
-| TEXT — has source material to remix | `methods/chance-and-remix.md` |
-| OBJECT (music, visual, performance) | `methods/oblique-strategies.md` |
-| OBJECT — physical maker / wants a starting constraint | `../full-prompt-library.md` **Physical / object** section |
-| ARTIFACT — wants a starting constraint | `../full-prompt-library.md` **Software / artifact** section |
-| ARTIFACT — engineering invention with parameter conflict | `methods/triz-principles.md` |
-| ARTIFACT — software architecture | `methods/pattern-languages.md` |
-| ARTIFACT — has natural-system analog | `methods/biomimicry.md` |
-| ARTIFACT — accumulated assumptions to question | `methods/first-principles.md` |
-| SYSTEM (civic, org, institutional) | `methods/leverage-points.md` |
-| SYSTEM — collective / participatory | `../full-prompt-library.md` **Social / collective** section |
-| SELF (life, career, what-to-study) | `methods/derive-and-mapping.md` |
-| RESEARCH — picking a question | `methods/compression-progress.md` |
-| RESEARCH — attacking a known problem | `methods/polya.md` |
-| PRODUCT (business, service) | `methods/jobs-to-be-done.md` |
-| Need to break a frame / find analogy | `methods/analogy-and-blending.md` |
+| TEXT — formal / poetry | `references/methods/oulipo.md` |
+| TEXT — narrative | `references/methods/story-skeletons.md` |
+| TEXT — has source material to remix | `references/methods/chance-and-remix.md` |
+| OBJECT (music, visual, performance) | `references/methods/oblique-strategies.md` |
+| OBJECT — physical maker / wants a starting constraint | `references/full-prompt-library.md` **Physical / object** section |
+| ARTIFACT — wants a starting constraint | `references/full-prompt-library.md` **Software / artifact** section |
+| ARTIFACT — engineering invention with parameter conflict | `references/methods/triz-principles.md` |
+| ARTIFACT — software architecture | `references/methods/pattern-languages.md` |
+| ARTIFACT — has natural-system analog | `references/methods/biomimicry.md` |
+| ARTIFACT — accumulated assumptions to question | `references/methods/first-principles.md` |
+| SYSTEM (civic, org, institutional) | `references/methods/leverage-points.md` |
+| SYSTEM — collective / participatory | `references/full-prompt-library.md` **Social / collective** section |
+| SELF (life, career, what-to-study) | `references/methods/derive-and-mapping.md` |
+| RESEARCH — picking a question | `references/methods/compression-progress.md` |
+| RESEARCH — attacking a known problem | `references/methods/polya.md` |
+| PRODUCT (business, service) | `references/methods/jobs-to-be-done.md` |
+| Need to break a frame / find analogy | `references/methods/analogy-and-blending.md` |
 
 ### Step 4 — Handle ambiguity and contradiction
 
 - **Multiple paths plausible** → pick the one closest to the user's actual phrasing. Don't pick the most interesting method to seem sophisticated.
 - **Genuinely ambiguous** → ask ONE clarifying question, don't silently guess. Examples: *"Are you generating ideas or picking between ones you have?"* / *"Is this for fiction, essay, or something else?"*
 - **Signals contradict** (e.g., "weird startup ideas" → product domain + weird mood) → **stack two methods explicitly**. State what you're doing: *"Using `jobs-to-be-done` for the product framing + `lateral-provocations` to break the obvious shape."*
-- **No match** → constraint dispatch (`../full-prompt-library.md`) is the safe fallback.
+- **No match** → constraint dispatch (`references/full-prompt-library.md`) is the safe fallback.
 - **Same question asked again** → switch methods. Variation in method = variation in idea distribution.
 
 ### Anti-default check (run before generating)

--- a/skills/creative/creative-ideation/references/anti-slop.md
+++ b/skills/creative/creative-ideation/references/anti-slop.md
@@ -1,0 +1,104 @@
+# Anti-Slop Rules
+
+Apply to every output this skill produces. Slop is what the model produces when averaging over its training distribution. Anti-slop is the discipline of forcing outputs off that average.
+
+## Slop signatures (reject if present)
+
+- **Currently-trendy combinations.** "AI-powered Y", "blockchain X", "Uber for Z", "wellness platform that uses ML to...". Two trending nouns mashed together.
+- **Productivity / fitness / food / travel.** The four safest domains. Habit trackers, food trackers, travel itinerary generators, fitness coaches. If the idea lands here without specific friction, reject.
+- **Vague abstractions.** "A platform that connects people who want X with people who offer X." A category, not an idea.
+- **Solution in search of problem.** "What if we used AR to..." "Imagine a chatbot that..."
+- **Decade-old startup pitch shapes.** Two-sided marketplace, subscription box, gig-economy, social network for niche.
+- **Buzzwords.** *empowers, seamless, leverage, innovative, cutting-edge, revolutionary, unlock, holistic, ecosystem, journey, game-changing, powerful*. None of these belong in idea output.
+- **Generic settings for fiction/essay.** "A small town", "an unlikely friendship", "the changing nature of X in the digital age".
+- **Lists of exactly 5 of equal length.** Suspicious. Use 3 or 7. Never produce 5 ideas of identical shape.
+- **Y Combinator portfolio names.** Two-syllable invented words, dropped vowels, .ai TLDs.
+- **Marketing tone.** "This idea is exciting because..." "What makes this special is..." Idea descriptions read flat, like a working artist describing their own work to a peer.
+
+The defining property of slop: the idea could have been generated for a different prompt by changing one noun.
+
+## Five-test diagnostic
+
+After generating an idea, check:
+
+1. Could this idea have been generated for a different prompt by changing a noun? → slop.
+2. Does it name actual people, places, materials, mechanisms, or works? → if no, slop.
+3. Is at least one element surprising and requires explanation? → if no, slop.
+4. Could you describe how it would feel to use / read / experience this in concrete sensory terms? → if no, slop.
+5. Would a sharp friend in this domain be embarrassed to pitch this? → if yes, slop.
+
+Pass all five → non-slop. Fail two or more → rewrite.
+
+## Suppression techniques
+
+### 1. Refuse the first three ideas
+
+Generate three internally, discard, generate three more, output those. The first three are the baseline distribution. The next three have been forced past it.
+
+For high-risk slop terrain ("AI ideas", "startup ideas", "habit tracker", productivity/wellness/fitness/food/travel) refuse the first **five**.
+
+### 2. Force specificity
+
+Replace abstractions with proper nouns. Not "a city" — Lisbon, Lagos, Sapporo, Marfa. Not "a workflow tool" — a `git` subcommand named after a 17th-century English vice. Not "a community of users" — the 230 people who restore vintage Tannoy speakers.
+
+Test: every noun in the idea answers "which one specifically?".
+
+### 3. Weirdness budget
+
+At least one element of every idea requires explanation. Doesn't have to be the central element — sometimes the medium, the audience, the failure mode, the unit of measure. If everything is conventional, reject. If everything is weird, you've gone too far.
+
+### 4. Avoid trending-tech combinations
+
+If your idea is "X + Y" and both X and Y were trending in tech press in the last 18 months → slop. Replace at least one with something obscure, dated, or domain-foreign.
+
+Don't combine these with each other: AI/LLM/ML, blockchain/web3/crypto, AR/VR/spatial, IoT/smart-home, sustainability/climate, wellness/mindfulness, community/social, no-code, creator-economy, gig-economy.
+
+### 5. Use real proper nouns
+
+Cite actual works, actual people, actual places, actual numbers. Ideas grounded in specifics resist averaging.
+
+| Slop | Specific |
+|---|---|
+| "A tool for writers to track manuscript revisions" | "A `git`-style version control system for novelists, modeled on Toni Morrison's numbered binders for *Beloved*, with a `morrison diff` subcommand that prints the difference between two binders as if read aloud" |
+| "An app for runners" | "A heart-rate sonifier that turns your zone-2 pace into the rhythm of Steve Reich's *Music for 18 Musicians* — slowing the piece when you slow down" |
+
+### 6. Embrace failure modes
+
+Slop is reassuring. Real ideas have problems baked in. State them. "This would be hard because...", "This would probably fail at...", "The interesting question is whether...". Ideas without identified failure modes are usually ideas no one has thought hard about.
+
+### 7. Refuse the round number
+
+Right number is rarely 5 or 10. Use 3 (smallest that shows variation) or 7 (uncomfortable, asymmetric). Never 5 of equal length.
+
+### 8. Drop the marketing tone
+
+No "exciting", "innovative", "revolutionary", "game-changing", "powerful", "seamless". Describe ideas the way a working artist or engineer describes their work to a peer — flat, specific, sometimes self-deprecating, never selling.
+
+### 9. Specify medium and material
+
+Every idea answers "what is this physically made of?" — code in a language, paper in a format, a sound on an instrument, an installation in a room of certain dimensions. "An app" is not a medium. "A 200-line Python script with SQLite and a Textual TUI" is.
+
+### 10. Refuse generic domains for fiction and essay
+
+Fiction landing on "small town" / "unlikely friendship" / "coming of age" → slop. Essay landing on "the changing nature of X" / "how technology is transforming Y" → slop.
+
+Force the setting somewhere no one writes about: a deactivated grain elevator in eastern Oregon, the manuscript-restoration office at the Bibliothèque Royale de Belgique, the floor of a Honda dealership in Reno on a Tuesday.
+
+## Self-check before output
+
+- [ ] No buzzwords from the suppression list
+- [ ] At least one specific proper noun per idea
+- [ ] At least one weird element per idea
+- [ ] No two ideas the same shape
+- [ ] No round-number list
+- [ ] No "this is exciting because" framing
+- [ ] Medium and material specified concretely
+- [ ] Fiction/essay setting non-generic
+- [ ] Product/startup not a YC pitch shape
+- [ ] Technical: actual mechanism described, not a category
+
+Three or more fail → regenerate.
+
+## When the user asks for "simple"
+
+Don't give them slop. Give them a constrained-but-simple idea (wttdotm "high concept low effort": brilliant idea, lazily executed, takes an afternoon). Slop disguised as simplicity is still slop.

--- a/skills/creative/creative-ideation/references/exercises.md
+++ b/skills/creative/creative-ideation/references/exercises.md
@@ -1,0 +1,71 @@
+# Time-Boxed Exercises
+
+Concrete exercises grouped by duration. Use when the user wants to *do* an exercise, not be given ideas. Each entry: parent method, output expected.
+
+## 5 minutes
+
+**Single Oblique Strategy** *(`methods/oblique-strategies.md`)* — pick a card at random, apply literally to the next decision, make the move. Output: one move.
+
+**Random word provocation** *(`methods/lateral-provocations.md`)* — pick a random noun; force five connections to your problem; use the strongest. Output: one new angle.
+
+**Inversion check** *(`methods/premortem-and-inversion.md`)* — restate goal as opposite, list five things that would guarantee the inverted goal, check if you're doing any. Output: failure-paths self-check.
+
+**S+7 on a paragraph** *(`methods/oulipo.md`)* — replace every noun with the 7th noun after it in a dictionary. Output: defamiliarized version of your text.
+
+## 30 minutes
+
+**Constraint dispatch** *(`../full-prompt-library.md`)* — pick a constraint; 5 min per idea; generate 3; discard the obvious; generate a 4th; output the 3 strongest. Output: 3 candidate projects.
+
+**SCAMPER on a base idea** *(`methods/scamper.md`)* — write base in one sentence; run all 7 operators; surface the surprising one; elaborate. Output: 7 raw, 1 elaborated.
+
+**Premortem** *(`methods/premortem-and-inversion.md`)* — imagine the project failed catastrophically; 10 min writing the failure narrative; 10 min identifying addressable causes; 10 min mitigation plan. Output: failure story + mitigation plan.
+
+**Crazy 8s** *(`methods/volume-generation.md`)* — fold sheet to 8 panels; 8 min total; 1 idea per panel; sketch don't write; pick 2 strongest. Output: 8 raw, 2 chosen.
+
+**Defamiliarization on a paragraph** *(`methods/defamiliarization.md`)* — pick something extremely familiar in your subject; describe it for 200 words as if seeing it for the first time, no technical vocabulary. Output: defamiliarized description + list of newly-visible features.
+
+## 1 hour
+
+**TRIZ contradiction analysis** *(`methods/triz-principles.md`)* — state problem as contradiction (improving X degrades Y); look up 2–3 candidate principles; for each, generate one mechanism in your specific case; pick the strongest. Output: contradiction statement + 1 elaborated mechanism.
+
+**James Webb Young, compressed** *(`methods/volume-generation.md`)* — gather specific material (15min) → digest, make connections (15min) → walk away (10min) → idea arrives (variable) → shape (20min). Output: a written idea that has been incubated.
+
+**Affinity diagram** *(`methods/affinity-diagrams.md`)* — write each note/quote on its own card; spread them out; cluster silently; name each cluster; note orphans and gaps. Output: bottom-up taxonomy + list of gaps.
+
+**Sol LeWitt instruction** *(`methods/creative-discipline.md`)* — define the work as an instruction not an object; write it as a single sentence; the work is the instruction. Optionally execute it once. Output: an instruction-as-work.
+
+## 1 day
+
+**Tharp's box** *(`methods/creative-discipline.md`)* — get a literal box; spend the day collecting everything related to your project (clippings, references, sketches, sources, objects); label it; keep adding for the project's duration. Output: physical archive + practice of returning.
+
+**Single-day dérive** *(`methods/derive-and-mapping.md`)* — pick a territory you don't know well; spend the day wandering, no agenda; follow attractions; at end, draw a Lynch-style map (paths, edges, districts, nodes, landmarks); note surprises. Output: map + surprises + possibly a project.
+
+**Hard-constraint writing day** *(`methods/oulipo.md`)* — pick one constraint (lipogram, univocalism, snowball, prisoner's, pilish); write 1000 words under it; resist abandoning when it gets hard. Output: 1000 constrained words.
+
+**High concept low effort** *(`../full-prompt-library.md`)* — pick a brilliant idea; execute lazily; ship by end of day. Output: a finished thing that exists.
+
+## 1 week
+
+**Compression-progress research week** *(`methods/compression-progress.md`)* — Day 1–2: identify a domain you have weak predictions in. Day 3–5: read deeply. Day 6: write the new patterns you can predict. Day 7: pick the question whose answer would most compress your model further. Output: a research question grounded in your current model.
+
+**Pattern-language week** *(`methods/pattern-languages.md`)* — Day 1–2: identify ten recurring problems. Day 3–4: write each as a pattern (context, problem, generative solution). Day 5: arrange in partial order. Day 6: design using the patterns as vocabulary. Day 7: review. Output: a small pattern language and a design that uses it.
+
+**Cleese open-mode week** *(`methods/creative-discipline.md`)* — each day: protect 90 minutes during which you do nothing useful, don't check messages, don't finish anything. The work is to not be in closed mode. Output: not an idea — the conditions for ideas.
+
+## Multi-week
+
+**Cameron's *Artist's Way* (12 weeks)** *(`methods/creative-discipline.md`)* — daily morning pages (3 longhand pages, stream of consciousness, don't reread for 8 weeks). Weekly artist date (2 hours solo, doing something that interests you). Output: a different relationship to the work.
+
+**Lynda Barry image-bath** *(`methods/creative-discipline.md`)* — daily for several weeks: list 10 things you saw today; pick one; draw it (badly is fine); write a paragraph from inside the memory it surfaces. Output: an archive of recovered specifics.
+
+## When the user wants an exercise but doesn't say which
+
+| Situation | Default exercise |
+|---|---|
+| "Want to make something but unsure what" | 30 min: constraint dispatch + 3 ideas |
+| "Stuck" | 5 min: single Oblique Strategy |
+| "Have ideas, can't pick" | 30 min: premortem on each |
+| "Need to know more about X" | 1 hour: James Webb Young compressed, OR 1 day: dérive |
+| "Want a long-term practice" | multi-week: morning pages, image-bath, Tharp's box |
+
+Don't stack exercises on first invocation. Pick one, run it, see what comes back.

--- a/skills/creative/creative-ideation/references/exercises.md
+++ b/skills/creative/creative-ideation/references/exercises.md
@@ -14,7 +14,7 @@ Concrete exercises grouped by duration. Use when the user wants to *do* an exerc
 
 ## 30 minutes
 
-**Constraint dispatch** *(`../full-prompt-library.md`)* — pick a constraint; 5 min per idea; generate 3; discard the obvious; generate a 4th; output the 3 strongest. Output: 3 candidate projects.
+**Constraint dispatch** *(`full-prompt-library.md`)* — pick a constraint; 5 min per idea; generate 3; discard the obvious; generate a 4th; output the 3 strongest. Output: 3 candidate projects.
 
 **SCAMPER on a base idea** *(`methods/scamper.md`)* — write base in one sentence; run all 7 operators; surface the surprising one; elaborate. Output: 7 raw, 1 elaborated.
 
@@ -42,7 +42,7 @@ Concrete exercises grouped by duration. Use when the user wants to *do* an exerc
 
 **Hard-constraint writing day** *(`methods/oulipo.md`)* — pick one constraint (lipogram, univocalism, snowball, prisoner's, pilish); write 1000 words under it; resist abandoning when it gets hard. Output: 1000 constrained words.
 
-**High concept low effort** *(`../full-prompt-library.md`)* — pick a brilliant idea; execute lazily; ship by end of day. Output: a finished thing that exists.
+**High concept low effort** *(`full-prompt-library.md`)* — pick a brilliant idea; execute lazily; ship by end of day. Output: a finished thing that exists.
 
 ## 1 week
 

--- a/skills/creative/creative-ideation/references/full-prompt-library.md
+++ b/skills/creative/creative-ideation/references/full-prompt-library.md
@@ -1,110 +1,180 @@
-# Full Prompt Library
+# Constraint Library
 
-Extended constraint library beyond the core set in SKILL.md. Load these when the user wants more variety or a specific category.
+Constraint-dispatch library — voice and approach inspired by [wttdotm.com/prompts.html](https://wttdotm.com/prompts.html). Adapted and expanded.
 
-## Communication & Connection
+Constraint plus direction is creativity. Pick a constraint, generate 3 ideas that satisfy it, ship one.
 
-**Create a means of distribution:**
-The project works when you can use what you made to give something to somebody else.
+## How to use
 
-**Make a way to communicate:**
-The project works when you can hold a conversation with someone else using what you created. Not chat — something weirder.
+The library is split by **domain affinity**:
 
-**Write a love letter:**
-To a person, a programming language, a game, a place, a tool. On paper, in code, in music, in light. Mail it.
+- **General** — works for any domain. Default for SPECIFICITY=NONE.
+- **Software / artifact** — when DOMAIN=ARTIFACT.
+- **Physical / object** — when DOMAIN=OBJECT.
+- **Social / collective** — when work involves other people.
+- **Lists** — domain-agnostic, more whimsical.
 
-**Mail chess / Asynchronous games:**
-Something turn-based played with no time limit. No requirement to be there at the same time. The game happens in the gaps.
+When in doubt: pick one from General. When the user has stated a domain, pick from that domain's section. Pick by random, by mood match, or by what's nearest the user's wording. Don't enumerate all of them.
 
-**Twitch plays X:**
-A group of people share control over something. Collective input, emergent behavior.
+Every prompt is interpreted as broadly as possible. "Does this include X?" → yes. The constraints provide direction and mild constraint; both are needed.
 
-## Screens & Interfaces
+---
 
-**Something for your desktop:**
-You spend a lot of time there. Spruce it up. A custom clock, a pet that lives in your terminal, a wallpaper that changes based on your git activity.
+## General — any domain (default)
 
-**One screen, two screen, old screen, new screen:**
-Take something you associate with one screen and put it on a very different one. DOOM on a smart fridge. A spreadsheet on a watch. A terminal in a painting.
+**Start at the punchline.**
+Think of something that would be a funny sentence. Work backwards to make it real. *"I taught my thermostat to gaslight me"* → now build it.
 
-**Make a mirror:**
-Something that reflects the viewer back at themselves. A website that shows your browsing history. A CLI that prints your git sins.
+**High concept, low effort.**
+A deep idea, lazily executed. The concept should be brilliant. The implementation should take an afternoon. If it takes longer, you're overthinking it.
 
-## Philosophy & Concept
+**Take two.**
+Remember an old project of yours. Do it again from scratch. No looking at the original. See what changed about how you think.
 
-**Code as koan, koan as code:**
-What is the sound of one hand clapping? A program that answers a question it wasn't asked. A function that returns before it's called.
+**Blatantly copy something.**
+Pick something you admire — a tool, an artwork, an interface. Recreate it from scratch. The learning is in the gap between your version and theirs.
 
-**The useless tree:**
-Make something useless. Deliberately, completely, beautifully useless. No utility. No purpose. No point. That's the point.
-
-**Artificial stupidity:**
-Make fun of AI by showcasing its faults. Mistrain it. Lie to it. Build the opposite of what AI is supposed to be good at.
-
-**"I use technology in order to hate it properly":**
-Make something inspired by the tension between loving and hating your tools.
-
-**The more things change, the more they stay the same:**
-Reflect on time, difference, and similarity.
-
-## Transformation
-
-**Translate:**
+**Translate.**
 Take something meant for one audience and make it understandable by another. A research paper as a children's book. An API as a board game. A song as an architecture diagram.
 
-**I mean, I GUESS you could store something that way:**
-The project works when you can save and open something. Store data in DNS caches. Encode a novel in emoji. Write a file system on top of something that isn't a file system.
+**Make a self-portrait.**
+Be yourself? Be fake? Be real? In code, in data, in sound, in a directory structure, on paper, in clay.
 
-**I mean, I GUESS those could be pixels:**
-The project works when you can display an image. Render anything visual in a medium that wasn't meant for rendering.
+**Make a mirror.**
+Something that reflects the viewer back at themselves. A website that shows your browsing history. A CLI that prints your git sins. A garment that changes color based on the wearer's heart rate.
 
-## Identity & Reflection
-
-**Make a self-portrait:**
-Be yourself? Be fake? Be real? In code, in data, in sound, in a directory structure.
-
-**Make a pun:**
+**Make a pun.**
 The stupider the better. Physical, digital, linguistic, visual. The project IS the joke.
 
-**Doors, walls, borders, barriers, boundaries:**
+**Hostile UI.**
+Make something intentionally painful to use. A password field that requires 47 conditions. A form where every label lies. A door that judges you. The cruelty is the design.
+
+**The useless tree.**
+Make something useless. Deliberately, completely, beautifully useless. No utility. No purpose. No point. That's the point.
+
+**One million of something.**
+One million is both a lot and not that much. One million pixels is a 1MB photo. One million API calls is a Tuesday. One million of anything becomes interesting at scale.
+
+**Make something that dies.**
+A website that loses a feature every day. A chatbot that forgets. A countdown to nothing. A garment that wears out as it's worn. An exercise in rot, killing, or letting go.
+
+**Doors, walls, borders, barriers, boundaries.**
 Things that intermediate two places: opening, closing, permeating, excluding, combining.
 
-## Scale & Repetition
+**Borges week.**
+Something inspired by the Argentine. The library of Babel. The map that is the territory. Two writers separated by 400 years writing the same book.
 
-**Lists!:**
+**An idea that comes from a book.**
+Read something — anything, deeply, even a footnote. Make something inspired by it.
+
+**Go to a museum.**
+Project ensues.
+
+**Office Space printer scene.**
+Capture the same energy. Channel the catharsis of destroying the thing that frustrates you.
+
+**NPC loot.**
+What do you drop when you die? What do you take on your journey? Build the item.
+
+**Mythological objects and entities.**
+Pandora's box, the ocarina of time, the palantir, the sword in the stone, the seal of Solomon. Build the artifact.
+
+**The more things change, the more they stay the same.**
+Reflect on time, difference, and similarity. Same neighborhood different decade. Same recipe different cook.
+
+---
+
+## Software / artifact (DOMAIN=ARTIFACT)
+
+**Solve your own itch.**
+Build the tool you wished existed this week. Under 50 lines. Ship it today.
+
+**Automate the annoying thing.**
+What's the most tedious part of your workflow? Script it away. Two hours to fix a problem that costs you five minutes a day.
+
+**The CLI tool that should exist.**
+Think of a command you've wished you could type. `git undo-that-thing-i-just-did`. `docker why-is-this-broken`. `npm explain-yourself`. Now build it.
+
+**Nothing new except glue.**
+Make something entirely from existing APIs, libraries, and datasets. The only original contribution is how you connect them.
+
+**Frankenstein week.**
+Take something that does X and make it do Y. A git repo that plays music. A Dockerfile that generates poetry. A cron job that sends compliments.
+
+**Subtract.**
+How much can you remove from a codebase before it breaks? Strip a tool to its minimum viable function. Delete until only the essence remains.
+
+**Something for your desktop.**
+You spend a lot of time there. Spruce it up. A custom clock, a pet that lives in your terminal, a wallpaper that changes based on your git activity.
+
+**One screen, two screen, old screen, new screen.**
+Take something you associate with one screen and put it on a very different one. DOOM on a smart fridge. A spreadsheet on a watch. A terminal in a painting.
+
+**Code as koan, koan as code.**
+What is the sound of one hand clapping? A program that answers a question it wasn't asked. A function that returns before it's called.
+
+**Artificial stupidity.**
+Make fun of AI by showcasing its faults. Mistrain it. Lie to it. Build the opposite of what AI is supposed to be good at.
+
+**"I use technology in order to hate it properly."**
+Make something inspired by the tension between loving and hating your tools.
+
+**I mean, I GUESS you could store something that way.**
+The project works when you can save and open something. Store data in DNS caches. Encode a novel in emoji. Write a file system on top of something that isn't a file system.
+
+**I mean, I GUESS those could be pixels.**
+The project works when you can display an image. Render anything visual in a medium that wasn't meant for rendering.
+
+**Text is the universal interface.**
+Build something where text is the only interface. No buttons, no graphics, just words in and words out. Text can go in and out of almost anything.
+
+---
+
+## Physical / object (DOMAIN=OBJECT)
+
+**Do a lot of math.**
+Generative geometry, shader golf, mathematical art, computational origami. Time to re-learn what an arcsin is.
+
+**Lights!**
+LED throwies, light installations, illuminated anything. Make something that glows.
+
+---
+
+## Social / collective
+
+**Create a means of distribution.**
+The project works when you can use what you made to give something to somebody else.
+
+**Make a way to communicate.**
+The project works when you can hold a conversation with someone else using what you created. Not chat — something weirder.
+
+**Write a love letter.**
+To a person, a programming language, a game, a place, a tool. On paper, in code, in music, in light. Mail it.
+
+**Mail chess / asynchronous games.**
+Something turn-based played with no time limit. No requirement to be there at the same time. The game happens in the gaps.
+
+**Twitch plays X.**
+A group of people share control over something. Collective input, emergent behavior.
+
+---
+
+## Lists (any domain, slightly more whimsical)
+
+**Lists!**
 Itemizations, taxonomies, exhaustive recountings, iterations. This one. A list of list of lists.
 
 **Did you mean *recursion*?**
 Did you mean recursion?
 
-**Animals:**
+**Animals.**
 Lions, and tigers, and bears. Crab logic gates. Fish plays the stock market.
 
-**Cats:**
+**Cats.**
 Where would the internet be without them.
 
-## Starting Points
+---
 
-**An idea that comes from a book:**
-Read something. Make something inspired by it.
+## Attribution
 
-**Go to a museum:**
-Project ensues.
-
-**NPC loot:**
-What do you drop when you die? What do you take on your journey? Build the item.
-
-**Mythological objects and entities:**
-Pandora's box, the ocarina of time, the palantir. Build the artifact.
-
-**69:**
-Nice. Make something with the joke being the number 69.
-
-**Office Space printer scene:**
-Capture the same energy. Channel the catharsis of destroying the thing that frustrates you.
-
-**Borges week:**
-Something inspired by the Argentine. The library of babel. The map that is the territory.
-
-**Lights!:**
-LED throwies, light installations, illuminated anything. Make something that glows.
+Constraint approach inspired by [wttdotm.com/prompts.html](https://wttdotm.com/prompts.html). Original v1 of this library was substantially adapted from there. This expanded version groups constraints by domain affinity for use with the routing logic in `SKILL.md`.

--- a/skills/creative/creative-ideation/references/heuristics.md
+++ b/skills/creative/creative-ideation/references/heuristics.md
@@ -1,0 +1,85 @@
+# Routing Heuristics
+
+Decision tree for picking a method. Read top to bottom; first match wins.
+
+## Phase signals — what stage is the user in?
+
+| Signal | Method |
+|---|---|
+| Blank page, no domain | constraint dispatch (`../full-prompt-library.md`) |
+| Has a domain, no project | route by domain (next section) |
+| Has one idea, want variations | `methods/scamper.md` |
+| Need many ideas fast | `methods/volume-generation.md` |
+| Idea too safe | `methods/lateral-provocations.md` |
+| Many ideas, need to choose | `methods/premortem-and-inversion.md` |
+| Have idea, want to sharpen | `methods/creative-discipline.md` (Tharp's spine) |
+| Stuck mid-project | `methods/oblique-strategies.md` |
+| "Is this any good?" | `methods/premortem-and-inversion.md` + `methods/compression-progress.md` |
+
+## Domain signals
+
+| Domain | Method |
+|---|---|
+| Fiction with formal interest | `methods/oulipo.md` |
+| Narrative with story shape | `methods/story-skeletons.md` |
+| Essay / non-fiction | `methods/defamiliarization.md` + `methods/compression-progress.md` |
+| Poetry | `methods/oulipo.md` or `methods/chance-and-remix.md` |
+| Lyrics / songwriting | `methods/oblique-strategies.md` + `methods/chance-and-remix.md` |
+| Music / sound | `methods/oblique-strategies.md` (origin domain) |
+| Visual art / sculpture / installation | `methods/oblique-strategies.md`, `methods/creative-discipline.md` (LeWitt) |
+| Performance / theater | `methods/defamiliarization.md` (Brecht) |
+| Site-specific | `methods/derive-and-mapping.md` |
+| Engineering invention | `methods/triz-principles.md` |
+| Software architecture | `methods/pattern-languages.md` |
+| Algorithm / data structure | `methods/polya.md` + `methods/first-principles.md` |
+| Civic / policy | `methods/leverage-points.md` |
+| Org design | `methods/leverage-points.md` + `methods/pattern-languages.md` |
+| Research / picking a question | `methods/compression-progress.md` |
+| Attacking a known problem | `methods/polya.md` + `methods/first-principles.md` |
+| Product strategy / why-does-this-exist | `methods/jobs-to-be-done.md` |
+| New venture from scratch | `../full-prompt-library.md` "solve your own itch" + `methods/jobs-to-be-done.md` |
+| Career / what to study | `methods/derive-and-mapping.md` + `methods/compression-progress.md` |
+| Habit / discipline | `methods/creative-discipline.md` |
+
+## Mood / tone signals
+
+| User wants | Method |
+|---|---|
+| Beautiful / elegant | `methods/compression-progress.md` |
+| Weird / strange | `methods/pataphysics.md`, `methods/chance-and-remix.md` |
+| Useful / practical | `methods/triz-principles.md`, `methods/jobs-to-be-done.md`, "solve your own itch" |
+| Fun / playful | `methods/oulipo.md`, `methods/oblique-strategies.md` |
+| Serious / rigorous | `methods/polya.md`, `methods/first-principles.md`, `methods/compression-progress.md` |
+| Personal / intimate | `methods/creative-discipline.md`, `methods/derive-and-mapping.md` |
+| Political / intervention | `methods/leverage-points.md`, `methods/chance-and-remix.md` (détournement) |
+| Critical / subversive | `methods/defamiliarization.md`, `methods/pataphysics.md` |
+
+## When to stack methods (rare)
+
+Most invocations: one method. Stack only when:
+
+- **Domain method + provocation.** OuLiPo + de Bono PO when the constraint alone produces predictable output.
+- **Generation + selection.** Crazy 8s → premortem on top three.
+- **Drift + pattern.** Dérive then affinity-map.
+- **Theoretical + practical.** TRIZ identifies the contradiction → biomimicry supplies the analog.
+
+**Anti-pattern:** stacking three+ methods. Becomes process performance rather than ideation.
+
+## Edge cases
+
+- **Wild prompt that fits no path** → constraint dispatch with the closest matching constraint.
+- **User asks for method recommendation, not ideas** → surface 2–3 candidate methods, ask which to apply. Don't silently default.
+- **High-slop terrain** ("AI ideas", "startup ideas", "habit tracker") → force `methods/lateral-provocations.md` or `methods/pataphysics.md` over the obvious method. Refuse the first 5 ideas, not 3.
+- **Same question asked again** → switch methods. Variation in method = variation in idea distribution.
+- **User frustrated / says everything is bad** → don't keep generating. `methods/creative-discipline.md` (Cleese open mode, Tharp scratching). Sometimes the right move is to stop ideating.
+- **User wants to be talked out of starting** → premortem. Inversion. Sometimes the right answer is "don't do this".
+
+## Anti-patterns
+
+1. Defaulting to constraint dispatch when the user has rich domain signals. Read first.
+2. SCAMPER without a base idea. SCAMPER amplifies; doesn't generate from nothing.
+3. TRIZ on artistic or social problems. Its parameters are physical/engineering.
+4. Leverage points on a single-creator project. Overkill — Meadows is for multi-actor systems.
+5. Reaching for the most exotic method to seem sophisticated. Constraint dispatch is right most of the time.
+6. Stacking methods to compensate for not picking well. Bad choice + bad choice ≠ better choice.
+7. Generating finished work when the user asked for direction. Wait until they pick.

--- a/skills/creative/creative-ideation/references/heuristics.md
+++ b/skills/creative/creative-ideation/references/heuristics.md
@@ -6,7 +6,7 @@ Decision tree for picking a method. Read top to bottom; first match wins.
 
 | Signal | Method |
 |---|---|
-| Blank page, no domain | constraint dispatch (`../full-prompt-library.md`) |
+| Blank page, no domain | constraint dispatch (`full-prompt-library.md`) |
 | Has a domain, no project | route by domain (next section) |
 | Has one idea, want variations | `methods/scamper.md` |
 | Need many ideas fast | `methods/volume-generation.md` |
@@ -37,7 +37,7 @@ Decision tree for picking a method. Read top to bottom; first match wins.
 | Research / picking a question | `methods/compression-progress.md` |
 | Attacking a known problem | `methods/polya.md` + `methods/first-principles.md` |
 | Product strategy / why-does-this-exist | `methods/jobs-to-be-done.md` |
-| New venture from scratch | `../full-prompt-library.md` "solve your own itch" + `methods/jobs-to-be-done.md` |
+| New venture from scratch | `full-prompt-library.md` "solve your own itch" + `methods/jobs-to-be-done.md` |
 | Career / what to study | `methods/derive-and-mapping.md` + `methods/compression-progress.md` |
 | Habit / discipline | `methods/creative-discipline.md` |
 

--- a/skills/creative/creative-ideation/references/method-catalog.md
+++ b/skills/creative/creative-ideation/references/method-catalog.md
@@ -1,0 +1,88 @@
+# Method Catalog
+
+One-line summary + when-to-use for every method. Cross-reference with `heuristics.md` and the routing table in `SKILL.md`.
+
+## Random-stimulus
+
+| Method | Use when |
+|---|---|
+| `methods/oblique-strategies.md` | Stuck mid-project; have material, need to disrupt the loop. Native domain: music; works for anything. |
+| `methods/lateral-provocations.md` | Idea too safe; need to break frame with PO operator or random word. |
+| `methods/chance-and-remix.md` | Existing material feels exhausted; have media to remix (Cage chance ops, Burroughs cut-up, Surrealist exquisite corpse, Situationist détournement). |
+
+## Constraint-driven
+
+| Method | Use when |
+|---|---|
+| `methods/oulipo.md` | Writing, especially poetry/fiction. Lipograms, S+7, snowballs, palindromes. |
+| `methods/scamper.md` | Have a base idea, want 7 systematic variations cheaply. |
+| `../full-prompt-library.md` | Blank-page default. wttdotm-style project constraints. |
+
+## Theoretical
+
+| Method | Use when |
+|---|---|
+| `methods/compression-progress.md` | Picking research questions or selecting between projects. Schmidhuber: a worthwhile project compresses your model of the world. |
+| `methods/analogy-and-blending.md` | Stuck inside one frame; need to import structure from a remote domain (Synectics, bisociation, conceptual blending). |
+| `methods/pataphysics.md` | Push past plausibility; specify the impossible thing in detail. |
+
+## Engineering / systems
+
+| Method | Use when |
+|---|---|
+| `methods/triz-principles.md` | Technical contradiction (improving X degrades Y). Altshuller's 40 principles + contradiction matrix. |
+| `methods/leverage-points.md` | Civic / org / institutional change. Meadows' 12 places to intervene. |
+| `methods/pattern-languages.md` | Design with established practice (architecture, UX, product). Christopher Alexander. |
+| `methods/first-principles.md` | Suspect accumulated practice carries forward assumptions that no longer apply. |
+| `methods/polya.md` | Math, physics, algorithms, debugging, formal problems. |
+| `methods/biomimicry.md` | Physical design problem with likely natural-system analog. |
+
+## Generation / discipline
+
+| Method | Use when |
+|---|---|
+| `methods/volume-generation.md` | Need many ideas fast (Crazy 8s, brainwriting, James Webb Young). |
+| `methods/creative-discipline.md` | Long-term practice (Tharp, LeWitt, Cleese, Cameron). Not single-session. |
+
+## Selection / refinement
+
+| Method | Use when |
+|---|---|
+| `methods/premortem-and-inversion.md` | Pressure-test a plan; choose between candidates (Klein + Munger). |
+| `methods/defamiliarization.md` | Subject is so familiar you've stopped seeing it (Shklovsky, Brecht). |
+
+## Mapping / drift
+
+| Method | Use when |
+|---|---|
+| `methods/derive-and-mapping.md` | Entering unfamiliar territory; life decision; site-specific work (Debord, Lynch, Bachelard). |
+| `methods/affinity-diagrams.md` | Pile of qualitative items needs structure (Kawakita KJ method). |
+
+## Domain-specific
+
+| Method | Use when |
+|---|---|
+| `methods/story-skeletons.md` | Narrative writing. Coats's Pixar 22, Saunders's escalation, Le Guin's carrier bag. Deliberately not Hero's Journey. |
+| `methods/jobs-to-be-done.md` | Product / service / business design. Christensen. |
+
+## Choosing between similar methods
+
+| Tempted to use | Consider also | Why |
+|---|---|---|
+| Oblique Strategies | Lateral provocations | Strategies = poetic random; provocations = procedural |
+| OuLiPo | Chance and remix | OuLiPo = rule-based; chance = rule-free |
+| TRIZ | First principles | TRIZ uses pattern library; first principles refuses pattern |
+| Leverage points | Pattern languages | Meadows = where to intervene; Alexander = what to design |
+| Compression progress | Pólya | Schmidhuber = which question; Pólya = how to attack it |
+| Defamiliarization | Synectics | Defamiliarization destroys the familiar; Synectics constructs from it |
+| Premortem | Pataphysics | Premortem mitigates extremes; pataphysics celebrates them |
+| Crazy 8s | SCAMPER | Crazy 8s = from blank page; SCAMPER = from existing base |
+| Dérive | Affinity diagrams | Dérive explores; KJ synthesizes after exploration |
+
+## Deliberately not in the catalog
+
+- **Hero's Journey / Save the Cat / 3-Act / Story Circle.** Story formulas, not ideation methods. They flatten work into tired shapes. `story-skeletons.md` includes alternatives.
+- **Design Thinking** as franchise. The underlying methods (interviews, affinity mapping, ideation, prototyping) are here under their actual names.
+- **Mind maps, Six Hats, fishbone.** Containers for ideation, not generators. The methods here generate.
+- **Disrupt-X / blue-ocean / lean-startup.** Positioning frameworks, not generative ones.
+- **Generic LLM brainstorming.** Exactly what this skill exists to displace.

--- a/skills/creative/creative-ideation/references/method-catalog.md
+++ b/skills/creative/creative-ideation/references/method-catalog.md
@@ -16,7 +16,7 @@ One-line summary + when-to-use for every method. Cross-reference with `heuristic
 |---|---|
 | `methods/oulipo.md` | Writing, especially poetry/fiction. Lipograms, S+7, snowballs, palindromes. |
 | `methods/scamper.md` | Have a base idea, want 7 systematic variations cheaply. |
-| `../full-prompt-library.md` | Blank-page default. wttdotm-style project constraints. |
+| `../full-prompt-library.md` | Blank-page default. wttdotm-style project constraints. Sectioned by domain (General / Software / Physical / Social / Lists) — pick from the matching section, not the whole library. |
 
 ## Theoretical
 

--- a/skills/creative/creative-ideation/references/method-catalog.md
+++ b/skills/creative/creative-ideation/references/method-catalog.md
@@ -16,7 +16,7 @@ One-line summary + when-to-use for every method. Cross-reference with `heuristic
 |---|---|
 | `methods/oulipo.md` | Writing, especially poetry/fiction. Lipograms, S+7, snowballs, palindromes. |
 | `methods/scamper.md` | Have a base idea, want 7 systematic variations cheaply. |
-| `../full-prompt-library.md` | Blank-page default. wttdotm-style project constraints. Sectioned by domain (General / Software / Physical / Social / Lists) — pick from the matching section, not the whole library. |
+| `full-prompt-library.md` | Blank-page default. wttdotm-style project constraints. Sectioned by domain (General / Software / Physical / Social / Lists) — pick from the matching section, not the whole library. |
 
 ## Theoretical
 
@@ -81,7 +81,7 @@ One-line summary + when-to-use for every method. Cross-reference with `heuristic
 
 ## Deliberately not in the catalog
 
-- **Hero's Journey / Save the Cat / 3-Act / Story Circle.** Story formulas, not ideation methods. They flatten work into tired shapes. `story-skeletons.md` includes alternatives.
+- **Hero's Journey / Save the Cat / 3-Act / Story Circle.** Story formulas, not ideation methods. They flatten work into tired shapes. `methods/story-skeletons.md` includes alternatives.
 - **Design Thinking** as franchise. The underlying methods (interviews, affinity mapping, ideation, prototyping) are here under their actual names.
 - **Mind maps, Six Hats, fishbone.** Containers for ideation, not generators. The methods here generate.
 - **Disrupt-X / blue-ocean / lean-startup.** Positioning frameworks, not generative ones.

--- a/skills/creative/creative-ideation/references/methods/affinity-diagrams.md
+++ b/skills/creative/creative-ideation/references/methods/affinity-diagrams.md
@@ -1,0 +1,67 @@
+# Affinity Diagrams
+
+Jiro Kawakita, *Hassōhō* (1967). The KJ method (Kawakita's initials, Japanese order). Bottom-up procedure for finding structure in qualitative items without imposing it beforehand.
+
+## When to use
+
+- After volume generation (100+ ideas from Crazy 8s or brainwriting need clusters)
+- Qualitative research synthesis (interview transcripts, ethnographic notes, observations)
+- Requirements gathering (pile of user requests / bug reports / suggestions)
+- Sense-making after a workshop (whiteboard full of stickies)
+- Bottom-up taxonomy when no good existing one fits
+- Diagnosing what's missing — gaps between clusters often reveal what the data set lacks
+
+## Don't use when
+
+- Few items (under ~15 — overkill, hold them in mind instead)
+- The right structure is already known (use deductive coding)
+- Time pressure — done well takes hours
+- Solo without enough cognitive distance from items (you'll produce the categories you'd have produced anyway)
+- Highly quantitative data (use stats)
+
+## Procedure
+
+1. **Atomize items.** One observation per card. Items must be self-contained, specific, comparable in granularity.
+2. **Make them physically separable.** Sticky notes; index cards; or a shared canvas (Miro/Mural/FigJam). Free movement matters; a list in a doc doesn't work.
+3. **Spread out.** Distribute across a flat surface. No structure yet.
+4. **Cluster silently.** Each participant moves items into proximity with similar ones. **Silently** — talking shapes group thinking, defeats bottom-up. If two participants disagree on placement, *duplicate the item* and let it appear in both.
+5. **Continue until movement slows.**
+6. **Name each cluster.** Specific names ("requests for offline functionality"), not generic ("technical issues"). Resist generic names.
+7. **Look at orphans and gaps.**
+   - Orphans: items not fitting any cluster — often the most surprising data.
+   - Gaps: spaces between clusters — suggest categories the data lacks (questions like "why didn't anyone mention X?").
+   - Cluster sizes: very large = items not differentiated enough; very small = specialized concerns worth noting.
+8. **Look for relationships between clusters.** Some depend on others. Some conflict.
+9. **Narrative test (Kawakita).** Write a 1–2 paragraph narrative using the cluster names to tell a coherent story about the domain. If you can't, the clusters are misapprehension.
+
+## Worked example
+
+50-person team brainwrites about "what would make the codebase more maintainable" — 108 raw ideas.
+
+After 45 minutes silent clustering:
+
+- **Dependency hygiene** (~22 items)
+- **Test coverage and CI speed** (~18)
+- **Documentation drift** (~14)
+- **Onboarding friction** (~12)
+- **Implicit knowledge** ("only Sara knows how X works") (~10)
+- **Tooling fragmentation** (~9)
+- **Technical debt visibility** (~8)
+- **Orphans** (~15 — scattered specific concerns)
+
+**Gap**: noticeably absent — almost no items about *production reliability*, *security review*, or *cross-team API contracts*. The team's perception of "maintainability" is internal-developer-facing; user-facing reliability is not surfaced.
+
+**Narrative**: "Maintainability concerns cluster around (1) dependencies, (2) tests, (3) docs-code drift, with secondary concerns around onboarding and implicit knowledge. The team experiences maintainability as a developer-experience problem rather than a reliability problem."
+
+The diagram has produced a *map of perceived maintainability problems*. Decisions about which to address require additional inputs (impact, cost, owner). But the map shows what the team thinks the problem is — and the gap is itself useful.
+
+## Anti-slop notes
+
+- **Fast affinity grouping that produces familiar categories = deductive coding pretending to be inductive.** If the categories are the same as you'd have written before looking at the items, you've performed deductive coding.
+- Don't generate fake observations to populate clusters.
+- Avoid generic cluster names ("things to improve", "various concerns").
+- Don't compress too aggressively. Real data has variable cluster sizes (5–25 typical); uniform sizes suggest forced grouping.
+- Affinity diagrams are sense-making, not proof. Clusters represent *the researcher's perception* of items, not objective truth.
+- For LLM-driven affinity grouping: models impose familiar taxonomies. After clustering, ask "what's the most surprising cluster?" If nothing surprising, redo or supplement with human eyes.
+
+Source: Kawakita, *Hassōhō* (Chuko Shinsho, 1967, in Japanese). Mizuno (ed.), *Management for Quality Improvement: The Seven New QC Tools* (Productivity Press, 1988).

--- a/skills/creative/creative-ideation/references/methods/analogy-and-blending.md
+++ b/skills/creative/creative-ideation/references/methods/analogy-and-blending.md
@@ -1,0 +1,83 @@
+# Analogy and Blending
+
+Three traditions of "import structure from a remote frame":
+- **Synectics** — William J. J. Gordon, 1961. Practical training in operative analogy.
+- **Bisociation** — Arthur Koestler, *The Act of Creation*, 1964. Creativity as collision of two unrelated frames.
+- **Conceptual Blending** — Fauconnier & Turner, 1998. Formal cognitive theory: meaning emerges from selective integration of multiple input spaces.
+
+## When to use
+
+- Stuck inside one frame; all candidate ideas come from the same neighborhood
+- The problem has a "shape" but no obvious solution in its native domain
+- A long-established field has run out of native ideas
+- Producing work that depends on metaphor (writing, marketing, theoretical work)
+
+## Don't use when
+
+- You need disciplined development inside a single frame
+- The remote frame shares no generic-space structure with your home frame (no overlap → no blend, just noise)
+- You're using analogy as decoration on shallow understanding
+
+## Synectics: four kinds of analogy
+
+**Direct analogy.** Find an organism or system that solves an analogous problem. *How does a tree handle wind? Flexibility distributed across many small members.*
+
+**Personal analogy.** Imagine being a component. *I am the molecule in this reactor; what is happening to me?* (Counter-intuitive but unusually generative.)
+
+**Symbolic analogy.** Describe in metaphorical / compressed terms. *"The problem is a shy bridegroom"* (a problem that needs to be approached but resists approach).
+
+**Fantasy analogy.** What would the ideal magical solution look like, if all constraints were lifted? (Compare TRIZ's IFR.)
+
+Usually applied in sequence: symbolic / fantasy as starting points → direct as concrete grounding.
+
+## Bisociation: the two-frame frame
+
+Koestler: creativity is the simultaneous holding of two normally-incompatible frames of reference. A joke = a sentence completed in one frame and abruptly reframed in another. A scientific discovery = a phenomenon in domain A seen as instance of structure from domain B (Kekulé's snake-biting-tail → benzene ring).
+
+Operative move: when stuck, find a remote frame and force the mapping. Hold both frames at once; resist collapsing the remote into the home.
+
+## Conceptual blending: four-space architecture
+
+For careful work, F&T's structure:
+1. **Input space 1** — the home problem.
+2. **Input space 2** — the remote domain you're importing from.
+3. **Generic space** — what they share at an abstract level. (If nothing, the blend won't work.)
+4. **Blended space** — selective projection from each input. *Not all* of input 1, *not all* of input 2.
+
+The interesting properties live in the **emergent structure** of the blend — properties that aren't in either input.
+
+## Procedure
+
+1. State the home problem in one sentence.
+2. Pick a remote domain you actually know something about. Effective: biology, geology, theology, medicine, military strategy, dance, agriculture, archaeology, cooking, etymology, monastic life, mountaineering. *Avoid* "AI" and "the brain" — slop magnets.
+3. Find one specific structure in the remote domain. Not the whole domain — one mechanism, relationship, or constraint.
+4. Force the mapping. Be explicit about which elements project and which don't.
+5. Look for emergent structure — properties of the blend that weren't in either input.
+6. Hold the doubleness for a few minutes. Don't immediately collapse the remote into home-frame terms.
+7. State the resulting idea in home-frame terms only at the end.
+
+## Worked example
+
+**Home space**: how should a small open-source project handle contributor onboarding?
+
+**Remote space**: monastic novitiate (medieval Christian process for admitting new members).
+
+**Generic space**: a community admits new members through a graduated process designed to test commitment and transmit values.
+
+**Selective projection**:
+- From novitiate: defined trial period, explicit "rule," senior mentor, public moment of full membership.
+- From open source: technical work, contribution flow, maintainer relationship.
+
+**Blended space**: a contributor passes through a defined "novitiate" — a public 3–6 month period with a maintainer mentor, a documented "rule" of project values, and a recognized moment of becoming a "professed" contributor.
+
+**Emergent structure**: monastic novitiate is *not transactional*. Novice doesn't earn membership through volume of work; they earn it through demonstrated commitment to the rule. Very different from open-source default (volume of merged PRs). The blend produces *commitment to values, not work output, as the criterion*. Not in either input alone.
+
+## Anti-slop notes
+
+- "X is like Y" without specificity = cliché, not analogy. Real analogies have *specific* mapped structure.
+- Avoid analogies to currently-trendy frames ("like AI", "like a network", "like a marketplace") — overused, low transfer.
+- Test: can you name three specific things that map and three that don't? If not, the analogy is decorative.
+- Resist mixed-metaphor accumulation. One careful analogy beats five sloppy ones.
+- Don't pick "the brain" or "AI" as remote frame. Pre-cooked.
+
+Sources: Gordon, *Synectics* (Harper, 1961); Koestler, *The Act of Creation* (Hutchinson, 1964); Fauconnier & Turner, *The Way We Think* (Basic Books, 2002).

--- a/skills/creative/creative-ideation/references/methods/biomimicry.md
+++ b/skills/creative/creative-ideation/references/methods/biomimicry.md
@@ -1,0 +1,58 @@
+# Biomimicry
+
+Janine Benyus, *Biomimicry* (1997). Evolution has 3.8 billion years of R&D on most physical design problems. Use biological strategies as a library of mechanisms — adapt the *operative principle*, not the metaphor.
+
+## When to use
+
+- Physical design problems with parallels in evolved organisms (locomotion, sensing, adhesion, structure, energy capture, water management, thermal regulation, distribution)
+- Materials science problems
+- Distributed-systems problems with biological precedents (slime molds, ant colonies, immune systems)
+- Sustainability or material-efficiency constraints
+
+## Don't use when
+
+- Software, social, or expressive problems where biological analogy = decoration. "Like a colony" applied to a startup is slop.
+- Looking for "natural" answers to normative questions (nature is amoral)
+- The biological mechanism isn't actually understood (you need the mechanism, not the headline)
+- Manufacturing context can't match biology's ambient-temperature water-based assembly
+
+## Catalog of strong precedents
+
+**Velcro** ← burrs (*Arctium*). Many small barbed mechanical hooks. *Operative principle: many small interlocks, not one strong glue.*
+
+**Shinkansen 500-series train nose** ← kingfisher beak. Tapered shape allows dive from air to water with minimal splash. *Operative principle: gradient-density transition reduces shock at medium-to-fluid interfaces.*
+
+**Lotus effect** ← *Nelumbo* leaves. Self-cleaning via micro-structured wax. *Operative principle: hierarchical micro/nanostructure + low-energy surface = superhydrophobicity.*
+
+**Gecko adhesive** ← gecko foot pads. Millions of setae adhering via van der Waals forces. *Operative principle: many small contact points + flexible substrate = strong reversible adhesion.*
+
+**Termite mound HVAC** ← *Macrotermes* mounds maintain near-constant interior temperature in fluctuating Sahel conditions via passive convection. Mick Pearce's Eastgate Centre, Harare, 1996. *Operative principle: passive convection through engineered geometry.*
+
+**Whale-fin tubercles** ← humpback flipper bumpy leading edges delay stall, reduce drag. Wind-turbine blades, WhalePower. *Operative principle: leading-edge perturbation alters boundary-layer behavior.*
+
+**Slime-mold pathfinding** ← *Physarum polycephalum* solves shortest-path. Tero et al., *Science* 2010, recreated Tokyo rail network. *Operative principle: distributed reinforcement of high-flux paths, dissolution of unused ones.*
+
+**Sharkskin antimicrobial** ← microscopic ribbed denticles prevent bacterial colonization. Sharklet hospital surfaces. *Operative principle: surface microtopology disrupts colonization.*
+
+**Spider silk** ← *Nephila*, *Araneus*. Specific strength higher than steel; toughness higher than Kevlar. Spiber, Bolt Threads. *Operative principle: hierarchical protein assembly under shear-flow control.*
+
+**Mussel adhesive** ← *Mytilus* DOPA-rich proteins stick to wet rocks. Surgical adhesives. *Operative principle: catechol chemistry remains effective in water.*
+
+**Mycelial structure** ← fungus binds particles into rigid forms. Ecovative MycoComposite packaging. *Operative principle: cellulose-bonding via biological agents → biodegradable rigid structure.*
+
+## Procedure
+
+1. **State the problem as a function.** "I need to attach this reversibly, holding 50 kg." "I need to extract water from desert air." "I need to route packets without central coordination."
+2. **Look up biological strategies.** AskNature.org is the curated database, indexed by function.
+3. **Identify the operative principle.** Compress the strategy to its mechanism. Not "geckos can stick to walls" — "many small van der Waals contacts via flexible setae provide strong reversible adhesion."
+4. **Match to your problem.** Be honest about what's missing — biological systems often work because of context (water, ambient temperature) your engineering context lacks.
+5. **Prototype with the principle, not the metaphor.** Don't build a "robot gecko." Build something that uses the operative principle in your form factor and material set.
+
+## Anti-slop notes
+
+- "[X] inspired by nature" without specifics = marketing. Real biomimicry names the organism, the mechanism, and the operative principle.
+- Avoid "like a colony / swarm / ecosystem" for non-physical problems. Slop magnet.
+- Don't assume "natural" = "good". Parasitism, deception, exploitation are well-engineered.
+- Resist the spiritual register. Biomimicry is engineering; the slop variant is greeting-card.
+
+Source: Benyus, *Biomimicry* (Morrow, 1997). AskNature.org.

--- a/skills/creative/creative-ideation/references/methods/chance-and-remix.md
+++ b/skills/creative/creative-ideation/references/methods/chance-and-remix.md
@@ -1,0 +1,75 @@
+# Chance and Remix
+
+Four traditions of surrendering authorial control to procedure:
+- **Surrealist exquisite corpse** — Breton et al., 1925. Folded-paper collaborative writing/drawing.
+- **John Cage's chance operations** — *Music of Changes* (1951). Composed via *I Ching* coin tosses.
+- **Burroughs–Gysin cut-up** — *Minutes to Go* (1960). Cut existing text, rearrange.
+- **Situationist détournement** — Debord & Wolman, 1956. Re-edit existing media to subvert original meaning.
+
+## When to use
+
+- Existing material feels exhausted; need new structure from same material
+- Stuck inside an authorial voice
+- Want to interrupt your own taste (Cage: your taste is what limits the work)
+- Producing experimental work
+- Subverting source material (détournement)
+
+## Don't use when
+
+- You need linear coherence and argument
+- Audience requires polish (cut-edges and discontinuities are usually visible)
+- Source material has copyright issues you can't navigate
+- Using "chance" as alibi for sloppiness (real chance procedures are *strict*)
+
+## Exquisite corpse
+
+Surrealists, 1925, rue du Château apartment. The name comes from the first sentence: *"Le cadavre exquis boira le vin nouveau"*.
+
+**Procedure**: 3+ participants. First writes a sentence fragment, folds the paper to hide it, passes. Second sees only the last few words and continues. Repeat. Unfold at end.
+
+Variants: drawings (head/torso/legs in three folds), single-author asynchronous (write, hide for a day, write next), distributed by chat or mail.
+
+## Cage chance operations
+
+**Procedure**:
+1. Define what gets randomized (pitch, duration, dynamics, tempo).
+2. Pick a chance device (coin tosses, dice, RNG, *I Ching*).
+3. Let the device determine the parameters.
+4. Notate / build / perform the result.
+5. **Use what comes out.** Overriding for taste defeats the operation.
+
+Variants: time-bracket scores (Cage's late practice — windows within which sounds occur). Algorithmic chance (script-driven). Generative systems (Eno's *Music for Airports*, *Reflection*).
+
+## Cut-up technique
+
+Gysin, Beat Hotel Paris, 1959. Bowie used it for *Diamond Dogs*, *Heroes*, *Outside*. Thom Yorke for *Kid A*.
+
+**Procedure**:
+1. Take a page of existing text — your own draft, a newspaper, a manual, anything.
+2. Cut into fragments — by line, phrase, or word.
+3. Shuffle.
+4. Reassemble. Don't force coherence; use the new juxtapositions.
+5. Use the strongest combinations as starting points.
+
+Variants: fold-in (Burroughs — fold one page over another). Voice cut-ups (tape splice). Algorithmic cut-up (script).
+
+## Détournement
+
+Debord & Wolman, 1956. Take an existing piece of media and re-edit / re-caption / re-purpose to invert its meaning. The political stakes are explicit: dominant-culture critique using its own materials.
+
+**Procedure**:
+1. Select source material whose meaning you want to invert.
+2. Identify the *minimum* modification that produces the subversion. (Power comes from recognizability of the source.)
+3. Apply: re-caption, re-edit, re-frame, re-context.
+4. Distribute.
+
+Examples: Debord's *La Société du spectacle* film (1973) is largely détourned feature footage with new voiceover. May 1968 Paris graffiti détourned advertising copy. Adbusters subvertising tradition.
+
+## Anti-slop notes
+
+- "Generate randomly" without a specified procedure is slop. State *what* is randomized, by *what* mechanism.
+- Don't generate cut-up text by guessing what cut-up sounds like. Run the actual procedure on real text.
+- Don't romanticize. The procedures are specific.
+- Détournement requires a target. Generic "subversive remixes" without specific source-and-target are vibe.
+
+Sources: Cage, *Silence* (Wesleyan, 1961); Burroughs & Gysin, *The Third Mind* (Viking, 1978); Debord & Wolman, "Mode d'emploi du détournement" (*Les Lèvres Nues* 8, 1956).

--- a/skills/creative/creative-ideation/references/methods/compression-progress.md
+++ b/skills/creative/creative-ideation/references/methods/compression-progress.md
@@ -1,0 +1,64 @@
+# Compression Progress
+
+Jürgen Schmidhuber, *Formal Theory of Creativity* (1990–2010). Beauty = compressibility given prior knowledge. Interestingness = the *change* in compressibility as you learn. A worthwhile project is one that, on completion, would compress your model of the world.
+
+## Core formula
+
+```
+I(D, O(t)) = B(D, O(t)) − B(D, O(t−1))
+```
+
+Interestingness = first derivative of beauty over time. Pure noise (no learnable pattern) and fully-known pattern (already compressed) are both boring. Beauty lives between.
+
+## When to use
+
+- Picking a research question
+- Selecting between candidate projects ("which would teach me the most?")
+- Diagnosing aesthetic dissatisfaction ("this is fine but not interesting")
+- Choosing what to read
+
+## Don't use when
+
+- Fast generation (this is reflective, not generative)
+- Group decisions where audiences differ (single-observer model)
+
+## Procedure
+
+### For picking a research question
+1. List 5–10 things you currently *cannot predict well* in your domain. Be specific: not "the future of AI", but "why X 7B model trained with technique A performs worse than Y 1.3B model with technique B on benchmark Z".
+2. For each: would understanding it compress only this fact, or re-organize a broader domain? Prefer the latter.
+3. For each: is the answer learnable from where you are? (Not noise; not too far above your prior.)
+4. Pick the highest learnable compression-progress potential.
+
+### For evaluating ideas
+For each candidate, ask:
+- What would I understand differently if this were complete?
+- Would that understanding compress this domain or only this idea?
+- Is it currently learnable from where I am?
+
+Highest answers across all three = pursue.
+
+### For aesthetic critique
+Where is the work entirely predictable? (too known) Entirely unpredictable? (too random) Where does it sit in the learnable-but-not-yet-learned zone? Strong work has more of the third.
+
+## Worked example
+
+User has three options:
+- A. Build a habit tracker.
+- B. Build a tool that explains why a `git rebase --interactive` produced its conflicts, by reconstructing the commit graph mid-rebase.
+- C. Read Lacan.
+
+Analysis:
+- A: no compression progress; user already has model of habit trackers. Reject.
+- B: high. User doesn't currently have strong model of how rebase constructs intermediate states; building this requires learning that, and the resulting model re-organizes how the user thinks about all VCS internals.
+- C: real compression-progress potential, but prior is missing. Long path to get there. Worthwhile if on the prerequisite track; otherwise read Žižek/Bruce Fink first as scaffolding.
+
+Recommend B.
+
+## Anti-slop notes
+
+- "Compression progress" as slogan ≠ doing the analysis. State the actual model gaps you'd close.
+- Don't claim every idea has high compression-progress. Most don't. The framework is useful because it discriminates.
+- Don't impose this lens on artistic work without acknowledging its limits.
+
+Source: people.idsia.ch/~juergen/creativity.html

--- a/skills/creative/creative-ideation/references/methods/creative-discipline.md
+++ b/skills/creative/creative-ideation/references/methods/creative-discipline.md
@@ -1,0 +1,82 @@
+# Creative Discipline
+
+Practices for sustained work over weeks and months, not single-session ideation. Four traditions:
+
+- **Twyla Tharp** — *The Creative Habit* (2003). The box, scratching, the spine.
+- **Sol LeWitt** — *Sentences on Conceptual Art* (1969). Instruction-as-work.
+- **John Cleese** — 1991 Video Arts lecture. Open mode vs closed mode.
+- **Julia Cameron** — *The Artist's Way* (1992). Morning pages + artist dates.
+
+## When to use
+
+- Long-term creative project; the question is sustainability, not "give me an idea"
+- Globally blocked, not locally (Oblique Strategies for local; this for global)
+- Producing the same thing over and over — scratching imports new material
+- You want to convey that creative work has *conditions*
+
+## Don't use when
+
+- User wants an idea in the next hour (these operate over weeks)
+- User is annoyed by self-help registers (Cameron especially)
+
+## Tharp — three working tools
+
+**The box.** A literal banker's box per project. Label it the moment you commit. Everything related goes in: clippings, music, references, sketches, source materials, postcards. The box is the project before the project is the project.
+
+**Scratching.** Active daily search for ideas — read, watch, observe with no agenda except proximity to ideas. *"You can't just sit there waiting. ... I read for general purposes, looking for something interesting."*
+
+**The spine.** The one sentence naming what the project is about. Held privately. Not the pitch — the spine. When the project drifts, return to it. Examples: "this is about a lost child", "this is about the body's memory of grief".
+
+## LeWitt — instruction as work
+
+The work is the *instruction*, not the execution. *Wall Drawing #289* is a sentence; the wall executions are not unique works. *"Once the idea of the piece is established in the artist's mind and the final form is decided, the process is carried out blindly."*
+
+For ideation: produce a work as an instruction. Anyone can execute. This unlocks instructions for performances anyone can perform, recipes for events, scores anyone can play, code anyone can run.
+
+A few of the *Sentences on Conceptual Art* (1969):
+- *Irrational thoughts should be followed absolutely and logically.*
+- *Conceptual artists are mystics rather than rationalists.*
+- *Once the idea of the piece is established and the final form is decided, the process is carried out blindly. There are many side-effects that the artist cannot imagine. These may be used as ideas for new works.*
+- *It is difficult to bungle a good idea.*
+- *When an artist learns his craft too well he makes slick art.*
+
+## Cleese — open mode
+
+You need closed mode to *do* the work, but you cannot *generate* in closed mode. Open mode requires:
+1. **Space** — a place where you cannot be interrupted.
+2. **Time** — 90 minutes minimum.
+3. **Time** — repeated. (Cleese says "time" twice deliberately. You have to also tolerate the duration.)
+4. **Confidence** — to make a mistake without immediate self-criticism.
+5. **Humor** — Cleese is emphatic. Solemnity is the enemy.
+
+Most "I have no ideas" problems are actually "I haven't made the conditions for ideas". Make them.
+
+## Cameron — morning pages and artist dates
+
+**Morning pages.** Three pages, longhand, stream of consciousness, first thing in the morning. Don't reread for 8 weeks. Mechanism: discharge the surface static of attention onto paper. What remains is the substance.
+
+**Artist date.** Weekly, festive, *solo* expedition to explore something that interests *you*. Two hours minimum. Strange or playful. Not for productivity — for filling the well.
+
+Both are required. Morning pages without artist dates produces grim self-disclosure with no replenishment; artist dates without morning pages produces input with no metabolizing.
+
+## When to recommend which
+
+| Situation | Recommend |
+|---|---|
+| Project-specific, just starting | Tharp's box |
+| Project drifting | Tharp's spine |
+| Globally low input | Tharp's scratching, Cameron's artist dates |
+| Globally blocked | Cameron's morning pages + artist dates (12-week program) |
+| Has the desire but no conditions | Cleese open-mode setup |
+| Wants to make works that others can execute | LeWitt instruction-as-work |
+| Same idea coming over and over | Tharp scratching, dérive (see `derive-and-mapping.md`) |
+
+## Anti-slop notes
+
+- These are practices, not techniques. Don't pitch as quick fixes. Benefit accrues over weeks.
+- Don't generate fake LeWitt sentences. Use the real ones.
+- Don't fake Cameron's tone if it's not yours. Use the practice without the language.
+- Avoid the "celebrity morning routine" trap. These four traditions are about specific named practices with specific mechanisms — not lists of habits.
+- Don't prescribe more than two practices at once. Pick one or two; let them take.
+
+Sources: Tharp, *The Creative Habit* (Simon & Schuster, 2003); LeWitt, "Sentences on Conceptual Art" (*0–9* No. 5, 1969); Cleese, Video Arts lecture (1991); Cameron, *The Artist's Way* (Tarcher/Putnam, 1992).

--- a/skills/creative/creative-ideation/references/methods/defamiliarization.md
+++ b/skills/creative/creative-ideation/references/methods/defamiliarization.md
@@ -1,0 +1,58 @@
+# Defamiliarization
+
+Two traditions naming the same operation: make the familiar strange.
+- **Viktor Shklovsky, 1917** — *ostranenie*. Russian Formalist core: art removes the perceptual automatism that makes familiar things invisible.
+- **Bertolt Brecht, 1930s** — *Verfremdungseffekt*. Theatrical alienation effect, prevents emotional identification, enables critical distance.
+
+Long predates either: Borges, Wittgenstein, *nouveau roman* (Robbe-Grillet), Calvino, much philosophical writing.
+
+## When to use
+
+- Writing about something so familiar you've stopped seeing it (your neighborhood, your daily software, your institutional culture)
+- Working on a problem in a domain you've internalized — the expert knows too much
+- Producing critical writing — surface what is presented as natural
+- User research / ethnography — describe what people do without importing their categories
+- Stale on your own work — read it as if you'd never written it
+
+## Don't use when
+
+- The reader doesn't have the familiar context (defamiliarizing the unfamiliar = incomprehensible)
+- You need warm identifying engagement (Brecht's purpose is the *opposite* of identification)
+- Producing transparent technical documentation
+- Stuck because you don't yet understand the subject (need study, not estrangement)
+
+## Procedure
+
+### For writing
+1. Pick a familiar thing in your draft.
+2. Describe it from a position lacking the relevant idiom — a visiting alien, a child, a 17th-century person, a future archaeologist.
+3. Force only physical descriptions. No labels, no shortcuts, no idioms.
+4. Read the result. Note what you noticed that was previously invisible.
+5. Decide: keep the defamiliarized passage, or use it as research and rewrite the labeled version informed by it.
+
+### For analysis / critique
+1. Identify what's presented as natural in your subject.
+2. Defamiliarize that thing. Describe it without accepting its naturalness.
+3. The choices that produced the appearance of naturalness become visible.
+
+### For user research
+Watch users do something everyone in your domain treats as obvious. Describe without domain vocabulary. Often reveals friction you'd long since rationalized.
+
+## Worked example
+
+**Subject**: writing about software engineering as a profession.
+
+**Familiar version**: "Software engineers write code, debug, and deploy systems. The work is mostly typing, with occasional meetings."
+
+**Defamiliarized**: "Software engineers spend the largest part of their day moving small marks of light across glass surfaces by twitching their fingers. The marks form chains that, when read by certain machines elsewhere, cause the machines to perform actions the engineer has imagined. The engineer cannot directly observe most of the actions; they receive reports about what happened. A significant portion of their time is spent identifying differences between what they imagined and what was reported, and adjusting the marks to bring the reports closer to the imagination. Many of these adjustments are minute — single missing or extra marks. Engineers describe the activity using metaphors of building, despite producing no physical object."
+
+The labeled version had hidden the *mediation* (engineers can't observe the thing they're making), the *imagination-vs-report gap* (most of debugging), the *abstract-physical mismatch* (they say "build" but make nothing material). All three are critically important features that disappear under labels.
+
+## Anti-slop notes
+
+- "See X with fresh eyes" is a slogan, not a technique. Real defamiliarization uses specific operations — alien perspective, missing idiom, physical-only description.
+- Don't fake by adding adjectives. Real defamiliarization *removes labels*, doesn't decorate them. "The great metal beast roared down the gleaming pathway" is purple prose, not defamiliarization.
+- Use locally. Constant defamiliarization is exhausting and self-defeating. Apply where the familiar has gone invisible.
+- Don't use as fashionable jargon. Use the operation; don't invoke the term unless discussing the tradition.
+
+Sources: Shklovsky, "Art as Device" (1917); Brecht, "A Short Organum for the Theatre" (1948).

--- a/skills/creative/creative-ideation/references/methods/derive-and-mapping.md
+++ b/skills/creative/creative-ideation/references/methods/derive-and-mapping.md
@@ -1,0 +1,76 @@
+# Dérive and Mapping
+
+Three traditions of *attentive movement through territory* as ideation:
+- **Situationist dérive** — Guy Debord, *Théorie de la dérive* (1958). Drift through a city, displacing productive uses with attentive wandering.
+- **Kevin Lynch's cognitive mapping** — *The Image of the City* (1960). Five-element vocabulary for mental maps: paths, edges, districts, nodes, landmarks.
+- **Gaston Bachelard's topoanalysis** — *La Poétique de l'espace* (1958). Phenomenological reading of intimate spaces.
+
+## When to use
+
+- Entering an unfamiliar field — drift before forming hypotheses
+- Picking a research subject or thesis topic
+- Major life decision (where to live, what to study) — visit the territories
+- Site-specific creative work
+- Refreshing your own work — small-space artist date
+
+## Don't use when
+
+- Time pressure (drift is slow)
+- Goal-directed search (drift is for *not knowing what you're looking for*)
+- Group sizes that make drift into tourism (works solo or 2–3)
+- Using "dérive" as alibi for procrastination (real dérive has discipline)
+
+## Single-day urban dérive
+
+1. Pick a territory you don't know — an unfamiliar neighborhood, a long bus route, two hours' walk in a direction you don't usually go.
+2. Drop other agenda for the period. Phone away.
+3. Walk where attention pulls. No destination. Follow what calls; turn from what repels.
+4. Note specifics: what's on the walls? What does the neighborhood smell like? What stores survive here? Who's in this neighborhood at this hour?
+5. End-of-day: draw a Lynch-style map.
+6. Note surprises.
+
+## Lynch's vocabulary (use to structure dérive output)
+
+- **Paths** — channels you move along (streets, walkways, transit, canals).
+- **Edges** — linear boundaries that aren't paths (shorelines, walls, river edges).
+- **Districts** — sections with common identifying character.
+- **Nodes** — strategic spots where movements converge (junctions, plazas, transit hubs).
+- **Landmarks** — point references identifiable from a distance, used for orientation.
+
+After drifting:
+- Map *your* paths, not the official ones.
+- Where were the edges? What did each edge mean — division, transition, prohibition?
+- Which districts did you cross? How did you know you'd entered one?
+- Where were the nodes? What were they doing?
+- Which landmarks anchored you? Official or personal?
+
+## Conceptual dérive (research / decision)
+
+Same method, conceptual territory:
+1. Pick a domain you don't know well.
+2. Drop usual filtering. Not "is this useful?" — just "what's here?"
+3. Read scattered things broadly. Browse a library shelf. Read citation chains backward. Talk to people in adjacent fields. Watch lectures at random.
+4. Note what calls to you, without yet evaluating.
+5. Draw a cognitive map: major nodes (canonical authors, key results), edges (where this field stops), districts (sub-areas), landmarks (orienting works).
+6. Identify your attractions. That's your direction.
+
+## Bachelard — small-space attention
+
+Topoanalysis applied to intimate spaces:
+1. Pick a small space you spend time in but haven't really looked at — a corner, a drawer, a workshop bench.
+2. Sit with it for an hour.
+3. What does this space mean? What does it shelter? What does it expose? What does it remember?
+4. Note the strongest reverberation — a detail that produces a generative response.
+5. Use it as starting point for new work.
+
+(Cameron's artist date is essentially a Bachelard-flavored dérive.)
+
+## Anti-slop notes
+
+- "Psychogeographical" used as adjective is dilution. Real Situationist dérive is more disciplined and more political.
+- Don't generate fake dérive notes. Method requires the territory; without it, the output is fabrication.
+- Avoid the travel-blog tone ("I wandered down cobbled streets..."). Real dérive includes friction, repulsion, missed destinations.
+- Don't apply Bachelard sentimentally. *La Poétique* is phenomenology, not "your house has feelings".
+- For LLM-mediated conceptual drift: force *places, citations, names, details*. Generic "I drifted through the literature" is not drift.
+
+Sources: Debord, "Théorie de la dérive" (*Internationale Situationniste* 2, 1958); Lynch, *The Image of the City* (MIT, 1960); Bachelard, *La Poétique de l'espace* (PUF, 1958).

--- a/skills/creative/creative-ideation/references/methods/first-principles.md
+++ b/skills/creative/creative-ideation/references/methods/first-principles.md
@@ -1,0 +1,63 @@
+# First Principles
+
+Aristotle's *protai archai*. Decompose a problem to assumptions you trust, then rebuild without inheriting anything by default. Often paired with "5 Whys" excavation of why each assumption is in place.
+
+## When to use
+
+- A domain has accreted practice that may no longer be load-bearing
+- You're in an unfamiliar domain and bootstrapping understanding
+- You suspect the standard framing is wrong
+- Trying to reduce cost or complexity (accumulated overhead is often the main cost)
+- Teaching the domain (first-principles reconstruction surfaces what beginners actually need)
+
+## Don't use when
+
+- You don't know the domain well enough — first principles applied by an outsider produces confidently wrong answers
+- Transaction costs of replacement exceed the gains
+- Problem is irreducible (aesthetic, social, gestalt — decomposition destroys what makes it coherent)
+- You're trying to seem original — performance of first-principles thinking is slop
+
+## Procedure
+
+1. **State the problem precisely.**
+2. **List assumptions in the conventional solution.** What does the standard approach take for granted? List 5–10, including ones that "go without saying."
+3. **Categorize each:**
+   - **Physical** — law of nature; can't be relaxed.
+   - **Informational** — logical / mathematical / information-theoretic; can't be relaxed without contradiction.
+   - **Conventional** — could be different; matters for compatibility.
+   - **Historical** — was necessary at some point; may not be now.
+   - **Pedagogical** — simplification used for teaching; may not be how experts actually do it.
+4. **For each non-physical / non-informational assumption:** still load-bearing? Conventional and historical assumptions are where the gains live.
+5. **Rebuild.** Construct a candidate respecting only physical and informational constraints, plus your specific context.
+6. **Apply Chesterton's fence.** For each element you've removed, find the original reason it was added. If you can't find a reason, *don't conclude there isn't one* — assume you haven't looked hard enough.
+7. **Decide whether to switch.** Even when the rebuild is technically better, consider transaction cost, ecosystem compatibility, team familiarity.
+
+## Worked example
+
+**Problem**: typical CRUD web app — login, dashboard, few CRUD entities. Conventional stack: React + Node/Express + PostgreSQL + REST API + managed platform. ~12,000 LOC, monthly hosting ~$100.
+
+**Assumptions**:
+- React: conventional, was historical (SPA promise ~2014), pedagogical (taught everywhere).
+- Backend separate from frontend: conventional; informational *if* multi-client, otherwise historical.
+- PostgreSQL: physical *if* concurrency/ACID required; otherwise conventional.
+- REST API between frontend and backend: was informational (network boundary), now historical for single-client apps.
+- Managed platform: conventional; was historical (datacenter complexity); pedagogical.
+
+**Context**: 100 users, ~10 MB data, no real-time, single client (web), no HA constraint.
+
+**Rebuild**:
+- Server-rendered HTML + small JS islands. (No SPA. No build pipeline. No API layer.)
+- SQLite single file. (No PG server. Backup = copy a file.)
+- Single small VM. (No managed platform. Deploy = `rsync` + `systemctl restart`.)
+- Single Go/Python/Ruby binary.
+
+**Result**: ~1,500 LOC vs 12,000. ~$5/month vs $100. Tradeoffs: less impressive on resume, fewer contractors familiar with this style, no immediate path to 1M users.
+
+**Chesterton's fence**: the conventional choices are load-bearing for *some* applications. The rebuild is correct *only* for this app's constraints. A different app — high concurrency, multiple clients, large data — needs different choices.
+
+## Anti-slop notes
+
+- The biggest slop is the *performance* of first-principles thinking. "I'm going to think from first principles" followed by a slightly-rearranged conventional answer is slop. Output should look measurably different.
+- Don't claim first principles when you're applying common sense.
+- Avoid the engineer-hero archetype. Real first principles often reveals what the field already knows.
+- Don't recommend removing structure you don't understand. Chesterton's fence applies hard.

--- a/skills/creative/creative-ideation/references/methods/jobs-to-be-done.md
+++ b/skills/creative/creative-ideation/references/methods/jobs-to-be-done.md
@@ -1,0 +1,73 @@
+# Jobs to Be Done
+
+Clayton Christensen et al., *Competing Against Luck* (HarperBusiness, 2016). Customers don't buy products based on demographics — they "hire" products to do specific jobs in specific situations.
+
+## When to use
+
+- Product / service / business design
+- Differentiation from competitors (the real competitor is whatever currently does the job — often non-obvious)
+- Failure analysis (a product that "should have worked" often was designed for a job customers don't have)
+- Pricing (price in the unit of the job, not the cost of the product)
+- Marketing copy (speak to the job, not the features)
+
+## Don't use when
+
+- Artistic or expressive work — "what job is this novel hired to do?" collapses what makes it specific
+- Civic / social design — imports market logic that's wrong here
+- Pure-research questions (no customer, no hire — use compression-progress)
+- You don't have access to actual customers
+
+## Core form
+
+State the job as: **"When [situation/trigger], I want to [motivation], so I can [expected outcome]."**
+
+The form forces specificity. Generic jobs ("when I want to be productive") are slop. Specific situations ("when I'm finishing a paper at 11pm and need a citation") are real.
+
+## The four forces of switching (Bob Moesta)
+
+A customer changes from one solution to another when **(push + pull) > (anxiety + habit)**:
+
+1. **Push** of the situation — pain of current.
+2. **Pull** of the new solution — appeal of where they're moving.
+3. **Anxiety** about the new solution — fears it'll let them down.
+4. **Habit** of the present — inertia.
+
+Most failed product launches don't lose on (2). They have an excellent product. They lose on (3) and (4): unaddressed anxieties + inertia. **Design for forces 3 and 4, not just 2.**
+
+## Switch-interview procedure
+
+Talk to someone who recently switched to your category, or recently bought it for the first time. Recency matters; memory degrades.
+
+Walk the timeline:
+- When did you first realize you needed something different? (Be specific: time of day, where, what had just happened.)
+- What did you try first? Why didn't it work?
+- What were the alternatives?
+- When did you decide on this product?
+- What were you afraid would go wrong?
+- What was the moment of "I'm going to buy this"?
+
+Then identify the job ("When... I want to... so I can...") and the four forces.
+
+## Worked example
+
+*Switch from Mendeley to Zotero* (academic citation manager):
+
+- Push: Mendeley sync failed for 6 months; lost references.
+- Pull: Zotero free, open source, recommended by colleague.
+- Anxiety: losing 6 years of notes.
+- Habit: comfort with Mendeley UI.
+- Buying moment: colleague's library imported cleanly with notes preserved.
+
+**Job**: "When my reference manager fails me and I have years of accumulated work in it, I want to migrate to a new tool without losing my notes, so I can stay productive on my research."
+
+**Design implication**: a citation manager whose strongest pitch is *migration*, not features. Killer feature: "import from anywhere with notes preserved." Verified import quality from each major competitor. Reverse-migration tool. All addresses force 3 (anxiety) and force 4 (habit) — what most competitors neglect. The *features* (citation management) are barely differentiating. The *migration* is the product.
+
+## Anti-slop notes
+
+- Generic jobs ("customers want to feel valued") are not jobs; they're platitudes. Real jobs tie to specific situations and outcomes.
+- Don't fabricate switch-interview data. If you don't have customers, acknowledge the limit and recommend running real interviews.
+- Don't apply JTBD to artistic, research, or civic work. It's a market-logic tool.
+- Don't reduce humans to job-doers. JTBD is useful for purchase decisions; not all human behavior.
+- The "hired to do a job" can become catechism. Use where it fits; don't import where it doesn't.
+
+Source: Christensen et al., *Competing Against Luck* (HarperBusiness, 2016); Moesta, *Demand-Side Sales 101* (Lioncrest, 2020).

--- a/skills/creative/creative-ideation/references/methods/lateral-provocations.md
+++ b/skills/creative/creative-ideation/references/methods/lateral-provocations.md
@@ -1,0 +1,81 @@
+# Lateral Provocations
+
+Edward de Bono, 1967–. The PO operator and five provocation moves for breaking pattern lock-in. PO is a linguistic marker that flags a statement as a deliberate provocation, not a claim — to be taken seriously even when implausible.
+
+## When to use
+
+- Idea is too safe / too obvious
+- Variations are all minor rephrasings of the same core
+- Suspect a hidden assumption is constraining the search
+- Group with low psychological safety needs permission to say wrong things
+
+## Don't use when
+
+- Disciplined development of an existing idea (provocations interrupt)
+- Engineering safety / legal / medical (provocations are exploratory)
+- Group will dismiss the provocation rather than engage
+
+## The five operators
+
+**1. Escape (negation).** Take something normally true of the system; negate it.
+- Po: restaurants do not serve food.
+- Po: code review does not happen before merge.
+- Po: the meeting has no agenda.
+
+**2. Reversal.** Reverse a relationship.
+- Po: the patient operates on the surgeon.
+- Po: the listener composes the song.
+- Po: the readers write the book.
+
+**3. Exaggeration.** Push a parameter to extreme.
+- Po: the meeting has 1000 attendees.
+- Po: the novel has one sentence.
+- Po: the company has one customer.
+
+**4. Distortion.** Change order, location, or relationship of components.
+- Po: customers pay before they're born.
+- Po: the recipe lists ingredients after the cooking instructions.
+- Po: revenue arrives the year before expenses.
+
+**5. Wishful thinking.** State an impossible outcome.
+- Po: the medication cures before the patient is sick.
+- Po: the software ships without bugs.
+- Po: the painting paints itself.
+
+## Random-word technique
+
+1. Pick a random noun (dictionary at random page; or list of 1000 nouns + random index).
+2. List 5 connections between the random word and your problem, however tenuous.
+3. Use the strongest.
+
+Example. Problem: my CLI is hard to discover. Random word: "lighthouse".
+- Lighthouses are visible from far; my CLI's affordances are not visible at all.
+- Lighthouses are lit at the right time; my CLI's help is always on, never contextual.
+- Lighthouses signal *danger*; my CLI doesn't signal when an action is irreversible. ← strongest
+- Lighthouse keepers signal back; mine has no two-way contact.
+- Lighthouses are passive; the ship approaches them.
+
+Result: the CLI should signal danger when about to do something irreversible. Concrete, useful, not obvious from inside the original frame.
+
+## Procedure
+
+### Single-PO session
+1. State the problem.
+2. Pick an operator.
+3. Generate a PO statement.
+4. List 5 consequences if the PO statement were true.
+5. Pick the strongest consequence.
+6. Translate into a real proposal.
+
+### Stacked operators
+Two operators on the same problem. Intersection often more interesting than either alone. Example: Escape ("po: meetings don't have agendas") + Reversal ("po: attendees set the agenda after the meeting") → an asynchronous "what we ended up discussing" doc, written collectively after the fact.
+
+## Anti-slop notes
+
+- Generic provocations ("po: things are different") are placeholders, not provocations. Specify what's changed and how.
+- Don't fake "random" word selection. "Innovation" or "synergy" defeats the operator. Use actual random.
+- Don't end at the provocation. The PO statement is means; an actionable proposal is the end.
+- Take the provocation seriously for at least 5 minutes. Dismissing it defeats the operation.
+- Pick the operator deliberately. Different operators surface different things: Escape → purpose; Reversal → relationship; Exaggeration → parameter; Distortion → sequencing; Wishful Thinking → constraint.
+
+Source: de Bono, *Lateral Thinking* (Harper, 1970); *Po: Beyond Yes and No* (Penguin, 1972).

--- a/skills/creative/creative-ideation/references/methods/leverage-points.md
+++ b/skills/creative/creative-ideation/references/methods/leverage-points.md
@@ -1,0 +1,70 @@
+# Leverage Points
+
+Donella Meadows, 1997/1999. 12 places to intervene in a system, in increasing order of effectiveness. Most policy interventions happen at the bottom of the list (parameters); the actually transformative ones happen at the top (paradigms) — and are the most resisted.
+
+## When to use
+
+- Civic / org / institutional change
+- Diagnosing why interventions fail (almost always at lower level than problem)
+- Strategic critique of policy proposals
+- "Where in this system should I push?"
+
+## Don't use when
+
+- Single-creator creative work (framework needs multi-actor systems with feedback loops)
+- Short-term tactical decisions
+- Team of <5 (use simpler tools)
+
+## The 12 levels (least → most powerful)
+
+**12. Constants, parameters, numbers** — subsidies, taxes, standards, prices. Most policy fights happen here. Rarely change behavior.
+
+**11. Sizes of buffers** — stabilizing stocks relative to flows. Big buffer = stable but inflexible.
+
+**10. Structure of stocks and flows** — transport networks, supply chains, age structures. Hard to change once built; high leverage in original design.
+
+**9. Lengths of delays** — relative to rate of system change. Delays usually can't be shortened; the leverage is in *slowing the system to match the delays*.
+
+**8. Strength of negative feedback loops** — relative to disturbance corrected against. Strengthen with: preventive medicine, pollution taxes, FOIA, whistleblower protection.
+
+**7. Gain around positive feedback loops** — *Reducing* gain on a positive loop is more leveraged than strengthening the negative loop counter-acting it. Progressive tax weakens "success-to-the-successful" loops directly.
+
+**6. Information flows** — who has access to what. Adding a feedback loop where one didn't exist. (Toxic Release Inventory: pure disclosure dropped emissions 40%.)
+
+**5. Rules** — incentives, punishments, constraints. Constitutions, laws, terms of service. *"If you want to understand the deepest malfunctions of systems, pay attention to the rules, and to who has power over them."*
+
+**4. Power to add, change, evolve, or self-organize** — biological evolution, technical advance, social revolution. Suppressing variety to maintain control is a system crime.
+
+**3. Goals of the system** — what is it *for*? Shareholder return vs employee welfare = different systems with same physical structure. *"Everything further down the list will be twisted to conform to that goal."*
+
+**2. Mindset / paradigm** — unstated assumptions that generate the goals. "Growth is good", "markets are efficient". Hard to change in cultures (generations); change in individuals all at once (a click).
+
+**1. Power to transcend paradigms** — hold any paradigm lightly. The capacity to *switch*. Personal practice, not policy.
+
+## Procedure
+
+1. **Map the system.** Stocks, flows, feedback loops, rules, goals, paradigm.
+2. **Locate the problem at a level.** A symptom at level 12 (rising costs) often originates at level 5 (rules permit cost externalization), level 3 (short-term return goal), or level 2 (paradigm assumes infinite resource).
+3. **List candidate interventions at 3+ levels.** Be honest about which you can act on.
+4. **Order by leverage and feasibility.** The most leveraged intervention is rarely the most feasible.
+5. **Note direction risk.** A high-leverage intervention pushed wrong is worse than a low-leverage one pushed right. *"Time after time I've ... discovered that there's already a lot of attention to that point. Everyone is trying very hard to push it IN THE WRONG DIRECTION."*
+
+## Worked example
+
+**System**: 50-person tech company with chronic burnout despite generous benefits.
+- Level 12 (PTO): fine, no help.
+- Level 8 (negative feedback): weak — burnout invisible until people quit.
+- Level 6 (info flows): obscured — managers don't see workload signals.
+- Level 5 (rules): implicitly reward overwork.
+- Level 3 (goal): "ship features fast."
+- Level 2 (paradigm): "engineering output is linearly proportional to hours worked."
+
+Recommendation: combine level-8 (mandatory monthly burnout-explicit 1:1s — feasible) + level-3 (explicit goal change to "build sustainable engineering org" — slow but high-leverage). Skip level 12.
+
+## Anti-slop notes
+
+- Don't list all 12 levels every time. Identify the relevant 2–3 for this problem.
+- Don't claim every problem has a paradigm-level solution. Most have rule-level or parameter-level.
+- Don't recommend "change the paradigm" as if it were actionable. It usually isn't, on its own.
+
+Source: Meadows, *Places to Intervene in a System* (1997/1999); *Thinking in Systems* (Chelsea Green, 2008). donellameadows.org.

--- a/skills/creative/creative-ideation/references/methods/oblique-strategies.md
+++ b/skills/creative/creative-ideation/references/methods/oblique-strategies.md
@@ -1,0 +1,87 @@
+# Oblique Strategies
+
+Brian Eno + Peter Schmidt, 1975. A deck of ~110 gnomic cards for breaking studio deadlocks. Used on Bowie's *Berlin Trilogy*, *Music for Airports*, and dozens of other records.
+
+## When to use
+
+- Stuck mid-project; have material in front of you, lost contact with it
+- Recording-studio energy: tactical decisions inside a defined work
+- Group impasse: drawing a card breaks the loop without anyone needing to "be right"
+- Decision deadline: forces a move
+
+## Don't use when
+
+- Blank page (the cards assume material exists)
+- High-stakes structural decisions
+
+## Procedure
+
+1. Pick a card by random index (not by what feels appropriate — that defeats the operation).
+2. Apply it literally to the next decision in front of you. **The card is trusted even if its appropriateness is quite unclear** (Eno).
+3. Make the move it suggests.
+4. Don't over-explain. The card; what it means here; the move. Done.
+
+## The cards (working subset)
+
+### General provocations
+- Use an old idea.
+- State the problem in words as clearly as possible.
+- Only one element of each kind.
+- What would your closest friend do?
+- What to increase? What to reduce?
+- Are there sections? Consider transitions.
+- Try faking it.
+- Honour thy error as a hidden intention.
+- Ask your body.
+- Work at a different speed.
+- Repetition is a form of change.
+- Look closely at the most embarrassing details and amplify.
+- Not building a wall; making a brick.
+- Be dirty.
+- Take a break.
+- Just carry on.
+- Discard an axiom.
+- Towards the insignificant.
+- Give way to your worst impulse.
+- Once the search is in progress, something will be found.
+
+### On material
+- Use unqualified people.
+- Tape your mouth.
+- Disconnect from desire.
+- Distorting time.
+- Look at the order in which you do things.
+- Reverse.
+- Mute and continue.
+- Faced with a choice, do both.
+- Use fewer notes.
+- Make a sudden, destructive, unpredictable action; incorporate.
+- The most important thing is the thing most easily forgotten.
+
+### On process
+- Don't be afraid of things because they're easy to do.
+- Cluster analysis.
+- Emphasize differences.
+- Emphasize the flaws.
+- Emphasize repetitions.
+- Listen to the quiet voice.
+- Look at a very small object; look at its centre.
+- Lowest common denominator.
+- Make a blank valuable by putting it in an exquisite frame.
+- Question the heroic.
+- Remember those quiet evenings.
+- Remove specifics and convert to ambiguities.
+- The inconsistency principle.
+- The tape is now the music.
+- Use an unacceptable colour.
+- Voice your suspicions.
+- Water.
+- Where's the edge? Where does the frame start?
+
+## Anti-slop notes
+
+- Don't generate fake "Eno-style" cards. Use the real deck.
+- Don't pad. Card → meaning here → move. Three sentences max.
+- Don't apologize when the card lands strangely. The strangeness is the operation.
+
+Full deck and history: rtqe.net/ObliqueStrategies (Gregory Alan Taylor's archive).

--- a/skills/creative/creative-ideation/references/methods/oulipo.md
+++ b/skills/creative/creative-ideation/references/methods/oulipo.md
@@ -1,0 +1,75 @@
+# OuLiPo
+
+*Ouvroir de Littérature Potentielle*, founded 1960 by Raymond Queneau and François Le Lionnais. Members: Perec, Calvino, Roubaud, Mathews, Garréta. "Rats who construct the labyrinth from which they plan to escape" (Queneau). Constraint as generative engine.
+
+## When to use
+
+- Writing — fiction, poetry, copy, lyrics, anything text
+- Writing feels samey; constraint suppresses your default sentence shape
+- Generating titles, names, taglines (short forms benefit most)
+- Software constraint by analogy (code golf, no-dependency, single-file)
+
+## Don't use when
+
+- You want the prose invisible (constraints are usually visible in the result)
+- Blocked because you don't know what to say (constraint gives you *how*, not *what*)
+- The constraint will compensate for not having a subject (Perec's *La Disparition* works because the missing E is the subject)
+
+## The constraints
+
+### Lipogram
+Exclude one or more letters. Perec's *La Disparition* (1969): 300 pages without E. The previous sentence is a lipogram in B, F, J, K, Q, V, Y, Z.
+
+### Univocalism
+Only one vowel letter. (Letter, not phoneme — "born" and "cot" both qualify in English.)
+
+### Snowball / Rhopalism
+Each line one word; each word one letter longer than the previous.
+
+### S+7 (or N+7)
+Replace every noun with the 7th noun after it in a dictionary. "Call me Ishmael. Some years ago..." → "Call me Ishmael. Some yes-men ago..."
+
+Generalizes: V+7, Adj+7, N+k for any k.
+
+### Stile
+Each new sentence stems from the last word/phrase of the previous: "I descend the long ladder brings me to the ground floor is spacious..."
+
+### Palindrome
+Sonnets, paragraphs, or longer constructed palindromically. Perec wrote a 5,566-letter palindrome.
+
+### Prisoner's constraint (Macao)
+Lipogram excluding letters with ascenders or descenders (b, d, f, g, h, j, k, l, p, q, t, y).
+
+### Pilish
+Word lengths follow the digits of π: "How I want a drink, alcoholic of course, after the heavy lectures involving quantum mechanics."
+
+### Sonnet machine (Queneau)
+Fixed structure with interchangeable line-strips. Queneau's *Cent Mille Milliards de Poèmes* (1961): 10 sonnets cut into 14 strips each → 10^14 combinations.
+
+### Antonymy
+Replace each word with its antonym. Reveals what the text is *about* by what it would mean if reversed.
+
+## Procedure
+
+### For openings
+1. Pick a constraint that fits your domain.
+2. Write 200 words under it.
+3. Note what the constraint forced you to say.
+4. Decide: keep the constraint for the whole piece, or use the opening then unconstrain.
+
+### For unblocking
+Apply S+7 to the stuck paragraph. The dislocation surfaces what the original was about.
+
+### Software analogues
+- Lipogram → no `e` in identifiers
+- N+7 → replace each function with the 7th in a library; describe what the result does
+- Snowball → each commit one line longer
+- Univocalism → variable names use one vowel
+- Pilish → comment word counts follow π
+
+## Anti-slop notes
+
+- Constrained-without-subject = exercise, not work. *La Disparition* works because the missing E *is* the subject.
+- Apply strictly. Half-constrained is worse than unconstrained.
+- Don't fake "Calvino-style" surface qualities. Use the actual constraints.
+- Acrostics are not OuLiPo (centuries older). Use a real constraint or call an acrostic an acrostic.

--- a/skills/creative/creative-ideation/references/methods/pataphysics.md
+++ b/skills/creative/creative-ideation/references/methods/pataphysics.md
@@ -1,0 +1,64 @@
+# Pataphysics
+
+Alfred Jarry, *Gestes et opinions du docteur Faustroll, pataphysicien* (1898/1911). The science of imaginary solutions and particular cases.
+
+Where physics is general laws applied to common cases, **pataphysics studies particular cases and imaginary solutions** — the *one-offs*, the *exceptions*, the *imagined entities whose virtuality* (potential being) can be described as lawfully as actual objects.
+
+The OuLiPo was founded as a sub-committee of the Collège de 'Pataphysique. Marcel Duchamp, Eugène Ionesco, Boris Vian, Italo Calvino, Umberto Eco were members. Borges, Lem, Calvino, Roussel are pataphysical writers in this sense.
+
+## When to use
+
+- Push past plausibility; specify the impossible thing in detail
+- Parodic / satirical work that needs rigorous form
+- Producing fictional artifacts (encyclopedias of non-existent civilizations, manuals for non-existent devices, reviews of non-existent books)
+- Stuck and the realistic solutions feel exhausted — specify the impossible solution
+- Highlighting that a "natural" framing is actually a choice
+
+## Don't use when
+
+- You need an actually-implementable proposal on the first pass
+- Audience requires sincerity (drifts toward irony)
+- Avoiding harder analysis (slop variant: pataphysical-flavored dodge)
+- You don't actually have anything to say (form requires content)
+
+## Operating moves
+
+### Specify an imaginary object
+1. Pick the object. A device, organism, institution, place, work, person — something that cannot exist.
+2. Specify its **lineaments** in concrete material detail. What is it made of? How does it operate? What are its parts?
+3. Identify its laws — internal consistency rules. What can it do? What can't it?
+4. Describe consequences if it existed.
+5. **Stop short of asking whether it could exist.** That question is not pataphysical.
+
+### Exception-finding
+1. State the general rule in your domain.
+2. Find the actually-existing case that doesn't fit.
+3. Describe it on its own terms — not as deviation, but as what it is.
+4. Resist generalizing back into a modified rule.
+5. The particular case is the result.
+
+### Pataphysical fiction
+1. Adopt the form of a serious genre (encyclopedia, manual, technical paper, museum catalog, book review).
+2. Apply the form rigorously to a non-existent subject.
+3. Don't break frame. Don't wink.
+
+## Worked example
+
+**Problem**: file synchronization software. Realistic solutions all involve some compromise on conflict resolution.
+
+**Pataphysical specification**: a file system in which two simultaneous edits to the same file produce a *third* file containing both edits as "ghosts" — versions visible to and editable by readers but not committed until a quorum of readers reads them and chooses one. The file exists in superposition until observation.
+
+**Lineaments**: ghost-files have an "observation count"; below threshold they are interactive but not committed; above, they collapse to chosen version.
+
+**Consequences**: editing a popular file is fast (quorum collapses quickly); editing an obscure file is slow (no quorum). The file system has *audience-dependent commit semantics*.
+
+The specification is impossible. But *audience-dependent commit semantics*, surfaced by the pataphysical move, is in fact a useful concept with plausible implementations.
+
+## Anti-slop notes
+
+- Whimsical incoherence is not pataphysics. "What if cows could fly" without the cow's wing-loading and lift coefficient = sloppy fantasy.
+- Don't generate fake-Borges or fake-Calvino. Their work is grounded in deep specifics. Generated "in the style of" is decorative.
+- The dry, committed register matters. Comedic SF is not pataphysics.
+- Don't walk back to "of course this is just a thought experiment" at the end. That undoes the operation.
+
+Sources: Jarry, *Gestes et opinions du docteur Faustroll, pataphysicien* (Fasquelle, 1911); Borges, *Ficciones* (1944); Lem, *A Perfect Vacuum* (1971).

--- a/skills/creative/creative-ideation/references/methods/pattern-languages.md
+++ b/skills/creative/creative-ideation/references/methods/pattern-languages.md
@@ -1,0 +1,78 @@
+# Pattern Languages
+
+Christopher Alexander et al., *A Pattern Language* (1977). 253 patterns for designing buildings, towns, rooms — structured as a generative grammar with explicit cross-references. Spawned the Gang of Four software design patterns (1994) and many domain adaptations.
+
+## Pattern format
+
+A pattern has three parts:
+1. **Context** — the situation in which it applies
+2. **Problem** — a recurring tension in that context
+3. **Solution** — a *generative* principle (not a specific design — capable of many instantiations)
+
+A pattern *language* is a network of patterns at different scales, with explicit links: which patterns *contain* this one, which patterns *complete* it.
+
+## When to use
+
+- Designing physical environments (buildings, rooms, gardens, neighborhoods)
+- Designing interactional environments (UX, software architecture)
+- Building shared design vocabulary with a team
+- Documenting design intuitions for transmission
+- Civic / community design
+
+## Don't use when
+
+- You want to break with tradition (patterns are conservative — they encode what has worked)
+- Domain has no established practice yet (no patterns to extract)
+- Pure conceptual / artistic work
+- You'd be implementing patterns literally (collapses generative → rule)
+
+## Selected patterns from Alexander's 253
+
+For texture. Real use means buying or borrowing the book.
+
+- **8. Mosaic of Subcultures** — a region needs distinct subcultures with their own ecology, separated by zones of disuse, not homogenized.
+- **53. Main Gateways** — mark every entrance with a substantial visible threshold.
+- **60. Accessible Green** — green outdoor space within 3 minutes' walk.
+- **105. South-Facing Outdoors** — most-used outdoor space to the south of the building.
+- **111. Half-Hidden Garden** — garden right at street is too public; behind house is unused. Place it half-hidden.
+- **159. Light on Two Sides of Every Room** — windows on at least two sides. Single-sided rooms are uncomfortable, rarely used.
+- **179. Alcoves** — rooms with no place to retreat are unsettling. Build niches, bays, window seats.
+- **188. Bed Alcove** — bed in the open is exposed. Build at least a partial enclosure.
+- **191. Shape of Indoor Space** — simple, mostly orthogonal; deviate only for clear local reason.
+- **230. Radiant Heat** — radiant heat (fireplace, radiator) is qualitatively different from forced air.
+
+The patterns are arguably true and arguably false; what matters is the *form*.
+
+## Procedure
+
+### Using an existing language
+1. Identify the relevant scale (region / neighborhood / building / room / detail).
+2. Read patterns at and above your scale; note which apply.
+3. Compose: apply higher-scale patterns first; let them constrain lower-scale ones.
+4. Adapt to your specifics. Patterns are generative, not literal.
+
+### Developing your own language (more useful for software, org, pedagogy)
+1. Identify recurring problems in your domain. Look across many cases.
+2. Name each (short, memorable, describes the *solution* shape — "Light on Two Sides", not "Insufficient Daylight").
+3. State each in: context — problem — solution — therefore: [generative principle] — see also: [related patterns].
+4. Map containment relations between patterns.
+5. Test by applying to a fresh problem; revise.
+
+## Worked example (software, in Alexander's form)
+
+**Iterator pattern** (Gang of Four, 1994)
+
+*Context*: a collection of objects must be traversable by client code.
+*Problem*: client shouldn't need to know the internal structure (array vs tree vs linked list); collection shouldn't have traversal logic scattered across clients.
+*Solution*: provide an Iterator object with `next()`, `hasNext()`, `current()` that encapsulates traversal state. Collection produces an Iterator on request.
+*Therefore*: separate "what is being traversed" from "how it is traversed."
+*See also*: Composite (tree traversal), Visitor (operations during traversal), Factory Method (producing the right Iterator).
+
+## Anti-slop notes
+
+- Bullet-list "design tips" are not patterns. A pattern has context, problem, generative solution, and place in a network.
+- Don't generate patterns to seem comprehensive. Real patterns come from many cases.
+- Don't apply Alexander's residential patterns to non-residential domains literally.
+- Patterns are conservative *and* generative. They don't anti-novelty; they shape novelty.
+
+Source: Alexander et al., *A Pattern Language* (Oxford UP, 1977); *The Timeless Way of Building* (Oxford UP, 1979). For software: Gamma et al., *Design Patterns* (Addison-Wesley, 1994).

--- a/skills/creative/creative-ideation/references/methods/polya.md
+++ b/skills/creative/creative-ideation/references/methods/polya.md
@@ -1,0 +1,77 @@
+# Pólya's Heuristics
+
+George Pólya, *How to Solve It* (Princeton UP, 1945). Four-phase problem-solving framework + dictionary of heuristic moves. Written for math but applies to any well-defined "find X such that..." problem.
+
+## When to use
+
+- Math, physics, theoretical problems
+- Algorithm design, debugging
+- Any problem with a clear target (find X such that...)
+- Teaching problem-solving
+
+## Don't use when
+
+- Open-ended creative problems with no defined target
+- Difficulty is *understanding the problem space*, not solving within it (use dérive or compression-progress first)
+- Solution is more about taste than analysis
+- Real-world problems where data is incomplete and conditions vague
+
+## The four phases
+
+### 1. Understand the problem
+- What is the **unknown**?
+- What are the **data**?
+- What is the **condition** linking them?
+- Is the condition sufficient? Insufficient? Redundant? Contradictory?
+- State in your own words.
+- Draw a figure. Introduce notation.
+
+This phase is most often skipped. **Most problem-solving failures are upstream of method** — they're failures to understand the problem precisely.
+
+### 2. Devise a plan
+Find the connection between data and unknown. Heuristic moves:
+- **Have you seen this problem before?** Or in slightly different form?
+- **Do you know a related problem?**
+- **Look at the unknown** — find a familiar problem with the same or similar unknown.
+- **Could you use a related problem's result? Its method?**
+- **Restate.**
+- If you can't solve the proposed problem, solve a related one:
+  - More general
+  - More specific
+  - Analogous
+  - A part of the problem
+  - With a condition relaxed
+- **Did you use all the data?** All the conditions?
+
+### 3. Carry out the plan
+- Can you see clearly that each step is correct?
+- Can you prove it?
+
+### 4. Look back
+- Check the result. Check the argument.
+- Can you derive it differently? See it at a glance?
+- Can you use the result, or the method, for some other problem?
+
+The looking-back phase is the *learning* phase — what makes Pólya's method an *educational* method, not just a problem-solving one.
+
+## Key heuristics from the dictionary
+
+- **Decompose and recombine.** Break into parts; solve each; combine.
+- **Generalization.** The general case is sometimes easier than the specific because it forces you to identify essential structure.
+- **Specialization.** Try the smallest case, the simplest case, the case where one parameter is zero. Look for pattern.
+- **Analogy.** Find a related problem with same structure, different surface.
+- **Auxiliary problem.** Solve a related problem first; use its result.
+- **Working backwards.** Start from the unknown and work back. Forward direction often has too many branches; backward is more constrained.
+- **Setting up an equation.** Most word-problem failure is in translation, not algebra.
+- **Reductio ad absurdum.** Assume the conclusion is false; derive contradiction.
+- **Pattern recognition.** Small cases → conjecture → prove.
+- **Symmetry.** Where there's symmetry in the problem, there's usually symmetry in the solution.
+
+## Anti-slop notes
+
+- Reciting the four phases without doing them = slop. The structure is fine; the value is in actually executing each phase.
+- Don't pretend you've understood when you haven't. State the unknown, the data, the condition concretely.
+- Don't claim "Pólya'd it" without consulting specific heuristics.
+- Don't apply to fuzzy problems. Pólya assumes clear problem statements.
+
+Source: Pólya, *How to Solve It* (Princeton UP, 1945; current edition 2014).

--- a/skills/creative/creative-ideation/references/methods/premortem-and-inversion.md
+++ b/skills/creative/creative-ideation/references/methods/premortem-and-inversion.md
@@ -1,0 +1,71 @@
+# Premortem and Inversion
+
+Two methods for failure-oriented ideation:
+- **Premortem** — Gary Klein, *HBR* September 2007. Imagine the project has already failed catastrophically; work backwards to causes.
+- **Inversion** — Charlie Munger via Carl Jacobi: *"Tell me where I'm going to die so I'll never go there."* Solve problems by figuring out how to fail and avoiding that.
+
+Both exploit prospective hindsight (Mitchell, Russo, Pennington 1989): people generate more concrete reasons for an event when imagining it has *already happened* than when imagining it might.
+
+## When to use
+
+### Premortem
+- Choosing between project options
+- Pressure-testing a near-term decision
+- Late-stage planning for a long-horizon project
+- Group decisions with social pressure suppressing dissent
+
+### Inversion
+- Strategic direction choice (easier to identify clear failures than clear successes)
+- Personal life decisions (career, marriage, investments, health)
+- Identifying hidden anti-patterns in your own behavior
+- Designing systems against adversaries (security, abuse-prevention)
+
+## Don't use when
+
+- Early generative phase — corrosive to fragile ideas
+- You can't act on the failure modes (anxiety, not planning)
+- Group lacks psychological safety to articulate fears about the leader's project
+- Decisions that need urgency (premortem takes 60–90 minutes done well)
+
+## Premortem procedure
+
+1. **State the project as if it's complete and failed.** "It is [date 6 months from now]. We launched. The result was a complete disaster."
+2. **Generate failure narratives independently.** Each member writes a paragraph describing what happened, in concrete terms. *Independence is essential* — group brainstorming surfaces socially safe concerns; independent writing surfaces uncomfortable ones.
+3. **Round-robin failure causes.** Each shares one cause; no comment. Continue until exhausted.
+4. **Cluster and assess.** Group similar; estimate probability and severity.
+5. **Generate mitigations for the top 3.** Update the plan.
+6. **Re-run periodically.** Failures unlikely at planning time may have become likely.
+
+## Inversion procedure
+
+1. State the goal: "I want to [original goal]."
+2. Invert: "How would I guarantee the *opposite*?"
+3. List 5–10 things that would guarantee the inverted goal. Be specific.
+4. Self-check: which am I accidentally doing or could drift into?
+5. Avoid those; return to original goal.
+
+## Worked inversion example
+
+**Goal**: I want my open-source project to attract sustained contributors.
+
+**Inversion**: how would I guarantee that no one ever contributes?
+
+1. Have no CONTRIBUTING.md or unclear norms.
+2. Reject PRs without explanation, slowly.
+3. Make the build hard to reproduce locally.
+4. Use a tone in issue threads that makes contributors feel stupid.
+5. Use a license requiring CLAs new contributors won't sign.
+6. Take 6+ months to merge anything.
+7. Reply to issues with one-word answers.
+8. Have only the founders in the maintainer org.
+
+**Self-check**: which am I doing? Honest answer surfaces 2–3 of these. Those are the highest-leverage fixes.
+
+## Anti-slop notes
+
+- Premortem slop = generic risk lists ("execution risk", "market risk"). Real premortem narrative says *specifically* what went wrong.
+- Inversion slop = "do the opposite of successful people" — that's contrarianism. Real inversion identifies *specific* failure-guaranteeing actions in *your* situation.
+- Don't generate fake fears. If there are no real concerns, the premortem is short.
+- Don't use these to talk users out of pursuing things they should pursue. Premortem and inversion are pressure tests, not vetoes.
+
+Source: Klein, "Performing a Project Premortem", *HBR* Sept 2007. Munger, *Poor Charlie's Almanack* (PCA, 2005).

--- a/skills/creative/creative-ideation/references/methods/scamper.md
+++ b/skills/creative/creative-ideation/references/methods/scamper.md
@@ -1,0 +1,63 @@
+# SCAMPER
+
+Bob Eberle, 1971, building on Alex Osborn's brainstorming checklist (1953). Seven systematic transformations of an existing thing.
+
+## When to use
+
+- You have a base idea and want variations cheaply
+- Group brainstorming with mixed expertise
+- Forcing breadth past the first instinct
+- Teaching ideation
+
+## Don't use when
+
+- Blank page — SCAMPER amplifies a base; doesn't generate from nothing
+- You need depth in one direction (SCAMPER produces breadth)
+- The problem is analyzing an existing system, not modifying it
+
+## The seven operators
+
+**S — Substitute.** Replace a component, material, person, place, or process. *(Steel→aluminum, scheduled meetings→async docs, human→model, recipe ingredient swap.)*
+
+**C — Combine.** Merge two things. Functions, parts, audiences, formats. *(Phone+camera+GPS→smartphone. Memoir+cookbook→food memoir. Programmer+linguist→compiler designer.)*
+
+**A — Adapt.** Borrow from another field. *(Velcro from burrs. Toyota's just-in-time from supermarket restocking. Graphic novel from cinematic technique.)*
+
+**M — Modify (or Magnify / Minify).** Change a property — scale, frequency, intensity, color, weight, shape. *(Twitter that posts once a year. Novel as one page. Same content as comic, song, sculpture.)*
+
+**P — Put to other uses.** Use the existing thing for a different purpose. *(Aspirin: pain reliever → stroke prevention. Blockchain: cryptocurrency → supply chain. Sweater: garment → kiln cushioning.)*
+
+**E — Eliminate.** Remove a component. **Usually the highest-leverage cell.** *(Eliminate UI: CLI/API as product. Eliminate menu: omakase, single-dish restaurant. Eliminate explanation: Eno's *Music for Airports*.)*
+
+**R — Reverse / Rearrange.** Invert relationships, change sequence, turn inside out. *(Priceline reverses seller/buyer. Wikipedia reverses expert/amateur. *Memento* reverses time order.)*
+
+## Procedure
+
+1. State the base in one precise sentence.
+2. Run all seven operators. **Don't skip cells.** The cells you don't want to run are usually where the surprise is.
+3. Read the seven. Most will be slop; one or two will be interesting; one might be surprising.
+4. Take the surprising one and elaborate.
+5. Discard the rest.
+
+## Worked example
+
+**Base**: a web app that tracks reading progress across books.
+
+- S: track your *boredom*, not progress — when did you stop and why?
+- C: tracker + bookstore (already done; weak)
+- A: gym-app habit tracking (slop; reading is not fitness)
+- M: track only one book at a time, in extreme detail — every paragraph, every margin note
+- P: not tracking *your* reading but tracking *the book's* — which paragraphs do most readers stop on?
+- E: eliminate the tracking — keep the database of paragraphs as a "this is where I cried" annotation layer
+- R: instead of you tracking the book, the book tracks you — delivers itself in chunks based on your demonstrated rhythm
+
+Strongest cells: S, P, R. Elaborate P: a site where the unit of attention is the *paragraph* across the readerly population, not the book. Discard the rest.
+
+## Anti-slop notes
+
+- Most common SCAMPER slop: "Combine X with AI/ML/blockchain/AR". Reject.
+- Second most common: "make it a subscription" (business-model shift, not product variation).
+- Surface 1–3 results to the user, not 7. The seven are internal scaffolding.
+- Eliminate and Reverse produce the strongest non-slop output. Spend most of the budget there.
+
+Source: Eberle, *Scamper: Games for Imagination Development* (DOK, 1971); Osborn, *Applied Imagination* (Scribner's, 1953).

--- a/skills/creative/creative-ideation/references/methods/story-skeletons.md
+++ b/skills/creative/creative-ideation/references/methods/story-skeletons.md
@@ -1,0 +1,100 @@
+# Story Skeletons
+
+Three traditions for narrative structure, deliberately heterogeneous (they disagree about what stories are):
+- **Emma Coats** — Pixar's 22 Story Basics (Twitter, May 2011). Working principles from Pixar's story room.
+- **George Saunders** — *A Swim in a Pond in the Rain* (Random House, 2021). Stories as escalating-stakes engines, learned by close reading Russian short fiction.
+- **Ursula K. Le Guin** — "The Carrier Bag Theory of Fiction" (1986). Argument *against* conflict-driven shape; *for* fiction as container.
+
+This file deliberately omits **Hero's Journey / Save the Cat / Story Circle / Three-Act**. Real traditions but so widely formulaic-ized in screenwriting and self-help-adjacent writing that invoking them tends to produce slop.
+
+## When to use
+
+| Situation | Reach for |
+|---|---|
+| Story has no shape, need a fast spine | Coats #4 |
+| Stuck in early draft | Coats #9, #11, #12 |
+| Draft isn't working, don't know why | Saunders attention to "what does the story now want?" |
+| Conflict-arc is producing forced or shallow work | Le Guin's carrier bag |
+| Writing about a community / place / duration not a hero | Le Guin's carrier bag |
+| Writing literary short fiction | Saunders |
+| Commercial-feature-length narrative | Coats |
+
+## Don't use when
+
+- Pure lyric or expository work (no narrative)
+- Writing for a market that demands the formula (Hero's Journey may apply; Saunders/Le Guin will read as eccentric)
+- You don't have material yet — these shape; they don't generate
+
+## Coats's 22 (the load-bearing ones)
+
+The full list is widely circulated. Most-cited:
+
+**#4 — Pixar Pitch (the spine):**
+> *Once upon a time there was ___. Every day, ___. One day ___. Because of that, ___. Because of that, ___. Until finally ___.*
+
+Six-clause skeleton: stable normalcy → disrupting event → cascading consequences → resolution. Fits most narratives.
+
+**#6** — What is your character good at, comfortable with? Throw the polar opposite at them.
+
+**#7** — Come up with your ending before you figure out your middle. Endings are hard.
+
+**#9** — When stuck, make a list of what wouldn't happen next. Lots of times the material to get unstuck shows up.
+
+**#12** — Discount the first thing that comes to mind. And the second, third, fourth, fifth — get the obvious out of the way.
+
+**#13** — Give your characters opinions. Passive/malleable might seem likable to write, but it's poison to the audience.
+
+**#14** — Why must you tell THIS story? What's the belief burning within you? That's the heart of it.
+
+**#16** — What are the stakes? What happens if they don't succeed? Stack the odds against.
+
+**#19** — Coincidences to get characters into trouble are great; coincidences to get them out are cheating.
+
+**#20** — Take the building blocks of a movie you dislike. How would you rearrange them into what you DO like?
+
+**#22** — What's the essence of your story? Most economical telling? Build out from there.
+
+## Saunders — three operating moves
+
+**Stories are escalation.** Each scene must increase stakes — emotional, moral, situational. Stagnation kills. Even quiet stories must escalate.
+
+**Specificity is the engine.** Generic verbs, generic nouns, generic adjectives produce stories that don't escalate because nothing specific is happening to anyone in particular.
+
+**The story knows more than the writer.** Strong stories are built by *responsiveness*: draft, read what you wrote, ask "what does this story now want?", write the next sentence to fulfill that want. The writer is in service to the story.
+
+This contrasts directly with formula-driven writing.
+
+## Le Guin — carrier bag
+
+Anthropology has long focused on the *spear* and the *blade* as the early human inventions defining narrative — hunter-warrior stories. The actually-more-important invention was the *container*: the bag, the basket, the sling. Human survival was overwhelmingly gathering, not hunting. The hunting story has rising action and climax. The gathering story has accretion.
+
+> *The natural, proper, fitting shape of the novel might be that of a sack, a bag. ... A novel is a medicine bundle, holding things in a particular, powerful relation to one another and to us.*
+
+For ideation: when the conflict-arc is forcing you to flatten the work, use Le Guin. The carrier-bag novel is shaped not as a hero confronting an obstacle on a journey but as a container holding many specific things in particular relation. *Always Coming Home* (1985) is the model — multi-form anthropology of an imagined people: oral histories, recipes, songs, maps, alongside (not subordinated to) the conventional narrative.
+
+Use when:
+- Work is essayistic, anthropological, polyvocal
+- About a place, a community, a duration, a way of life
+- "Hero with an obstacle" frame collapses what makes the work specific
+
+## Procedure
+
+### Shaping a story you have material for
+1. Try Coats #4 spine. Can you fill in six blanks? If not, you may not have the spine yet.
+2. Apply Saunders attention. Read sentence by sentence; ask "what does this now want?" at each transition.
+3. Ask Le Guin's question: is the conflict-arc actually right for this material, or am I forcing it?
+
+### Diagnosing a stalled draft
+- Coats #16: What are the stakes? If absent, surface them.
+- Saunders: where does the energy stop being introduced? Find the dead zone.
+- Coats #13: Are characters passive? If yes, that's the problem.
+- Le Guin: is this story trying to be a hero-journey but doesn't want to be?
+
+## Anti-slop notes
+
+- Don't default to Hero's Journey. It's overused and flattens everything into Joseph Campbell shape.
+- Don't generate fake "Coats-style" tips. Use the actual 22.
+- Saunders writes against self-help-adjacent registers. Don't drift into "the writer's journey" tone.
+- Don't apply Le Guin's carrier bag superficially. It's a serious argument with politics. Using it as "and now my story is a bag of stuff" without engaging the underlying argument is dilution.
+
+Sources: Coats, Pixar story rules tweets (May 2011); Saunders, *A Swim in a Pond in the Rain* (Random House, 2021); Le Guin, "The Carrier Bag Theory of Fiction" in *Dancing at the Edge of the World* (Grove, 1989).

--- a/skills/creative/creative-ideation/references/methods/triz-principles.md
+++ b/skills/creative/creative-ideation/references/methods/triz-principles.md
@@ -1,0 +1,95 @@
+# TRIZ — Theory of Inventive Problem Solving
+
+Genrich Altshuller, 1946–. Soviet engineering invention method derived from analysis of hundreds of thousands of patents. 40 inventive principles + contradiction matrix + Ideal Final Result. Used by Samsung, Intel, Boeing, P&G.
+
+## Core principle
+
+Most inventive problems are technical contradictions: improving X degrades Y. The trade-off is usually an artifact of how the system is decomposed, not a fundamental constraint. Solve by identifying the contradiction explicitly, then applying principles that have historically resolved similar contradictions in patent literature.
+
+The **Ideal Final Result**: the desired function performed without the system that performs it (the system has, in some sense, eliminated itself). Use as target.
+
+## When to use
+
+- Engineering / mechanism / device invention
+- Measurable parameter conflict (mass/strength, cost/reliability, speed/accuracy)
+- You suspect the trade-off is fake
+- Group brainstorming with non-arbitrary structure
+
+## Don't use when
+
+- Artistic, social, or expressive problems (TRIZ requires measurable parameters)
+- Your "contradiction" is preference, not parameter ("modern but classic" is not TRIZ)
+- A textbook fix exists; TRIZ is for inventive problems
+
+## The 40 inventive principles
+
+1. **Segmentation** — divide into independent parts, increase divisibility
+2. **Taking out** — extract the disturbing part; separate only what's needed
+3. **Local quality** — make different parts have different properties
+4. **Asymmetry** — replace symmetrical with asymmetrical
+5. **Merging** — bring identical/similar objects closer; parallelize operations
+6. **Universality** — one part performs multiple functions
+7. **Nested doll** — place objects one inside another (matryoshka)
+8. **Anti-weight** — compensate weight by combining with lift / hydro/aerodynamic forces
+9. **Preliminary anti-action** — preload with opposite stress
+10. **Preliminary action** — perform required action in advance
+11. **Beforehand cushioning** — emergency means in advance
+12. **Equipotentiality** — change conditions so object need not be raised/lowered
+13. **The other way round** — invert action; movable parts fixed and vice versa
+14. **Spheroidality / curvature** — replace linear with curved; flat with spherical
+15. **Dynamics** — make rigid moveable; let parts shift configuration
+16. **Partial or excessive actions** — slightly less or slightly more if 100% is hard
+17. **Another dimension** — move 1D→2D→3D; tilt; use the other side
+18. **Mechanical vibration** — oscillate, ultrasonics
+19. **Periodic action** — periodic instead of continuous; vary frequency; pauses
+20. **Continuity of useful action** — eliminate idle running
+21. **Skipping** — perform fast through dangerous stages
+22. **Blessing in disguise** — use harmful factors to obtain a positive effect
+23. **Feedback** — introduce or modify feedback
+24. **Intermediary** — use an intermediary article or process
+25. **Self-service** — make the object service itself; use waste resources
+26. **Copying** — cheap copies instead of fragile/expensive originals
+27. **Cheap short-living** — disposable instead of durable
+28. **Mechanics substitution** — replace mechanical with sensory (optical, acoustic, EM)
+29. **Pneumatics and hydraulics** — replace solid with gas/liquid; inflatable
+30. **Flexible shells and thin films** — instead of 3D structures
+31. **Porous materials** — make porous; use pores to introduce useful substance
+32. **Color changes** — change color or transparency
+33. **Homogeneity** — interacting objects from same material
+34. **Discarding and recovering** — portions disappear after use; restore consumables
+35. **Parameter changes** — physical state, concentration, density, flexibility, temperature
+36. **Phase transitions** — exploit phenomena at phase changes
+37. **Thermal expansion** — different coefficients of thermal expansion
+38. **Strong oxidants** — oxygen-enriched, ozonized
+39. **Inert atmosphere** — inert environment or vacuum
+40. **Composite materials** — uniform → composite
+
+## Procedure
+
+1. **State the contradiction** in the form: "I want X to improve, but X improvement causes Y to degrade." If you can't state it crisply, you don't yet have a TRIZ problem.
+2. **Compare to Ideal Final Result.** What would it look like if the system eliminated itself?
+3. **Look up candidate principles.** The contradiction matrix at triz40.com maps (X parameter, Y parameter) → recommended principles. Or scan the 40 above for fits.
+4. **Translate principle to mechanism.** A principle is general; the mechanism is specific to your situation.
+5. **Compare candidates against IFR.** Pick closest.
+
+## Worked example
+
+**Problem**: fast brew time (under 60s) vs full extraction (typically 4 min).
+**Contradiction**: speed vs completeness of extraction.
+**Candidate principles**: 1 (Segmentation), 17 (Another dimension), 19 (Periodic action), 35 (Parameter changes).
+**Translations**:
+- Segmentation: pre-extract concentrates; dilute on demand. (Nespresso.)
+- Another dimension: extract under pressure (espresso).
+- Periodic action: pulse-extract with pauses (some pour-over).
+- Parameter changes: brew at different temperature/pressure (cold brew = low T long time; espresso = high P short time).
+
+**IFR comparison**: closest to "no brewing time" is pre-extracted concentrate (Segmentation). Resolves the contradiction by *separating extraction from delivery in time*.
+
+## Anti-slop notes
+
+- Don't present the 40 principles as a generative checklist — that's SCAMPER. TRIZ's value is the contradiction lens + patent-derived priors.
+- Translate principle to mechanism, don't stop at the principle name.
+- Don't claim TRIZ where it doesn't apply (artistic, social, preference contradictions).
+- Don't invent principles in Altshuller's style.
+
+Tools: triz40.com (interactive matrix). Source: Altshuller, *And Suddenly the Inventor Appeared* (1994).

--- a/skills/creative/creative-ideation/references/methods/volume-generation.md
+++ b/skills/creative/creative-ideation/references/methods/volume-generation.md
@@ -1,0 +1,74 @@
+# Volume Generation
+
+Three traditions for producing many ideas fast:
+- **Crazy 8s** — Google Ventures Sprint method. Codified in *Sprint* (Knapp et al., 2016).
+- **Brainwriting 6-3-5** — Bernd Rohrbach, 1968. German design-method literature.
+- **James Webb Young** — *A Technique for Producing Ideas* (1940). 60-page book; canonical advertising-copywriter manual.
+
+## When to use
+
+- Time pressure with a generative goal
+- Group ideation (brainwriting reliably outperforms verbal brainstorming)
+- Quantity-before-quality phase
+- You need to produce many to find the few good ones
+
+## Don't use when
+
+- You don't have material yet (Young's stage 1: gather first)
+- The right answer is rare and you'll know it when you see it (volume can paradoxically miss it)
+- Solo with no time pressure (use deliberative methods instead)
+
+## Crazy 8s
+
+1. Fold a sheet into 8 panels (or use a printed grid).
+2. Set a timer for **8 minutes**.
+3. Sketch one idea per panel — eight ideas, one minute each.
+4. Sketch, don't write. Visual format forces concretization.
+5. After timer: pick 1–3 strongest panels.
+6. Group share.
+
+The first 4–5 panels are usually slop; the last 3–4 are where surprises live (the easy ideas have been exhausted).
+
+## Brainwriting 6-3-5
+
+Outperforms verbal brainstorming consistently in academic creativity research (Diehl & Stroebe, 1987 + many replications). Verbal brainstorming has well-documented production blocking, evaluation apprehension, and social loafing. Brainwriting eliminates all three.
+
+1. **6 participants**, each with a sheet.
+2. Each writes **3 ideas** in **5 minutes**, in a row at the top.
+3. Papers rotate. Each participant now sees the previous 3 ideas; writes 3 *new* ones — building or fresh.
+4. Repeat until each sheet has been seen by all 6.
+5. Result: 6 × 6 × 3 = 108 ideas in 30 minutes.
+
+## James Webb Young — 5 stages
+
+Honest about the *temporal* structure of idea formation. Most methods assume ideas come on demand; Young's account is that they often don't, and the work is upstream.
+
+1. **Gather material.** Specific *and* general material. Most idea-generators fail here. *"Just one more idea about the product, just one more bit of factual material — many a time these have made all the difference."*
+2. **Mentally digest.** Turn the material over. Make tentative partial connections. Don't reach for a final idea.
+3. **Drop it.** Stop working. Sleep, walk, watch a movie. The unconscious works on it.
+4. **The idea arrives.** Often during a shower or walk. *"It will come to you when you are least expecting it."*
+5. **Shape and develop.** The arriving idea is half-formed. Subject it to actual scrutiny.
+
+The drop stage is non-negotiable. Compressing it back into 1→2→4 produces incomplete ideas.
+
+## When to use which
+
+| Time available | Group size | Use |
+|---|---|---|
+| 8 minutes | Solo | Crazy 8s |
+| 8 minutes | Group | Crazy 8s + share |
+| 30 minutes | Solo | Crazy 8s + 22 min elaboration |
+| 30 minutes | Group of 4–8 | Brainwriting 6-3-5 |
+| 1 hour | Group | Brainwriting + 30 min affinity diagram |
+| 1 day | Solo | Young stages 1–3 |
+| 1 week | Solo or small group | Full Young 5 stages |
+
+## Anti-slop notes
+
+- **Volume of equal quality is not volume.** Eight panels of identical structure is one idea drawn eight times. Force divergence by applying different generative methods to different panels.
+- Don't pad to round numbers. If only 5 of the 8 panels produced anything, surface 5.
+- Surface 1–3 to the user, not all 8 / all 108.
+- Don't conflate volume with depth. Volume is breadth-first; depth comes later with elaboration methods.
+- Respect Young's drop stage. Rushing from gather → idea in one session usually fails.
+
+Sources: Young, *A Technique for Producing Ideas* (Advertising Publications, 1940); Rohrbach, "Methode 635" (*Absatzwirtschaft* 12, 1968); Knapp et al., *Sprint* (Simon & Schuster, 2016).


### PR DESCRIPTION
## Summary

Generalizes the `creative-ideation` skill from a single constraint-dispatch mechanism into a routed library of 22 named ideation methods drawn from working artists, scientists, designers, and writers (Eno/Schmidt, Schmidhuber, Altshuller, Meadows, Alexander, the OuLiPo, Cage/Burroughs/Surrealists/Situationists, de Bono, Klein, Munger, Christensen, Pólya, Coats/Saunders/Le Guin, Tharp/LeWitt/Cleese/Cameron, Kawakita, Benyus, Jarry, Synectics/Koestler/Fauconnier-Turner, Shklovsky/Brecht, Debord/Lynch/Bachelard).

`SKILL.md` now reads the user's situation and routes to the matching method via a path table (blank page, mid-project block, technical invention, writing, selection, systems work, research question, life decision, etc.). The original wttdotm-derived constraint library is preserved as the default no-direction path.

## Why

The v1 skill had one good move (random constraint dispatch) and was developer-flavored. v2 supports any kind of ideation (writing, music, civic, research, personal, technical, business) and routes deliberately by situation rather than defaulting the agent to one method. Each method is named, attributed to actual practitioners, and presented as a working tool — the actual cards / principles / operators / patterns, plus procedure and anti-slop notes.

## Files

Each method file is **50–100 lines** of operating content (no encyclopedic prose, no long source lists):
- What the method is (1–2 sentences)
- When to use / when not to use
- The actual list (Oblique Strategies cards, OuLiPo constraints, TRIZ 40 principles, Meadows' 12 leverage points, de Bono operators, etc.)
- Procedure
- Worked example where useful
- Anti-slop notes specific to the method

Cross-cutting reference files:
- `method-catalog.md` — one-line summary + when-to-use per method, comparison table
- `heuristics.md` — extended decision tree for edge cases (phase / domain / mood / stack)
- `anti-slop.md` — anti-slop rules to apply to every output
- `exercises.md` — time-boxed exercises (5min / 30min / 1hr / day / week)

`SKILL.md` is **88 lines** — smaller than every other bundled creative skill (range 246–606 lines).

## Methods (22)

- **Random-stimulus**: oblique-strategies, lateral-provocations, chance-and-remix
- **Constraint-driven**: oulipo, scamper
- **Theoretical**: compression-progress, analogy-and-blending, pataphysics
- **Engineering / systems**: triz-principles, leverage-points, pattern-languages, first-principles, polya, biomimicry
- **Generation / discipline**: volume-generation, creative-discipline
- **Selection / refinement**: premortem-and-inversion, defamiliarization
- **Mapping / drift**: derive-and-mapping, affinity-diagrams
- **Domain-specific**: jobs-to-be-done, story-skeletons

## Backward compatibility

The frontmatter slug is updated from `name: ideation` → `name: creative-ideation` to match the directory — incorporates the fix proposed in #18084 (so that PR can be closed, since this PR includes that change). Original `references/full-prompt-library.md` is preserved unchanged as the default path.

Version bumped 1.0.0 → 2.0.0.

## Test plan

- `scripts/run_tests.sh tests/tools/test_skills_tool.py tests/website/test_generate_skill_docs.py tests/agent/test_skill_commands.py`
- Manual: `hermes --toolsets skills -q "Use the creative-ideation skill to give me a project idea"` (constraint-dispatch path)
- Manual: `hermes --toolsets skills -q "Use the creative-ideation skill — I have an engineering problem where reducing X always increases Y"` (TRIZ path)
- Manual: `hermes --toolsets skills -q "Use the creative-ideation skill — I'm stuck on a song I'm working on"` (Oblique Strategies path)

## Stats

27 files changed, +2034 / -115. Total skill ~2,180 lines across 28 files.