### PR TITLE
fix(cli): zsh completion _arguments error and compinit registration failure

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -199,8 +199,10 @@ def generate_zsh(parser: argparse.ArgumentParser) -> str:
 
     return f"""#compdef hermes
 # Hermes Agent zsh completion
-# Add to ~/.zshrc:
-#   eval "$(hermes completion zsh)"
+# Install by saving to a file in your fpath (e.g. ~/.zsh/completions/_hermes):
+#   hermes completion zsh > ~/.zsh/completions/_hermes
+#   # Ensure fpath includes that directory before compinit in ~/.zshrc:
+#   fpath=(~/.zsh/completions $fpath)
 
 _hermes_profiles() {{
     local -a profiles
@@ -237,8 +239,6 @@ _hermes() {{
             ;;
     esac
 }}
-
-_hermes "$@"
 """
 
 


### PR DESCRIPTION
## Problem

Running `eval "$(hermes completion zsh)"` in `~/.zshrc` produces two bugs:

1. **`_arguments:comparguments:327: can only be called from completion function`** — The generated zsh script ends with `_hermes "$@"`, which executes outside any completion context at shell init time, triggering `_arguments` errors on every new terminal.

2. **Completions never register** — The `#compdef hermes` directive at the top of the output is only processed by `compinit` when reading files from `fpath`, not when eval-'d as a string. So `eval "$(hermes completion zsh)"` silently fails to set up completions.

## Fix

- **Remove the trailing `_hermes "$@"`** from `generate_zsh()` output. The completion function should only be invoked by zsh's completion system, not at definition time.
- **Update the installation comment** to recommend the file-based approach that actually works with compinit:
  ```zsh
  hermes completion zsh > ~/.zsh/completions/_hermes
  # Ensure fpath includes that directory before compinit
  ```

## Testing

Verified locally that `generate_zsh()` output:
- Ends with `}}` (function close), not `_hermes "$@"`
- Contains `#compdef hermes` directive
- Recommends file-based installation via `fpath`
- Does not contain `eval` in the installation instructions

Fixes #19439

## Platforms tested

- Linux (zsh 5.9)