### PR TITLE
fix(gateway): preserve tool and reasoning continuity

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -601,18 +601,23 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # user turn) separates them — an intervening ``tool`` message means
     # two distinct, valid tool-call rounds that must NOT be merged.
     #
-    # Codex Responses interim turns are exempt: the codex_responses
-    # api_mode legitimately keeps multiple consecutive incomplete
+    # Codex Responses interim turns are exempt only for the codex_responses
+    # api_mode: it legitimately keeps multiple consecutive incomplete
     # assistant turns in history, each carrying its own encrypted
     # continuation state (codex_reasoning_items / codex_message_items)
     # that must be replayed verbatim. Collapsing them corrupts the
     # Responses replay chain (the duplicate-detection logic at
     # conversation_loop.py already de-dups identical codex interims).
+    api_mode = getattr(agent, "api_mode", None)
+
     def _is_codex_interim(m: Dict) -> bool:
         return bool(
-            m.get("codex_reasoning_items")
-            or m.get("codex_message_items")
-            or m.get("finish_reason") == "incomplete"
+            api_mode == "codex_responses"
+            and (
+                m.get("codex_reasoning_items")
+                or m.get("codex_message_items")
+                or m.get("finish_reason") == "incomplete"
+            )
         )
 
     def _is_verification_candidate(m: Dict) -> bool:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -463,6 +463,45 @@ def _normalize_chat_content(
         return ""
 
 
+def _normalize_history_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a client-provided history message.
+
+    Keeps role/content plus only the continuity fields needed to replay tool
+    chains across turns:
+
+    - non-system roles: ``name``
+    - assistant: ``tool_calls``, ``reasoning_content``,
+      ``codex_reasoning_items``, ``codex_message_items``
+    - tool: ``tool_call_id``
+
+    All other keys are intentionally dropped.
+    """
+    role = str(message.get("role", "")).strip().lower()
+    normalized_message: Dict[str, Any] = {
+        "role": role,
+        "content": _normalize_multimodal_content(message.get("content", "")),
+    }
+
+    if role != "system":
+        if "name" in message:
+            normalized_message["name"] = message.get("name")
+
+    if role == "assistant":
+        if "tool_calls" in message:
+            normalized_message["tool_calls"] = message.get("tool_calls")
+        if "reasoning_content" in message:
+            normalized_message["reasoning_content"] = message.get("reasoning_content")
+        if "codex_reasoning_items" in message:
+            normalized_message["codex_reasoning_items"] = message.get("codex_reasoning_items")
+        if "codex_message_items" in message:
+            normalized_message["codex_message_items"] = message.get("codex_message_items")
+    elif role == "tool":
+        if "tool_call_id" in message:
+            normalized_message["tool_call_id"] = message.get("tool_call_id")
+
+    return normalized_message
+
+
 # Content part type aliases used by the OpenAI Chat Completions and Responses
 # APIs.  We accept both spellings on input and emit a single canonical internal
 # shape (``{"type": "text", ...}`` / ``{"type": "image_url", ...}``) that the
@@ -3675,25 +3714,24 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: List[Dict[str, Any]] = []
 
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
-            raw_content = msg.get("content", "")
             if role == "system":
                 # System messages don't support images (Anthropic rejects, OpenAI
                 # text-model systems don't render them).  Flatten to text.
-                content = _normalize_chat_content(raw_content)
+                content = _normalize_chat_content(msg.get("content", ""))
                 if system_prompt is None:
                     system_prompt = content
                 else:
                     system_prompt = system_prompt + "\n" + content
-            elif role in {"user", "assistant"}:
+            elif role in {"user", "assistant", "tool"}:
                 try:
-                    content = _normalize_multimodal_content(raw_content)
+                    normalized_msg = _normalize_history_message(msg)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
-                conversation_messages.append({"role": role, "content": content})
+                conversation_messages.append(normalized_msg)
 
         # Extract the last user message as the primary input
         user_message: Any = ""
@@ -4856,14 +4894,20 @@ class APIServerAdapter(BasePlatformAdapter):
         elif isinstance(raw_input, list):
             for idx, item in enumerate(raw_input):
                 if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
+                    normalized_item = {
+                        "role": "user",
+                        "content": _normalize_chat_content(item),
+                    }
+                    input_messages.append(normalized_item)
                 elif isinstance(item, dict):
                     role = item.get("role", "user")
+                    msg = dict(item)
+                    msg["role"] = role
                     try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
+                        normalized_msg = _normalize_history_message(msg)
                     except ValueError as exc:
                         return _multimodal_validation_error(exc, param=f"input[{idx}].content")
-                    input_messages.append({"role": role, "content": content})
+                    input_messages.append(normalized_msg)
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 
@@ -4886,10 +4930,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         status=400,
                     )
                 try:
-                    entry_content = _normalize_multimodal_content(entry["content"])
+                    entry = _normalize_history_message(entry)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
-                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
+                conversation_history.append(entry)
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -6002,7 +6046,22 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        user_message: Any = ""
+        if isinstance(raw_input, str):
+            user_message = raw_input
+        elif isinstance(raw_input, list) and raw_input:
+            last_raw = raw_input[-1]
+            if isinstance(last_raw, dict):
+                last_input_msg = dict(last_raw)
+                if "role" not in last_input_msg:
+                    last_input_msg["role"] = "user"
+                try:
+                    normalized_last = _normalize_history_message(last_input_msg)
+                    user_message = normalized_last.get("content", "")
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param="input[-1].content")
+            else:
+                user_message = str(last_raw)
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -6011,7 +6070,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -6025,7 +6084,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                try:
+                    conversation_history.append(_normalize_history_message(entry))
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -6043,15 +6105,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # Only fires when no explicit history was provided.
         if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
             for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+                if isinstance(msg, dict) and msg.get("role"):
+                    try:
+                        normalized_msg = _normalize_history_message(msg)
+                    except ValueError as exc:
+                        return _multimodal_validation_error(exc, param="input[...].content")
+                    conversation_history.append(normalized_msg)
 
         session_id = body.get("session_id") or stored_session_id
         route = self._resolve_route(body.get("model"))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -665,6 +665,31 @@ def _normalize_multimodal_content(content: Any) -> Any:
     return normalized_parts
 
 
+def _normalize_history_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a client-provided history message and keep replay metadata."""
+    role = str(message.get("role", "")).strip().lower()
+    normalized_message: Dict[str, Any] = {
+        "role": role,
+        "content": _normalize_multimodal_content(message.get("content", "")),
+    }
+
+    if role != "system" and "name" in message:
+        normalized_message["name"] = message["name"]
+    if role == "assistant":
+        for key in (
+            "tool_calls",
+            "reasoning_content",
+            "codex_reasoning_items",
+            "codex_message_items",
+        ):
+            if key in message:
+                normalized_message[key] = message[key]
+    elif role == "tool" and "tool_call_id" in message:
+        normalized_message["tool_call_id"] = message["tool_call_id"]
+
+    return normalized_message
+
+
 def _content_has_visible_payload(content: Any) -> bool:
     """True when content has any text or image attachment.  Used to reject empty turns."""
     if isinstance(content, str):
@@ -4050,25 +4075,24 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: List[Dict[str, Any]] = []
 
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
-            raw_content = msg.get("content", "")
             if role == "system":
                 # System messages don't support images (Anthropic rejects, OpenAI
                 # text-model systems don't render them).  Flatten to text.
-                content = _normalize_chat_content(raw_content)
+                content = _normalize_chat_content(msg.get("content", ""))
                 if system_prompt is None:
                     system_prompt = content
                 else:
                     system_prompt = system_prompt + "\n" + content
-            elif role in {"user", "assistant"}:
+            elif role in {"user", "assistant", "tool"}:
                 try:
-                    content = _normalize_multimodal_content(raw_content)
+                    normalized_msg = _normalize_history_message(msg)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
-                conversation_messages.append({"role": role, "content": content})
+                conversation_messages.append(normalized_msg)
 
         # Extract the last user message as the primary input
         user_message: Any = ""
@@ -5230,18 +5254,20 @@ class APIServerAdapter(BasePlatformAdapter):
         # Normalize input to message list
         input_messages: List[Dict[str, Any]] = []
         if isinstance(raw_input, str):
-            input_messages = [{"role": "user", "content": raw_input}]
+            input_messages.append(_normalize_history_message({"role": "user", "content": raw_input}))
         elif isinstance(raw_input, list):
             for idx, item in enumerate(raw_input):
                 if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
+                    item = {"role": "user", "content": item}
                 elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
-                    except ValueError as exc:
-                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
-                    input_messages.append({"role": role, "content": content})
+                    item = dict(item)
+                    item.setdefault("role", "user")
+                else:
+                    item = {"role": "user", "content": item}
+                try:
+                    input_messages.append(_normalize_history_message(item))
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"input[{idx}].content")
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 
@@ -5264,10 +5290,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         status=400,
                     )
                 try:
