### PR TITLE
fix(anthropic): route OAuth auth flow at correct claude.com/cai endpoints (#15291)

### DIFF
--- a/PATCH.md
+++ b/PATCH.md
@@ -1,0 +1,39 @@
+# ev/oauth-max-billing
+
+## Problem
+On Claude Max subscriptions, OAuth-authenticated Hermes requests bill to
+"extra usage" (org credits) instead of consuming the Max plan quota.
+
+## Root cause
+Wrong OAuth authorize/token/redirect URLs and missing scopes in
+`agent/anthropic_adapter.py`. The legacy `claude.ai/oauth/authorize` URL
+routes through the Console / API-key flow; the current Max flow lives at
+`claude.com/cai/oauth/authorize` with `platform.claude.com` token endpoints.
+
+## Files changed
+- `agent/anthropic_adapter.py` — OAuth constants + one inline URL reference
+
+## Test command (obsolete-if condition)
+This patch is obsolete IF stock upstream `agent/anthropic_adapter.py` already
+contains all of the following constants:
+- `_OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"` (or equivalent)
+- `_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"`
+- `_OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"`
+- `_OAUTH_SCOPES` includes `user:sessions:claude_code`
+
+Quick check:
+```bash
+grep -E '(claude\.com/cai/oauth/authorize|platform\.claude\.com/v1/oauth/token|user:sessions:claude_code)' agent/anthropic_adapter.py | wc -l
+# obsolete if output >= 3
+```
+
+## Watched upstream issues / PRs
+- https://github.com/NousResearch/hermes-agent/issues/15291 (primary — "OAuth CC billing all usage as extra usage")
+- https://github.com/NousResearch/hermes-agent/issues/15080
+- https://github.com/NousResearch/hermes-agent/issues/10575
+- Our PR will be linked here after open.
+
+## Evidence
+See ANALYSIS.md (saved at /tmp/oauth-fix-cc/ANALYSIS.md at investigation time)
+or the original investigation in this session's record. Independent verification
+from the actual claude CLI v2.1.126 binary confirmed the four wrong constants.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1012,10 +1012,19 @@ def run_oauth_setup_token() -> Optional[str]:
 # Mirrors the flow used by Claude Code, pi-ai, and OpenCode.
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
+# OAuth flow constants — match Claude Code v2.1.x prod config (binary symbol v_q).
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-_OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
-_OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
+_OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
+_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+_OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+_OAUTH_SCOPES = (
+    "org:create_api_key "
+    "user:profile "
+    "user:inference "
+    "user:sessions:claude_code "
+    "user:mcp_servers "
+    "user:file_upload"
+)
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
 
 
@@ -1051,7 +1060,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     }
     from urllib.parse import urlencode
 
-    auth_url = f"https://claude.ai/oauth/authorize?{urlencode(params)}"
+    auth_url = f"{_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"
 
     print()
     print("Authorize Hermes with your Claude Pro/Max subscription.")


### PR DESCRIPTION
## Summary

On Claude Max subscriptions, every Hermes request authenticated via OAuth was billing against "extra usage" (org credits) instead of consuming the Max plan quota. This patch fixes four wrong constants in the OAuth flow that were routing users into the Console / API-key flow rather than the Claude Max subscription flow.

Fixes #15291. Related (same-symptom): #15080, #10575.

## Root cause

`agent/anthropic_adapter.py` was using legacy / Console-flow URLs and an incomplete scope set. The post-auth classifier in the actual Claude Code binary (`shouldUseClaudeAIAuth` / `Np`) treats a token as a Claude-AI/Max token iff its scope set contains `user:inference` — but the issued token's billing lane is decided by **which authorize endpoint produced it**, not by the scopes alone. Hitting `claude.ai/oauth/authorize` (the value Hermes was using) routes users into the Console / API-credit lane even when `user:inference` is requested.

## Changes

