### PR TITLE
fix(models): add alibaba-coding-plan to _PROVIDER_MODELS curated list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -359,6 +359,18 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.7",
         "MiniMax-M2.5",
     ],
+    # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),
+    # separate provider ID with its own base_url_env_var.
+    "alibaba-coding-plan": [
+        "qwen3.6-plus",
+        "qwen3.5-plus",
+        "qwen3-coder-plus",
+        "qwen3-coder-next",
+        "kimi-k2.5",
+        "glm-5",
+        "glm-4.7",
+        "MiniMax-M2.5",
+    ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     "huggingface": [
         "moonshotai/Kimi-K2.5",


### PR DESCRIPTION
## Problem

The `alibaba-coding-plan` provider (DashScope coding-intl endpoint) is defined in `providers.py` with its own `HermesOverlay` and `ALIBABA_CODING_PLAN_API_KEY` env var, but was missing from the `_PROVIDER_MODELS` curated list in `models.py`.

This caused `/model` and `hermes model` to show **"0 models"** for this provider even when credentials were configured and the provider was fully functional.

## Fix

Add the `alibaba-coding-plan` entry to `_PROVIDER_MODELS` with the same curated model list as `alibaba` (they share the same DashScope coding-intl platform, just different base URL / API key).

## Impact

- Users with `provider: alibaba-coding-plan` in config.yaml will now see their available models in the `/model` picker
- `list_authenticated_providers()` in `model_switch.py` will correctly populate models for this provider
- No breaking changes — additive only