### PR TITLE
fix(cli): follow 307 redirects in MiniMax OAuth httpx clients

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4283,7 +4283,8 @@ def _minimax_oauth_login(
     print(f"Portal: {portal_base_url}")
 
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      headers={"Accept": "application/json"}) as client:
+                      headers={"Accept": "application/json"},
+                      follow_redirects=True) as client:
         code_data = _minimax_request_user_code(
             client, portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
@@ -4360,7 +4361,8 @@ def _refresh_minimax_oauth_state(
         return state
 
     portal_base_url = state["portal_base_url"]
-    with httpx.Client(timeout=httpx.Timeout(timeout_seconds)) as client:
+    with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
+                      follow_redirects=True) as client:
         response = client.post(
             f"{portal_base_url}/oauth/token",
             data={

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -622,6 +622,7 @@ AUTHOR_MAP = {
     "2557058999@qq.com": "Disaster-Terminator",
     "cine.dreamer.one@gmail.com": "LeonSGP43",
     "zyprothh@gmail.com": "Zyproth",
+    "amitgaur@gmail.com": "amitgaur",
     "leozeli@qq.com": "leozeli",
     "linlehao@cuhk.edu.cn": "LehaoLin",
     "liutong@isacas.ac.cn": "I3eg1nner",


### PR DESCRIPTION
Salvage of #19335 by @amitgaur onto current main.

## Summary
The MiniMax OAuth endpoints moved from `api.minimax.io` to `account.minimax.io` and the old paths now respond with HTTP 307. `httpx` defaults to `follow_redirects=False`, so device-code and token-refresh flows were failing with `Temporary Redirect`. Enables redirect-following on both clients.

## Changes
- hermes_cli/auth.py: `follow_redirects=True` on the two MiniMax OAuth httpx clients (+4/-2)
- scripts/release.py: AUTHOR_MAP entry for @amitgaur

## Validation
scripts/run_tests.sh tests/hermes_cli/ -k minimax → 42 passed

Original PR: #19335