### PR TITLE
Emit Warp CLI-agent notifications

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -334,6 +334,7 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
+            "warp_notifications": "auto",  # auto | on | off: Warp CLI-agent notifications
 
             "skin": "default",
         },
@@ -2294,6 +2295,80 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+
+        # Warp Terminal CLI-agent notifications (OSC 777).  Disabled unless
+        # Warp advertises WARP_CLI_AGENT_PROTOCOL_VERSION=1 or the user forces
+        # display.warp_notifications / HERMES_WARP_NOTIFICATIONS to on.
+        self._warp_session_started = False
+        self._warp_turn_needs_stop = False
+        try:
+            from hermes_cli.warp_notifications import WarpAgentNotifier
+            self._warp_notifier = WarpAgentNotifier.from_config(
+                CLI_CONFIG,
+                session_id=self.session_id,
+                cwd=os.getcwd(),
+            )
+        except Exception:
+            self._warp_notifier = None
+
+    def _warp_notify(self, event: str, **fields) -> bool:
+        """Best-effort Warp CLI-agent notification emission."""
+        notifier = getattr(self, "_warp_notifier", None)
+        if notifier is None:
+            return False
+        try:
+            notifier.session_id = self.session_id
+            notifier.cwd = os.getcwd()
+            if not notifier.project:
+                try:
+                    from hermes_cli.warp_notifications import project_name_for_cwd
+                    notifier.project = project_name_for_cwd(notifier.cwd)
+                except Exception:
+                    pass
+            return notifier.emit(event, **fields)
+        except Exception:
+            logging.debug("Warp notification emit failed for %s", event, exc_info=True)
+            return False
+
+    def _warp_notify_session_start(self) -> None:
+        """Emit exactly one session_start event for Warp's CLI-agent listener."""
+        if getattr(self, "_warp_session_started", False):
+            return
+        notifier = getattr(self, "_warp_notifier", None)
+        if notifier is None or not getattr(notifier, "enabled", False):
+            self._warp_session_started = True
+            return
+        try:
+            from hermes_cli import __version__ as _hermes_version
+        except Exception:
+            _hermes_version = None
+        if self._warp_notify(
+            "session_start",
+            summary="Hermes session started",
+            plugin_version=_hermes_version,
+        ):
+            self._warp_session_started = True
+
+    def _warp_notify_prompt_submit(self) -> None:
+        self._warp_notify_session_start()
+        if self._warp_notify("prompt_submit", summary="Hermes is working"):
+            self._warp_turn_needs_stop = True
+
+    def _warp_notify_stop(self, *, failed: bool = False, interrupted: bool = False) -> None:
+        if interrupted:
+            summary = "Hermes was interrupted"
+            response = "Interrupted"
+        elif failed:
+            summary = "Hermes stopped with an error"
+            response = "Error"
+        else:
+            summary = "Hermes finished"
+            response = "Response ready"
+        self._warp_notify("stop", summary=summary, response=response)
+        self._warp_turn_needs_stop = False
+
+    def _warp_notify_permission_replied(self) -> None:
+        self._warp_notify("permission_replied", summary="User replied")
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -8073,6 +8148,19 @@ class HermesCLI:
         """
         if event_type == "tool.completed":
             self._tool_start_time = 0.0
+            if function_name and not function_name.startswith("_"):
+                duration = kwargs.get("duration", 0.0)
+                is_error = kwargs.get("is_error", False)
+                try:
+                    duration_f = float(duration)
+                except (TypeError, ValueError):
+                    duration_f = 0.0
+                status = "failed" if is_error else "completed"
+                self._warp_notify(
+                    "tool_complete",
+                    summary=f"Tool {function_name} {status} ({duration_f:.1f}s)",
+                    tool_name=function_name,
+                )
             # Print stacked scrollback line for "all" / "new" modes
             if function_name and self.tool_progress_mode in ("all", "new"):
                 duration = kwargs.get("duration", 0.0)
@@ -8620,6 +8708,10 @@ class HermesCLI:
         self._clarify_deadline = _time.monotonic() + timeout
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
+        self._warp_notify(
+            "question_asked",
+            summary="Hermes needs your answer",
+        )
 
         # Trigger prompt_toolkit repaint from this (non-main) thread
         self._invalidate()
@@ -8638,6 +8730,7 @@ class HermesCLI:
             try:
                 result = response_queue.get(timeout=1)
                 self._clarify_deadline = 0
+                self._warp_notify_permission_replied()
                 return result
             except queue.Empty:
                 remaining = self._clarify_deadline - _time.monotonic()
@@ -8657,6 +8750,7 @@ class HermesCLI:
         self._clarify_freetext = False
         self._clarify_deadline = 0
         self._invalidate()
+        self._warp_notify_permission_replied()
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (
             "The user did not provide a response within the time limit. "
@@ -8738,6 +8832,11 @@ class HermesCLI:
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
+            self._warp_notify(
+                "permission_request",
+                summary="Dangerous command approval requested",
+                tool_name="terminal",
+            )
 
             self._invalidate()
 
@@ -8748,6 +8847,7 @@ class HermesCLI:
                     self._approval_state = None
                     self._approval_deadline = 0
                     self._invalidate()
+                    self._warp_notify_permission_replied()
                     return result
                 except queue.Empty:
                     remaining = self._approval_deadline - _time.monotonic()
@@ -8761,6 +8861,7 @@ class HermesCLI:
             self._approval_state = None
             self._approval_deadline = 0
             self._invalidate()
+            self._warp_notify_permission_replied()
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
             return "deny"
 
@@ -9140,10 +9241,11 @@ class HermesCLI:
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
 
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
-        print(flush=True)
-        
         try:
+            self._warp_notify_prompt_submit()
+            ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+            print(flush=True)
+
             # Run the conversation with interrupt monitoring
             result = None
 
@@ -9462,6 +9564,10 @@ class HermesCLI:
                     response = response + "\n\n---\n_[Interrupted - processing new message]_"
 
             response_previewed = result.get("response_previewed", False) if result else False
+            self._warp_notify_stop(
+                failed=bool(result and result.get("failed")),
+                interrupted=bool(result and result.get("interrupted")),
+            )
 
             # Display reasoning (thinking) box if enabled and available.
             # Skip when streaming already showed reasoning live.  Use the
@@ -9587,6 +9693,16 @@ class HermesCLI:
             print(f"Error: {e}")
             return None
         finally:
+            # If a turn emitted prompt_submit but exited before the normal
+            # response path, close the Warp lifecycle so the tab state does not
+            # remain stuck as "working" after errors or interrupts.
+            if getattr(self, "_warp_turn_needs_stop", False):
+                exc_type, _, _ = sys.exc_info()
+                interrupted = bool(getattr(self, "_should_exit", False) or exc_type is KeyboardInterrupt)
+                self._warp_notify_stop(
+                    failed=not interrupted,
+                    interrupted=interrupted,
+                )
             # Ensure streaming TTS resources are cleaned up even on error.
             # Normal path sends the sentinel at line ~3568; this is a safety
             # net for exception paths that skip it.  Duplicate sentinels are
@@ -11711,6 +11827,8 @@ class HermesCLI:
                     self.agent.interrupt()
                 except Exception:
                     pass
+            if getattr(self, "_warp_turn_needs_stop", False):
+                self._warp_notify_stop(interrupted=True)
             # Shut down voice recorder (release persistent audio stream)
             if hasattr(self, '_voice_recorder') and self._voice_recorder:
                 try:
@@ -12002,27 +12120,42 @@ def main(
                     # status lines).  The response is printed once below.
                     cli.agent.stream_delta_callback = None
                     cli.agent.tool_gen_callback = None
-                    result = cli.agent.run_conversation(
-                        user_message=effective_query,
-                        conversation_history=cli.conversation_history,
-                    )
-                    # Sync session_id if mid-run compression created a
-                    # continuation session. The exit line below reports
-                    # session_id to stderr for automation wrappers; without
-                    # this sync it would point at the ended parent.
-                    if (
-                        getattr(cli.agent, "session_id", None)
-                        and cli.agent.session_id != cli.session_id
-                    ):
-                        cli.session_id = cli.agent.session_id
-                    response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                    if response:
-                        print(response)
-                    # Session ID goes to stderr so piped stdout is clean.
-                    print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
-                    
-                    # Ensure proper exit code for automation wrappers
-                    sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+                    cli._warp_notify_prompt_submit()
+                    result = None
+                    try:
+                        result = cli.agent.run_conversation(
+                            user_message=effective_query,
+                            conversation_history=cli.conversation_history,
+                        )
+                        # Sync session_id if mid-run compression created a
+                        # continuation session. The exit line below reports
+                        # session_id to stderr for automation wrappers; without
+                        # this sync it would point at the ended parent.
+                        if (
+                            getattr(cli.agent, "session_id", None)
+                            and cli.agent.session_id != cli.session_id
+                        ):
+                            cli.session_id = cli.agent.session_id
+                        response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                        cli._warp_notify_stop(
+                            failed=bool(isinstance(result, dict) and result.get("failed")),
+                            interrupted=bool(isinstance(result, dict) and result.get("interrupted")),
+                        )
+                        if response:
+                            print(response)
+                        # Session ID goes to stderr so piped stdout is clean.
+                        print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+
+                        # Ensure proper exit code for automation wrappers
+                        sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+                    except KeyboardInterrupt:
+                        if getattr(cli, "_warp_turn_needs_stop", False):
+                            cli._warp_notify_stop(interrupted=True)
+                        raise
+                    except BaseException:
+                        if getattr(cli, "_warp_turn_needs_stop", False):
+                            cli._warp_notify_stop(failed=True)
+                        raise
             
             # Exit with error code if credentials or agent init fails
             sys.exit(1)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -775,6 +775,7 @@ DEFAULT_CONFIG = {
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
         "bell_on_complete": False,
+        "warp_notifications": "auto",  # auto | on | off: emit Warp CLI-agent OSC notifications when available
         "show_reasoning": False,
         "streaming": False,
         "final_response_markdown": "strip",  # render | strip | raw

--- a/hermes_cli/warp_notifications.py
+++ b/hermes_cli/warp_notifications.py
@@ -1,0 +1,202 @@
+"""Warp Terminal CLI-agent notification support.
+
+Warp's in-app agent notifications are delivered over OSC 777 as structured
+``warp://cli-agent`` events.  This module keeps the integration deliberately
+small and side-effect-free unless Warp advertises the protocol, and writes to
+``/dev/tty`` so redirected stdout/stderr remain clean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+OSC_PREFIX = "\x1b]777;notify;warp://cli-agent;"
+OSC_SUFFIX = "\x07"
+AGENT_NAME = "hermes"
+DEFAULT_MODE = "auto"
+MAX_TEXT_CHARS = 160
+
+_TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
+_FALSE_VALUES = {"0", "false", "no", "off", "disabled", "none"}
+_SECRETISH_RE = re.compile(
+    r"(?i)\b(?P<key>[A-Za-z0-9_-]*(?:api[_-]?key|token|secret|password|passwd|pwd|authorization|bearer)[A-Za-z0-9_-]*)\b\s*[:=]\s*(?:bearer\s+)?\S+"
+)
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _normalize_mode(value: Any) -> str:
+    """Return ``auto``, ``on`` or ``off`` for config/env values."""
+    if isinstance(value, bool):
+        return "on" if value else "off"
+    text = str(value if value is not None else DEFAULT_MODE).strip().lower()
+    if text in _TRUE_VALUES or text == "always":
+        return "on"
+    if text in _FALSE_VALUES:
+        return "off"
+    if text in {"auto", "warp"}:
+        return "auto"
+    return DEFAULT_MODE
+
+
+def configured_mode(config: Mapping[str, Any] | None, environ: Mapping[str, str] | None = None) -> str:
+    """Resolve the Warp notification mode from env/config.
+
+    ``HERMES_WARP_NOTIFICATIONS`` wins over config.  Config lives at
+    ``display.warp_notifications`` and accepts ``auto`` (default), ``on`` or
+    ``off``; booleans are accepted for convenience.
+    """
+    env = environ if environ is not None else os.environ
+    if "HERMES_WARP_NOTIFICATIONS" in env:
+        return _normalize_mode(env.get("HERMES_WARP_NOTIFICATIONS"))
+    display = config.get("display", {}) if isinstance(config, Mapping) else {}
+    value = display.get("warp_notifications", DEFAULT_MODE) if isinstance(display, Mapping) else DEFAULT_MODE
+    return _normalize_mode(value)
+
+
+def warp_protocol_available(environ: Mapping[str, str] | None = None) -> bool:
+    """Return True when the current terminal advertises Warp's CLI-agent protocol."""
+    env = environ if environ is not None else os.environ
+    return (
+        env.get("TERM_PROGRAM") == "WarpTerminal"
+        and env.get("WARP_CLI_AGENT_PROTOCOL_VERSION") == "1"
+    )
+
+
+def should_enable(config: Mapping[str, Any] | None = None, environ: Mapping[str, str] | None = None) -> bool:
+    """Return whether Hermes should emit Warp CLI-agent notifications."""
+    mode = configured_mode(config, environ)
+    if mode == "off":
+        return False
+    if mode == "on":
+        return True
+    return warp_protocol_available(environ)
+
+
+def _safe_text(value: Any, *, max_chars: int = MAX_TEXT_CHARS) -> str | None:
+    """Sanitize short UI strings without preserving full prompts/results.
+
+    The payload is visible to the terminal application.  Keep it short, remove
+    control characters, and redact obvious secret-looking assignments.
+    """
+    if value is None:
+        return None
+    text = str(value)
+    text = _CONTROL_RE.sub(" ", text)
+    text = " ".join(text.split())
+    text = _SECRETISH_RE.sub(lambda m: f"{m.group('key')}=[REDACTED]", text)
+    if len(text) > max_chars:
+        text = text[: max_chars - 1].rstrip() + "…"
+    return text or None
+
+
+def project_name_for_cwd(cwd: str | Path | None) -> str | None:
+    if cwd is None:
+        return None
+    try:
+        name = Path(cwd).resolve().name
+    except Exception:
+        name = Path(str(cwd)).name
+    return name or None
+
+
+class WarpAgentNotifier:
+    """Emit structured Warp CLI-agent OSC notifications for Hermes."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        session_id: str,
+        cwd: str | Path | None = None,
+        project: str | None = None,
+        tty_path: str | Path = "/dev/tty",
+        writer: Callable[[str], None] | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self.session_id = session_id
+        self.cwd = str(cwd or os.getcwd())
+        self.project = project or project_name_for_cwd(self.cwd)
+        self.tty_path = str(tty_path)
+        self._writer = writer
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Mapping[str, Any] | None,
+        *,
+        session_id: str,
+        cwd: str | Path | None = None,
+        project: str | None = None,
+        environ: Mapping[str, str] | None = None,
+        tty_path: str | Path = "/dev/tty",
+        writer: Callable[[str], None] | None = None,
+    ) -> "WarpAgentNotifier":
+        return cls(
+            enabled=should_enable(config, environ),
+            session_id=session_id,
+            cwd=cwd,
+            project=project,
+            tty_path=tty_path,
+            writer=writer,
+        )
+
+    def build_payload(self, event: str, **fields: Any) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "v": 1,
+            "agent": AGENT_NAME,
+            "event": event,
+            "session_id": self.session_id,
+            "cwd": self.cwd,
+            "project": self.project,
+        }
+        for key, value in fields.items():
+            if value is None:
+                continue
+            if key == "tool_input" and isinstance(value, Mapping):
+                # Tool input may contain private commands, paths, or API args.
+                # Keep only a tiny redacted command/file preview for Warp UI.
+                preview: dict[str, str] = {}
+                for preview_key in ("command", "file_path"):
+                    if preview_key in value:
+                        safe = _safe_text(value.get(preview_key))
+                        if safe:
+                            preview[preview_key] = safe
+                            break
+                if preview:
+                    payload[key] = preview
+                continue
+            safe = _safe_text(value)
+            if safe is not None:
+                payload[key] = safe
+        return payload
+
+    def encode(self, event: str, **fields: Any) -> str:
+        body = json.dumps(
+            self.build_payload(event, **fields),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        return f"{OSC_PREFIX}{body}{OSC_SUFFIX}"
+
+    def emit(self, event: str, **fields: Any) -> bool:
+        if not self.enabled:
+            return False
+        data = self.encode(event, **fields)
+        try:
+            self._write(data)
+            return True
+        except OSError:
+            # Never let terminal notification plumbing affect the agent run.
+            return False
+
+    def _write(self, data: str) -> None:
+        if self._writer is not None:
+            self._writer(data)
+            return
+        with open(self.tty_path, "w", encoding="utf-8", errors="replace") as tty:
+            tty.write(data)
+            tty.flush()

--- a/tests/test_warp_notifications.py
+++ b/tests/test_warp_notifications.py
@@ -1,0 +1,143 @@
+import json
+
+from hermes_cli.warp_notifications import (
+    OSC_PREFIX,
+    OSC_SUFFIX,
+    WarpAgentNotifier,
+    _safe_text,
+    configured_mode,
+    should_enable,
+    warp_protocol_available,
+)
+
+
+def test_warp_protocol_detection_requires_warp_and_protocol():
+    assert warp_protocol_available(
+        {
+            "TERM_PROGRAM": "WarpTerminal",
+            "WARP_CLI_AGENT_PROTOCOL_VERSION": "1",
+        }
+    )
+    assert not warp_protocol_available({"TERM_PROGRAM": "WarpTerminal"})
+    assert not warp_protocol_available(
+        {
+            "TERM_PROGRAM": "Apple_Terminal",
+            "WARP_CLI_AGENT_PROTOCOL_VERSION": "1",
+        }
+    )
+
+
+def test_config_mode_supports_env_override():
+    config = {"display": {"warp_notifications": "off"}}
+    assert configured_mode(config, {"HERMES_WARP_NOTIFICATIONS": "on"}) == "on"
+    assert configured_mode({"display": {"warp_notifications": True}}, {}) == "on"
+    assert configured_mode({"display": {"warp_notifications": False}}, {}) == "off"
+    assert configured_mode({}, {}) == "auto"
+
+
+def test_auto_enable_only_when_warp_protocol_is_available():
+    config = {"display": {"warp_notifications": "auto"}}
+    assert should_enable(
+        config,
+        {
+            "TERM_PROGRAM": "WarpTerminal",
+            "WARP_CLI_AGENT_PROTOCOL_VERSION": "1",
+        },
+    )
+    assert not should_enable(config, {"TERM_PROGRAM": "WarpTerminal"})
+    assert should_enable({"display": {"warp_notifications": "on"}}, {})
+    assert not should_enable({"display": {"warp_notifications": "off"}}, {})
+
+
+def test_safe_text_redacts_prefixed_env_style_secrets():
+    text = _safe_text(
+        "OPENAI_API_KEY=sk-test ANTHROPIC_API_KEY=sk-ant "
+        "GITHUB_TOKEN=ghp_secret AWS_SECRET_ACCESS_KEY=awssecret "
+        "Authorization: Bearer bearersecret"
+    )
+
+    assert "sk-test" not in text
+    assert "sk-ant" not in text
+    assert "ghp_secret" not in text
+    assert "awssecret" not in text
+    assert "bearersecret" not in text
+    assert "OPENAI_API_KEY=[REDACTED]" in text
+
+
+def test_emit_writes_structured_cli_agent_osc_to_writer():
+    writes = []
+    notifier = WarpAgentNotifier(
+        enabled=True,
+        session_id="session-1",
+        cwd="/tmp/hermes-project",
+        writer=writes.append,
+    )
+
+    assert notifier.emit(
+        "permission_request",
+        summary="Approval requested: OPENAI_API_KEY=sk-test123 and GITHUB_TOKEN=ghp_secret123",
+        tool_name="terminal",
+        tool_input={"command": "curl -H 'Authorization: Bearer secret' https://example.test"},
+    )
+
+    assert len(writes) == 1
+    data = writes[0]
+    assert data.startswith(OSC_PREFIX)
+    assert data.endswith(OSC_SUFFIX)
+    payload = json.loads(data[len(OSC_PREFIX) : -len(OSC_SUFFIX)])
+    assert payload["v"] == 1
+    assert payload["agent"] == "hermes"
+    assert payload["event"] == "permission_request"
+    assert payload["session_id"] == "session-1"
+    assert payload["cwd"] == "/tmp/hermes-project"
+    assert payload["project"] == "hermes-project"
+    assert payload["tool_name"] == "terminal"
+    assert "sk-test123" not in payload["summary"]
+    assert "ghp_secret123" not in payload["summary"]
+    assert "secret" not in payload["tool_input"]["command"]
+
+
+def test_disabled_notifier_does_not_write():
+    writes = []
+    notifier = WarpAgentNotifier(
+        enabled=False,
+        session_id="session-1",
+        writer=writes.append,
+    )
+
+    assert notifier.emit("stop", summary="Done") is False
+    assert writes == []
+
+
+def test_cli_warp_lifecycle_sets_and_clears_pending_stop():
+    from cli import HermesCLI
+
+    class FakeNotifier:
+        enabled = True
+        project = None
+        cwd = None
+        session_id = None
+
+        def __init__(self):
+            self.events = []
+
+        def emit(self, event, **fields):
+            self.events.append((event, fields))
+            return True
+
+    fake = FakeNotifier()
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "session-1"
+    cli._warp_notifier = fake
+    cli._warp_session_started = False
+    cli._warp_turn_needs_stop = False
+
+    cli._warp_notify_prompt_submit()
+    assert [event for event, _ in fake.events] == ["session_start", "prompt_submit"]
+    assert cli._warp_session_started is True
+    assert cli._warp_turn_needs_stop is True
+
+    cli._warp_notify_stop(failed=True)
+    assert fake.events[-1][0] == "stop"
+    assert fake.events[-1][1]["summary"] == "Hermes stopped with an error"
+    assert cli._warp_turn_needs_stop is False


### PR DESCRIPTION
## Summary

Adds Hermes-side support for Warp Terminal's structured CLI-agent notification protocol.

Changes:
- add `hermes_cli.warp_notifications` for OSC 777 `warp://cli-agent` events
- auto-enable only when Warp advertises `WARP_CLI_AGENT_PROTOCOL_VERSION=1` (`display.warp_notifications: auto` by default; `on`/`off` supported, with `HERMES_WARP_NOTIFICATIONS` override)
- write to `/dev/tty` instead of stdout/stderr so redirected CLI output stays clean
- emit safe/minimal lifecycle events: `session_start`, `prompt_submit`, `tool_complete`, `stop`, `permission_request`, `permission_replied`, and `question_asked`
- avoid sending full prompts, full responses, approval commands, or tool results; sanitize/truncate short strings and redact env-style secrets such as `OPENAI_API_KEY`, `GITHUB_TOKEN`, `AWS_SECRET_ACCESS_KEY`, and `Authorization: Bearer ...`
- add tests for protocol detection, config/env behavior, OSC payload encoding, redaction, disabled mode, and CLI lifecycle stop tracking

This is the Hermes-side half of Warp Agent Notifications support. The matching Warp-side PR adds Hermes as a supported CLI-agent listener target.

Related:
- Addresses #17390
- Adjacent to #19302, but this is Warp in-app CLI-agent/tab attention support rather than local desktop notifications

## Verification

- `uv run --with pytest --with pytest-xdist python -m pytest tests/test_warp_notifications.py -q` => 7 passed
- `uv run python -m py_compile hermes_cli/warp_notifications.py cli.py hermes_cli/config.py tests/test_warp_notifications.py` passed
- `git diff --check` passed
- Static added-line scan found no hardcoded secrets/shell/eval/pickle/SQL issues
- Independent review passed after fixes with no blocking issues

