### PR TITLE
fix(gateway): surface a user-visible warning on /new when the session's pinned model is no longer valid

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2404,10 +2404,31 @@ class GatewayRunner:
                 pass
             self._cleanup_agent_resources(agent)
 
-    def _cleanup_agent_resources(self, agent: Any) -> None:
-        """Best-effort cleanup for temporary or cached agent instances."""
+    # Exception class names (matched by ``type(exc).__name__``) that we
+    # treat as "the session's pinned model has become invalid" during
+    # cleanup.  Matching by name avoids hard-importing optional SDK
+    # exception types (openai, anthropic) here.  See #6426.
+    _PINNED_MODEL_EXC_NAMES = frozenset({
+        "BadRequestError",
+        "NotFoundError",
+        "AuthenticationError",
+        "PermissionDeniedError",
+    })
+
+    def _cleanup_agent_resources(self, agent: Any) -> Optional[str]:
+        """Best-effort cleanup for temporary or cached agent instances.
+
+        Returns a user-facing warning string when the memory-provider
+        shutdown step fails with a known model/auth error class — typically
+        because the session was pinned to a model the user has since removed
+        from ``config.yaml`` / ``.env`` (issue #6426).  Returns ``None``
+        when cleanup succeeded or when the failure was something else
+        (network blip, plugin bug, etc.).  Callers that don't surface a
+        user-visible message can ignore the return value.
+        """
         if agent is None:
-            return
+            return None
+        cleanup_warning: Optional[str] = None
         try:
             if hasattr(agent, "shutdown_memory_provider"):
                 # Pass the agent's own conversation transcript so memory
@@ -2425,8 +2446,29 @@ class GatewayRunner:
                     agent.shutdown_memory_provider(session_messages)
                 else:
                     agent.shutdown_memory_provider()
-        except Exception:
-            pass
+        except Exception as exc:
+            # Distinguish "your pinned model is gone" from other plugin
+            # failures so /new can tell the user *why* their long-term
+            # memory wasn't summarized into the new session, instead of
+            # silently swallowing the error (the prior behaviour, which
+            # made the deadlock in #6426 invisible to users).  All other
+            # exception classes stay silent — cleanup is best-effort.
+            exc_class = type(exc).__name__
+            if exc_class in self._PINNED_MODEL_EXC_NAMES:
+                logger.warning(
+                    "Memory provider shutdown hit %s — the session's pinned "
+                    "model may no longer be valid; proceeding with reset. (%s)",
+                    exc_class, exc,
+                )
+                cleanup_warning = (
+                    "⚠️ Could not summarize this session into long-term "
+                    "memory before resetting (the previous turn's model is "
+                    "no longer available). Starting fresh anyway."
+                )
+            else:
+                logger.debug(
+                    "Memory provider shutdown failed (best-effort): %s", exc,
+                )
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) to prevent zombie
         # process accumulation.
@@ -2444,6 +2486,7 @@ class GatewayRunner:
             cleanup_stale_async_clients()
         except Exception:
             pass
+        return cleanup_warning
 
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
@@ -6764,13 +6807,17 @@ class GatewayRunner:
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.
         # Guard with getattr because test fixtures may skip __init__.
+        # Capture any user-facing warning from cleanup (e.g. the session's
+        # pinned model is no longer valid — issue #6426) so we can prepend
+        # it to the reset response below.
+        cleanup_warning: Optional[str] = None
         _cache_lock = getattr(self, "_agent_cache_lock", None)
         if _cache_lock is not None:
             with _cache_lock:
                 _cached = self._agent_cache.get(session_key)
                 _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
             if _old_agent is not None:
-                self._cleanup_agent_resources(_old_agent)
+                cleanup_warning = self._cleanup_agent_resources(_old_agent)
         self._evict_cached_agent(session_key)
 
         # Discard any /queue overflow for this session — /new is a
@@ -6860,8 +6907,12 @@ class GatewayRunner:
             _tip_line = ""
 
         if session_info:
