### PR TITLE
fix: remove INSECURE_NO_AUTH webhook authentication bypass

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -316,7 +316,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Validate HMAC signature FIRST
         secret = route_config.get("secret", self._global_secret)
         if secret:
-          if not self._validate_signature(request, raw_body, secret):
+            if not self._validate_signature(request, raw_body, secret):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
                 )

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -313,7 +313,7 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)
 
-        # Validate HMAC signature FIRST (skip for INSECURE_NO_AUTH testing mode)
+        # Validate HMAC signature FIRST
         secret = route_config.get("secret", self._global_secret)
         if secret:
            if not self._validate_signature(request, raw_body, secret):

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -23,7 +23,6 @@ Security:
   - Rate limiting per route (fixed-window, configurable)
   - Idempotency cache prevents duplicate agent runs on webhook retries
   - Body size limits checked before reading payload
-  - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
 import asyncio
@@ -56,7 +55,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8644
-_INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 
 
@@ -122,8 +120,7 @@ class WebhookAdapter(BasePlatformAdapter):
             if not secret:
                 raise ValueError(
                     f"[webhook] Route '{name}' has no HMAC secret. "
-                    f"Set 'secret' on the route or globally. "
-                    f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
+                    f"Set 'secret' on the route or globally."
                 )
 
             # deliver_only routes bypass the agent — the POST body becomes a
@@ -318,8 +315,8 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Validate HMAC signature FIRST (skip for INSECURE_NO_AUTH testing mode)
         secret = route_config.get("secret", self._global_secret)
-        if secret and secret != _INSECURE_NO_AUTH:
-            if not self._validate_signature(request, raw_body, secret):
+        if secret:
+           if not self._validate_signature(request, raw_body, secret):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
                 )

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -316,7 +316,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Validate HMAC signature FIRST
         secret = route_config.get("secret", self._global_secret)
         if secret:
-           if not self._validate_signature(request, raw_body, secret):
+          if not self._validate_signature(request, raw_body, secret):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
                 )


### PR DESCRIPTION
## Summary

- Removes the `INSECURE_NO_AUTH` constant that allowed complete HMAC signature validation bypass in webhook routes
- All webhook routes now require a valid HMAC secret — no exceptions
- Updates startup validation error message and docstrings

## Security Impact

The `INSECURE_NO_AUTH` mechanism allowed any webhook route to skip all authentication by setting the secret to the literal string `"INSECURE_NO_AUTH"`. This creates several attack vectors:

1. **Accidental production exposure**: Developers testing locally may copy configs with `INSECURE_NO_AUTH` into production, leaving webhooks completely unauthenticated
2. **Config injection**: Any code path that can write to the webhook route config (skills, plugins, file_write_tool) can disable auth by setting this value
3. **Unauthenticated agent triggering**: Without HMAC validation, anyone who discovers the webhook URL can trigger arbitrary agent runs, deliver messages, or execute actions

When bypassed, the endpoint accepts unauthenticated requests that can:
- Trigger agent runs on arbitrary prompts
- Use `deliver_only` mode to push notifications to any configured target (Telegram, Discord, Slack, GitHub comments)
- Bypass rate limiting (auth happens before rate limiting)

## Fix

Removed the bypass entirely. Testing environments should use a dummy secret (e.g., `secret: "test-secret-123"`) instead of disabling auth. This follows the principle that auth should never be silently bypassable via a configuration value.

## Files Changed

- `gateway/platforms/webhook.py`: Removed `_INSECURE_NO_AUTH` constant, bypass logic, and related documentation

## Migration Guide

If you were using `secret: "INSECURE_NO_AUTH"` in your webhook routes:

1. **Replace with a dummy secret:**
   ```yaml
   platforms:
     webhook:
       routes:
         my_route:
           secret: "your-test-secret-here"  # was: "INSECURE_NO_AUTH"


Update your test requests to include a valid HMAC-SHA256 signature:

# Generate signature
SECRET="your-test-secret-here"
BODY='{"event":"test"}'
SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')

# Send request
curl -X POST http://localhost:8644/webhooks/my_route \
  -H "X-Webhook-Signature: $SIG" \
  -H "Content-Type: application/json" \
  -d "$BODY"

GitHub/GitLab webhooks: No change needed — they already send valid signatures.

Custom integrations: Use any HMAC library in your language to sign requests with the same secret configured in config.yaml.