### PR TITLE
fix(skills): hash byte-backed bundle files (closes #13408)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -621,6 +621,8 @@ AUTHOR_MAP = {
     "2114364329@qq.com": "cuyua9",
     "2557058999@qq.com": "Disaster-Terminator",
     "cine.dreamer.one@gmail.com": "LeonSGP43",
+    "dodofun@126.com": "colorcross",
+    "1615063567@qq.com": "zhao0112",
     "leozeli@qq.com": "leozeli",
     "linlehao@cuhk.edu.cn": "LehaoLin",
     "liutong@isacas.ac.cn": "I3eg1nner",

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -917,6 +917,53 @@ class TestCheckForSkillUpdates:
 
         assert digest.startswith("sha256:")
 
+    def test_bundle_content_hash_bytes_matches_str_equivalent(self):
+        """Bytes content must hash identically to its str-decoded form."""
+        text_bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "references/checklist.md": "- [ ] security\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        bytes_bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": b"same content",
+                "references/checklist.md": b"- [ ] security\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+
+        assert bundle_content_hash(bytes_bundle) == bundle_content_hash(text_bundle)
+
+    def test_bundle_content_hash_mixed_matches_on_disk(self, tmp_path):
+        """In-memory bundle hash must equal on-disk content_hash for mixed bytes+str."""
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": b"# Demo Skill\n",
+                "references/checklist.md": "- [ ] security\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"# Demo Skill\n")
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -901,6 +901,22 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_accepts_binary_files(self):
+        bundle = SkillBundle(
+            name="demo-binary-skill",
+            files={
+                "SKILL.md": "# Demo\n",
+                "assets/logo.png": b"\x89PNG\r\n\x1a\nbinary",
+            },
+            source="github",
+            identifier="owner/repo/demo-binary-skill",
+            trust_level="community",
+        )
+
+        digest = bundle_content_hash(bundle)
+
+        assert digest.startswith("sha256:")
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2801,7 +2801,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Summary
`hermes skills update` no longer crashes when a bundle contains binary files (images, other byte-valued assets).

Root cause: `bundle_content_hash()` called `.encode("utf-8")` on every file value, but bundle files can be `bytes` (binary assets). Fix: isinstance-branch before `h.update()`.

Salvaged from three duplicate PRs submitted by community contributors:
- #9925 (@colorcross, Apr 14) — source fix + binary-asset test. Cherry-picked as-is with original authorship preserved.
- #14108 (@LeonSGP43, Apr 22) — bytes-vs-str equivalence test. Added as follow-up with Co-authored-by.
- #13531 (@zhao0112, Apr 21, draft) — mixed bytes+str vs on-disk `content_hash` parity test. Added as follow-up with Co-authored-by.

## Changes
- `tools/skills_hub.py`: isinstance-branch bytes vs str in `bundle_content_hash()` (colorcross's commit)
- `tests/tools/test_skills_hub.py`: three tests — binary-asset no-crash (colorcross), bytes/str equivalence (LeonSGP43), bundle hash == on-disk content_hash (zhao0112)
- `scripts/release.py`: map `dodofun@126.com` → colorcross and `1615063567@qq.com` → zhao0112 for AUTHOR_MAP

## Validation
| | Before | After |
|---|---|---|
| Binary-asset bundle hash | `AttributeError: 'bytes' object has no attribute 'encode'` | `sha256:68838f27b22652d4` |
| bundle_content_hash == content_hash (on-disk) | n/a (crash) | matches |
| `tests/tools/test_skills_hub.py -k bundle_content_hash` | 1 passing | 4 passing |

Closes #13408.