### PR TITLE
feat: add incognito mode for ephemeral turns

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1827,6 +1827,20 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "memory":
         def _execute(next_args: dict) -> Any:
+            # Incognito guard: block durable memory writes when session
+            # persistence is disabled. Reads pass through. Covers single-op
+            # and batch `operations` shapes.
+            if not getattr(agent, "persist_session", True):
+                _ops = next_args.get("operations")
+                _is_write = (
+                    any(isinstance(op, dict) and op.get("action") in {"add", "replace", "remove"} for op in _ops)
+                    if _ops else next_args.get("action") in {"add", "replace", "remove"}
+                )
+                if _is_write:
+                    return json.dumps({
+                        "success": False,
+                        "error": "Incognito mode is ON — durable memory writes are disabled for this session."
+                    }, ensure_ascii=False)
             target = next_args.get("target", "memory")
             operations = next_args.get("operations")
             from tools.memory_tool import memory_tool as _memory_tool
@@ -1853,6 +1867,13 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             return _finish_agent_tool(result, next_args)
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
         def _execute(next_args: dict) -> Any:
+            # Incognito guard: block external memory retention tools
+            # (hindsight_retain, etc.) when persistence is disabled.
+            if not getattr(agent, "persist_session", True) and function_name.endswith("_retain"):
+                return json.dumps({
+                    "success": False,
+                    "error": "Incognito mode is ON — external memory retention is disabled for this session."
+                }, ensure_ascii=False)
             return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, next_args), next_args)
     elif function_name == "clarify":
         def _execute(next_args: dict) -> Any:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1098,6 +1098,20 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
             def _execute(next_args: dict) -> Any:
+                # Incognito guard: block durable memory writes when session
+                # persistence is disabled. Reads pass through. Covers single-op
+                # and batch `operations` shapes.
+                if not getattr(agent, "persist_session", True):
+                    _ops = next_args.get("operations")
+                    _is_write = (
+                        any(isinstance(op, dict) and op.get("action") in {"add", "replace", "remove"} for op in _ops)
+                        if _ops else next_args.get("action") in {"add", "replace", "remove"}
+                    )
+                    if _is_write:
+                        return json.dumps({
+                            "success": False,
+                            "error": "Incognito mode is ON — durable memory writes are disabled for this session."
+                        }, ensure_ascii=False)
                 target = next_args.get("target", "memory")
                 operations = next_args.get("operations")
                 from tools.memory_tool import memory_tool as _memory_tool
@@ -1254,6 +1268,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _mem_result = None
             try:
                 def _execute(next_args: dict) -> Any:
