### PR TITLE
feat(discord): interactive components — buttons, select menus, REST + WebSocket paths

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -876,8 +876,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 # to {(component_type, custom_id): Item}.  If any entry
                 # exists, a View callback will handle (or is handling) this
                 # interaction — don't interfere.
-                view_store = adapter_self._client._connection._view_store
-                if message_id and view_store._views.get(int(message_id)):
+                try:
+                    view_store = adapter_self._client._connection._view_store
+                    view_registered = (
+                        message_id
+                        and view_store._views.get(int(message_id))
+                    )
+                except (AttributeError, KeyError):
+                    # discord.py internal — may change across versions
+                    view_registered = False
+
+                if view_registered:
                     return
 
                 # Check if this is an agent component we sent via REST

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -67,6 +67,66 @@ from gateway.platforms.base import (
 )
 from tools.url_safety import is_safe_url
 
+from gateway.platforms.discord_components import (
+    CUSTOM_ID_PREFIX,
+    build_view_from_spec,
+    component_store,
+)
+
+
+def _normalize_component_spec(raw_spec):
+    """Normalize a component spec from the send_message tool to builder format.
+
+    The send_message tool uses the Discord API format::
+
+        [{"components": [{"type": "button", "label": "X", ...}]}]
+
+    The builder expects the friendlier format::
+
+        {"action_rows": [{"buttons": [...]}, {"select": {...}}]}
+
+    This function detects the input format and converts as needed.
+    """
+    if not raw_spec:
+        return None
+    if not isinstance(raw_spec, (list, dict)):
+        logger.warning("Component spec is not a list or dict: %r", type(raw_spec))
+        return None
+
+    # Already in builder format (has "action_rows" key)
+    if isinstance(raw_spec, dict) and "action_rows" in raw_spec:
+        return raw_spec
+
+    # API format: list of action rows, each with a "components" array
+    if isinstance(raw_spec, list):
+        action_rows = []
+        for row in raw_spec:
+            if not isinstance(row, dict):
+                continue
+            row_components = row.get("components", [])
+            buttons = []
+            select = None
+            for comp in row_components:
+                if not isinstance(comp, dict):
+                    continue
+                comp_type = comp.get("type", "button")
+                if comp_type == "button":
+                    buttons.append(comp)
+                elif comp_type in ("string_select", "select"):
+                    select = comp
+            row_dict = {}
+            if buttons:
+                row_dict["buttons"] = buttons
+            if select:
+                row_dict["select"] = select
+            if row_dict:
+                action_rows.append(row_dict)
+        if action_rows:
+            return {"action_rows": action_rows}
+
+    logger.warning("Could not normalize component spec: %r", raw_spec)
+    return None
+
 
 def _clean_discord_id(entry: str) -> str:
     """Strip common prefixes from a Discord user ID or username entry.
@@ -785,6 +845,162 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._handle_message(message)
 
             @self._client.event
+            async def on_interaction(interaction):
+                """Handle Discord component interactions for REST-sent messages.
+
+                discord.py's View system automatically intercepts interactions
+                for messages sent via ``channel.send(view=...)`` (websocket
+                path).  But components sent via the REST API (aiohttp in
+                ``_send_discord``) have no View attached — Discord fires the
+                interaction but nobody acknowledges it, resulting in "This
+                interaction failed" errors.
+
+                This handler catches those orphaned interactions by checking
+                if the message has a registered discord.py View.  If not, it
+                looks up the message_id in the ComponentStore for REST-sent
+                entries, acknowledges the interaction, and routes it as a
+                MessageEvent.
+
+                Note: discord.py 2.x dispatches ``on_interaction`` for ALL
+                interaction types.  We only handle component interactions
+                (type 3) with no registered View.
+                """
+                # Only handle component interactions
+                if interaction.type != discord.InteractionType.component:
+                    return
+
+                message_id = str(interaction.message.id) if interaction.message else ""
+
+                # Check if discord.py has a registered View for this message.
+                # The view_store._views dict is keyed by message_id and maps
+                # to {(component_type, custom_id): Item}.  If any entry
+                # exists, a View callback will handle (or is handling) this
+                # interaction — don't interfere.
+                view_store = adapter_self._client._connection._view_store
+                if message_id and view_store._views.get(int(message_id)):
+                    return
+
+                # Check if this is an agent component we sent via REST
+                tracked = component_store.get(message_id)
+                if not tracked or not tracked.rest_sent:
+                    return
+
+                # Single-use guard: if this interaction was already handled,
+                # acknowledge and ignore (Discord requires *some* response).
+                if tracked.resolved:
+                    try:
+                        await interaction.response.defer()
+                    except Exception:
+                        pass
+                    return
+
+                # Extract component info from the interaction
+                data = interaction.data or {}
+                custom_id_raw = data.get("custom_id", "")
+                component_type = data.get("component_type", 0)
+
+                # Only handle agent components (hermes: prefix)
+                if not custom_id_raw.startswith(CUSTOM_ID_PREFIX):
+                    return
+
+                # Strip the prefix to get the original custom_id
+                original_custom_id = custom_id_raw[len(CUSTOM_ID_PREFIX):]
+
+                # Build interaction text
+                from gateway.platforms.discord_components import (
+                    _format_interaction_text,
+                )
+
+                if component_type == 2:  # Button
+                    label = data.get("label", "")
+                    kind = "Button clicked"
+                    interaction_text = _format_interaction_text(
+                        kind,
+                        label=label,
+                        custom_id=original_custom_id,
+                    )
+                elif component_type == 3:  # String Select
+                    values = data.get("values", [])
+                    kind = "Select chosen"
+                    interaction_text = _format_interaction_text(
+                        kind,
+                        label=values[0] if values else "",
+                        custom_id=original_custom_id,
+                        values=values,
+                    )
+                else:
+                    logger.debug("Unhandled component type %d in on_interaction", component_type)
+                    return
+
+                # Acknowledge the interaction — update the message to disable
+                # components (single-use behavior) and show the user we got it
+                try:
+                    channel = adapter_self._client.get_channel(int(tracked.chat_id))
+                    if channel is None:
+                        channel = await adapter_self._client.fetch_channel(int(tracked.chat_id))
+                    msg = await channel.fetch_message(int(message_id))
+
+                    # Build updated components with all items disabled
+                    updated_components = []
+                    for action_row in (msg.components or []):
+                        row_data = {}
+                        row_comps = []
+                        for comp in action_row.children:
+                            comp_dict = comp.to_dict()
+                            comp_dict["disabled"] = True
+                            row_comps.append(comp_dict)
+                        if row_comps:
+                            row_data["type"] = 1
+                            row_data["components"] = row_comps
+                            updated_components.append(row_data)
+
+                    await interaction.response.edit_message(
+                        content=msg.content,
+                        components=updated_components,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to edit REST-sent component message %s on interaction",
+                        message_id,
+                        exc_info=True,
+                    )
+                    # Fallback: at least acknowledge to prevent the error
+                    try:
+                        await interaction.response.defer()
+                    except Exception:
+                        pass
+
+                # Mark as resolved
+                tracked.resolved = True
+
+                # Route the interaction as a MessageEvent
+                from gateway.platforms.base import MessageEvent, MessageType
+
+                source = adapter_self.build_source(
+                    chat_id=tracked.chat_id,
+                    user_id=str(interaction.user.id),
+                    user_name=str(interaction.user),
+                )
+
+                event = MessageEvent(
+                    text=interaction_text,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    raw_message=interaction,
+                    message_id=message_id,
+                    reply_to_message_id=message_id,
+                )
+
+                try:
+                    await adapter_self.handle_message(event)
+                except Exception:
+                    logger.error(
+                        "Error routing REST component interaction for message %s",
+                        message_id,
+                        exc_info=True,
+                    )
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -1386,6 +1602,12 @@ class DiscordAdapter(BasePlatformAdapter):
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
+            # Build interactive view from component spec in metadata
+            view = None
+            component_spec = None
+            if metadata and metadata.get("components"):
+                component_spec = metadata["components"]
+
             message_ids = []
             reference = None
 
@@ -1404,11 +1626,34 @@ class DiscordAdapter(BasePlatformAdapter):
                     chunk_reference = reference
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
+
+                # Attach the view only to the last chunk
+                chunk_view = None
+                if i == len(chunks) - 1 and component_spec:
+                    # Build the view lazily on first use
+                    if view is None:
+                        session_key = metadata.get("session_key", "") if metadata else ""
+                        # Convert API-format spec to builder format if needed
+                        normalized = _normalize_component_spec(component_spec)
+                        view = build_view_from_spec(
+                            spec=normalized,
+                            message_id="",  # placeholder; updated after send
+                            session_key=session_key,
+                            source=None,  # set after we have channel context
+                            interaction_callback=lambda event: asyncio.ensure_future(
+                                adapter_self.handle_message(event)
+                            ),
+                        )
+                    chunk_view = view
+
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    send_kwargs: dict = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    if chunk_view is not None:
+                        send_kwargs["view"] = chunk_view
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -1427,13 +1672,33 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        send_kwargs_retry: dict = {
+                            "content": chunk,
+                            "reference": None,
+                        }
+                        if chunk_view is not None:
+                            send_kwargs_retry["view"] = chunk_view
+                        msg = await channel.send(**send_kwargs_retry)
                     else:
                         raise
                 message_ids.append(str(msg.id))
+
+            # Store the view and update message_id in ComponentStore
+            if view and message_ids:
+                session_key = metadata.get("session_key", "") if metadata else ""
+                view._message_id = str(message_ids[-1])
+                # Update the view's source with actual channel/user context
+                source = self.build_source(chat_id=str(channel.id), user_id="", user_name="")
+                view._source = source
+                component_store.register(
+                    message_id=message_ids[-1],
+                    view=view,
+                    session_key=session_key,
+                    interaction_callback=lambda event: asyncio.ensure_future(
+                        self.handle_message(event)
+                    ),
+                    source=source,
+                )
 
             return SendResult(
                 success=True,

--- a/gateway/platforms/discord_components.py
+++ b/gateway/platforms/discord_components.py
@@ -1,0 +1,664 @@
+"""
+Discord interactive UI component builders.
+
+Provides View, Button, Select, and Modal builders that allow agents to send
+rich interactive messages through the send_message tool.  Component interactions
+are routed back to the agent as MessageEvent instances.
+
+Uses discord.py's native View system (v1 components).  Views are stored in a
+ComponentStore keyed by message_id for interaction routing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Discord import guard (mirrors discord.py adapter pattern)
+# ---------------------------------------------------------------------------
+try:
+    import discord
+
+    DISCORD_AVAILABLE = True
+except ImportError:
+    DISCORD_AVAILABLE = False
+    discord = None  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CUSTOM_ID_PREFIX = "hermes:"
+"""Prefix baked into every custom_id so we can distinguish agent-created
+components from other bot interactions or native Discord UI."""
+
+DISCORD_CUSTOM_ID_MAX = 100
+"""Discord enforces a 100-character limit on custom_id strings."""
+
+DISCORD_BUTTONS_PER_ROW = 5
+DISCORD_SELECTS_PER_ROW = 1
+DISCORD_ACTION_ROWS_MAX = 5
+
+VIEW_DEFAULT_TIMEOUT = 300  # 5 minutes, matches _ExecApprovalView
+
+# Button style mapping: agent-friendly names → discord.ButtonStyle
+_BUTTON_STYLE_MAP: Dict[str, "discord.ButtonStyle"] = {
+    "primary": discord.ButtonStyle.blurple if discord else None,
+    "secondary": discord.ButtonStyle.grey if discord else None,
+    "success": discord.ButtonStyle.green if discord else None,
+    "danger": discord.ButtonStyle.red if discord else None,
+    "link": discord.ButtonStyle.link if discord else None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _truncate_custom_id(custom_id: str) -> str:
+    """Ensure *custom_id* does not exceed Discord's 100-char limit.
+
+    If truncation is needed, a short content-hash suffix is appended so IDs
+    remain unique even after truncation.
+    """
+    if len(custom_id) <= DISCORD_CUSTOM_ID_MAX:
+        return custom_id
+    hsh = hashlib.sha256(custom_id.encode()).hexdigest()[:8]
+    return f"{custom_id[:DISCORD_CUSTOM_ID_MAX - 9]}_{hsh}"
+
+
+def _format_interaction_text(
+    kind: str,
+    *,
+    label: str = "",
+    value: str = "",
+    custom_id: str = "",
+    values: Optional[List[str]] = None,
+) -> str:
+    """Build a human-readable structured text for an interaction event."""
+    parts = [f"[{kind}]"]
+    if label:
+        parts.append(f"label='{label}'")
+    if value:
+        parts.append(f"value='{value}'")
+    if custom_id:
+        parts.append(f"custom_id='{custom_id}'")
+    if values:
+        parts.append(f"values={values}")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Component spec types (plain dicts, no external dependencies)
+# ---------------------------------------------------------------------------
+
+# Expected component spec shapes (JSON from the agent):
+#
+#   {
+#       "action_rows": [
+#           {
+#               "buttons": [
+#                   {"label": "...", "style": "primary", "custom_id": "...",
+#                    "emoji": "✅", "disabled": false},
+#                   ...
+#               ],
+#               "select": {          # optional, mutually exclusive with buttons
+#                   "placeholder": "Pick one…",
+#                   "custom_id": "...",
+#                   "options": [
+#                       {"label": "A", "value": "a", "description": "Option A"},
+#                       ...
+#                   ],
+#                   "min_values": 1,
+#                   "max_values": 1,
+#               }
+#           },
+#           ...
+#       ],
+#       "timeout": 300,
+#       "single_use": true,
+#   }
+
+
+# ---------------------------------------------------------------------------
+# ComponentStore — tracks live views for interaction routing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _TrackedView:
+    """Internal bookkeeping for a single tracked component view."""
+
+    view: Any  # discord.ui.View (None for REST-sent components)
+    session_key: str
+    interaction_callback: Callable
+    source: Any  # SessionSource
+    created_at: float = field(default_factory=time.time)
+    resolved: bool = False
+    rest_sent: bool = False
+    """True if the components were sent via REST API (aiohttp) rather than
+    through discord.py's websocket adapter.  REST-sent components have no
+    discord.py View attached and need the adapter's on_raw_interaction
+    handler to acknowledge and route them."""
+    chat_id: str = ""
+    """Discord channel ID (populated for REST-sent components so the
+    adapter can build a proper MessageEvent without a View reference)."""
+
+
+class ComponentStore:
+    """Singleton-style store mapping message_id → tracked view metadata.
+
+    The Discord adapter should register views here after sending a message
+    with components.  When a Discord interaction arrives whose custom_id
+    starts with ``CUSTOM_ID_PREFIX``, the adapter can look up the originating
+    view via the interaction's message reference.
+
+    Thread-safety note: all access is expected to happen on the asyncio event
+    loop thread (same as discord.py callbacks), so no explicit locking.
+    """
+
+    def __init__(self) -> None:
+        self._store: Dict[str, _TrackedView] = {}
+
+    # -- public API --------------------------------------------------------
+
+    def register(
+        self,
+        message_id: str,
+        view: Any,
+        session_key: str,
+        interaction_callback: Callable,
+        source: Any,
+        rest_sent: bool = False,
+        chat_id: str = "",
+    ) -> None:
+        """Register a view for the given *message_id*.
+
+        Parameters
+        ----------
+        rest_sent:
+            If True, the components were sent via REST (aiohttp) rather than
+            through the discord.py websocket adapter.  The adapter's
+            ``on_raw_interaction`` handler will be responsible for
+            acknowledging and routing these interactions.
+        chat_id:
+            Discord channel ID (required when *rest_sent* is True).
+        """
+        self._store[message_id] = _TrackedView(
+            view=view,
+            session_key=session_key,
+            interaction_callback=interaction_callback,
+            source=source,
+            rest_sent=rest_sent,
+            chat_id=chat_id,
+        )
+        logger.debug(
+            "Registered component view for message %s (session=%s, rest_sent=%s)",
+            message_id,
+            session_key,
+            rest_sent,
+        )
+
+    def get(self, message_id: str) -> Optional[_TrackedView]:
+        """Return tracked metadata for *message_id*, or ``None``."""
+        return self._store.get(message_id)
+
+    def remove(self, message_id: str) -> None:
+        """Remove a tracked view entry."""
+        self._store.pop(message_id, None)
+
+    def cleanup(self, max_age: float = 600.0) -> int:
+        """Remove entries older than *max_age* seconds.
+
+        Returns the number of entries removed.
+        """
+        now = time.time()
+        expired = [
+            mid for mid, tv in self._store.items()
+            if now - tv.created_at > max_age or tv.resolved
+        ]
+        for mid in expired:
+            del self._store[mid]
+        if expired:
+            logger.debug("Cleaned up %d expired component entries", len(expired))
+        return len(expired)
+
+    @property
+    def size(self) -> int:
+        """Number of currently tracked views."""
+        return len(self._store)
+
+
+# Module-level singleton
+component_store = ComponentStore()
+
+
+# ---------------------------------------------------------------------------
+# AgentComponentView — generic discord.ui.View built from a JSON spec
+# ---------------------------------------------------------------------------
+
+class AgentComponentView(discord.ui.View if discord else object):  # type: ignore[misc]
+    """A :class:`discord.ui.View` dynamically constructed from an agent's
+    component specification dict.
+
+    Parameters
+    ----------
+    spec:
+        The full component spec dict (see module docstring for shape).
+    message_id:
+        The Discord snowflake ID of the message this view is attached to.
+    session_key:
+        Hermes session key for routing the interaction back.
+    source:
+        :class:`SessionSource` that identifies the originating session.
+    interaction_callback:
+        Async callable ``(MessageEvent) -> None`` invoked when a user
+        interacts with any component in this view.
+    timeout:
+        View timeout in seconds (default 300).
+    single_use:
+        If ``True`` (default), components are disabled after the first
+        interaction.
+    """
+
+    def __init__(
+        self,
+        spec: Dict[str, Any],
+        message_id: str,
+        session_key: str,
+        source: Any,
+        interaction_callback: Callable,
+        timeout: float = VIEW_DEFAULT_TIMEOUT,
+        single_use: bool = True,
+    ) -> None:
+        if not DISCORD_AVAILABLE:
+            raise RuntimeError("discord.py is not installed")
+        super().__init__(timeout=timeout)
+        self._message_id = message_id
+        self._session_key = session_key
+        self._source = source
+        self._interaction_callback = interaction_callback
+        self._single_use = single_use
+        self._resolved = False
+        self._spec = spec
+        self._build_from_spec(spec)
+
+    # -- spec parsing -------------------------------------------------------
+
+    def _build_from_spec(self, spec: Dict[str, Any]) -> None:
+        """Populate this View with buttons/selects from *spec*."""
+        action_rows: List[Dict[str, Any]] = spec.get("action_rows", [])
+        if not action_rows:
+            logger.warning("Component spec has no action_rows — view will be empty")
+            return
+
+        for row_idx, row_spec in enumerate(action_rows):
+            if row_idx >= DISCORD_ACTION_ROWS_MAX:
+                logger.warning(
+                    "Component spec has more than %d action rows; truncating",
+                    DISCORD_ACTION_ROWS_MAX,
+                )
+                break
+
+            buttons = row_spec.get("buttons", [])
+            select_spec = row_spec.get("select")
+
+            if buttons and select_spec:
+                logger.warning(
+                    "Action row %d has both buttons and a select menu; "
+                    "Discord only allows one type per row. Select will be ignored.",
+                    row_idx,
+                )
+                select_spec = None
+
+            if buttons:
+                self._add_buttons(buttons)
+            elif select_spec:
+                self._add_select(select_spec)
+
+    def _add_buttons(self, buttons: List[Dict[str, Any]]) -> None:
+        """Add up to 5 buttons for the current action row."""
+        for btn_spec in buttons[:DISCORD_BUTTONS_PER_ROW]:
+            try:
+                btn = self._make_button(btn_spec)
+                if btn is not None:
+                    self.add_item(btn)
+            except Exception:
+                logger.warning(
+                    "Failed to create button from spec %s",
+                    btn_spec,
+                    exc_info=True,
+                )
+
+    def _add_select(self, select_spec: Dict[str, Any]) -> None:
+        """Add a string select menu for the current action row."""
+        try:
+            select = self._make_select(select_spec)
+            if select is not None:
+                self.add_item(select)
+        except Exception:
+            logger.warning(
+                "Failed to create select from spec %s",
+                select_spec,
+                exc_info=True,
+            )
+
+    def _make_button(self, spec: Dict[str, Any]) -> Optional[Any]:
+        """Build a :class:`discord.ui.Button` from a button spec dict.
+
+        Returns ``None`` for link-style buttons with invalid URLs.
+        """
+        style_name = spec.get("style", "secondary")
+        style = _BUTTON_STYLE_MAP.get(style_name)
+        if style is None:
+            logger.warning("Unknown button style '%s'; falling back to secondary", style_name)
+            style = _BUTTON_STYLE_MAP["secondary"]
+
+        label = str(spec.get("label", ""))[:80]  # Discord label limit
+        emoji = spec.get("emoji")
+        disabled = bool(spec.get("disabled", False))
+        custom_id = spec.get("custom_id", "")
+
+        # Link buttons don't use custom_id; they use url instead
+        url = spec.get("url")
+        if style_name == "link":
+            if not url:
+                logger.warning("Link button has no URL; skipping")
+                return None
+            btn = discord.ui.Button(
+                style=style,
+                label=label or None,
+                emoji=emoji,
+                url=url,
+                disabled=disabled,
+            )
+            # Link buttons are not interactive — no callback needed
+            return btn
+
+        if not custom_id:
+            logger.warning("Non-link button has no custom_id; skipping")
+            return None
+
+        full_custom_id = _truncate_custom_id(f"{CUSTOM_ID_PREFIX}{custom_id}")
+
+        btn = discord.ui.Button(
+            style=style,
+            label=label or None,
+            emoji=emoji,
+            custom_id=full_custom_id,
+            disabled=disabled,
+        )
+        btn.callback = self._make_button_callback(label, custom_id, full_custom_id)
+        return btn
+
+    def _make_select(self, spec: Dict[str, Any]) -> Optional[Any]:
+        """Build a :class:`discord.ui.Select` from a select spec dict."""
+        custom_id = spec.get("custom_id", "")
+        if not custom_id:
+            logger.warning("Select menu has no custom_id; skipping")
+            return None
+
+        full_custom_id = _truncate_custom_id(f"{CUSTOM_ID_PREFIX}{custom_id}")
+        placeholder = str(spec.get("placeholder", "Select an option…"))[:100]
+        min_values = max(1, int(spec.get("min_values", 1)))
+        max_values = min(25, int(spec.get("max_values", 1)))
+        if max_values < min_values:
+            max_values = min_values
+        disabled = bool(spec.get("disabled", False))
+
+        options: List[discord.SelectOption] = []
+        for opt in spec.get("options", [])[:25]:
+            opt_label = str(opt.get("label", ""))[:100]
+            opt_value = str(opt.get("value", opt_label))[:100]
+            opt_desc = opt.get("description")
+            if opt_desc:
+                opt_desc = str(opt_desc)[:100]
+            opt_emoji = opt.get("emoji")
+            opt_default = bool(opt.get("default", False))
+            options.append(
+                discord.SelectOption(
+                    label=opt_label,
+                    value=opt_value,
+                    description=opt_desc,
+                    emoji=opt_emoji,
+                    default=opt_default,
+                )
+            )
+
+        if not options:
+            logger.warning("Select menu has no options; skipping")
+            return None
+
+        select = discord.ui.Select(
+            custom_id=full_custom_id,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            options=options,
+            disabled=disabled,
+        )
+        select.callback = self._make_select_callback(custom_id, full_custom_id)
+        return select
+
+    # -- interaction callbacks ----------------------------------------------
+
+    def _make_button_callback(
+        self, label: str, original_custom_id: str, full_custom_id: str
+    ) -> Callable:
+        """Return an async callback for a button interaction."""
+
+        async def _callback(interaction: discord.Interaction) -> None:
+            await self._handle_interaction(
+                interaction,
+                kind="Button clicked",
+                label=label,
+                original_custom_id=original_custom_id,
+            )
+
+        return _callback
+
+    def _make_select_callback(
+        self, original_custom_id: str, full_custom_id: str
+    ) -> Callable:
+        """Return an async callback for a select-menu interaction."""
+
+        async def _callback(interaction: discord.Interaction) -> None:
+            values = list(interaction.data.get("values", []))
+            # Use the first selected value as label for readability
+            label = values[0] if values else ""
+            await self._handle_interaction(
+                interaction,
+                kind="Select chosen",
+                label=label,
+                original_custom_id=original_custom_id,
+                values=values,
+            )
+
+        return _callback
+
+    async def _handle_interaction(
+        self,
+        interaction: discord.Interaction,
+        *,
+        kind: str,
+        label: str,
+        original_custom_id: str,
+        values: Optional[List[str]] = None,
+    ) -> None:
+        """Common handler for all component interactions.
+
+        1. Acknowledge the interaction (edit the message).
+        2. Format structured text describing what was clicked.
+        3. Build a MessageEvent and forward it via the callback.
+        4. Optionally disable the component (single-use mode).
+        """
+        if self._resolved:
+            # Already handled (race guard)
+            try:
+                await interaction.response.defer()
+            except Exception:
+                pass
+            return
+
+        # --- format the interaction as structured text ---------------------
+        text = _format_interaction_text(
+            kind,
+            label=label,
+            custom_id=original_custom_id,
+            values=values,
+        )
+
+        # --- update the message to acknowledge the click -------------------
+        try:
+            # Disable clicked component(s) after interaction
+            if self._single_use:
+                for child in self.children:
+                    if isinstance(child, (discord.ui.Button, discord.ui.Select)):
+                        child.disabled = True
+                self._resolved = True
+                # Also mark the tracked view as resolved
+                tracked = component_store.get(self._message_id)
+                if tracked:
+                    tracked.resolved = True
+
+            await interaction.response.edit_message(view=self)
+        except Exception:
+            logger.debug(
+                "Failed to edit message on interaction for %s; "
+                "attempting deferred response",
+                self._message_id,
+                exc_info=True,
+            )
+            try:
+                await interaction.response.defer()
+            except Exception:
+                pass
+
+        # --- build a MessageEvent and route it to the gateway ---------------
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=self._source,
+            raw_message=interaction,
+            message_id=str(interaction.message.id) if interaction.message else None,
+            reply_to_message_id=self._message_id,
+        )
+
+        try:
+            result = self._interaction_callback(event)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:
+            logger.error(
+                "Error routing component interaction for message %s",
+                self._message_id,
+                exc_info=True,
+            )
+
+    # -- lifecycle ----------------------------------------------------------
+
+    async def on_timeout(self) -> None:
+        """Disable all children when the view expires."""
+        self._resolved = True
+        tracked = component_store.get(self._message_id)
+        if tracked:
+            tracked.resolved = True
+        for child in self.children:
+            child.disabled = True
+        logger.debug(
+            "AgentComponentView timed out for message %s", self._message_id
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public factory function
+# ---------------------------------------------------------------------------
+
+def build_view_from_spec(
+    spec: Dict[str, Any],
+    message_id: str,
+    session_key: str,
+    source: Any,
+    interaction_callback: Callable,
+) -> Optional[AgentComponentView]:
+    """Factory: create an :class:`AgentComponentView` from a JSON spec.
+
+    Parameters
+    ----------
+    spec:
+        Component specification dict (see module docstring).
+    message_id:
+        Discord message ID the view will be attached to.
+    session_key:
+        Hermes session key for routing.
+    source:
+        :class:`~gateway.session.SessionSource` identifying the session.
+    interaction_callback:
+        Async callable ``(MessageEvent) -> None`` to dispatch interactions.
+
+    Returns
+    -------
+    AgentComponentView or ``None`` if the spec is invalid or discord.py is
+    not available.
+    """
+    if not DISCORD_AVAILABLE:
+        logger.warning("discord.py not available; cannot build component view")
+        return None
+
+    if not isinstance(spec, dict):
+        logger.warning("Component spec is not a dict: %r", spec)
+        return None
+
+    action_rows = spec.get("action_rows")
+    if not action_rows:
+        logger.warning("Component spec has empty or missing action_rows")
+        return None
+
+    if not isinstance(action_rows, list):
+        logger.warning("Component spec action_rows is not a list: %r", action_rows)
+        return None
+
+    timeout = float(spec.get("timeout", VIEW_DEFAULT_TIMEOUT))
+    single_use = bool(spec.get("single_use", True))
+
+    try:
+        view = AgentComponentView(
+            spec=spec,
+            message_id=message_id,
+            session_key=session_key,
+            source=source,
+            interaction_callback=interaction_callback,
+            timeout=timeout,
+            single_use=single_use,
+        )
+    except Exception:
+        logger.error(
+            "Failed to build AgentComponentView from spec for message %s",
+            message_id,
+            exc_info=True,
+        )
+        return None
+
+    # Register in the component store
+    component_store.register(
+        message_id=message_id,
+        view=view,
+        session_key=session_key,
+        interaction_callback=interaction_callback,
+        source=source,
+    )
+
+    return view
+
+
+def is_agent_component(custom_id: str) -> bool:
+    """Return ``True`` if *custom_id* belongs to an agent-created component."""
+    return bool(custom_id) and custom_id.startswith(CUSTOM_ID_PREFIX)

--- a/model_tools.py
+++ b/model_tools.py
@@ -459,6 +459,29 @@ def _compute_tool_definitions(
                     }
                     break
 
+    # Strip components schema from send_message when Discord is not configured.
+    # The components property is Discord-only (buttons, select menus); including
+    # it for non-Discord users adds permanent token tax for an unusable feature.
+    if "send_message" in available_tool_names:
+        try:
+            from gateway.config import Platform, load_gateway_config
+            _cfg = load_gateway_config()
+            _discord_connected = Platform.DISCORD in _cfg.get_connected_platforms()
+        except Exception:
+            _discord_connected = False
+        if not _discord_connected:
+            for i, td in enumerate(filtered_tools):
+                if td.get("function", {}).get("name") == "send_message":
+                    props = td["function"]["parameters"].get("properties", {})
+                    if "components" in props:
+                        props.pop("components")
+                        # Also remove from required if present
+                        req = td["function"]["parameters"].get("required", [])
+                        if "components" in req:
+                            req.remove("components")
+                        filtered_tools[i] = td
+                    break
+
     if not quiet_mode:
         if filtered_tools:
             tool_names = [t["function"]["name"] for t in filtered_tools]

--- a/model_tools.py
+++ b/model_tools.py
@@ -20,8 +20,9 @@ Public API (signatures preserved from the original 2,400-line version):
     check_tool_availability(quiet) -> tuple
 """
 
-import json
 import asyncio
+import copy
+import json
 import logging
 import threading
 import time
@@ -261,6 +262,44 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def _discord_components_schema_enabled() -> bool:
+    """Return True when Discord is configured for live gateway delivery.
+
+    The send_message ``components`` parameter is Discord-only.  Keep it out of
+    schemas for users without an active Discord platform so every model call
+    does not pay a permanent token tax for an unusable feature.
+    """
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        return Platform.DISCORD in cfg.get_connected_platforms()
+    except Exception:
+        return False
+
+
+def _without_send_message_components_schema(tool_def: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``tool_def`` without send_message.components.
+
+    Registry schemas are shallow-copied by ``registry.get_definitions()``, so
+    mutating nested ``parameters.properties`` in place would permanently remove
+    the Discord schema from the registered base schema for the process.
+    """
+    function = dict(tool_def.get("function") or {})
+    parameters = copy.deepcopy(function.get("parameters") or {})
+    properties = parameters.get("properties")
+    if not isinstance(properties, dict) or "components" not in properties:
+        return tool_def
+
+    properties.pop("components", None)
+    required = parameters.get("required")
+    if isinstance(required, list) and "components" in required:
+        parameters["required"] = [item for item in required if item != "components"]
+
+    function["parameters"] = parameters
+    return {**tool_def, "function": function}
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -307,6 +346,7 @@ def get_tool_definitions(
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
+            _discord_components_schema_enabled(),
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -462,25 +502,11 @@ def _compute_tool_definitions(
     # Strip components schema from send_message when Discord is not configured.
     # The components property is Discord-only (buttons, select menus); including
     # it for non-Discord users adds permanent token tax for an unusable feature.
-    if "send_message" in available_tool_names:
-        try:
-            from gateway.config import Platform, load_gateway_config
-            _cfg = load_gateway_config()
-            _discord_connected = Platform.DISCORD in _cfg.get_connected_platforms()
-        except Exception:
-            _discord_connected = False
-        if not _discord_connected:
-            for i, td in enumerate(filtered_tools):
-                if td.get("function", {}).get("name") == "send_message":
-                    props = td["function"]["parameters"].get("properties", {})
-                    if "components" in props:
-                        props.pop("components")
-                        # Also remove from required if present
-                        req = td["function"]["parameters"].get("required", [])
-                        if "components" in req:
-                            req.remove("components")
-                        filtered_tools[i] = td
-                    break
+    if "send_message" in available_tool_names and not _discord_components_schema_enabled():
+        for i, td in enumerate(filtered_tools):
+            if td.get("function", {}).get("name") == "send_message":
+                filtered_tools[i] = _without_send_message_components_schema(td)
+                break
 
     if not quiet_mode:
         if filtered_tools:

--- a/tests/gateway/test_discord_components.py
+++ b/tests/gateway/test_discord_components.py
@@ -1,0 +1,642 @@
+"""Tests for Discord interactive components feature.
+
+Covers three areas:
+  1. gateway/platforms/discord_components.py — ComponentStore, helpers, AgentComponentView
+  2. tools/send_message_tool.py — _build_discord_components()
+  3. gateway/platforms/discord.py — _normalize_component_spec()
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Discord mock — must be injected before any module that does
+# ``import discord`` (e.g. discord_components.py, discord.py).
+# ---------------------------------------------------------------------------
+
+def _install_full_mock(discord_mod):
+    """Install full mock classes with proper **kwargs handling onto discord_mod."""
+    class MockView:
+        def __init__(self, **kw):
+            self.children = []
+            self.timeout = kw.get("timeout")
+        def add_item(self, item):
+            self.children.append(item)
+
+    class MockButton:
+        def __init__(self, **kw):
+            self.style = kw.get("style")
+            self.label = kw.get("label")
+            self.emoji = kw.get("emoji")
+            self.url = kw.get("url")
+            self.custom_id = kw.get("custom_id")
+            self.disabled = kw.get("disabled", False)
+            self.callback = None
+
+    class MockSelect:
+        def __init__(self, **kw):
+            self.custom_id = kw.get("custom_id")
+            self.placeholder = kw.get("placeholder")
+            self.min_values = kw.get("min_values", 1)
+            self.max_values = kw.get("max_values", 1)
+            self.options = kw.get("options", [])
+            self.disabled = kw.get("disabled", False)
+            self.callback = None
+
+    class MockSelectOption:
+        def __init__(self, **kw):
+            self.label = kw.get("label")
+            self.value = kw.get("value")
+            self.description = kw.get("description")
+            self.emoji = kw.get("emoji")
+            self.default = kw.get("default", False)
+
+    # discord.ui.button is a decorator (returns the decorated fn unchanged)
+    _button_decorator = lambda *a, **kw: (lambda fn: fn)
+
+    discord_mod.ui = SimpleNamespace(
+        View=MockView,
+        Button=MockButton,
+        Select=MockSelect,
+        button=_button_decorator,
+        select=_button_decorator,
+    )
+    discord_mod.SelectOption = MockSelectOption
+
+
+def _ensure_discord_mock():
+    """Install a lightweight discord mock into sys.modules if needed."""
+    # Ensure ButtonStyle has 'link' (other test mocks may lack it)
+    existing = sys.modules.get("discord")
+    if existing is not None and hasattr(existing, "ButtonStyle"):
+        bs = existing.ButtonStyle
+        if not hasattr(bs, "link"):
+            bs.link = 5
+        # Ensure ui classes accept **kwargs and store attributes
+        # (other test mocks may use plain object())
+        if hasattr(existing, "ui"):
+            ui = existing.ui
+            needs_button = not (callable(getattr(ui.Button, "__init__", None))
+                                and "kwargs" in str(ui.Button.__init__.__code__.co_varnames))
+            needs_select = not (callable(getattr(ui.Select, "__init__", None))
+                                and "kwargs" in str(ui.Select.__init__.__code__.co_varnames))
+            needs_view = not (callable(getattr(ui.View, "__init__", None))
+                              and "kwargs" in str(ui.View.__init__.__code__.co_varnames))
+        else:
+            needs_button = needs_select = needs_view = True
+        if needs_button or needs_select or needs_view or not hasattr(existing, "ui"):
+            _install_full_mock(existing)
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.ButtonStyle = SimpleNamespace(
+        success=1, primary=2, secondary=2, danger=3,
+        green=1, grey=2, blurple=2, red=3,
+        link=5,
+    )
+    discord_mod.Interaction = type("Interaction", (), {})
+    discord_mod.InteractionType = SimpleNamespace(component=3)
+    _install_full_mock(discord_mod)
+
+    sys.modules.setdefault("discord", discord_mod)
+
+
+_ensure_discord_mock()
+
+# Now safe to import the modules under test
+from gateway.platforms.discord_components import (
+    _truncate_custom_id,
+    _format_interaction_text,
+    ComponentStore,
+    is_agent_component,
+    build_view_from_spec,
+    AgentComponentView,
+    component_store,
+    CUSTOM_ID_PREFIX,
+    DISCORD_CUSTOM_ID_MAX,
+)
+from tools.send_message_tool import _build_discord_components
+from gateway.platforms.discord import _normalize_component_spec
+
+
+# ===================================================================
+# 1. _truncate_custom_id
+# ===================================================================
+
+class TestTruncateCustomId:
+    def test_no_truncation_short_string(self):
+        assert _truncate_custom_id("abc") == "abc"
+
+    def test_no_truncation_exact_boundary(self):
+        cid = "x" * DISCORD_CUSTOM_ID_MAX
+        assert _truncate_custom_id(cid) == cid
+        assert len(_truncate_custom_id(cid)) == DISCORD_CUSTOM_ID_MAX
+
+    def test_truncation_adds_hash_suffix(self):
+        cid = "x" * (DISCORD_CUSTOM_ID_MAX + 20)
+        result = _truncate_custom_id(cid)
+        assert len(result) == DISCORD_CUSTOM_ID_MAX
+        # Last 9 chars should be _<8-hex-digits>
+        assert result[-9] == "_"
+        assert len(result[-8:]) == 8
+        int(result[-8:], 16)  # must be valid hex
+
+    def test_truncated_id_differs_for_different_inputs(self):
+        a = "a" * (DISCORD_CUSTOM_ID_MAX + 10)
+        b = "b" * (DISCORD_CUSTOM_ID_MAX + 10)
+        assert _truncate_custom_id(a) != _truncate_custom_id(b)
+
+
+# ===================================================================
+# 2. _format_interaction_text
+# ===================================================================
+
+class TestFormatInteractionText:
+    def test_all_fields(self):
+        result = _format_interaction_text(
+            "Button clicked",
+            label="Approve",
+            value="yes",
+            custom_id="act:approve",
+            values=["a", "b"],
+        )
+        assert "[Button clicked]" in result
+        assert "label='Approve'" in result
+        assert "value='yes'" in result
+        assert "custom_id='act:approve'" in result
+        assert "values=['a', 'b']" in result
+
+    def test_partial_fields(self):
+        result = _format_interaction_text("Select chosen", label="Pick A")
+        assert "[Select chosen]" in result
+        assert "label='Pick A'" in result
+        assert "value=" not in result
+        assert "custom_id=" not in result
+
+    def test_empty_fields(self):
+        result = _format_interaction_text("Button clicked")
+        assert result == "[Button clicked]"
+
+    def test_values_list(self):
+        result = _format_interaction_text("Multi", values=["x", "y", "z"])
+        assert "values=['x', 'y', 'z']" in result
+
+
+# ===================================================================
+# 3. ComponentStore
+# ===================================================================
+
+class TestComponentStore:
+    def setup_method(self):
+        self.store = ComponentStore()
+
+    def test_register_and_get(self):
+        self.store.register("msg1", view=None, session_key="s1",
+                            interaction_callback=lambda e: None, source=None)
+        entry = self.store.get("msg1")
+        assert entry is not None
+        assert entry.session_key == "s1"
+
+    def test_get_missing_returns_none(self):
+        assert self.store.get("nonexistent") is None
+
+    def test_remove(self):
+        self.store.register("msg1", view=None, session_key="s1",
+                            interaction_callback=lambda e: None, source=None)
+        self.store.remove("msg1")
+        assert self.store.get("msg1") is None
+
+    def test_remove_nonexistent_is_noop(self):
+        self.store.remove("nope")  # should not raise
+
+    def test_size_property(self):
+        assert self.store.size == 0
+        self.store.register("m1", view=None, session_key="s1",
+                            interaction_callback=lambda e: None, source=None)
+        assert self.store.size == 1
+        self.store.register("m2", view=None, session_key="s2",
+                            interaction_callback=lambda e: None, source=None)
+        assert self.store.size == 2
+
+    def test_cleanup_expired_entries(self):
+        self.store.register("old", view=None, session_key="s1",
+                            interaction_callback=lambda e: None, source=None)
+        # Simulate age by monkey-patching created_at
+        entry = self.store.get("old")
+        entry.created_at = time.time() - 9999  # well past default 600s
+
+        self.store.register("new", view=None, session_key="s2",
+                            interaction_callback=lambda e: None, source=None)
+
+        removed = self.store.cleanup(max_age=600)
+        assert removed == 1
+        assert self.store.get("old") is None
+        assert self.store.get("new") is not None
+
+    def test_cleanup_resolved_entries(self):
+        self.store.register("resolved", view=None, session_key="s1",
+                            interaction_callback=lambda e: None, source=None)
+        self.store.get("resolved").resolved = True
+
+        removed = self.store.cleanup()
+        assert removed == 1
+        assert self.store.get("resolved") is None
+
+
+# ===================================================================
+# 4. is_agent_component
+# ===================================================================
+
+class TestIsAgentComponent:
+    def test_prefix_match(self):
+        assert is_agent_component("hermes:action:approve") is True
+
+    def test_no_prefix(self):
+        assert is_agent_component("some_other_id") is False
+
+    def test_empty_string(self):
+        assert is_agent_component("") is False
+
+    def test_non_hermes_prefix(self):
+        assert is_agent_component("other:action:do") is False
+
+
+# ===================================================================
+# 5. build_view_from_spec
+# ===================================================================
+
+class TestBuildViewFromSpec:
+    def _make_callback(self):
+        return AsyncMock()
+
+    def test_valid_spec_returns_view(self):
+        spec = {
+            "action_rows": [
+                {"buttons": [{"label": "OK", "style": "primary", "custom_id": "ok"}]}
+            ]
+        }
+        view = build_view_from_spec(spec, "msg1", "sess", None, self._make_callback())
+        assert view is not None
+        assert isinstance(view, AgentComponentView)
+
+    def test_missing_action_rows_returns_none(self):
+        view = build_view_from_spec({}, "msg1", "sess", None, self._make_callback())
+        assert view is None
+
+    def test_empty_action_rows_returns_none(self):
+        view = build_view_from_spec(
+            {"action_rows": []}, "msg1", "sess", None, self._make_callback()
+        )
+        assert view is None
+
+    def test_non_dict_spec_returns_none(self):
+        view = build_view_from_spec("not a dict", "msg1", "sess", None, self._make_callback())
+        assert view is None
+
+    def test_action_rows_not_list_returns_none(self):
+        view = build_view_from_spec(
+            {"action_rows": "oops"}, "msg1", "sess", None, self._make_callback()
+        )
+        assert view is None
+
+
+# ===================================================================
+# 6. AgentComponentView._build_from_spec
+# ===================================================================
+
+class TestAgentComponentViewBuildFromSpec:
+    def _make_view(self, spec):
+        cb = AsyncMock()
+        return AgentComponentView(
+            spec=spec, message_id="m1", session_key="s1",
+            source=None, interaction_callback=cb,
+        )
+
+    def test_empty_action_rows(self):
+        view = self._make_view({"action_rows": []})
+        assert len(view.children) == 0
+
+    def test_more_than_five_rows_truncated(self):
+        rows = [
+            {"buttons": [{"label": f"B{i}", "style": "primary", "custom_id": f"b{i}"}]}
+            for i in range(8)
+        ]
+        view = self._make_view({"action_rows": rows})
+        # Max 5 rows, each with 1 button → 5 children
+        assert len(view.children) == 5
+
+    def test_row_with_both_buttons_and_select_ignores_select(self):
+        spec = {
+            "action_rows": [
+                {
+                    "buttons": [{"label": "Btn", "style": "primary", "custom_id": "btn1"}],
+                    "select": {
+                        "custom_id": "sel1",
+                        "options": [{"label": "A", "value": "a"}],
+                    },
+                }
+            ]
+        }
+        view = self._make_view(spec)
+        assert len(view.children) == 1
+        # The child should be a button, not a select
+        # Use the mock class from the mock module
+        from discord import ui as _ui
+        assert isinstance(view.children[0], _ui.Button)
+
+
+# ===================================================================
+# 7. AgentComponentView._make_button
+# ===================================================================
+
+class TestAgentComponentViewMakeButton:
+    def _view(self):
+        cb = AsyncMock()
+        return AgentComponentView(
+            spec={"action_rows": []}, message_id="m1", session_key="s1",
+            source=None, interaction_callback=cb,
+        )
+
+    def test_primary_style(self):
+        btn = self._view()._make_button(
+            {"label": "Go", "style": "primary", "custom_id": "go"}
+        )
+        assert btn is not None
+        assert btn.style == 2  # blurple
+
+    def test_secondary_style(self):
+        btn = self._view()._make_button(
+            {"label": "Meh", "style": "secondary", "custom_id": "meh"}
+        )
+        assert btn is not None
+        assert btn.style == 2  # grey
+
+    def test_success_style(self):
+        btn = self._view()._make_button(
+            {"label": "Yes", "style": "success", "custom_id": "yes"}
+        )
+        assert btn.style == 1  # green
+
+    def test_danger_style(self):
+        btn = self._view()._make_button(
+            {"label": "No", "style": "danger", "custom_id": "no"}
+        )
+        assert btn.style == 3  # red
+
+    def test_link_with_url_returns_button(self):
+        btn = self._view()._make_button(
+            {"label": "Link", "style": "link", "url": "https://example.com"}
+        )
+        assert btn is not None
+        assert btn.url == "https://example.com"
+        assert btn.custom_id is None  # link buttons have no custom_id
+
+    def test_link_without_url_returns_none(self):
+        btn = self._view()._make_button(
+            {"label": "Broken", "style": "link"}
+        )
+        assert btn is None
+
+    def test_unknown_style_falls_back_to_secondary(self):
+        btn = self._view()._make_button(
+            {"label": "X", "style": "neon", "custom_id": "x"}
+        )
+        assert btn is not None
+        assert btn.style == 2  # secondary
+
+    def test_custom_id_truncation(self):
+        long_id = "a" * 200
+        btn = self._view()._make_button(
+            {"label": "T", "style": "primary", "custom_id": long_id}
+        )
+        assert btn is not None
+        assert len(btn.custom_id) <= DISCORD_CUSTOM_ID_MAX
+        assert btn.custom_id.startswith(CUSTOM_ID_PREFIX)
+
+    def test_label_truncation_to_80_chars(self):
+        long_label = "L" * 200
+        btn = self._view()._make_button(
+            {"label": long_label, "style": "primary", "custom_id": "cid"}
+        )
+        assert len(btn.label) == 80
+
+    def test_disabled_flag(self):
+        btn = self._view()._make_button(
+            {"label": "Off", "style": "primary", "custom_id": "off", "disabled": True}
+        )
+        assert btn.disabled is True
+
+    def test_missing_custom_id_on_non_link_returns_none(self):
+        btn = self._view()._make_button(
+            {"label": "NoId", "style": "primary"}
+        )
+        assert btn is None
+
+
+# ===================================================================
+# 8. AgentComponentView._make_select
+# ===================================================================
+
+class TestAgentComponentViewMakeSelect:
+    def _view(self):
+        cb = AsyncMock()
+        return AgentComponentView(
+            spec={"action_rows": []}, message_id="m1", session_key="s1",
+            source=None, interaction_callback=cb,
+        )
+
+    def test_valid_select(self):
+        sel = self._view()._make_select({
+            "custom_id": "pick",
+            "options": [{"label": "A", "value": "a"}],
+        })
+        assert sel is not None
+        assert len(sel.options) == 1
+        assert sel.custom_id.startswith(CUSTOM_ID_PREFIX)
+
+    def test_no_custom_id_returns_none(self):
+        sel = self._view()._make_select({
+            "options": [{"label": "A", "value": "a"}],
+        })
+        assert sel is None
+
+    def test_empty_options_returns_none(self):
+        sel = self._view()._make_select({
+            "custom_id": "empty",
+            "options": [],
+        })
+        assert sel is None
+
+    def test_min_max_clamping_when_max_less_than_min(self):
+        sel = self._view()._make_select({
+            "custom_id": "clamp",
+            "options": [{"label": "A", "value": "a"}],
+            "min_values": 3,
+            "max_values": 1,
+        })
+        assert sel is not None
+        assert sel.min_values == 3
+        assert sel.max_values == 3  # clamped up to min_values
+
+    def test_placeholder_truncation(self):
+        long_ph = "P" * 200
+        sel = self._view()._make_select({
+            "custom_id": "ph",
+            "options": [{"label": "A", "value": "a"}],
+            "placeholder": long_ph,
+        })
+        assert len(sel.placeholder) == 100
+
+    def test_option_count_capped_at_25(self):
+        opts = [{"label": f"O{i}", "value": f"v{i}"} for i in range(30)]
+        sel = self._view()._make_select({
+            "custom_id": "many",
+            "options": opts,
+        })
+        assert len(sel.options) == 25
+
+
+# ===================================================================
+# 9. _build_discord_components (tools/send_message_tool.py)
+# ===================================================================
+
+class TestBuildDiscordComponents:
+    def test_empty_spec_returns_none(self):
+        assert _build_discord_components([]) is None
+
+    def test_none_spec_returns_none(self):
+        assert _build_discord_components(None) is None
+
+    def test_single_primary_button(self):
+        result = _build_discord_components([
+            {"components": [{"type": "button", "label": "Go", "style": "primary", "custom_id": "go"}]}
+        ])
+        assert result is not None
+        assert len(result) == 1
+        row = result[0]
+        assert row["type"] == 1
+        btn = row["components"][0]
+        assert btn["type"] == 2
+        assert btn["style"] == 1  # primary maps to 1 in this module
+        assert btn["label"] == "Go"
+        assert btn["custom_id"].startswith("hermes:")
+
+    def test_link_button_has_url_no_custom_id(self):
+        result = _build_discord_components([
+            {"components": [{"type": "button", "label": "Link", "style": "link", "url": "https://x.com"}]}
+        ])
+        btn = result[0]["components"][0]
+        assert btn["url"] == "https://x.com"
+        assert "custom_id" not in btn
+
+    def test_link_button_without_url_is_skipped(self):
+        result = _build_discord_components([
+            {"components": [{"type": "button", "label": "BadLink", "style": "link"}]}
+        ])
+        assert result is None  # no valid components → no rows
+
+    def test_string_select(self):
+        result = _build_discord_components([
+            {"components": [{
+                "type": "string_select",
+                "custom_id": "pick",
+                "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+            }]}
+        ])
+        sel = result[0]["components"][0]
+        assert sel["type"] == 3
+        assert sel["custom_id"].startswith("hermes:")
+        assert len(sel["options"]) == 2
+
+    def test_unknown_component_type_skipped(self):
+        result = _build_discord_components([
+            {"components": [{"type": "image_card", "label": "X"}]}
+        ])
+        assert result is None
+
+    def test_disabled_button(self):
+        result = _build_discord_components([
+            {"components": [{"type": "button", "label": "Off", "style": "secondary", "custom_id": "off", "disabled": True}]}
+        ])
+        btn = result[0]["components"][0]
+        assert btn["disabled"] is True
+
+    def test_multiple_action_rows(self):
+        result = _build_discord_components([
+            {"components": [{"type": "button", "label": "A", "style": "primary", "custom_id": "a"}]},
+            {"components": [{"type": "button", "label": "B", "style": "secondary", "custom_id": "b"}]},
+        ])
+        assert len(result) == 2
+        assert result[0]["components"][0]["label"] == "A"
+        assert result[1]["components"][0]["label"] == "B"
+
+    def test_custom_id_prefixing(self):
+        result = _build_discord_components([
+            {"components": [{"type": "button", "label": "X", "style": "primary", "custom_id": "my_action"}]}
+        ])
+        cid = result[0]["components"][0]["custom_id"]
+        assert cid.startswith("hermes:")
+
+
+# ===================================================================
+# 10. _normalize_component_spec (gateway/platforms/discord.py)
+# ===================================================================
+
+class TestNormalizeComponentSpec:
+    def test_none_returns_none(self):
+        assert _normalize_component_spec(None) is None
+
+    def test_empty_list_returns_none(self):
+        assert _normalize_component_spec([]) is None
+
+    def test_non_list_or_dict_returns_none(self):
+        assert _normalize_component_spec("bad") is None
+
+    def test_already_in_builder_format_returned_as_is(self):
+        spec = {"action_rows": [{"buttons": [{"label": "X"}]}]}
+        result = _normalize_component_spec(spec)
+        assert result is spec  # same object
+
+    def test_api_format_converted_to_builder(self):
+        api_spec = [
+            {"components": [{"type": "button", "label": "Go", "custom_id": "go"}]}
+        ]
+        result = _normalize_component_spec(api_spec)
+        assert result == {"action_rows": [{"buttons": [{"type": "button", "label": "Go", "custom_id": "go"}]}]}
+
+    def test_mixed_row_with_buttons_and_select(self):
+        api_spec = [
+            {
+                "components": [
+                    {"type": "button", "label": "A", "custom_id": "a"},
+                    {"type": "string_select", "custom_id": "sel", "options": [{"label": "X", "value": "x"}]},
+                ]
+            }
+        ]
+        result = _normalize_component_spec(api_spec)
+        rows = result["action_rows"]
+        assert len(rows) == 1
+        assert "buttons" in rows[0]
+        assert "select" in rows[0]
+
+    def test_unknown_component_types_ignored(self):
+        api_spec = [
+            {"components": [{"type": "unknown_type", "label": "X"}]}
+        ]
+        result = _normalize_component_spec(api_spec)
+        # The row has no recognized components → no action_rows
+        assert result is None
+
+    def test_non_dict_items_in_list_skipped(self):
+        api_spec = [
+            "not a dict",
+            {"components": [{"type": "button", "label": "OK", "custom_id": "ok"}]},
+        ]
+        result = _normalize_component_spec(api_spec)
+        assert result is not None
+        assert len(result["action_rows"]) == 1

--- a/tests/test_model_tools_discord_components_schema.py
+++ b/tests/test_model_tools_discord_components_schema.py
@@ -1,0 +1,70 @@
+import copy
+
+import model_tools
+from tools.registry import registry
+from tools.send_message_tool import SEND_MESSAGE_SCHEMA
+
+
+def _send_message_schema(tool_defs):
+    for tool_def in tool_defs:
+        function = tool_def.get("function", {})
+        if function.get("name") == "send_message":
+            return function
+    raise AssertionError("send_message schema not found")
+
+
+def _force_send_message_available(monkeypatch):
+    entry = registry.get_entry("send_message")
+    assert entry is not None
+    monkeypatch.setattr(entry, "check_fn", lambda: True)
+
+
+def _clear_tool_caches():
+    model_tools._clear_tool_defs_cache()
+    try:
+        from tools.registry import invalidate_check_fn_cache
+
+        invalidate_check_fn_cache()
+    except Exception:
+        pass
+
+
+def test_send_message_components_schema_hidden_without_discord(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(model_tools, "_discord_components_schema_enabled", lambda: False)
+    _force_send_message_available(monkeypatch)
+    _clear_tool_caches()
+
+    tool_defs = model_tools.get_tool_definitions(enabled_toolsets=["messaging"], quiet_mode=True)
+
+    properties = _send_message_schema(tool_defs)["parameters"]["properties"]
+    assert "components" not in properties
+
+
+def test_send_message_components_schema_restored_when_discord_enabled(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    _force_send_message_available(monkeypatch)
+    _clear_tool_caches()
+
+    monkeypatch.setattr(model_tools, "_discord_components_schema_enabled", lambda: False)
+    without_discord = model_tools.get_tool_definitions(enabled_toolsets=["messaging"], quiet_mode=True)
+    assert "components" not in _send_message_schema(without_discord)["parameters"]["properties"]
+
+    model_tools._clear_tool_defs_cache()
+    monkeypatch.setattr(model_tools, "_discord_components_schema_enabled", lambda: True)
+    with_discord = model_tools.get_tool_definitions(enabled_toolsets=["messaging"], quiet_mode=True)
+
+    assert "components" in _send_message_schema(with_discord)["parameters"]["properties"]
+    assert "components" in SEND_MESSAGE_SCHEMA["parameters"]["properties"]
+
+
+def test_strip_send_message_components_schema_does_not_mutate_input():
+    original = {
+        "type": "function",
+        "function": copy.deepcopy(SEND_MESSAGE_SCHEMA),
+    }
+
+    stripped = model_tools._without_send_message_components_schema(original)
+
+    assert "components" not in stripped["function"]["parameters"]["properties"]
+    assert "components" in original["function"]["parameters"]["properties"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -138,6 +138,52 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/hermes/cache/img_xxx.jpg') in the message — the platform will deliver it as a native media attachment."
+            },
+            "components": {
+                "type": "array",
+                "description": (
+                    "Discord interactive components (buttons, select menus) to attach to the message. "
+                    "Each element is an action row containing components. Supported component types: "
+                    "'button' (type 2) with styles 'primary'(1), 'secondary'(2), 'success'(3), 'danger'(4), 'link'(5); "
+                    "'string_select' (type 3) with options array of {label, value}. "
+                    "Link buttons (style 'link') use 'url' instead of 'custom_id' and navigate the user to that URL. "
+                    "Non-link buttons require 'custom_id' to receive click interactions. "
+                    "All buttons support optional 'disabled': true. "
+                    "Example: [{\"components\": [{\"type\": \"button\", \"style\": \"primary\", \"label\": \"Approve\", \"custom_id\": \"approve\"}, "
+                    "{\"type\": \"button\", \"style\": \"danger\", \"label\": \"Reject\", \"custom_id\": \"reject\"}]}] "
+                    "Only used for Discord targets; ignored for other platforms."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "components": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {"type": "string", "enum": ["button", "string_select"]},
+                                    "style": {"type": "string", "enum": ["primary", "secondary", "success", "danger", "link"]},
+                                    "label": {"type": "string"},
+                                    "custom_id": {"type": "string", "description": "Required for non-link buttons. Ignored for link buttons."},
+                                    "url": {"type": "string", "description": "Required for link buttons (style 'link'). Opens URL on click."},
+                                    "disabled": {"type": "boolean", "description": "If true, the component is shown but not interactive."},
+                                    "options": {
+                                        "type": "array",
+                                        "description": "Options for string_select menus.",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "label": {"type": "string", "description": "User-visible option label (max 100 chars)."},
+                                                "value": {"type": "string", "description": "Internal value returned on selection (max 100 chars)."}
+                                            },
+                                            "required": ["label", "value"]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "required": []
@@ -168,6 +214,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    components = args.get("components")
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -284,6 +331,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                components=components,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -432,6 +480,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    components=None,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -458,7 +507,10 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                result = await adapter.send(chat_id=chat_id, content=chunk)
+                metadata = {}
+                if components:
+                    metadata["components"] = components
+                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata or None)
             except asyncio.CancelledError:
                 raise
             except Exception as e:
@@ -484,6 +536,7 @@ async def _send_via_adapter(
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                components=components,
             )
         except asyncio.CancelledError:
             raise
@@ -511,7 +564,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, components=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -610,6 +663,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chunk,
                 media_files=media_files if is_last else [],
                 thread_id=thread_id,
+                components=components if is_last else None,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -697,7 +751,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         )
 
     last_result = None
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
+        is_last = (i == len(chunks) - 1)
         if platform == Platform.SLACK:
             result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
@@ -737,6 +792,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                components=components if is_last else None,
             )
 
         if isinstance(result, dict) and result.get("error"):
@@ -923,7 +979,101 @@ def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
     return _DISCORD_CHANNEL_TYPE_PROBE_CACHE.get(str(chat_id))
 
 
-async def _send_discord(token, chat_id, message, thread_id=None, media_files=None):
+_DISCORD_BUTTON_STYLE_MAP = {
+    "primary": 1,
+    "secondary": 2,
+    "success": 3,
+    "danger": 4,
+    "link": 5,
+}
+_DISCORD_COMPONENT_TYPE_MAP = {
+    "button": 2,
+    "string_select": 3,
+}
+
+
+def _prefix_custom_id(custom_id: str) -> str:
+    """Add the ``hermes:`` prefix to a custom_id for agent component filtering.
+
+    Mirrors the truncation logic in ``discord_components._truncate_custom_id``
+    so REST-sent and websocket-sent components use identical custom_ids.
+    """
+    if not custom_id:
+        return custom_id
+    import hashlib
+    prefixed = f"hermes:{custom_id}"
+    if len(prefixed) <= 100:
+        return prefixed
+    hsh = hashlib.sha256(custom_id.encode()).hexdigest()[:8]
+    return f"hermes:{custom_id[:100 - 9 - 7]}_{hsh}"
+
+
+def _build_discord_components(spec):
+    """Convert agent-friendly component spec to Discord API action-row format.
+
+    Input: list of action-row dicts, each with a ``components`` array of
+    button/select specs using human-readable type/style names.
+
+    Output: list of Discord API action-row objects ready for the REST JSON
+    payload (``components`` field on ``POST /messages``).
+    """
+    if not spec:
+        return None
+
+    action_rows = []
+    for row in spec:
+        api_components = []
+        for comp in row.get("components", []):
+            comp_type = comp.get("type", "button")
+            api_type = _DISCORD_COMPONENT_TYPE_MAP.get(comp_type)
+            if api_type is None:
+                continue
+
+            if api_type == 2:  # Button
+                style = _DISCORD_BUTTON_STYLE_MAP.get(comp.get("style", "secondary"), 2)
+                is_link = (style == 5)
+
+                api_comp: dict = {
+                    "type": 2,
+                    "style": style,
+                    "label": comp.get("label", ""),
+                }
+
+                if is_link:
+                    # Link buttons use `url` instead of `custom_id`.
+                    # Discord rejects custom_id on link buttons.
+                    url = comp.get("url", "")
+                    if not url:
+                        continue  # skip malformed link buttons
+                    api_comp["url"] = url
+                else:
+                    custom_id = comp.get("custom_id", "")
+                    api_comp["custom_id"] = _prefix_custom_id(custom_id)
+
+                if comp.get("disabled"):
+                    api_comp["disabled"] = True
+            elif api_type == 3:  # String Select
+                custom_id = comp.get("custom_id", "")
+                api_comp = {
+                    "type": 3,
+                    "custom_id": _prefix_custom_id(custom_id),
+                    "options": [
+                        {"label": opt.get("label", ""), "value": opt.get("value", "")}
+                        for opt in comp.get("options", [])
+                    ],
+                }
+            else:
+                continue
+
+            api_components.append(api_comp)
+
+        if api_components:
+            action_rows.append({"type": 1, "components": api_components})
+
+    return action_rows if action_rows else None
+
+
+async def _send_discord(token, chat_id, message, thread_id=None, media_files=None, components=None):
     """Send a single message via Discord REST API (no websocket client needed).
 
     Chunking is handled by _send_to_platform() before this is called.
@@ -1075,7 +1225,11 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
             if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
+                payload = {"content": message}
+                discord_components = _build_discord_components(components)
+                if discord_components:
+                    payload["components"] = discord_components
+                async with session.post(url, headers=json_headers, json=payload, **_req_kw) as resp:
                     if resp.status not in (200, 201):
                         body = await resp.text()
                         return _error(f"Discord API error ({resp.status}): {body}")
@@ -1115,6 +1269,24 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         result = {"success": True, "platform": "discord", "chat_id": chat_id, "message_id": last_data.get("id")}
         if warnings:
             result["warnings"] = warnings
+
+        # Register REST-sent components in the ComponentStore so the
+        # Discord adapter's on_raw_interaction handler can route clicks.
+        if discord_components and result.get("message_id"):
+            try:
+                from gateway.platforms.discord_components import component_store
+                component_store.register(
+                    message_id=result["message_id"],
+                    view=None,  # No discord.py View for REST-sent messages
+                    session_key="",  # Filled by adapter on interaction
+                    interaction_callback=None,  # Handled by adapter directly
+                    source=None,  # Built by adapter on interaction
+                    rest_sent=True,
+                    chat_id=str(chat_id),
+                )
+            except Exception:
+                logger.warning("Failed to register REST-sent components in ComponentStore", exc_info=True)
+
         return result
     except Exception as e:
         return _error(f"Discord send failed: {e}")


### PR DESCRIPTION
## What does this PR do?

Add Discord Message Component v1 support to the `send_message` tool, enabling agents to send messages with clickable **buttons** and **string-select menus**. Component interactions route back to the agent as `MessageEvent` instances.

Two send paths are supported:
- **WebSocket** — `discord.py` attaches a `discord.ui.View` to `channel.send()`, interactions handled automatically via `AgentComponentView`
- **REST** — `_build_discord_components()` builds raw JSON payloads; an `on_interaction` handler acknowledges and routes orphaned interactions via `ComponentStore`

## Related Issue

None — feature addition.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/discord_components.py` (NEW) — `ComponentStore`, `AgentComponentView`, `build_view_from_spec()`, helpers (`_truncate_custom_id`, `_format_interaction_text`)
- `gateway/platforms/discord.py` — `_normalize_component_spec()` format adapter, `on_interaction` REST handler, View attachment in `send()`
- `tools/send_message_tool.py` — `components` JSON schema, `_build_discord_components()` REST builder, `_prefix_custom_id()`, `ComponentStore` registration after REST send
- `tests/gateway/test_discord_components.py` (NEW) — 62 tests across 10 classes covering all public functions and edge cases

## How to Test

1. Run the test suite: `pytest tests/gateway/test_discord_components.py -v` (62 tests)
2. Start the gateway and use `send_message` with `components` parameter to send button/select messages to a Discord channel
3. Click buttons and select menu options — verify interactions route back to the agent as `MessageEvent` instances
4. Test edge cases: disabled buttons, link buttons (no `custom_id`), >5 row truncation, label/custom_id length clamping, empty component specs

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(discord):`, `style(discord):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (62 tests across 10 classes)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — **N/A** (no user-facing docs changes needed; tool schema is self-documenting)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A** (no new config keys)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A** (additive change, no architecture changes)
- [ ] I've considered cross-platform impact (Windows, macOS) — **N/A** (Discord API is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior (components schema added to `send_message`)

---

<details>
<summary>🔧 Implementation Details</summary>

### Features
- **Buttons**: primary, secondary, success, danger, link (with `url` field, no `custom_id`)
- **String Select Menus**: up to 25 options, configurable `min_values`/`max_values`, placeholder text
- **Multi-row layouts**: up to 5 action rows per message
- **Disabled state**: supported on both buttons and select menus
- **Custom IDs**: auto-prefixed with `hermes:` namespace to avoid collisions
- **Label/custom_id truncation**: gracefully handles Discord's 80/100 char limits

### Test Coverage (62 tests)

| Class | Area | Tests |
|-------|------|-------|
| `TestTruncateCustomId` | Helper | 4 |
| `TestFormatInteractionText` | Helper | 4 |
| `TestComponentStore` | CRUD + cleanup | 7 |
| `TestIsAgentComponent` | Prefix check | 4 |
| `TestBuildViewFromSpec` | Factory | 5 |
| `TestAgentComponentViewBuildFromSpec` | Spec parsing | 3 |
| `TestAgentComponentViewMakeButton` | Button builder | 11 |
| `TestAgentComponentViewMakeSelect` | Select builder | 6 |
| `TestBuildDiscordComponents` | REST builder | 9 |
| `TestNormalizeComponentSpec` | Format normalizer | 9 |

### `send_message` Schema Addition

```json
{
  "components": [
    {
      "components": [
        { "type": "button", "style": "primary", "label": "Approve", "custom_id": "approve" },
        { "type": "button", "style": "link", "label": "Docs", "url": "https://..." }
      ]
    },
    {
      "components": [
        {
          "type": "string_select",
          "custom_id": "priority",
          "label": "Priority",
          "placeholder": "Choose...",
          "options": [
            { "label": "High", "value": "high" },
            { "label": "Low", "value": "low" }
          ]
        }
      ]
    }
  ]
}
```

### Out of Scope (Future Work)

- **Modal support** (text input components)
- **User/Role/Channel select menus**
- **Interaction routing unit tests** (`on_interaction` async handler — requires complex Discord mock setup)
- **Ephemeral response support**
</details>