### PR TITLE
fix(session_search): resolve child sessions to root, raise FTS scan limit, demote cron sessions

### DIFF
--- a/tests/tools/test_session_search_bug3_bug4.py
+++ b/tests/tools/test_session_search_bug3_bug4.py
@@ -1,0 +1,139 @@
+"""Tests for session_search fixes from issue #19434.
+
+Bug 3: Child sessions were blindly skipped in _list_recent_sessions().
+       Fix: resolve to root and deduplicate.
+
+Bug 4: FTS scan limit of 50 caused cron sessions to dominate BM25 ranking.
+       Fix: raise limit to 300 and demote cron sessions.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+
+def _make_session(sid, source="cli", parent=None, title=None):
+    return {
+        "id": sid,
+        "title": title or sid,
+        "source": source,
+        "started_at": "2026-01-01T00:00:00",
+        "last_active": "2026-01-02T00:00:00",
+        "message_count": 5,
+        "preview": f"preview of {sid}",
+        "parent_session_id": parent,
+    }
+
+
+def _make_db(sessions=None, session_map=None, fts_rows=None):
+    db = MagicMock()
+    db.list_sessions_rich.return_value = sessions or []
+    db.search_messages.return_value = fts_rows or []
+    db.get_messages_as_conversation.return_value = []
+    session_map = session_map or {}
+    db.get_session.side_effect = lambda sid: session_map.get(sid)
+    return db
+
+
+class TestChildSessionResolution:
+
+    def _list_recent(self, db, limit=5, current=None):
+        from tools.session_search_tool import _list_recent_sessions
+        raw = _list_recent_sessions(db, limit, current)
+        return json.loads(raw) if isinstance(raw, str) else raw
+
+    def test_root_session_with_no_parent_appears(self):
+        root = _make_session("root-1", source="cli")
+        db = _make_db(sessions=[root], session_map={"root-1": root})
+        result = self._list_recent(db)
+        ids = [s["session_id"] for s in result.get("results", [])]
+        assert "root-1" in ids
+
+    def test_child_session_resolved_to_root(self):
+        """Child must be listed under root ID, not silently dropped (Bug 3)."""
+        root = _make_session("root-1", source="telegram")
+        child = _make_session("child-1", source="telegram", parent="root-1")
+        db = _make_db(
+            sessions=[child],
+            session_map={"root-1": root, "child-1": child},
+        )
+        result = self._list_recent(db)
+        ids = [s["session_id"] for s in result.get("results", [])]
+        assert "root-1" in ids, f"Root not surfaced from child. Got: {ids}"
+        assert "child-1" not in ids, f"Child ID leaked. Got: {ids}"
+
+    def test_root_and_child_not_duplicated(self):
+        root = _make_session("root-1")
+        child = _make_session("child-1", parent="root-1")
+        db = _make_db(
+            sessions=[root, child],
+            session_map={"root-1": root, "child-1": child},
+        )
+        result = self._list_recent(db)
+        ids = [s["session_id"] for s in result.get("results", [])]
+        assert ids.count("root-1") == 1, f"Root duplicated: {ids}"
+
+    def test_deeply_nested_child_resolves_to_root(self):
+        root = _make_session("root-1")
+        child = _make_session("child-1", parent="root-1")
+        grandchild = _make_session("grandchild-1", parent="child-1")
+        session_map = {"root-1": root, "child-1": child, "grandchild-1": grandchild}
+        db = _make_db(sessions=[grandchild], session_map=session_map)
+        result = self._list_recent(db)
+        ids = [s["session_id"] for s in result.get("results", [])]
+        assert "root-1" in ids, f"Root not surfaced from grandchild. Got: {ids}"
+
+    def test_current_session_lineage_excluded(self):
+        root = _make_session("active-root")
+        child = _make_session("active-child", parent="active-root")
+        other = _make_session("other-1")
+        session_map = {"active-root": root, "active-child": child, "other-1": other}
+        db = _make_db(sessions=[root, child, other], session_map=session_map)
+        result = self._list_recent(db, current="active-child")
+        ids = [s["session_id"] for s in result.get("results", [])]
+        assert "active-root" not in ids
+        assert "other-1" in ids
+
+
+class TestFtsScanLimitAndCronDemotion:
+
+    def test_fts_search_uses_limit_300_or_more(self):
+        """search_messages must use limit >= 300 (was 50). Fixes Bug 4."""
+        db = _make_db(fts_rows=[])
+        from tools.session_search_tool import session_search
+        session_search(db=db, query="test query", limit=3)
+        db.search_messages.assert_called_once()
+        _, kwargs = db.search_messages.call_args
+        limit_used = kwargs.get("limit")
+        assert limit_used is not None and limit_used >= 300, (
+            f"FTS scan limit too low: {limit_used}."
+        )
+
+    def test_demoted_sources_constant_contains_cron(self):
+        from tools.session_search_tool import _DEMOTED_SOURCES
+        assert "cron" in _DEMOTED_SOURCES
+
+    def test_demoted_sources_does_not_include_user_sources(self):
+        from tools.session_search_tool import _DEMOTED_SOURCES
+        user_sources = {"telegram", "cli", "discord", "api", "slack"}
+        assert not (user_sources & _DEMOTED_SOURCES), (
+            f"User sources should not be demoted: {user_sources & _DEMOTED_SOURCES}"
+        )
+
+    def test_cron_rerank_puts_user_sessions_first(self):
+        """Cron rows must appear after non-cron rows after reranking."""
+        from tools.session_search_tool import _DEMOTED_SOURCES
+        fts_rows = [
+            {"session_id": "cron-1", "source": "cron"},
+            {"session_id": "cron-2", "source": "cron"},
+            {"session_id": "tg-1", "source": "telegram"},
+        ]
+        primary = [r for r in fts_rows if r["source"] not in _DEMOTED_SOURCES]
+        secondary = [r for r in fts_rows if r["source"] in _DEMOTED_SOURCES]
+        reranked = primary + secondary
+
+        sources = [r["source"] for r in reranked]
+        first_cron = next(i for i, s in enumerate(sources) if s == "cron")
+        first_tg = next(i for i, s in enumerate(sources) if s == "telegram")
+        assert first_tg < first_cron, (
+            f"telegram (pos {first_tg}) should precede cron (pos {first_cron})"
+        )

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -262,6 +262,11 @@ async def _summarize_session(
 # HERMES_SESSION_SOURCE=tool so they don't clutter the user's session history.
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
+# Sources demoted to the end of FTS results so user-facing sessions
+# (telegram, cli, discord, api, etc.) surface before automation noise.
+# Fixes #19434 Bug 2 / Bug 4.
+_DEMOTED_SOURCES = frozenset({"cron"})
+
 
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
@@ -288,22 +293,52 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             except Exception:
                 current_root = current_session_id
 
+        # Helper: walk parent chain to reach the root session.
+        def _walk_to_root(session_id: str) -> str:
+            visited: set = set()
+            sid = session_id
+            while sid and sid not in visited:
+                visited.add(sid)
+                try:
+                    s2 = db.get_session(sid)
+                    parent = s2.get("parent_session_id") if s2 else None
+                    if parent:
+                        sid = parent
+                    else:
+                        break
+                except Exception:
+                    break
+            return sid
+
         results = []
+        seen_roots: set = set()
         for s in sessions:
             sid = s.get("id", "")
-            if current_root and (sid == current_root or sid == current_session_id):
+            # Resolve child sessions (compression continuations, delegation
+            # threads, branch sessions) to their root so we don't list the
+            # same conversation twice under different session IDs.  The
+            # original blanket skip of any session with parent_session_id
+            # hid these sessions entirely -- fixes #19434 Bug 3.
+            root_sid = _walk_to_root(sid) if s.get("parent_session_id") else sid
+            if current_root and (root_sid == current_root or sid == current_session_id):
                 continue
-            # Skip child/delegation sessions (they have parent_session_id)
-            if s.get("parent_session_id"):
+            if root_sid in seen_roots:
                 continue
+            seen_roots.add(root_sid)
+            # Fetch root session metadata so the listing reflects the
+            # conversation anchor, not an intermediate child shard.
+            if root_sid != sid:
+                root_meta = db.get_session(root_sid) or s
+            else:
+                root_meta = s
             results.append({
-                "session_id": sid,
-                "title": s.get("title") or None,
-                "source": s.get("source", ""),
-                "started_at": s.get("started_at", ""),
-                "last_active": s.get("last_active", ""),
-                "message_count": s.get("message_count", 0),
-                "preview": s.get("preview", ""),
+                "session_id": root_sid,
+                "title": root_meta.get("title") or None,
+                "source": root_meta.get("source", ""),
+                "started_at": root_meta.get("started_at", ""),
+                "last_active": root_meta.get("last_active", ""),
+                "message_count": root_meta.get("message_count", 0),
+                "preview": root_meta.get("preview", ""),
             })
             if len(results) >= limit:
                 break
@@ -359,12 +394,16 @@ def session_search(
         if role_filter and role_filter.strip():
             role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
-        # FTS5 search -- get matches ranked by relevance
+        # FTS5 search -- get matches ranked by relevance.
+        # Scan limit raised from 50 to 300 so that cron/automation sessions
+        # (which produce many repetitive high-BM25 hits) don't crowd out the
+        # first few unique sessions and prevent user sessions from appearing.
+        # Fixes #19434 Bug 4 / Bug 2.
         raw_results = db.search_messages(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            limit=50,  # Get more matches to find unique sessions
+            limit=300,  # Raised from 50 to allow source-diverse session selection
             offset=0,
         )
 
@@ -376,6 +415,15 @@ def session_search(
                 "count": 0,
                 "message": "No matching sessions found.",
             }, ensure_ascii=False)
+
+        # Rerank: demote automation/cron sessions so user-facing sessions
+        # (telegram, cli, discord, api, etc.) surface first.  BM25 ranking
+        # alone over-weights cron sessions because they repeat project
+        # vocabulary constantly.  Stable sort -- FTS rank order preserved
+        # within each bucket.  Fixes #19434 Bug 2 / Bug 4.
+        _primary = [r for r in raw_results if r.get("source") not in _DEMOTED_SOURCES]
+        _secondary = [r for r in raw_results if r.get("source") in _DEMOTED_SOURCES]
+        raw_results = _primary + _secondary
 
         # Resolve child sessions to their parent — delegation stores detailed
         # content in child sessions, but the user's conversation is the parent.


### PR DESCRIPTION
Fixes #19434 (Bug 3 and Bug 4)

**Bug 3 -- Child sessions hidden from recent browse (MEDIUM)**
_list_recent_sessions() had a blanket `continue` that skipped any session with parent_session_id, hiding compression continuations, delegation threads, and branch sessions entirely. Fix: walk the parent chain to the root session, list the root instead, and deduplicate by root ID so the same conversation doesn't appear twice.

**Bug 4 -- Cron sessions dominate FTS ranking (HIGH)**
Two related issues:
1. FTS scan limit was 50 rows -- cron sessions with repetitive vocabulary (project names, dates) scored high BM25 and filled all 3 unique-session slots before user sessions appeared.
2. No source weighting meant cron sessions were treated equally to telegram/cli sessions.

Fix: Raise scan limit from 50 to 300, and add a stable-sort rerank that moves cron-sourced rows after all other sources. FTS rank order is preserved within each bucket.

9 new tests in tests/tools/test_session_search_bug3_bug4.py. All 46 tests (9 new + 37 existing) pass.