### PR TITLE
feat(cli): add GET /api/mcp dashboard endpoint

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2661,6 +2661,137 @@ async def get_toolsets():
 
 
 # ---------------------------------------------------------------------------
+# MCP servers endpoint
+# ---------------------------------------------------------------------------
+#
+# Read-only listing of MCP servers configured under ``mcp_servers`` in
+# config.yaml. Surfaces enough shape for dashboard UIs (e.g. hermes-workspace)
+# to render the configured servers without needing to parse YAML themselves.
+#
+# Secret-looking values in ``env`` and ``headers`` are masked before serving.
+# Mutating endpoints (add/remove/test) are intentionally out of scope for this
+# first cut — they live in ``hermes mcp`` CLI for now.
+
+
+_MCP_SECRET_HINTS = (
+    "token",
+    "secret",
+    "password",
+    "pass",
+    "apikey",
+    "api_key",
+    "auth",
+    "bearer",
+    "key",
+    "credential",
+)
+_MCP_MASK = "••••"
+
+
+def _mcp_mask_dict(value: Any) -> Dict[str, str]:
+    """Return a copy of ``value`` with secret-looking values masked.
+
+    Non-dict input is treated as empty. Non-string keys are dropped. Values
+    are stringified; empty values stay empty (so the UI can distinguish
+    "set" from "unset"). Keys whose lowercased name contains any of
+    :data:`_MCP_SECRET_HINTS` have their value replaced with the mask
+    sentinel when truthy.
+    """
+    if not isinstance(value, dict):
+        return {}
+    masked: Dict[str, str] = {}
+    for k, v in value.items():
+        if not isinstance(k, str):
+            continue
+        sval = "" if v is None else str(v)
+        kl = k.lower()
+        if sval and any(hint in kl for hint in _MCP_SECRET_HINTS):
+            masked[k] = _MCP_MASK
+        else:
+            masked[k] = sval
+    return masked
+
+
+def _mcp_serialize_server(name: str, raw: Any) -> Optional[Dict[str, Any]]:
+    """Convert a single ``mcp_servers[name]`` config entry to a serializable
+    dict with secrets masked. Returns ``None`` for non-dict entries."""
+    if not isinstance(raw, dict):
+        return None
+
+    # Transport: explicit field wins, otherwise infer from url/command.
+    transport = raw.get("transport") or raw.get("transportType")
+    if isinstance(transport, str) and transport.strip().lower() in ("stdio", "http"):
+        transport = transport.strip().lower()
+    elif isinstance(raw.get("url"), str) and raw["url"].strip():
+        transport = "http"
+    else:
+        transport = "stdio"
+
+    args = raw.get("args") or []
+    if not isinstance(args, list):
+        args = []
+    args = [str(a) for a in args if a is not None]
+
+    enabled = raw.get("enabled")
+    if not isinstance(enabled, bool):
+        enabled = True
+
+    server: Dict[str, Any] = {
+        "name": name,
+        "enabled": enabled,
+        "transport": transport,
+        "command": raw.get("command") if isinstance(raw.get("command"), str) else None,
+        "args": args,
+        "url": raw.get("url") if isinstance(raw.get("url"), str) else None,
+        "env": _mcp_mask_dict(raw.get("env")),
+        "headers": _mcp_mask_dict(raw.get("headers")),
+    }
+
+    # Pass-through optional fields the dashboard normalizer reads. Only
+    # include them when present so the response stays compact.
+    for key in (
+        "auth",
+        "tool_mode",
+        "toolMode",
+        "include_tools",
+        "includeTools",
+        "exclude_tools",
+        "excludeTools",
+        "timeout",
+        "connectTimeout",
+    ):
+        if key in raw:
+            server[key] = raw[key]
+
+    # Auth field — if it's a dict, mask token/secret-bearing children.
+    auth = server.get("auth")
+    if isinstance(auth, dict):
+        server["auth"] = _mcp_mask_dict(auth)
+
+    return server
+
+
+@app.get("/api/mcp")
+async def get_mcp_servers():
+    """List MCP servers configured under ``mcp_servers`` in config.yaml.
+
+    Returns ``{"servers": [...]}``. Read-only; secret-looking values in
+    ``env``, ``headers``, and ``auth`` are masked.
+    """
+    from hermes_cli.mcp_config import _get_mcp_servers
+
+    raw_servers = _get_mcp_servers()
+    servers: List[Dict[str, Any]] = []
+    for name, raw_config in raw_servers.items():
+        if not isinstance(name, str):
+            continue
+        entry = _mcp_serialize_server(name, raw_config)
+        if entry is not None:
+            servers.append(entry)
+    return {"servers": servers}
+
+
+# ---------------------------------------------------------------------------
 # Raw YAML config endpoint
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -853,6 +853,70 @@ class TestNewEndpoints:
             },
         ]
 
