### PR TITLE
fix(security): bind Meet node server to localhost and restrict token file to owner read

### DIFF
--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -43,7 +43,7 @@ class NodeServer:
 
     def __init__(
         self,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         port: int = 18789,
         token_path: Optional[Path] = None,
         display_name: str = "hermes-meet-node",
@@ -76,6 +76,13 @@ class NodeServer:
             json.dumps({"token": tok, "generated_at": time.time()}, indent=2),
             encoding="utf-8",
         )
+        # Restrict to owner-read-write only — the token grants full RPC
+        # access to the meet bot (start, transcribe, speak in meetings).
+        try:
+            tmp.chmod(0o600)
+        except (OSError, NotImplementedError):
+            # Best-effort on non-POSIX filesystems; mode is set on POSIX.
+            pass
         tmp.replace(self.token_path)
         self._token = tok
         return tok


### PR DESCRIPTION
## What does this PR do?

The Google Meet plugin's node server (`plugins/google_meet/node/server.py`)
has two security weaknesses that combine into a network-exploitable
RPC takeover.

### 1. Default binding to 0.0.0.0 (network exposure)

```python
# Before (vulnerable)
def __init__(
    self,
    host: str = "0.0.0.0",   # ← exposed on all interfaces
    port: int = 18789,
    ...
```

The node server listens on all interfaces. On a developer's laptop on
corporate Wi-Fi, **any machine on the same network** can send requests
to port 18789.

### 2. Token file world-readable (0644)

```python
# Before (vulnerable)
tmp = self.token_path.with_suffix(".json.tmp")
tmp.write_text(
    json.dumps({"token": tok, "generated_at": time.time()}, indent=2),
    encoding="utf-8",
)
tmp.replace(self.token_path)
```

`Path.write_text()` does not set restrictive permissions. With a typical
umask of `022`, the file at `~/.hermes/workspace/meetings/node_token.json`
is created as `-rw-r--r--` (0644) — readable by **any local user** on
the machine.

### Combined attack scenario

1. Developer runs Hermes Meet node server on laptop at `10.0.0.42`
2. Another machine on the same Wi-Fi subnet finds port 18789 open
3. Attacker reads `node_token.json` via any local access path (VS Code
   extension, npm package, browser exploit) — gets the 128-bit token
4. Sends RPC commands to `ws://10.0.0.42:18789` with the stolen token:
   - `start_bot` → bot joins target meeting
   - `transcribe` → reads transcripts
   - `say` → injects attacker text into the meeting
5. Full RPC takeover with no authentication challenge

## Fix

### 1. Default host = `127.0.0.1`

Bind to localhost only by default. For remote deployments that
legitimately need external access, the user must pass `--host 0.0.0.0`
explicitly (and document the firewall rule they need).

```python
def __init__(
    self,
    host: str = "127.0.0.1",   # ← localhost only by default
    ...
```

### 2. `chmod 0o600` on token file

Restrict the token file to owner read/write only, before the atomic
replace:

```python
tmp.write_text(...)
try:
    tmp.chmod(0o600)
except (OSError, NotImplementedError):
    # Best-effort on non-POSIX filesystems
    pass
tmp.replace(self.token_path)
```

The `chmod` is wrapped in try/except for non-POSIX filesystems
(Windows, some FUSE mounts) where it may not apply.

## Type of Change

- [x] 🔒 Security fix (HIGH — credential exposure + network exposure)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Restrictive default — operators must explicitly opt into network exposure
- [x] Best-effort chmod for cross-platform compatibility
- [x] No behavior change for legitimate localhost usage