### PR TITLE
fix(discord): add voice and command sync config knobs

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -25,6 +25,22 @@ logger = logging.getLogger(__name__)
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 
+
+def _positive_float_env(name: str, default: float) -> float:
+    """Parse a positive float environment variable without breaking import."""
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %.2f", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Invalid %s=%r; value must be > 0; using default %.2f", name, raw, default)
+        return default
+    return value
+
 try:
     import discord
     from discord import Message as DiscordMessage, Intents
@@ -488,8 +504,9 @@ class DiscordAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 2000
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
 
-    # Auto-disconnect from voice channel after this many seconds of inactivity
-    VOICE_TIMEOUT = 300
+    # Auto-disconnect from voice channel after this many seconds of inactivity.
+    # Override with HERMES_DISCORD_VOICE_TIMEOUT, e.g. 3600 for one hour.
+    VOICE_TIMEOUT_DEFAULT = 300.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -824,9 +841,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.info("[%s] Skipping Discord slash command sync (policy=off)", self.name)
                 return
 
+            sync_guild_id = self._get_discord_command_sync_guild_id()
+            sync_guild = discord.Object(id=sync_guild_id) if sync_guild_id else None
+            sync_scope = f"guild {sync_guild_id}" if sync_guild_id else "global"
+
             if sync_policy == "bulk":
-                synced = await asyncio.wait_for(self._client.tree.sync(), timeout=30)
-                logger.info("[%s] Synced %d slash command(s) via bulk tree sync", self.name, len(synced))
+                if sync_guild is not None:
+                    # Guild-scoped command registration propagates immediately and
+                    # uses a separate, friendlier bucket. This is useful for live
+                    # debugging without touching global application commands.
+                    self._client.tree.copy_global_to(guild=sync_guild)
+                    synced = await asyncio.wait_for(self._client.tree.sync(guild=sync_guild), timeout=30)
+                else:
+                    synced = await asyncio.wait_for(self._client.tree.sync(), timeout=30)
+                logger.info("[%s] Synced %d slash command(s) via bulk tree sync (%s)", self.name, len(synced), sync_scope)
                 return
 
             # Discord's per-app command-management bucket is ~5 writes / 20 s,
@@ -836,11 +864,14 @@ class DiscordAdapter(BasePlatformAdapter):
             # left slash commands broken for ~60 min until the bucket fully
             # recovered. Use a wide ceiling; the cap still guards against a
             # true hang. (#16713)
