### PR TITLE
Add native vision path for main models

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -566,8 +566,11 @@ class ContextCompressor(ContextEngine):
             if msg.get("role") != "tool":
                 continue
             content = msg.get("content") or ""
-            # Skip multimodal content (list of content blocks)
-            if isinstance(content, list):
+            # Skip multimodal content only when it contains non-text blocks.
+            if isinstance(content, list) and any(
+                not isinstance(part, dict) or part.get("type") not in {"text", "input_text"}
+                for part in content
+            ):
                 continue
             if len(content) < 200:
                 continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -653,6 +653,30 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
+def _native_vision_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return bool(cfg.get("auxiliary", {}).get("native_vision", False))
+    except Exception:
+        return False
+
+
+def _make_native_vision_user_content(user_text: str, image_paths: List[str]) -> list[dict[str, Any]]:
+    content: list[dict[str, Any]] = []
+    text = str(user_text or "")
+    if text.strip():
+        content.append({"type": "text", "text": text})
+    elif image_paths:
+        content.append({"type": "text", "text": "The user sent image(s)."})
+    for path in image_paths:
+        content.append({
+            "type": "image_url",
+            "image_url": {"url": str(path), "detail": "auto"},
+        })
+    return content
+
+
 def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
     """Consume and return the full pending event for a session.
 
@@ -5396,7 +5420,7 @@ class GatewayRunner:
         event: MessageEvent,
         source: SessionSource,
         history: List[Dict[str, Any]],
-    ) -> Optional[str]:
+    ) -> Optional[Any]:
         """Prepare inbound event text for the agent.
 
         Keep the normal inbound path and the queued follow-up path on the same
@@ -10577,7 +10601,7 @@ class GatewayRunner:
         self,
         user_text: str,
         image_paths: List[str],
-    ) -> str:
+    ) -> Any:
         """
         Auto-analyze user-attached images with the vision tool and prepend
         the descriptions to the message text.
@@ -10594,6 +10618,9 @@ class GatewayRunner:
         Returns:
             The enriched message string with vision descriptions prepended.
         """