| Constant | Before | After |
|---|---|---|
| Authorize URL (was inline-hardcoded) | `https://claude.ai/oauth/authorize` | `https://claude.com/cai/oauth/authorize` |
| Token URL | `https://console.anthropic.com/v1/oauth/token` | `https://platform.claude.com/v1/oauth/token` |
| Redirect URI | `https://console.anthropic.com/oauth/code/callback` | `https://platform.claude.com/oauth/code/callback` |
| Scopes | `org:create_api_key user:profile user:inference` | adds `user:sessions:claude_code user:mcp_servers user:file_upload` |

`_OAUTH_CLIENT_ID` (`9d1c250a-…`), the `oauth-2025-04-20` and `claude-code-20250219` beta headers, and the `claude-cli/{version} (external, cli)` user-agent / `x-app: cli` header are all unchanged — they were already correct.

The hardcoded `auth_url = f"https://claude.ai/oauth/authorize?{urlencode(params)}"` line in `run_hermes_oauth_login_pure` is now replaced with `auth_url = f"{_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"` so the constant is the single source of truth.

## Verification

Constants extracted and verified directly against the official Claude Code v2.1.126 binary at `/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`. Relevant minified prod-config object (binary symbol `v_q`):

```js
v_q = {
  BASE_API_URL: "https://api.anthropic.com",
  CONSOLE_AUTHORIZE_URL: "https://platform.claude.com/oauth/authorize",
  CLAUDE_AI_AUTHORIZE_URL: "https://claude.com/cai/oauth/authorize",
  TOKEN_URL: "https://platform.claude.com/v1/oauth/token",
  MANUAL_REDIRECT_URL: "https://platform.claude.com/oauth/code/callback",
  CLIENT_ID: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
  ...
}
```

Scope sets in the same module:
```js
N_q  = ["org:create_api_key", "user:profile"]                                                   // CONSOLE_OAUTH_SCOPES
qv_  = ["user:profile", "user:inference", "user:sessions:claude_code",
        "user:mcp_servers", "user:file_upload"]                                                 // CLAUDE_AI_OAUTH_SCOPES
ZV6  = dedup(N_q ∪ qv_)                                                                         // ALL_OAUTH_SCOPES
```

The authorize-URL builder (`buildAuthUrl` / `GI_`) attaches `ALL_OAUTH_SCOPES` when `loginWithClaudeAi=true && inferenceOnly=false` (the standard Max sign-in case) — which is why this patch keeps `org:create_api_key` rather than dropping it. The real CLI sends it on the Max flow too.

Notably: the legacy URL `https://claude.ai/oauth/authorize` is **not present anywhere** in the current `claude` binary — confirming it's a deprecated / aliased URL that is now routing to the Console flow server-side.

## Test plan

Manual end-to-end on a Claude Max account:
1. Run `hermes auth add anthropic` → OAuth browser flow now opens `claude.com/cai/oauth/authorize` and lists the full Claude-Code scope set on the consent screen.
2. Disable extra usage at https://claude.ai/settings/usage.
3. Confirm normal agent usage no longer fails with HTTP 400 "out of extra usage" and that Max-plan quota counters move (`https://claude.ai/settings/usage` reflects consumption).

I'll happily provide additional artifacts from the binary investigation (full constant export map, `buildAuthUrl` source, `shouldUseClaudeAIAuth` check) if useful for review.

## Remaining uncertainty

The exact server-side mechanism that distinguishes a Max-token from a Console-token at issuance time is not directly observable from the client binary — only the symptom is. The client-side branching in `buildAuthUrl` (`loginWithClaudeAi ? CLAUDE_AI_AUTHORIZE_URL : CONSOLE_AUTHORIZE_URL`) plus the absence of any other discriminating parameter in the authorize-URL request strongly implies the host/path is the discriminator, but I cannot prove that vs. e.g. a server-side scope-set check. The client-side fix is identical either way.
