### PR TITLE
fix: use Feishu audio speech_to_text

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -849,6 +849,18 @@ def normalize_feishu_message(
             mentions=mention_refs,
         )
     if normalized_type in {"file", "audio", "media"}:
+        if normalized_type == "audio":
+            speech_to_text = str(payload.get("speech_to_text", "") or "").strip()
+            if speech_to_text:
+                return FeishuNormalizedMessage(
+                    raw_type=normalized_type,
+                    text_content=_normalize_feishu_text(speech_to_text, mentions_map),
+                    preferred_message_type="text",
+                    relation_kind="audio",
+                    metadata={"source": "feishu_speech_to_text"},
+                    mentions=mention_refs,
+                )
+
         media_ref = _build_media_ref_from_payload(payload, resource_type=normalized_type)
         placeholder = _attachment_placeholder(media_ref.file_name)
         return FeishuNormalizedMessage(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -158,6 +158,45 @@ class TestFeishuMessageNormalization(unittest.TestCase):
             "Build Failed\nService: payments-api\nBranch: main\nView Logs\nRetry\nActions: View Logs, Retry",
         )
 
+    def test_normalize_audio_uses_feishu_speech_to_text_when_present(self):
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="audio",
+            raw_content=json.dumps(
+                {
+                    "file_key": "audio_file_key",
+                    "file_name": "voice.opus",
+                    "speech_to_text": "  飞书已经转写好的语音内容  ",
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.raw_type, "audio")
+        self.assertEqual(normalized.text_content, "飞书已经转写好的语音内容")
+        self.assertEqual(normalized.preferred_message_type, "text")
+        self.assertEqual(normalized.relation_kind, "audio")
+        self.assertEqual(normalized.media_refs, [])
+        self.assertEqual(normalized.metadata, {"source": "feishu_speech_to_text"})
+
+    def test_normalize_audio_without_speech_to_text_keeps_media_fallback(self):
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="audio",
+            raw_content=json.dumps(
+                {
+                    "file_key": "audio_file_key",
+                    "file_name": "voice.opus",
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.text_content, "")
+        self.assertEqual(normalized.preferred_message_type, "audio")
+        self.assertEqual(normalized.relation_kind, "audio")
+        self.assertEqual(len(normalized.media_refs), 1)
+
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @patch.dict(os.environ, {


### PR DESCRIPTION
## Summary
- Prefer Feishu-provided audio `speech_to_text` during inbound message normalization.
- Avoid downloading/transcribing audio when Feishu already supplied a transcript.
- Preserve the existing audio media fallback when `speech_to_text` is absent.

## Test Plan
- `python -m pytest tests/gateway/test_feishu.py::TestFeishuMessageNormalization -q -o 'addopts='`
- `python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='`