### PR TITLE
fix(kanban): share board paths across profiles

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -61,16 +61,26 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # Paths
 # ---------------------------------------------------------------------------
 
+def kanban_root() -> Path:
+    """Return the shared Kanban root for the active Hermes installation.
+
+    Kanban is intentionally profile-agnostic: tasks assigned to different
+    profiles must all see the same board. In profile mode, ``HERMES_HOME``
+    points at ``<root>/profiles/<name>``, so use the profile root instead of
+    the active profile home.
+    """
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root()
+
+
 def kanban_db_path() -> Path:
-    """Return the path to ``kanban.db`` inside the active HERMES_HOME."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban.db"
+    """Return the shared ``kanban.db`` path for this Hermes installation."""
+    return kanban_root() / "kanban.db"
 
 
 def workspaces_root() -> Path:
     """Return the directory under which ``scratch`` workspaces are created."""
-    from hermes_constants import get_hermes_home
-    return get_hermes_home() / "kanban" / "workspaces"
+    return kanban_root() / "kanban" / "workspaces"
 
 
 # ---------------------------------------------------------------------------
@@ -2104,9 +2114,8 @@ def _default_spawn(task: Task, workspace: str) -> Optional[int]:
         "chat",
         "-q", prompt,
     ])
-    # Redirect output to a per-task log under HERMES_HOME/kanban/logs/.
-    from hermes_constants import get_hermes_home
-    log_dir = get_hermes_home() / "kanban" / "logs"
+    # Redirect output to a per-task log under the shared Kanban root.
+    log_dir = kanban_root() / "kanban" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"
     _rotate_worker_log(log_path, DEFAULT_LOG_ROTATE_BYTES)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+import subprocess
 import time
 from pathlib import Path
 
@@ -21,6 +22,68 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+def test_paths_use_shared_root_when_active_home_is_profile(tmp_path, monkeypatch):
+    """Profile workers must share the root Kanban board.
+
+    The dispatcher starts workers as ``hermes -p <assignee>``. Profile mode
+    sets HERMES_HOME to ``<root>/profiles/<assignee>``, but Kanban tasks,
+    workspaces, and logs are intentionally shared across profiles.
+    """
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "researcher"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    assert kb.kanban_root() == root
+    assert kb.kanban_db_path() == root / "kanban.db"
+    assert kb.workspaces_root() == root / "kanban" / "workspaces"
+
+
+def test_default_spawn_writes_log_under_shared_root(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "researcher"
+    workspace = root / "kanban" / "workspaces" / "t_profile"
+    workspace.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    class FakePopen:
+        pid = 4242
+
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+    task = kb.Task(
+        id="t_profile",
+        title="profile worker uses shared board",
+        body=None,
+        assignee="researcher",
+        status="ready",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=str(workspace),
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+    )
+
+    assert kb._default_spawn(task, str(workspace)) == 4242
+    assert (root / "kanban" / "logs" / "t_profile.log").exists()
+    assert not (profile_home / "kanban" / "logs" / "t_profile.log").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make Kanban DB, scratch workspace, and worker log paths resolve through the shared Hermes installation root instead of the active profile home
- preserve the documented multi-profile Kanban behavior where dispatcher, dashboard, operator CLI, and profile workers all use the same `~/.hermes/kanban.db`
- add regression coverage for profile-mode path resolution and worker log placement

## Problem
The Kanban tutorial describes the dashboard and CLI as sharing the same SQLite database at `~/.hermes/kanban.db`, and the dispatcher runs assignee workers as profile-specific Hermes processes.

However, profile mode sets `HERMES_HOME` to `<root>/profiles/<profile>`. The previous Kanban path helpers used `get_hermes_home()`, so a dispatched worker could read/write `<root>/profiles/<profile>/kanban.db` while the dispatcher/operator/dashboard continued using `<root>/kanban.db`. That splits the board state across profiles.

## Fix
Use `get_default_hermes_root()` for Kanban board/workspace/log roots so profile workers operate on the shared Kanban board for the installation.

## Test plan
- `python -m py_compile hermes_cli/kanban_db.py hermes_constants.py`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban*.py -q`
