### PR TITLE
test(weixin): cover direct send cross-loop fallback

### DIFF
--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -498,6 +498,40 @@ class TestWeixinMarkdownLinks:
         assert "[link](https://example.com)" in result
 
 
+class TestWeixinDirectSend:
+    @patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock)
+    def test_send_weixin_direct_ignores_live_adapter_from_different_loop(
+        self,
+        api_post_mock,
+        tmp_path,
+    ):
+        """Cron/direct sends must not reuse an aiohttp session from another event loop."""
+
+        class _OtherLoopSession:
+            closed = False
+            _loop = object()
+
+        api_post_mock.return_value = {"ret": 0}
+        live_adapter = _make_adapter()
+        live_adapter._send_session = _OtherLoopSession()
+        live_adapter.send = AsyncMock(side_effect=AssertionError("cross-loop live adapter reused"))
+
+        with patch.dict(weixin._LIVE_ADAPTERS, {"test-token": live_adapter}, clear=True), \
+             patch("gateway.platforms.weixin.get_hermes_home", return_value=tmp_path):
+            result = asyncio.run(
+                weixin.send_weixin_direct(
+                    extra={"account_id": "test-account", "base_url": "https://weixin.example.com"},
+                    token="test-token",
+                    chat_id="wxid_test123",
+                    message="hello from cron",
+                )
+            )
+
+        assert result["success"] is True
+        live_adapter.send.assert_not_awaited()
+        api_post_mock.assert_awaited_once()
+
+
 class TestWeixinBlankMessagePrevention:
     """Regression tests for the blank-bubble bugs.
 


### PR DESCRIPTION
## Summary
- Add regression coverage for Weixin direct sends when a live gateway adapter exists on another event loop
- Verify direct/cron delivery falls back to a fresh one-shot session instead of reusing the cross-loop live adapter

## Context
The production guard for this case is already present on `main` (`send_session._loop is asyncio.get_running_loop()`). This PR locks the behavior with a focused test so cron/send_message delivery does not regress to errors like:

`Timeout context manager should be used inside a task`

## Test Plan
- [x] `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_weixin.py -q -o 'addopts='`
