### PR TITLE
fix(api_server): fall back to default port on malformed API_SERVER_PORT

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -62,6 +62,14 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
 
+def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
+    """Parse a listen port without letting malformed env/config values crash startup."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -573,7 +581,10 @@ class APIServerAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
         self._host: str = extra.get("host", os.getenv("API_SERVER_HOST", DEFAULT_HOST))
-        self._port: int = int(extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))))
+        raw_port = extra.get("port")
+        if raw_port is None:
+            raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
+        self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -240,6 +240,12 @@ class TestAdapterInit:
             "http://127.0.0.1:3000",
         )
 
+    def test_invalid_port_from_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_PORT", "not-a-port")
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        assert adapter._port == 8642
+
 
 # ---------------------------------------------------------------------------
 # Auth checking


### PR DESCRIPTION
## Summary

Fix API server startup so a malformed `API_SERVER_PORT` no longer crashes the adapter during initialization.

## Problem

`gateway.config._apply_env_overrides()` already treats an invalid `API_SERVER_PORT` defensively and simply skips setting `platforms.api_server.extra["port"]`.

But `APIServerAdapter.__init__()` re-read the raw environment variable and did:

    int(os.getenv("API_SERVER_PORT", str(DEFAULT_PORT)))

That meant a value like `API_SERVER_PORT=not-a-port` could still raise `ValueError` and crash API server startup, even though config loading had already tried to tolerate the bad input.

In practice this created an authority mismatch between normalized gateway config and adapter initialization.

## Fix

- Add a small local `_coerce_port()` helper in `gateway/platforms/api_server.py`
- Use normalized `extra["port"]` when present
- Only fall back to `API_SERVER_PORT` when `extra["port"]` is absent
- If the fallback env value is malformed, use `DEFAULT_PORT` (`8642`) instead of crashing

## Why this approach

This keeps the fix narrow and preserves current behavior for valid values while making malformed env input non-fatal. It also aligns adapter startup behavior with the gateway config loader’s existing defensive parsing.

## Tests

Added a regression test in `tests/gateway/test_api_server.py`:

- `test_invalid_port_from_env_falls_back_to_default`

Verified:

- `tests/gateway/test_api_server.py::TestAdapterInit` -> `4 passed`

## User impact

Users with a stale or malformed `API_SERVER_PORT` in their environment will now get the documented default port instead of a startup failure.
