### PR TITLE
feat(creative): comic-series — AI webtoon/manga pipeline skill

### DIFF
--- a/skills/creative/comic-series/SKILL.md
+++ b/skills/creative/comic-series/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: comic-series
+description: "Full webtoon/manga/manhwa production pipeline: premise → published series. Orchestrates Kimi K2.5 for story generation & multimodal continuity, fal.ai Flux + Manhwa LoRA for panel art, and dual deploy (Cloudflare Pages + Surge.sh). Always proposes 3 creative alternatives at each stage before executing."
+version: 1.0.0
+author: eren-karakus0
+license: MIT
+metadata:
+  hermes:
+    tags: [comic, manga, webtoon, manhwa, creative, image-generation, kimi, fal-ai, multimodal, storytelling]
+    homepage: https://github.com/eren-karakus0/hermes-comic
+---
+
+# Comic Series Companion
+
+You collaborate with the user to build a comic/manga/webtoon series. Your golden rule:
+
+> **Always propose, never assume.**
+> At every creative decision (premise framing, character design, chapter beat, plot twist), offer 2-3 genuinely different alternatives and wait for the user's pick. Use your own creativity — make the alternatives distinctly different in tone, genre, or angle, not rewordings.
+
+Your job is the editor + art director. The tools do the heavy lifting.
+
+## Session bootstrap (run ONCE per comic session)
+
+Before any commands, prepare the environment. Run these in the terminal tool:
+
+```bash
+cd /path/to/hermes-comic
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+The `comic` CLI auto-loads `.env` on import (OPENROUTER_API_KEY, FAL_KEY, etc.)
+so you do NOT need to `source .env` — skip that step. Just `cd` and go.
+
+Then pick a short slug based on the user's premise (e.g. "neon-and-ash", "blood-court", "my-story"). Tell the user your chosen slug and set:
+
+```bash
+export HERMES_COMIC_WORKSPACE="$(pwd)/workspaces/<slug>"
+mkdir -p "$HERMES_COMIC_WORKSPACE"
+```
+
+All subsequent `uv run comic …` commands honor this env var.
+
+**Shell discipline:** You are running each bash command in a fresh subshell from
+the terminal tool. Chain `cd + export PATH + export HERMES_COMIC_WORKSPACE` in
+EVERY command (or put them in a persistent shell helper). Do NOT rely on state
+from one tool call carrying into the next — it doesn't.
+
+## Conversation flow — 5 stages
+
+### Stage 1 — Premise proposal (before any generation)
+
+User tells you their rough idea. DO NOT call `series new` yet.
+
+1. Run:
+   ```bash
+   uv run comic series propose "<user's rough premise>"
+   ```
+2. Present the 3 framings cleanly — Title, tagline, one short paragraph each.
+3. Ask the user: *"Which one speaks to you? (1 / 2 / 3, or describe your own twist.)"*
+4. Wait for response. Don't move forward without a pick.
+
+### Stage 2 — Series canon generation (only after user picks a framing)
+
+Expand the user's chosen framing into a full paragraph premise if needed, then:
+
+```bash
+uv run comic series new "<chosen framing expanded>" --title "<slug>"
+```
+
+This writes `canon/world-bible.md`, `character-bible.md`, `style-card.md`, `continuity-log.md` in the workspace. Read them back (via file tool) and summarize to the user in 3-5 bullets. Ask: *"Keep this canon, or should I regenerate with adjustments?"*
+
+### Stage 3 — Character design + references (for each main character)
+
+For each character in `character-bible.md`:
+
+1. Run:
+   ```bash
+   uv run comic character propose "<name>" --role "<role>"
+   ```
+2. Present 3 archetype designs (archetype / visual / personality / voice).
+3. User picks one.
+4. Tell user you'll generate visual references; run:
+   ```bash
+   uv run python scripts/gen_references.py --workspace "$HERMES_COMIC_WORKSPACE" --set <set-name> --candidates 3
+   ```
+   (If using Neon & Ash or Red vs Blue presets, use those set names; otherwise you may need to adapt `scripts/gen_references.py` CHARACTERS dict — check with the user first.)
+5. Tell user to open in Windows Explorer:
+   ```
+   <workspace>\characters\<name>\_candidates\
+   ```
+6. Ask user which numbers per pose (portrait / full_body / action).
+7. Apply picks:
+   ```bash
+   bash scripts/pick_ref.sh <name> portrait <N>
+   bash scripts/pick_ref.sh <name> full_body <N>
+   bash scripts/pick_ref.sh <name> action <N>
+   ```
+
+### Stage 4 — Chapter loop (3 chapters typical for a demo)
+
+For each chapter (aim for 3):
+
+1. Ask user for their rough chapter idea (or propose cold if they want).
+2. Run:
+   ```bash
+   uv run comic chapter propose "<user's idea>"
+   ```
+3. Show 3 beat alternatives (title / hook / beat). User picks.
+4. Generate spec (default ≈10 panels — long enough to breathe, short enough to stay punchy):
+   ```bash
+   uv run comic chapter new "<chosen beat>" --panels 10
+   ```
+   If the user wants a tighter/longer chapter, ask them ("6-8 quick, 10-12 balanced, 14-18 long-form") and pass `--panels` accordingly. Valid range: 4-24.
+5. Summarize: title, summary, number of panels, preview of each panel's description + dialogue.
+6. Ask user if they want to render. If yes:
+   ```bash
+   uv run comic chapter render <N> --seed 42 --concurrency 5
+   ```
+   Concurrency 5 is the default — 5 panels render in parallel, ~1 min for 6-panel chapter, ~2 min for 12-panel chapter. If fal rate-limits appear, drop to `--concurrency 3`.
+7. Tell user the chapter.png path:
+   ```
+   <workspace>\chapters\<NN>\chapter.png
+   ```
+8. **From chapter 2 onward**, offer multimodal continuity check as flagship feature:
+   ```bash
+   uv run comic chapter continuity <N> --multimodal
+   ```
+   Kimi K2.5 will see previous chapter panel images and flag visual inconsistencies. Report issues to user. Offer to regenerate or accept.
+9. Ask user for feedback. If they give style direction (e.g. "more silent panels", "bigger action"):
+   ```bash
+   uv run comic chapter feedback "<user's feedback>"
+   ```
+   This patches `style-card.md` (auto version bump + history snapshot). Let them know next chapter will adapt.
+10. Optional: if user wants plot surprises, propose plot twists:
+    ```bash
+    uv run comic chapter twist <next_chapter>
+    ```
+    Kimi K2-Thinking proposes 3 alternatives with 3-chapter outlines. User picks or declines.
+11. Loop to step 1 for the next chapter.
+
+### Stage 5 — Series export
+
+When the user is satisfied:
+
+```bash
+uv run comic series export
+```
+
+Outputs `<workspace>/series.png` — full webtoon composite with chapter separators. Tell user the path.
+
+Ask if they want a short narrative synopsis written — you can generate one by reading the canon and chapter specs.
+
+### Stage 6 — Publish to a public URL (Optional)
+
+After export, offer the user a real shareable webtoon URL:
+
+*"Your series is ready locally. Want me to publish it as a mobile-first webtoon site with a public URL? I'll build a static bundle (vertical scroll, Twitter share card) and deploy it to surge.sh — takes ~30 seconds."*
+
+If yes:
+```bash
+uv run comic series publish --tagline "<one-line series tagline for Twitter card>"
+```
+
+This:
+1. Builds `<workspace>/_publish/` with `index.html` + copied chapter PNGs
+2. Deploys to `hermes-comic-<slug>.surge.sh` (or user's chosen domain)
+3. Returns the live URL
+
+Surface the URL prominently — user can open on mobile, share on Twitter (cover image + tagline preview), or send to friends.
+
+**Prerequisites (one-time per machine):**
+```bash
+npm install -g surge
+surge login    # free account, first-run prompt
+```
+
+If surge isn't installed, do NOT fall back to hand-written HTML or a fake URL. Report the exact error with the setup commands above.
+
+If the user prefers not to publish:
+```bash
+uv run comic series publish --no-deploy
+```
+Builds bundle locally; user can deploy to Vercel / Netlify / GitHub Pages themselves.
+
+## Presentation rules
+
+- **Format proposals cleanly, not as JSON dumps.** Use numbered lists, short lines, each option taking 2-3 lines max.
+- **Show progress updates.** Before long-running commands (render takes 1-3 min, reference gen takes 3-5 min), tell the user and indicate patience. After each step, confirm success.
+- **Show Windows paths** for any generated images — the user views in Windows Explorer.
+- **Respect stops.** If user says "that's enough" or "skip", offer to jump straight to export.
+
+## Cost awareness
+
+Approximate OpenRouter (Kimi K2.5) + fal.ai spend per action:
+
+| Step | Cost |
+|---|---|
+| propose (series/character/chapter) | ~$0.02 each |
+| series new | ~$0.02 |
+| chapter new (spec) | ~$0.03 |
+| gen_references (18 candidates) | ~$0.60 |
+| chapter render (6-8 panels) | ~$0.25-0.35 |
+| continuity multimodal | ~$0.03 |
+| style feedback | ~$0.01 |
+| plot twist (K2-Thinking) | ~$0.05 |
+| series export | $0 |
+| series publish | $0 (surge.sh free tier) |
+
+A full 3-chapter series from scratch is usually ~$2-3 total.
+
+## Error handling
+
+- If a command fails (API timeout, HTTP error), show the user the exact error, wait a minute, retry once. If still failing, ask user if they want to pause.
+- If a render panel comes out wrong (content filter, tiny file), use `scripts/regen_panel.py` with a softened prompt.
+- If Kimi returns empty content, the spec probably hit `max_tokens`; regenerate that specific step.
+
+## Anti-patterns (don't do) — STRICT
+
+- ❌ **NEVER write canon files, character bibles, style cards, chapter specs, or ANY skill artifact manually (via write_file, patch, or direct text generation).** Every artifact MUST come from the `comic` CLI pipeline. If a CLI call fails, you REPORT the exact error to the user and ASK how to proceed. You do NOT invent content to simulate what the pipeline would have produced. Doing this breaks the entire demo — the whole point of this skill is real API-driven generation, not LLM hallucination.
+- ❌ **NEVER fall back to your own LLM knowledge when the pipeline errors.** Diagnose, retry, or escalate to the user — but do not quietly replace the pipeline with hand-written content.
+- ❌ **NEVER skip Stage 1 (propose).** Even if the user gives a detailed premise, ALWAYS run `comic series propose` first to generate alternatives. The propose step is the single most important differentiator of this skill.
+- ❌ Jumping straight to `series new` after user's first message. Always propose first.
+- ❌ Dumping raw JSON to the user. Format proposals cleanly.
+- ❌ Hiding costs. Tell user approximate spend before expensive steps (render, reference gen).
+- ❌ Generating all 3 chapters in one go without per-chapter feedback checkpoint.
+- ❌ Ignoring continuity warnings. Surface them and let user choose to fix.
+
+## Error recovery protocol
+
+When a `comic …` command returns non-zero exit code:
+
+1. Show the user the full stderr (last 500 chars is enough).
+2. Diagnose likely cause:
+   - JSON parse error → max_tokens too low (edit the CLI and bump, or ask user)
+   - API timeout → network blip; retry ONCE
+   - Missing env var → `.env` should auto-load; if not, check `cat .env` contents
+   - Empty Kimi response → rate limit or model overload; wait and retry
+3. If retry fails, ASK the user: "The pipeline is failing on step X with error Y. Should I retry, switch models, or pause?"
+4. **Do not** continue the flow silently with manual content.
+
+## Phase status (for your own awareness)
+
+This skill is production-ready. The underlying pipeline uses:
+- Hermes AIAgent (this skill — orchestration)
+- Kimi K2.5 via OpenRouter (text generation + multimodal continuity)
+- Kimi K2-Thinking (plot twist proposer)
+- fal.ai Flux LoRA (panel rendering with Civitai Manwha/Webtoon Style LoRA)
+- PIL composer (webtoon assembly with speech bubbles + tails)


### PR DESCRIPTION
## comic-series skill

Full webtoon/manga/manhwa production pipeline orchestrated by Hermes, powered by Kimi K2.5 + fal.ai Flux.

### What it does

One `/comic-series` invocation takes the user from a single sentence premise to a fully published multi-chapter webtoon:

1. **Premise → 3 variants** — Kimi K2.5 proposes 3 distinct story framings, user picks one
2. **World bible + character bible** — canon documents generated and saved to workspace
3. **Character art** — fal.ai Flux + Manhwa LoRA renders portrait / full_body / action references per character
4. **Chapter loop** — for each chapter: beat proposal → 10-panel spec → render (5 panels concurrently) → multimodal continuity check
5. **Multimodal continuity** — Kimi K2.5 sees previous chapter panels as images, flags visual inconsistencies across chapters
6. **Publish** — static mobile-first webtoon viewer deployed to Cloudflare Pages (primary) + Surge.sh (fallback), with Twitter/OG card

### Key features

- **Always proposes, never assumes** — 3 alternatives at every creative decision point
- **Self-improving style** — `chapter feedback` patches `style-card.md` with version history; next chapter adapts
- **Plot twist engine** — optional Kimi K2-Thinking call for long-horizon narrative pivots
- **`comic auto`** — non-interactive one-shot mode for full-series generation from a single command

### Requirements

- `OPENROUTER_API_KEY` or `KIMI_API_KEY`
- `FAL_KEY`
- `SURGE_LOGIN` + `SURGE_TOKEN` (for publish)
- `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` (optional, for CF Pages)

Full setup: https://github.com/eren-karakus0/hermes-comic

### Demo

Live webtoon generated with this skill: https://hermes-comic-timekeeper.surge.sh  
Demo video + X post: https://x.com/Knkchn0/status/2051023382284562716

Built for the Nous × Kimi Creative Hackathon (2026-05-03).