### PR TITLE
fix(cli): rewrite stale MiniMax OAuth verification_uri and surface setup failures

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6874,6 +6874,33 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
 # ==================== MiniMax Portal OAuth ====================
 
+# MiniMax's /oauth/code endpoint currently returns a verification_uri pointing
+# at https://www.minimax.io/oauth-authorize?... which 307-redirects to the
+# marketing homepage and has no OAuth approval UI. The live approval page is
+# served from platform.minimax.io. Rewrite the host client-side until upstream
+# returns the correct one. Tracked in issue #19337.
+_MINIMAX_STALE_VERIFY_HOSTS = frozenset({"www.minimax.io", "minimax.io"})
+_MINIMAX_LIVE_VERIFY_HOST = "platform.minimax.io"
+
+
+def _normalize_minimax_verification_uri(url: str) -> str:
+    """Return *url* with the OAuth approval host rewritten if it is stale."""
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+    if (parsed.hostname or "").lower() not in _MINIMAX_STALE_VERIFY_HOSTS:
+        return url
+    if not parsed.path.startswith("/oauth-authorize"):
+        return url
+    new_netloc = _MINIMAX_LIVE_VERIFY_HOST
+    if parsed.port:
+        new_netloc = f"{new_netloc}:{parsed.port}"
+    return parsed._replace(netloc=new_netloc).geturl()
+
+
 def _minimax_pkce_pair() -> tuple:
     """Generate (code_verifier, code_challenge_S256, state) for MiniMax OAuth."""
     import secrets
@@ -6922,6 +6949,9 @@ def _minimax_request_user_code(
             "MiniMax OAuth state mismatch (possible CSRF).",
             provider="minimax-oauth", code="state_mismatch",
         )
+    payload["verification_uri"] = _normalize_minimax_verification_uri(
+        str(payload["verification_uri"])
+    )
     return payload
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3602,17 +3602,33 @@ def _model_flow_minimax_oauth(config, current_model="", args=None):
                 timeout=getattr(args, "timeout", None) or 15.0,
             )
             _login_minimax_oauth(mock_args, PROVIDER_REGISTRY["minimax-oauth"])
+        except KeyboardInterrupt:
+            print()
+            print("MiniMax OAuth login cancelled. Provider not configured.", flush=True)
+            return
         except SystemExit:
-            print("Login cancelled or failed.")
+            # _login_minimax_oauth raises SystemExit(1) after printing
+            # format_auth_error(exc); surface a clear next step so the wizard
+            # doesn't appear to silently advance (#19336).
+            print(
+                "MiniMax OAuth login did not complete. Provider not configured. "
+                "Re-run 'hermes model' to retry.",
+                flush=True,
+            )
             return
         except Exception as exc:
-            print(f"Login failed: {exc}")
+            logger.warning("MiniMax OAuth login failed", exc_info=True)
+            print(f"MiniMax OAuth login failed: {exc}", flush=True)
+            print(
+                "Provider not configured. Re-run 'hermes model' to retry.",
+                flush=True,
+            )
             return
 
     try:
         creds = resolve_minimax_oauth_runtime_credentials()
     except AuthError as exc:
