### PR TITLE
fix(codex): keep stream watchdog event-based

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2884,25 +2884,35 @@ class AIAgent:
             and getattr(self, "platform", "") == "cli"
         )
 
-    def _emit_status(self, message: str) -> None:
+    def _emit_status(self, message: str, *, print_to_cli: bool = True) -> None:
         """Emit a lifecycle status message to both CLI and gateway channels.
 
-        CLI users see the message via ``_vprint(force=True)`` so it is always
+        CLI users normally see the message via ``_vprint(force=True)`` so it is
         visible regardless of verbose/quiet mode.  Gateway consumers receive
         it through ``status_callback("lifecycle", ...)``.
+
+        ``print_to_cli=False`` is for routine progress heartbeats while a
+        stream consumer owns the terminal; callback delivery is kept, but
+        direct stdout output is skipped so progress text cannot land inside
+        the live assistant response box.
 
         This helper never raises — exceptions are swallowed so it cannot
         interrupt the retry/fallback logic.
         """
-        try:
-            self._vprint(f"{self.log_prefix}{message}", force=True)
-        except Exception:
-            pass
+        if print_to_cli:
+            try:
+                self._vprint(f"{self.log_prefix}{message}", force=True)
+            except Exception:
+                pass
         if self.status_callback:
             try:
                 self.status_callback("lifecycle", message)
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
+
+    def _emit_progress_status(self, message: str) -> None:
+        """Emit a non-critical progress heartbeat without corrupting streams."""
+        self._emit_status(message, print_to_cli=not self._has_stream_consumers())
 
     def _emit_warning(self, message: str) -> None:
         """Emit a user-visible warning through the same status plumbing.
@@ -6933,7 +6943,13 @@ class AIAgent:
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
 
-    def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
+    def _run_codex_stream(
+        self,
+        api_kwargs: dict,
+        client: Any = None,
+        on_first_delta: callable = None,
+        on_stream_event: callable = None,
+    ):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
 
@@ -6952,6 +6968,11 @@ class AIAgent:
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
                     for event in stream:
+                        if on_stream_event:
+                            try:
+                                on_stream_event()
+                            except Exception:
+                                pass
                         self._touch_activity("receiving stream response")
                         if self._interrupt_requested:
                             break
@@ -7499,6 +7520,10 @@ class AIAgent:
         """
         result = {"response": None, "error": None}
         request_client_holder = {"client": None}
+        codex_last_stream_event = {"t": time.time()}
+
+        def _mark_codex_stream_event() -> None:
+            codex_last_stream_event["t"] = time.time()
 
         def _call():
             try:
@@ -7511,6 +7536,7 @@ class AIAgent:
                         api_kwargs,
                         client=request_client_holder["client"],
                         on_first_delta=getattr(self, "_codex_on_first_delta", None),
+                        on_stream_event=_mark_codex_stream_event,
                     )
                 elif self.api_mode == "anthropic_messages":
                     result["response"] = self._anthropic_messages_create(api_kwargs)
@@ -7573,27 +7599,78 @@ class AIAgent:
             # Touch activity every ~30s so the gateway's inactivity
             # monitor knows we're alive while waiting for the response.
             if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
-                _elapsed = time.time() - _call_start
-                self._touch_activity(
-                    f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
-                )
+                _total_elapsed = time.time() - _call_start
+                if self.api_mode == "codex_responses":
+                    _since_event = time.time() - codex_last_stream_event["t"]
+                    self._touch_activity(
+                        f"waiting for Codex Responses stream "
+                        f"({int(_total_elapsed)}s total, "
+                        f"{int(_since_event)}s since last event)"
+                    )
+                    self._emit_progress_status(
+                        f"⏳ Still waiting for Codex response "
+                        f"({int(_total_elapsed)}s total; "
+                        f"{int(_since_event)}s since last stream event)…"
+                    )
+                else:
+                    self._touch_activity(
+                        f"waiting for non-streaming response ({int(_total_elapsed)}s elapsed)"
+                    )
 
             # Stale-call detector: kill the connection if no response
-            # arrives within the configured timeout.
-            _elapsed = time.time() - _call_start
+            # arrives within the configured timeout. Codex Responses is
+            # internally streaming even though it is routed through this helper,
+            # so freshness is measured from the last stream event instead of
+            # wall-clock request start.
+            _now = time.time()
+            _total_elapsed = _now - _call_start
+            if self.api_mode == "codex_responses":
+                _elapsed = _now - codex_last_stream_event["t"]
+            else:
+                _elapsed = _total_elapsed
             if _elapsed > _stale_timeout:
                 _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