-            summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
+            summary = await asyncio.wait_for(
+                self._safe_sync_slash_commands(guild_id=sync_guild_id), timeout=600
+            )
             logger.info(
-                "[%s] Safely reconciled %d slash command(s): unchanged=%d updated=%d recreated=%d created=%d deleted=%d",
+                "[%s] Safely reconciled %d slash command(s) (%s): unchanged=%d updated=%d recreated=%d created=%d deleted=%d",
                 self.name,
                 summary["total"],
+                sync_scope,
                 summary["unchanged"],
                 summary["updated"],
                 summary["recreated"],
@@ -859,16 +890,43 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
 
     def _get_discord_command_sync_policy(self) -> str:
-        raw = str(os.getenv("DISCORD_COMMAND_SYNC_POLICY", "safe") or "").strip().lower()
+        raw_value = self.config.extra.get(
+            "command_sync_policy",
+            self.config.extra.get("sync_policy", os.getenv("DISCORD_COMMAND_SYNC_POLICY", "safe")),
+        )
+        raw = str(raw_value or "").strip().lower()
         if raw in _DISCORD_COMMAND_SYNC_POLICIES:
             return raw
         if raw:
             logger.warning(
-                "[%s] Invalid DISCORD_COMMAND_SYNC_POLICY=%r; falling back to 'safe'",
+                "[%s] Invalid Discord command sync policy %r; falling back to 'safe'",
                 self.name,
                 raw,
             )
         return "safe"
+
+    def _get_discord_command_sync_guild_id(self) -> Optional[int]:
+        """Optional guild ID for faster, isolated Discord command sync.
+
+        Global application commands are slow to propagate and share the app's
+        harsh command-management bucket. A guild ID keeps live debugging out of
+        the global bucket and makes slash command changes visible quickly.
+        """
+        raw_value = self.config.extra.get(
+            "command_sync_guild_id",
+            self.config.extra.get("sync_guild_id", os.getenv("DISCORD_COMMAND_SYNC_GUILD_ID", "")),
+        )
+        raw = str(raw_value or "").strip()
+        if not raw:
+            return None
+        if raw.isdigit():
+            return int(raw)
+        logger.warning(
+            "[%s] Ignoring invalid Discord command sync guild ID %r",
+            self.name,
+            raw,
+        )
+        return None
 
     def _canonicalize_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Reduce command payloads to the semantic fields Hermes manages."""
@@ -961,8 +1019,13 @@ class DiscordAdapter(BasePlatformAdapter):
             "options": canonical["options"],
         }
 
-    async def _safe_sync_slash_commands(self) -> Dict[str, int]:
-        """Diff existing global commands and only mutate the commands that changed."""
+    async def _safe_sync_slash_commands(self, guild_id: Optional[int] = None) -> Dict[str, int]:
+        """Diff existing commands and only mutate the commands that changed.
+
+        When ``guild_id`` is provided, reconcile guild-scoped commands instead
+        of global commands. This is much faster for development and avoids the
+        global application-command propagation/bucket mess.
+        """
         if not self._client:
             return {
                 "total": 0,
@@ -983,7 +1046,8 @@ class DiscordAdapter(BasePlatformAdapter):
             (int(payload.get("type", 1) or 1), str(payload.get("name", "") or "").lower()): payload
             for payload in desired_payloads
         }
-        existing_commands = await tree.fetch_commands()
+        fetch_guild = discord.Object(id=guild_id) if guild_id else None
+        existing_commands = await tree.fetch_commands(guild=fetch_guild)
         existing_by_key = {
             (
                 int(getattr(getattr(command, "type", None), "value", getattr(command, "type", 1)) or 1),
@@ -1002,7 +1066,10 @@ class DiscordAdapter(BasePlatformAdapter):
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:
-                await http.upsert_global_command(app_id, desired)
+                if guild_id:
+                    await http.upsert_guild_command(app_id, guild_id, desired)
+                else:
+                    await http.upsert_global_command(app_id, desired)
                 created += 1
                 continue
 
@@ -1014,16 +1081,26 @@ class DiscordAdapter(BasePlatformAdapter):
                 continue
 
             if self._patchable_app_command_payload(current_existing_payload) == self._patchable_app_command_payload(desired):
-                await http.delete_global_command(app_id, current.id)
-                await http.upsert_global_command(app_id, desired)
+                if guild_id:
+                    await http.delete_guild_command(app_id, guild_id, current.id)
+                    await http.upsert_guild_command(app_id, guild_id, desired)
+                else:
+                    await http.delete_global_command(app_id, current.id)
+                    await http.upsert_global_command(app_id, desired)
                 recreated += 1
                 continue
 
-            await http.edit_global_command(app_id, current.id, desired)
+            if guild_id:
+                await http.edit_guild_command(app_id, guild_id, current.id, desired)
+            else:
+                await http.edit_global_command(app_id, current.id, desired)
             updated += 1
 
         for current in existing_by_key.values():
-            await http.delete_global_command(app_id, current.id)
+            if guild_id:
+                await http.delete_guild_command(app_id, guild_id, current.id)
+            else:
+                await http.delete_global_command(app_id, current.id)
             deleted += 1
 
         return {
@@ -1717,10 +1794,14 @@ class DiscordAdapter(BasePlatformAdapter):
             self._voice_timeout_handler(guild_id)
         )
 
+    def _get_voice_timeout(self) -> float:
+        """Return the Discord voice-channel inactivity timeout in seconds."""
+        return _positive_float_env("HERMES_DISCORD_VOICE_TIMEOUT", self.VOICE_TIMEOUT_DEFAULT)
+
     async def _voice_timeout_handler(self, guild_id: int) -> None:
-        """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
+        """Auto-disconnect after the configured voice inactivity timeout."""
         try:
-            await asyncio.sleep(self.VOICE_TIMEOUT)
+            await asyncio.sleep(self._get_voice_timeout())
         except asyncio.CancelledError:
             return
         text_ch_id = self._voice_text_channels.get(guild_id)

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -74,6 +74,7 @@ class FakeTree:
     def __init__(self):
         self.sync = AsyncMock(return_value=[])
         self.fetch_commands = AsyncMock(return_value=[])
+        self.copy_global_to = MagicMock()
         self._commands = []
 
     def command(self, *args, **kwargs):
@@ -274,6 +275,7 @@ async def test_connect_does_not_wait_for_slash_sync(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 
     monkeypatch.setenv("DISCORD_COMMAND_SYNC_POLICY", "bulk")
+    monkeypatch.delenv("DISCORD_COMMAND_SYNC_GUILD_ID", raising=False)
     monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
     monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
 
@@ -718,3 +720,108 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+@pytest.mark.asyncio
+async def test_post_connect_bulk_sync_can_target_guild(monkeypatch):
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={"command_sync_policy": "bulk", "command_sync_guild_id": "1234"},
+        )
+    )
+
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "Object",
+        lambda *, id: SimpleNamespace(id=id),
+        raising=False,
+    )
+
+    fake_tree = FakeTree()
+    adapter._client = SimpleNamespace(tree=fake_tree)
+
+    await adapter._run_post_connect_initialization()
+
+    copied_guild = fake_tree.copy_global_to.call_args.kwargs["guild"]
+    synced_guild = fake_tree.sync.await_args.kwargs["guild"]
+    assert copied_guild.id == 1234
+    assert synced_guild.id == 1234
+
+
+@pytest.mark.asyncio
+async def test_safe_sync_slash_commands_can_target_guild(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "Object",
+        lambda *, id: SimpleNamespace(id=id),
+        raising=False,
+    )
+
+    desired = {
+        "name": "voice",
+        "description": "Voice controls",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+    }
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            assert tree is not None
+            return dict(desired)
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand()],
+        fetch_commands=AsyncMock(return_value=[]),
+    )
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(),
+        upsert_guild_command=AsyncMock(),
+        edit_guild_command=AsyncMock(),
+        delete_guild_command=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands(guild_id=1234)
+
+    assert summary["created"] == 1
+    assert fake_tree.fetch_commands.await_args.kwargs["guild"].id == 1234
+    fake_http.upsert_guild_command.assert_awaited_once_with(999, 1234, desired)
+    fake_http.upsert_global_command.assert_not_awaited()
+
+
+def test_discord_command_sync_config_prefers_config_extra(monkeypatch):
+    monkeypatch.setenv("DISCORD_COMMAND_SYNC_POLICY", "off")
+    monkeypatch.setenv("DISCORD_COMMAND_SYNC_GUILD_ID", "1111")
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={"command_sync_policy": "bulk", "command_sync_guild_id": "2222"},
+        )
+    )
+
+    assert adapter._get_discord_command_sync_policy() == "bulk"
+    assert adapter._get_discord_command_sync_guild_id() == 2222
+
+
+def test_discord_voice_timeout_env_parser(monkeypatch):
+    monkeypatch.setenv("HERMES_DISCORD_VOICE_TIMEOUT", "3600")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    assert adapter._get_voice_timeout() == 3600.0
+
+
+def test_discord_voice_timeout_env_parser_rejects_non_positive(monkeypatch):
+    monkeypatch.setenv("HERMES_DISCORD_VOICE_TIMEOUT", "0")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    assert adapter._get_voice_timeout() == 300.0


### PR DESCRIPTION
## Summary
- add `HERMES_DISCORD_VOICE_TIMEOUT` for Discord voice-channel idle disconnects
- allow Discord slash command sync policy and guild ID to come from config extras as well as env vars
- support guild-scoped safe/bulk command sync to avoid global command propagation and rate-limit pain

## Test Plan
- `python -m py_compile gateway/platforms/discord.py tests/gateway/test_discord_connect.py`
- `python -m pytest tests/gateway/test_discord_connect.py -q -o 'addopts='`
- `git diff --check upstream/main...HEAD`