+    def test_mcp_list_empty(self, monkeypatch):
+        import hermes_cli.mcp_config as mcp_config
+
+        monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: {})
+        resp = self.client.get("/api/mcp")
+        assert resp.status_code == 200
+        assert resp.json() == {"servers": []}
+
+    def test_mcp_list_returns_configured_servers(self, monkeypatch):
+        import hermes_cli.mcp_config as mcp_config
+
+        fake_servers = {
+            "stdio-server": {
+                "command": "node",
+                "args": ["/path/to/server.js"],
+                "env": {"FOO_TOKEN": "supersecret", "DEBUG": "1"},
+            },
+            "http-server": {
+                "url": "https://mcp.example.com/sse",
+                "headers": {"Authorization": "Bearer xyz"},
+            },
+        }
+        monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: fake_servers)
+
+        resp = self.client.get("/api/mcp")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "servers" in body
+        servers_by_name = {s["name"]: s for s in body["servers"]}
+
+        stdio = servers_by_name["stdio-server"]
+        assert stdio["transport"] == "stdio"
+        assert stdio["command"] == "node"
+        assert stdio["args"] == ["/path/to/server.js"]
+        assert stdio["enabled"] is True
+        # Token-bearing env keys must be masked.
+        assert stdio["env"]["FOO_TOKEN"] != "supersecret"
+        assert stdio["env"]["FOO_TOKEN"] == "••••"
+        # Non-secret env values pass through as-is.
+        assert stdio["env"]["DEBUG"] == "1"
+
+        http = servers_by_name["http-server"]
+        assert http["transport"] == "http"
+        assert http["url"] == "https://mcp.example.com/sse"
+        # Authorization header must be masked.
+        assert http["headers"]["Authorization"] != "Bearer xyz"
+        assert http["headers"]["Authorization"] == "••••"
+
+    def test_mcp_list_skips_malformed_entries(self, monkeypatch):
+        import hermes_cli.mcp_config as mcp_config
+
+        # Non-dict entries (e.g. user typo where they wrote a string) must
+        # be silently dropped rather than crashing the endpoint.
+        fake_servers = {
+            "good": {"command": "node", "args": []},
+            "bad": "this is not a dict",
+        }
+        monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: fake_servers)
+
+        resp = self.client.get("/api/mcp")
+        assert resp.status_code == 200
+        names = [s["name"] for s in resp.json()["servers"]]
+        assert names == ["good"]
+
     def test_toolsets_list(self):
         resp = self.client.get("/api/tools/toolsets")
         assert resp.status_code == 200


### PR DESCRIPTION
## What

Adds a read-only `GET /api/mcp` endpoint to the dashboard web server that lists MCP servers configured under `mcp_servers` in `config.yaml`.

Response shape: `{servers: [...]}` where each entry includes:

- `name`, `enabled`, `transport` (inferred from explicit field, else `url`/`command`)
- `command`, `args`, `url`
- `env`, `headers` (with secrets masked)
- Optional pass-through: `auth`, `toolMode`/`tool_mode`, `includeTools`/`include_tools`, `excludeTools`/`exclude_tools`, `timeout`, `connectTimeout`

## Why

External dashboard UIs (e.g. [hermes-workspace](https://github.com/outsourc-e/hermes-workspace)) currently have no way to enumerate the MCP servers Hermes is using — they have to either parse YAML themselves or show a "MCP Servers — not available on this backend" placeholder.

This endpoint closes that gap with a small, focused change that only exposes data already in `config.yaml`, with secret-looking values masked.

## Scope

Read-only only. Mutating endpoints (`POST`/`PUT`/`DELETE`/`/test`/`/logs`) are deliberately out of scope for this PR — they're better as follow-ups once the read shape is locked in. The existing `hermes mcp` CLI subcommands continue to handle add/remove/test.

## Implementation notes

- Uses the existing `_get_mcp_servers()` helper from `hermes_cli/mcp_config.py`
- Secret masking follows the same hint list (`token`, `secret`, `password`, `key`, `auth`, `bearer`, `credential`, `apikey`, `pass`) that `/api/env` uses
- Non-dict entries in the config are silently dropped rather than crashing the endpoint
- Transport inference: explicit `transport`/`transportType` field wins, else infers `http` from a `url`, falls back to `stdio`

## Testing

- **Unit tests** (`tests/hermes_cli/test_web_server.py`): 3 new tests covering empty list, configured servers with secret-masking verification, and malformed-entry tolerance. All pass: `pytest tests/hermes_cli/test_web_server.py -v -k mcp` → 3 passed.
- **Live-tested** against a deployment with three MCP servers (Gmail, Google Drive, Google Calendar). hermes-workspace's MCP tab transitions from "Not available on this backend" to listing all three with correct transport detection and masked credentials.

## Platforms tested

- Linux (Ubuntu 24.04, Python 3.11.15)