### PR TITLE
fix: prune stale Discord slash commands before creating

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -999,6 +999,21 @@ class DiscordAdapter(BasePlatformAdapter):
         deleted = 0
         http = self._client.http
 
+        # Discord caps global application commands at 100. If the remote app is
+        # already at the cap, creating replacement commands before pruning stale
+        # ones fails with "maximum number of application commands reached" and
+        # leaves the stale bloat intact. Prune commands Hermes no longer wants
+        # first so the later upserts have room to succeed.
+        stale_by_key = {
+            key: command
+            for key, command in existing_by_key.items()
+            if key not in desired_by_key
+        }
+        for key, current in stale_by_key.items():
+            await http.delete_global_command(app_id, current.id)
+            existing_by_key.pop(key, None)
+            deleted += 1
+
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1071,8 +1071,9 @@ DEFAULT_CONFIG = {
         # Accepts comma-separated string ("list_guilds,list_channels,fetch_messages")
         # or YAML list. Unknown names are dropped with a warning at load time.
         # Actions: list_guilds, server_info, list_channels, channel_info,
-        # list_roles, member_info, search_members, fetch_messages, list_pins,
-        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        # create_channel, list_roles, member_info, search_members, fetch_messages,
+        # list_pins, pin_message, unpin_message, create_thread, add_role,
+        # remove_role.
         "server_actions": "",
     },
 

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -448,6 +448,80 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
+async def test_safe_sync_slash_commands_prunes_stale_before_creating():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    calls = []
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            assert tree is not None
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+            self._payload = payload
+
+        def to_dict(self):
+            return {"id": self.id, "application_id": 999, **self._payload}
+
+    desired_created = {
+        "name": "status",
+        "description": "Show Hermes session status",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+    }
+    existing_deleted = _ExistingCommand(
+        13,
+        {
+            "name": "stale-skill",
+            "description": "Legacy per-skill slash command",
+            "type": 1,
+            "options": [],
+            "nsfw": False,
+            "dm_permission": True,
+            "default_member_permissions": None,
+        },
+    )
+
+    async def _delete(_app_id, command_id):
+        calls.append(("delete", command_id))
+
+    async def _upsert(_app_id, payload):
+        calls.append(("upsert", payload["name"]))
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand(desired_created)],
+        fetch_commands=AsyncMock(return_value=[existing_deleted]),
+    )
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(side_effect=_upsert),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(side_effect=_delete),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary["created"] == 1
+    assert summary["deleted"] == 1
+    assert calls == [("delete", 13), ("upsert", "status")]
+
+
+@pytest.mark.asyncio
 async def test_safe_sync_slash_commands_recreates_metadata_only_diffs():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -21,6 +21,7 @@ from tools.discord_tool import (
     _enrich_403,
     _get_bot_token,
     _load_allowed_actions_config,
+    _normalize_channel_name,
     _reset_capability_cache,
     check_discord_tool_requirements,
     discord_admin_handler,
@@ -283,6 +284,140 @@ class TestChannelInfo:
         assert result["name"] == "general"
         assert result["type"] == "text"
         assert result["guild_id"] == "111"
+
+
+# ---------------------------------------------------------------------------
+# Action: create_channel
+# ---------------------------------------------------------------------------
+
+class TestCreateChannel:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel_minimal(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "99", "name": "ai-command-center", "type": 0,
+            "guild_id": "111", "parent_id": None, "topic": None,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="ai-command-center",
+        ))
+        assert result["success"] is True
+        assert result["channel_id"] == "99"
+        assert result["name"] == "ai-command-center"
+        assert result["type"] == "text"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "ai-command-center", "type": 0},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel_with_parent_and_topic(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "100", "name": "research", "type": 0,
+            "guild_id": "111", "parent_id": "10", "topic": "Research work",
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="research",
+            parent_id="10", topic="Research work",
+        ))
+        assert result["success"] is True
+        assert result["parent_id"] == "10"
+        assert result["topic"] == "Research work"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={
+                "name": "research", "type": 0,
+                "parent_id": "10", "topic": "Research work",
+            },
+        )
+
+    def test_create_channel_requires_guild_id_and_name(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(action="create_channel"))
+        assert "error" in result
+        assert "guild_id" in result["error"]
+        assert "name" in result["error"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_normalizes_uppercase_and_spaces(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "200", "name": "ai-command-center", "type": 0,
+            "guild_id": "111", "parent_id": None, "topic": None,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="  AI Command Center  ",
+        ))
+        assert result["success"] is True
+        # Body sent to Discord uses the normalized name, not the raw input.
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "ai-command-center", "type": 0},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_strips_invalid_chars(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "201", "name": "research-q3", "type": 0,
+            "guild_id": "111", "parent_id": None, "topic": None,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="Research! Q3 ★ #2024",
+        ))
+        assert result["success"] is True
+        # '!', '★', '#' are stripped; whitespace becomes '-', '#2024' loses '#'.
+        sent_name = mock_req.call_args.kwargs["body"]["name"]
+        assert sent_name == "research-q3-2024"
+
+    def test_create_channel_rejects_empty_after_normalization(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        # All characters get stripped; nothing remains.
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="!!!★",
+        ))
+        assert "error" in result
+        assert "empty after normalization" in result["error"]
+
+    def test_create_channel_rejects_too_long_name(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="x" * 101,
+        ))
+        assert "error" in result
+        assert "1-100" in result["error"]
+
+    def test_create_channel_rejects_whitespace_only(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="   ",
+        ))
+        assert "error" in result
+        # Whitespace-only collapses to length 0 after .strip().
+        assert "1-100" in result["error"]
+
+
+class TestNormalizeChannelName:
+    def test_lowercases_and_dashes_spaces(self):
+        assert _normalize_channel_name("Hello World") == "hello-world"
+
+    def test_collapses_repeated_dashes(self):
+        assert _normalize_channel_name("a   b") == "a-b"
+        assert _normalize_channel_name("a---b") == "a-b"
+
+    def test_strips_edge_dashes(self):
+        assert _normalize_channel_name("--ops--") == "ops"
+
+    def test_drops_disallowed_chars(self):
+        assert _normalize_channel_name("ops!@#$%^&*()") == "ops"
+
+    def test_keeps_underscore_and_digits(self):
+        assert _normalize_channel_name("Build_Logs_2024") == "build_logs_2024"
+
+    def test_empty_after_normalization(self):
+        assert _normalize_channel_name("!!!") == ""
+        assert _normalize_channel_name("   ") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -585,6 +720,7 @@ class TestRegistration:
         entry = registry._tools["discord_admin"]
         desc = entry.schema["description"]
         assert "list_guilds()" in desc