-                    entry_content = _normalize_multimodal_content(entry["content"])
+                    normalized_entry = _normalize_history_message(entry)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
-                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
+                conversation_history.append(normalized_entry)
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -6500,7 +6526,21 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        input_messages: List[Dict[str, Any]] = []
+        if isinstance(raw_input, str):
+            input_messages.append(_normalize_history_message({"role": "user", "content": raw_input}))
+        elif isinstance(raw_input, list):
+            for idx, item in enumerate(raw_input):
+                if isinstance(item, dict):
+                    item = dict(item)
+                    item.setdefault("role", "user")
+                else:
+                    item = {"role": "user", "content": item}
+                try:
+                    input_messages.append(_normalize_history_message(item))
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+        user_message = input_messages[-1].get("content", "") if input_messages else ""
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -6509,7 +6549,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -6523,7 +6563,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                try:
+                    conversation_history.append(_normalize_history_message(entry))
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -6539,17 +6582,8 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        if not conversation_history:
+            conversation_history.extend(input_messages[:-1])
 
         session_id = body.get("session_id") or stored_session_id
         route = self._resolve_route(body.get("model"))

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1291,6 +1291,62 @@ class TestChatCompletionsEndpoint:
             assert '"status": "running"' not in body
             assert '"status": "completed"' not in body
 