-            return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
-        return EphemeralReply(f"{header}{_tip_line}")
+            body = f"{header}\n\n{session_info}{_tip_line}"
+        else:
+            body = f"{header}{_tip_line}"
+        if cleanup_warning:
+            return EphemeralReply(f"{cleanup_warning}\n\n{body}")
+        return EphemeralReply(body)
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -139,3 +139,142 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
     assert other_key in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_new_command_completes_when_pinned_model_invalid_during_cleanup():
+    """Regression for #6426.
+
+    When a session was pinned to a model that the user has since removed
+    from ``config.yaml`` / ``.env``, ``shutdown_memory_provider`` (called
+    on /new before reset_session) makes a summarisation LLM call to that
+    invalid model and the SDK raises a ``BadRequestError``-class
+    exception.  Previously this exception was silently swallowed by a
+    broad ``except Exception: pass`` in ``_cleanup_agent_resources`` and,
+    when combined with the upstream timeout/deadlock surface, left the
+    user with no signal that their long-term memory wasn't summarized.
+
+    This test confirms two guarantees:
+
+    1. The reset still completes (returns a reply, the session_store
+       reset_session call still fires).
+    2. The user is told *why* the summary was skipped — the warning text
+       is prepended to the reset response so the user knows the previous
+       model is no longer available and can fix their config.
+    """
+    import threading
+
+    runner = _make_runner()
+    runner._agent_cache_lock = threading.Lock()
+
+    # Synthetic exception class whose ``__name__`` matches what the
+    # OpenAI / Anthropic SDKs actually raise on an unknown model.  We
+    # don't import the real SDKs — ``_cleanup_agent_resources`` matches
+    # by class-name string for exactly that reason (see the
+    # ``_PINNED_MODEL_EXC_NAMES`` frozenset).
+    class BadRequestError(Exception):
+        pass
+
+    mock_agent = MagicMock()
+
+    def _raise_invalid_model(*args, **kwargs):
+        raise BadRequestError("Invalid model: gpt-4o-deleted")
+
+    mock_agent.shutdown_memory_provider = MagicMock(side_effect=_raise_invalid_model)
+    mock_agent._session_messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi back"},
+    ]
+    # ``close()`` is exercised after the memory-provider step in the
+    # cleanup function — make it a no-op so we test the memory-shutdown
+    # path in isolation.
+    mock_agent.close = MagicMock()
+
+    session_key = build_session_key(_make_source())
+    runner._agent_cache = {session_key: mock_agent}
+
+    reply = await runner._handle_reset_command(_make_event("/new"))
+
+    # Reply is an EphemeralReply (str subclass) so we can substring-check.
+    text = str(reply)
+    assert "Could not summarize" in text, (
+        f"Reset response should include the user-visible warning explaining "
+        f"why long-term memory wasn't summarized, got: {text!r}"
+    )
+    assert "no longer available" in text, (
+        f"Warning should explain the pinned model is no longer available, "
+        f"got: {text!r}"
+    )
+    assert "Session reset" in text or "New session" in text, (
+        f"Reset must still surface the normal reset header so the user "
+        f"sees the operation completed, got: {text!r}"
+    )
+
+    # The cleanup call was actually attempted (not skipped) — the broken
+    # memory provider was invoked exactly once.
+    mock_agent.shutdown_memory_provider.assert_called_once_with(
+        mock_agent._session_messages
+    )
+
+    # The reset itself still happened — session_store.reset_session was
+    # called for this session, so the user is no longer pinned to the
+    # broken model on the next message.
+    runner.session_store.reset_session.assert_called_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_new_command_silent_when_cleanup_succeeds():
+    """Companion to the #6426 regression: when cleanup succeeds the reset
+    response must NOT include the warning prefix.  Otherwise every /new
+    on a healthy session would scare the user.
+    """
+    import threading
+
+    runner = _make_runner()
+    runner._agent_cache_lock = threading.Lock()
+
+    mock_agent = MagicMock()
+    mock_agent.shutdown_memory_provider = MagicMock(return_value=None)
+    mock_agent._session_messages = []
+    mock_agent.close = MagicMock()
+
+    session_key = build_session_key(_make_source())
+    runner._agent_cache = {session_key: mock_agent}
+
+    reply = await runner._handle_reset_command(_make_event("/new"))
+    text = str(reply)
+
+    assert "Could not summarize" not in text
+    assert "no longer available" not in text
+    assert "Session reset" in text or "New session" in text
+
+
+@pytest.mark.asyncio
+async def test_new_command_silent_for_non_model_cleanup_errors():
+    """Companion: unrelated cleanup failures (network blip, plugin bug)
+    must NOT produce the model-specific warning — those stay in debug
+    logs only, matching the prior best-effort cleanup contract.
+    """
+    import threading
+
+    runner = _make_runner()
+    runner._agent_cache_lock = threading.Lock()
+
+    mock_agent = MagicMock()
+    mock_agent.shutdown_memory_provider = MagicMock(
+        side_effect=RuntimeError("plugin internal failure")
+    )
+    mock_agent._session_messages = []
+    mock_agent.close = MagicMock()
+
+    session_key = build_session_key(_make_source())
+    runner._agent_cache = {session_key: mock_agent}
+
+    reply = await runner._handle_reset_command(_make_event("/new"))
+    text = str(reply)
+
+    # No model-specific warning for generic exceptions
+    assert "Could not summarize" not in text
+    assert "no longer available" not in text
+    # But the reset still completes
+    assert "Session reset" in text or "New session" in text


