### PR TITLE
test(skills): cover symlink skip path

### DIFF
--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
@@ -49,6 +51,13 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 
 class TestScanSkillCommands:
+    def test_symlink_category_skips_when_symlinks_unavailable(self, tmp_path):
+        with (
+            patch.object(Path, "symlink_to", side_effect=OSError("no symlink")),
+            pytest.raises(pytest.skip.Exception),
+        ):
+            _symlink_category(tmp_path / "skills", tmp_path / "repo", "linked")
+
     def test_finds_skills(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "my-skill")


### PR DESCRIPTION
## Summary
- Fixes #14995
- Import pytest in the skill command tests so the symlink-unavailable helper can call pytest.skip
- Add regression coverage that forces symlink creation to fail and verifies the helper takes the skip path

## Verification
- scripts/run_tests.sh tests/agent/test_skill_commands.py
- git diff --check