### PR TITLE
feat(plugins): add pre-model route hook

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -492,8 +492,8 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     skipping the translation silently breaks every ``pre_tool_call``
     block directive.
 
-    For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    For ``pre_model_route`` and ``pre_llm_call``, route/context payloads are
+    passed through unchanged to match the existing plugin-hook contracts.
 
     Anything else returns ``None``.
     """
@@ -522,6 +522,19 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
             message = data.get("reason") or data.get("message") or ""
             if isinstance(message, str) and message:
                 return {"action": "block", "message": message}
+        return None
+
+    if event == "pre_model_route":
+        model = data.get("model") or data.get("new_model")
+        if isinstance(model, str) and model.strip():
+            result = {"model": model.strip()}
+            provider = data.get("provider") or data.get("target_provider")
+            reason = data.get("reason")
+            if isinstance(provider, str) and provider.strip():
+                result["provider"] = provider.strip()
+            if isinstance(reason, str) and reason.strip():
+                result["reason"] = reason.strip()
+            return result
         return None
 
     context = data.get("context")

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -134,6 +134,16 @@ _DEFAULT_PAYLOADS = {
         "model": "gpt-4",
         "platform": "cli",
     },
+    "pre_model_route": {
+        "session_id": "test-session",
+        "user_message": "Review this pull request",
+        "conversation_history": [],
+        "is_first_turn": True,
+        "model": "glm-5.1",
+        "provider": "zai",
+        "platform": "cli",
+        "sender_id": "user-1",
+    },
     "post_llm_call": {
         "session_id": "test-session",
         "model": "gpt-4",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -80,6 +80,7 @@ VALID_HOOKS: Set[str] = {
     "post_tool_call",
     "transform_terminal_output",
     "transform_tool_result",
+    "pre_model_route",
     "pre_llm_call",
     "post_llm_call",
     "pre_api_request",
@@ -1060,8 +1061,13 @@ class PluginManager:
 
         Returns a list of non-``None`` return values from callbacks.
 
-        For ``pre_llm_call``, callbacks may return a dict describing
-        context to inject into the current turn's user message::
+        ``pre_model_route`` callbacks may return a dict describing a runtime
+        model route proposal::
+
+            {"provider": "openai-codex", "model": "gpt-5.4"}
+
+        ``pre_llm_call`` callbacks may return a dict describing context to
+        inject into the current turn's user message::
 
             {"context": "recalled text..."}
             "recalled text..."          # plain string, equivalent

--- a/run_agent.py
+++ b/run_agent.py
@@ -2279,7 +2279,16 @@ class AIAgent:
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(
+        self,
+        new_model,
+        new_provider,
+        api_key='',
+        base_url='',
+        api_mode='',
+        *,
+        prune_fallback_chain=True,
+    ):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -2292,6 +2301,10 @@ class AIAgent:
         client-swap logic but also updates ``_primary_runtime`` so the
         change persists across turns (unlike fallback which is
         turn-scoped).
+
+        ``prune_fallback_chain`` is kept on for explicit user switches. Plugin
+        route hooks can disable it so task-aware routing does not permanently
+        remove configured fallback providers while moving between models.
         """
         from hermes_cli.providers import determine_api_mode
 
@@ -2449,7 +2462,7 @@ class AIAgent:
         old_norm = (old_provider or "").strip().lower()
         new_norm = (new_provider or "").strip().lower()
         fallback_chain = list(getattr(self, "_fallback_chain", []) or [])
-        if old_norm and new_norm and old_norm != new_norm:
+        if prune_fallback_chain and old_norm and new_norm and old_norm != new_norm:
             fallback_chain = [
                 entry for entry in fallback_chain
                 if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
@@ -2461,6 +2474,114 @@ class AIAgent:
             "Model switched in-place: %s (%s) -> %s (%s)",
             old_model, old_provider, new_model, new_provider,
         )
