### PR TITLE
fix(vision): guard user_prompt type before debug_call_data construction

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -439,6 +439,8 @@ async def vision_analyze_tool(
         - For local file paths, the file is used directly and NOT deleted
         - Supports common image formats (JPEG, PNG, GIF, WebP, etc.)
     """
+    if not isinstance(user_prompt, str):
+        user_prompt = str(user_prompt) if user_prompt is not None else ""
     debug_call_data = {
         "parameters": {
             "image_url": image_url,


### PR DESCRIPTION
## What does this PR do?

`vision_analyze_tool` builds `debug_call_data` before the `try` block, calling `len(user_prompt)` and `user_prompt[:200]` directly. If `user_prompt` is not a string (`None`, `int`, etc.), this raises an uncaught `TypeError` before the function's error handling activates.

## Type of Change
- [x] Bug fix

## Changes Made
- Added type guard at function entry to normalize `user_prompt` to `str` before `debug_call_data` is constructed

## How to Test
```python
vision_analyze_tool(image_url="http://example.com/img.jpg", user_prompt=None)
```
Before: raises `TypeError`. After: returns proper error response.

## Checklist
- [x] Tested locally
- [x] No secrets in diff