### PR TITLE
feat: add gateway activity inbox

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4131,3 +4131,81 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
     agent_rows = next(section["rows"] for section in sections if section["title"] == "Agent")
 
     assert ["Max Turns", "120"] in agent_rows
+
+
+
+def test_activity_create_list_mark_read_and_artifact_roundtrip(tmp_path, monkeypatch):
+    from tui_gateway.activity_store import ActivityStore
+
+    store = ActivityStore(tmp_path / "activity")
+    monkeypatch.setattr(server, "_activity_store", store)
+
+    create_resp = server.dispatch({
+        "jsonrpc": "2.0",
+        "id": 101,
+        "method": "activity.create",
+        "params": {
+            "kind": "report.generated",
+            "title": "Benchmark report ready",
+            "summary": "DFlash run finished",
+            "severity": "info",
+            "source": "cron",
+            "session_id": "sid123",
+            "artifacts": [
+                {
+                    "name": "report.html",
+                    "mime_type": "text/html",
+                    "content": "<html><body>ok</body></html>",
+                }
+            ],
+        },
+    })
+
+    item = create_resp["result"]["activity"]
+    assert item["id"].startswith("act_")
+    assert item["artifacts"][0]["id"].startswith("art_")
+
+    list_resp = server.dispatch({"jsonrpc": "2.0", "id": 102, "method": "activity.list", "params": {}})
+    assert list_resp["result"]["count"] == 1
+    assert list_resp["result"]["items"][0]["title"] == "Benchmark report ready"
+
+    read_resp = server.dispatch({
+        "jsonrpc": "2.0",
+        "id": 103,
+        "method": "activity.mark_read",
+        "params": {"activity_id": item["id"]},
+    })
+    assert read_resp["result"]["activity"]["read"] is True
+
+    artifact_id = item["artifacts"][0]["id"]
+    artifact_resp = server.dispatch({
+        "jsonrpc": "2.0",
+        "id": 104,
+        "method": "activity.artifacts.get",
+        "params": {"artifact_id": artifact_id},
+    })
+    artifact = artifact_resp["result"]["artifact"]
+    assert artifact["name"] == "report.html"
+    assert artifact["content"] == "<html><body>ok</body></html>"
+    assert artifact["encoding"] == "utf-8"
+
+
+def test_emit_mirrors_high_signal_events_to_activity_store(tmp_path, monkeypatch):
+    from tui_gateway.activity_store import ActivityStore
+
+    store = ActivityStore(tmp_path / "activity")
+    monkeypatch.setattr(server, "_activity_store", store)
+
+    frames = []
+    monkeypatch.setattr(server, "write_json", lambda obj: frames.append(obj) or True)
+
+    server._emit("approval.request", "sid999", {"command": "rm -rf build"})
+
+    items = store.list()
+    assert len(items) == 1
+    assert items[0]["kind"] == "approval.request"
+    assert items[0]["summary"] == "rm -rf build"
+    assert any(
+        f.get("params", {}).get("type") == "activity.created"
+        for f in frames
+    )