### PR DESCRIPTION
## Summary

When a session was pinned to a specific model and the user later removed or replaced that model in `config.yaml` / `.env`, sending `/new` would trigger `_cleanup_agent_resources` → `agent.shutdown_memory_provider` → the memory provider's summarisation LLM call against the now-invalid model. The OpenAI / Anthropic SDK raises `BadRequestError` (or similar) on the 400, which the existing `except Exception: pass` swallowed silently, leaving the user with no signal about *why* their long-term memory wasn't summarised into the new session — and contributing to the deadlock-shaped UX described in #6426 where the user perceives `/new` as broken.

## What changed

`_cleanup_agent_resources` (gateway/run.py) now narrows its exception handling: known \"your-model-is-gone\" classes (`BadRequestError`, `NotFoundError`, `AuthenticationError`, `PermissionDeniedError` — matched by class name to avoid hard-importing optional SDK exception types) are surfaced through a new `Optional[str]` return value, and `_handle_reset_command` prepends that warning to the reset response so the user sees:

> ⚠️ Could not summarize this session into long-term memory before resetting (the previous turn's model is no longer available). Starting fresh anyway.

All other exception classes stay silent — cleanup is best-effort and a transient plugin/network failure shouldn't scare the user. The reset itself unconditionally proceeds in all cases (the function still returns and `reset_session` still runs), so /new can never deadlock on this exception path.

The other 7 callers of `_cleanup_agent_resources` (shutdown finalize, soft eviction, /compress workflow, etc.) ignore the return value — they aren't user-facing and the prior None semantics still hold for them.

## Test coverage

3 new tests in `tests/gateway/test_session_model_reset.py`:

- `test_new_command_completes_when_pinned_model_invalid_during_cleanup` — monkey-patches `shutdown_memory_provider` to raise a synthetic `BadRequestError` and asserts (a) the reset reply contains the warning text, (b) `reset_session` was still called, (c) the broken provider was actually invoked exactly once.
- `test_new_command_silent_when_cleanup_succeeds` — guard against false positives; healthy /new must not show the scary warning.
- `test_new_command_silent_for_non_model_cleanup_errors` — confirms unrelated exceptions (network blip, plugin bug) do NOT trigger the model-specific warning, so the prior best-effort cleanup contract is preserved.

Targeted run: \`pytest tests/gateway/test_session_model_reset.py tests/gateway/test_session_boundary_hooks.py tests/run_agent/test_background_review.py -o addopts=''\` → **12 passed**, no regressions in adjacent cleanup paths.

## Scope note

This addresses the exception path called out in #6426. If the underlying memory-provider LLM call HANGS instead of raising (which is possible with SDK retry loops or generous default timeouts), bounding cleanup time is a separate fix that would require running cleanup in an executor under `asyncio.wait_for` — left for a follow-up so this PR stays focused on the silent-swallow problem.

Fixes #6426

Made with [Cursor](https://cursor.com)