### PR TITLE
fix(kanban): drop worker identity claim from KANBAN_GUIDANCE

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -183,8 +183,8 @@ SKILLS_GUIDANCE = (
 )
 
 KANBAN_GUIDANCE = (
-    "# You are a Kanban worker\n"
-    "You were spawned by the Hermes Kanban dispatcher to execute ONE task from "
+    "# Kanban task execution protocol\n"
+    "You have been assigned ONE task from "
     "the shared board at `~/.hermes/kanban.db`. Your task id is in "
     "`$HERMES_KANBAN_TASK`; your workspace is `$HERMES_KANBAN_WORKSPACE`. "
     "The `kanban_*` tools in your schema are your primary coordination surface — "


### PR DESCRIPTION
Fixes #19351.

## Summary
KANBAN_GUIDANCE no longer redeclares agent identity. SOUL.md stays the sole identity slot; layer 3 describes task-execution protocol only.

## Root cause
`KANBAN_GUIDANCE` at layer 3 of the system prompt opened with `# You are a Kanban worker`, contradicting the profile's SOUL.md at layer 1. Profiles with strict role boundaries (e.g. a reviewer profile that never writes code) still executed implementation tasks — the kanban identity claim diluted SOUL.

## Change
| | Before | After |
|---|---|---|
| Header | `# You are a Kanban worker` | `# Kanban task execution protocol` |
| First sentence | `You were spawned by the Hermes Kanban dispatcher to execute ONE task from...` | `You have been assigned ONE task from...` |

Lifecycle, orchestrator-mode, and Do-NOT sections are byte-identical.

## Validation
Reporter's empirical test: a reviewer-only profile given a Python implementation kanban task wrote the code + 12 tests (pre-fix). With this change, the same profile calls `kanban_block(reason="Role violation...")` and refuses.