### PR TITLE
fix(profiles): honor active profile in docker root

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -114,11 +114,17 @@ def _apply_profile_override() -> None:
             consume = 1
             break
 
-    # 1.5 If HERMES_HOME is already set and no explicit flag was given, trust it.
-    # This lets child processes (relaunch, subprocess) inherit the parent's
-    # profile choice without having to pass --profile again.
-    if profile_name is None and os.environ.get("HERMES_HOME"):
-        return
+    # 1.5 If HERMES_HOME is already a profile-specific path and no explicit
+    # flag was given, trust it.  Docker/custom deployments set HERMES_HOME to
+    # the profile root itself; in that case we must still read active_profile
+    # below so `hermes profile use <name>` becomes sticky on later invocations.
+    env_home = os.environ.get("HERMES_HOME")
+    if profile_name is None and env_home:
+        try:
+            if Path(env_home).expanduser().parent.name == "profiles":
+                return
+        except Exception:
+            return
 
     # 2. If no flag, check active_profile in the hermes root
     if profile_name is None:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -8,6 +8,8 @@ and shell completion generation.
 import json
 import io
 import os
+import subprocess
+import sys
 import tarfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -914,6 +916,38 @@ class TestInternalHelpers:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_active_profile_name() == "orchestrator"
+
+    def test_main_profile_override_reads_active_profile_from_docker_root(self, tmp_path):
+        """Docker sets HERMES_HOME to the root, so sticky active_profile must still apply."""
+        docker_home = tmp_path / "opt" / "data"
+        profile = docker_home / "profiles" / "orchestrator"
+        profile.mkdir(parents=True)
+        (docker_home / "active_profile").write_text("orchestrator\n")
+
+        env = os.environ.copy()
+        env["HOME"] = str(tmp_path)
+        env["HERMES_HOME"] = str(docker_home)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import os, sys; "
+                    "sys.argv = ['hermes', 'profile', 'list']; "
+                    "import hermes_cli.main; "
+                    "print(os.environ['HERMES_HOME'])"
+                ),
+            ],
+            cwd=Path(__file__).resolve().parents[2],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().splitlines()[-1] == str(profile)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Let the startup profile override continue past `HERMES_HOME` when it points at a Docker/custom profile root rather than an already-selected profile directory.
- Keep trusting inherited profile-specific `HERMES_HOME` paths such as `<root>/profiles/<name>` for child processes.
- Add a subprocess-style regression that imports `hermes_cli.main` with Docker-style `HERMES_HOME` plus `active_profile` and verifies the selected profile home is applied.

## Why
Issue #19299 reports that `hermes profile use <name>` appears to succeed in Docker but later commands keep using the previous/default profile. In Docker/custom deployments, `HERMES_HOME` is commonly set to the root volume, so the old early return skipped reading the sticky `active_profile` file entirely.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py` - 95 passed, 4 existing event-loop deprecation warnings

Fixes #19299
