### PR TITLE
fix(kanban): remove identity override from KANBAN_GUIDANCE to preserve SOUL.md role-purity

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -183,8 +183,8 @@ SKILLS_GUIDANCE = (
 )
 
 KANBAN_GUIDANCE = (
-    "# You are a Kanban worker\n"
-    "You were spawned by the Hermes Kanban dispatcher to execute ONE task from "
+    "# Kanban task execution protocol\n"
+    "You have been assigned a task from the Hermes Kanban board. Execute ONE task from "
     "the shared board at `~/.hermes/kanban.db`. Your task id is in "
     "`$HERMES_KANBAN_TASK`; your workspace is `$HERMES_KANBAN_WORKSPACE`. "
     "The `kanban_*` tools in your schema are your primary coordination surface — "

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -444,7 +444,7 @@ def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
         skip_memory=True,
     )
     prompt = a._build_system_prompt()
-    assert "You are a Kanban worker" not in prompt
+    assert "Kanban task execution protocol" not in prompt
     assert "kanban_show()" not in prompt
 
 
@@ -468,7 +468,7 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     )
     prompt = a._build_system_prompt()
     # Header phrase
-    assert "You are a Kanban worker" in prompt
+    assert "Kanban task execution protocol" in prompt
     # Lifecycle signals
     assert "kanban_show()" in prompt
     assert "kanban_complete" in prompt


### PR DESCRIPTION
## Summary

`KANBAN_GUIDANCE` in `agent/prompt_builder.py` previously started with `"# You are a Kanban worker"`, which redefined the agent identity at layer 3 of the system prompt, overriding the profile-specific `SOUL.md` loaded at layer 1. This broke role-purity enforcement — e.g., a code-reviewer profile bound by SOUL.md to never write code would still implement code when spawned as a Kanban worker.

## Changes

- **`agent/prompt_builder.py`**: Replace `"# You are a Kanban worker"` with `"# Kanban task execution protocol"` and rephrase the opening sentence from `"You were spawned by the Hermes Kanban dispatcher to execute ONE task"` to `"You have been assigned a task from the Hermes Kanban board. Execute ONE task"` — removing identity-redefining language while preserving all lifecycle instructions unchanged.
- **`tests/tools/test_kanban_tools.py`**: Update assertions to match the new header text.

## Root Cause

`_build_system_prompt()` in `run_agent.py` assembles the prompt as:
1. SOUL.md (identity)
2. HERMES_AGENT_HELP_GUIDANCE
3. KANBAN_GUIDANCE ← was redefining identity here
4. Memory, Skills, Context files

The identity statement at layer 3 diluted SOUL.md at layer 1, and combined with recency bias from the task user message, completed the override chain.

## Testing

All 31 tests in `tests/tools/test_kanban_tools.py` pass, including both `test_kanban_guidance_not_in_normal_prompt` and `test_kanban_guidance_in_worker_prompt`.

Fixes #19351