### PR TITLE
fix(tui): render structured content on resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -254,6 +254,24 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
     ]
 
 
+def test_history_to_messages_renders_multimodal_content():
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look here"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        },
+        {"role": "assistant", "content": "saw it"},
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "look here\n[image]"},
+        {"role": "assistant", "text": "saw it"},
+    ]
+
+
 def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1909,6 +1909,36 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     return text or "What do you see in this image?"
 
 
+def _content_display_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (int, float)):
+        return str(content)
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            text = _content_display_text(part).strip()
+            if text:
+                parts.append(text)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        kind = content.get("type")
+        if kind in {"text", "input_text", "output_text"}:
+            return str(content.get("text") or content.get("content") or "")
+        if kind in {"image_url", "input_image", "image"}:
+            return "[image]"
+        if kind in {"input_audio", "audio"}:
+            return "[audio]"
+        if kind:
+            return f"[{kind}]"
+        if "text" in content:
+            return str(content.get("text") or "")
+        return "[structured content]"
+    return str(content)
+
+
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -1919,6 +1949,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         role = m.get("role")
         if role not in ("user", "assistant", "tool", "system"):
             continue
+        content_text = _content_display_text(m.get("content"))
         if role == "assistant" and m.get("tool_calls"):
             for tc in m["tool_calls"]:
                 fn = tc.get("function", {})
@@ -1929,7 +1960,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-            if not (m.get("content") or "").strip():
+            if not content_text.strip():
                 continue
         if role == "tool":
             tc_id = m.get("tool_call_id", "")
@@ -1940,9 +1971,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                 {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
             )
             continue
-        if not (m.get("content") or "").strip():
+        if not content_text.strip():
             continue
-        messages.append({"role": role, "text": m.get("content") or ""})
+        messages.append({"role": role, "text": content_text})
 
     return messages
 


### PR DESCRIPTION
## Rationale

Resuming TUI sessions can fail when persisted history contains structured or multimodal message content, such as pasted images. The TUI resume display path currently assumes every message `content` is a string and calls `.strip()`, which raises when decoded session history contains list/dict content.

## Summary

- Add a display-boundary normalizer for structured message content in `tui_gateway.server._history_to_messages`.
- Render text parts as text, image parts as `[image]`, audio parts as `[audio]`, and unknown structured parts with compact placeholders.
- Preserve existing tool-call resume display behavior.
- Add regression coverage for multimodal resume-history rendering.

## Test Plan

- [x] `./scripts/run_tests.sh tests/test_tui_gateway_server.py::test_history_to_messages_renders_multimodal_content tests/test_tui_gateway_server.py::test_history_to_messages_preserves_tool_calls_for_resume_display tests/test_tui_gateway_server.py::test_session_resume_uses_parent_lineage_for_display -q`
- [x] Local `session.resume` probe for `20260503_200544_75d449` returns `resumed=20260503_200544_75d449` with no error.

## Known unrelated validation failures

These also fail on the current checkout and appear unrelated to this patch:

- `./scripts/run_tests.sh tests/test_tui_gateway_server.py -q` → 2 failures:
  - `test_session_create_drops_pending_title_on_valueerror`
  - `test_browser_manage_connect_default_local_reports_launch_hint`
- `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` reports pre-existing lint issues outside the touched lines.
