### PR TITLE
feat(discord): discord channel management

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1141,7 +1141,9 @@ DEFAULT_CONFIG = {
         # or YAML list. Unknown names are dropped with a warning at load time.
         # Actions: list_guilds, server_info, list_channels, channel_info,
         # list_roles, member_info, search_members, fetch_messages, list_pins,
-        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        # pin_message, unpin_message, create_thread, add_role, remove_role,
+        # create_channel, update_channel. delete_channel is destructive and
+        # requires explicit opt-in by naming it here.
         "server_actions": "",
     },
 

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -503,6 +503,114 @@ class TestRoleManagement:
 
 
 # ---------------------------------------------------------------------------
+# Actions: create_channel / update_channel / delete_channel
+# ---------------------------------------------------------------------------
+
+class TestChannelManagement:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "900", "name": "test-channel", "type": 0,
+            "guild_id": "111", "position": 24, "parent_id": "10",
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="test-channel",
+            type=0,
+            parent_id="10",
+            position=24,
+        ))
+        assert result["success"] is True
+        assert result["message"] == "Channel 'test-channel' created with ID 900."
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "test-channel", "type": 0, "parent_id": "10", "position": 24},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_type_zero_not_treated_as_missing(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "901", "name": "text", "type": 0,
+            "guild_id": "111", "position": 0, "parent_id": None,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="text", type=0,
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "text", "type": 0},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_update_channel(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "900", "name": "renamed", "type": 0,
+            "guild_id": "111", "position": 25, "parent_id": "10",
+        }
+        result = json.loads(discord_admin_handler(
+            action="update_channel", channel_id="900", name="renamed", position=25,
+        ))
+        assert result["success"] is True
+        assert result["message"] == "Channel 900 updated."
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/900", "test-token",
+            body={"name": "renamed", "position": 25},
+        )
+
+    def test_update_channel_requires_update_fields(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(action="update_channel", channel_id="900"))
+        assert "error" in result
+        assert "name, parent_id, or position" in result["error"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_update_channel_can_clear_parent_category(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "900", "name": "general", "type": 0, "parent_id": None}
+        result = json.loads(discord_admin_handler(
+            action="update_channel", channel_id="900", parent_id=None,
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/900", "test-token",
+            body={"parent_id": None},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_delete_channel(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ["delete_channel"]}},
+        )
+        mock_req.return_value = {
+            "id": "900", "name": "deleted", "type": 0,
+            "guild_id": "111", "position": 24, "parent_id": "10",
+        }
+        result = json.loads(discord_admin_handler(action="delete_channel", channel_id="900"))
+        assert result["success"] is True
+        assert result["message"] == "Channel 900 deleted."
+        mock_req.assert_called_once_with("DELETE", "/channels/900", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_delete_channel_requires_explicit_opt_in(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        result = json.loads(discord_admin_handler(action="delete_channel", channel_id="900"))
+        assert "error" in result
+        assert "requires explicit opt-in" in result["error"]
+        mock_req.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
 
@@ -567,7 +675,10 @@ class TestRegistration:
         from tools.registry import registry
         entry = registry._tools["discord_admin"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
+        expected_admin = (
+            set(_ACTIONS.keys())
+            - {"fetch_messages", "search_members", "create_thread", "delete_channel"}
+        )
         assert actions == expected_admin
 
     def test_all_actions_covered(self):
@@ -582,6 +693,7 @@ class TestRegistration:
         assert props["limit"]["minimum"] == 1
         assert props["limit"]["maximum"] == 100
         assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
+        assert props["parent_id"]["type"] == ["string", "null"]
 
     def test_core_schema_description(self):
         """Core schema description should mention core actions."""
@@ -603,6 +715,9 @@ class TestRegistration:
         assert "list_guilds()" in desc
         assert "add_role(guild_id, user_id, role_id)" in desc
         assert "delete_message(channel_id, message_id)" in desc
+        assert "create_channel(guild_id, name, type)" in desc
+        assert "update_channel(channel_id)" in desc
+        assert "delete_channel(channel_id)" not in desc
         # Core actions should NOT be in admin description
         assert "fetch_messages(" not in desc
         assert "create_thread(" not in desc
@@ -839,7 +954,14 @@ class TestConfigAllowlist:
 class TestAvailableActions:
     def test_all_available_when_unrestricted(self):
         caps = {"detected": True, "has_members_intent": True, "has_message_content": True}
-        assert _available_actions(caps, None) == list(_ACTIONS.keys())
+        assert _available_actions(caps, None) == [
+            action for action in _ACTIONS if action != "delete_channel"
+        ]
+
+    def test_destructive_actions_require_allowlist_opt_in(self):
+        caps = {"detected": True, "has_members_intent": True, "has_message_content": True}
+        actions = _available_actions(caps, ["list_guilds", "delete_channel"])
+        assert actions == ["list_guilds", "delete_channel"]
 
     def test_no_members_intent_hides_member_actions(self):
         caps = {"detected": True, "has_members_intent": False, "has_message_content": True}
@@ -917,10 +1039,23 @@ class TestDynamicSchema:
         mock_req.return_value = {"flags": (1 << 14) | (1 << 18)}
         schema = get_dynamic_schema_admin()
         actions = set(schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == set(_ADMIN_ACTIONS.keys())
+        assert actions == set(_ADMIN_ACTIONS.keys()) - {"delete_channel"}
         assert schema["name"] == "discord_admin"
         # No content warning when MESSAGE_CONTENT is enabled
         assert "MESSAGE_CONTENT" not in schema["description"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_delete_channel_only_in_admin_schema_when_allowlisted(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": "list_guilds,delete_channel"}},
+        )
+        mock_req.return_value = {"flags": (1 << 14) | (1 << 18)}
+        schema = get_dynamic_schema_admin()
+        actions = schema["parameters"]["properties"]["action"]["enum"]
+        assert actions == ["list_guilds", "delete_channel"]
+        assert "delete_channel(channel_id)" in schema["description"]
 
     @patch("tools.discord_tool._discord_request")
     def test_no_members_intent_removes_member_actions_from_admin_schema(
@@ -1049,6 +1184,12 @@ class Test403Enrichment:
         msg = _enrich_403("add_role", '{"message":"Missing Permissions"}')
         assert "MANAGE_ROLES" in msg
         assert "Missing Permissions" in msg  # Raw body preserved
+
+    @pytest.mark.parametrize("action", ["create_channel", "update_channel", "delete_channel"])
+    def test_enrich_channel_management_actions(self, action):
+        msg = _enrich_403(action, '{"message":"Missing Permissions"}')
+        assert "MANAGE_CHANNELS" in msg
+        assert "Missing Permissions" in msg
 
     def test_enrich_unknown_action_includes_body(self):
         msg = _enrich_403("some_new_action", '{"message":"weird"}')

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -18,7 +18,8 @@ The schema exposed to the model is filtered by two gates:
 2. User config allowlist at ``discord.server_actions``. If the user
    sets a comma-separated list (or YAML list) of action names, only
    those appear in the schema. Empty/unset means all intent-available
-   actions are exposed.
+   actions are exposed, except explicitly destructive actions such as
+   ``delete_channel`` which require opt-in.
 
 Per-guild permissions (MANAGE_ROLES etc.) are NOT pre-checked — Discord
 returns a 403 at call time and :func:`_enrich_403` maps it to
@@ -45,6 +46,12 @@ _FLAG_GATEWAY_GUILD_MEMBERS = 1 << 14
 _FLAG_GATEWAY_GUILD_MEMBERS_LIMITED = 1 << 15
 _FLAG_GATEWAY_MESSAGE_CONTENT = 1 << 18
 _FLAG_GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
+
+_UNSET = object()
+
+# Actions that can permanently destroy server state should never appear just
+# because a deployment already had the broad discord_admin toolset enabled.
+_EXPLICIT_OPT_IN_ACTIONS = frozenset({"delete_channel"})
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -466,6 +473,58 @@ def _remove_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwarg
     return json.dumps({"success": True, "message": f"Role {role_id} removed from user {user_id}."})
 
 
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    type: int,
+    parent_id: Any = _UNSET,
+    position: Optional[int] = None,
+    **_kwargs: Any,
+) -> str:
+    """Create a guild channel."""
+    body: Dict[str, Any] = {"name": name, "type": type}
+    if parent_id is not _UNSET and parent_id not in (None, ""):
+        body["parent_id"] = parent_id
+    if position is not None:
+        body["position"] = position
+
+    channel = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+    return json.dumps({"success": True, "message": f"Channel '{name}' created with ID {channel['id']}."})
+
+
+def _update_channel(
+    token: str,
+    channel_id: str,
+    name: str = "",
+    parent_id: Any = _UNSET,
+    position: Optional[int] = None,
+    **_kwargs: Any,
+) -> str:
+    """Update a channel's editable metadata."""
+    body: Dict[str, Any] = {}
+    if name:
+        body["name"] = name
+    if parent_id is not _UNSET and parent_id != "":
+        body["parent_id"] = parent_id
+    if position is not None:
+        body["position"] = position
+
+    if not body:
+        return json.dumps({
+            "error": "Missing update parameters for 'update_channel': name, parent_id, or position",
+        })
+
+    _discord_request("PATCH", f"/channels/{channel_id}", token, body=body)
+    return json.dumps({"success": True, "message": f"Channel {channel_id} updated."})
+
+
+def _delete_channel(token: str, channel_id: str, **_kwargs: Any) -> str:
+    """Delete a channel."""
+    _discord_request("DELETE", f"/channels/{channel_id}", token)
+    return json.dumps({"success": True, "message": f"Channel {channel_id} deleted."})
+
+
 # ---------------------------------------------------------------------------
 # Action dispatch + metadata
 # ---------------------------------------------------------------------------
@@ -486,6 +545,9 @@ _ACTIONS = {
     "create_thread": _create_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
+    "create_channel": _create_channel,
+    "delete_channel": _delete_channel,
+    "update_channel": _update_channel,
 }
 
 _CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
@@ -513,6 +575,9 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
+    ("create_channel", "(guild_id, name, type)", "create a text, voice, or category channel"),
+    ("delete_channel", "(channel_id)", "delete a channel"),
+    ("update_channel", "(channel_id)", "update a channel's name, parent category, or position"),
 ]
 
 # Actions that require the GUILD_MEMBERS privileged intent.
@@ -534,6 +599,9 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "create_thread": ["channel_id", "name"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
+    "create_channel": ["guild_id", "name", "type"],
+    "delete_channel": ["channel_id"],
+    "update_channel": ["channel_id"],
 }
 
 
@@ -592,6 +660,9 @@ def _available_actions(
     """
     actions: List[str] = []
     for name in _ACTIONS:
+        # Destructive actions must be explicitly named in the config allowlist.
+        if allowlist is None and name in _EXPLICIT_OPT_IN_ACTIONS:
+            continue
         # Intent filter
         if not caps.get("has_members_intent", True) and name in _INTENT_GATED_MEMBERS:
             continue
@@ -691,7 +762,25 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "New thread/channel name (create_thread, create_channel, update_channel).",
+            "minLength": 1,
+            "maxLength": 100,
+        },
+        "type": {
+            "type": "integer",
+            "enum": [0, 2, 4],
+            "description": "Discord guild channel type for create_channel: 0=text, 2=voice, 4=category.",
+        },
+        "parent_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Parent category channel ID for create_channel or update_channel. "
+                "Pass null with update_channel to remove the channel from its category."
+            ),
+        },
+        "position": {
+            "type": "integer",
+            "description": "Sorting position for create_channel or update_channel.",
         },
         "limit": {
             "type": "integer",
@@ -782,6 +871,16 @@ _ACTION_403_HINT = {
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
         "than the bot's highest role."
     ),
+    "create_channel": (
+        "Bot lacks MANAGE_CHANNELS permission in this guild, or cannot create "
+        "channels under the requested parent category."
+    ),
+    "delete_channel": (
+        "Bot lacks MANAGE_CHANNELS permission in this channel or guild."
+    ),
+    "update_channel": (
+        "Bot lacks MANAGE_CHANNELS permission in this channel or guild."
+    ),
     "fetch_messages": (
         "Bot cannot view this channel (missing VIEW_CHANNEL or READ_MESSAGE_HISTORY)."
     ),
@@ -835,6 +934,9 @@ def _run_discord_action(
     message_id: str = "",
     query: str = "",
     name: str = "",
+    type: Optional[int] = None,
+    parent_id: Any = _UNSET,
+    position: Optional[int] = None,
     limit: int = 50,
     before: str = "",
     after: str = "",
@@ -856,6 +958,15 @@ def _run_discord_action(
     # but a stale cached schema from a prior config should not let denied
     # actions through).
     allowlist = _load_allowed_actions_config()
+    if action in _EXPLICIT_OPT_IN_ACTIONS and (
+        allowlist is None or action not in allowlist
+    ):
+        return json.dumps({
+            "error": (
+                f"Action '{action}' is destructive and requires explicit opt-in "
+                "via discord.server_actions. Add it to that allowlist to enable it."
+            ),
+        })
     if allowlist is not None and action not in allowlist:
         return json.dumps({
             "error": (
@@ -872,9 +983,15 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "type": type,
+        "parent_id": parent_id,
+        "position": position,
     }
 
-    missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
+    missing = [
+        p for p in _REQUIRED_PARAMS.get(action, [])
+        if local_vars.get(p) is None or local_vars.get(p) == ""
+    ]
     if missing:
         return json.dumps({
             "error": f"Missing required parameters for '{action}': {', '.join(missing)}",
@@ -890,6 +1007,9 @@ def _run_discord_action(
             message_id=message_id,
             query=query,
             name=name,
+            type=type,
+            parent_id=parent_id,
+            position=position,
             limit=limit,
             before=before,
             after=after,
@@ -922,7 +1042,8 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
-    "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "type": None, "parent_id": _UNSET, "position": None, "limit": 50,
+    "before": "", "after": "", "auto_archive_duration": 1440,
 }
 
 
@@ -937,7 +1058,9 @@ _STATIC_CORE_SCHEMA = _build_schema(
     list(_CORE_ACTIONS.keys()), caps={"detected": False}, tool_name="discord",
 )
 _STATIC_ADMIN_SCHEMA = _build_schema(
-    list(_ADMIN_ACTIONS.keys()), caps={"detected": False}, tool_name="discord_admin",
+    [a for a in _ADMIN_ACTIONS if a not in _EXPLICIT_OPT_IN_ACTIONS],
+    caps={"detected": False},
+    tool_name="discord_admin",
 )
 
 registry.register(

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -202,7 +202,7 @@ Registered on the `hermes-discord` platform toolset. Moderation actions require 
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `discord_admin` | Manage a Discord server via the REST API: list guilds/channels/roles, create/edit/delete channels, manage role grants, timeouts, kicks, and bans. | `DISCORD_BOT_TOKEN` + bot permissions |
+| `discord_admin` | Manage a Discord server via the REST API: list guilds/channels/roles, create/edit/delete channels, manage role grants, timeouts, kicks, and bans. `delete_channel` is destructive and is disabled by default unless explicitly allowlisted in `discord.server_actions`.| `DISCORD_BOT_TOKEN` + bot permissions |
 
 ## `spotify` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -59,7 +59,7 @@ Or in-session:
 | `debugging` | composite (`file` + `terminal` + `web`) | Debug bundle — file, process/terminal, web extract/search. |
 | `delegation` | `delegate_task` | Spawn isolated subagent instances for parallel work. |
 | `discord` | `discord` | Core Discord text/embed/DM actions (gateway-only). Active on the `hermes-discord` toolset. |
-| `discord_admin` | `discord_admin` | Discord moderation (bans, role changes, channel management). Active on the `hermes-discord` toolset; requires the bot to hold the relevant Discord permissions. |
+| `discord_admin` | `discord_admin` | Discord moderation (bans, role changes, channel management). Active on the `hermes-discord` toolset; requires the bot to hold the relevant Discord permissions. `delete_channel` exists but is destructive, so it stays disabled unless explicitly allowlisted in `discord.server_actions` |
 | `feishu_doc` | `feishu_doc_read` | Read Feishu/Lark document content. Used by the Feishu document-comment intelligent-reply handler. |
 | `feishu_drive` | `feishu_drive_add_comment`, `feishu_drive_list_comments`, `feishu_drive_list_comment_replies`, `feishu_drive_reply_comment` | Feishu/Lark drive comment operations. Scoped to the comment agent; not exposed on `hermes-cli` or other messaging toolsets. |
 | `file` | `patch`, `read_file`, `search_files`, `write_file` | File reading, writing, searching, and editing. |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -307,6 +307,7 @@ discord:
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
+  server_actions: []              # Allowlist for Discord tools in `discord` and `discord_admin` toolsets; empty list allows all tools except `delete_channel` tool must be named explicitly to be allowed
   channel_prompts: {}             # Per-channel ephemeral system prompts
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
@@ -398,6 +399,29 @@ discord:
 ```
 
 Useful for channels dedicated to bot interaction where threads would add unnecessary noise.
+
+#### `discord.server_actions`
+
+**Type:** string or list — **Default:** `""` / `[]`
+
+Allowlist for the Discord REST actions exposed through the gateway's `discord` and `discord_admin` tools. The empty default keeps the normal action set available, but destructive actions still stay gated.
+
+Important behavior:
+- `create_channel` and `update_channel` are available as normal `discord_admin` actions.
+- `delete_channel` is treated as destructive and is never enabled by default.
+- To expose `delete_channel`, you must explicitly include it in `discord.server_actions`.
+
+```yaml
+discord:
+  server_actions:
+    - list_guilds
+    - list_channels
+    - create_channel
+    - update_channel
+    - delete_channel   # explicit opt-in required
+```
+
+You can also use a comma-separated string instead of a YAML list. Unknown action names are ignored with a warning at load time.
 
 #### `discord.channel_prompts`
 


### PR DESCRIPTION
## What does this PR do?

Implements the Discord channel management capabilities that were already documented as supported, but were not yet fully implemented in the source.

## Related Issue

Fixes #22352

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `create_channel` support to `discord_admin` toolset
- add `update_channel` support to `discord_admin` toolset
- add `delete_channel` support to `discord_admin` toolset
- exclude `delete_channel` from the default available-action set and default schema unless explicit opt-in via `discord.server_actions` in config.yaml
- add runtime gating for `delete_channel` even if a stale schema still advertises it
- allows `update_channel` to clear a category with `parent_id: null`
- update docs slightly so the implementation now matches the documented feature set

## How to Test

- targeted Discord tool tests pass
- added regression coverage for:
  - default denial of `delete_channel`
  - allowlisted `delete_channel` success path
  - dynamic schema visibility when explicitly enabled
  - default schema exclusion of `delete_channel`
  - `update_channel` with `parent_id: null`
  - permission-hint behavior for channel management failures

Ask Hermes to create, update, or delete a channel per the Use Case section above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A