### PR TITLE
fix(dashboard): improve kanban code contrast

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -376,6 +376,7 @@
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.72rem;
   color: var(--color-foreground);
+  text-shadow: none;
 }
 
 .hermes-kanban-comment {
@@ -412,6 +413,8 @@
 }
 .hermes-kanban-event-payload {
   color: var(--color-muted-foreground);
+  background: transparent;
+  text-shadow: none;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -605,8 +608,11 @@
 /* ---- Markdown rendering -------------------------------------------- */
 
 .hermes-kanban-md {
+  font-family: inherit;
   font-size: 0.8rem;
   line-height: 1.55;
+  letter-spacing: normal;
+  text-transform: none;
   color: var(--color-foreground);
 }
 .hermes-kanban-md p  { margin: 0.25rem 0; }
@@ -636,6 +642,8 @@
   padding: 0.05rem 0.3rem;
   background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
   border-radius: 3px;
+  color: var(--color-foreground);
+  text-shadow: none;
 }
 .hermes-kanban-md-code {
   margin: 0.35rem 0;
@@ -644,12 +652,15 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 0.25rem);
   overflow-x: auto;
+  color: var(--color-foreground);
+  text-shadow: none;
 }
 .hermes-kanban-md-code code {
   background: transparent;
   padding: 0;
   font-size: 0.75rem;
   white-space: pre;
+  color: inherit;
 }
 .hermes-kanban-md strong { font-weight: 600; }
 
@@ -754,6 +765,8 @@
   font-size: 0.65rem;
   padding: 0.15rem 0 0;
   color: var(--color-muted-foreground);
+  background: transparent;
+  text-shadow: none;
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, ui-monospace, monospace);

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -629,6 +629,43 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
     assert data["render_markdown"] is False
 
 
+def test_markdown_code_uses_theme_foreground_for_contrast():
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert ".hermes-kanban-md code" in css
+    assert "color: var(--color-foreground);" in css
+    assert ".hermes-kanban-md-code code" in css
+    assert "color: inherit;" in css
+    assert "text-shadow: none;" in css
+
+
+def test_markdown_prose_preserves_source_casing_and_normal_font():
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert ".hermes-kanban-md {" in css
+    assert "font-family: inherit;" in css
+    assert "letter-spacing: normal;" in css
+    assert "text-transform: none;" in css
+    assert "font-family: var(--theme-font-mono" not in css
+    assert ".hermes-kanban-md code" in css
+    assert "font-family: var(--font-mono, ui-monospace, monospace);" in css
+
+
+def test_drawer_json_code_chips_do_not_inherit_global_highlight_background():
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    event_payload = css[css.index(".hermes-kanban-event-payload {"):css.index(".hermes-kanban-drawer-comment-row {")]
+    assert "background: transparent;" in event_payload
+    assert "text-shadow: none;" in event_payload
+
+    run_meta = css[css.index(".hermes-kanban-run-meta {"):]
+    assert "background: transparent;" in run_meta
+    assert "text-shadow: none;" in run_meta
+
+
 # ---------------------------------------------------------------------------
 # Runs surfacing (vulcan-artivus RFC feedback)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Force Kanban markdown inline code and fenced code blocks to use the active theme foreground color
- Clear inherited text shadows on code/pre blocks so theme-specific code styling cannot reduce contrast
- Add a regression test that checks the Kanban dashboard CSS keeps code contrast tied to foreground

## Test Plan
- python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='