+        assert "create_channel(guild_id, name)" in desc
         assert "add_role(guild_id, user_id, role_id)" in desc
         # Core actions should NOT be in admin description
         assert "fetch_messages(" not in desc

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -28,6 +28,7 @@ actionable guidance the model can relay to the user.
 import json
 import logging
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -291,6 +292,68 @@ def _channel_info(token: str, channel_id: str, **_kwargs: Any) -> str:
     })
 
 
+_CHANNEL_NAME_ALLOWED = re.compile(r"[^a-z0-9_-]")
+_CHANNEL_NAME_WS = re.compile(r"\s+")
+_CHANNEL_NAME_DASHES = re.compile(r"-{2,}")
+
+
+def _normalize_channel_name(name: str) -> str:
+    """Normalize a Discord text-channel name.
+
+    Lowercases, replaces whitespace runs with hyphens, drops chars outside
+    ``[a-z0-9_-]``, collapses repeated hyphens, and trims edge hyphens.
+    Returns ``""`` if the result is empty.
+    """
+    s = (name or "").strip().lower()
+    s = _CHANNEL_NAME_WS.sub("-", s)
+    s = _CHANNEL_NAME_ALLOWED.sub("", s)
+    return _CHANNEL_NAME_DASHES.sub("-", s).strip("-")
+
+
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    parent_id: str = "",
+    topic: str = "",
+    **_kwargs: Any,
+) -> str:
+    """Create a narrow, text-only Discord channel in a guild."""
+    raw = (name or "").strip()
+    if not 1 <= len(raw) <= 100:
+        return json.dumps({
+            "error": f"Channel name length must be 1-100 chars (got {len(raw)}).",
+        })
+    normalized = _normalize_channel_name(raw)
+    if not normalized:
+        return json.dumps({
+            "error": (
+                f"Channel name '{name}' is empty after normalization. "
+                "Allowed chars: a-z, 0-9, '_', '-'."
+            ),
+        })
+
+    body: Dict[str, Any] = {
+        "name": normalized,
+        "type": 0,  # GUILD_TEXT — intentionally narrow, no voice/forum/category creation.
+    }
+    if parent_id:
+        body["parent_id"] = parent_id
+    if topic:
+        body["topic"] = topic
+
+    ch = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+    return json.dumps({
+        "success": True,
+        "channel_id": ch["id"],
+        "name": ch.get("name"),
+        "type": _channel_type_name(ch.get("type", 0)),
+        "guild_id": ch.get("guild_id"),
+        "parent_id": ch.get("parent_id"),
+        "topic": ch.get("topic"),
+    })
+
+
 def _list_roles(token: str, guild_id: str, **_kwargs: Any) -> str:
     """List all roles in a guild."""
     roles = _discord_request("GET", f"/guilds/{guild_id}/roles", token)
