### PR TITLE
fix(browser): detect configured system chrome

### DIFF
--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -15,8 +15,11 @@ from tools import browser_tool as bt
 
 
 @pytest.fixture(autouse=True)
-def _reset_chromium_cache():
+def _reset_chromium_cache(monkeypatch):
     bt._cached_chromium_installed = None
+    monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+    monkeypatch.setattr(bt.shutil, "which", lambda name: None)
+    monkeypatch.setattr(bt, "_SYSTEM_CHROMIUM_PATHS", ())
     yield
     bt._cached_chromium_installed = None
 
@@ -41,6 +44,50 @@ class TestChromiumSearchRoots:
 
 
 class TestChromiumInstalled:
+    def test_true_when_agent_browser_executable_path_points_to_file(self, monkeypatch, tmp_path):
+        browser = tmp_path / "chrome"
+        browser.write_text("#!/bin/sh\n")
+        browser.chmod(0o755)
+        monkeypatch.setenv("AGENT_BROWSER_EXECUTABLE_PATH", str(browser))
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path / "empty"))
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / "fakehome"))
+
+        assert bt._chromium_installed() is True
+
+    def test_true_when_agent_browser_executable_path_resolves_on_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AGENT_BROWSER_EXECUTABLE_PATH", "custom-chrome")
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path / "empty"))
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / "fakehome"))
+        monkeypatch.setattr(
+            bt.shutil,
+            "which",
+            lambda name: "/usr/local/bin/custom-chrome" if name == "custom-chrome" else None,
+        )
+
+        assert bt._chromium_installed() is True
+
+    def test_true_when_system_chromium_binary_on_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path / "empty"))
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / "fakehome"))
+        monkeypatch.setattr(
+            bt.shutil,
+            "which",
+            lambda name: "/usr/bin/google-chrome" if name == "google-chrome" else None,
+        )
+
+        assert bt._chromium_installed() is True
+
+    def test_true_when_system_chromium_known_path_exists(self, monkeypatch, tmp_path):
+        browser = tmp_path / "opt" / "google" / "chrome" / "chrome"
+        browser.parent.mkdir(parents=True)
+        browser.write_text("#!/bin/sh\n")
+        browser.chmod(0o755)
+        monkeypatch.setattr(bt, "_SYSTEM_CHROMIUM_PATHS", (str(browser),))
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path / "empty"))
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / "fakehome"))
+
+        assert bt._chromium_installed() is True
+
     def test_true_when_chromium_dir_present(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
         (tmp_path / "chromium-1208").mkdir()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2725,6 +2725,33 @@ def cleanup_all_browsers() -> None:
 # Cache for Chromium discovery. Invalidated by _reset_browser_caches.
 _cached_chromium_installed: Optional[bool] = None
 
+_SYSTEM_CHROMIUM_BINARIES = (
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium-browser",
+    "chromium",
+    "chrome",
+    "brave-browser",
+    "microsoft-edge",
+    "chrome.exe",
+    "msedge.exe",
+    "brave.exe",
+    "chromium.exe",
+)
+
+_SYSTEM_CHROMIUM_PATHS = (
+    "/opt/google/chrome/chrome",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/snap/bin/chromium",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+)
+
 
 def _chromium_search_roots() -> List[str]:
     """Directories to scan for a Chromium / headless-shell build.
@@ -2754,11 +2781,26 @@ def _chromium_search_roots() -> List[str]:
     return roots
 
 
+def _is_browser_executable(path: str) -> bool:
+    """Return True when *path* names a browser executable on disk or PATH."""
+    candidate = path.strip()
+    if not candidate:
+        return False
+    if candidate.startswith("~"):
+        candidate = os.path.expanduser(candidate)
+    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return True
+    return shutil.which(candidate) is not None
+
+
 def _chromium_installed() -> bool:
     """Return True when a usable Chromium (or headless-shell) build is on disk.
 
     agent-browser (0.26+) downloads Playwright's chromium / headless-shell
     builds into ``PLAYWRIGHT_BROWSERS_PATH`` and won't start without them.
+    It can also launch a user-provided browser via
+    ``AGENT_BROWSER_EXECUTABLE_PATH`` or common system Chrome/Chromium
+    installations.
     When the CLI is present but no browser build is, the first browser tool
     call hangs for the full command timeout (often ~30s each) before
     surfacing a useless error. Guarding the tool behind this check prevents
@@ -2767,6 +2809,21 @@ def _chromium_installed() -> bool:
     global _cached_chromium_installed
     if _cached_chromium_installed is not None:
         return _cached_chromium_installed
+
+    configured_browser = os.environ.get("AGENT_BROWSER_EXECUTABLE_PATH", "")
+    if configured_browser and _is_browser_executable(configured_browser):
+        _cached_chromium_installed = True
+        return True
+
+    for name in _SYSTEM_CHROMIUM_BINARIES:
+        if shutil.which(name):
+            _cached_chromium_installed = True
+            return True
+
+    for path in _SYSTEM_CHROMIUM_PATHS:
+        if _is_browser_executable(path):
+            _cached_chromium_installed = True
+            return True
 
     for root in _chromium_search_roots():
         if not root or not os.path.isdir(root):


### PR DESCRIPTION
## Summary
- Teach `_chromium_installed()` to accept `AGENT_BROWSER_EXECUTABLE_PATH` when it points to an executable browser.
- Detect common system Chrome/Chromium binaries and install paths before falling back to the existing Playwright cache scan.
- Extend Chromium detection tests for env-configured, PATH-resolved, and known-path browser installs while keeping negative cases deterministic.

## Why
Issue #19294 reports that browser tools are gated off even when `agent-browser` can launch a configured system Chrome via `AGENT_BROWSER_EXECUTABLE_PATH`. The requirements check only looked for Playwright-style cache directories, so valid local browser setups were hidden.

## Verification
- `scripts/run_tests.sh tests/tools/test_browser_chromium_check.py` - 20 passed, 4 existing event-loop deprecation warnings

Fixes #19294
