### PR TITLE
feat: add clean dashboard theme

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3939,6 +3939,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
+    {"name": "clean",     "label": "Clean",          "description": "Clean, calm, readable light theme for the Hermes dashboard."},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
 ]

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -130,6 +130,344 @@ export const monoTheme: DashboardTheme = {
   },
 };
 
+export const cleanTheme: DashboardTheme = {
+  name: "clean",
+  label: "Clean",
+  description: "Clean, calm, readable light theme for the Hermes dashboard.",
+  palette: {
+    background: { hex: "#f4f1e9", alpha: 1 },
+    midground: { hex: "#1f3f37", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0.06 },
+    warmGlow: "rgba(47, 143, 122, 0.06)",
+    noiseOpacity: 0,
+  },
+  typography: {
+    fontSans: `"IBM Plex Sans", Inter, ${SYSTEM_SANS}`,
+    fontMono: `"IBM Plex Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap",
+    baseSize: "14px",
+    lineHeight: "1.55",
+    letterSpacing: "0",
+  },
+  layout: {
+    radius: "0.7rem",
+    density: "comfortable",
+  },
+  layoutVariant: "standard",
+  colorOverrides: {
+    card: "#fffefa",
+    cardForeground: "#1d2926",
+    popover: "#fffefa",
+    popoverForeground: "#1d2926",
+    primary: "#287d6b",
+    primaryForeground: "#ffffff",
+    secondary: "#e7eee9",
+    secondaryForeground: "#203b34",
+    muted: "#eef1ec",
+    mutedForeground: "#5e6c67",
+    accent: "#dcebe4",
+    accentForeground: "#1f3f37",
+    destructive: "#b4403e",
+    destructiveForeground: "#ffffff",
+    success: "#287d6b",
+    warning: "#8a650f",
+    border: "#d3d9d4",
+    input: "#bccbc4",
+    ring: "#5c9f8d",
+  },
+  componentStyles: {
+    page: {
+      background: "#f4f1e9",
+    },
+    card: {
+      background: "#fffefa",
+      border: "1px solid #cbd5cf",
+      boxShadow: "0 8px 24px rgba(29, 41, 38, 0.06)",
+    },
+    header: {
+      background: "rgba(244, 241, 233, 0.96)",
+      borderBottom: "1px solid #d7ddd8",
+      backdropFilter: "blur(12px) saturate(120%)",
+    },
+    sidebar: {
+      background: "#efede6",
+      borderRight: "1px solid #d7ddd8",
+    },
+    badge: {
+      borderRadius: "999px",
+    },
+    tab: {
+      borderRadius: "0.55rem",
+    },
+    backdrop: {
+      opacity: "0",
+      fillerOpacity: "0",
+      fillerBlendMode: "normal",
+    },
+  },
+  customCSS: `
+    :root {
+      color-scheme: light;
+      --clean-bg: #f4f1e9;
+      --clean-panel: #fffefa;
+      --clean-sidebar: #efede6;
+      --clean-text: #1d2926;
+      --clean-heading: #153a33;
+      --clean-muted: #52665f;
+      --clean-border: #cbd5cf;
+      --clean-accent: #287d6b;
+      --clean-accent-soft: #dcebe4;
+      --clean-danger: #b4403e;
+    }
+
+    html,
+    body,
+    #root,
+    [data-layout-variant] {
+      background: var(--clean-bg) !important;
+      color: var(--clean-text) !important;
+      font-family: var(--theme-font-sans) !important;
+      text-transform: none !important;
+      letter-spacing: normal !important;
+      text-shadow: none !important;
+      accent-color: var(--clean-accent) !important;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    [class*="bg-black"],
+    .bg-black,
+    main,
+    main > div,
+    [class*="bg-background"],
+    [class*="bg-background-base"] {
+      background-color: var(--clean-bg) !important;
+    }
+
+    [style*="mix-blend-mode"],
+    [style*="mixBlendMode"],
+    .theme-default-filler,
+    img.theme-default-filler,
+    .pointer-events-none.fixed.inset-0[style*="mix-blend-mode"] {
+      mix-blend-mode: normal !important;
+      opacity: 0 !important;
+      visibility: hidden !important;
+    }
+
+    *,
+    [class*="uppercase"],
+    [class*="tracking-"] {
+      letter-spacing: normal !important;
+      text-transform: none !important;
+      text-shadow: none !important;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    [class*="font-expanded"] {
+      color: var(--clean-heading) !important;
+      font-family: var(--theme-font-sans) !important;
+      font-weight: 700 !important;
+    }
+
+    h1 { font-size: 1.45rem !important; }
+    h2 { font-size: 1.18rem !important; }
+    h3 { font-size: 1.02rem !important; }
+
+    aside,
+    [data-sidebar],
+    nav[class*="border-r"],
+    .border-r {
+      background-color: var(--clean-sidebar) !important;
+      border-color: #d7ddd8 !important;
+    }
+
+    aside nav a > span[aria-hidden] {
+      display: none !important;
+      opacity: 0 !important;
+      background: transparent !important;
+    }
+
+    aside nav ul li a:not(.text-midground),
+    aside nav ul li a:not(.text-midground):hover,
+    aside nav ul li a:not(.text-midground):focus,
+    aside nav ul li a:not(.text-midground):visited {
+      background: transparent !important;
+      color: #123b34 !important;
+      box-shadow: none !important;
+      opacity: 1 !important;
+    }
+
+    aside nav ul li a.text-midground {
+      background: var(--clean-accent-soft) !important;
+      color: #0f332d !important;
+      box-shadow: inset 3px 0 0 var(--clean-accent) !important;
+      opacity: 1 !important;
+    }
+
+    aside nav a svg,
+    aside nav a svg *,
+    aside nav a > span:not([aria-hidden]) {
+      background: transparent !important;
+      color: currentColor !important;
+      opacity: 1 !important;
+    }
+
+    header,
+    header h1,
+    header h2,
+    header span,
+    header div,
+    .text-midground,
+    [class*="text-midground"] {
+      color: var(--clean-heading) !important;
+    }
+
+    .text-muted-foreground,
+    [class*="text-muted-foreground"],
+    [class*="text-muted"],
+    [class*="text-midground/"],
+    [class*="text-current/"] {
+      color: var(--clean-muted) !important;
+      opacity: 1 !important;
+    }
+
+    [class*="bg-card"],
+    [class*="bg-popover"],
+    [class*="bg-background/40"],
+    [class*="bg-background/50"],
+    [class*="bg-background-base/40"],
+    [class*="bg-background-base/50"] {
+      background-color: var(--clean-panel) !important;
+      color: var(--clean-text) !important;
+    }
+
+    .border,
+    .border-border,
+    [class*="border-border"],
+    [class*="rounded"] {
+      border-color: var(--clean-border) !important;
+    }
+
+    main [class*="border-b"],
+    main [class*="border-b"] * {
+      background: #fbfaf6 !important;
+      border-color: var(--clean-border) !important;
+      color: #24453e !important;
+      mix-blend-mode: normal !important;
+      opacity: 1 !important;
+    }
+
+    input,
+    select,
+    textarea,
+    [role="combobox"],
+    input[class*="text-"],
+    textarea[class*="text-"],
+    select[class*="text-"] {
+      min-height: 2.45rem !important;
+      background: #fffefa !important;
+      border: 1px solid #bccbc4 !important;
+      border-radius: 0.65rem !important;
+      color: #172b27 !important;
+      font-family: var(--theme-font-sans) !important;
+      font-size: 0.95rem !important;
+      line-height: 1.45 !important;
+    }
+
+    input::placeholder,
+    textarea::placeholder {
+      color: #62756f !important;
+      opacity: 1 !important;
+    }
+
+    button,
+    [role="button"] {
+      border-radius: 0.65rem !important;
+      font-family: var(--theme-font-sans) !important;
+      font-weight: 600 !important;
+      letter-spacing: normal !important;
+      text-transform: none !important;
+    }
+
+    button:not([class*="bg-primary"]):not([class*="text-primary"]),
+    [role="button"]:not([class*="bg-primary"]):not([class*="text-primary"]) {
+      background-color: #f8f7f2 !important;
+      border-color: #c9d2cc !important;
+      color: #183c35 !important;
+    }
+
+    button[class*="bg-primary"],
+    [class*="bg-primary"] {
+      background: var(--clean-accent) !important;
+      border-color: #216b5c !important;
+      color: #ffffff !important;
+    }
+
+    code,
+    pre,
+    kbd,
+    samp,
+    .font-mono,
+    [class*="font-mono"] {
+      font-family: var(--theme-font-mono) !important;
+      letter-spacing: 0 !important;
+    }
+
+    small,
+    [class*="text-[0.65rem]"],
+    [class*="text-[0.7rem]"],
+    [class*="text-[0.75rem]"],
+    [class*="text-xs"]:not(input):not(textarea):not(select) {
+      color: var(--clean-muted) !important;
+      font-size: 0.8rem !important;
+      line-height: 1.35 !important;
+      opacity: 1 !important;
+    }
+
+    mark,
+    mark.bg-warning\\/30,
+    mark.text-warning,
+    .bg-warning\\/30,
+    .text-warning.bg-warning\\/30 {
+      background: #d7eec7 !important;
+      color: #25493f !important;
+      border-radius: 0.18rem !important;
+      box-decoration-break: clone !important;
+      -webkit-box-decoration-break: clone !important;
+      mix-blend-mode: normal !important;
+      text-shadow: none !important;
+    }
+
+    ::selection,
+    *::selection,
+    input::selection,
+    textarea::selection,
+    code::selection,
+    pre::selection {
+      background: #b8d8cc !important;
+      color: #08241f !important;
+      text-shadow: none !important;
+    }
+
+    ::-moz-selection,
+    *::-moz-selection,
+    input::-moz-selection,
+    textarea::-moz-selection,
+    code::-moz-selection,
+    pre::-moz-selection {
+      background: #b8d8cc !important;
+      color: #08241f !important;
+      text-shadow: none !important;
+    }
+  `,
+};
+
 export const cyberpunkTheme: DashboardTheme = {
   name: "cyberpunk",
   label: "Cyberpunk",
@@ -210,6 +548,7 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
+  clean: cleanTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
 };


### PR DESCRIPTION
## Summary
- Add a built-in Clean dashboard theme
- Register the theme in the dashboard theme API metadata
- Tune light-theme typography, sidebar states, panels, controls, text selection, and search highlights for readability

## Validation
- npx eslint src/themes/presets.ts
- npx tsc -p tsconfig.app.json --noEmit
- python AST parse for hermes_cli/web_server.py
