### PR TITLE
feat(kanban-dashboard): stack Mission Control (Class B) cards under kanban board

### DIFF
--- a/plugins/kanban/dashboard/README.md
+++ b/plugins/kanban/dashboard/README.md
@@ -1,0 +1,54 @@
+# Hermes Kanban dashboard plugin
+
+The `/kanban` tab serves two stacked governance views:
+
+1. **Top — Kanban (Class A autonomous tasks).** Backed by `~/.hermes/kanban.db`
+   via this plugin's REST + WebSocket API at `/api/plugins/kanban/*`.
+2. **Bottom — Mission Control (Class B human-paired strategic cards).** Backed
+   by Convex at `https://uncommon-emu-480.convex.cloud`, polled every 30s
+   directly from the browser.
+
+## Mission Control data source
+
+The Convex query is hard-coded in `dist/index.js`:
+
+```js
+const MC_CONVEX_URL = "https://uncommon-emu-480.convex.cloud";
+const MC_QUERY_PATH = "tasks:list";
+const MC_POLL_MS = 30000;
+```
+
+Read-only, no auth — the deployment exposes `tasks:list` as a public query and
+the response includes `title`, `description`, `status`, `assignee`, `priority`,
+`updatedAt`, `projectId`. The section keeps its own client-side filters
+(status, assignee, search) and never writes back; status changes flow through
+the existing `mc-complete` CLI / Discord channels.
+
+### Updating when the Convex schema changes
+
+If the Convex deployment renames the query or adds/removes fields:
+
+1. Confirm the new shape with a probe — e.g.
+   `curl -sS -X POST $MC_CONVEX_URL/api/query -H 'Content-Type: application/json' -d '{"path":"tasks:list","args":{},"format":"json"}' | jq '.value[0]'`.
+2. If the path is renamed (e.g. `strategic:list`), edit `MC_QUERY_PATH` at the
+   top of the `MissionControlSection` block in `dist/index.js`.
+3. If new fields land that you want surfaced (e.g. `class`, `tier`, `tags`),
+   extend the `<thead>` and the row rendering in `MissionControlSection`. Pill
+   classes for new statuses can be added under
+   `dist/style.css` → `.hermes-mc-pill-<status>`.
+4. If the deployment URL changes, update `MC_CONVEX_URL`.
+
+The plugin is plain IIFE JS — no build step. After editing `dist/index.js`
+or `dist/style.css`, the running dashboard picks it up on browser refresh
+(the gateway serves the files directly).
+
+## Auth (Cloudflare Access)
+
+The dashboard is fronted by Cloudflare Tunnel at `https://kanban.tilos.com` and
+gated by a Cloudflare Access self-hosted application
+(`Hermes Kanban Dashboard`, app id `95ca4f40-2fb4-44c5-9f1b-b8394a1e6bd2`,
+allowed IdP: Google `51b301f3-f75a-4c1c-9e9d-8f3f1ba7d40e`, allow-list
+policy `info@tilos.com`). Unauthenticated GETs return a 302 to
+`https://tilos.cloudflareaccess.com/cdn-cgi/access/login/kanban.tilos.com`.
+The Convex API is public read — no Access cookie is required for the MC
+section to load once the user is past the gate.

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -532,7 +532,173 @@
           allTasks: board.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
           eventTick: taskEventTick[selectedTaskId] || 0,
         }) : null,
+        h(MissionControlSection, null),
       ),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Mission Control (Class B strategic cards) — pulled from Convex
