### PR TITLE
fix(curator): protect hub skills by frontmatter name

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -223,6 +223,47 @@ def test_agent_created_excludes_hub_installed(skills_home):
     assert "hub-skill" not in names
 
 
+def test_agent_created_excludes_hub_installed_frontmatter_name(skills_home):
+    from tools.skill_usage import is_agent_created, list_agent_created_skill_names
+
+    skills_dir = skills_home / "skills"
+    hub_skill = skills_dir / "productivity" / "getnote"
+    hub_skill.mkdir(parents=True)
+    (hub_skill / "SKILL.md").write_text(
+        """---
+name: Get笔记
+description: test skill
+---
+
+# body
+""",
+        encoding="utf-8",
+    )
+    _write_skill(skills_dir, "my-skill")
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "installed": {
+                    "getnote": {
+                        "source": "taps/main",
+                        "install_path": "productivity/getnote",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    names = list_agent_created_skill_names()
+    assert "my-skill" in names
+    assert "Get笔记" not in names
+    assert is_agent_created("Get笔记") is False
+    assert is_agent_created("getnote") is False
+
+
 def test_is_agent_created(skills_home):
     from tools.skill_usage import is_agent_created
     skills_dir = skills_home / "skills"

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -142,7 +142,26 @@ def _read_hub_installed_names() -> Set[str]:
         if isinstance(data, dict):
             installed = data.get("installed") or {}
             if isinstance(installed, dict):
-                return {str(k) for k in installed.keys()}
+                names = {str(k) for k in installed.keys()}
+                skills_dir = _skills_dir()
+                for entry in installed.values():
+                    if not isinstance(entry, dict):
+                        continue
+                    install_path = entry.get("install_path")
+                    if not isinstance(install_path, str) or not install_path.strip():
+                        continue
+                    skill_dir = Path(install_path)
+                    if not skill_dir.is_absolute():
+                        skill_dir = skills_dir / skill_dir
+                    try:
+                        resolved = skill_dir.resolve()
+                        resolved.relative_to(skills_dir.resolve())
+                    except (OSError, ValueError):
+                        continue
+                    skill_md = resolved / "SKILL.md"
+                    if skill_md.exists():
+                        names.add(_read_skill_name(skill_md, fallback=resolved.name))
+                return names
     except (OSError, json.JSONDecodeError) as e:
         logger.debug("Failed to read hub lock file: %s", e)
     return set()


### PR DESCRIPTION
## Summary
- Extend the curator provenance guard for hub-installed skills to include the installed skill's `SKILL.md` frontmatter name, not only the hub slug.
- Resolve hub lock `install_path` entries under the skills directory before reading frontmatter, so slug/display-name mismatches stay protected.
- Add a regression for a hub slug `getnote` whose installed skill is named `Get笔记`.

## Why
Issue #19293 reports that the curator treats hub-installed skills with localized or otherwise non-slug `name` fields as agent-created. The lock file tracks the hub slug, while curator candidate discovery compares the SKILL.md name, so `getnote` did not protect `Get笔记`.

## Verification
- `scripts/run_tests.sh tests/tools/test_skill_usage.py` - 39 passed, 4 existing event-loop deprecation warnings

Fixes #19293
