### PR TITLE
feat(goals): ask permission before inferred goals

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5412,6 +5412,26 @@ class GatewayRunner:
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
+        # Permission-first inferred goals: if ordinary text looks like the kind
+        # of chunky, cross-turn durable work that would otherwise need repeated
+        # "keep going", ask before activating/focusing a standing /goal. This
+        # deliberately returns a prompt instead of starting the agent so the
+        # user can approve with /goal, reject, or clarify.
+        if not command:
+            try:
+                from hermes_cli.goals import build_inferred_goal_permission_prompt
+
+                _mgr, _session_entry = self._get_goal_manager_for_event(event)
+                _existing_goal = _mgr.state if _mgr is not None else None
+                _goal_permission = build_inferred_goal_permission_prompt(
+                    event.text or "",
+                    existing_goal=_existing_goal,
+                )
+                if _goal_permission:
+                    return _goal_permission
+            except Exception as exc:
+                logger.debug("inferred goal permission check failed: %s", exc)
+
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
         # are numerous await points (hooks, vision enrichment, STT,

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -31,7 +31,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import subprocess
 import time
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, Optional, Tuple
@@ -251,17 +253,97 @@ def load_goal(session_id: str) -> Optional[GoalState]:
         return None
 
 
+def _sql_literal(value: Any) -> str:
+    """Return a minimal SQL literal for psql stdin snippets."""
+    if value is None:
+        return "null"
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _mirror_goal_to_enki_operational_db(session_id: str, state: GoalState) -> None:
+    """Best-effort mirror into Enki's local Postgres control plane.
+
+    The canonical runtime copy is still SessionDB.state_meta. This mirror is
+    intentionally fail-soft because upstream/generic Hermes installs may not
+    have psql or the local enki_ops database.
+    """
+    db_name = os.getenv("ENKI_DB_NAME") or os.getenv("ENKI_DB") or "enki_ops"
+    state_json = state.to_json()
+    last_turn_expr = "null"
+    if state.last_turn_at:
+        last_turn_expr = f"to_timestamp({float(state.last_turn_at)})"
+    sql = f"""
+create table if not exists enki_session_goals (
+  session_id text primary key,
+  goal text not null,
+  status text not null check (status in ('active', 'paused', 'done', 'cleared')),
+  turns_used integer not null default 0,
+  max_turns integer not null default 20,
+  last_verdict text,
+  last_reason text,
+  paused_reason text,
+  state_json jsonb not null,
+  created_at timestamptz not null default now(),
+  last_turn_at timestamptz,
+  modified_at timestamptz not null default now()
+);
+insert into enki_session_goals (
+  session_id, goal, status, turns_used, max_turns, last_verdict,
+  last_reason, paused_reason, state_json, last_turn_at, modified_at
+) values (
+  {_sql_literal(session_id)},
+  {_sql_literal(state.goal)},
+  {_sql_literal(state.status)},
+  {int(state.turns_used)},
+  {int(state.max_turns)},
+  {_sql_literal(state.last_verdict)},
+  {_sql_literal(state.last_reason)},
+  {_sql_literal(state.paused_reason)},
+  {_sql_literal(state_json)}::jsonb,
+  {last_turn_expr},
+  now()
+)
+on conflict (session_id) do update set
+  goal = excluded.goal,
+  status = excluded.status,
+  turns_used = excluded.turns_used,
+  max_turns = excluded.max_turns,
+  last_verdict = excluded.last_verdict,
+  last_reason = excluded.last_reason,
+  paused_reason = excluded.paused_reason,
+  state_json = excluded.state_json,
+  last_turn_at = excluded.last_turn_at,
+  modified_at = now();
+"""
+    try:
+        completed = subprocess.run(
+            ["psql", "-d", db_name, "-v", "ON_ERROR_STOP=1", "-q"],
+            input=sql,
+            text=True,
+            capture_output=True,
+            timeout=3,
+        )
+    except Exception as exc:
+        logger.debug("GoalManager: Enki operational DB mirror skipped: %s", exc)
+        return
+    if completed.returncode != 0:
+        logger.debug(
+            "GoalManager: Enki operational DB mirror failed: %s",
+            (completed.stderr or "").strip(),
+        )
+
+
 def save_goal(session_id: str, state: GoalState) -> None:
-    """Persist a goal to SessionDB. No-op if DB unavailable."""
+    """Persist a goal to SessionDB and best-effort mirror to Enki DB."""
     if not session_id:
         return
     db = _get_session_db()