+        if _native_vision_enabled():
+            return _make_native_vision_user_content(user_text, image_paths)
+
         from tools.vision_tools import vision_analyze_tool
         from agent.memory_manager import sanitize_context
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -683,6 +683,7 @@ DEFAULT_CONFIG = {
     # All tasks fall back to openrouter:google/gemini-3-flash-preview if
     # the configured provider is unavailable.
     "auxiliary": {
+        "native_vision": False,  # when true, pass image blocks to the main model instead of forcing auxiliary OCR text
         "vision": {
             "provider": "auto",    # auto | openrouter | nous | codex | custom
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"

--- a/run_agent.py
+++ b/run_agent.py
@@ -175,6 +175,7 @@ from agent.trajectory import (
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_var_enabled, normalize_proxy_url
 from hermes_cli.config import cfg_get
+from tools.vision_tools import parse_native_vision_marker
 
 
 
@@ -1312,6 +1313,7 @@ class AIAgent:
         # single tool loop does not repeatedly re-run auxiliary vision on the
         # same image history.
         self._anthropic_image_fallback_cache: Dict[str, str] = {}
+        self._native_vision_enabled = self._load_native_vision_enabled()
 
         # Initialize LLM client via centralized provider router.
         # The router handles auth resolution, base URL, headers, and
@@ -7954,7 +7956,54 @@ class AIAgent:
         except Exception:
             return False
 
+    @staticmethod
+    def _load_native_vision_enabled() -> bool:
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            return bool(cfg.get("auxiliary", {}).get("native_vision", False))
+        except Exception:
+            return False
+
+    @staticmethod
+    def _message_content_to_text(content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for part in content:
+                if isinstance(part, str) and part.strip():
+                    parts.append(part.strip())
+                elif isinstance(part, dict):
+                    text = str(part.get("text", "") or "").strip()
+                    if text:
+                        parts.append(text)
+            return "\n".join(parts).strip()
+        return str(content or "")
+
+    def _coerce_native_vision_content(self, content: Any, role: str) -> Any:
+        if not self._native_vision_enabled:
+            return content
+        marker = parse_native_vision_marker(content) if isinstance(content, str) else None
+        if not marker:
+            return content
+        text = marker.get("text", "").strip()
+        source = marker.get("source", "vision")
+        if not text:
+            text = f"[{source} attached an image for native vision.]"
+        return [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": marker["image_url"], "detail": "auto"}},
+        ]
+
+    def _prepare_message_content_for_api(self, content: Any, role: str) -> Any:
+        content = self._coerce_native_vision_content(content, role)
+        if self.api_mode == "anthropic_messages":
+            return self._preprocess_anthropic_content(content, role)
+        return content
+
     def _preprocess_anthropic_content(self, content: Any, role: str) -> Any:
+        content = self._coerce_native_vision_content(content, role)
         if not self._content_has_image_parts(content):
             return content
 
@@ -10881,6 +10930,10 @@ class AIAgent:
             api_messages = []
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
+                api_msg["content"] = self._prepare_message_content_for_api(
+                    api_msg.get("content"),
+                    str(api_msg.get("role", "user") or "user"),
+                )
 
                 # Inject ephemeral context into the current turn's user message.
                 # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -83,6 +83,31 @@ def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
 
+def test_make_native_vision_user_content_builds_multimodal_blocks():
+    content = gateway_run._make_native_vision_user_content("describe this", ["/tmp/image.png"])
+    assert content == [
+        {"type": "text", "text": "describe this"},
+        {"type": "image_url", "image_url": {"url": "/tmp/image.png", "detail": "auto"}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_vision_returns_native_blocks_when_enabled(monkeypatch):
+    runner = _make_runner()
+    monkeypatch.setattr(gateway_run, "_native_vision_enabled", lambda: True)
+
+    result = await gateway_run.GatewayRunner._enrich_message_with_vision(
+        runner,
+        "caption",
+        ["/tmp/image.png"],
+    )
+
+    assert result == [
+        {"type": "text", "text": "caption"},
+        {"type": "image_url", "image_url": {"url": "/tmp/image.png", "detail": "auto"}},
+    ]
+
+
 def test_turn_route_injects_priority_processing_without_changing_runtime():
     runner = _make_runner()
     runner._service_tier = "priority"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3918,6 +3918,45 @@ class TestAnthropicImageFallback:
         assert mock_vision.await_count == 1
 
 
+class TestNativeVisionMainModel:
+    def test_prepare_message_content_for_api_converts_native_marker_to_multimodal(self, agent):
+        agent.api_mode = "chat_completions"
+        agent._native_vision_enabled = True
+
+        prepared = agent._prepare_message_content_for_api(
+            "[[HERMES_NATIVE_VISION]]{\"image_url\":\"/tmp/test.png\",\"text\":\"inspect this screenshot\",\"source\":\"browser_vision\"}",
+            "tool",
+        )
+
+        assert isinstance(prepared, list)
+        assert prepared[0]["type"] == "text"
+        assert prepared[0]["text"] == "inspect this screenshot"
+        assert prepared[1]["type"] == "image_url"
+        assert prepared[1]["image_url"]["url"] == "/tmp/test.png"
+        assert prepared[1]["image_url"]["detail"] == "auto"
+
+    def test_prepare_message_content_for_api_keeps_anthropic_fallback_text(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent._native_vision_enabled = True
+
+        with patch.object(agent, "_describe_image_for_anthropic_fallback", return_value="[fallback description]"):
+            prepared = agent._prepare_message_content_for_api(
+                "[[HERMES_NATIVE_VISION]]{\"image_url\":\"/tmp/test.png\",\"text\":\"inspect this screenshot\",\"source\":\"browser_vision\"}",
+                "tool",
+            )
+
+        assert isinstance(prepared, str)
+        assert "fallback description" in prepared
+
+    def test_message_content_to_text_handles_multimodal_lists(self, agent):
+        text = agent._message_content_to_text([
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {"url": "/tmp/test.png"}},
+            "world",
+        ])
+        assert text == "hello\nworld"
+
+
 class TestFallbackAnthropicProvider:
     """Bug fix: _try_activate_fallback had no case for anthropic provider."""
 

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from tools.vision_tools import (
+    _NATIVE_VISION_MARKER,
     _validate_image_url,
     _handle_vision_analyze,
     _determine_mime_type,
@@ -19,6 +20,8 @@ from tools.vision_tools import (
     _is_image_size_error,
     _MAX_BASE64_BYTES,
     _RESIZE_TARGET_BYTES,
+    native_vision_marker_payload,
+    parse_native_vision_marker,
     vision_analyze_tool,
     check_vision_requirements,
 )
@@ -168,6 +171,25 @@ class TestImageToBase64DataUrl:
 # ---------------------------------------------------------------------------
 # _handle_vision_analyze — type signature & behavior
 # ---------------------------------------------------------------------------
+
+
+class TestNativeVisionMarkers:
+    def test_marker_round_trip(self):
+        marker = native_vision_marker_payload(
+            image_url="/tmp/example.png",
+            text="inspect this image",
+            source="browser_vision",
+        )
+        assert marker.startswith(_NATIVE_VISION_MARKER)
+        parsed = parse_native_vision_marker(marker)
+        assert parsed == {
+            "image_url": "/tmp/example.png",
+            "text": "inspect this image",
+            "source": "browser_vision",
+        }
+
+    def test_parse_invalid_marker_returns_none(self):
+        assert parse_native_vision_marker("not-a-marker") is None
 
 
 class TestHandleVisionAnalyze:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -69,6 +69,7 @@ from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 from hermes_cli.config import cfg_get
+from tools.vision_tools import native_vision_marker_payload
 
 try:
     from tools.website_policy import check_website_access
@@ -205,6 +206,15 @@ def _get_command_timeout() -> int:
 def _get_vision_model() -> Optional[str]:
     """Model for browser_vision (screenshot analysis — multimodal)."""
     return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+
+
+def _native_vision_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return bool(cfg.get("auxiliary", {}).get("native_vision", False))
+    except Exception:
+        return False
 
 
 def _get_extraction_model() -> Optional[str]:
@@ -2466,7 +2476,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                     "role": "user",
                     "content": [
                         {"type": "text", "text": vision_prompt},
-                        {"type": "image_url", "image_url": {"url": data_url}},
+                        {"type": "image_url", "image_url": {"url": data_url, "detail": "auto"}},
                     ],
                 }
             ],
@@ -2507,6 +2517,12 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             "analysis": analysis or "Vision analysis returned no content.",
             "screenshot_path": str(screenshot_path),
         }
+        if _native_vision_enabled():
+            response_data["native_vision"] = native_vision_marker_payload(
+                image_url=str(screenshot_path),
+                text=question,
+                source="browser_vision",
+            )
         # Include annotation data if annotated screenshot was taken
         if annotate and result.get("data", {}).get("annotations"):
             response_data["annotations"] = result["data"]["annotations"]

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -46,6 +46,41 @@ logger = logging.getLogger(__name__)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
+_NATIVE_VISION_MARKER = "[[HERMES_NATIVE_VISION]]"
+
+
+def native_vision_marker_payload(*, image_url: str, text: str = "", source: str = "vision") -> str:
+    """Encode an image reference for models that can consume native vision blocks."""
+    payload = {
+        "image_url": str(image_url or ""),
+        "text": str(text or ""),
+        "source": str(source or "vision"),
+    }
+    return f"{_NATIVE_VISION_MARKER}{json.dumps(payload, ensure_ascii=False)}"
+
+
+def parse_native_vision_marker(text: str) -> Optional[Dict[str, str]]:
+    """Decode a native-vision marker payload embedded in text."""
+    if not isinstance(text, str) or not text.startswith(_NATIVE_VISION_MARKER):
+        return None
+    raw = text[len(_NATIVE_VISION_MARKER):].strip()
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    image_url = str(payload.get("image_url", "") or "").strip()
+    if not image_url:
+        return None
+    return {
+        "image_url": image_url,
+        "text": str(payload.get("text", "") or ""),
+        "source": str(payload.get("source", "vision") or "vision"),
+    }
+
 # Configurable HTTP download timeout for _download_image().
 # Separate from auxiliary.vision.timeout which governs the LLM API call.
 # Resolution: config.yaml auxiliary.vision.download_timeout → env var → 30s default.
@@ -250,6 +285,15 @@ def _determine_mime_type(image_path: Path) -> str:
         '.svg': 'image/svg+xml'
     }
     return mime_types.get(extension, 'image/jpeg')
+
+
+def _native_vision_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return bool(cfg.get("auxiliary", {}).get("native_vision", False))
+    except Exception:
+        return False
 
 
 def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None) -> str:
@@ -541,7 +585,8 @@ async def vision_analyze_tool(
                     {
                         "type": "image_url",
                         "image_url": {
-                            "url": image_data_url
+                            "url": image_data_url,
+                            "detail": "auto",
                         }
                     }
                 ]
@@ -613,6 +658,12 @@ async def vision_analyze_tool(
             "success": True,
             "analysis": analysis or "There was a problem with the request and the image could not be analyzed."
         }
+        if _native_vision_enabled():
+            result["native_vision"] = native_vision_marker_payload(
+                image_url=image_url,
+                text=user_prompt,
+                source="vision_analyze",
+            )
         
         debug_call_data["success"] = True
         debug_call_data["analysis_length"] = analysis_length


### PR DESCRIPTION
## Summary
- add native vision message preparation so vision-capable main models receive multimodal image content directly
- keep Anthropic fallback behavior intact and preserve text rendering/compression compatibility
- add regression tests for run_agent, vision tools, and gateway fast-command behavior

## Validation
- `source venv/bin/activate && pytest tests/tools/test_vision_tools.py tests/gateway/test_fast_command.py -q`
- targeted native-vision tests currently hit an existing local `AIAgent` init/provider-test failure unrelated to this branch