### PR TITLE
fix(security): require explicit allowlist or TEAMS_ALLOW_ALL_USERS opt-in for Teams approval buttons

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -371,8 +371,25 @@ class TeamsAdapter(BasePlatformAdapter):
             )
 
         # Only authorized users may click approval buttons.
+        # Default-deny: require either TEAMS_ALLOWED_USERS or an explicit
+        # TEAMS_ALLOW_ALL_USERS=true opt-in. Without one of these set, the
+        # bot silently treated every clicker as authorized — meaning any
+        # Teams user who could message the bot could approve dangerous commands.
         allowed_csv = os.getenv("TEAMS_ALLOWED_USERS", "").strip()
-        if allowed_csv:
+        allow_all = os.getenv("TEAMS_ALLOW_ALL_USERS", "").strip().lower() in ("1", "true", "yes")
+
+        if not allow_all:
+            if not allowed_csv:
+                logger.warning(
+                    "[teams] card action rejected: TEAMS_ALLOWED_USERS not configured "
+                    "and TEAMS_ALLOW_ALL_USERS not set — default deny"
+                )
+                return InvokeResponse(
+                    status=200,
+                    body=AdaptiveCardActionMessageResponse(
+                        value="⛔ Approval buttons require TEAMS_ALLOWED_USERS to be configured."
+                    ),
+                )
             from_account = ctx.activity.from_
             clicker_id = getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")
             allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}


### PR DESCRIPTION
## What does this PR do?

The Teams platform adapter (`plugins/platforms/teams/adapter.py`) had
an asymmetric configuration model that defaulted to **silent open
access** for approval button clicks.

### The vulnerability

```python
# Before (vulnerable)
allowed_csv = os.getenv("TEAMS_ALLOWED_USERS", "").strip()
if allowed_csv:               # ← only enters guard when env var SET
    ...check clicker_id...
# else: falls through directly to resolve_gateway_approval()
```

When `TEAMS_ALLOWED_USERS` was not configured, the authorization block
was entirely skipped. Any Teams user who could message the bot could
click "Always Allow" on a command approval card.

The setup wizard saves a separate `TEAMS_ALLOW_ALL_USERS=true` flag
when the operator skips the allowlist (line 650), but **`_on_card_action`
never reads that flag**. The two flags were not symmetric.

### Attack scenario

1. Org deploys Hermes Teams bot without setting `TEAMS_ALLOWED_USERS`
2. Alice (unprivileged user) sends a message to the bot — starts a session
3. Bot tries to execute `rm -rf /important/data` and posts an approval
   card to the conversation
4. Alice sees the card, clicks "Always Allow" — approval resolves before
   the intended admin notices
5. The command runs. `resolve_gateway_approval(session_key, "always")`
   has no caller-identity check

Group chats amplify this: multiple non-admin users all have click
access to every approval card sent there.

## Fix

Default-deny: require either `TEAMS_ALLOWED_USERS` or explicit
`TEAMS_ALLOW_ALL_USERS=true` opt-in. The two flags are now symmetric
and the setup wizard's "open access" path is honored:

```python
allowed_csv = os.getenv("TEAMS_ALLOWED_USERS", "").strip()
allow_all = os.getenv("TEAMS_ALLOW_ALL_USERS", "").strip().lower() in ("1", "true", "yes")

if not allow_all:
    if not allowed_csv:
        logger.warning("[teams] card action rejected: ...")
        return InvokeResponse(
            status=200,
            body=AdaptiveCardActionMessageResponse(
                value="⛔ Approval buttons require TEAMS_ALLOWED_USERS to be configured."
            ),
        )
    # ...existing allowlist check...
```

This is consistent with the fail-closed pattern used elsewhere in the
codebase (cron SSRF #10180, TUI shell.exec).

## Type of Change

- [x] 🔒 Security fix (CRITICAL — authorization bypass / silent default-allow)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Symmetric with the setup wizard's `TEAMS_ALLOW_ALL_USERS` flag
- [x] No behavior change for properly-configured deployments
- [x] Default-deny — operators get a clear error message instead of silent allow