### PR TITLE
fix(vision): guard user_prompt type in video_analyze_tool before debug_call_data construction

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -918,6 +918,8 @@ async def video_analyze_tool(
     model: str = None,
 ) -> str:
     """Analyze a video via multimodal LLM. Returns JSON {success, analysis}."""
+    if not isinstance(user_prompt, str):
+        user_prompt = str(user_prompt) if user_prompt is not None else ""
     debug_call_data = {
         "parameters": {
             "video_url": video_url,


### PR DESCRIPTION
Salvage of #19368 by @sprmn24 onto current main.

## Summary
Same bug class as #19395: `video_analyze_tool` builds `debug_call_data` before the `try` block, calling `len(user_prompt)` and `user_prompt[:200]` directly. Non-string `user_prompt` raises `TypeError` before the function's error handling activates. Coerce to string at entry.

## Changes
- tools/vision_tools.py: type guard + str coercion at entry of `video_analyze_tool` (+2/-0)

## Validation
scripts/run_tests.sh tests/tools/ -k "vision or video" → 120 passed

Original PR: #19368