--- a/tui_gateway/activity_store.py
+++ b/tui_gateway/activity_store.py
@@ -1,0 +1,280 @@
+"""Durable activity inbox + artifact registry for gateway clients.
+
+The activity inbox is intentionally small and transport-neutral: gateway code can
+record high-signal events once, then native/web/TUI clients can list and inspect
+them without scraping chat history or reading arbitrary files.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import os
+import re
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+_ALLOWED_ARTIFACT_BYTES = 10 * 1024 * 1024
+_FILENAME_RE = re.compile(r"[^A-Za-z0-9._ -]+")
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _safe_name(name: str, fallback: str = "artifact") -> str:
+    cleaned = _FILENAME_RE.sub("_", (name or fallback).strip()).strip(". ")
+    return cleaned[:160] or fallback
+
+
+def _preview(text: str, limit: int = 240) -> str:
+    single = " ".join((text or "").split())
+    if len(single) <= limit:
+        return single
+    return single[: limit - 1].rstrip() + "…"
+
+
+class ActivityStore:
+    """JSONL-backed activity store with file-backed artifacts.
+
+    V0 keeps the storage deliberately simple and append-friendly. Mutating read
+    state rewrites the compact JSONL index atomically; artifacts are addressed by
+    generated IDs and never by caller-supplied paths.
+    """
+
+    def __init__(self, root: str | Path | None = None):
+        base = Path(root) if root is not None else Path(get_hermes_home()) / "activity"
+        self.root = base
+        self.artifacts_root = base / "artifacts"
+        self.index_path = base / "activity.jsonl"
+        self._lock = threading.RLock()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.artifacts_root.mkdir(parents=True, exist_ok=True)
+
+    def create(
+        self,
+        *,
+        kind: str,
+        title: str,
+        summary: str = "",
+        severity: str = "info",
+        source: str = "gateway",
+        session_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+        actions: list[dict[str, Any]] | None = None,
+        external_refs: list[dict[str, Any]] | None = None,
+        artifacts: list[dict[str, Any]] | None = None,
+        activity_id: str | None = None,
+        created_at: float | None = None,
+    ) -> dict[str, Any]:
+        now = _now() if created_at is None else float(created_at)
+        item_id = activity_id or f"act_{uuid.uuid4().hex[:16]}"
+        item_artifacts = [self._store_artifact(item_id, art) for art in artifacts or []]
+        item = {
+            "id": item_id,
+            "created_at": now,
+            "updated_at": now,
+            "kind": kind or "activity",
+            "severity": severity or "info",
+            "source": source or "gateway",
+            "title": title or kind or "Activity",
+            "summary": summary or "",
+            "session_id": session_id or "",
+            "read": False,
+            "dismissed": False,
+            "actions": actions or [],
+            "external_refs": external_refs or [],
+            "artifacts": item_artifacts,
+            "payload": payload or {},
+        }
+        with self._lock:
+            with self.index_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
+        return item
+
+    def list(self, *, limit: int = 100, include_read: bool = True, include_dismissed: bool = False) -> list[dict[str, Any]]:
+        items = self._read_all()
+        if not include_read:
+            items = [i for i in items if not i.get("read")]
+        if not include_dismissed:
+            items = [i for i in items if not i.get("dismissed")]
+        items.sort(key=lambda i: float(i.get("created_at") or 0), reverse=True)
+        return items[: max(1, min(int(limit or 100), 500))]
+
+    def get(self, activity_id: str) -> dict[str, Any] | None:
+        for item in self._read_all():
+            if item.get("id") == activity_id:
+                return item
+        return None
+
+    def mark_read(self, activity_id: str, read: bool = True) -> dict[str, Any] | None:
+        return self._update(activity_id, {"read": bool(read), "updated_at": _now()})
+
+    def dismiss(self, activity_id: str, dismissed: bool = True) -> dict[str, Any] | None:
+        return self._update(activity_id, {"dismissed": bool(dismissed), "updated_at": _now()})
+
+    def list_artifacts(self, activity_id: str) -> list[dict[str, Any]]:
+        item = self.get(activity_id)
+        return list((item or {}).get("artifacts") or [])
+
+    def get_artifact(self, artifact_id: str) -> dict[str, Any] | None:
+        artifact_id = str(artifact_id or "")
+        if not artifact_id.startswith("art_"):
+            return None
+        for item in self._read_all():
+            for meta in item.get("artifacts") or []:
+                if meta.get("id") == artifact_id:
+                    path = self._artifact_path(meta)
+                    if path is None or not path.exists() or not path.is_file():
+                        return None
+                    data = path.read_bytes()
+                    result = dict(meta)
+                    result["activity_id"] = item.get("id", "")
+                    if self._is_text(meta.get("mime_type", ""), path.name):
+                        result["content"] = data.decode("utf-8", errors="replace")
+                        result["encoding"] = "utf-8"
+                    else:
+                        result["content_base64"] = base64.b64encode(data).decode("ascii")
+                        result["encoding"] = "base64"
+                    return result
+        return None
+
+    def _read_all(self) -> list[dict[str, Any]]:
+        with self._lock:
+            if not self.index_path.exists():
+                return []
+            items: list[dict[str, Any]] = []
+            for line in self.index_path.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    value = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(value, dict):
+                    items.append(value)
+            return items
+
+    def _update(self, activity_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
+        with self._lock:
+            items = self._read_all()
+            found: dict[str, Any] | None = None
+            for item in items:
+                if item.get("id") == activity_id:
+                    item.update(updates)
+                    found = item
+                    break
+            if found is None:
+                return None
+            tmp = self.index_path.with_suffix(".jsonl.tmp")
+            with tmp.open("w", encoding="utf-8") as fh:
+                for item in items:
+                    fh.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
+            os.replace(tmp, self.index_path)
+            return found
+
+    def _store_artifact(self, activity_id: str, artifact: dict[str, Any]) -> dict[str, Any]:
+        art_id = f"art_{uuid.uuid4().hex[:16]}"
+        name = _safe_name(str(artifact.get("name") or art_id))
+        mime_type = str(artifact.get("mime_type") or mimetypes.guess_type(name)[0] or "application/octet-stream")
+        data = self._artifact_bytes(artifact)
+        if len(data) > _ALLOWED_ARTIFACT_BYTES:
+            raise ValueError(f"artifact {name} exceeds {_ALLOWED_ARTIFACT_BYTES} bytes")
+        directory = self.artifacts_root / art_id
+        directory.mkdir(parents=True, exist_ok=False)
+        path = directory / name
+        path.write_bytes(data)
+        rel = path.relative_to(self.artifacts_root).as_posix()
+        return {
+            "id": art_id,
+            "name": name,
+            "mime_type": mime_type,
+            "size": len(data),
+            "created_at": _now(),
+            "preview": artifact.get("preview") or _preview(data.decode("utf-8", errors="ignore")) if self._is_text(mime_type, name) else "",
+            "storage": rel,
+        }
+
+    def _artifact_bytes(self, artifact: dict[str, Any]) -> bytes:
+        if "content_base64" in artifact:
+            return base64.b64decode(str(artifact.get("content_base64") or ""), validate=True)
+        content = artifact.get("content", artifact.get("text", ""))
+        if isinstance(content, bytes):
+            return content
+        return str(content).encode("utf-8")
+
+    def _artifact_path(self, meta: dict[str, Any]) -> Path | None:
+        storage = str(meta.get("storage") or "")
+        if not storage or storage.startswith("/") or ".." in Path(storage).parts:
+            return None
+        path = (self.artifacts_root / storage).resolve()
+        try:
+            path.relative_to(self.artifacts_root.resolve())
+        except ValueError:
+            return None
+        return path
+
+    @staticmethod
+    def _is_text(mime_type: str, name: str) -> bool:
+        mt = (mime_type or "").lower()
+        if mt.startswith("text/") or mt in {"application/json", "application/xml", "application/javascript"}:
+            return True
+        return Path(name).suffix.lower() in {".md", ".txt", ".log", ".json", ".csv", ".html", ".htm", ".xml"}
+
+
+def activity_from_gateway_event(kind: str, session_id: str, payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Map noisy live gateway events into durable high-signal inbox items."""
+    payload = payload or {}
+    if kind == "message.complete":
+        status = str(payload.get("status") or "complete")
+        if status == "interrupted":
+            return None
+        text = str(payload.get("text") or payload.get("rendered") or "")
+        return {
+            "kind": kind,
+            "title": "Session response completed" if status == "complete" else "Session response failed",
+            "summary": _preview(text or status),
+            "severity": "error" if status == "error" else "info",
+            "source": "session",
+        }
+    if kind == "approval.request":
+        command = str(payload.get("command") or payload.get("raw_args") or "Approval requested")
+        return {
+            "kind": kind,
+            "title": "Approval required",
+            "summary": _preview(command),
+            "severity": "warning",
+            "source": "approval",
+        }
+    if kind == "clarify.request":
+        return {
+            "kind": kind,
+            "title": "Clarification needed",
+            "summary": _preview(str(payload.get("question") or "Hermes needs input")),
+            "severity": "warning",
+            "source": "clarify",
+        }
+    if kind == "background.complete":
+        return {
+            "kind": kind,
+            "title": "Background task completed",
+            "summary": _preview(str(payload.get("text") or "Done")),
+            "severity": "info",
+            "source": "background",
+        }
+    if kind == "error":
+        return {
+            "kind": kind,
+            "title": "Gateway error",
+            "summary": _preview(str(payload.get("message") or "Unknown error")),
+            "severity": "error",
+            "source": "gateway",
+        }
+    return None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
+from tui_gateway.activity_store import ActivityStore, activity_from_gateway_event
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tui_gateway.transport import (
@@ -32,6 +33,7 @@ _hermes_home = get_hermes_home()
 load_hermes_dotenv(
     hermes_home=_hermes_home, project_env=Path(__file__).parent.parent / ".env"
 )
+_activity_store = ActivityStore()
 
 
 # ── Panic logger ─────────────────────────────────────────────────────
@@ -380,6 +382,26 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     if payload is not None:
         params["payload"] = payload
     write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+
+    # Mirror high-signal gateway events into the durable Activity Inbox so
+    # clients can show a notification list without scraping chat history.
+    try:
+        mapped = activity_from_gateway_event(event, sid, payload or {})
+        if mapped:
+            item = _activity_store.create(
+                session_id=sid,
+                payload=payload or {},
+                actions=([{"type": "open_session", "label": "Open session", "session_id": sid}] if sid else []),
+                **mapped,
+            )
+            activity_params = {
+                "type": "activity.created",
+                "session_id": sid,
+                "payload": {"activity": item},
+            }
+            write_json({"jsonrpc": "2.0", "method": "event", "params": activity_params})
+    except Exception as exc:
+        logger.debug("activity inbox mirror failed for %s: %s", event, exc)
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -6010,6 +6032,122 @@ def _(rid, params: dict) -> dict:
         )
     except Exception as e:
         return _err(rid, 5033, str(e))
