### PR TITLE
fix(delegate): normalize ACP args before delegation

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -46,6 +46,20 @@ def _resolve_args() -> list[str]:
     return shlex.split(raw)
 
 
+def _normalize_acp_args(value: Any) -> list[str]:
+    """Return ACP subprocess args as a list without iterating arbitrary objects."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return shlex.split(value)
+    if isinstance(value, dict):
+        return []
+    try:
+        return [str(item) for item in value]
+    except TypeError:
+        return []
+
+
 def _resolve_home_dir() -> str:
     """Return a stable HOME for child ACP processes."""
 
@@ -329,7 +343,12 @@ class CopilotACPClient:
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        explicit_args = acp_args if acp_args is not None else args
+        self._acp_args = (
+            _normalize_acp_args(explicit_args)
+            if explicit_args is not None
+            else _resolve_args()
+        )
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 import os
 import random
 import re
+import shlex
 import ssl
 import sys
 import tempfile
@@ -88,6 +89,21 @@ class _OpenAIProxy:
 
 
 OpenAI = _OpenAIProxy()
+
+
+def _normalize_acp_args(value: Any) -> list[str]:
+    """Return ACP subprocess args as a list without iterating arbitrary objects."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return shlex.split(value)
+    if isinstance(value, dict):
+        return []
+    try:
+        return [str(item) for item in value]
+    except TypeError:
+        return []
+
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -1039,7 +1055,9 @@ class AIAgent:
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
-        self.acp_args = list(acp_args or args or [])
+        self.acp_args = _normalize_acp_args(
+            acp_args if acp_args is not None else args
+        )
         if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from agent.copilot_acp_client import CopilotACPClient
@@ -144,6 +145,15 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
 
         self.assertIn("error", response)
         self.assertFalse(outside.exists())
+
+    def test_namespace_acp_args_do_not_crash_client_init(self):
+        client = CopilotACPClient(
+            acp_command="copilot",
+            acp_args=SimpleNamespace(acp_args=["--acp", "--stdio"]),
+            acp_cwd="/tmp",
+        )
+
+        self.assertEqual(client._acp_args, [])
 
 
 if __name__ == "__main__":

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4011,6 +4011,27 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_ignores_namespace_acp_args_alias():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+    ):
+        agent = AIAgent(
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            provider="copilot-acp",
+            acp_command="/usr/local/bin/copilot",
+            args=SimpleNamespace(acp_args=["--acp", "--stdio"]),
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.acp_args == []
+    assert mock_acp_client.call_args.kwargs["args"] == []
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -1132,6 +1133,35 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs.get("override_api_mode"), "chat_completions")
             self.assertEqual(kwargs.get("override_acp_command"), "custom-copilot")
             self.assertEqual(kwargs.get("override_acp_args"), ["--stdio-custom"])
+
+    def test_build_child_agent_drops_non_iterable_acp_args(self):
+        """ACP delegation should not crash when parent ACP args are a Namespace."""
+        parent = _make_mock_parent(depth=0)
+        parent.acp_args = SimpleNamespace(acp_args=["--acp", "--stdio"])
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = MagicMock()
+            MockAgent.return_value = child
+
+            _build_child_agent(
+                task_index=0,
+                goal="ACP delegation test",
+                context=None,
+                toolsets=None,
+                model="copilot-model",
+                max_iterations=45,
+                task_count=1,
+                parent_agent=parent,
+                override_provider="copilot-acp",
+                override_base_url="acp://copilot",
+                override_api_key="copilot-acp",
+                override_api_mode="chat_completions",
+                override_acp_command="custom-copilot",
+                override_acp_args=None,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs.get("acp_args"), [])
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,6 +22,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 import os
+import shlex
 import threading
 import time
 from concurrent.futures import (
@@ -319,6 +320,20 @@ def _normalize_role(r: Optional[str]) -> str:
         return r_norm
     logger.warning("Unknown delegate_task role=%r, coercing to 'leaf'", r)
     return "leaf"
+
+
+def _normalize_acp_args(value: Any) -> List[str]:
+    """Return ACP subprocess args as a list without iterating arbitrary objects."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return shlex.split(value)
+    if isinstance(value, dict):
+        return []
+    try:
+        return [str(item) for item in value]
+    except TypeError:
+        return []
 
 
 def _get_max_concurrent_children() -> int:
@@ -987,7 +1002,7 @@ def _build_child_agent(
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )
-    effective_acp_args = list(
+    effective_acp_args = _normalize_acp_args(
         override_acp_args
         if override_acp_args is not None
         else (getattr(parent_agent, "acp_args", []) or [])


### PR DESCRIPTION
## Summary
- normalize ACP command args before they reach `AIAgent`, delegated child agents, or `CopilotACPClient`
- handle non-iterable runtime objects such as `SimpleNamespace` without raising `TypeError`
- add regressions for direct agent construction, delegate child construction, and ACP client initialization

## Why
Fixes #19462. The failing path reports `TypeError: types.SimpleNamespace object is not iterable` before the ACP delegated task can complete. The fix keeps ACP arg handling list-shaped and drops invalid namespace/dict values instead of iterating them.

## Test
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py::test_aiagent_ignores_namespace_acp_args_alias tests/tools/test_delegate.py::TestDelegationProviderIntegration::test_build_child_agent_drops_non_iterable_acp_args tests/agent/test_copilot_acp_client.py::CopilotACPClientSafetyTests::test_namespace_acp_args_do_not_crash_client_init`

## Note
- Broader `scripts/run_tests.sh tests/tools/test_delegate.py tests/agent/test_copilot_acp_client.py` currently hits the existing heartbeat timing assertion `TestDelegateHeartbeat::test_heartbeat_does_not_trip_idle_stale_while_inside_tool`; the ACP regression tests above pass.