+    @pytest.mark.asyncio
+    async def test_history_allowlist_preserves_tool_chain(self, adapter):
+        messages = [
+            {
+                "role": "user",
+                "name": "caller",
+                "content": [{"type": "input_text", "text": "Read this"}],
+                "tool_calls": [{"id": "drop-user-call"}],
+                "metadata": {"drop": True},
+            },
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [{"id": "call-read", "type": "function"}],
+                "reasoning_content": "thinking",
+                "codex_reasoning_items": [{"id": "rs-1"}],
+                "codex_message_items": [{"id": "msg-1"}],
+                "tool_call_id": "drop-assistant-id",
+                "metadata": {"drop": True},
+            },
+            {
+                "role": "tool",
+                "name": "tool-runner",
+                "content": "ok",
+                "tool_call_id": "call-read",
+                "reasoning_content": "drop-tool-reasoning",
+                "codex_reasoning_items": [{"id": "drop-tool-rs"}],
+                "codex_message_items": [{"id": "drop-tool-msg"}],
+                "metadata": {"drop": True},
+            },
+            {"role": "user", "content": "Summarize"},
+        ]
+        result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/chat/completions", json={"messages": messages})
+
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["user_message"] == "Summarize"
+        assert mock_run.call_args.kwargs["conversation_history"] == [
+            {"role": "user", "name": "caller", "content": "Read this"},
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [{"id": "call-read", "type": "function"}],
+                "reasoning_content": "thinking",
+                "codex_reasoning_items": [{"id": "rs-1"}],
+                "codex_message_items": [{"id": "msg-1"}],
+            },
+            {"role": "tool", "name": "tool-runner", "content": "ok", "tool_call_id": "call-read"},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # _derive_chat_session_id unit tests
@@ -1349,6 +1405,72 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+
+    @pytest.mark.parametrize("input_mode", ("array", "explicit"))
+    @pytest.mark.asyncio
+    async def test_history_allowlist_preserves_tool_chain(self, adapter, input_mode):
+        history = [
+            {
+                "role": "user",
+                "name": "caller",
+                "content": [{"type": "input_text", "text": "Read this"}],
+                "tool_calls": [{"id": "drop-user-call"}],
+                "metadata": {"drop": True},
+            },
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [{"id": "call-read", "type": "function"}],
+                "reasoning_content": "thinking",
+                "codex_reasoning_items": [{"id": "rs-1"}],
+                "codex_message_items": [{"id": "msg-1"}],
+                "tool_call_id": "drop-assistant-id",
+                "metadata": {"drop": True},
+            },
+            {
+                "role": "tool",
+                "name": "tool-runner",
+                "content": "ok",
+                "tool_call_id": "call-read",
+                "reasoning_content": "drop-tool-reasoning",
+                "codex_reasoning_items": [{"id": "drop-tool-rs"}],
+                "codex_message_items": [{"id": "drop-tool-msg"}],
+                "metadata": {"drop": True},
+            },
+        ]
+        payload = {
+            "model": "hermes-agent",
+            "input": [*history, {"role": "user", "content": "Summarize"}]
+            if input_mode == "array"
+            else "Summarize",
+        }
+        if input_mode == "explicit":
+            payload["conversation_history"] = history
+
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "Done", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post("/v1/responses", json=payload)
+
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["user_message"] == "Summarize"
+        assert mock_run.call_args.kwargs["conversation_history"] == [
+            {"role": "user", "name": "caller", "content": "Read this"},
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [{"id": "call-read", "type": "function"}],
+                "reasoning_content": "thinking",
+                "codex_reasoning_items": [{"id": "rs-1"}],
+                "codex_message_items": [{"id": "msg-1"}],
+            },
+            {"role": "tool", "name": "tool-runner", "content": "ok", "tool_call_id": "call-read"},
+        ]
 
 
     @pytest.mark.asyncio