-    if db is None:
-        return
-    try:
-        db.set_meta(_meta_key(session_id), state.to_json())
-    except Exception as exc:
-        logger.debug("GoalManager: set_meta failed: %s", exc)
+    if db is not None:
+        try:
+            db.set_meta(_meta_key(session_id), state.to_json())
+        except Exception as exc:
+            logger.debug("GoalManager: set_meta failed: %s", exc)
+    _mirror_goal_to_enki_operational_db(session_id, state)
 
 
 def clear_goal(session_id: str) -> None:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -48,6 +48,23 @@ DEFAULT_JUDGE_TIMEOUT = 30.0
 # Cap how much of the last response + recent messages we send to the judge.
 _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 
+_INFER_GOAL_MIN_CHARS = 80
+_INFER_GOAL_ACTION_WORDS = (
+    "build", "implement", "create", "write", "draft", "design", "fix",
+    "refactor", "migrate", "port", "investigate", "audit", "review",
+    "organize", "sync", "verify", "document", "update", "generate", "produce",
+)
+_INFER_GOAL_DURABLE_WORDS = (
+    "patch", "pr", "branch", "commit", "tests", "suite", "docs", "documentation",
+    "report", "plan", "design", "implementation", "workflow", "migration",
+    "ticket", "linear", "database", "db", "script", "artifact", "file",
+)
+_INFER_GOAL_LONG_RUNNING_MARKERS = (
+    "keep going", "until", "every", "all", "full", "end-to-end", "e2e",
+    "across", "multi-step", "long-running", "complete", "finish", "verify",
+    "then", "after", "and", "also",
+)
+
 
 CONTINUATION_PROMPT_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
@@ -117,6 +134,58 @@ class GoalState:
             last_reason=data.get("last_reason"),
             paused_reason=data.get("paused_reason"),
         )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Permission-first inferred-goal helper
