### PR TITLE
fix(skills): check directory name against hub lock to protect non-ASCII SKILL.md names from curator

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -223,6 +223,35 @@ def test_agent_created_excludes_hub_installed(skills_home):
     assert "hub-skill" not in names
 
 
+def test_agent_created_excludes_hub_installed_non_ascii_name(skills_home):
+    """Hub-installed skills whose SKILL.md `name:` is non-ASCII (e.g.
+    'Get笔记') but whose lock key is a ASCII slug (e.g. 'getnote') must
+    still be excluded from agent-created lists.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/19293
+    """
+    from tools.skill_usage import list_agent_created_skill_names
+    skills_dir = skills_home / "skills"
+    # Directory name matches hub slug; SKILL.md name is non-ASCII
+    d = skills_dir / "getnote"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        "---\nname: Get笔记\ndescription: test\n---\n\n# body\n",
+        encoding="utf-8",
+    )
+    _write_skill(skills_dir, "my-skill")
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps({"version": 1, "installed": {"getnote": {"source": "taps/main"}}}),
+        encoding="utf-8",
+    )
+    names = list_agent_created_skill_names()
+    assert "my-skill" in names
+    assert "Get笔记" not in names
+    assert "getnote" not in names
+
+
 def test_is_agent_created(skills_home):
     from tools.skill_usage import is_agent_created
     skills_dir = skills_home / "skills"

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -174,7 +174,12 @@ def list_agent_created_skill_names() -> List[str]:
         if parts and (parts[0].startswith(".") or parts[0] == "node_modules"):
             continue
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
-        if name in off_limits:
+        # Guard against non-ASCII SKILL.md names: hub lock keys are ASCII
+        # slugs (e.g. "getnote") while the displayed name may be non-ASCII
+        # (e.g. "Get笔记").  Check both the parsed name AND the directory
+        # name so that hub-installed skills with non-ASCII names are still
+        # protected from curator processing.
+        if name in off_limits or skill_md.parent.name in off_limits:
             continue
         names.append(name)
     return sorted(set(names))


### PR DESCRIPTION
## Summary

`list_agent_created_skill_names()` compares each SKILL.md's parsed `name:` field against the hub lock keys to determine provenance. When a hub-installed skill has a non-ASCII `name:` (e.g. `Get笔记`) but the lock key is an ASCII slug (e.g. `getnote`), the comparison misses and the curator treats the skill as agent-created — making it eligible for consolidation and archival.

## Root Cause

In `tools/skill_usage.py::list_agent_created_skill_names()`:

```python
name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
if name in off_limits:
    continue
```

`_read_hub_installed_names()` returns lock keys (`{"getnote", ...}`), but `_read_skill_name()` returns the SKILL.md `name:` field (`"Get笔记"`). The mismatch lets the skill pass the filter.

## Fix

Also check the skill directory name (which matches the hub slug) against `off_limits`:

```python
if name in off_limits or skill_md.parent.name in off_limits:
    continue
```

## Regression Coverage

- New test: `test_agent_created_excludes_hub_installed_non_ascii_name` — creates a hub-installed skill with non-ASCII SKILL.md name and verifies it is excluded from agent-created lists.
- All 39 existing tests pass (no behavioral change for ASCII-named skills).

## Testing

```bash
python -m pytest tests/tools/test_skill_usage.py -x -q
# 39 passed in 1.78s
```