@@ -2865,4 +2987,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2199,6 +2199,102 @@ class TestChatCompletionsEndpoint:
             assert call_kwargs["conversation_history"][1] == {"role": "assistant", "content": "2"}
 
     @pytest.mark.asyncio
+    async def test_tool_chain_history_is_preserved_for_chat(self, adapter):
+        """Tool-call messages keep continuity metadata and drop extra fields."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+        codex_reasoning_items = [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "Need tool output first."}],
+            }
+        ]
+        codex_message_items = [
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Tool call pending."}],
+            }
+        ]
+        messages = [
+            {"role": "user", "content": "Read this file"},
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"foo.txt\"}",
+                        },
+                    }
+                ],
+                "reasoning_content": "Need tool output first.",
+                "codex_reasoning_items": codex_reasoning_items,
+                "codex_message_items": codex_message_items,
+                "metadata": {"trace_id": "deadbeef"},
+                "finish_reason": "tool_calls",
+            },
+            {
+                "role": "tool",
+                "name": "tool-writer",
+                "tool_call_id": "call_read",
+                "content": "{\"content\": \"ok\"}",
+                "reasoning_content": "tool thinking",
+                "codex_reasoning_items": [{"type": "reasoning", "id": "tool-r"}],
+                "codex_message_items": [{"type": "message", "id": "tool-m"}],
+            },
+            {"role": "user", "content": "Summarize it"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/chat/completions", json={"model": "hermes-agent", "messages": messages})
+
+        assert resp.status == 200
+        call_kwargs = mock_run.call_args.kwargs
+        expected_history = [
+            {"role": "user", "content": "Read this file"},
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"foo.txt\"}",
+                        },
+                    }
+                ],
+                "reasoning_content": "Need tool output first.",
+                "codex_reasoning_items": codex_reasoning_items,
+                "codex_message_items": codex_message_items,
+            },
+            {
+                "role": "tool",
+                "name": "tool-writer",
+                "content": "{\"content\": \"ok\"}",
+                "tool_call_id": "call_read",
+            },
+        ]
+        assert call_kwargs["conversation_history"] == expected_history
+        assert call_kwargs["user_message"] == "Summarize it"
+        assert "metadata" not in call_kwargs["conversation_history"][1]
+        assert "finish_reason" not in call_kwargs["conversation_history"][1]
+        assert "tool_call_id" not in call_kwargs["conversation_history"][1]
+        assert "codex_reasoning_items" not in call_kwargs["conversation_history"][2]
+        assert "codex_message_items" not in call_kwargs["conversation_history"][2]
+
+    @pytest.mark.asyncio
     async def test_agent_error_returns_500(self, adapter):
         """Agent exception returns 500."""
         app = _create_app(adapter)
@@ -2421,6 +2517,191 @@ class TestResponsesEndpoint:
             # Last message is user_message, rest are history
             assert call_kwargs["user_message"] == "What is 2+2?"
             assert len(call_kwargs["conversation_history"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_conversation_history_preserves_tool_chain(self, adapter):
+        """Explicit response history preserves only continuity-relevant fields."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+        codex_reasoning_items = [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "Need tool output first."}],
+            }
+        ]
+        codex_message_items = [
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Tool call pending."}],
+            }
+        ]
+        explicit_history = [
+            {
+                "role": "user",
+                "content": "Read this file",
+                "metadata": {"bad": "drop-me"},
+            },
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"foo.txt\"}"},
+                    }
+                ],
+                "reasoning_content": "Tool needed",
+                "codex_reasoning_items": codex_reasoning_items,
+                "codex_message_items": codex_message_items,
+                "reasoning_details": {"depth": "high"},
+                "finish_reason": "tool_calls",
+            },
+            {
+                "role": "tool",
+                "content": "{\"content\":\"ok\"}",
+                "tool_call_id": "call_read",
+                "codex_reasoning_items": ["ignore"],
+                "codex_message_items": ["ignore"],
+            },
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Please summarize",
+                        "conversation_history": explicit_history,
+                    },
+                )
+
+            assert resp.status == 200
+
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["user_message"] == "Please summarize"
+        assert call_kwargs["conversation_history"] == [
+            {"role": "user", "content": "Read this file"},
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"foo.txt\"}"},
+                    }
+                ],
+                "reasoning_content": "Tool needed",
+                "codex_reasoning_items": codex_reasoning_items,
+                "codex_message_items": codex_message_items,
+            },
+            {
+                "role": "tool",
+                "content": "{\"content\":\"ok\"}",
+                "tool_call_id": "call_read",
+            },
+        ]
+        assert "metadata" not in call_kwargs["conversation_history"][0]
+        assert "reasoning_details" not in call_kwargs["conversation_history"][1]
+        assert "finish_reason" not in call_kwargs["conversation_history"][1]
+        assert "codex_reasoning_items" not in call_kwargs["conversation_history"][2]
+        assert "codex_message_items" not in call_kwargs["conversation_history"][2]
+
+    @pytest.mark.asyncio
+    async def test_array_input_preserves_tool_chain(self, adapter):
+        """Array input preserves tool-call continuity metadata."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+        codex_reasoning_items = [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "Need tool output first."}],
+            }
+        ]
+        codex_message_items = [
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Tool call pending."}],
+            }
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "Read this file", "metadata": {"bad": True}},
+                            {
+                                "role": "assistant",
+                                "content": "",
+                                "tool_calls": [
+                                    {
+                                        "id": "call_read",
+                                        "type": "function",
+                                        "function": {"name": "read_file", "arguments": "{\"path\":\"foo.txt\"}"},
+                                    }
+                                ],
+                                "reasoning_content": "Need content",
+                                "codex_reasoning_items": codex_reasoning_items,
+                                "codex_message_items": codex_message_items,
+                                "reasoning_details": {"secret": "drop"},
+                            },
+                            {
+                                "role": "tool",
+                                "tool_call_id": "call_read",
+                                "content": "{\"content\":\"ok\"}",
+                                "codex_reasoning_items": ["drop"],
+                                "codex_message_items": ["drop"],
+                            },
+                            {"role": "user", "content": "Now summarize"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["user_message"] == "Now summarize"
+        assert call_kwargs["conversation_history"] == [
+            {"role": "user", "content": "Read this file"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"foo.txt\"}"},
+                    }
+                ],
+                "reasoning_content": "Need content",
+                "codex_reasoning_items": codex_reasoning_items,
+                "codex_message_items": codex_message_items,
+            },
+            {
+                "role": "tool",
+                "content": "{\"content\":\"ok\"}",
+                "tool_call_id": "call_read",
+            },
+        ]
+        assert "metadata" not in call_kwargs["conversation_history"][0]
+        assert "reasoning_details" not in call_kwargs["conversation_history"][1]
+        assert "codex_reasoning_items" not in call_kwargs["conversation_history"][2]
+        assert "codex_message_items" not in call_kwargs["conversation_history"][2]
 
     @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -218,6 +218,209 @@ class TestStartRun:
         assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_start_preserves_tool_chain_with_explicit_history(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                codex_reasoning_items = [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [{"type": "summary_text", "text": "Need tool output first."}],
+                    }
+                ]
+                codex_message_items = [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Tool call pending."}],
+                    }
+                ]
+                explicit_history = [
+                    {"role": "user", "content": "Read this file", "finish_reason": "stop"},
+                    {
+                        "role": "assistant",
+                        "name": "assistant-main",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_read",
+                                "type": "function",
+                                "function": {"name": "read_file", "arguments": '{"path":"foo.txt"}'},
+                            }
+                        ],
+                        "reasoning_content": "Need tool output first.",
+                        "codex_reasoning_items": codex_reasoning_items,
+                        "codex_message_items": codex_message_items,
+                        "metadata": {"trace_id": "deadbeef"},
+                    },
+                    {
+                        "role": "tool",
+                        "name": "tool-writer",
+                        "tool_call_id": "call_read",
+                        "content": '{"content": "ok"}',
+                        "reasoning_content": "tool thinking",
+                    },
+                ]
+
+                start_resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Now summarize",
+                        "conversation_history": explicit_history,
+                    },
+                )
+                assert start_resp.status == 202
+                run_id = (await start_resp.json())["run_id"]
+
+                # Wait for background execution to consume the constructed history.
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] in {"completed", "failed", "error"}:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert mock_agent.run_conversation.call_count == 1
+                call_kwargs = mock_agent.run_conversation.call_args.kwargs
+                assert call_kwargs["user_message"] == "Now summarize"
+                assert call_kwargs["conversation_history"] == [
+                    {"role": "user", "content": "Read this file"},
+                    {
+                        "role": "assistant",
+                        "name": "assistant-main",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_read",
+                                "type": "function",
+                                "function": {"name": "read_file", "arguments": '{"path":"foo.txt"}'},
+                            }
+                        ],
+                        "reasoning_content": "Need tool output first.",
+                        "codex_reasoning_items": codex_reasoning_items,
+                        "codex_message_items": codex_message_items,
+                    },
+                    {
+                        "role": "tool",
+                        "name": "tool-writer",
+                        "tool_call_id": "call_read",
+                        "content": '{"content": "ok"}',
+                    },
+                ]
+                assert "finish_reason" not in call_kwargs["conversation_history"][0]
+                assert "metadata" not in call_kwargs["conversation_history"][1]
+                assert "reasoning_content" not in call_kwargs["conversation_history"][2]
+
+    @pytest.mark.asyncio
+    async def test_start_array_input_preserves_tool_chain(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                codex_reasoning_items = [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [{"type": "summary_text", "text": "Need tool output first."}],
+                    }
+                ]
+                codex_message_items = [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Tool call pending."}],
+                    }
+                ]
+                start_resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "Read this file", "metadata": {"trace": "skip"}},
+                            {
+                                "role": "assistant",
+                                "content": "",
+                                "tool_calls": [
+                                    {
+                                        "id": "call_read",
+                                        "type": "function",
+                                        "function": {"name": "read_file", "arguments": '{"path":"foo.txt"}'},
+                                    }
+                                ],
+                                "reasoning_content": "Need content",
+                                "codex_reasoning_items": codex_reasoning_items,
+                                "codex_message_items": codex_message_items,
+                                "reasoning_details": {"secret": "drop"},
+                            },
+                            {
+                                "role": "tool",
+                                "tool_call_id": "call_read",
+                                "content": '{"content":"ok"}',
+                                "codex_reasoning_items": ["drop"],
+                                "codex_message_items": ["drop"],
+                            },
+                            {"role": "user", "content": "Now summarize"},
+                        ],
+                    },
+                )
+                assert start_resp.status == 202
+                run_id = (await start_resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] in {"completed", "failed", "error"}:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert mock_agent.run_conversation.call_count == 1
+                call_kwargs = mock_agent.run_conversation.call_args.kwargs
+                assert call_kwargs["user_message"] == "Now summarize"
+                assert call_kwargs["conversation_history"] == [
+                    {"role": "user", "content": "Read this file"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_read",
+                                "type": "function",
+                                "function": {"name": "read_file", "arguments": '{"path":"foo.txt"}'},
+                            }
+                        ],
+                        "reasoning_content": "Need content",
+                        "codex_reasoning_items": codex_reasoning_items,
+                        "codex_message_items": codex_message_items,
+                    },
+                    {
+                        "role": "tool",
+                        "content": '{"content":"ok"}',
+                        "tool_call_id": "call_read",
+                    },
+                ]
+                assert "metadata" not in call_kwargs["conversation_history"][0]
+                assert "reasoning_details" not in call_kwargs["conversation_history"][1]
+                assert "codex_reasoning_items" not in call_kwargs["conversation_history"][2]
+                assert "codex_message_items" not in call_kwargs["conversation_history"][2]
+
+    @pytest.mark.asyncio
     async def test_start_invalid_history_does_not_allocate_run(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -258,6 +258,83 @@ class TestStartRun:
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
 
+    @pytest.mark.parametrize("input_mode", ("array", "explicit"))
+    @pytest.mark.asyncio
+    async def test_start_history_allowlist_preserves_tool_chain(self, adapter, input_mode):
+        history = [
+            {
+                "role": "user",
+                "name": "caller",
+                "content": [{"type": "input_text", "text": "Read this"}],
+                "tool_calls": [{"id": "drop-user-call"}],
+                "metadata": {"drop": True},
+            },
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [{"id": "call-read", "type": "function"}],
+                "reasoning_content": "thinking",
+                "codex_reasoning_items": [{"id": "rs-1"}],
+                "codex_message_items": [{"id": "msg-1"}],
+                "tool_call_id": "drop-assistant-id",
+                "metadata": {"drop": True},
+            },
+            {
+                "role": "tool",
+                "name": "tool-runner",
+                "content": "ok",
+                "tool_call_id": "call-read",
+                "reasoning_content": "drop-tool-reasoning",
+                "codex_reasoning_items": [{"id": "drop-tool-rs"}],
+                "codex_message_items": [{"id": "drop-tool-msg"}],
+                "metadata": {"drop": True},
+            },
+        ]
+        payload = {
+            "input": [*history, {"role": "user", "content": "Summarize"}]
+            if input_mode == "array"
+            else "Summarize",
+        }
+        if input_mode == "explicit":
+            payload["conversation_history"] = history
+
+        async with TestClient(TestServer(_create_runs_app(adapter))) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                start_resp = await cli.post("/v1/runs", json=payload)
+                assert start_resp.status == 202
+                run_id = (await start_resp.json())["run_id"]
+
+                for _ in range(20):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert mock_agent.run_conversation.call_count == 1
+
+        assert mock_agent.run_conversation.call_args.kwargs["user_message"] == "Summarize"
+        assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == [
+            {"role": "user", "name": "caller", "content": "Read this"},
+            {
+                "role": "assistant",
+                "name": "assistant-main",
+                "content": "",
+                "tool_calls": [{"id": "call-read", "type": "function"}],
+                "reasoning_content": "thinking",
+                "codex_reasoning_items": [{"id": "rs-1"}],
+                "codex_message_items": [{"id": "msg-1"}],
+            },
+            {"role": "tool", "name": "tool-runner", "content": "ok", "tool_call_id": "call-read"},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -9,6 +9,8 @@ providers (violating role alternation), which retriggered the empty-retry
 recovery every turn.
 """
 