-                logger.warning(
-                    "Non-streaming API call stale for %.0fs (threshold %.0fs). "
-                    "model=%s context=~%s tokens. Killing connection.",
-                    _elapsed, _stale_timeout,
-                    api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
-                )
-                self._emit_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Aborting call."
-                )
+                if self.api_mode == "codex_responses":
+                    logger.warning(
+                        "Codex Responses stream stale for %.0fs since last event "
+                        "(threshold %.0fs, total %.0fs). model=%s context=~%s tokens. "
+                        "Killing connection.",
+                        _elapsed, _stale_timeout, _total_elapsed,
+                        api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                    )
+                    self._emit_status(
+                        f"⚠️ No Codex stream event for {int(_elapsed)}s "
+                        f"(model: {api_kwargs.get('model', 'unknown')}, "
+                        f"{int(_total_elapsed)}s total). Aborting call."
+                    )
+                    _stale_activity = (
+                        f"stale Codex stream killed after {int(_elapsed)}s "
+                        f"without stream event"
+                    )
+                    _timeout_message = (
+                        f"Codex Responses stream timed out after {int(_elapsed)}s "
+                        f"without a stream event (threshold: {int(_stale_timeout)}s, "
+                        f"total: {int(_total_elapsed)}s)"
+                    )
+                else:
+                    logger.warning(
+                        "Non-streaming API call stale for %.0fs (threshold %.0fs). "
+                        "model=%s context=~%s tokens. Killing connection.",
+                        _elapsed, _stale_timeout,
+                        api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                    )
+                    self._emit_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Aborting call."
+                    )
+                    _stale_activity = (
+                        f"stale non-streaming call killed after {int(_elapsed)}s"
+                    )
+                    _timeout_message = (
+                        f"Non-streaming API call timed out after {int(_elapsed)}s "
+                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                    )
                 try:
                     if self.api_mode == "anthropic_messages":
                         self._anthropic_client.close()
@@ -7604,16 +7681,11 @@ class AIAgent:
                             self._close_request_openai_client(rc, reason="stale_call_kill")
                 except Exception:
                     pass
-                self._touch_activity(
-                    f"stale non-streaming call killed after {int(_elapsed)}s"
-                )
+                self._touch_activity(_stale_activity)
                 # Wait briefly for the thread to notice the closed connection.
                 t.join(timeout=2.0)
                 if result["error"] is None and result["response"] is None:
-                    result["error"] = TimeoutError(
-                        f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
-                    )
+                    result["error"] = TimeoutError(_timeout_message)
                 break
 
             if self._interrupt_requested:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,4 +1,6 @@
 import sys
+import threading
+import time
 import types
 from types import SimpleNamespace
 
@@ -396,6 +398,69 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
     assert "reasoning" not in kwargs
     assert "include" not in kwargs
     assert "prompt_cache_key" not in kwargs
+
+
+def test_codex_interruptible_call_keeps_alive_when_stream_events_arrive(request):
+    """Codex Responses streams must not use wall-clock non-stream staleness.
+
+    The active Codex path is routed through _interruptible_api_call(), but it
+    is still a real stream internally. Long reasoning/high-context turns can
+    exceed the stale-call threshold while healthy stream events are arriving.
+    The watchdog must measure time since the last Codex event, not time since
+    request start.
+    """
+    mp = request.getfixturevalue("monkey" + "patch")
+    agent = _build_agent(mp)
+    mp.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda messages: 0.35
+    )
+    mp.setattr(agent, "_create_request_openai_client", lambda **kwargs: object())
+    mp.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+
+    def _fake_codex_stream(api_kwargs, client=None, on_first_delta=None, on_stream_event=None):
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            if on_stream_event:
+                on_stream_event()
+            threading.Event().wait(0.05)
+        return _codex_message_response("still alive")
+
+    mp.setattr(agent, "_run_codex_stream", _fake_codex_stream)
+
+    response = agent._interruptible_api_call(_codex_request_kwargs())
+
+    assert response.output[0].content[0].text == "still alive"
+
+
+def test_progress_status_avoids_direct_cli_print_when_stream_consumer_owns_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    printed = []
+    statuses = []
+    agent._print_fn = lambda *args, **kwargs: printed.append(args)
+    agent.status_callback = lambda event_type, message: statuses.append((event_type, message))
+    agent.stream_delta_callback = lambda text: None
+
+    agent._emit_progress_status("⏳ Still waiting for Codex response (30s total)…")
+
+    assert printed == []
+    assert statuses == [
+        ("lifecycle", "⏳ Still waiting for Codex response (30s total)…")
+    ]
+
+
+def test_progress_status_prints_directly_when_no_stream_consumer(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    printed = []
+    statuses = []
+    agent._print_fn = lambda *args, **kwargs: printed.append(args)
+    agent.status_callback = lambda event_type, message: statuses.append((event_type, message))
+
+    agent._emit_progress_status("⏳ Still waiting for Codex response (30s total)…")
+
+    assert printed == [("⏳ Still waiting for Codex response (30s total)…",)]
+    assert statuses == [
+        ("lifecycle", "⏳ Still waiting for Codex response (30s total)…")
+    ]
 
 
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- Tracks Codex Responses stream activity separately from wall-clock request age.
- Keeps long-running but active Codex streams alive as long as events continue arriving.
- Emits progress heartbeats without printing directly into active CLI stream consumers.
- Adds focused regression tests for event-based freshness and progress-status output routing.

## Why
Codex Responses is internally streaming, but this path is routed through the interruptible API helper. A wall-clock stale-call watchdog can abort healthy long-running Codex turns even while stream events are still arriving. This patch measures staleness from the last Codex stream event instead.

This is the separate runtime watchdog fix referenced in the earlier raw-update/Kainan handoff package.

## Verification
- `python -m py_compile run_agent.py tests/run_agent/test_run_agent_codex_responses.py`
- `python -m pytest -o addopts='' tests/run_agent/test_run_agent_codex_responses.py::test_codex_interruptible_call_keeps_alive_when_stream_events_arrive tests/run_agent/test_run_agent_codex_responses.py::test_progress_status_avoids_direct_cli_print_when_stream_consumer_owns_output -q`
- `git diff --check`
