### PR TITLE
fix(agent): read model.max_tokens from config.yaml

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2773,6 +2773,60 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_max_tokens(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Look up a per-model ``max_tokens`` override from ``custom_providers``.
+
+    Mirrors :func:`get_custom_provider_context_length` for the output cap. Used
+    when a custom OpenAI-compatible proxy forwards to Anthropic models, which
+    require ``max_tokens`` whenever ``tools`` are present (see #19360).
+    Returns ``None`` when no override applies.
+    """
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_max = model_cfg.get("max_tokens")
+        if raw_max is None:
+            continue
+        try:
+            max_tokens = int(raw_max)
+        except (TypeError, ValueError):
+            continue
+        if max_tokens > 0:
+            return max_tokens
+    return None
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1884,6 +1884,34 @@ class AIAgent:
                 )
                 _config_context_length = None
 
+        # Read explicit max_tokens (output cap) override from model config.
+        # OpenAI-compatible proxies that forward to Anthropic models require
+        # max_tokens when tools are present, otherwise the upstream API rejects
+        # the call with HTTP 400. See #19360.
+        # Constructor-passed max_tokens wins over config; only fill in when the
+        # caller didn't supply one.
+        if self.max_tokens is None and isinstance(_model_cfg, dict):
+            _config_max_tokens = _model_cfg.get("max_tokens")
+            if _config_max_tokens is not None:
+                try:
+                    _parsed_max = int(_config_max_tokens)
+                    if _parsed_max <= 0:
+                        raise ValueError
+                    self.max_tokens = _parsed_max
+                    self._session_init_model_config["max_tokens"] = _parsed_max
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Invalid model.max_tokens in config.yaml: %r — "
+                        "must be a positive integer. Ignoring.",
+                        _config_max_tokens,
+                    )
+                    print(
+                        f"\n⚠ Invalid model.max_tokens in config.yaml: {_config_max_tokens!r}\n"
+                        f"  Must be a positive integer (e.g. 4096).\n"
+                        f"  Ignoring; the request will omit max_tokens.\n",
+                        file=sys.stderr,
+                    )
+
         # Resolve custom_providers list once for reuse below (startup
         # context-length override and plugin context-engine init).
         try:
@@ -1946,6 +1974,23 @@ class AIAgent:
         # Persist for reuse on switch_model / fallback activation. Must come
         # AFTER the custom_providers branch so per-model overrides aren't lost.
         self._config_context_length = _config_context_length
+
+        # Per-model max_tokens override from custom_providers (#19360).
+        # Only applies when the caller didn't pass an explicit max_tokens and
+        # no top-level model.max_tokens was set above.
+        if self.max_tokens is None and _custom_providers:
+            try:
+                from hermes_cli.config import get_custom_provider_max_tokens
+                _cp_max_resolved = get_custom_provider_max_tokens(
+                    model=self.model,
+                    base_url=self.base_url,
+                    custom_providers=_custom_providers,
+                )
+                if _cp_max_resolved:
+                    self.max_tokens = int(_cp_max_resolved)
+                    self._session_init_model_config["max_tokens"] = self.max_tokens
+            except Exception:
+                pass
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
 

--- a/tests/run_agent/test_max_tokens_config.py
+++ b/tests/run_agent/test_max_tokens_config.py
@@ -1,0 +1,165 @@
+"""Tests for model.max_tokens config wiring (#19360).
+
+OpenAI-compatible proxies that forward to Anthropic models require
+``max_tokens`` whenever ``tools`` are present, so users must be able to set
+the output cap from config.yaml.
+"""
+
+from unittest.mock import patch
+
+
+def _build_agent(
+    model_cfg,
+    custom_providers=None,
+    model="anthropic/claude-opus-4.6",
+    constructor_max_tokens=None,
+):
+    cfg = {"model": model_cfg}
+    if custom_providers is not None:
+        cfg["custom_providers"] = custom_providers
+
+    base_url = model_cfg.get("base_url", "")
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_tokens=constructor_max_tokens,
+        )
+    return agent
+
+
+def test_model_max_tokens_from_config():
+    """model.max_tokens in config.yaml should be applied to self.max_tokens."""
+    agent = _build_agent({
+        "default": "claude-opus-4.6",
+        "provider": "custom",
+        "base_url": "http://proxy:8045/v1",
+        "max_tokens": 4096,
+    })
+    assert agent.max_tokens == 4096
+    assert agent._session_init_model_config["max_tokens"] == 4096
+
+
+def test_model_max_tokens_string_numeric_works():
+    """String '4096' should parse via int()."""
+    agent = _build_agent({
+        "default": "claude-opus-4.6",
+        "provider": "custom",
+        "base_url": "http://proxy:8045/v1",
+        "max_tokens": "4096",
+    })
+    assert agent.max_tokens == 4096
+
+
+def test_model_max_tokens_invalid_warns_and_ignored():
+    """Invalid values should warn and leave max_tokens unset."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4.6",
+            "provider": "custom",
+            "base_url": "http://proxy:8045/v1",
+            "max_tokens": "4K",
+        })
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "Invalid model.max_tokens" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_model_max_tokens_zero_is_ignored():
+    """A non-positive value isn't a useful cap; ignore it."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4.6",
+            "provider": "custom",
+            "base_url": "http://proxy:8045/v1",
+            "max_tokens": 0,
+        })
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "Invalid model.max_tokens" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_constructor_max_tokens_wins_over_config():
+    """Explicit constructor argument should override config."""
+    agent = _build_agent(
+        {
+            "default": "claude-opus-4.6",
+            "provider": "custom",
+            "base_url": "http://proxy:8045/v1",
+            "max_tokens": 4096,
+        },
+        constructor_max_tokens=8192,
+    )
+    assert agent.max_tokens == 8192
+
+
+def test_no_max_tokens_in_config_keeps_none():
+    """Without config or constructor value, max_tokens stays None."""
+    agent = _build_agent({
+        "default": "claude-opus-4.6",
+        "provider": "custom",
+        "base_url": "http://proxy:8045/v1",
+    })
+    assert agent.max_tokens is None
+
+
+def test_custom_providers_per_model_max_tokens():
+    """custom_providers[i].models.<name>.max_tokens should apply."""
+    custom_providers = [
+        {
+            "name": "AntigravityProxy",
+            "base_url": "http://proxy:8045/v1",
+            "models": {
+                "claude-opus-4-6-thinking": {"max_tokens": 16384},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {
+            "default": "claude-opus-4-6-thinking",
+            "provider": "custom",
+            "base_url": "http://proxy:8045/v1",
+        },
+        custom_providers=custom_providers,
+        model="claude-opus-4-6-thinking",
+    )
+    assert agent.max_tokens == 16384
+
+
+def test_top_level_model_max_tokens_wins_over_custom_providers():
+    """Top-level model.max_tokens takes precedence over per-model entry."""
+    custom_providers = [
+        {
+            "name": "AntigravityProxy",
+            "base_url": "http://proxy:8045/v1",
+            "models": {
+                "claude-opus-4-6-thinking": {"max_tokens": 16384},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {
+            "default": "claude-opus-4-6-thinking",
+            "provider": "custom",
+            "base_url": "http://proxy:8045/v1",
+            "max_tokens": 4096,
+        },
+        custom_providers=custom_providers,
+        model="claude-opus-4-6-thinking",
+    )
+    assert agent.max_tokens == 4096


### PR DESCRIPTION
Wire `model.max_tokens` (and `custom_providers[i].models.<name>.max_tokens`) through `AIAgent.__init__` so requests sent to OpenAI-compatible proxies that forward to Anthropic models include the required output cap when tools are present.

## What changed and why
- `AIAgent.__init__` now reads `model.max_tokens` from `config.yaml` and applies it to `self.max_tokens` when the constructor caller did not pass an explicit value. The example config has documented this field for some time, but nothing in the agent actually read it — so requests went out without `max_tokens`, and proxies translating OpenAI → Anthropic Messages rejected any tool-using request with HTTP 400 ("Request contains an invalid argument"). Reported in #19360.
- Mirrors the existing `context_length` resolution path: top-level `model.max_tokens` first, then per-custom-provider `custom_providers[i].models.<name>.max_tokens`. Invalid (non-positive / non-integer) values log a warning and are ignored.
- Added a `get_custom_provider_max_tokens` helper in `hermes_cli/config.py`, mirroring `get_custom_provider_context_length`, so the lookup has a single source of truth.
- Constructor-passed `max_tokens` still wins over config (preserves existing programmatic overrides).

## How to test
- `pytest tests/run_agent/test_max_tokens_config.py -q` — 8 new tests covering: top-level `model.max_tokens`, string-numeric parsing, invalid value warning, zero/negative ignored, constructor precedence, no-config default, per-custom-provider override, and top-level winning over per-custom-provider entry.
- Manually: set `model.max_tokens: 4096` in `config.yaml`, point `model.base_url` at an OpenAI-compatible proxy that forwards to Anthropic, and confirm tool-using requests no longer 400.

## What platforms tested on
- macOS on darwin-arm64 (local) — full `tests/run_agent/` and `tests/hermes_cli/` config-related suites green. Pre-existing unrelated failures (concurrent_interrupt, systemd/WSL, update flag) reproduce on `main` and are out of scope.

Fixes #19360

<!-- autocontrib:worker-id=issue-new-eda9a382 kind=pr-open -->