### PR TITLE
fix(tools): expand composite toolsets in delegate intersection

### DIFF
--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -9,7 +9,11 @@ arbitrary toolsets.
 from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import (
+    _resolve_parent_tool_universe,
+    _strip_blocked_tools,
+    _toolset_subset_of_parent,
+)
 
 
 class TestToolsetIntersection:
@@ -64,3 +68,66 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+class TestCompositeToolsetIntersection:
+    """Composite presets (hermes-cli, hermes-acp, …) must be expanded before
+    intersecting with the child's requested toolsets — otherwise the child
+    gets zero tools because the toolset names don't compare equal even though
+    the underlying tools are present (issue #19447)."""
+
+    def test_resolve_parent_tool_universe_expands_hermes_cli(self):
+        tools = _resolve_parent_tool_universe({"hermes-cli"})
+        assert "web_search" in tools
+        assert "web_extract" in tools
+        assert "terminal" in tools
+        assert "read_file" in tools
+
+    def test_web_subset_of_hermes_cli(self):
+        parent_tools = _resolve_parent_tool_universe({"hermes-cli"})
+        assert _toolset_subset_of_parent("web", parent_tools) is True
+
+    def test_terminal_subset_of_hermes_cli(self):
+        parent_tools = _resolve_parent_tool_universe({"hermes-cli"})
+        assert _toolset_subset_of_parent("terminal", parent_tools) is True
+
+    def test_browser_not_subset_of_terminal_only_parent(self):
+        parent_tools = _resolve_parent_tool_universe({"terminal"})
+        assert _toolset_subset_of_parent("browser", parent_tools) is False
+
+    def test_web_subset_of_hermes_acp(self):
+        parent_tools = _resolve_parent_tool_universe({"hermes-acp"})
+        assert _toolset_subset_of_parent("web", parent_tools) is True
+
+    def test_unknown_toolset_is_not_subset(self):
+        """Unknown/unresolvable toolset names cannot smuggle access in."""
+        parent_tools = _resolve_parent_tool_universe({"hermes-cli"})
+        assert _toolset_subset_of_parent("does-not-exist", parent_tools) is False
+
+    def test_intersection_with_composite_parent_keeps_requested(self):
+        """End-to-end shape of the new intersection: parent runs hermes-cli,
+        child requests ['web', 'file'] — both should survive the filter."""
+        parent_toolsets = {"hermes-cli"}
+        parent_tools = _resolve_parent_tool_universe(parent_toolsets)
+        requested = ["web", "file", "browser"]
+        scoped = [
+            t for t in requested
+            if t in parent_toolsets
+            or _toolset_subset_of_parent(t, parent_tools)
+        ]
+        assert "web" in scoped
+        assert "file" in scoped
+        assert "browser" in scoped
+
+    def test_intersection_with_composite_parent_drops_uncovered(self):
+        """A toolset whose tools aren't in the parent's universe is dropped."""
+        parent_toolsets = {"web"}
+        parent_tools = _resolve_parent_tool_universe(parent_toolsets)
+        requested = ["web", "terminal"]
+        scoped = [
+            t for t in requested
+            if t in parent_toolsets
+            or _toolset_subset_of_parent(t, parent_tools)
+        ]
+        assert "web" in scoped
+        assert "terminal" not in scoped

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -644,6 +644,42 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _resolve_parent_tool_universe(parent_toolset_names) -> set:
+    """Return the set of tool names a parent with these toolsets effectively has.
+
+    Composite/preset toolsets (``hermes-cli``, ``hermes-acp``, …) bundle tools
+    drawn from many individual toolsets. The intersection that scopes a child
+    must compare at the tool level so a child requesting ``web`` from a parent
+    with ``hermes-cli`` is allowed (because ``hermes-cli`` already exposes
+    ``web_search``/``web_extract``).
+    """
+    from toolsets import resolve_toolset
+
+    tools: set[str] = set()
+    for name in parent_toolset_names:
+        try:
+            tools.update(resolve_toolset(name))
+        except Exception:
+            continue
+    return tools
+
+
+def _toolset_subset_of_parent(toolset_name: str, parent_tools: set) -> bool:
+    """True when every tool the requested toolset would add is already on the parent.
+
+    Falls back to False when the requested toolset resolves to an empty set
+    (unknown name or stub), so the child cannot smuggle in toolsets the
+    registry can't account for.
+    """
+    from toolsets import resolve_toolset
+
+    try:
+        ts_tools = set(resolve_toolset(toolset_name))
+    except Exception:
+        return False
+    return bool(ts_tools) and ts_tools.issubset(parent_tools)
+
+
 def _build_child_progress_callback(
     task_index: int,
     goal: str,
@@ -907,8 +943,16 @@ def _build_child_agent(
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
     if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks
-        child_toolsets = [t for t in toolsets if t in parent_toolsets]
+        # Intersect with parent — subagent must not gain tools the parent lacks.
+        # Compare at the tool level so requests like toolsets=["web"] succeed
+        # when the parent runs a composite preset (hermes-cli, hermes-acp, …)
+        # that already bundles those tools.
+        parent_tool_universe = _resolve_parent_tool_universe(parent_toolsets)
+        child_toolsets = [
+            t for t in toolsets
+            if t in parent_toolsets
+            or _toolset_subset_of_parent(t, parent_tool_universe)
+        ]
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets


### PR DESCRIPTION
Expand composite/preset toolsets (hermes-cli, hermes-acp, …) when scoping a subagent so child requests like `toolsets=["web"]` are no longer silently dropped to an empty set.

## What changed and why
- `tools/delegate_tool.py`: replaced the name-only intersection in `_build_child_agent` with a tool-level subset check. A requested child toolset is allowed when every tool it would add is already present in the union of the parent's resolved tools, in addition to the original name-equality fast path.
- Added two small helpers next to `_strip_blocked_tools`: `_resolve_parent_tool_universe` (parent toolset names → set of tool names) and `_toolset_subset_of_parent` (requested toolset's tools ⊆ parent universe).
- The MCP-preservation and blocked-toolset stripping behavior is unchanged; only the intersection step was widened.
- `tests/tools/test_delegate_toolset_scope.py`: added a `TestCompositeToolsetIntersection` class covering the issue scenario (hermes-cli parent + web/file/browser child requests), the hermes-acp variant, the negative case (terminal-only parent rejects browser), the unknown-toolset case, and the end-to-end shape of the new intersection.

## How to test
- `pytest tests/tools/test_delegate_toolset_scope.py -q` — 13 passing (5 original + 8 new).
- Repro from the issue: with `toolsets: [hermes-cli]` in `~/.hermes/config.yaml`, calling `delegate_task(goal="Research X", toolsets=["web"])` now hands the child the `web` toolset (and `web_search`/`web_extract`) rather than an empty tool list.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #19447

<!-- autocontrib:worker-id=issue-new-cc21e225 kind=pr-open -->