### PR TITLE
fix(skills): protect hub-installed skills with non-ASCII display names from curator

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -237,6 +237,87 @@ def test_is_agent_created(skills_home):
     assert is_agent_created("hubbed") is False
 
 
+def test_hub_installed_non_ascii_display_name_excluded_from_list(skills_home):
+    """Hub skill whose SKILL.md name: is non-ASCII must not appear in curator list.
+
+    Regression for #19293: lock.json key is the URL slug (e.g. "getnote") but
+    _read_skill_name() returns the display name (e.g. "Get笔记"). Before the fix,
+    the display name was not in the off_limits set so the skill was wrongly
+    classified as agent-created and eligible for archiving.
+    """
+    from tools.skill_usage import list_agent_created_skill_names
+    skills_dir = skills_home / "skills"
+
+    # Hub-installed skill: directory slug "getnote", SKILL.md name "Get笔记"
+    hub_skill_dir = skills_dir / "getnote"
+    hub_skill_dir.mkdir(parents=True)
+    (hub_skill_dir / "SKILL.md").write_text(
+        "---\nname: Get笔记\ndescription: get note\n---\n",
+        encoding="utf-8",
+    )
+
+    # Unrelated agent-created skill that must still appear
+    _write_skill(skills_dir, "my-agent-skill")
+
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps({
+            "version": 1,
+            "installed": {
+                "getnote": {
+                    "source": "well-known",
+                    "install_path": "getnote",
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    names = list_agent_created_skill_names()
+    assert "Get笔记" not in names, "hub-installed skill with non-ASCII name must be excluded"
+    assert "getnote" not in names, "hub slug must also be excluded"
+    assert "my-agent-skill" in names, "unrelated agent skill must still appear"
+
+
+def test_is_agent_created_non_ascii_display_name(skills_home):
+    """is_agent_created() must return False for the non-ASCII display name of a
+    hub-installed skill, not just for its slug.
+
+    Regression for #19293: archive_skill("Get笔记") would proceed when it should
+    be blocked, because is_agent_created("Get笔记") returned True even though the
+    skill was recorded in lock.json under slug "getnote".
+    """
+    from tools.skill_usage import is_agent_created
+    skills_dir = skills_home / "skills"
+
+    hub_skill_dir = skills_dir / "getnote"
+    hub_skill_dir.mkdir(parents=True)
+    (hub_skill_dir / "SKILL.md").write_text(
+        "---\nname: Get笔记\ndescription: get note\n---\n",
+        encoding="utf-8",
+    )
+
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps({
+            "version": 1,
+            "installed": {
+                "getnote": {
+                    "source": "well-known",
+                    "install_path": "getnote",
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    assert is_agent_created("Get笔记") is False, "display name must be recognised as hub-installed"
+    assert is_agent_created("getnote") is False, "slug must still be recognised as hub-installed"
+    assert is_agent_created("other-skill") is True, "unrelated skill must still be agent-created"
+
+
 def test_agent_created_skips_archive_and_hub_dirs(skills_home):
     from tools.skill_usage import list_agent_created_skill_names
     skills_dir = skills_home / "skills"

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -133,6 +133,9 @@ def _read_hub_installed_names() -> Set[str]:
     """Return the set of skill names installed via the Skills Hub.
 
     Reads ~/.hermes/skills/.hub/lock.json (see tools/skills_hub.py :: HubLockFile).
+    Returns both the lock-file slug keys (e.g. ``"getnote"``) and the SKILL.md
+    ``name:`` display values (e.g. ``"Get笔记"``) so that hub-installed skills
+    with non-ASCII display names are correctly protected from curator pruning.
     """
     lock_path = _skills_dir() / ".hub" / "lock.json"
     if not lock_path.exists():
@@ -142,7 +145,20 @@ def _read_hub_installed_names() -> Set[str]:
         if isinstance(data, dict):
             installed = data.get("installed") or {}
             if isinstance(installed, dict):
-                return {str(k) for k in installed.keys()}
+                names: Set[str] = {str(k) for k in installed.keys()}
+                skills_base = _skills_dir()
+                for slug, entry in installed.items():
+                    install_path = (
+                        entry.get("install_path")
+                        if isinstance(entry, dict)
+                        else None
+                    )
+                    skill_dir = install_path or str(slug)
+                    skill_md = skills_base / skill_dir / "SKILL.md"
+                    if skill_md.exists():
+                        display_name = _read_skill_name(skill_md, fallback=str(slug))
+                        names.add(display_name)
+                return names
     except (OSError, json.JSONDecodeError) as e:
         logger.debug("Failed to read hub lock file: %s", e)
     return set()


### PR DESCRIPTION
## What does this PR do?

`_read_hub_installed_names()` returned only the lock.json slug keys (e.g. \`"getnote"\`). `list_agent_created_skill_names()` reads each SKILL.md's \`name:\` field via `_read_skill_name()` and checks it against that slug-only set. When the display name is non-ASCII (e.g. \`"Get笔记"\`), it is never found in the set — so the skill is wrongly classified as agent-created and handed to the curator, which archives (silently deletes) it.

**Root cause:** `_read_hub_installed_names()` line 145 — `return {str(k) for k in installed.keys()}` — only collects slugs. `is_agent_created("Get笔记")` checks whether \`"Get笔记"\` is in \`{"getnote"}\` → False → returns True (wrongly agent-created). Same mismatch hits `archive_skill()` and the mutation guards.

**Fix:** After collecting slugs, iterate over installed entries and read each skill's SKILL.md display name via the existing `_read_skill_name()` helper; add it to the set alongside the slug. Uses `install_path` from the lock entry as the directory path (falls back to slug for lock files written before `install_path` was recorded). No behaviour change for ASCII-only names where slug == display name.

## Related Issue

Fixes #19293

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/skill_usage.py`: extend `_read_hub_installed_names()` to also include SKILL.md display names (+17 lines)
- `tests/tools/test_skill_usage.py`: 2 regression tests — `list_agent_created_skill_names` excludes non-ASCII hub skill; `is_agent_created` returns False for non-ASCII display name (+81 lines)

## How to Test

```bash
python3.11 -m pytest tests/tools/test_skill_usage.py -v --override-ini="addopts="
```

All 40 tests pass (38 existing + 2 new).

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] Single logical change
- [x] pytest run — 40 passed
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A (pure Python, Path-safe)
- [x] Tool descriptions — N/A