### PR TITLE
fix(compressor): skip non-string tool content in dedup pass to prevent AttributeError

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -569,6 +569,8 @@ class ContextCompressor(ContextEngine):
             # Skip multimodal content (list of content blocks)
             if isinstance(content, list):
                 continue
+            if not isinstance(content, str):
+                continue
             if len(content) < 200:
                 continue
             h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]


### PR DESCRIPTION
## What does this PR do?

In `_prune_old_tool_results`, the deduplication pass skips `list` content but then calls `content.encode()` directly. If a tool result has non-string content (e.g. `dict`, `int`, `bool`), this raises `AttributeError` and breaks context compression entirely.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `if not isinstance(content, str): continue` guard immediately after the existing list check in the dedup pass

## How to Test
Pass a tool message with `dict` content through `_prune_old_tool_results` — before this fix it raises `AttributeError`, after it skips safely.

## Checklist
- [x] 66 tests passing
- [x] No secrets in diff