### PR TITLE
feat(obsidian): add OBSIDIAN_EXCLUDE_DIRS support to vault listing and search

### DIFF
--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -9,6 +9,8 @@ description: Read, search, and create notes in the Obsidian vault.
 
 If unset, defaults to `~/Documents/Obsidian Vault`.
 
+**Excluding directories:** Set `OBSIDIAN_EXCLUDE_DIRS` to a colon-separated list of directory names to skip during listing and search (e.g. `archive:templates`). Useful when the vault contains symlinked or large directories that should not be enumerated.
+
 Note: Vault paths may contain spaces - always quote them.
 
 ## Read a note
@@ -23,8 +25,15 @@ cat "$VAULT/Note Name.md"
 ```bash
 VAULT="${OBSIDIAN_VAULT_PATH:-$HOME/Documents/Obsidian Vault}"
 
+# Build find exclude args from OBSIDIAN_EXCLUDE_DIRS (colon-separated directory names)
+FIND_EXCLUDES=()
+if [ -n "$OBSIDIAN_EXCLUDE_DIRS" ]; then
+  IFS=: read -ra _EXCL <<< "$OBSIDIAN_EXCLUDE_DIRS"
+  for _d in "${_EXCL[@]}"; do FIND_EXCLUDES+=( -not -path "$VAULT/$_d/*" ); done
+fi
+
 # All notes
-find "$VAULT" -name "*.md" -type f
+find "$VAULT" -name "*.md" -type f "${FIND_EXCLUDES[@]}"
 
 # In a specific folder
 ls "$VAULT/Subfolder/"
@@ -35,11 +44,22 @@ ls "$VAULT/Subfolder/"
 ```bash
 VAULT="${OBSIDIAN_VAULT_PATH:-$HOME/Documents/Obsidian Vault}"
 
+# Build exclude args from OBSIDIAN_EXCLUDE_DIRS (colon-separated directory names)
+FIND_EXCLUDES=()
+GREP_EXCLUDES=()
+if [ -n "$OBSIDIAN_EXCLUDE_DIRS" ]; then
+  IFS=: read -ra _EXCL <<< "$OBSIDIAN_EXCLUDE_DIRS"
+  for _d in "${_EXCL[@]}"; do
+    FIND_EXCLUDES+=( -not -path "$VAULT/$_d/*" )
+    GREP_EXCLUDES+=( --exclude-dir="$_d" )
+  done
+fi
+
 # By filename
-find "$VAULT" -name "*.md" -iname "*keyword*"
+find "$VAULT" -name "*.md" -iname "*keyword*" "${FIND_EXCLUDES[@]}"
 
 # By content
-grep -rli "keyword" "$VAULT" --include="*.md"
+grep -rli "keyword" "$VAULT" --include="*.md" "${GREP_EXCLUDES[@]}"
 ```
 
 ## Create a note


### PR DESCRIPTION
## Summary

Adds opt-in directory exclusion via `OBSIDIAN_EXCLUDE_DIRS` environment variable (colon-separated list of directory names).

When set, `find` and `grep` operations in the **List notes** and **Search** sections skip the named directories, preventing unwanted enumeration of symlinked or large subdirectories inside the vault.

- **List notes**: builds `FIND_EXCLUDES` array (`-not -path "$VAULT/$dir/*"` per entry)
- **Search by filename**: same `FIND_EXCLUDES` array appended to `find`
- **Search by content**: adds `GREP_EXCLUDES` array (`--exclude-dir="$dir"` per entry)

When `OBSIDIAN_EXCLUDE_DIRS` is unset the commands are **unchanged** — fully backwards-compatible.

## Example

```bash
export OBSIDIAN_EXCLUDE_DIRS="archive:templates"
# find and grep will now skip $VAULT/archive/ and $VAULT/templates/
```

## Motivation

Vaults that contain symlinked directories (e.g. pointers to large external repos or system config trees) currently have no way to tell Hermes to skip them during vault-wide listing or search. This causes excessive enumeration and can expose unintended content to the agent context.