### PR TITLE
fix(windows): enforce UTF-8 stdout/stderr to prevent UnicodeEncodeError crash

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -5,11 +5,43 @@ Provides subcommands for:
 - hermes chat          - Interactive chat (same as ./hermes)
 - hermes gateway       - Run gateway in foreground
 - hermes gateway start - Start gateway service
-- hermes gateway stop  - Stop gateway service  
+- hermes gateway stop  - Stop gateway service
 - hermes setup         - Interactive setup wizard
 - hermes status        - Show status of all components
 - hermes cron          - Manage cron jobs
 """
 
+import os
+import sys
+
 __version__ = "0.12.0"
 __release_date__ = "2026.4.30"
+
+
+def _ensure_utf8():
+    """Force UTF-8 stdout/stderr on Windows to prevent UnicodeEncodeError.
+
+    Windows services and terminals default to cp1252, which cannot encode
+    box-drawing characters used in CLI output. This causes unhandled
+    UnicodeEncodeError crashes on gateway startup.
+    """
+    if sys.platform != "win32":
+        return
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if stream is None:
+            continue
+        try:
+            if getattr(stream, "encoding", "").lower().replace("-", "") != "utf8":
+                new_stream = open(
+                    stream.fileno(), "w", encoding="utf-8",
+                    buffering=1, closefd=False,
+                )
+                setattr(sys, stream_name, new_stream)
+        except (AttributeError, OSError):
+            pass
+
+
+_ensure_utf8()


### PR DESCRIPTION
Salvage of #19259 by @alanxchen85 onto current main.

## Summary
Windows services and terminals default to cp1252, which can't encode the box-drawing characters used in CLI output. Gateway startup crashes with `UnicodeEncodeError` in a restart loop on Windows services. Set `PYTHONUTF8=1`, `PYTHONIOENCODING=utf-8`, and re-open stdout/stderr with UTF-8 encoding early in `hermes_cli/__init__.py`.

Windows-only — `_ensure_utf8()` returns immediately on non-win32 platforms.

## Changes
- hermes_cli/__init__.py: `_ensure_utf8()` platform-gated to win32 (+32/-0)

## Validation
Import check passes; Linux/Mac CI unaffected (early return).

Original PR: #19259