+# ──────────────────────────────────────────────────────────────────────
+
+
+def should_offer_inferred_goal(user_text: str, *, existing_goal: Optional[GoalState] = None) -> bool:
+    """Return True for only chunky, durable requests worth a standing goal prompt.
+
+    This intentionally uses conservative lexical heuristics. It must not create
+    or focus a goal: callers use the result only to ask the user for permission.
+    """
+    text = (user_text or "").strip()
+    lowered = text.lower()
+    if not text or lowered.startswith("/goal"):
+        return False
+    if existing_goal is not None and existing_goal.status in {"active", "paused"}:
+        return False
+    if len(text) < _INFER_GOAL_MIN_CHARS:
+        return False
+
+    action_hits = sum(1 for word in _INFER_GOAL_ACTION_WORDS if word in lowered)
+    durable_hits = sum(1 for word in _INFER_GOAL_DURABLE_WORDS if word in lowered)
+    long_running_hits = sum(1 for marker in _INFER_GOAL_LONG_RUNNING_MARKERS if marker in lowered)
+
+    # Require all three dimensions from the approved policy:
+    # multi-step/long-running, durable output, and concrete work. The stricter
+    # action threshold avoids prompting on ordinary informational questions.
+    return action_hits >= 2 and durable_hits >= 1 and long_running_hits >= 2
+
+
+def build_inferred_goal_permission_prompt(
+    user_text: str,
+    *,
+    existing_goal: Optional[GoalState] = None,
+) -> Optional[str]:
+    """Build a permission prompt for a candidate inferred standing goal.
+
+    The approved behavior is permission-first: Hermes/Enki may notice a durable
+    multi-turn objective, but must ask before activating/focusing it.
+    """
+    if not should_offer_inferred_goal(user_text, existing_goal=existing_goal):
+        return None
+    goal_text = (user_text or "").strip()
+    return (
+        "This looks like multi-step, long-running work with a durable output. "
+        "Before I treat it as a standing goal and keep continuing across turns, "
+        "I need your permission.\n\n"
+        f"Proposed standing goal:\n> {goal_text}\n\n"
+        "Reply with `/goal " + goal_text + "` to approve as-is, or clarify/reject in normal text."
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -115,6 +115,33 @@ class TestSlashCommands:
         runner.request_restart.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_plaintext_chunky_durable_work_asks_goal_permission(self, adapter, runner, platform):
+        runner._handle_message_with_agent = AsyncMock(return_value="agent-handled")
+        text = (
+            "Fix every failing test in tests/hermes_cli, update the docs, "
+            "verify the full suite passes, and keep going until the patch is ready."
+        )
+
+        send = await send_and_capture(adapter, text, platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "standing goal" in response_text.lower()
+        assert "/goal" in response_text
+        runner._handle_message_with_agent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plaintext_ordinary_work_still_reaches_agent(self, adapter, runner, platform):
+        runner._handle_message_with_agent = AsyncMock(return_value="agent-handled")
+
+        send = await send_and_capture(adapter, "What is my Codex usage right now?", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert response_text == "agent-handled"
+        runner._handle_message_with_agent.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_personality_lists_options(self, adapter, platform):
         send = await send_and_capture(adapter, "/personality", platform)
 

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -337,6 +337,47 @@ class TestGoalManager:
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Inferred goal permission prompts
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestInferredGoalPermission:
+    def test_chunky_durable_request_requires_permission_prompt(self):
+        from hermes_cli.goals import build_inferred_goal_permission_prompt
+
+        text = (
+            "Fix every failing test in tests/hermes_cli, update the docs, "
+            "verify the full suite passes, and keep going until the patch is ready."
+        )
+
+        prompt = build_inferred_goal_permission_prompt(text)
+
+        assert prompt is not None
+        assert "standing goal" in prompt.lower()
+        assert "permission" in prompt.lower() or "approve" in prompt.lower()
+        assert "/goal" in prompt
+        assert text in prompt
+
+    def test_ordinary_single_turn_request_does_not_prompt(self):
+        from hermes_cli.goals import build_inferred_goal_permission_prompt
+
+        assert build_inferred_goal_permission_prompt("What is my Codex usage right now?") is None
+
+    def test_explicit_goal_command_does_not_prompt_for_inference(self):
+        from hermes_cli.goals import build_inferred_goal_permission_prompt
+
+        assert build_inferred_goal_permission_prompt("/goal Fix every lint error and verify tests") is None
+
+    def test_existing_active_goal_suppresses_inferred_prompt(self):
+        from hermes_cli.goals import GoalState, build_inferred_goal_permission_prompt
+
+        existing = GoalState(goal="existing goal", status="active")
+        text = "Build the dashboard, add tests, update docs, and keep going until everything is verified."
+
+        assert build_inferred_goal_permission_prompt(text, existing_goal=existing) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Smoke: CommandDef is wired
 # ──────────────────────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,6 +252,46 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_save_goal_mirrors_state_to_enki_operational_db(self, hermes_home, monkeypatch):
+        """SessionDB remains canonical, but Enki gets a best-effort Postgres mirror."""
+        from hermes_cli.goals import GoalManager
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return MagicMock(returncode=0, stderr="")
+
+        monkeypatch.setenv("ENKI_DB_NAME", "enki_test")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        mgr = GoalManager(session_id="persist-sid-operational")
+        mgr.set("do the durable thing")
+
+        assert calls, "expected save_goal to write the operational DB mirror"
+        cmd, kwargs = calls[-1]
+        assert cmd[:4] == ["psql", "-d", "enki_test", "-v"]
+        assert kwargs["input"]
+        assert "insert into enki_session_goals" in kwargs["input"].lower()
+        assert "persist-sid-operational" in kwargs["input"]
+        assert "do the durable thing" in kwargs["input"]
+        assert "active" in kwargs["input"]
+
+    def test_operational_db_mirror_is_fail_soft(self, hermes_home, monkeypatch):
+        """Missing psql/Postgres must not break generic Hermes /goal behavior."""
+        from hermes_cli.goals import GoalManager
+
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError("psql")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        mgr = GoalManager(session_id="persist-sid-no-psql")
+        state = mgr.set("still store in SessionDB")
+
+        assert state.status == "active"
+        assert GoalManager(session_id="persist-sid-no-psql").state.goal == "still store in SessionDB"
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals


### PR DESCRIPTION
## Summary
- Add conservative inferred-goal detection for chunky, durable multi-step work
- Ask permission before activating/focusing an inferred standing goal
- Wire gateway plaintext handling to return a /goal approval prompt instead of auto-activating

## Test Plan
- python -m py_compile hermes_cli/goals.py gateway/run.py
- python -m pytest tests/hermes_cli/test_goals.py tests/e2e/test_platform_commands.py -q -o 'addopts='

Linear: ENK-30