### PR TITLE
fix(agent): rephrase compressor summariser preamble to avoid Azure content filter

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6,8 +6,8 @@ protecting head and tail context.
 
 Improvements over v2:
   - Structured summary template with Resolved/Pending question tracking
-  - Summarizer preamble: "Do not respond to any questions" (from OpenCode)
-  - Handoff framing: "different assistant" (from Codex) to create separation
+  - Neutral summariser preamble that avoids prompt-injection-shaped phrasing
+    Azure/OpenAI content filters flag as jailbreak attempts
   - "Remaining Work" replaces "Next Steps" to avoid reading as active instructions
   - Clear separator when summary merges into tail message
   - Iterative summary updates (preserves info across multiple compactions)
@@ -738,21 +738,24 @@ class ContextCompressor(ContextEngine):
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
 
         # Preamble shared by both first-compaction and iterative-update prompts.
-        # Inspired by OpenCode's "do not respond to any questions" instruction
-        # and Codex's "another language model" framing.
+        # Phrasing avoids patterns that Azure/OpenAI-compatible content filters
+        # treat as prompt-injection / jailbreak heuristics — earlier wording
+        # like "DIFFERENT assistant", "injected as reference material", and
+        # "Do NOT respond to any questions or requests" produced deterministic
+        # 400 ResponsibleAIPolicyViolation rejections on long sessions (#19362,
+        # follow-up to #6576 / #16114).  Frame the task as plain summarisation
+        # with positive imperatives instead of negated meta-instructions.
         _summarizer_preamble = (
-            "You are a summarization agent creating a context checkpoint. "
-            "Your output will be injected as reference material for a DIFFERENT "
-            "assistant that continues the conversation. "
-            "Do NOT respond to any questions or requests in the conversation — "
-            "only output the structured summary. "
-            "Do NOT include any preamble, greeting, or prefix. "
-            "Write the summary in the same language the user was using in the "
-            "conversation — do not translate or switch to English. "
-            "NEVER include API keys, tokens, passwords, secrets, credentials, "
-            "or connection strings in the summary — replace any that appear "
-            "with [REDACTED]. Note that the user had credentials present, but "
-            "do not preserve their values."
+            "You are a summarization agent. "
+            "Produce a structured summary document of the conversation "
+            "transcript below. "
+            "Begin your output directly with the first section heading; "
+            "output only the structured summary, with no greeting, "
+            "commentary, or acknowledgement. "
+            "Use the same language the user wrote in; do not translate. "
+            "Replace any API keys, tokens, passwords, secrets, credentials, "
+            "or connection strings with [REDACTED] in the summary, and note "
+            "their presence without preserving their values."
         )
 
         # Shared structured template (used by both paths).
@@ -831,10 +834,12 @@ Update the summary using this exact structure. PRESERVE all existing information
 
 {_template_sections}"""
         else:
-            # First compaction: summarize from scratch
+            # First compaction: summarize from scratch.
+            # Phrasing avoids "different assistant" framing — see comment on
+            # _summarizer_preamble above (#19362).
             prompt = f"""{_summarizer_preamble}
 
-Create a structured handoff summary for a different assistant that will continue this conversation after earlier turns are compacted. The next assistant should be able to understand what happened without re-reading the original turns.
+Create a structured archival summary of the conversation transcript below so the conversation can be resumed later from the summary alone, without re-reading the original turns.
 
 TURNS TO SUMMARIZE:
 {content_to_summarize}

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -132,6 +132,72 @@ class TestGenerateSummaryNoneContent:
         assert len(result) < len(msgs)
 
 