+
+    def _apply_pre_model_route_hook(
+        self,
+        user_message: str,
+        conversation_history: list,
+        is_first_turn: bool,
+    ) -> None:
+        """Allow plugins to route the current turn before the system prompt/API call.
+
+        The hook returns a route proposal, not credentials. Credentials,
+        base_url, api_mode, aliases, and provider-specific normalization stay
+        inside Hermes's existing model_switch pipeline.
+        """
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _route_results = _invoke_hook(
+                "pre_model_route",
+                session_id=self.session_id,
+                user_message=user_message,
+                conversation_history=list(conversation_history or []),
+                is_first_turn=is_first_turn,
+                model=self.model,
+                provider=self.provider,
+                platform=getattr(self, "platform", None) or "",
+                sender_id=getattr(self, "_user_id", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("pre_model_route hook failed: %s", exc)
+            return
+
+        route = None
+        requested_model = ""
+        requested_provider = ""
+        route_reason = ""
+        for candidate in _route_results or []:
+            if not isinstance(candidate, dict):
+                continue
+            requested_model = str(
+                candidate.get("model") or candidate.get("new_model") or ""
+            ).strip()
+            if not requested_model:
+                logger.warning("pre_model_route result ignored: missing model")
+                continue
+            route = candidate
+            requested_provider = str(
+                route.get("provider") or route.get("target_provider") or ""
+            ).strip()
+            route_reason = str(route.get("reason") or "").strip()
+            break
+        if not route:
+            return
+
+        current_provider = (self.provider or "").strip()
+        effective_provider = requested_provider or current_provider
+        if (
+            requested_model == (self.model or "")
+            and effective_provider == current_provider
+        ):
+            return
+
+        try:
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                load_config,
+            )
+            from hermes_cli.model_switch import switch_model as _switch_model
+
+            config = load_config()
+            user_providers = config.get("providers", {}) if isinstance(config, dict) else {}
+            custom_providers = get_compatible_custom_providers(config)
+            result = _switch_model(
+                raw_input=requested_model,
+                current_provider=self.provider or "",
+                current_model=self.model or "",
+                current_base_url=self.base_url or "",
+                current_api_key=getattr(self, "api_key", "") or "",
+                is_global=False,
+                explicit_provider=requested_provider,
+                user_providers=user_providers,
+                custom_providers=custom_providers,
+            )
+            if not result.success:
+                logger.warning(
+                    "pre_model_route result ignored: %s",
+                    result.error_message or "model switch failed",
+                )
+                return
+
+            old_model = self.model
+            old_provider = self.provider
+            self.switch_model(
+                new_model=result.new_model,
+                new_provider=result.target_provider,
+                api_key=result.api_key,
+                base_url=result.base_url,
+                api_mode=result.api_mode,
+                prune_fallback_chain=False,
+            )
+            logging.info(
+                "pre_model_route switched model for this turn: %s (%s) -> %s (%s)%s",
+                old_model,
+                old_provider,
+                self.model,
+                self.provider,
+                f" reason={route_reason!r}" if route_reason else "",
+            )
+        except Exception as exc:
+            logger.warning("pre_model_route switch failed: %s", exc)
 
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.
@@ -10542,6 +10663,12 @@ class AIAgent:
         if not self.quiet_mode:
             _print_preview = _summarize_user_message_for_log(user_message)
             self._safe_print(f"💬 Starting conversation: '{_print_preview[:60]}{'...' if len(_print_preview) > 60 else ''}'")
+
+        self._apply_pre_model_route_hook(
+            original_user_message,
+            messages,
+            is_first_turn=(not bool(conversation_history)),
+        )
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -87,6 +87,23 @@ class TestParseResponse:
         )
         assert r == {"context": "today is Friday"}
 
