### PR TITLE
fix(cli): follow 307 redirects in MiniMax OAuth httpx clients

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4283,7 +4283,8 @@ def _minimax_oauth_login(
     print(f"Portal: {portal_base_url}")
 
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      headers={"Accept": "application/json"}) as client:
+                      headers={"Accept": "application/json"},
+                      follow_redirects=True) as client:
         code_data = _minimax_request_user_code(
             client, portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
@@ -4360,7 +4361,8 @@ def _refresh_minimax_oauth_state(
         return state
 
     portal_base_url = state["portal_base_url"]
-    with httpx.Client(timeout=httpx.Timeout(timeout_seconds)) as client:
+    with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
+                      follow_redirects=True) as client:
         response = client.post(
             f"{portal_base_url}/oauth/token",
             data={


### PR DESCRIPTION
## What & Why

The MiniMax OAuth API endpoints have moved from `api.minimax.io` to `account.minimax.io` and the old paths now respond with HTTP 307. `httpx` defaults to `follow_redirects=False` (unlike `requests`), so the device-code and token-refresh flows currently fail with:

```
MiniMax OAuth authorization failed: Temporary Redirect
```

This patch adds `follow_redirects=True` to the two `httpx.Client` instances in `hermes_cli/auth.py` used by the MiniMax OAuth flow:

1. The client wrapping `_minimax_request_user_code` + `_minimax_poll_token` (device-code flow).
2. The client used by `_refresh_minimax_oauth_state` (refresh-token flow).

This is forward-compatible: if the endpoints move again, the redirect chain is followed automatically. Note also that the upstream redirects are asymmetric (`/oauth/code` -> `oauth2/device/code`, `/oauth/token` -> `oauth2/token`), so a hardcoded URL fix would need to special-case both paths -- redirect-following sidesteps that. The constants at lines ~78-79 (`MINIMAX_OAUTH_GLOBAL_BASE` etc.) are intentionally untouched; if maintainers want hardcoded URLs as defense-in-depth that's a separate change.

## How to test

Repro before patch (without the fix, both POSTs return 307):

```
curl -i -X POST https://api.minimax.io/oauth/code
# -> HTTP/2 307, location: https://account.minimax.io/oauth2/device/code

curl -i -X POST https://api.minimax.io/oauth/token
# -> HTTP/2 307, location: https://account.minimax.io/oauth2/token
```

After patch:
- `hermes model` -> "MiniMax via OAuth browser login" completes the device-code flow successfully.
- Token refresh on a stored credential succeeds.
- `pytest tests/test_minimax_oauth.py` -- all 15 existing tests still pass.

## Test plan

- [x] Verified end-to-end against a real MiniMax Plus account on macOS (Darwin 25.4.0, Python 3.11).
- [x] `tests/test_minimax_oauth.py` (15 tests, mocked httpx) all pass after the change.
- [ ] Cross-platform: change is a one-keyword kwarg on `httpx.Client`; no platform-specific surface.

## Notes / scope

- One logical change. Bug fix only. No refactor, no new tests.
- A separate issue has been filed for an unrelated MiniMax server-side bug (stale `verification_uri` host) -- not bundled here.
- A separate issue has been filed for a `hermes setup` quick-wizard UX bug (auth errors swallowed silently) -- not bundled here.