### PR TITLE
fix(update): avoid npm install fallback in lockfile-preserving paths

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1042,18 +1042,17 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     if _tui_need_npm_install(tui_dir):
         if not os.environ.get("HERMES_QUIET"):
             print("Installing TUI dependencies…")
-        result = subprocess.run(
-            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
-            cwd=str(tui_dir),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            text=True,
+        result = _run_npm_install_deterministic(
+            npm,
+            tui_dir,
+            extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
+            allow_install_fallback=False,
             env={**os.environ, "CI": "1"},
         )
         if result.returncode != 0:
             err = (result.stderr or "").strip()
             preview = "\n".join(err.splitlines()[-30:])
-            print("npm install failed.")
+            print("npm ci failed.")
             if preview:
                 print(preview)
             sys.exit(1)
@@ -5266,15 +5265,19 @@ def _run_npm_install_deterministic(
     *,
     extra_args: tuple[str, ...] = (),
     capture_output: bool = True,
+    allow_install_fallback: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
-    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present;
-    falls back to ``npm install`` only if ``npm ci`` fails (e.g. lockfile out of
-    sync on a WIP checkout).  Without this, ``npm install`` on npm ≥ 10 silently
-    rewrites committed lockfiles (stripping ``"peer": true`` etc.), which leaves
-    the working tree dirty and causes the next ``hermes update`` to stash the
-    lockfile — repeatedly.
+    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present.
+    Callers running in update/deployment contexts should set
+    ``allow_install_fallback=False`` so a failed ``npm ci`` leaves the checkout
+    clean instead of falling back to ``npm install``.  The fallback remains
+    available for WIP checkouts where updating the lockfile is acceptable.
+    Without this, ``npm install`` on npm >= 10 silently rewrites committed
+    lockfiles (stripping ``"peer": true`` etc.), leaving the working tree dirty
+    and causing the next ``hermes update`` to stash the lockfile repeatedly.
     """
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
@@ -5285,11 +5288,12 @@ def _run_npm_install_deterministic(
             capture_output=capture_output,
             text=True,
             check=False,
+            env=env,
         )
-        if ci_result.returncode == 0:
+        if ci_result.returncode == 0 or not allow_install_fallback:
             return ci_result
-        # Fall through to `npm install` — lockfile may be out of sync on a
-        # WIP fork/branch, or `npm ci` may not be available on very old npm.
+        # Fall through to `npm install` only for callers that explicitly allow
+        # mutating a WIP checkout to repair an out-of-sync lockfile.
     install_cmd = [npm, "install", *extra_args]
     return subprocess.run(
         install_cmd,
@@ -5297,6 +5301,7 @@ def _run_npm_install_deterministic(
         capture_output=capture_output,
         text=True,
         check=False,
+        env=env,
     )
 
 
@@ -6273,6 +6278,7 @@ def _update_node_dependencies() -> None:
             npm,
             path,
             extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
+            allow_install_fallback=False,
         )
         if result.returncode == 0:
             print(f"  ✓ {label}")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.main import cmd_update, PROJECT_ROOT, _run_npm_install_deterministic
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -163,3 +163,38 @@ class TestCmdUpdateBranchFallback:
             mock_input.assert_not_called()
             captured = capsys.readouterr()
             assert "Non-interactive session" in captured.out
+
+
+def test_deterministic_npm_install_can_refuse_install_fallback(tmp_path):
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="ci failed")
+
+    with patch("subprocess.run", side_effect=fake_run) as mock_run:
+        result = _run_npm_install_deterministic(
+            "/usr/bin/npm",
+            tmp_path,
+            extra_args=("--silent",),
+            allow_install_fallback=False,
+        )
+
+    assert result.returncode == 1
+    assert [call.args[0][1] for call in mock_run.call_args_list] == ["ci"]
+
+
+def test_deterministic_npm_install_fallback_remains_opt_in(tmp_path):
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="failed")
+
+    with patch("subprocess.run", side_effect=fake_run) as mock_run:
+        _run_npm_install_deterministic(
+            "/usr/bin/npm",
+            tmp_path,
+            extra_args=("--silent",),
+            allow_install_fallback=True,
+        )
+
+    assert [call.args[0][1] for call in mock_run.call_args_list] == ["ci", "install"]


### PR DESCRIPTION
## Summary
- Adds an explicit `allow_install_fallback` switch to the deterministic npm install helper.
- Keeps the fallback available for WIP checkouts, but disables it for update/TUI dependency paths where a committed `package-lock.json` should not be rewritten.
- Routes TUI dependency installation through the deterministic helper with `npm ci` when a lockfile exists.

## Why
`npm install` can rewrite committed lockfiles on newer npm versions even when dependency versions do not materially change. In update/deployment contexts that leaves the checkout dirty immediately after an update. If `npm ci` fails in those contexts, the safer behavior is to report the failure and leave the tree clean instead of falling back to a lockfile-mutating install.

## Test plan
```bash
python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py
python -m pytest -o addopts='' tests/hermes_cli/test_cmd_update.py -q
git diff --check
```
