### PR TITLE
fix: accept Telegram image documents

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -122,6 +122,16 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+SUPPORTED_IMAGE_DOCUMENT_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+    ".bmp": "image/bmp",
+}
+
+
 # ---------------------------------------------------------------------------
 # Markdown table → Telegram-friendly row groups
 # ---------------------------------------------------------------------------
@@ -3131,6 +3141,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
                     ext = video_mime_to_ext.get(doc.mime_type, "")
 
+                if not ext and doc.mime_type:
+                    image_mime_to_ext = {v: k for k, v in SUPPORTED_IMAGE_DOCUMENT_TYPES.items()}
+                    ext = image_mime_to_ext.get(doc.mime_type.lower(), "")
+
                 if ext in SUPPORTED_VIDEO_TYPES:
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()
@@ -3142,8 +3156,33 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
+                if ext in SUPPORTED_IMAGE_DOCUMENT_TYPES or (doc.mime_type or "").lower().startswith("image/"):
+                    if not doc.file_size or doc.file_size > 20 * 1024 * 1024:
+                        event.text = (
+                            "The image is too large or its size could not be verified. "
+                            "Maximum: 20 MB."
+                        )
+                        logger.info("[Telegram] Image document too large: %s bytes", doc.file_size)
+                        await self.handle_message(event)
+                        return
+
+                    image_ext = ext if ext in SUPPORTED_IMAGE_DOCUMENT_TYPES else ".jpg"
+                    file_obj = await doc.get_file()
+                    image_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [SUPPORTED_IMAGE_DOCUMENT_TYPES.get(image_ext, (doc.mime_type or "image/jpeg"))]
+                    event.message_type = MessageType.PHOTO
+                    logger.info("[Telegram] Cached user image document at %s", cached_path)
+                    media_group_id = getattr(msg, "media_group_id", None)
+                    if media_group_id:
+                        await self._queue_media_group_event(str(media_group_id), event)
+                    else:
+                        await self.handle_message(event)
+                    return
+
                 # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                elif ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
                     event.text = (
                         f"Unsupported document type '{ext or 'unknown'}'. "

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -146,6 +146,9 @@ def _redirect_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
     )
+    monkeypatch.setattr(
+        "gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "image_cache"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +259,59 @@ class TestDocumentDownloadBlock:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls and event.media_urls[0].endswith("archive.zip")
         assert event.media_types == ["application/zip"]
+
+    @pytest.mark.asyncio
+    async def test_image_document_with_jpg_extension_is_cached_as_photo(self, adapter):
+        jpg_bytes = b"\xff\xd8\xff fake jpeg bytes"
+        file_obj = _make_file_obj(jpg_bytes)
+        doc = _make_document(
+            file_name="photo.jpg", mime_type="image/jpeg",
+            file_size=len(jpg_bytes), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc, caption="what is this?")
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.text == "what is this?"
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_urls[0].endswith(".jpg")
+        assert event.media_types == ["image/jpeg"]
+
+    @pytest.mark.asyncio
+    async def test_image_document_without_extension_uses_image_mime(self, adapter):
+        png_bytes = b"\x89PNG\r\n\x1a\n fake png bytes"
+        file_obj = _make_file_obj(png_bytes)
+        doc = _make_document(
+            file_name=None, mime_type="image/png",
+            file_size=len(png_bytes), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_urls[0].endswith(".png")
+        assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_image_document_over_size_is_rejected(self, adapter):
+        doc = _make_document(
+            file_name="photo.jpeg", mime_type="image/jpeg",
+            file_size=25 * 1024 * 1024,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert "image is too large" in event.text
 
     @pytest.mark.asyncio
     async def test_oversized_file_rejected(self, adapter):


### PR DESCRIPTION
## Summary
- treats Telegram document uploads with image extensions/MIME types as photos for agent processing
- supports .jpg, .jpeg, .png, .webp, .gif, and .bmp when they arrive through Telegram's document path
- keeps normal document validation for non-image files

## Test Plan
- python -m pytest tests/gateway/test_telegram_documents.py -q -o 'addopts='
- git diff --check
- python -m py_compile gateway/platforms/telegram.py