### PR TITLE
fix(docker): chown runtime node_modules trees to hermes user (#18800)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,14 @@ RUN cd web && npm run build && \
 # ---------- Permissions ----------
 # Make install dir world-readable so any HERMES_UID can read it at runtime.
 # The venv needs to be traversable too.
+# node_modules trees additionally need to be writable by the hermes user
+# so the runtime `npm install` triggered by _tui_need_npm_install() in
+# hermes_cli/main.py succeeds (see #18800). /opt/hermes/web is build-time
+# only (HERMES_WEB_DIST points at hermes_cli/web_dist) and is intentionally
+# not chowned here.
 USER root
-RUN chmod -R a+rX /opt/hermes
+RUN chmod -R a+rX /opt/hermes && \
+    chown -R hermes:hermes /opt/hermes/ui-tui /opt/hermes/node_modules
 # Start as root so the entrypoint can usermod/groupmod + gosu.
 # If HERMES_UID is unset, the entrypoint drops to the default hermes user (10000).
 

--- a/tests/tools/test_dockerfile_node_modules_perms.py
+++ b/tests/tools/test_dockerfile_node_modules_perms.py
@@ -1,0 +1,39 @@
+"""contract test: dockerfile chowns runtime node_modules trees to hermes
+
+regression guard for #18800. the container drops privileges to the hermes
+user (uid 10000) in entrypoint.sh, then the TUI launcher's
+_tui_need_npm_install() trips on every startup (see the
+npm_config_install_links=false comment in the Dockerfile) and runs
+`npm install` in /opt/hermes/ui-tui. that install fails with EACCES unless
+the runtime node_modules trees are owned by hermes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+
+def test_dockerfile_chowns_runtime_node_modules_to_hermes_user() -> None:
+    text = DOCKERFILE.read_text()
+
+    chown_lines = [
+        line for line in text.splitlines()
+        if "chown" in line and "hermes:hermes" in line
+    ]
+    assert chown_lines, (
+        "Dockerfile must contain a chown -R hermes:hermes for the runtime "
+        "node_modules trees; see #18800"
+    )
+
+    chown_block = "\n".join(chown_lines)
+
+    # both runtime-mutable trees must be passed to the chown command.
+    # /opt/hermes/web is intentionally excluded: it is build-time only,
+    # because HERMES_WEB_DIST points at hermes_cli/web_dist for runtime.
+    for required_path in ("/opt/hermes/ui-tui", "/opt/hermes/node_modules"):
+        assert required_path in chown_block, (
+            f"{required_path} must be passed to a chown -R hermes:hermes "
+            f"command in the Dockerfile (see #18800)"
+        )


### PR DESCRIPTION
## What does this PR do?

the container drops privileges to the hermes user (uid 10000) in entrypoint.sh, but /opt/hermes/ui-tui and /opt/hermes/node_modules are root-owned from build time. the TUI launcher's _tui_need_npm_install() check trips on every startup (see the existing npm_config_install_links=false comment in the Dockerfile) and runs npm install in /opt/hermes/ui-tui, which fails with EACCES and the Chat tab closes immediately as `[session ended]`

chown both runtime trees to hermes:hermes in the existing permissions block. /opt/hermes/web is build-time only (HERMES_WEB_DIST points at hermes_cli/web_dist for runtime) and is intentionally not chowned

## Related Issue

Fixes #18800

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `Dockerfile`: chained `chown -R hermes:hermes /opt/hermes/ui-tui /opt/hermes/node_modules` onto the existing `chmod -R a+rX /opt/hermes` RUN under the Permissions block, with a short comment explaining why /opt/hermes/web is excluded
- `tests/tools/test_dockerfile_node_modules_perms.py`: new contract test asserting both runtime trees are passed to a chown -R hermes:hermes command in the Dockerfile

## How to Test

1. before the patch, build the image and exec into a running container as the hermes user, then run `npm install` in /opt/hermes/ui-tui — fails with EACCES on `/opt/hermes/ui-tui/packages/hermes-ink/node_modules/@esbuild/aix-ppc64`
2. with the patch applied, the same `npm install` succeeds
3. open the dashboard with HERMES_DASHBOARD_TUI=1 and click the Chat tab — input is accepted instead of closing as `[session ended]`
4. run `python -m pytest tests/tools/test_dockerfile_node_modules_perms.py -q` — passes against the patched Dockerfile, fails if either path is removed from the chown

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux/amd64 via Docker

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

repro of the failure before the patch, from #18800:

```
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'mkdir',
npm ERR!   path: '/opt/hermes/ui-tui/packages/hermes-ink/node_modules/@esbuild/aix-ppc64'
```

after the patch, the same code path completes and the dashboard Chat tab is interactive