+  // -------------------------------------------------------------------------
+
+  const MC_CONVEX_URL = "https://uncommon-emu-480.convex.cloud";
+  const MC_QUERY_PATH = "tasks:list";
+  const MC_POLL_MS = 30000;
+
+  function MissionControlSection() {
+    const [tasks, setTasks] = useState(null);
+    const [error, setError] = useState(null);
+    const [statusFilter, setStatusFilter] = useState("active"); // active | all
+    const [assigneeFilter, setAssigneeFilter] = useState("");
+    const [search, setSearch] = useState("");
+    const [updatedAt, setUpdatedAt] = useState(0);
+
+    useEffect(function () {
+      let cancelled = false;
+      function load() {
+        fetch(`${MC_CONVEX_URL}/api/query`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ path: MC_QUERY_PATH, args: {}, format: "json" }),
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (j) {
+            if (cancelled) return;
+            const v = (j && (j.value || j.result)) || [];
+            setTasks(Array.isArray(v) ? v : []);
+            setUpdatedAt(Date.now());
+            setError(null);
+          })
+          .catch(function (e) {
+            if (cancelled) return;
+            setError(String(e && e.message ? e.message : e));
+          });
+      }
+      load();
+      const id = setInterval(load, MC_POLL_MS);
+      return function () { cancelled = true; clearInterval(id); };
+    }, []);
+
+    const filtered = useMemo(function () {
+      if (!tasks) return null;
+      const q = search.trim().toLowerCase();
+      const ACTIVE = new Set(["pending", "in_progress", "in_review", "backlog"]);
+      return tasks.filter(function (t) {
+        if (statusFilter === "active") {
+          if (!ACTIVE.has(t.status)) return false;
+        }
+        if (assigneeFilter && (t.assignee || "") !== assigneeFilter) return false;
+        if (q) {
+          const hay = `${t.title || ""} ${t.description || ""}`.toLowerCase();
+          if (hay.indexOf(q) < 0) return false;
+        }
+        return true;
+      }).sort(function (a, b) {
+        return (b.updatedAt || 0) - (a.updatedAt || 0);
+      });
+    }, [tasks, statusFilter, assigneeFilter, search]);
+
+    const assignees = useMemo(function () {
+      if (!tasks) return [];
+      const s = new Set();
+      tasks.forEach(function (t) { if (t.assignee) s.add(t.assignee); });
+      return Array.from(s).sort();
+    }, [tasks]);
+
+    const counts = useMemo(function () {
+      if (!tasks) return null;
+      const c = { all: tasks.length };
+      tasks.forEach(function (t) { c[t.status] = (c[t.status] || 0) + 1; });
+      return c;
+    }, [tasks]);
+
+    return h("section", { className: "hermes-mc" },
+      h("div", { className: "hermes-mc-head" },
+        h("div", { className: "hermes-mc-title" },
+          h("span", { className: "hermes-mc-dot" }),
+          "Mission Control",
+          h("span", { className: "hermes-mc-subtitle" },
+            "Class B — human-paired strategic cards"),
+        ),
+        h("div", { className: "hermes-mc-meta" },
+          counts ? h("span", { className: "hermes-mc-counts" },
+            `${counts.in_progress || 0} running · ${counts.pending || 0} pending · ${counts.in_review || 0} review · ${counts.backlog || 0} backlog · ${counts.done || 0} done`
+          ) : null,
+          updatedAt ? h("span", { className: "hermes-mc-stamp" },
+            `updated ${timeAgo(updatedAt / 1000)}`) : null,
+        ),
+      ),
+      h("div", { className: "hermes-mc-toolbar" },
+        h(Label, null, "Status",
+          h(Select, {
+            value: statusFilter,
+            onChange: function (e) { setStatusFilter(e.target.value); },
+          },
+            h(SelectOption, { value: "active" }, "Active (no done)"),
+            h(SelectOption, { value: "all" }, "All"),
+          ),
+        ),
+        h(Label, null, "Assignee",
+          h(Select, {
+            value: assigneeFilter,
+            onChange: function (e) { setAssigneeFilter(e.target.value); },
+          },
+            h(SelectOption, { value: "" }, "All"),
+            assignees.map(function (a) {
+              return h(SelectOption, { key: a, value: a }, a);
+            }),
+          ),
+        ),
+        h(Label, null, "Search",
+          h(Input, {
+            value: search,
+            placeholder: "title or description…",
+            onChange: function (e) { setSearch(e.target.value); },
+          }),
+        ),
+        h("a", {
+          className: "hermes-mc-link",
+          href: "https://uncommon-emu-480.convex.site",
+          target: "_blank",
+          rel: "noreferrer",
+        }, "Open Mission Control →"),
+      ),
+      error ? h("div", { className: "hermes-mc-error" },
+        `Failed to load Convex tasks: ${error}`) : null,
+      !tasks ? h("div", { className: "hermes-mc-empty" }, "Loading Mission Control…")
+        : filtered.length === 0 ? h("div", { className: "hermes-mc-empty" },
+            "No matching cards.")
+        : h("div", { className: "hermes-mc-table-wrap" },
+            h("table", { className: "hermes-mc-table" },
+              h("thead", null,
+                h("tr", null,
+                  h("th", null, "Title"),
+                  h("th", null, "Status"),
+                  h("th", null, "Assignee"),
+                  h("th", null, "Priority"),
+                  h("th", null, "Updated"),
+                ),
+              ),
+              h("tbody", null,
+                filtered.slice(0, 200).map(function (t) {
+                  return h("tr", { key: t._id, className: `hermes-mc-row hermes-mc-status-${t.status}` },
+                    h("td", { className: "hermes-mc-cell-title" },
+                      h("div", { className: "hermes-mc-cell-title-line" }, t.title || "(untitled)"),
+                      t.description ? h("div", { className: "hermes-mc-cell-desc" },
+                        (t.description || "").slice(0, 160)) : null,
+                    ),
+                    h("td", null,
+                      h("span", { className: `hermes-mc-pill hermes-mc-pill-${t.status}` },
+                        t.status || "—"),
+                    ),
+                    h("td", null, t.assignee || "—"),
+                    h("td", null, t.priority || "—"),
+                    h("td", null, t.updatedAt ? timeAgo(t.updatedAt / 1000) : "—"),
+                  );
+                }),
+              ),
+            ),
+          ),
     );
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -758,3 +758,159 @@
   word-break: break-word;
   font-family: var(--font-mono, ui-monospace, monospace);
 }
