### PR TITLE
fix(feishu): 7 patches for card content, text parsing, reply truncation, parent_id fallback, markdown table

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -159,6 +159,10 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_MARKDOWN_TABLE_BLOCK_RE = re.compile(
+    r"(?:^|\n)(\|[^\n]+\|)\n\|[-:\s|]+\|\n((?:\|[^\n]+\|\n?)+)",
+    re.MULTILINE,
+)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -946,7 +950,7 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
     if actions:
         lines.append(f"Actions: {', '.join(actions)}")
 
-    text_content = "\n".join(lines[:12]).strip() or FALLBACK_INTERACTIVE_TEXT
+    text_content = "\n".join(lines[:100]).strip() or FALLBACK_INTERACTIVE_TEXT
     return FeishuNormalizedMessage(
         raw_type=message_type,
         text_content=text_content,
@@ -2762,6 +2766,15 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "upper_message_id", None)
             or None
         )
+        # WebSocket events may lack parent_id — proactively call REST API to fill it in
+        if not reply_to_message_id:
+            api_message = await self._fetch_message_detail(message_id)
+            if api_message:
+                reply_to_message_id = (
+                    getattr(api_message, "parent_id", None)
+                    or getattr(api_message, "upper_message_id", None)
+                    or None
+                )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
         sender_primary = (
@@ -3651,6 +3664,20 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to fetch bot names for %s", bot_ids, exc_info=True)
             return None
 
+    async def _fetch_message_detail(self, message_id: str) -> Optional[Any]:
+        """Fetch full message object from Feishu API (includes parent_id/root_id for replies)."""
+        if not self._client or not message_id:
+            return None
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                return None
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            return items[0] if items else None
+        except Exception:
+            return None
+
     async def _fetch_message_text(self, message_id: str) -> Optional[str]:
         if not self._client or not message_id:
             return None
@@ -3989,7 +4016,21 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    @staticmethod
+    def _wrap_markdown_tables(content: str) -> str:
+        """Wrap markdown table blocks in code fences so Feishu renders them.
+
+        Feishu's ``text`` message type strips markdown table syntax entirely,
+        and its ``post`` type ``md`` tag doesn't support tables either.
+        Wrapping in code fences preserves the table content for the reader.
+        """
+        return _MARKDOWN_TABLE_BLOCK_RE.sub(
+            lambda m: f"\n```\n{m.group(0).strip()}\n```\n",
+            content,
+        )
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        content = self._wrap_markdown_tables(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
@@ -4282,9 +4323,12 @@ class FeishuAdapter(BasePlatformAdapter):
         return SimpleNamespace(chat_id=chat_id)
 
     @staticmethod
-    def _build_get_message_request(message_id: str) -> Any:
+    def _build_get_message_request(message_id: str, card_msg_content_type: str = "user_card_content") -> Any:
         if "GetMessageRequest" in globals():
-            return GetMessageRequest.builder().message_id(message_id).build()
+            req = GetMessageRequest.builder().message_id(message_id).build()
+            if card_msg_content_type:
+                req.add_query("card_msg_content_type", card_msg_content_type)
+            return req
         return SimpleNamespace(message_id=message_id)
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5614,14 +5614,25 @@ class GatewayRunner:
                 message_text = f"{context_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
-            # Always inject the reply-to pointer — even when the quoted text
-            # already appears in history. The prefix isn't deduplication, it's
-            # disambiguation: it tells the agent *which* prior message the user
-            # is referencing. History can contain the same or similar text
-            # multiple times, and without an explicit pointer the agent has to
-            # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
-            message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            full_reply_text = event.reply_to_text
+            _REPLY_TO_LIMIT = 3000
+            if len(full_reply_text) > _REPLY_TO_LIMIT:
+                reply_snippet = full_reply_text[:_REPLY_TO_LIMIT] + "\n…[已截断，原文过长]"
+            else:
+                reply_snippet = full_reply_text
+            # _prepare_inbound_message_text is called before session_entry is bound,
+            # pass session_id via event._session_id (injected by the caller)
+            _session_id = getattr(event, "_session_id", "") or ""
+            history_messages = self.session_store.load_transcript(_session_id)
+            found_in_history = any(
+                reply_snippet in (msg.get("content") or "")
+                for msg in reversed(history_messages)
+            )
+            if not found_in_history:
+                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            else:
+                marker_preview = reply_snippet[:80].replace("\n", " ")
+                message_text = f"[Replying to earlier message: {marker_preview}...]\n\n{message_text}"
 
         if "@" in message_text:
             try:
@@ -6199,6 +6210,8 @@ class GatewayRunner:
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
+        # Inject session_id into event for reply-context lookups in _prepare_inbound_message_text
+        event._session_id = session_entry.session_id
         message_text = await self._prepare_inbound_message_text(
             event=event,
             source=source,


### PR DESCRIPTION
## Summary
7 patches applied to latest upstream/main, no conflicts.

### Patches
1. card_msg_content_type via add_query() — real card content
2. _fetch_message_detail REST fallback
3. parent_id REST fallback
4. 3000 char truncation + Chinese prompt
5. Replying to earlier message history-aware marker
6. Markdown table auto-wrap in code fences
7. Interactive message line limit 12→100

Files: feishu.py (+57/-3), run.py (+11/-8)