+                    # Incognito guard: block external memory retention tools
+                    # (hindsight_retain, etc.) when persistence is disabled.
+                    if not getattr(agent, "persist_session", True) and function_name.endswith("_retain"):
+                        return json.dumps({
+                            "success": False,
+                            "error": "Incognito mode is ON — external memory retention is disabled for this session."
+                        }, ensure_ascii=False)
                     return agent._memory_manager.handle_tool_call(function_name, next_args)
                 function_result, function_args = _run_agent_tool_execution_middleware(
                     agent,

--- a/cli.py
+++ b/cli.py
@@ -3738,6 +3738,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._last_ctrl_c_time = 0
         self._clarify_state = None
         self._clarify_freetext = False
+        # Incognito mode: when True, subsequent turns are not persisted to
+        # state.db or sessions/*.jsonl. Toggled via /incognito slash command.
+        self._incognito_mode = False
         self._clarify_deadline = 0
         self._sudo_state = None
         self._sudo_deadline = 0
@@ -8023,6 +8026,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "incognito":
+            self._handle_incognito_command(cmd_original)
         elif canonical == "profile":
             self._handle_profile_command()
         elif canonical == "tools":
@@ -8568,6 +8573,52 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         return True
     
+
+    def _handle_incognito_command(self, cmd: str):
+        """Handle /incognito [on|off|status] — toggle ephemeral persistence.
+
+        When ON, subsequent turns in the current REPL session are NOT persisted
+        to state.db or sessions/*.jsonl. Useful as a scratchpad for adversarial
+        testing / probing where you don't want probes to contaminate the agent's
+        memory or auto-reflection. Toggle OFF to resume normal persistence.
+        """
+        parts = cmd.strip().split(maxsplit=1)
+        sub = parts[1].strip().lower() if len(parts) > 1 else ""
+
+        if sub == "status":
+            state = "🔒 ON" if self._incognito_mode else "🔓 OFF"
+            _cprint(f"  Incognito mode: {state}")
+            return
+
+        if sub == "on":
+            desired = True
+        elif sub == "off":
+            desired = False
+        elif sub == "":
+            desired = not self._incognito_mode
+        else:
+            _cprint("  Usage: /incognito [on|off|status]")
+            _cprint("  (no argument toggles the current state)")
+            return
+
+        if desired == self._incognito_mode:
+            current = "ON" if self._incognito_mode else "OFF"
+            _cprint(f"  Incognito mode already {current}.")
+            return
+
+        self._incognito_mode = desired
+        if self.agent is not None:
+            try:
+                self.agent.persist_session = not desired
+            except Exception as e:
+                _cprint(f"  ⚠ Warning: could not flip agent.persist_session: {e}")
+
+        if desired:
+            _cprint("  🔒 Incognito ON — subsequent turns will NOT be persisted.")
+            _cprint("     These turns won't be remembered; background reflection won't see them.")
+            _cprint("     Toggle back with /incognito or /incognito off.")
+        else:
+            _cprint("  🔓 Incognito OFF — persistence resumed for subsequent turns.")
 
     @staticmethod
     def _try_launch_chrome_debug(port: int, system: str) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8018,11 +8018,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # /fast and /reasoning are config-only and take effect next
             # message, so they fall through to the catch-all busy response
             # below — users should wait and set them between turns.
-            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose"}:
+            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose", "incognito"}:
                 if _cmd_def_inner.name == "yolo":
                     return await self._handle_yolo_command(event)
                 if _cmd_def_inner.name == "verbose":
                     return await self._handle_verbose_command(event)
+                if _cmd_def_inner.name == "incognito":
+                    return await self._handle_incognito_command(event)
                 if _cmd_def_inner.name == "footer":
                     return await self._handle_footer_command(event)
 
@@ -8286,6 +8288,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         if canonical == "help":
             return await self._handle_help_command(event)
+
+        if canonical == "incognito":
+            return await self._handle_incognito_command(event)
 
         if canonical == "start":
             logger.info("Ignoring /start platform ping for session %s", _quick_key)
@@ -10708,6 +10713,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+
+    async def _handle_incognito_command(self, event: MessageEvent) -> str:
+        """Handle /incognito [on|off|status] — toggle ephemeral persistence per session."""
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        if not hasattr(self, "_incognito_sessions"):
+            self._incognito_sessions: set = set()
+
+        arg = (event.get_command_args() or "").strip().lower()
+        currently_on = session_key in self._incognito_sessions
+
+        if arg == "status":
+            return f"Incognito mode: {'🔒 ON' if currently_on else '🔓 OFF'}"
+
+        if arg == "on":
+            desired = True
+        elif arg == "off":
+            desired = False
+        elif arg == "":
+            desired = not currently_on
+        else:
+            return "Usage: /incognito [on|off|status]\n(no argument toggles current state)"
+
+        if desired == currently_on:
+            state = "ON" if currently_on else "OFF"
+            return f"Incognito already {state}."
+
+        if desired:
+            self._incognito_sessions.add(session_key)
+        else:
+            self._incognito_sessions.discard(session_key)
+
+        try:
+            cached = getattr(self, "_agent_cache", {}).get(session_key)
+            _cached_agent = cached[0] if isinstance(cached, tuple) and cached else None
+            if _cached_agent is not None and _cached_agent is not _AGENT_PENDING_SENTINEL:
+                _cached_agent.persist_session = not desired
+        except Exception:
+            pass
+
+        if desired:
+            return (
+                "🔒 Incognito ON — subsequent turns in this chat will NOT be persisted.\n"
+                "They won't be remembered and background reflection won't see them.\n"
+                "Toggle back with /incognito (or /incognito off)."
+            )
+        return "🔓 Incognito OFF — persistence resumed for this chat."
 
     async def _handle_suggestions_command(self, event: MessageEvent) -> str:
         """Handle /suggestions in the gateway.
@@ -15765,6 +15818,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # Refresh agent max_iterations from current config
                             # (cached agent may have been created with old config)
                             agent.max_iterations = max_iterations
+                            # Incognito: refresh persist_session from current
+                            # incognito state for this session_key.
+                            try:
+                                _inc = session_key in getattr(self, "_incognito_sessions", set())
+                                agent.persist_session = not _inc
+                            except Exception:
+                                pass
                             logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
@@ -15801,6 +15861,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
+                # Incognito: a freshly-built agent must inherit the current
+                # session incognito state, else a session toggled incognito
+                # before its first turn would persist despite /incognito ON.
+                _incognito = session_key in getattr(self, "_incognito_sessions", set())
+                agent.persist_session = not _incognito
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
                         _cache[session_key] = (agent, _sig, _current_msg_count)

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -405,6 +405,13 @@ class CLIAgentSetupMixin:
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint
+            # Incognito: a freshly-built agent must inherit the current session
+            # incognito state. The /incognito handler only flips persist_session
+            # on an already-existing agent; toggling BEFORE the first turn (when
+            # self.agent was still None) would otherwise leave the new agent at
+            # the default persist_session=True and the session would persist
+            # despite /incognito status reporting ON.
+            self.agent.persist_session = not getattr(self, "_incognito_mode", False)
             # Hydrate credits notices at session OPEN (parity with the TUI), so a
             # depletion / usage-band warning shows before the first message. The
             # notice_callback is bound above → _on_notice renders the line. Idempotent

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -101,6 +101,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>"),
+    CommandDef("incognito", "Toggle incognito mode — subsequent turns are not persisted to state.db or sessions/*.jsonl (scratchpad for adversarial probing)", "Session",
+               aliases=("inc", "private"), args_hint="[on|off|status]"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1513,7 +1513,12 @@ class AIAgent:
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
+
+        Incognito guard: if ``persist_session = False`` (set by ``/incognito``),
+        skip all durable writes entirely — the session leaves no trace.
         """
+        if not getattr(self, "persist_session", True):
+            return
         self._drop_trailing_empty_response_scaffolding(messages)
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
@@ -3110,6 +3115,12 @@ class AIAgent:
         backend must not block the user from seeing their response.
         """
         if interrupted:
+            return
+        # Incognito uses ``persist_session = False`` as the session-wide
+        # contract for leaving no durable trace. Honor that here too so
+        # external memory providers (e.g. Hindsight auto_retain) do not
+        # ingest turns that were intentionally marked ephemeral.
+        if not getattr(self, "persist_session", True):
             return
         if not (self._memory_manager and final_response and original_user_message):
             return

--- a/tests/cli/test_incognito_command.py
+++ b/tests/cli/test_incognito_command.py
@@ -1,0 +1,76 @@
+"""Tests for the /incognito CLI command."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+class TestHandleIncognitoCommand:
+    def _make_cli(self, incognito=False, with_agent=True):
+        return SimpleNamespace(
+            _incognito_mode=incognito,
+            agent=MagicMock() if with_agent else None,
+        )
+
+    def test_status_shows_off_by_default(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(incognito=False)
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_incognito_command(stub, "/incognito status")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Incognito mode" in printed
+        assert "OFF" in printed
+
+    def test_on_toggles_mode_and_disables_persistence(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(incognito=False)
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_incognito_command(stub, "/incognito on")
+
+        assert stub._incognito_mode is True
+        assert stub.agent.persist_session is False
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Incognito ON" in printed
+        assert "NOT be persisted" in printed
+
+    def test_off_toggles_mode_and_restores_persistence(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(incognito=True)
+        stub.agent.persist_session = False
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_incognito_command(stub, "/incognito off")
+
+        assert stub._incognito_mode is False
+        assert stub.agent.persist_session is True
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Incognito OFF" in printed
+        assert "persistence resumed" in printed
+
+    def test_invalid_argument_shows_usage(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli(incognito=False)
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_incognito_command(stub, "/incognito maybe")
+
+        assert stub._incognito_mode is False
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Usage: /incognito [on|off|status]" in printed

--- a/tests/gateway/test_incognito_command.py
+++ b/tests/gateway/test_incognito_command.py
@@ -1,0 +1,89 @@
+"""Tests for the /incognito gateway command."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    return runner
+
+
+class TestHandleIncognitoCommand:
+    @pytest.mark.asyncio
+    async def test_status_defaults_off(self):
+        runner = _make_runner()
+
+        result = await runner._handle_incognito_command(_make_event("/incognito status"))
+
+        assert result == "Incognito mode: 🔓 OFF"
+
+    @pytest.mark.asyncio
+    async def test_on_sets_session_flag_and_cached_agent(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        cached_agent = MagicMock()
+        cached_agent.persist_session = True
+        runner._agent_cache[session_key] = (cached_agent, object())
+
+        result = await runner._handle_incognito_command(_make_event("/incognito on"))
+
+        assert session_key in runner._incognito_sessions
+        assert cached_agent.persist_session is False
+        assert "Incognito ON" in result
+        assert "NOT be persisted" in result
+
+    @pytest.mark.asyncio
+    async def test_off_clears_session_flag_and_restores_cached_agent(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        cached_agent = MagicMock()
+        cached_agent.persist_session = False
+        runner._incognito_sessions = {session_key}
+        runner._agent_cache[session_key] = (cached_agent, object())
+
+        result = await runner._handle_incognito_command(_make_event("/incognito off"))
+
+        assert session_key not in runner._incognito_sessions
+        assert cached_agent.persist_session is True
+        assert result == "🔓 Incognito OFF — persistence resumed for this chat."
+
+    @pytest.mark.asyncio
+    async def test_invalid_argument_shows_usage(self):
+        runner = _make_runner()
+
+        result = await runner._handle_incognito_command(_make_event("/incognito maybe"))
+
+        assert result == "Usage: /incognito [on|off|status]\n(no argument toggles current state)"

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -136,6 +136,22 @@ async def test_verbose_dispatches_mid_run(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_incognito_dispatches_mid_run(monkeypatch):
+    """/incognito mid-run must dispatch to its handler, not hit the catch-all."""
+    runner = _make_runner()
+    runner._handle_incognito_command = AsyncMock(
+        return_value="🔒 Incognito ON — subsequent turns in this chat will NOT be persisted."
+    )
+
+    result = await runner._handle_message(_make_event("/incognito on"))
+
+    runner._handle_incognito_command.assert_awaited_once()
+    assert result is not None
+    assert "can't run mid-turn" not in result
+    assert "Incognito ON" in result
+
+
+@pytest.mark.asyncio
 async def test_fast_rejected_mid_run():
     """/fast mid-run must hit the busy catch-all — config-only, next message."""
     runner = _make_runner()

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -129,6 +129,29 @@ class TestFlushDeduplication:
             finally:
                 db.close()
 
+    def test_persist_session_false_skips_db_and_jsonl_writes(self):
+        """persist_session=False must bypass both SQLite and session-log writes."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db)
+            agent.persist_session = False
+            agent._save_session_log = MagicMock()
+
+            messages = [
+                {"role": "user", "content": "secret prompt"},
+                {"role": "assistant", "content": "secret answer"},
+            ]
+
+            agent._persist_session(messages, [])
+
+            rows = db.get_messages(agent.session_id)
+            assert rows == []
+            agent._save_session_log.assert_not_called()
+
     def test_flush_reset_after_compression(self):
         """After compression creates a new session, flush index resets."""
         from hermes_state import SessionDB

--- a/tests/run_agent/test_incognito_memory_persistence.py
+++ b/tests/run_agent/test_incognito_memory_persistence.py
@@ -1,0 +1,86 @@
+import json
+from unittest.mock import MagicMock
+
+
+def _bare_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_manager = MagicMock()
+    agent._memory_store = MagicMock()
+    agent._todo_store = MagicMock()
+    agent._session_db = None
+    agent.session_id = "incog-test-session"
+    agent.valid_tool_names = None
+    agent.persist_session = False
+    agent._build_memory_write_metadata = lambda **kwargs: {"ok": True}
+    return agent
+
+
+def test_incognito_skips_external_memory_sync():
+    agent = _bare_agent()
+
+    agent._sync_external_memory_for_turn(
+        original_user_message="remember this secret probe",
+        final_response="Understood.",
+        interrupted=False,
+    )
+
+    agent._memory_manager.sync_all.assert_not_called()
+    agent._memory_manager.queue_prefetch_all.assert_not_called()
+
+
+def test_incognito_blocks_built_in_memory_write(monkeypatch):
+    agent = _bare_agent()
+
+    called = {"memory_tool": False}
+
+    def _fake_memory_tool(**kwargs):
+        called["memory_tool"] = True
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr("tools.memory_tool.memory_tool", _fake_memory_tool)
+
+    result = agent._invoke_tool(
+        "memory",
+        {"action": "add", "target": "memory", "content": "top secret preference"},
+        effective_task_id="task-1",
+        tool_call_id="tool-1",
+    )
+    parsed = json.loads(result)
+
+    assert parsed["success"] is False
+    assert "Incognito mode is ON" in parsed["error"]
+    assert called["memory_tool"] is False
+    agent._memory_manager.on_memory_write.assert_not_called()
+
+
+def test_incognito_blocks_external_retain_but_allows_recall():
+    agent = _bare_agent()
+    agent._memory_manager.has_tool.side_effect = lambda name: name in {"hindsight_retain", "hindsight_recall"}
+    agent._memory_manager.handle_tool_call.return_value = json.dumps({"success": True, "items": []})
+
+    retain_result = agent._invoke_tool(
+        "hindsight_retain",
+        {"content": "should not persist"},
+        effective_task_id="task-2",
+        tool_call_id="tool-2",
+    )
+    retain_parsed = json.loads(retain_result)
+    assert retain_parsed["success"] is False
+    assert "external memory retention is disabled" in retain_parsed["error"]
+
+    recall_result = agent._invoke_tool(
+        "hindsight_recall",
+        {"query": "older private continuity"},
+        effective_task_id="task-3",
+        tool_call_id="tool-3",
+    )
+    recall_parsed = json.loads(recall_result)
+    assert recall_parsed["success"] is True
+
+    assert agent._memory_manager.handle_tool_call.call_count == 1
+    agent._memory_manager.handle_tool_call.assert_called_with(
+        "hindsight_recall",
+        {"query": "older private continuity"},
+    )


### PR DESCRIPTION
> **Status (refreshed 2026-06-24):** rebased onto the latest `main` and squashed to a single clean commit. Re-applied cleanly across the recent agent-runtime refactor (tool dispatch is now closure + middleware based; the CLI agent build moved to `hermes_cli/cli_agent_setup_mixin.py`). The session-scoped incognito guards live at the new build/dispatch sites. PR is now **mergeable**; the incognito test suite passes against current `main`.

## Summary
- add `/incognito [on|off|status]` to the central slash-command registry
- implement CLI-side incognito mode to suppress persistence for subsequent turns
- implement gateway-side per-session incognito toggling, including cached-agent updates
- allow `/incognito` to dispatch safely while an agent is already running
- make `AIAgent._persist_session()` honor `persist_session=False`
- block built-in `memory` writes while incognito is on
- block external memory-provider retain tools (for example `hindsight_retain`) while incognito is on
- skip external memory auto-retain / prefetch (`sync_all` / `queue_prefetch_all`) for incognito turns
- add CLI, gateway, running-agent, persistence, and external-memory regression tests

## Why
Hermes currently has no built-in scratchpad mode for prompts that should not be written into `state.db`, transcripts, or downstream reflection/retrieval layers. This is useful for adversarial probing, sensitive experiments, and other ephemeral turns where the user wants continuity in the live session without polluting durable memory.

This PR adds a session-scoped `/incognito` toggle that:
- disables transcript/session persistence for subsequent turns
- blocks new durable memory writes while still allowing read-only recall
- works in both CLI and gateway sessions
- updates cached agents immediately
- remains safe to toggle mid-turn

In other words, `/incognito` means "read existing memory if needed, but leave no new durable trace" — not just "skip transcript files."

## Why this is a core patch instead of a plugin
I explicitly evaluated whether this could live in Hermes' plugin model instead of touching core files.

Short answer: a plugin could approximate part of the behavior, but not the full contract this PR is trying to guarantee.

Why not a plugin:
- Plugin slash commands currently receive only `raw_args: str`, not full session/gateway runtime context. For `/incognito`, the feature must toggle state per active session/chat and immediately update cached live agents.
- The strongest requirement here is not just "add a command" — it is "change the persistence contract for subsequent turns." That crosses CLI, gateway, transcript persistence, and external memory sync.
- The critical Hindsight/external-memory paths (`_sync_external_memory_for_turn`, `sync_all`, `queue_prefetch_all`) are internal runtime behavior, not ordinary model tool calls. A plugin can block explicit tool invocations via `pre_tool_call`, but that does not cleanly cover automatic provider sync at end-of-turn.
- The built-in memory tool and external retain tools (e.g. `hindsight_retain`) also need coordinated blocking under the same session-scoped flag. Implementing this as a plugin today would require reaching into private runtime internals rather than using a stable plugin API.

What a plugin could do today:
- register a custom slash command
- block some explicit tool calls
- provide a partial local policy

What it cannot cleanly guarantee today:
- a single upstream-grade, session-scoped "no durable trace" contract spanning transcript persistence, built-in memory writes, external provider retain calls, and automatic external memory sync/prefetch.

If Hermes later exposes session-scoped persistence policy hooks (for example pre/post external-memory-sync or first-class session runtime flags), this could become a plugin candidate. In the current architecture, though, I believe this belongs in core because it changes a runtime guarantee rather than merely adding an extension behavior.

## Test Plan
- `python -m pytest tests/hermes_cli/test_commands.py tests/cli/test_incognito_command.py tests/gateway/test_incognito_command.py tests/gateway/test_running_agent_session_toggles.py tests/run_agent/test_860_dedup.py tests/run_agent/test_incognito_memory_persistence.py tests/run_agent/test_memory_sync_interrupted.py tests/gateway/test_background_command.py tests/gateway/test_session_model_reset.py -q -o addopts=''`

Passed locally:
- `193 passed, 7 warnings in 3.36s`

Additional compatibility check run locally:
- `python -m pytest tests/run_agent/test_860_dedup.py tests/gateway/test_signal.py tests/gateway/test_signal_format.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer.py -q -o addopts=''`
- `264 passed, 7 warnings in 27.68s`