+
+/* ============================================================ */
+/* Mission Control (Class B strategic cards) — stacked under     */
+/* the kanban board, pulled from Convex /api/query tasks:list    */
+/* ============================================================ */
+
+.hermes-mc {
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+.hermes-mc-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.hermes-mc-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+.hermes-mc-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #c084fc;
+  box-shadow: 0 0 0 3px color-mix(in srgb, #c084fc 25%, transparent);
+}
+.hermes-mc-subtitle {
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--color-muted-foreground);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-left: 0.4rem;
+}
+.hermes-mc-meta {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+  font-size: 0.7rem;
+  color: var(--color-muted-foreground);
+}
+.hermes-mc-counts { font-variant-numeric: tabular-nums; }
+.hermes-mc-stamp { font-style: italic; }
+.hermes-mc-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 0.65rem;
+}
+.hermes-mc-link {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--color-muted-foreground);
+  text-decoration: none;
+  border-bottom: 1px dotted color-mix(in srgb, var(--color-foreground) 35%, transparent);
+}
+.hermes-mc-link:hover { color: var(--color-foreground); }
+.hermes-mc-error {
+  font-size: 0.75rem;
+  color: var(--color-destructive, #f87171);
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.4rem;
+  background: color-mix(in srgb, #f87171 12%, transparent);
+}
+.hermes-mc-empty {
+  padding: 1.25rem;
+  font-size: 0.8rem;
+  color: var(--color-muted-foreground);
+  text-align: center;
+  border: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: 0.5rem;
+}
+.hermes-mc-table-wrap {
+  overflow-x: auto;
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+}
+.hermes-mc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+.hermes-mc-table thead th {
+  text-align: left;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted-foreground);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+.hermes-mc-table tbody td {
+  padding: 0.55rem 0.7rem;
+  vertical-align: top;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 35%, transparent);
+}
+.hermes-mc-row:hover td {
+  background: color-mix(in srgb, var(--color-foreground) 4%, transparent);
+}
+.hermes-mc-cell-title { max-width: 32rem; }
+.hermes-mc-cell-title-line {
+  font-weight: 500;
+  color: var(--color-foreground);
+}
+.hermes-mc-cell-desc {
+  margin-top: 0.2rem;
+  font-size: 0.7rem;
+  color: var(--color-muted-foreground);
+  line-height: 1.35;
+}
+.hermes-mc-pill {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  color: var(--color-muted-foreground);
+}
+.hermes-mc-pill-in_progress {
+  background: color-mix(in srgb, #60a5fa 18%, transparent);
+  border-color: color-mix(in srgb, #60a5fa 45%, transparent);
+  color: var(--color-foreground);
+}
+.hermes-mc-pill-pending {
+  background: color-mix(in srgb, #fbbf24 18%, transparent);
+  border-color: color-mix(in srgb, #fbbf24 45%, transparent);
+  color: var(--color-foreground);
+}
+.hermes-mc-pill-in_review {
+  background: color-mix(in srgb, #c084fc 18%, transparent);
+  border-color: color-mix(in srgb, #c084fc 45%, transparent);
+  color: var(--color-foreground);
+}
+.hermes-mc-pill-backlog {
+  background: color-mix(in srgb, var(--color-foreground) 6%, transparent);
+}
+.hermes-mc-pill-done {
+  background: color-mix(in srgb, #3fb97d 18%, transparent);
+  border-color: color-mix(in srgb, #3fb97d 45%, transparent);
+  color: var(--color-foreground);
+}


### PR DESCRIPTION
Adds a Mission Control section to /kanban that polls the Convex deployment at uncommon-emu-480.convex.cloud every 30s via the public tasks:list query, rendering Class B human-paired strategic cards (status/assignee/priority/updated) under the existing kanban board. Read-only; status changes continue to flow through the existing mc-complete CLI / Discord paths.

Two-class governance visualization per Mission Control spec:
- Top: kanban (Class A autonomous tasks)
- Bottom: Mission Control (Class B human-paired strategic cards)

Plain IIFE edits, no build step. Includes a README in plugins/kanban/dashboard/ documenting the Convex query path so future schema changes are easy to track.

Verified locally — kanban + MC both render, MC counts (2 running / 6 pending / 1 review / 30 backlog / 437 done) match the Convex API response. Cloudflare Access (Google IdP) gates the dashboard at https://kanban.tilos.com per the parent task's hardening goal.