+    def test_pre_model_route_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_model_route",
+            '{"provider": "openai-codex", "model": "gpt-5.4", "reason": "coding"}',
+        )
+        assert r == {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "reason": "coding",
+        }
+
+    def test_pre_model_route_requires_model(self):
+        r = shell_hooks._parse_response(
+            "pre_model_route", '{"provider": "openai-codex"}',
+        )
+        assert r is None
+
     def test_subagent_stop_context_passthrough(self):
         r = shell_hooks._parse_response(
             "subagent_stop", '{"context": "child role=leaf"}',

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -328,6 +328,7 @@ class TestPluginHooks:
     def test_valid_hooks_include_request_scoped_api_hooks(self):
         assert "pre_api_request" in VALID_HOOKS
         assert "post_api_request" in VALID_HOOKS
+        assert "pre_model_route" in VALID_HOOKS
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
 

--- a/tests/run_agent/test_pre_model_route_hook.py
+++ b/tests/run_agent/test_pre_model_route_hook.py
@@ -1,0 +1,100 @@
+"""Tests for plugin-driven pre-turn model routing."""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.model_switch import ModelSwitchResult
+from run_agent import AIAgent
+
+
+def _make_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "session-1"
+    agent.model = "glm-5.1"
+    agent.provider = "zai"
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent.api_key = "zai-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent._client_kwargs = {
+        "api_key": "zai-key",
+        "base_url": "https://api.z.ai/api/coding/paas/v4",
+    }
+    agent.context_compressor = None
+    agent._cached_system_prompt = "cached"
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = [
+        {"provider": "openai-codex", "model": "gpt-5.4"},
+        {"provider": "zai", "model": "glm-5.1"},
+    ]
+    agent._fallback_model = agent._fallback_chain[0]
+    agent._user_id = "user-1"
+    agent.platform = "slack"
+    return agent
+
+
+def test_pre_model_route_switches_with_model_switch_pipeline():
+    agent = _make_agent()
+
+    route = {
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "reason": "coding task",
+    }
+    result = ModelSwitchResult(
+        success=True,
+        new_model="gpt-5.4",
+        target_provider="openai-codex",
+        api_key="codex-key",
+        base_url="https://api.openai.com/v1",
+        api_mode="codex_responses",
+    )
+
+    with (
+        patch("hermes_cli.plugins.invoke_hook", return_value=[route]) as hook,
+        patch("hermes_cli.config.load_config", return_value={"providers": {}}),
+        patch("hermes_cli.config.get_compatible_custom_providers", return_value=[]),
+        patch("hermes_cli.model_switch.switch_model", return_value=result) as switch,
+        patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        patch.object(agent, "_anthropic_prompt_cache_policy", return_value=(False, False)),
+        patch.object(agent, "_ensure_lmstudio_runtime_loaded"),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent._apply_pre_model_route_hook(
+            "please review this code",
+            [{"role": "user", "content": "please review this code"}],
+            is_first_turn=True,
+        )
+
+    hook.assert_called_once()
+    switch.assert_called_once()
+    assert switch.call_args.kwargs["raw_input"] == "gpt-5.4"
+    assert switch.call_args.kwargs["explicit_provider"] == "openai-codex"
+    assert switch.call_args.kwargs["current_provider"] == "zai"
+    assert agent.model == "gpt-5.4"
+    assert agent.provider == "openai-codex"
+    assert agent.api_mode == "codex_responses"
+    assert agent._fallback_chain == [
+        {"provider": "openai-codex", "model": "gpt-5.4"},
+        {"provider": "zai", "model": "glm-5.1"},
+    ]
+
+
+def test_pre_model_route_ignores_missing_model():
+    agent = _make_agent()
+
+    with (
+        patch("hermes_cli.plugins.invoke_hook", return_value=[{"provider": "openai-codex"}]),
+        patch("hermes_cli.model_switch.switch_model") as switch,
+    ):
+        agent._apply_pre_model_route_hook(
+            "hello",
+            [{"role": "user", "content": "hello"}],
+            is_first_turn=False,
+        )
+
+    switch.assert_not_called()
+    assert agent.model == "glm-5.1"
+    assert agent.provider == "zai"
+

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -431,6 +431,7 @@ Each hook is documented in full on the **[Event Hooks reference](/docs/user-guid
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | ignored |
 | [`post_tool_call`](/docs/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
+| [`pre_model_route`](/docs/user-guide/features/hooks#pre_model_route) | Once per turn, before system prompt build and LLM calls | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, provider: str, platform: str` | `{"provider": str, "model": str, "reason": str}` to switch runtime model for the turn |
 | [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/docs/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |
@@ -438,13 +439,13 @@ Each hook is documented in full on the **[Event Hooks reference](/docs/user-guid
 | [`on_session_finalize`](/docs/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/docs/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_model_route`, which can switch the runtime model for the turn, and `pre_llm_call`, which can inject context into the conversation.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
 
 #### Return format
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -367,7 +367,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Three hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_model_route`](#pre_model_route) can **switch the runtime model**, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
 
 ### Quick reference
 
@@ -375,6 +375,7 @@ def register(ctx):
 |------|-----------|---------|
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
+| [`pre_model_route`](#pre_model_route) | Once per turn, before system prompt build and LLM calls | `{"provider": str, "model": str, "reason": str}` to switch runtime model for the turn |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
@@ -500,9 +501,66 @@ def register(ctx):
 
 ---
 
+### `pre_model_route`
+
+Fires **once per turn**, before Hermes builds the system prompt and before any LLM API call. Plugins can use this hook to choose a runtime model based on the current message, conversation history, platform, user, benchmark policy, or account limits.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, user_message: str, conversation_history: list,
+                is_first_turn: bool, model: str, provider: str,
+                platform: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_id` | `str` | Unique identifier for the current session |
+| `user_message` | `str` | The user's original message for this turn |
+| `conversation_history` | `list` | Copy of the message list at the start of the turn |
+| `is_first_turn` | `bool` | `True` if this is the first turn of a new session |
+| `model` | `str` | Current model before routing |
+| `provider` | `str` | Current provider before routing |
+| `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, `"discord"`, etc. |
+
+**Return value — runtime route proposal:**
+
+```python
+return {
+    "provider": "openai-codex",
+    "model": "gpt-5.4",
+    "reason": "coding task"
+}
+```
+
+`model` is required. `provider` is optional; if omitted, Hermes resolves the model against the current provider. Hermes treats the return value as a route proposal, not raw credentials. API keys, base URLs, aliases, API mode, and provider-specific normalization are resolved through the same `model_switch` pipeline used by `/model`.
+
+If multiple plugins return route proposals, the first valid dict result wins. Invalid proposals are logged and ignored so the turn continues on the current model.
+
+**Use cases:** Benchmark-driven routing, task-aware model selection, per-user subscription policy, account limit steering, and low-cost default routing with high-capability escalation.
+
+**Example — route coding tasks to a stronger model:**
+
+```python
+def route_model(user_message: str, model: str, provider: str, **kwargs):
+    text = (user_message or "").lower()
+    if any(word in text for word in ("bug", "test", "refactor", "pull request")):
+        return {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "reason": "coding task",
+        }
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_model_route", route_model)
+```
+
+---
+
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. It can inject context into the current turn's user message.
 
 **Callback signature:**
 
@@ -1117,6 +1175,7 @@ Shell hooks are registered by calling `agent.shell_hooks.register_from_config(cf
 | Events | `VALID_HOOKS` (incl. `subagent_stop`) | `VALID_HOOKS` | Gateway lifecycle (`gateway:startup`, `agent:*`, `command:*`) |
 | Can block a tool call | Yes (`pre_tool_call`) | Yes (`pre_tool_call`) | No |
 | Can inject LLM context | Yes (`pre_llm_call`) | Yes (`pre_llm_call`) | No |
+| Can route the runtime model | Yes (`pre_model_route`) | Yes (`pre_model_route`) | No |
 | Consent | First-use prompt per `(event, command)` pair | Implicit (Python plugin trust) | Implicit (dir trust) |
 | Inter-process isolation | Yes (subprocess) | No (in-process) | No (in-process) |
 
@@ -1151,7 +1210,7 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 }
 ```
 
-`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
+`tool_name` and `tool_input` are `null` for non-tool events (`pre_model_route`, `pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
 
 **stdout — optional response:**
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -243,6 +243,8 @@ Visually the target is the familiar Linear / Fusion layout: dark theme, column h
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
+<!-- ascii-guard-ignore -->
+
 ```
 ┌────────────────────────┐      WebSocket (tails task_events)
 │   React SPA (plugin)   │ ◀──────────────────────────────────┐
@@ -262,6 +264,8 @@ The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer wi
 │  (WAL, shared)         │
 └────────────────────────┘
 ```
+
+<!-- ascii-guard-ignore-end -->
 
 ### REST surface
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -138,6 +138,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 |------|-----------|
 | [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes |
 | [`post_tool_call`](/docs/user-guide/features/hooks#post_tool_call) | After any tool returns |
+| [`pre_model_route`](/docs/user-guide/features/hooks#pre_model_route) | Once per turn, before system prompt build and LLM calls — can return `{"provider": "...", "model": "..."}` to switch the runtime model |
 | [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/docs/user-guide/features/hooks#pre_llm_call) |
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
 | [`on_session_start`](/docs/user-guide/features/hooks#on_session_start) | New session created (first turn only) |


### PR DESCRIPTION
## Summary / What changed

- Add a new `pre_model_route` plugin hook that fires once per turn before system prompt construction and LLM calls.
- Route proposals go through the existing `model_switch` pipeline, so credentials, base URLs, API mode, aliases, and provider normalization stay inside Hermes.
- Preserve configured fallback chains for plugin-driven task routing by adding a `prune_fallback_chain` guard to `AIAgent.switch_model()`.
- Document the new hook and add Python and shell-hook tests.

## Why

Plugins can currently observe LLM calls or inject context, but they cannot safely choose the runtime model for a turn. This adds a small extension point for benchmark-driven routing, task-aware model selection, subscription-aware routing, and similar plugins without requiring each plugin to reimplement provider credentials or mutate request payloads directly.

## Tests

- `python -m py_compile run_agent.py hermes_cli/plugins.py hermes_cli/hooks.py agent/shell_hooks.py`
- `python -m pytest tests/run_agent/test_pre_model_route_hook.py tests/agent/test_shell_hooks.py::TestParseResponse tests/hermes_cli/test_plugins.py::TestPluginHooks tests/run_agent/test_switch_model_fallback_prune.py tests/run_agent/test_switch_model_context.py -q`

## Real-world validation

Not deployed. This PR is a focused extension point with unit coverage.