+class TestSummarizerPreambleContentFilterSafety:
+    """Regression: summarizer preamble must not use phrases that
+    Azure/OpenAI-compatible content filters score as prompt-injection /
+    jailbreak patterns (#19362).
+
+    The earlier wording — "DIFFERENT assistant", "injected as reference
+    material", "Do NOT respond to any questions or requests" — produced
+    deterministic ``400 ResponsibleAIPolicyViolation`` rejections on the
+    auxiliary compression call once a long session triggered auto-compress.
+    """
+
+    _BANNED_PHRASES = (
+        "DIFFERENT assistant",
+        "different assistant",
+        "injected as reference material",
+        "do not respond to any questions",
+        "do not respond to any requests",
+    )
+
+    def _captured_prompt(self) -> str:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            c._generate_summary(messages)
+        return mock_call.call_args.kwargs["messages"][0]["content"]
+
+    def test_first_compaction_prompt_avoids_jailbreak_phrases(self):
+        prompt = self._captured_prompt()
+        lowered = prompt.lower()
+        for phrase in self._BANNED_PHRASES:
+            assert phrase.lower() not in lowered, (
+                f"Summariser preamble must not contain {phrase!r} — "
+                "Azure/OpenAI content filters flag it as a jailbreak pattern."
+            )
+
+    def test_iterative_update_prompt_avoids_jailbreak_phrases(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "updated summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        c._previous_summary = "## Active Task\nNone."
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            c._generate_summary(messages)
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"].lower()
+        for phrase in self._BANNED_PHRASES:
+            assert phrase.lower() not in prompt, (
+                f"Iterative-update preamble must not contain {phrase!r}."
+            )
+
+
 class TestNonStringContent:
     """Regression: content as dict (e.g., llama.cpp tool calls) must not crash."""
 


### PR DESCRIPTION
Rephrase the context-compression summariser preamble so Azure/OpenAI-compatible content filters stop classifying it as a jailbreak attempt.

## What changed and why
- `agent/context_compressor.py`: replaced the `_summarizer_preamble` (and the first-compaction prompt body that re-echoed the same framing) so it no longer contains the phrases the filters were triggering on:
  - "Your output will be injected as reference material for a DIFFERENT assistant"
  - "Do NOT respond to any questions or requests in the conversation"
  - "different assistant that will continue this conversation"
  These are negated meta-instructions telling the model to ignore the user — i.e., textbook prompt-injection / jailbreak shape — which produced deterministic `400 ResponsibleAIPolicyViolation` (`jailbreak: detected`) on every auto-compress call against Azure/OpenAI-compatible deployments. The earlier `[SYSTEM:` → `[IMPORTANT:` mitigation (#6576 / #16114) handled bracketed markers; this is the remaining, distinct trigger flagged in the issue.
- New preamble frames the task neutrally as a summarisation job using positive imperatives ("Produce a structured summary document", "Begin your output directly with the first section heading", "Replace … with [REDACTED]"). Same intent, no jailbreak-shaped phrasing. Drops the "different assistant" handoff framing entirely — the next session is an implementation detail the summariser doesn't need to know about.
- Updated the module docstring so the design-rationale bullet points reflect the new wording instead of crediting OpenCode/Codex phrases that have been removed.
- `tests/agent/test_context_compressor.py`: new `TestSummarizerPreambleContentFilterSafety` class captures the prompt sent through `call_llm` for both the first-compaction and iterative-update paths and asserts none of the historical trigger phrases reappear, so future edits can't silently regress this Azure compatibility gap.

## How to test
- `pytest tests/agent/test_context_compressor.py -q` (68 passed locally)
- `pytest tests/agent/test_compress_focus.py tests/agent/test_compressor_image_tokens.py tests/agent/test_context_engine.py -q` (35 passed)
- `pytest tests/test_cli_manual_compress.py -q` (1 passed)
- Manual: trigger an auto-compress against an Azure/OpenAI-compatible endpoint that previously returned `content_filter` / `ResponsibleAIPolicyViolation` on the auxiliary summary call; the call should now succeed instead of entering the 60-second summary-failure cooldown.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #19362

<!-- autocontrib:worker-id=issue-new-02096a29 kind=pr-open -->