+
+
+
+# ── Methods: activity inbox ───────────────────────────────────────────
+
+
+@method("activity.list")
+def _(rid, params: dict) -> dict:
+    try:
+        items = _activity_store.list(
+            limit=int(params.get("limit", 100) or 100),
+            include_read=bool(params.get("include_read", True)),
+            include_dismissed=bool(params.get("include_dismissed", False)),
+        )
+        return _ok(rid, {"success": True, "count": len(items), "items": items})
+    except Exception as e:
+        return _err(rid, 5036, str(e))
+
+
+@method("activity.get")
+def _(rid, params: dict) -> dict:
+    activity_id = str(params.get("activity_id") or params.get("id") or "")
+    if not activity_id:
+        return _err(rid, 4028, "activity_id required")
+    item = _activity_store.get(activity_id)
+    if item is None:
+        return _err(rid, 4040, "activity not found")
+    return _ok(rid, {"success": True, "activity": item})
+
+
+@method("activity.create")
+def _(rid, params: dict) -> dict:
+    try:
+        item = _activity_store.create(
+            kind=str(params.get("kind") or "manual"),
+            title=str(params.get("title") or "Activity"),
+            summary=str(params.get("summary") or ""),
+            severity=str(params.get("severity") or "info"),
+            source=str(params.get("source") or "gateway"),
+            session_id=str(params.get("session_id") or ""),
+            payload=params.get("payload") if isinstance(params.get("payload"), dict) else {},
+            actions=params.get("actions") if isinstance(params.get("actions"), list) else [],
+            external_refs=params.get("external_refs") if isinstance(params.get("external_refs"), list) else [],
+            artifacts=params.get("artifacts") if isinstance(params.get("artifacts"), list) else [],
+        )
+        write_json({
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "activity.created",
+                "session_id": item.get("session_id", ""),
+                "payload": {"activity": item},
+            },
+        })
+        return _ok(rid, {"success": True, "activity": item})
+    except Exception as e:
+        return _err(rid, 5037, str(e))
+
+
+@method("activity.mark_read")
+def _(rid, params: dict) -> dict:
+    activity_id = str(params.get("activity_id") or params.get("id") or "")
+    if not activity_id:
+        return _err(rid, 4029, "activity_id required")
+    item = _activity_store.mark_read(activity_id, bool(params.get("read", True)))
+    if item is None:
+        return _err(rid, 4041, "activity not found")
+    write_json({
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "activity.updated",
+            "session_id": item.get("session_id", ""),
+            "payload": {"activity": item},
+        },
+    })
+    return _ok(rid, {"success": True, "activity": item})
+
+
+@method("activity.dismiss")
+def _(rid, params: dict) -> dict:
+    activity_id = str(params.get("activity_id") or params.get("id") or "")
+    if not activity_id:
+        return _err(rid, 4030, "activity_id required")
+    item = _activity_store.dismiss(activity_id, bool(params.get("dismissed", True)))
+    if item is None:
+        return _err(rid, 4042, "activity not found")
+    write_json({
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "activity.updated",
+            "session_id": item.get("session_id", ""),
+            "payload": {"activity": item},
+        },
+    })
+    return _ok(rid, {"success": True, "activity": item})
+
+
+@method("activity.artifacts.list")
+def _(rid, params: dict) -> dict:
+    activity_id = str(params.get("activity_id") or params.get("id") or "")
+    if not activity_id:
+        return _err(rid, 4031, "activity_id required")
+    return _ok(rid, {"success": True, "artifacts": _activity_store.list_artifacts(activity_id)})
+
+
+@method("activity.artifacts.get")
+def _(rid, params: dict) -> dict:
+    artifact_id = str(params.get("artifact_id") or params.get("id") or "")
+    if not artifact_id:
+        return _err(rid, 4032, "artifact_id required")
+    artifact = _activity_store.get_artifact(artifact_id)
+    if artifact is None:
+        return _err(rid, 4043, "artifact not found")
+    return _ok(rid, {"success": True, "artifact": artifact})
 
 
 @method("cron.manage")


### PR DESCRIPTION
## Summary
- add a durable gateway activity inbox backed by `$HERMES_HOME/activity/activity.jsonl`
- expose `activity.*` JSON-RPC methods for listing, reading, dismissing, and fetching artifacts
- mirror high-signal live events into durable `activity.created` events for native clients

## Details
- Artifacts are stored under generated IDs in `$HERMES_HOME/activity/artifacts/`
- Native clients fetch artifact content by `artifact_id`, never arbitrary filesystem paths
- Text artifacts return UTF-8 content; binary artifacts return base64

## Validation
- `python -m pytest tests/test_tui_gateway_server.py -q -k 'activity or write_json'` → 4 passed

Companion native PR: pending