-        print(format_auth_error(exc))
+        print(format_auth_error(exc), flush=True)
         return
 
     from hermes_cli.models import _PROVIDER_MODELS

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -30,6 +30,7 @@ from hermes_cli.auth import (
     _minimax_request_user_code,
     _minimax_poll_token,
     _minimax_resolve_token_expiry_unix,
+    _normalize_minimax_verification_uri,
     _refresh_minimax_oauth_state,
     resolve_minimax_oauth_runtime_credentials,
     get_minimax_oauth_auth_status,
@@ -837,3 +838,104 @@ def test_resolve_returns_string_by_default():
 
     assert creds["api_key"] == "tok"
     assert isinstance(creds["api_key"], str)
+
+
+# ---------------------------------------------------------------------------
+# 16. test_normalize_verification_uri_rewrites_stale_host
+# ---------------------------------------------------------------------------
+
+def test_normalize_verification_uri_rewrites_stale_host():
+    """www.minimax.io/oauth-authorize 307s to the homepage; rewrite to platform."""
+    stale = "https://www.minimax.io/oauth-authorize?user_code=ABC&client=OpenClaw"
+    rewritten = _normalize_minimax_verification_uri(stale)
+    assert rewritten == (
+        "https://platform.minimax.io/oauth-authorize?user_code=ABC&client=OpenClaw"
+    )
+
+
+def test_normalize_verification_uri_preserves_unrelated_urls():
+    """Don't rewrite hosts or paths that aren't the known stale OAuth approval URL."""
+    cases = [
+        "https://platform.minimax.io/oauth-authorize?user_code=ABC",
+        "https://www.minimax.io/some-other-page",
+        "https://example.com/oauth-authorize?user_code=ABC",
+        "https://api.minimax.io/oauth/code",
+        "",
+        "not a url at all",
+    ]
+    for url in cases:
+        assert _normalize_minimax_verification_uri(url) == url, url
+
+
+def test_request_user_code_normalizes_stale_verification_uri():
+    """End-to-end: a stale verification_uri from /oauth/code is rewritten."""
+    state = "test-state-rewrite"
+    stale = "https://www.minimax.io/oauth-authorize?user_code=ABC-123&client=OpenClaw"
+    mock_response = _make_httpx_response(200, {
+        "user_code": "ABC-123",
+        "verification_uri": stale,
+        "expired_in": int(time.time() * 1000) + 300_000,
+        "state": state,
+    })
+
+    client = MagicMock()
+    client.post.return_value = mock_response
+
+    result = _minimax_request_user_code(
+        client,
+        portal_base_url=MINIMAX_OAUTH_GLOBAL_BASE,
+        client_id=MINIMAX_OAUTH_CLIENT_ID,
+        code_challenge="challenge",
+        state=state,
+    )
+
+    assert result["verification_uri"] == (
+        "https://platform.minimax.io/oauth-authorize?user_code=ABC-123&client=OpenClaw"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 17. test_model_flow_minimax_oauth_surfaces_login_failure
+# ---------------------------------------------------------------------------
+
+def test_model_flow_minimax_oauth_surfaces_login_failure_systemexit(capsys):
+    """If _login_minimax_oauth raises SystemExit, the wizard must announce it."""
+    from hermes_cli.main import _model_flow_minimax_oauth
+
+    with patch("hermes_cli.auth.get_provider_auth_state", return_value=None), \
+         patch("hermes_cli.auth._login_minimax_oauth", side_effect=SystemExit(1)):
+        _model_flow_minimax_oauth({}, current_model="")
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Provider not configured" in combined
+    assert "hermes model" in combined  # tells user how to retry
+
+
+def test_model_flow_minimax_oauth_surfaces_login_failure_exception(capsys):
+    """Generic exceptions from login must not be swallowed silently."""
+    from hermes_cli.main import _model_flow_minimax_oauth
+
+    with patch("hermes_cli.auth.get_provider_auth_state", return_value=None), \
+         patch("hermes_cli.auth._login_minimax_oauth",
+               side_effect=RuntimeError("network blew up")):
+        _model_flow_minimax_oauth({}, current_model="")
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "network blew up" in combined
+    assert "Provider not configured" in combined
+
+
+def test_model_flow_minimax_oauth_surfaces_keyboard_interrupt(capsys):
+    """User Ctrl-C during login should print a clear cancelled message."""
+    from hermes_cli.main import _model_flow_minimax_oauth
+
+    with patch("hermes_cli.auth.get_provider_auth_state", return_value=None), \
+         patch("hermes_cli.auth._login_minimax_oauth", side_effect=KeyboardInterrupt):
+        _model_flow_minimax_oauth({}, current_model="")
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "cancelled" in combined.lower()
+    assert "Provider not configured" in combined


### PR DESCRIPTION
Fixes the silent failure of `hermes setup` quick-wizard for MiniMax OAuth and the stale `verification_uri` that returns from MiniMax's `/oauth/code`.

## What changed and why
- `hermes_cli/auth.py`: Added `_normalize_minimax_verification_uri()` and apply it inside `_minimax_request_user_code()`. MiniMax currently returns `https://www.minimax.io/oauth-authorize?...` which 307-redirects to the marketing homepage and has no OAuth approval UI — the live approval page is at `platform.minimax.io/oauth-authorize?...`. Rewrite the host client-side until upstream is fixed. Bare paths and unrelated hosts are left untouched.
- `hermes_cli/main.py`: Replaced the catch-all `except SystemExit: print("Login cancelled or failed.")` in `_model_flow_minimax_oauth()` with explicit `KeyboardInterrupt` / `SystemExit` / `Exception` branches. Each branch flushes stdout, logs a traceback at warning level for the generic case, and tells the user the provider was not configured and how to retry. This stops the wizard from appearing to silently advance after an OAuth error.
- `tests/test_minimax_oauth.py`: Added 5 tests — `_normalize_minimax_verification_uri` happy/unrelated/end-to-end, plus three `_model_flow_minimax_oauth` tests covering the SystemExit, generic-Exception, and KeyboardInterrupt paths.

## How to test
- `pytest tests/test_minimax_oauth.py -q` (21 passed).
- Manual: simulate a failing OAuth login (e.g. block `api.minimax.io` in `/etc/hosts`) and run `hermes setup` → "MiniMax via OAuth browser login". The wizard now prints `MiniMax OAuth login failed: ... Provider not configured. Re-run 'hermes model' to retry.` instead of advancing silently.
- Verify the printed verification URL points at `platform.minimax.io` rather than `www.minimax.io`.

## What platforms tested on
- macOS on darwin-arm64 (local) — full `pytest tests/hermes_cli tests/test_minimax_oauth.py` run: 1359 passed, 1 skipped, 1 pre-existing systemd test failure unrelated to this change.

Fixes #19336
Fixes #19337

<!-- autocontrib:worker-id=issue-new-2a43147f kind=pr-open -->