@@ -469,6 +532,7 @@ _ACTIONS = {
     "server_info": _server_info,
     "list_channels": _list_channels,
     "channel_info": _channel_info,
+    "create_channel": _create_channel,
     "list_roles": _list_roles,
     "member_info": _member_info,
     "search_members": _search_members,
@@ -495,6 +559,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("server_info", "(guild_id)", "server details + member counts"),
     ("list_channels", "(guild_id)", "all channels grouped by category"),
     ("channel_info", "(channel_id)", "single channel details"),
+    ("create_channel", "(guild_id, name)", "create a text channel; optional parent_id/topic"),
     ("list_roles", "(guild_id)", "roles sorted by position"),
     ("member_info", "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", "(guild_id, query)", "find members by name prefix"),
@@ -514,6 +579,7 @@ _INTENT_GATED_MEMBERS = frozenset({"member_info", "search_members"})
 _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "server_info": ["guild_id"],
     "list_channels": ["guild_id"],
+    "create_channel": ["guild_id", "name"],
     "list_roles": ["guild_id"],
     "member_info": ["guild_id", "user_id"],
     "search_members": ["guild_id", "query"],
@@ -637,8 +703,10 @@ def _build_schema(
             "Available actions:\n"
             f"{manifest_block}\n\n"
             "Call list_guilds first to discover guild_ids, then list_channels for "
-            "channel_ids. Runtime errors will tell you if the bot lacks a specific "
-            "per-guild permission (e.g. MANAGE_ROLES for add_role)."
+            "channel_ids. create_channel only creates text channels and requires "
+            "the bot to have MANAGE_CHANNELS. Runtime errors will tell you if "
+            "the bot lacks a specific per-guild permission (e.g. MANAGE_ROLES "
+            "for add_role)."
             f"{content_note}"
         )
     else:
@@ -682,7 +750,15 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "New thread name (create_thread) or text channel name (create_channel).",
+        },
+        "parent_id": {
+            "type": "string",
+            "description": "Optional Discord category ID to place a created text channel under (create_channel).",
+        },
+        "topic": {
+            "type": "string",
+            "description": "Optional text channel topic, max 1024 characters (create_channel).",
         },
         "limit": {
             "type": "integer",
@@ -754,6 +830,11 @@ _ACTION_403_HINT = {
         "Bot lacks MANAGE_MESSAGES permission in this channel. "
         "Ask the server admin to grant the bot a role that has MANAGE_MESSAGES, "
         "or a per-channel overwrite."
+    ),
+    "create_channel": (
+        "Bot lacks MANAGE_CHANNELS permission in this server, or the bot role "
+        "does not have access to the requested category. Grant Manage Channels "
+        "to the bot role and keep it below Administrator."
     ),
     "unpin_message": (
         "Bot lacks MANAGE_MESSAGES permission in this channel."
@@ -827,6 +908,8 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    parent_id: str = "",
+    topic: str = "",
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -860,6 +943,8 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "parent_id": parent_id,
+        "topic": topic,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -882,6 +967,8 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            parent_id=parent_id,
+            topic=topic,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -911,6 +998,7 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "parent_id": "", "topic": "",
 }
 
 


### PR DESCRIPTION
## Summary
- preserve the local Discord create_channel tool action as a commit
- fix Discord slash-command reconciliation so stale commands are deleted before new commands are created
- prevents 100-command-limit failures when old per-skill/plugin slash commands fill the Discord app quota

## Test plan
- python -m pytest tests/gateway/test_discord_connect.py tests/gateway/test_discord_slash_commands.py tests/tools/test_discord_tool.py -q

## Notes
The observed failure was Discord error 30032: maximum number of application commands reached (100). Desired Hermes commands are ~40; the app had 76 stale commands, mostly legacy per-skill commands. The reconcile order was creating before pruning, so it hit the cap before cleanup could happen.