### PR TITLE
fix(compressor): skip non-string tool content in dedup pass to prevent AttributeError

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -569,6 +569,8 @@ class ContextCompressor(ContextEngine):
             # Skip multimodal content (list of content blocks)
             if isinstance(content, list):
                 continue
+            if not isinstance(content, str):
+                continue
             if len(content) < 200:
                 continue
             h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]


### PR DESCRIPTION
Salvage of #19373 by @sprmn24 onto current main.

## Summary
`_prune_old_tool_results` skips `list` content (multimodal blocks) but then calls `content.encode()` directly. If a tool result has non-string content (`dict`, `int`, `bool`), this raises `AttributeError` and breaks context compression entirely. Add an `isinstance(content, str)` guard before the length/hash path.

## Changes
- agent/context_compressor.py: isinstance guard before .encode() (+2/-0)

## Validation
scripts/run_tests.sh tests/agent/ -k compress → 91 passed

Original PR: #19373