### PR TITLE
fix(run_agent): gate iteration-limit provider routing to OpenRouter

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10300,7 +10300,10 @@ class AIAgent:
                     provider_preferences["order"] = self.providers_order
                 if self.provider_sort:
                     provider_preferences["sort"] = self.provider_sort
-                if provider_preferences:
+                if provider_preferences and (
+                    (self.provider or "").strip().lower() == "openrouter"
+                    or self._is_openrouter_url()
+                ):
                     summary_extra_body["provider"] = provider_preferences
 
                 if summary_extra_body:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2181,6 +2181,34 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
+        agent.base_url = "https://api.openai.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "openai"
+        agent.providers_allowed = ["Anthropic"]
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "provider" not in kwargs.get("extra_body", {})
+
+    def test_summary_keeps_provider_preferences_for_openrouter(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "openrouter"
+        agent.providers_allowed = ["Anthropic"]
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"]["only"] == ["Anthropic"]
+
     def test_codex_summary_sanitizes_orphan_tool_results(self, agent):
         agent.api_mode = "codex_responses"
         agent.provider = "openai-codex"


### PR DESCRIPTION
## Summary

Fix the iteration-limit summary path so OpenRouter-specific provider routing is only sent to OpenRouter endpoints.

The normal chat-completions request path already gates `extra_body.provider` behind OpenRouter detection, but `_handle_max_iterations()` rebuilt that request shape separately and always forwarded provider preferences when they were configured. On non-OpenRouter providers, that can leak an unsupported `provider` field into the summary request.

This change keeps the summary path aligned with the main request path:
- omit `extra_body.provider` for non-OpenRouter providers
- preserve existing behavior for OpenRouter
- add regression coverage for both cases

Fixes #8591.

## Why this matters

When the agent hits `max_iterations`, it falls back to a final summary call. If provider routing preferences are configured, that fallback request could become invalid on strict non-OpenRouter backends even though normal requests were shaped correctly.

This is a small parity fix, but it affects a user-facing recovery path and prevents avoidable summary-call failures.

## Testing

Ran:
- `tests/run_agent/test_run_agent.py::TestHandleMaxIterations`

Result:
- `7 passed`

Added regression tests for:
- non-OpenRouter summary requests omitting provider preferences
- OpenRouter summary requests preserving provider preferences

