### PR TITLE
feat(image-gen): honor image_gen.model from config.yaml in plugin dispatch

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -879,6 +879,21 @@ IMAGE_GENERATE_SCHEMA = {
 }
 
 
+def _read_configured_image_model():
+    """Return the value of ``image_gen.model`` from config.yaml, or None."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        if isinstance(section, dict):
+            value = section.get("model")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    except Exception as exc:
+        logger.debug("Could not read image_gen.model: %s", exc)
+    return None
+
+
 def _read_configured_image_provider():
     """Return the value of ``image_gen.provider`` from config.yaml, or None.
 
@@ -915,6 +930,9 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     if not configured or configured == "fal":
         return None
 
+    # Also read configured model so we can pass it to the plugin
+    configured_model = _read_configured_image_model()
+
     try:
         # Import locally so plugin discovery isn't triggered just by
         # importing this module (tests rely on that).
@@ -950,7 +968,10 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        if configured_model:
+            kwargs["model"] = configured_model
+        result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",


### PR DESCRIPTION
## Summary

The image generation tool dispatches to plugin providers without a `model` argument, leaving the plugin to pick its default. Users on OpenRouter, ComfyUI, or custom backends have no config-level way to select a specific model — they have to fork the plugin or patch the tool.

## Change

- Add `_read_configured_image_model()` that reads `image_gen.model` from the active profile's `~/.hermes/config.yaml` (profile-aware via `get_hermes_home()`).
- In `_dispatch_to_plugin_provider()`, forward the resolved model into the plugin's `generate(**kwargs)` call.
- When `image_gen.model` is unset, the plugin falls back to its own default, so existing users see zero behavior change.

## Config example

```yaml
image_gen:
  provider: openrouter
  model: flux-pro          # NEW — forwarded to the plugin
```

## Test plan

- [x] `pytest tests/tools -k image -q` → 170 passed, 7 skipped.
- [x] Manual: set `image_gen.model: flux-pro`, run `hermes image-gen "..."` — the plugin receives `flux-pro`.
- [x] Manual: unset `image_gen.model` — plugin uses its own default (backward compatible).

## Risk

Low. Purely additive: missing config → unchanged behavior. The only new code path is an opt-in config read.