+import pytest
+
 from run_agent import AIAgent
 
 
@@ -157,6 +159,81 @@ def test_repair_keeps_tool_matching_only_call_id():
     assert any(m.get("role") == "tool" for m in messages)
 
 
+@pytest.mark.parametrize(
+    ("interim_field", "interim_value"),
+    [
+        ("codex_reasoning_items", [{"id": "rs-1"}]),
+        ("codex_message_items", [{"id": "msg-1"}]),
+        ("finish_reason", "incomplete"),
+    ],
+)
+def test_repair_keeps_codex_replay_turns_separate_for_codex_responses(
+    interim_field, interim_value
+):
+    agent = _bare_agent()
+    agent.api_mode = "codex_responses"
+    messages = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "",
+            interim_field: interim_value,
+        },
+        {
+            "role": "assistant",
+            "content": "continued",
+            interim_field: interim_value,
+        },
+    ]
+
+    assert AIAgent._repair_message_sequence(agent, messages) == 0
+    assert len(messages) == 3
+
+
+@pytest.mark.parametrize(
+    ("with_agent", "api_mode"),
+    [
+        (True, "chat_completions"),
+        (True, ""),
+        (True, None),
+        (True, "unknown"),
+        (False, None),
+    ],
+)
+@pytest.mark.parametrize(
+    ("interim_field", "interim_value"),
+    [
+        ("codex_reasoning_items", [{"id": "rs-1"}]),
+        ("codex_message_items", [{"id": "msg-1"}]),
+        ("finish_reason", "incomplete"),
+    ],
+)
+def test_repair_merges_codex_interims_outside_codex_responses(
+    with_agent, api_mode, interim_field, interim_value
+):
+    agent = _bare_agent() if with_agent else None
+    if agent is not None:
+        agent.api_mode = api_mode
+    messages = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "",
+            interim_field: interim_value,
+        },
+        {
+            "role": "assistant",
+            "content": "continued",
+            interim_field: interim_value,
+        },
+        {"role": "user", "content": "next"},
+    ]
+
+    assert repair_message_sequence(agent, messages) == 1
+    assert [message["role"] for message in messages] == ["user", "assistant", "user"]
+    assert messages[1]["content"] == "continued"
+
+
 
 
 
