### PR TITLE
feat(agent): check credential pool exhaustion before API calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11113,6 +11113,39 @@ class AIAgent:
                     except Exception:
                         pass  # Never let rate guard break the agent loop
 
+
+                # ── Credential pool exhaustion guard ──────────────
+                # If the credential pool exists but ALL entries are in
+                # exhaustion cooldown (429/402), skip the API call and
+                # activate fallback immediately instead of burning retries
+                # against credentials that will just fail again.
+                if self._credential_pool is not None and not self._credential_pool.has_available():
+                    self._vprint(
+                        f"{self.log_prefix}⏳ All credentials in cooldown — trying fallback...",
+                        force=True,
+                    )
+                    self._emit_status("⏳ All credentials in cooldown — trying fallback...")
+                    if self._try_activate_fallback():
+                        retry_count = 0
+                        compression_attempts = 0
+                        primary_recovery_attempted = False
+                        continue
+                    # No fallback available — wait out the cooldown
+                    _cooldown_msg = "All provider credentials are in rate-limit cooldown."
+                    self._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": (
+                            f"⏳ {_cooldown_msg}\n\n"
+                            "No fallback provider available. "
+                            "Try again in a few minutes, or add a "
+                            "fallback provider in config.yaml."
+                        ),
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": _cooldown_msg,
+                    }
                 try:
                     self._reset_stream_delivery_tracking()
                     api_kwargs = self._build_api_kwargs(api_messages)


### PR DESCRIPTION
## Problem

When all credentials in a pool enter cooldown (429 rate limit / 402 billing), the main conversation loop continues making API calls. Every call burns a retry, hits the exhausted credential immediately, and wastes time in a loop of guaranteed failures until the rate guard eventually kicks in.

**Init time** already handles this (PR #17929), but the **runtime loop** doesn't.

## Fix

Adds a 33-line guard in the main loop, right before the API call:

```
if credential_pool is not None and not credential_pool.has_available():
    → try fallback provider immediately
    → if no fallback, return clear cooldown message
```

When fallback is available, it activates seamlessly — resets retry counters and continues. When no fallback exists, it persists the session and returns a clear message telling the user what's happening and how to fix it.

## Testing

- [x] Local: tested with exhausted DeepSeek pool → Gemini fallback activated cleanly
- [x] Local: tested with all pools exhausted → graceful cooldown message returned
- [x] No behavior change when credential pool is healthy (guard is a no-op)

## Related

- PR #17929 — init-time exhaustion check
- PR #9893 — compression exhaustion infinite loop fix