### PR TITLE
fix(tui): respect configured voice record key

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -81,6 +81,31 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_voice_toggle_returns_configured_record_key(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"voice": {"record_key": "ctrl+o"}},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.voice_mode",
+        types.SimpleNamespace(
+            check_voice_requirements=lambda: {"available": True, "details": ""}
+        ),
+    )
+
+    on_resp = server.dispatch(
+        {"id": "voice-on", "method": "voice.toggle", "params": {"action": "on"}}
+    )
+    status_resp = server.dispatch(
+        {"id": "voice-status", "method": "voice.toggle", "params": {"action": "status"}}
+    )
+
+    assert on_resp["result"]["record_key"] == "ctrl+o"
+    assert status_resp["result"]["record_key"] == "ctrl+o"
+
+
 def test_load_enabled_toolsets_prefers_tui_env(monkeypatch):
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "web, terminal, ,memory")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5247,6 +5247,12 @@ def _voice_tts_enabled() -> bool:
     return os.environ.get("HERMES_VOICE_TTS", "").strip() == "1"
 
 
+def _voice_record_key() -> str:
+    voice_cfg = _load_cfg().get("voice") or {}
+    raw = voice_cfg.get("record_key", "ctrl+b")
+    return str(raw or "ctrl+b")
+
+
 @method("voice.toggle")
 def _(rid, params: dict) -> dict:
     """CLI parity for the ``/voice`` slash command.
@@ -5269,6 +5275,7 @@ def _(rid, params: dict) -> dict:
         # isn't working ("STT provider: MISSING ..." is the common case).
         payload: dict = {
             "enabled": _voice_mode_enabled(),
+            "record_key": _voice_record_key(),
             "tts": _voice_tts_enabled(),
         }
         try:
@@ -5305,7 +5312,10 @@ def _(rid, params: dict) -> dict:
             except Exception as e:
                 logger.warning("voice: stop_continuous failed during toggle off: %s", e)
 
-        return _ok(rid, {"enabled": enabled, "tts": _voice_tts_enabled()})
+        return _ok(
+            rid,
+            {"enabled": enabled, "record_key": _voice_record_key(), "tts": _voice_tts_enabled()},
+        )
 
     if action == "tts":
         if not _voice_mode_enabled():
@@ -5313,7 +5323,7 @@ def _(rid, params: dict) -> dict:
         new_value = not _voice_tts_enabled()
         # Runtime-only flag (CLI parity) — see voice.toggle on/off above.
         os.environ["HERMES_VOICE_TTS"] = "1" if new_value else "0"
-        return _ok(rid, {"enabled": True, "tts": new_value})
+        return _ok(rid, {"enabled": True, "record_key": _voice_record_key(), "tts": new_value})
 
     return _err(rid, 4013, f"unknown voice action: {action}")
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -173,6 +173,28 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith(expect.stringContaining('usage: /skills'))
   })
 
+  it('/voice status displays the configured record key from the gateway', async () => {
+    const rpc = vi.fn(() => Promise.resolve({ enabled: false, record_key: 'ctrl+o', tts: false }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/voice status')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('  Record key: Ctrl+O')
+    })
+  })
+
+  it('/voice on displays the configured record key from the gateway', async () => {
+    const rpc = vi.fn(() => Promise.resolve({ enabled: true, record_key: 'alt+o', tts: false }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/voice on')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('  Alt+O to start/stop recording')
+    })
+  })
+
   it('cycles details mode and persists it', async () => {
     const ctx = buildCtx()
 
@@ -648,6 +670,7 @@ const buildTranscript = () => ({
 })
 
 const buildVoice = () => ({
+  recordKey: 'ctrl+b',
   setVoiceEnabled: vi.fn()
 })
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -173,20 +173,20 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith(expect.stringContaining('usage: /skills'))
   })
 
-  it('/voice status displays the configured record key from the gateway', async () => {
+  it('/voice status displays the active frontend record key state', async () => {
     const rpc = vi.fn(() => Promise.resolve({ enabled: false, record_key: 'ctrl+o', tts: false }))
-    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc }, voice: { ...buildVoice(), recordKey: 'alt+o' } })
 
     expect(createSlashHandler(ctx)('/voice status')).toBe(true)
 
     await vi.waitFor(() => {
-      expect(ctx.transcript.sys).toHaveBeenCalledWith('  Record key: Ctrl+O')
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('  Record key: Alt+O')
     })
   })
 
-  it('/voice on displays the configured record key from the gateway', async () => {
-    const rpc = vi.fn(() => Promise.resolve({ enabled: true, record_key: 'alt+o', tts: false }))
-    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+  it('/voice on displays the active frontend record key state', async () => {
+    const rpc = vi.fn(() => Promise.resolve({ enabled: true, record_key: 'ctrl+o', tts: false }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc }, voice: { ...buildVoice(), recordKey: 'alt+o' } })
 
     expect(createSlashHandler(ctx)('/voice on')).toBe(true)
 

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -60,6 +60,20 @@ describe('isCopyShortcut', () => {
 })
 
 describe('isVoiceToggleKey', () => {
+  it('matches configured Ctrl key instead of hardcoded Ctrl+B', async () => {
+    const { isVoiceToggleKey } = await importPlatform('linux')
+
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'o', 'ctrl+o')).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'b', 'ctrl+o')).toBe(false)
+  })
+
+  it('matches configured Alt key chords', async () => {
+    const { isVoiceToggleKey } = await importPlatform('linux')
+
+    expect(isVoiceToggleKey({ ctrl: false, meta: true, super: false }, 'o', 'alt+o')).toBe(true)
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'o', 'alt+o')).toBe(false)
+  })
+
   it('matches raw Ctrl+B on macOS (doc-default across platforms)', async () => {
     const { isVoiceToggleKey } = await importPlatform('darwin')
 

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -74,6 +74,16 @@ describe('isVoiceToggleKey', () => {
     expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'o', 'alt+o')).toBe(false)
   })
 
+  it('falls back to the exported default for missing or invalid configured keys', async () => {
+    const { DEFAULT_VOICE_RECORD_KEY, formatVoiceRecordKey, isVoiceToggleKey, normalizeVoiceRecordKey } = await importPlatform('linux')
+
+    expect(normalizeVoiceRecordKey(undefined)).toBe(DEFAULT_VOICE_RECORD_KEY)
+    expect(normalizeVoiceRecordKey('not-a-key')).toBe(DEFAULT_VOICE_RECORD_KEY)
+    expect(formatVoiceRecordKey(undefined)).toBe('Ctrl+B')
+    expect(formatVoiceRecordKey('not-a-key')).toBe('Ctrl+B')
+    expect(isVoiceToggleKey({ ctrl: true, meta: false, super: false }, 'b', 'not-a-key')).toBe(true)
+  })
+
   it('matches raw Ctrl+B on macOS (doc-default across platforms)', async () => {
     const { isVoiceToggleKey } = await importPlatform('darwin')
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -210,6 +210,7 @@ export interface InputHandlerContext {
   }
   voice: {
     enabled: boolean
+    recordKey: string
     recording: boolean
     setProcessing: StateSetter<boolean>
     setRecording: StateSetter<boolean>
@@ -290,6 +291,7 @@ export interface SlashHandlerContext {
     trimLastExchange: (items: Msg[]) => Msg[]
   }
   voice: {
+    recordKey: string
     setVoiceEnabled: StateSetter<boolean>
   }
 }

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -10,6 +10,7 @@ import type {
   SessionUsageResponse,
   VoiceToggleResponse
 } from '../../../gatewayTypes.js'
+import { formatVoiceRecordKey } from '../../../lib/platform.js'
 import { fmtK } from '../../../lib/text.js'
 import type { PanelSection } from '../../../types.js'
 import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
@@ -220,6 +221,7 @@ export const sessionCommands: SlashCommand[] = [
       ctx.gateway.rpc<VoiceToggleResponse>('voice.toggle', { action }).then(
         ctx.guarded<VoiceToggleResponse>(r => {
           ctx.voice.setVoiceEnabled(!!r.enabled)
+          const recordKeyDisplay = formatVoiceRecordKey(r.record_key ?? ctx.voice.recordKey)
 
           // Match CLI's _show_voice_status / _enable_voice_mode /
           // _toggle_voice_tts output shape so users don't have to learn
@@ -230,7 +232,7 @@ export const sessionCommands: SlashCommand[] = [
             ctx.transcript.sys('Voice Mode Status')
             ctx.transcript.sys(`  Mode:       ${mode}`)
             ctx.transcript.sys(`  TTS:        ${tts}`)
-            ctx.transcript.sys('  Record key: Ctrl+B')
+            ctx.transcript.sys(`  Record key: ${recordKeyDisplay}`)
 
             // CLI's "Requirements:" block — surfaces STT/audio setup issues
             // so the user sees "STT provider: MISSING ..." instead of
@@ -259,7 +261,7 @@ export const sessionCommands: SlashCommand[] = [
           if (r.enabled) {
             const tts = r.tts ? ' (TTS enabled)' : ''
             ctx.transcript.sys(`Voice mode enabled${tts}`)
-            ctx.transcript.sys('  Ctrl+B to start/stop recording')
+            ctx.transcript.sys(`  ${recordKeyDisplay} to start/stop recording`)
             ctx.transcript.sys('  /voice tts  to toggle speech output')
             ctx.transcript.sys('  /voice off  to disable voice mode')
           } else {

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -221,7 +221,7 @@ export const sessionCommands: SlashCommand[] = [
       ctx.gateway.rpc<VoiceToggleResponse>('voice.toggle', { action }).then(
         ctx.guarded<VoiceToggleResponse>(r => {
           ctx.voice.setVoiceEnabled(!!r.enabled)
-          const recordKeyDisplay = formatVoiceRecordKey(r.record_key ?? ctx.voice.recordKey)
+          const recordKeyDisplay = formatVoiceRecordKey(ctx.voice.recordKey)
 
           // Match CLI's _show_voice_status / _enable_voice_mode /
           // _toggle_voice_tts output shape so users don't have to learn

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -7,6 +7,7 @@ import type {
   ConfigMtimeResponse,
   ReloadMcpResponse
 } from '../gatewayTypes.js'
+import { normalizeVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult } from '../lib/rpc.js'
 
 import {
@@ -109,7 +110,20 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
   })
 }
 
-export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid }: UseConfigSyncOptions) {
+export const applyVoiceRecordKey = (cfg: ConfigFullResponse | null, setVoiceRecordKey: (v: string) => void) => {
+  setVoiceRecordKey(normalizeVoiceRecordKey(cfg?.config?.voice?.record_key))
+}
+
+const applyFullConfig = (
+  cfg: ConfigFullResponse | null,
+  setBell: (v: boolean) => void,
+  setVoiceRecordKey: (v: string) => void
+) => {
+  applyDisplay(cfg, setBell)
+  applyVoiceRecordKey(cfg, setVoiceRecordKey)
+}
+
+export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid }: UseConfigSyncOptions) {
   const mtimeRef = useRef(0)
 
   useEffect(() => {
@@ -125,8 +139,10 @@ export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid }: U
     quietRpc<ConfigMtimeResponse>(gw, 'config.get', { key: 'mtime' }).then(r => {
       mtimeRef.current = Number(r?.mtime ?? 0)
     })
-    quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r => applyDisplay(r, setBellOnComplete))
-  }, [gw, setBellOnComplete, setVoiceEnabled, sid])
+    quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r =>
+      applyFullConfig(r, setBellOnComplete, setVoiceRecordKey)
+    )
+  }, [gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid])
 
   useEffect(() => {
     if (!sid) {
@@ -154,17 +170,20 @@ export function useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid }: U
         quietRpc<ReloadMcpResponse>(gw, 'reload.mcp', { session_id: sid, confirm: true }).then(
           r => r && turnController.pushActivity('MCP reloaded after config change')
         )
-        quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r => applyDisplay(r, setBellOnComplete))
+        quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' }).then(r =>
+          applyFullConfig(r, setBellOnComplete, setVoiceRecordKey)
+        )
       })
     }, MTIME_POLL_MS)
 
     return () => clearInterval(id)
-  }, [gw, setBellOnComplete, sid])
+  }, [gw, setBellOnComplete, setVoiceRecordKey, sid])
 }
 
 export interface UseConfigSyncOptions {
   gw: GatewayClient
   setBellOnComplete: (v: boolean) => void
   setVoiceEnabled: (v: boolean) => void
+  setVoiceRecordKey: (v: string) => void
   sid: null | string
 }

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -439,7 +439,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return
     }
 
-    if (isVoiceToggleKey(key, ch)) {
+    if (isVoiceToggleKey(key, ch, voice.recordKey)) {
       return voiceRecordToggle()
     }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -17,7 +17,7 @@ import type {
 import { useGitBranch } from '../hooks/useGitBranch.js'
 import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { appendTranscriptMessage } from '../lib/messages.js'
-import { isMac } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, isMac } from '../lib/platform.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
@@ -101,6 +101,7 @@ export function useMainApp(gw: GatewayClient) {
   const [stickyPrompt, setStickyPrompt] = useState('')
   const [catalog, setCatalog] = useState<null | SlashCatalog>(null)
   const [voiceEnabled, setVoiceEnabled] = useState(false)
+  const [voiceRecordKey, setVoiceRecordKey] = useState(DEFAULT_VOICE_RECORD_KEY)
   const [voiceRecording, setVoiceRecording] = useState(false)
   const [voiceProcessing, setVoiceProcessing] = useState(false)
   const [sessionStartedAt, setSessionStartedAt] = useState(() => Date.now())
@@ -384,7 +385,7 @@ export function useMainApp(gw: GatewayClient) {
     }
   }, [ui.busy])
 
-  useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid: ui.sid })
+  useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
   const model = ui.info?.model?.replace(/^.*\//, '') ?? ''
@@ -529,6 +530,7 @@ export function useMainApp(gw: GatewayClient) {
     terminal: { hasSelection, scrollRef, scrollWithSelection, selection, stdout },
     voice: {
       enabled: voiceEnabled,
+      recordKey: voiceRecordKey,
       recording: voiceRecording,
       setProcessing: setVoiceProcessing,
       setRecording: setVoiceRecording,
@@ -632,7 +634,7 @@ export function useMainApp(gw: GatewayClient) {
         },
         slashFlightRef,
         transcript: { page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
-        voice: { setVoiceEnabled }
+        voice: { recordKey: voiceRecordKey, setVoiceEnabled }
       }),
     [
       catalog,
@@ -648,7 +650,8 @@ export function useMainApp(gw: GatewayClient) {
       selection,
       send,
       session,
-      sys
+      sys,
+      voiceRecordKey
     ]
   )
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -75,8 +75,12 @@ export interface ConfigDisplayConfig {
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
 }
 
+export interface ConfigVoiceConfig {
+  record_key?: string
+}
+
 export interface ConfigFullResponse {
-  config?: { display?: ConfigDisplayConfig }
+  config?: { display?: ConfigDisplayConfig; voice?: ConfigVoiceConfig }
 }
 
 export interface ConfigMtimeResponse {
@@ -279,6 +283,7 @@ export interface VoiceToggleResponse {
   available?: boolean
   details?: string
   enabled?: boolean
+  record_key?: string
   stt_available?: boolean
   tts?: boolean
 }

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -50,14 +50,71 @@ export const isCopyShortcut = (
     // even though raw Ctrl+C should remain interrupt on local macOS.
     (isMac && key.ctrl && (key.meta || key.super === true)))
 
+export const DEFAULT_VOICE_RECORD_KEY = 'ctrl+b'
+
+type VoiceRecordModifier = 'alt' | 'ctrl'
+
+interface VoiceRecordKeySpec {
+  key: string
+  modifier: VoiceRecordModifier
+}
+
+const parseVoiceRecordKey = (raw: unknown): VoiceRecordKeySpec => {
+  if (typeof raw !== 'string') {
+    return { key: 'b', modifier: 'ctrl' }
+  }
+
+  const match = raw.trim().toLowerCase().match(/^(ctrl|control|c|alt|option|meta|a)\s*\+\s*(.)$/)
+
+  if (!match) {
+    return { key: 'b', modifier: 'ctrl' }
+  }
+
+  const modifier: VoiceRecordModifier = ['alt', 'option', 'meta', 'a'].includes(match[1]) ? 'alt' : 'ctrl'
+
+  return { key: match[2], modifier }
+}
+
+export const normalizeVoiceRecordKey = (raw: unknown): string => {
+  const spec = parseVoiceRecordKey(raw)
+
+  return `${spec.modifier}+${spec.key}`
+}
+
+export const formatVoiceRecordKey = (raw: unknown): string => {
+  const spec = parseVoiceRecordKey(raw)
+  const modifier = spec.modifier === 'ctrl' ? 'Ctrl' : 'Alt'
+
+  return `${modifier}+${spec.key.toUpperCase()}`
+}
+
 /**
- * Voice recording toggle key (Ctrl+B).
+ * Voice recording toggle key from config.yaml's voice.record_key.
  *
- * Documented as "Ctrl+B" everywhere: tips.py, config.yaml's voice.record_key
- * default, and the Python CLI prompt_toolkit handler. We accept raw Ctrl+B on
- * every platform so the TUI matches those docs. On macOS we additionally
- * accept Cmd+B (the platform action modifier) so existing macOS muscle memory
- * keeps working.
+ * Supported config spellings mirror the classic CLI's documented forms:
+ * `ctrl+x` and `alt+x` (case-insensitive). Invalid values fall back to the
+ * config default, Ctrl+B. For the default chord we keep the existing macOS
+ * action-modifier+B compatibility; explicit non-default chords must match the
+ * configured modifier/key so the TUI does not keep hardcoding Ctrl+B.
  */
-export const isVoiceToggleKey = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string): boolean =>
-  (key.ctrl || isActionMod(key)) && ch.toLowerCase() === 'b'
+export const isVoiceToggleKey = (
+  key: { ctrl: boolean; meta: boolean; super?: boolean },
+  ch: string,
+  recordKey: string = DEFAULT_VOICE_RECORD_KEY
+): boolean => {
+  const spec = parseVoiceRecordKey(recordKey)
+  const target = ch.toLowerCase() === spec.key
+
+  if (!target) {
+    return false
+  }
+
+  if (spec.modifier === 'alt') {
+    return key.meta && !key.ctrl && key.super !== true
+  }
+
+  return (
+    key.ctrl ||
+    (normalizeVoiceRecordKey(recordKey) === DEFAULT_VOICE_RECORD_KEY && isActionMod(key))
+  )
+}

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -59,20 +59,37 @@ interface VoiceRecordKeySpec {
   modifier: VoiceRecordModifier
 }
 
-const parseVoiceRecordKey = (raw: unknown): VoiceRecordKeySpec => {
-  if (typeof raw !== 'string') {
-    return { key: 'b', modifier: 'ctrl' }
-  }
+const VOICE_RECORD_KEY_PATTERN = /^(ctrl|control|c|alt|option|meta|a)\s*\+\s*(.)$/
 
-  const match = raw.trim().toLowerCase().match(/^(ctrl|control|c|alt|option|meta|a)\s*\+\s*(.)$/)
+const parseVoiceRecordKeySpec = (raw: string): null | VoiceRecordKeySpec => {
+  const match = raw.trim().toLowerCase().match(VOICE_RECORD_KEY_PATTERN)
 
   if (!match) {
-    return { key: 'b', modifier: 'ctrl' }
+    return null
   }
 
-  const modifier: VoiceRecordModifier = ['alt', 'option', 'meta', 'a'].includes(match[1]) ? 'alt' : 'ctrl'
+  const [, modifierToken = '', key = ''] = match
+  const modifier: VoiceRecordModifier = ['alt', 'option', 'meta', 'a'].includes(modifierToken) ? 'alt' : 'ctrl'
 
-  return { key: match[2], modifier }
+  return { key, modifier }
+}
+
+const DEFAULT_VOICE_RECORD_KEY_SPEC = (() => {
+  const spec = parseVoiceRecordKeySpec(DEFAULT_VOICE_RECORD_KEY)
+
+  if (!spec) {
+    throw new Error(`Invalid DEFAULT_VOICE_RECORD_KEY: ${DEFAULT_VOICE_RECORD_KEY}`)
+  }
+
+  return spec
+})()
+
+const parseVoiceRecordKey = (raw: unknown): VoiceRecordKeySpec => {
+  if (typeof raw !== 'string') {
+    return DEFAULT_VOICE_RECORD_KEY_SPEC
+  }
+
+  return parseVoiceRecordKeySpec(raw) ?? DEFAULT_VOICE_RECORD_KEY_SPEC
 }
 
 export const normalizeVoiceRecordKey = (raw: unknown): string => {


### PR DESCRIPTION
## What does this PR do?

Makes the TUI honor the configured `voice.record_key` instead of effectively assuming the default `Ctrl+B` chord at runtime.

The voice record key is configurable in Hermes config, but the TUI input handler still used a hardcoded/default key check. Config reload handling also only reapplied display settings, so a changed voice key was not reflected in the running TUI.

This threads the configured key through the gateway response, TUI config sync, UI state, shortcut display, and input handling path.

## Related Issue

Fixes #18994

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`
  - Returns `record_key` with `voice.toggle` responses so the TUI can consume the active configured key.
- `ui-tui/src/lib/platform.ts`
  - Adds normalization/formatting helpers for configured voice keys.
  - Supports documented `ctrl+x` / `alt+x` style spellings, with aliases such as `control`, `option`, and `meta`.
  - Falls back to `ctrl+b` for invalid or missing config values.
- `ui-tui/src/app/useConfigSync.ts`
  - Applies `voice.record_key` during initial config sync and config reload polling.
- `ui-tui/src/app/useMainApp.ts`, `ui-tui/src/app/useInputHandlers.ts`, `ui-tui/src/app/slash/commands/session.ts`
  - Stores the active record key in TUI state, passes it into input handling, and displays the configured shortcut.
- Tests
  - Adds backend coverage for `record_key` in voice responses.
  - Adds frontend coverage for key parsing, fallback behavior, and slash/UI wiring.

## How to Test

```bash
pytest tests/ -v
scripts/run_tests.sh
scripts/run_tests.sh tests/test_tui_gateway_server.py
npm --prefix ui-tui test -- src/__tests__/platform.test.ts src/__tests__/createSlashHandler.test.ts
npm --prefix ui-tui run type-check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux
