### PR TITLE
fix(vision): guard user_prompt type before debug_call_data construction

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -440,6 +440,8 @@ async def vision_analyze_tool(
         - For local file paths, the file is used directly and NOT deleted
         - Supports common image formats (JPEG, PNG, GIF, WebP, etc.)
     """
+    if not isinstance(user_prompt, str):
+        user_prompt = str(user_prompt) if user_prompt is not None else ""
     debug_call_data = {
         "parameters": {
             "image_url": image_url,


### PR DESCRIPTION
Salvage of #19363 by @sprmn24 onto current main.

## Summary
`vision_analyze_tool` builds `debug_call_data` before the `try` block, calling `len(user_prompt)` and `user_prompt[:200]` directly. If `user_prompt` is a non-string (`None`, `int`, etc.) the function raises `TypeError` before its own error handling activates. Coerce to string at entry.

## Changes
- tools/vision_tools.py: type guard + str coercion at entry (+2/-0)

## Validation
scripts/run_tests.sh tests/tools/ -k vision → passed

Original PR: #19363