### PR TITLE
fix(kanban): use shared board path for profile workers

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -366,7 +366,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- log ---
     p_log = sub.add_parser(
         "log",
-        help="Print the worker log for a task (from $HERMES_HOME/kanban/logs/)",
+        help="Print the worker log for a task (from <kanban-root>/kanban/logs/)",
     )
     p_log.add_argument("task_id")
     p_log.add_argument("--tail", type=int, default=None,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1,8 +1,16 @@
 """SQLite-backed Kanban board for multi-profile collaboration.
 
-The board lives at ``$HERMES_HOME/kanban.db`` (profile-agnostic on purpose:
-multiple profiles on the same machine all see the same board, which IS the
-coordination primitive).
+The board lives at ``<root>/kanban.db`` where ``<root>`` is the **shared
+Hermes root** (the parent of any active profile). Profiles intentionally
+collapse onto a single board: it IS the cross-profile coordination
+primitive. A worker spawned with ``hermes -p <profile>`` joins the same
+board as the dispatcher that claimed the task. The same applies to
+``<root>/kanban/workspaces/`` and ``<root>/kanban/logs/``.
+
+In standard installs ``<root>`` is ``~/.hermes``. In Docker / custom
+deployments where ``HERMES_HOME`` points outside ``~/.hermes`` (e.g.
+``/opt/hermes``), ``<root>`` is ``HERMES_HOME``. Set ``HERMES_KANBAN_HOME``
+to override the resolution explicitly (tests, unusual deployments).
 
 Schema is intentionally small: tasks, task_links, task_comments,
 task_events.  The ``workspace_kind`` field decouples coordination from git
@@ -61,16 +69,46 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # Paths
 # ---------------------------------------------------------------------------
 
+def kanban_home() -> Path:
+    """Return the shared Hermes root that anchors the kanban board.
+
+    Resolution order:
+
+    1. ``HERMES_KANBAN_HOME`` env var when set and non-empty (explicit
+       override for tests and unusual deployments).
+    2. ``get_default_hermes_root()``, which already returns ``<root>``
+       when ``HERMES_HOME`` is ``<root>/profiles/<name>``, and returns
+       ``HERMES_HOME`` directly for Docker / custom deployments.
+
+    The kanban board is shared across profiles **by design** (see the
+    module docstring). Resolving the kanban paths through the active
+    profile's ``HERMES_HOME`` would silently fork the board per profile,
+    which breaks the dispatcher / worker handoff.
+    """
+    override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
+    if override:
+        return Path(override)
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root()
+
+
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban.db"
+    """Return the path to the shared ``kanban.db``.
+
+    Anchored at :func:`kanban_home`, not the active profile's
+    ``HERMES_HOME``, so profile workers and the dispatcher converge on
+    the same board.
+    """
+    return kanban_home() / "kanban.db"
 
 
 def workspaces_root() -> Path:
-    """Return the directory under which ``scratch`` workspaces are created."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban" / "workspaces"
+    """Return the directory under which ``scratch`` workspaces are created.
+
+    Anchored at :func:`kanban_home` so workspace paths are stable across
+    profile workers spawned by the dispatcher.
+    """
+    return kanban_home() / "kanban" / "workspaces"
 
 
 # ---------------------------------------------------------------------------
@@ -1516,12 +1554,15 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
 def resolve_workspace(task: Task) -> Path:
     """Resolve (and create if needed) the workspace for a task.
 
-    - ``scratch``: a fresh dir under ``$HERMES_HOME/kanban/workspaces/<id>/``.
+    - ``scratch``: a fresh dir under ``<kanban-root>/kanban/workspaces/<id>/``,
+      where ``<kanban-root>`` is the shared Hermes root (see
+      :func:`kanban_home`). The path is the same for the dispatcher and
+      every profile worker, so handoff is path-stable.
     - ``dir:<path>``: the path stored in ``workspace_path``.  Created
       if missing.  MUST be absolute — relative paths are rejected to
       prevent confused-deputy traversal where ``../../../tmp/attacker``
       resolves against the dispatcher's CWD instead of a meaningful
-      root.  Users who want a HERMES_HOME-relative workspace should
+      root.  Users who want a kanban-root-relative workspace should
       compute the absolute path themselves.
     - ``worktree``: a git worktree at ``workspace_path``.  Not created
       automatically in v1 -- the kanban-worker skill documents
@@ -2104,9 +2145,10 @@ def _default_spawn(task: Task, workspace: str) -> Optional[int]:
         "chat",
         "-q", prompt,
     ])
-    # Redirect output to a per-task log under HERMES_HOME/kanban/logs/.
-    from hermes_constants import get_hermes_home
-    log_dir = get_hermes_home() / "kanban" / "logs"
+    # Redirect output to a per-task log under <kanban-root>/kanban/logs/.
+    # Anchored at the shared kanban root, not the worker's profile home,
+    # so `hermes kanban tail` reads the same file the worker writes to.
+    log_dir = kanban_home() / "kanban" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"
     _rotate_worker_log(log_path, DEFAULT_LOG_ROTATE_BYTES)
@@ -2591,8 +2633,7 @@ def gc_worker_logs(
     """Delete worker log files older than ``older_than_seconds``. Returns
     the number of files removed. Kept separate from ``gc_events`` because
     log files live on disk, not in SQLite."""
-    from hermes_constants import get_hermes_home
-    log_dir = get_hermes_home() / "kanban" / "logs"
+    log_dir = kanban_home() / "kanban" / "logs"
     if not log_dir.exists():
         return 0
     cutoff = time.time() - older_than_seconds
@@ -2614,8 +2655,7 @@ def gc_worker_logs(
 def worker_log_path(task_id: str) -> Path:
     """Return the path to a worker's log file. The file may not exist
     (task never spawned, or log already GC'd)."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban" / "logs" / f"{task_id}.log"
+    return kanban_home() / "kanban" / "logs" / f"{task_id}.log"
 
 
 def read_worker_log(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -436,3 +436,174 @@ def test_tenant_propagates_to_events(kanban_home):
     # The "created" event should have tenant in its payload.
     created = [e for e in events if e.kind == "created"]
     assert created and created[0].payload.get("tenant") == "biz-a"
+
+
+# ---------------------------------------------------------------------------
+# Shared-board path resolution (issue #19348)
+#
+# The kanban board is a cross-profile coordination primitive: a worker
+# spawned with `hermes -p <profile>` must read/write the same kanban.db
+# as the dispatcher that claimed the task. These tests exercise the
+# path-resolution layer directly and would have caught the regression
+# where `kanban_db_path()` resolved to the active profile's HERMES_HOME.
+# ---------------------------------------------------------------------------
+
+class TestSharedBoardPaths:
+    """`kanban_home`/`kanban_db_path`/`workspaces_root`/`worker_log_path`
+    must anchor at the **shared root**, not the active profile's HERMES_HOME."""
+
+    def _set_home(self, monkeypatch, tmp_path, hermes_home):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+
+    def test_default_install_anchors_at_home_dot_hermes(
+        self, tmp_path, monkeypatch
+    ):
+        # Standard install: HERMES_HOME == ~/.hermes, no profile active.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+
+        assert kb.kanban_home() == default_home
+        assert kb.kanban_db_path() == default_home / "kanban.db"
+        assert kb.workspaces_root() == default_home / "kanban" / "workspaces"
+        assert (
+            kb.worker_log_path("t_demo")
+            == default_home / "kanban" / "logs" / "t_demo.log"
+        )
+
+    def test_profile_worker_resolves_to_shared_root(
+        self, tmp_path, monkeypatch
+    ):
+        # Reproduces the bug: dispatcher uses ~/.hermes/kanban.db,
+        # worker spawned with -p <profile> previously resolved to
+        # ~/.hermes/profiles/<profile>/kanban.db. After the fix both
+        # converge on ~/.hermes/kanban.db.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        profile_home = default_home / "profiles" / "nehemiahkanban"
+        profile_home.mkdir(parents=True)
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        # All four resolvers must anchor at the shared root, not the
+        # profile-local HERMES_HOME.
+        assert kb.kanban_home() == default_home
+        assert kb.kanban_db_path() == default_home / "kanban.db"
+        assert kb.workspaces_root() == default_home / "kanban" / "workspaces"
+        assert (
+            kb.worker_log_path("t_0d214f19")
+            == default_home / "kanban" / "logs" / "t_0d214f19.log"
+        )
+
+        # Sanity: the profile-local path that used to be returned is
+        # explicitly NOT what we resolve to anymore.
+        assert kb.kanban_db_path() != profile_home / "kanban.db"
+
+    def test_dispatcher_and_profile_worker_converge(
+        self, tmp_path, monkeypatch
+    ):
+        # End-to-end convergence: resolve the path under each side's
+        # HERMES_HOME and confirm equality. This is the property the
+        # dispatcher/worker handoff actually depends on.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        profile_home = default_home / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+
+        # Dispatcher's perspective.
+        self._set_home(monkeypatch, tmp_path, default_home)
+        dispatcher_db = kb.kanban_db_path()
+        dispatcher_ws = kb.workspaces_root()
+        dispatcher_log = kb.worker_log_path("t_handoff")
+
+        # Worker's perspective (profile activated by `hermes -p coder`).
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        worker_db = kb.kanban_db_path()
+        worker_ws = kb.workspaces_root()
+        worker_log = kb.worker_log_path("t_handoff")
+
+        assert dispatcher_db == worker_db
+        assert dispatcher_ws == worker_ws
+        assert dispatcher_log == worker_log
+
+    def test_docker_custom_hermes_home_uses_env_path_directly(
+        self, tmp_path, monkeypatch
+    ):
+        # Docker / custom deployment: HERMES_HOME points outside ~/.hermes.
+        # `get_default_hermes_root()` returns env_home directly when it
+        # is not a `<root>/profiles/<name>` shape and not under
+        # `Path.home() / ".hermes"`.
+        custom_root = tmp_path / "opt" / "hermes"
+        custom_root.mkdir(parents=True)
+        self._set_home(monkeypatch, tmp_path, custom_root)
+
+        assert kb.kanban_home() == custom_root
+        assert kb.kanban_db_path() == custom_root / "kanban.db"
+
+    def test_docker_profile_layout_uses_grandparent(
+        self, tmp_path, monkeypatch
+    ):
+        # Docker profile shape: HERMES_HOME=/opt/hermes/profiles/coder;
+        # `get_default_hermes_root()` walks up to /opt/hermes because
+        # the immediate parent dir is named "profiles".
+        custom_root = tmp_path / "opt" / "hermes"
+        profile = custom_root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        self._set_home(monkeypatch, tmp_path, profile)
+
+        assert kb.kanban_home() == custom_root
+        assert kb.kanban_db_path() == custom_root / "kanban.db"
+
+    def test_explicit_override_via_hermes_kanban_home(
+        self, tmp_path, monkeypatch
+    ):
+        # Explicit override: HERMES_KANBAN_HOME beats every other
+        # resolution rule.
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "any"
+        profile_home.mkdir(parents=True)
+        override = tmp_path / "shared-board"
+        override.mkdir()
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(override))
+
+        assert kb.kanban_home() == override
+        assert kb.kanban_db_path() == override / "kanban.db"
+        assert kb.workspaces_root() == override / "kanban" / "workspaces"
+
+    def test_empty_override_falls_through(self, tmp_path, monkeypatch):
+        # Empty/whitespace override is treated as unset.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        monkeypatch.setenv("HERMES_KANBAN_HOME", "   ")
+
+        assert kb.kanban_home() == default_home
+
+    def test_dispatcher_and_worker_share_a_real_database(
+        self, tmp_path, monkeypatch
+    ):
+        # Belt-and-suspenders: round-trip a task across the two
+        # HERMES_HOME perspectives via a real SQLite file. Without the
+        # fix the worker would open a different file and see no rows.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        profile_home = default_home / "profiles" / "nehemiahkanban"
+        profile_home.mkdir(parents=True)
+
+        # Dispatcher creates the board and a task.
+        self._set_home(monkeypatch, tmp_path, default_home)
+        kb.init_db()
+        with kb.connect() as conn:
+            task_id = kb.create_task(conn, title="cross-profile")
+
+        # Worker switches to the profile HERMES_HOME and reads.
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        with kb.connect() as conn:
+            task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.title == "cross-profile"


### PR DESCRIPTION
## What does this PR do?

The Kanban board is documented as shared across all Hermes profiles, but the implementation resolved `kanban.db`, the workspaces root, and the per-task log directory through `get_hermes_home()`, which returns the **active profile's** HERMES_HOME. So when the dispatcher spawned a worker with `hermes -p <profile> --skills kanban-worker chat -q "work kanban task <id>"`, the worker's `_apply_profile_override()` rewrote HERMES_HOME to `~/.hermes/profiles/<profile>` before `kanban_db.py` imported, opening a profile-local `kanban.db` that did not contain the dispatcher's task. `kanban_show` and `kanban_complete` failed; the dispatcher's row stayed `running` and got retried/crashed. The same defect applied to the worker log directory, so `hermes kanban tail` did not see worker output either.

This PR adds a `kanban_home()` helper that anchors at the shared Hermes root (the parent of any active profile) and reroutes every kanban path consumer through it. Profile-specific config, `.env`, memory, and sessions stay isolated; only the kanban surface is shared, matching the user-guide page and the long-standing module docstring ("profile-agnostic on purpose").

The helper resolves through:

1. `HERMES_KANBAN_HOME` env var (explicit override for tests and unusual deployments).
2. `get_default_hermes_root()`, which already understands the `<root>/profiles/<name>` shape and Docker / custom HERMES_HOME paths.

## Related Issue

Fixes #19348

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`:
  - Add `kanban_home()` (resolves `HERMES_KANBAN_HOME` first, then `get_default_hermes_root()`).
  - Reroute `kanban_db_path()`, `workspaces_root()`, `_default_spawn`'s log dir, `gc_worker_logs`, and `worker_log_path()` through it.
  - Refresh module docstring and the `kanban_db_path` / `workspaces_root` / `resolve_workspace` docstrings to describe shared-root behavior.
- `hermes_cli/kanban.py`: tiny help-string update for the `log` subcommand (was `$HERMES_HOME/kanban/logs/`, now `<kanban-root>/kanban/logs/`).
- `tests/hermes_cli/test_kanban_db.py`: new `TestSharedBoardPaths` regression class (8 tests).

The user-guide page already says "shared across all your Hermes profiles", so the docs are not changed in this PR. The `HERMES_KANBAN_HOME` override is documented in the helper's docstring.

No schema changes, no new config keys, no changes to the dispatcher loop, claim/heartbeat logic, or CLI command surface.

## How to Test

Reproduction (without the fix):

1. On a host with at least one non-default profile (e.g. `nehemiahkanban`), start the gateway (no profile) so the dispatcher uses `~/.hermes/kanban.db`.
2. `hermes kanban create "smoke" --assignee nehemiahkanban`. The task lands in `~/.hermes/kanban.db`.
3. The dispatcher claims and spawns `hermes -p nehemiahkanban --skills kanban-worker chat -q "work kanban task <id>"`.
4. Worker resolves `kanban_db_path()` to `~/.hermes/profiles/nehemiahkanban/kanban.db` (a different file). `kanban_show` / `kanban_complete` fail; the row stays `running`.

After the fix, both sides resolve to `~/.hermes/kanban.db` and the worker can complete the task.

Automated coverage:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py
```

The bug-reproducing tests in `TestSharedBoardPaths` (notably `test_profile_worker_resolves_to_shared_root`, `test_dispatcher_and_profile_worker_converge`, and `test_dispatcher_and_worker_share_a_real_database`) fail on `origin/main` and pass with this PR. The full kanban surface (186 tests) stays green.

Manual cross-platform note: the fix only changes path computation through `pathlib.Path` (no shell, no process management changes). Windows-safe.

### Migrating an in-flight installation

If the bug has already produced profile-local `kanban.db` files, kanban tooling will stop reaching them after this fix. Either:

- Move the rows you care about into `~/.hermes/kanban.db`, or
- Delete the stale profile-local boards (e.g. `rm ~/.hermes/profiles/<name>/kanban.db*`).

The original symlink workaround documented in #19348 (`ln -s ~/.hermes/kanban.db ~/.hermes/profiles/<name>/kanban.db`) keeps working as a stop-gap if needed.

### Note on the `Tests` workflow

The `Tests` job currently fails on `main` with 15 unrelated test failures (gateway teams, systemd unit generation, update flow, concurrent interrupt, credential pool env fallback, dockerfile pid1 reaping, etc.). The exact same set of failures appears on this PR. None of them touch the kanban path layer or are caused by this change. Once the upstream regressions land green on `main`, this PR should follow.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py` and 186 tests pass
- [x] I've added tests for my changes (regression tests fail on `origin/main`, pass with this PR)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`kanban_db.py` docstrings describe the shared-root behavior; the user-guide page already says "shared across all your Hermes profiles")
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; `HERMES_KANBAN_HOME` is an env-var-only escape hatch)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (the fix follows AGENTS.md's existing "Profile operations are HOME-anchored, not HERMES_HOME-anchored" guidance for the same architectural reason)
- [x] I've considered cross-platform impact — only `pathlib.Path` arithmetic, Windows-safe
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