@@ -171,7 +248,7 @@ def test_repair_keeps_tool_matching_only_call_id():
 
 # ── repair_message_sequence_with_cursor (#44837) ───────────────────────────
 
-from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
+from agent.agent_runtime_helpers import repair_message_sequence, repair_message_sequence_with_cursor
 
 
 def test_cursor_clamped_when_compaction_shrinks_below_cursor():
@@ -368,7 +445,6 @@ def test_sanitize_drops_empty_tool_calls_array():
 # "all messages must have non-empty content except for the optional final
 # assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
 # such turns on the per-call copy so the session recovers itself in memory.
-
 
 
 


### PR DESCRIPTION
## Context

The API server rebuilt client-supplied history as `{role, content}` before handing it to the Agent. That dropped tool linkage and provider replay metadata required for multi-turn Codex Responses continuity. Separately, sequence repair treated persisted Codex metadata as an unconditional exemption, leaving invalid adjacent assistant turns after switching to a strict Chat Completions runtime.

## What Changed

- Added one role-aware history normalizer for `/v1/chat/completions`, `/v1/responses`, and `/v1/runs`.
- Preserved only known continuity fields: `name`, assistant `tool_calls`/reasoning/Codex items, and tool `tool_call_id`.
- Continued dropping arbitrary and wrong-role client metadata.
- Scoped the adjacent Codex-interim exemption to `codex_responses`, while retaining legacy behavior when no runtime mode is available.
- Added paired Codex Responses and Chat Completions sequence-repair regressions.

## Why It Matters

OpenAI recommends replaying prior reasoning/output items to preserve reasoning across calls. Hermes already captures these opaque items; this repairs the gateway boundary and provider-switch path without exposing them as user-readable reasoning.

## Verification

Tested locally on Linux against current `main`:

- `python -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py -q` — **120 passed**
- `python -m pytest tests/run_agent/test_message_sequence_repair.py -q` — **16 passed**
- Python compile, Ruff on changed files, and `git diff --check` — passed

## Risks / Follow-ups

The allowlist is intentionally narrow. Provider-specific wire translation remains downstream. WebUI counterpart nesquena/hermes-webui#6514 supplies these fields only through its private Agent-history projection.
