### PR TITLE
fix(install): remove uv exclude-newer cutoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,3 @@ not-iterable = "ignore"
 
 [tool.ruff]
 exclude = ["*"]
-
-[tool.uv]
-exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "agent-client-protocol"
 version = "0.9.0"


### PR DESCRIPTION
## Summary
- Fixes #17795
- Remove the repository-level uv exclude-newer cutoff so mirror-backed installs without upload-time metadata do not filter out every package
- Drop the matching lockfile cutoff metadata without changing dependency pins

## Verification
- python - <<'PY'
from pathlib import Path
import tomllib
pyproject = tomllib.loads(Path('pyproject.toml').read_text())
assert 'exclude-newer' not in pyproject.get('tool', {}).get('uv', {})
lock = Path('uv.lock').read_text()
assert 'exclude-newer' not in lock
print('exclude-newer absent from pyproject.toml and uv.lock')
PY
- uv lock --check
- scripts/run_tests.sh tests/test_project_metadata.py
- git diff --check