### PR TITLE
fix(cli): honour active_profile when HERMES_HOME is set to root directory

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -114,11 +114,16 @@ def _apply_profile_override() -> None:
             consume = 1
             break
 
-    # 1.5 If HERMES_HOME is already set and no explicit flag was given, trust it.
-    # This lets child processes (relaunch, subprocess) inherit the parent's
-    # profile choice without having to pass --profile again.
+    # 1.5 If HERMES_HOME already points to a named profile directory (parent dir
+    # is "profiles"), trust it — a parent process already resolved the active
+    # profile and the child should inherit it without re-reading active_profile.
+    # But if HERMES_HOME is the root (~/.hermes or a Docker custom root like
+    # /opt/data), we must still check active_profile so `hermes profile use`
+    # takes effect on the next invocation.
     if profile_name is None and os.environ.get("HERMES_HOME"):
-        return
+        from pathlib import Path as _Path
+        if _Path(os.environ["HERMES_HOME"]).parent.name == "profiles":
+            return
 
     # 2. If no flag, check active_profile in the hermes root
     if profile_name is None:

--- a/tests/hermes_cli/test_profile_override.py
+++ b/tests/hermes_cli/test_profile_override.py
@@ -1,0 +1,104 @@
+"""Regression tests for _apply_profile_override in hermes_cli.main.
+
+Issue #19299: `hermes profile use` stopped switching the active profile after
+v0.12.0 introduced an early-return when HERMES_HOME was already set. The early
+return was too broad — it also suppressed the active_profile check when
+HERMES_HOME pointed to the root directory rather than a specific profile dir.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run_override(monkeypatch, tmp_path, hermes_home_val, argv=None):
+    """Set up env, call _apply_profile_override, return resulting HERMES_HOME."""
+    if argv is None:
+        argv = ["hermes", "chat"]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("HERMES_HOME", hermes_home_val)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli.main import _apply_profile_override
+    _apply_profile_override()
+    return os.environ.get("HERMES_HOME")
+
+
+class TestApplyProfileOverrideRootHome:
+    """HERMES_HOME points to the root: active_profile must still be honoured."""
+
+    def test_root_home_with_active_profile_switches(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        profile_dir = hermes_home / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        (hermes_home / "active_profile").write_text("coder\n")
+
+        result = _run_override(monkeypatch, tmp_path, str(hermes_home))
+
+        assert result == str(profile_dir)
+
+    def test_root_home_no_active_profile_unchanged(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+
+        result = _run_override(monkeypatch, tmp_path, str(hermes_home))
+
+        assert result == str(hermes_home)
+
+    def test_docker_root_with_active_profile_switches(self, monkeypatch, tmp_path):
+        docker_root = tmp_path / "opt" / "data"
+        docker_root.mkdir(parents=True)
+        profile_dir = docker_root / "profiles" / "prod"
+        profile_dir.mkdir(parents=True)
+        (docker_root / "active_profile").write_text("prod\n")
+
+        result = _run_override(monkeypatch, tmp_path, str(docker_root))
+
+        assert result == str(profile_dir)
+
+
+class TestApplyProfileOverrideProfileDir:
+    """HERMES_HOME already points to a profile dir: early return, no change."""
+
+    def test_profile_dir_trusts_env(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        profile_dir = hermes_home / "profiles" / "dev"
+        profile_dir.mkdir(parents=True)
+        # active_profile says something different — should be ignored
+        (hermes_home / "active_profile").write_text("staging\n")
+
+        result = _run_override(monkeypatch, tmp_path, str(profile_dir))
+
+        assert result == str(profile_dir)
+
+    def test_docker_profile_dir_trusts_env(self, monkeypatch, tmp_path):
+        docker_root = tmp_path / "opt" / "data"
+        docker_root.mkdir(parents=True)
+        profile_dir = docker_root / "profiles" / "qa"
+        profile_dir.mkdir(parents=True)
+        (docker_root / "active_profile").write_text("prod\n")
+
+        result = _run_override(monkeypatch, tmp_path, str(profile_dir))
+
+        assert result == str(profile_dir)
+
+
+class TestApplyProfileOverrideExplicitFlag:
+    """Explicit --profile flag always wins, regardless of HERMES_HOME."""
+
+    def test_explicit_flag_overrides_root_home(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        profile_dir = hermes_home / "profiles" / "staging"
+        profile_dir.mkdir(parents=True)
+        (hermes_home / "active_profile").write_text("coder\n")
+
+        result = _run_override(
+            monkeypatch, tmp_path, str(hermes_home),
+            argv=["hermes", "--profile", "staging", "chat"],
+        )
+
+        assert result == str(profile_dir)


### PR DESCRIPTION
The `hermes profile use` command stopped switching the active profile in v0.12.0.

## What changed and why

- `_apply_profile_override()` in `hermes_cli/main.py` had an early-return (added in #95f2802) that skipped reading `active_profile` whenever `HERMES_HOME` was set in the environment — regardless of whether it pointed to a named profile dir or the root directory.
- Docker containers and users who export `HERMES_HOME=~/.hermes` in their shell rc always had `HERMES_HOME` set to the root, so `hermes profile use` correctly wrote the profile name to `~/.hermes/active_profile`, but the next invocation returned early before ever checking that file.
- The fix narrows the early-return: only skip `active_profile` when `HERMES_HOME`'s parent directory is named `"profiles"` (e.g. `~/.hermes/profiles/coder` or `/opt/data/profiles/prod`). This reliably identifies a path already resolved by a parent process. Root paths (`~/.hermes`, `/opt/data`) fall through to the existing `active_profile` logic unchanged.
- Added 6 regression tests covering: standard root, Docker root, named profile dir inheritance, and explicit `--profile` flag precedence.

## How to test

1. `hermes profile create dev && hermes profile create staging`
2. `hermes profile use dev`
3. `hermes profile list` — `dev` should be marked active
4. Run `pytest tests/hermes_cli/test_profile_override.py -v`

## What platforms tested on

- macOS on darwin-arm64 (local)
- Debian GNU/Linux (Docker, the environment described in the issue)

Fixes #19299

<!-- autocontrib:worker-id=issue-new-acb0c54b kind=pr-open -->