### PR TITLE
fix(agent): plumb main_runtime through vision aux resolution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2625,6 +2625,7 @@ def resolve_vision_provider_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     async_mode: bool = False,
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
 
@@ -2632,11 +2633,19 @@ def resolve_vision_provider_client(
     provider overrides still use the generic provider router for non-standard
     backends, so users can intentionally force experimental providers. Auto mode
     stays conservative and only tries vision backends known to work today.
+
+    When ``main_runtime`` is provided, its provider/model take precedence over
+    the config-read main provider/model in the auto branch — keeping vision in
+    sync with the live agent runtime after a ``/model`` switch or fallback
+    activation. External callers without an active agent (config feasibility
+    checks, gateway probes) may omit it and the existing config fallback
+    applies.
     """
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         "vision", provider, model, base_url, api_key
     )
     requested = _normalize_vision_provider(requested)
+    runtime = _normalize_main_runtime(main_runtime)
 
     def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
         if sync_client is None:
@@ -2672,8 +2681,11 @@ def resolve_vision_provider_client(
         #   2. OpenRouter  (vision-capable aggregator fallback)
         #   3. Nous Portal (vision-capable aggregator fallback)
         #   4. Stop
-        main_provider = _read_main_provider()
-        main_model = _read_main_model()
+        # Runtime overrides config so vision tracks /model switches and
+        # fallback activations live, instead of reading the stale config.yaml
+        # the agent was started with.
+        main_provider = runtime.get("provider") or _read_main_provider()
+        main_model = runtime.get("model") or _read_main_model()
         if main_provider and main_provider not in ("auto", ""):
             vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
             if main_provider == "nous":
@@ -3405,6 +3417,7 @@ def call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=False,
+            main_runtime=main_runtime,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -3415,6 +3428,7 @@ def call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=False,
+                main_runtime=main_runtime,
             )
         if client is None:
             raise RuntimeError(
@@ -3568,6 +3582,7 @@ def call_llm(
                         provider=resolved_provider,
                         model=final_model,
                         async_mode=False,
+                        main_runtime=main_runtime,
                     )[1:]
                     if task == "vision"
                     else _get_cached_client(
@@ -3695,6 +3710,7 @@ async def async_call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
     max_tokens: int = None,
@@ -3718,6 +3734,7 @@ async def async_call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=True,
+            main_runtime=main_runtime,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -3728,6 +3745,7 @@ async def async_call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=True,
+                main_runtime=main_runtime,
             )
         if client is None:
             raise RuntimeError(
@@ -3743,6 +3761,7 @@ async def async_call_llm(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            main_runtime=main_runtime,
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
@@ -3755,7 +3774,8 @@ async def async_call_llm(
             if not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", async_mode=True)
+                client, final_model = _get_cached_client(
+                    "auto", async_mode=True, main_runtime=main_runtime)
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -3859,6 +3879,7 @@ async def async_call_llm(
                         provider=resolved_provider,
                         model=final_model,
                         async_mode=True,
+                        main_runtime=main_runtime,
                     )
                 else:
                     retry_client, retry_model = _get_cached_client(
@@ -3868,6 +3889,7 @@ async def async_call_llm(
                         base_url=resolved_base_url,
                         api_key=resolved_api_key,
                         api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
                     )
                 if retry_client is not None:
                     retry_kwargs = _build_call_kwargs(

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -396,6 +396,76 @@ class TestResolveVisionMainFirst:
         assert provider == "nous"
         mock_strict.assert_called_once_with("nous", None)
 
+    def test_runtime_override_wins_over_config_for_vision(self):
+        """main_runtime kwarg overrides config-read main provider/model in vision auto."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openrouter",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="config/cfg-model",
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ):
+            mock_resolve.return_value = (MagicMock(), "runtime-model")
+
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, _client, _model = resolve_vision_provider_client(
+                main_runtime={
+                    "provider": "anthropic",
+                    "model": "runtime-model",
+                    "base_url": "",
+                    "api_key": "",
+                    "api_mode": "",
+                },
+            )
+
+        # Runtime override wins — vision routes to anthropic/runtime-model
+        # even though config still says openrouter/cfg-model.
+        assert provider == "anthropic"
+        assert mock_resolve.call_args.args[0] == "anthropic"
+        assert mock_resolve.call_args.args[1] == "runtime-model"
+        assert mock_resolve.call_args.kwargs.get("is_vision") is True
+
+    def test_call_llm_vision_forwards_main_runtime(self):
+        """call_llm(task='vision', main_runtime=...) reaches resolve_vision_provider_client."""
+        captured: dict = {}
+
+        def _fake_vision(**kwargs):
+            captured.update(kwargs)
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = MagicMock(
+                choices=[MagicMock(message=MagicMock(content="ok"))],
+            )
+            return "anthropic", mock_client, "runtime-vision-model"
+
+        with patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            side_effect=_fake_vision,
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ):
+            from agent.auxiliary_client import call_llm
+
+            runtime = {
+                "provider": "anthropic",
+                "model": "runtime-vision-model",
+                "base_url": "",
+                "api_key": "",
+                "api_mode": "",
+            }
+            call_llm(
+                task="vision",
+                main_runtime=runtime,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert captured.get("main_runtime") == runtime
+
 
 # ── Constant cleanup ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Vision auxiliary tasks diverged from the main agent runtime after `/model` switches or fallback activations because `resolve_vision_provider_client()` resolved through `_read_main_provider()` / `_read_main_model()` — the config-only path — even when the caller had a live runtime snapshot.

## What changed and why
- `resolve_vision_provider_client()` accepts an optional `main_runtime` and uses it in the auto branch before falling back to config (`agent/auxiliary_client.py`).
- `call_llm(task="vision", ...)` forwards its existing `main_runtime` kwarg into the vision resolver and into the auth-error retry path.
- `async_call_llm()` gains a `main_runtime` parameter (parity with `call_llm`) and forwards it to both the vision resolver and `_get_cached_client` (including the auto fallback and auth-error retry).
- The text-only resolution path was already runtime-aware; this closes the gap for the vision path called out in the issue (`resolve_vision_provider_client` listed under "Affected Code Paths").

## How to test
- `pytest tests/agent/test_auxiliary_main_first.py -q` — covers existing main-first behaviour plus two new regression tests:
  - `test_runtime_override_wins_over_config_for_vision` — runtime provider wins over config in the vision auto branch.
  - `test_call_llm_vision_forwards_main_runtime` — `call_llm(task="vision")` reaches `resolve_vision_provider_client` with `main_runtime` intact.
- `pytest tests/agent tests/run_agent tests/tools/test_web_tools_config.py -q` — full auxiliary + run_agent coverage stays green (the only failures are pre-existing on `main`: `tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::*` and `tests/run_agent/test_concurrent_interrupt.py`).

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #19437

<!-- autocontrib:worker-id=issue-new-521180ae kind=pr-open -->