### PR TITLE
fix(gateway): replace zombie scoped lock owners

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -35,6 +35,7 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
+_NON_RUNNING_PROCESS_STATES = {"T", "t", "Z", "X", "x"}
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
@@ -116,6 +117,21 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         return int(stat_path.read_text().split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
         return None
+
+
+def _get_process_state(pid: int) -> Optional[str]:
+    """Return the Linux /proc state code for a process when available."""
+    status_path = Path(f"/proc/{pid}/status")
+    try:
+        if not status_path.exists():
+            return None
+        for line in status_path.read_text().splitlines():
+            if line.startswith("State:"):
+                parts = line.split()
+                return parts[1] if len(parts) > 1 else None
+    except (OSError, PermissionError):
+        return None
+    return None
 
 
 def get_process_start_time(pid: int) -> Optional[int]:
@@ -516,21 +532,10 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still respond to os.kill(pid, 0) but are not
-                # actually running. Treat them as stale so --replace works.
+                # Stopped or zombie processes still respond to os.kill(pid, 0)
+                # but cannot own a healthy gateway lock.
                 if not stale:
-                    try:
-                        _proc_status = Path(f"/proc/{existing_pid}/status")
-                        if _proc_status.exists():
-                            for _line in _proc_status.read_text().splitlines():
-                                if _line.startswith("State:"):
-                                    _state = _line.split()[1]
-                                    if _state in ("T", "t"):  # stopped or tracing stop
-                                        stale = True
-                                    break
-                    except (OSError, PermissionError):
-                        pass
+                    stale = _get_process_state(existing_pid) in _NON_RUNNING_PROCESS_STATES
         if stale:
             try:
                 lock_path.unlink(missing_ok=True)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -440,6 +440,36 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_replaces_zombie_owner(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = (
+            tmp_path
+            / "locks"
+            / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        )
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_get_process_state", lambda pid: "Z")
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token",
+            "secret",
+            metadata={"platform": "telegram"},
+        )
+
+        assert acquired is True
+        assert existing is None
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
     def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
         """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))


### PR DESCRIPTION
Fixes #18822

## Summary
- classify stopped, zombie, and dead Linux process states as stale scoped-lock owners
- move /proc state lookup into a small helper so scoped-lock behavior is testable
- add a regression test for a zombie owner PID that still passes os.kill(pid, 0)

## Verification
- scripts/run_tests.sh tests/gateway/test_status.py