### PR TITLE
feat: add mission control dashboard foundation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -56,6 +56,11 @@ AUTH_TYPE_API_KEY = "api_key"
 
 SOURCE_MANUAL = "manual"
 
+
+def _is_claude_code_source(source: str) -> bool:
+    return source in {"claude_code", f"{SOURCE_MANUAL}:claude_code"}
+
+
 STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
 STRATEGY_RANDOM = "random"
@@ -427,7 +432,7 @@ class CredentialPool:
         writes the new pair to ~/.claude/.credentials.json. The pool entry's
         refresh token becomes stale. This method detects that and syncs.
         """
-        if self.provider != "anthropic" or entry.source != "claude_code":
+        if self.provider != "anthropic" or not _is_claude_code_source(entry.source):
             return entry
         try:
             from agent.anthropic_adapter import read_claude_code_credentials
@@ -659,7 +664,7 @@ class CredentialPool:
                 # Keep ~/.claude/.credentials.json in sync so that the
                 # fallback path (resolve_anthropic_token) and other profiles
                 # see the latest tokens.
-                if entry.source == "claude_code":
+                if _is_claude_code_source(entry.source):
                     try:
                         from agent.anthropic_adapter import _write_claude_code_credentials
                         _write_claude_code_credentials(
@@ -721,7 +726,7 @@ class CredentialPool:
             # For anthropic claude_code entries: the refresh token may have been
             # consumed by another process. Check if ~/.claude/.credentials.json
             # has a newer token pair and retry once.
-            if self.provider == "anthropic" and entry.source == "claude_code":
+            if self.provider == "anthropic" and _is_claude_code_source(entry.source):
                 synced = self._sync_anthropic_entry_from_credentials_file(entry)
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug("Retrying refresh with synced token from credentials file")
@@ -835,7 +840,7 @@ class CredentialPool:
             # For anthropic claude_code entries, sync from the credentials file
             # before any status/refresh checks. This picks up tokens refreshed
             # by other processes (Claude Code CLI, other Hermes profiles).
-            if (self.provider == "anthropic" and entry.source == "claude_code"
+            if (self.provider == "anthropic" and _is_claude_code_source(entry.source)
                     and entry.last_status == STATUS_EXHAUSTED):
                 synced = self._sync_anthropic_entry_from_credentials_file(entry)
                 if synced is not entry:

--- a/docs/plans/2026-05-03-mission-control-phase-1.md
+++ b/docs/plans/2026-05-03-mission-control-phase-1.md
@@ -1,0 +1,80 @@
+# Hermes Mission Control Phase 1 Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build the first read-only Hermes Mission Control dashboard that combines chat-adjacent operational awareness with projects, agents, usage/cost, cron, sessions, and skills.
+
+**Architecture:** Extend the existing local Hermes Web Dashboard instead of introducing a separate app. Add one protected REST endpoint that aggregates existing Hermes state, then add a React page and sidebar tab that renders the command-center view. Phase 1 is read-only and local-first.
+
+**Tech Stack:** FastAPI backend in `hermes_cli/web_server.py`; React/Vite TypeScript frontend in `web/src`; existing Hermes session DB, cron job store, skill finder, project index at `~/.hermes/projects/`.
+
+---
+
+## Task 1: Backend overview endpoint
+
+**Objective:** Add `/api/mission-control/overview` that returns read-only command-center data.
+
+**Files:**
+- Modify: `hermes_cli/web_server.py`
+- Test: `tests/hermes_cli/test_mission_control_dashboard.py`
+
+**Steps:**
+1. Add project inventory helpers that read `get_hermes_home() / "projects" / "inventory.json"` and group projects by bucket.
+2. Add lightweight process scanner for Hermes/OpenClaw/Codex/Claude/OpenCode processes using `ps`.
+3. Add usage summary helper using the existing `sessions` table columns.
+4. Add active sessions, cron, and skills summaries using existing code paths.
+5. Expose `GET /api/mission-control/overview` with no side effects.
+6. Add tests for project grouping and process parsing.
+
+## Task 2: Frontend API types
+
+**Objective:** Add typed API client support for the new overview endpoint.
+
+**Files:**
+- Modify: `web/src/lib/api.ts`
+
+**Steps:**
+1. Add `getMissionControlOverview()` API method.
+2. Add TypeScript interfaces for projects, agents, usage, cron, skills, sessions, and overview response.
+
+## Task 3: Mission Control page
+
+**Objective:** Add a read-only dashboard page that renders the overview data.
+
+**Files:**
+- Create: `web/src/pages/MissionControlPage.tsx`
+
+**Steps:**
+1. Fetch overview on mount and refresh button.
+2. Show summary cards: cost, tokens, active agents, current/planning/future projects.
+3. Render project buckets.
+4. Render active agents/processes and active sessions.
+5. Render cron jobs, skills summary, and recent sessions.
+6. Keep all controls read-only except navigation links to existing tabs.
+
+## Task 4: Navigation integration
+
+**Objective:** Make Mission Control the dashboard home.
+
+**Files:**
+- Modify: `web/src/App.tsx`
+
+**Steps:**
+1. Import `MissionControlPage`.
+2. Route `/mission-control` to the page.
+3. Add sidebar nav item before Sessions.
+4. Redirect `/` to `/mission-control`.
+
+## Task 5: Verification
+
+**Objective:** Confirm backend tests and frontend build/type checks pass.
+
+**Commands:**
+- `python -m pytest tests/hermes_cli/test_mission_control_dashboard.py -q`
+- `npm --prefix web run build`
+
+**Acceptance Criteria:**
+- `/api/mission-control/overview` returns JSON without mutating Hermes state.
+- Dashboard has Mission Control tab and home redirect.
+- Page shows token/cost, projects by bucket, active processes/agents, cron, sessions, and skills.
+- Phase 1 does not create/start/kill agents or mutate projects.

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -221,6 +221,50 @@ def auth_add_command(args) -> None:
     if provider == "anthropic":
         from agent import anthropic_adapter as anthropic_mod
 
+        # Prefer an existing Claude Code OAuth login when available. This lets
+        # `hermes auth add anthropic --type oauth` link the user's Claude
+        # Pro/Max subscription without launching a second browser/PKCE flow.
+        cc_creds = None
+        try:
+            cc_creds = anthropic_mod.read_claude_code_credentials()
+        except Exception:
+            cc_creds = None
+        if cc_creds and (
+            anthropic_mod.is_claude_code_token_valid(cc_creds)
+            or bool(cc_creds.get("refreshToken"))
+        ):
+            access_token = cc_creds.get("accessToken", "")
+            label = (getattr(args, "label", None) or "").strip() or label_from_token(
+                access_token,
+                "claude_code",
+            )
+            existing = next(
+                (
+                    item for item in pool.entries()
+                    if item.auth_type == AUTH_TYPE_OAUTH
+                    and item.source in {"claude_code", f"{SOURCE_MANUAL}:claude_code"}
+                ),
+                None,
+            )
+            if existing is not None:
+                print(f'{provider} Claude Code OAuth credential already exists: "{existing.label}"')
+                return
+            entry = PooledCredential(
+                provider=provider,
+                id=uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source=f"{SOURCE_MANUAL}:claude_code",
+                access_token=access_token,
+                refresh_token=cc_creds.get("refreshToken"),
+                expires_at_ms=cc_creds.get("expiresAt"),
+                base_url=_provider_base_url(provider),
+            )
+            pool.add_entry(entry)
+            print(f'Added {provider} Claude Code OAuth credential #{len(pool.entries())}: "{entry.label}"')
+            return
+
         creds = anthropic_mod.run_hermes_oauth_login_pure()
         if not creds:
             raise SystemExit("Anthropic OAuth login did not return credentials.")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -614,6 +614,371 @@ async def get_status():
 
 
 # ---------------------------------------------------------------------------
+# Mission Control overview (read-only)
+# ---------------------------------------------------------------------------
+
+_MISSION_CONTROL_AGENT_KEYWORDS = ("hermes", "openclaw", "claude", "codex", "opencode")
+_MISSION_CONTROL_EXCLUDE_PROCESS_MARKERS = (
+    "hermes dashboard",
+    "hermes_cli.main dashboard",
+    "hermes_cli.web_server",
+    "uvicorn",
+    "fastapi.testclient",
+    "/api/mission-control/overview",
+    "chrome_crashpad_handler",
+)
+_PROJECT_BUCKETS = ("current", "planning", "future", "archive")
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except Exception:
+        return default
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _project_name_from_markdown(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                return stripped[2:].strip()
+    except Exception:
+        pass
+    return path.stem.replace("-", " ").title()
+
+
+def _read_mission_control_projects(projects_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Read the local Hermes project index and group it by bucket.
+
+    This is intentionally read-only and tolerant of partial/missing project
+    state.  The project index is user-maintained operational context, not a
+    hard dependency for starting the dashboard.
+    """
+    root = projects_root or (get_hermes_home() / "projects")
+    buckets: Dict[str, List[Dict[str, Any]]] = {bucket: [] for bucket in _PROJECT_BUCKETS}
+    inventory_path = root / "inventory.json"
+
+    if inventory_path.exists():
+        try:
+            raw = json.loads(inventory_path.read_text(encoding="utf-8"))
+            for item in raw.get("projects", []) if isinstance(raw, dict) else []:
+                if not isinstance(item, dict):
+                    continue
+                bucket = str(item.get("bucket") or "planning").lower()
+                if bucket not in buckets:
+                    buckets[bucket] = []
+                brief = str(item.get("brief") or "")
+                brief_path = root / brief if brief else None
+                enriched = {
+                    "id": item.get("id") or (brief_path.stem if brief_path else item.get("name", "project")),
+                    "name": item.get("name") or item.get("id") or "Untitled project",
+                    "bucket": bucket,
+                    "priority": item.get("priority") or "",
+                    "brief": brief,
+                    "brief_path": str(brief_path) if brief_path else None,
+                    "updated_at": brief_path.stat().st_mtime if brief_path and brief_path.exists() else None,
+                }
+                buckets[bucket].append(enriched)
+        except Exception:
+            _log.exception("Failed to read mission-control project inventory")
+
+    # Fallback for homes with markdown briefs but no inventory.json.
+    if not any(buckets.values()) and root.exists():
+        for bucket in _PROJECT_BUCKETS:
+            bucket_dir = root / bucket
+            if not bucket_dir.is_dir():
+                continue
+            for brief_path in sorted(bucket_dir.glob("*.md")):
+                buckets[bucket].append({
+                    "id": brief_path.stem,
+                    "name": _project_name_from_markdown(brief_path),
+                    "bucket": bucket,
+                    "priority": "",
+                    "brief": f"{bucket}/{brief_path.name}",
+                    "brief_path": str(brief_path),
+                    "updated_at": brief_path.stat().st_mtime,
+                })
+
+    for values in buckets.values():
+        values.sort(key=lambda p: (str(p.get("priority") or "P9"), str(p.get("name") or "")))
+
+    counts = {bucket: len(items) for bucket, items in buckets.items()}
+    return {
+        "root": str(root),
+        "inventory_path": str(inventory_path),
+        "buckets": buckets,
+        "counts": counts,
+        "total": sum(counts.values()),
+    }
+
+
+def _classify_agent_process(args: str, command: str = "") -> str:
+    lower = f"{command} {args}".lower()
+    if "openclaw" in lower:
+        return "openclaw"
+    if "claude" in lower:
+        return "claude"
+    if "opencode" in lower:
+        return "opencode"
+    if "codex" in lower:
+        return "codex"
+    if "hermes" in lower:
+        return "hermes"
+    return "agent"
+
+
+def _parse_agent_process_line(line: str) -> Optional[Dict[str, Any]]:
+    """Parse one `ps -axo pid=,etime=,comm=,args=` line for agent processes."""
+    parts = line.strip().split(None, 3)
+    if len(parts) < 4:
+        return None
+    pid_raw, elapsed, command, args = parts
+    searchable = f"{command} {args}".lower()
+    if not any(k in searchable for k in _MISSION_CONTROL_AGENT_KEYWORDS):
+        return None
+    if any(marker in searchable for marker in _MISSION_CONTROL_EXCLUDE_PROCESS_MARKERS):
+        return None
+    if "/applications/claude.app/" in searchable and "claude-code" not in searchable:
+        return None
+    pid = _safe_int(pid_raw, -1)
+    if pid <= 0 or pid == os.getpid():
+        return None
+    agent_type = _classify_agent_process(args, command)
+    label = agent_type.capitalize()
+    if agent_type == "hermes":
+        if "gateway" in searchable:
+            label = "Hermes Gateway"
+        elif "cron" in searchable:
+            label = "Hermes Cron"
+        else:
+            label = "Hermes Agent"
+    command_display = Path(command).name or command
+    return {
+        "pid": pid,
+        "agent_type": agent_type,
+        "label": label,
+        "status": "running",
+        "elapsed": elapsed,
+        # Do not expose raw command-line arguments in the dashboard. Agent CLI
+        # invocations often carry prompts, bearer tokens, API keys, file paths,
+        # or OAuth/session material. The raw args are only used locally above to
+        # classify the process; the read-only API returns safe metadata only.
+        "command": command_display,
+        "current_work": f"{label} process detected",
+    }
+
+
+def _scan_mission_control_agents(limit: int = 25) -> List[Dict[str, Any]]:
+    try:
+        output = subprocess.check_output(
+            ["ps", "-axo", "pid=,etime=,comm=,args="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+    except Exception:
+        return []
+    agents: List[Dict[str, Any]] = []
+    seen: set[int] = set()
+    for line in output.splitlines():
+        parsed = _parse_agent_process_line(line)
+        if not parsed:
+            continue
+        pid = parsed["pid"]
+        if pid in seen:
+            continue
+        seen.add(pid)
+        agents.append(parsed)
+        if len(agents) >= limit:
+            break
+    return agents
+
+
+def _mission_control_usage(days: int = 7) -> Dict[str, Any]:
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        now = time.time()
+        lt = time.localtime(now)
+        today_start = time.mktime((lt.tm_year, lt.tm_mon, lt.tm_mday, 0, 0, 0, lt.tm_wday, lt.tm_yday, lt.tm_isdst))
+        period_start = now - (days * 86400)
+
+        def totals_since(cutoff: float) -> Dict[str, Any]:
+            cur = db._conn.execute("""
+                SELECT COALESCE(SUM(input_tokens), 0) as input_tokens,
+                       COALESCE(SUM(output_tokens), 0) as output_tokens,
+                       COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                       COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
+                       COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
+                       COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
+                       COUNT(*) as sessions,
+                       COALESCE(SUM(api_call_count), 0) as api_calls
+                FROM sessions WHERE started_at > ?
+            """, (cutoff,))
+            row = dict(cur.fetchone())
+            total_tokens = _safe_int(row.get("input_tokens")) + _safe_int(row.get("output_tokens"))
+            return {
+                "input_tokens": _safe_int(row.get("input_tokens")),
+                "output_tokens": _safe_int(row.get("output_tokens")),
+                "cache_read_tokens": _safe_int(row.get("cache_read_tokens")),
+                "reasoning_tokens": _safe_int(row.get("reasoning_tokens")),
+                "total_tokens": total_tokens,
+                "estimated_cost": _safe_float(row.get("estimated_cost")),
+                "actual_cost": _safe_float(row.get("actual_cost")),
+                "sessions": _safe_int(row.get("sessions")),
+                "api_calls": _safe_int(row.get("api_calls")),
+            }
+
+        cur = db._conn.execute("""
+            SELECT model,
+                   billing_provider,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
+                   COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
+                   COUNT(*) as sessions
+            FROM sessions
+            WHERE started_at > ? AND model IS NOT NULL AND model != ''
+            GROUP BY model, billing_provider
+            ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            LIMIT 8
+        """, (period_start,))
+        by_model = [dict(r) for r in cur.fetchall()]
+        return {
+            "today": totals_since(today_start),
+            "period_days": days,
+            "period": totals_since(period_start),
+            "by_model": by_model,
+        }
+    except Exception:
+        _log.exception("Failed to compute mission-control usage")
+        return {
+            "today": {},
+            "period_days": days,
+            "period": {},
+            "by_model": [],
+        }
+    finally:
+        db.close()
+
+
+def _mission_control_sessions(limit: int = 8) -> Dict[str, Any]:
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        sessions = db.list_sessions_rich(limit=limit)
+        now = time.time()
+        active = []
+        for session in sessions:
+            session["is_active"] = (
+                session.get("ended_at") is None
+                and (now - session.get("last_active", session.get("started_at", 0))) < 300
+            )
+            if session["is_active"]:
+                active.append(session)
+        return {"active": active, "recent": sessions, "total": db.session_count()}
+    except Exception:
+        _log.exception("Failed to read mission-control sessions")
+        return {"active": [], "recent": [], "total": 0}
+    finally:
+        db.close()
+
+
+def _mission_control_cron(limit: int = 8) -> Dict[str, Any]:
+    try:
+        from cron.jobs import list_jobs
+        jobs = list_jobs(include_disabled=True)
+        enabled = [
+            job for job in jobs
+            if job.get("enabled", True) and str(job.get("state") or "").lower() != "paused"
+        ]
+        jobs_sorted = sorted(
+            enabled,
+            key=lambda job: str(job.get("next_run_at") or "9999-99-99"),
+        )
+        return {
+            "total": len(jobs),
+            "enabled": len(enabled),
+            "paused": len(jobs) - len(enabled),
+            "upcoming": jobs_sorted[:limit],
+        }
+    except Exception:
+        _log.exception("Failed to read mission-control cron jobs")
+        return {"total": 0, "enabled": 0, "paused": 0, "upcoming": []}
+
+
+def _mission_control_skills(limit: int = 8) -> Dict[str, Any]:
+    try:
+        from tools.skills_tool import _find_all_skills
+        from hermes_cli.skills_config import get_disabled_skills
+
+        config = load_config()
+        disabled = get_disabled_skills(config)
+        # Historical quirk: skip_disabled=True means "do not apply the disabled
+        # filter" in _find_all_skills, so this returns both enabled and disabled
+        # skills. Count only disabled names that are present in the discovered
+        # set, because config can retain names for removed skills.
+        skills = _find_all_skills(skip_disabled=True)
+        disabled_names = set(disabled)
+        categories: Dict[str, int] = {}
+        for skill in skills:
+            if skill.get("name") in disabled_names:
+                continue
+            cat = skill.get("category") or "general"
+            categories[cat] = categories.get(cat, 0) + 1
+        disabled_count = sum(1 for skill in skills if skill.get("name") in disabled_names)
+        top_categories = [
+            {"category": category, "count": count}
+            for category, count in sorted(categories.items(), key=lambda item: item[1], reverse=True)[:limit]
+        ]
+        return {
+            "total": len(skills),
+            "enabled": len(skills) - disabled_count,
+            "disabled": disabled_count,
+            "top_categories": top_categories,
+        }
+    except Exception:
+        _log.exception("Failed to read mission-control skills")
+        return {"total": 0, "enabled": 0, "disabled": 0, "top_categories": []}
+
+
+@app.get("/api/mission-control/overview")
+async def get_mission_control_overview():
+    """Return a read-only mission-control snapshot for the dashboard."""
+    status = await get_status()
+    sessions = _mission_control_sessions()
+    agents = _scan_mission_control_agents()
+    return {
+        "generated_at": time.time(),
+        "status": status,
+        "usage": _mission_control_usage(days=7),
+        "projects": _read_mission_control_projects(),
+        "agents": {
+            "processes": agents,
+            "active_processes": len(agents),
+            "active_sessions": len(sessions.get("active", [])),
+        },
+        "sessions": sessions,
+        "cron": _mission_control_cron(),
+        "skills": _mission_control_skills(),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Gateway + update actions (invoked from the Status page).
 #
 # Both commands are spawned as detached subprocesses so the HTTP request

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -70,6 +70,10 @@ def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
     token = _jwt_with_email("claude@example.com")
     monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: None,
+    )
+    monkeypatch.setattr(
         "agent.anthropic_adapter.run_hermes_oauth_login_pure",
         lambda: {
             "access_token": token,
@@ -95,6 +99,60 @@ def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["source"] == "manual:hermes_pkce"
     assert entry["refresh_token"] == "refresh-token"
     assert entry["expires_at_ms"] == 1711234567000
+
+
+def test_auth_add_anthropic_oauth_links_existing_claude_code_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("claude-code@example.com")
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": token,
+            "refreshToken": "refresh-token",
+            "expiresAt": 1711234567000,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.is_claude_code_token_valid",
+        lambda creds: True,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda: pytest.fail("should use existing Claude Code credentials"),
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["anthropic"]
+    claude_code_entries = [item for item in entries if item["source"] == "manual:claude_code"]
+    assert len(claude_code_entries) == 1
+    entry = claude_code_entries[0]
+    assert entry["label"] == "claude-code@example.com"
+    assert entry["source"] == "manual:claude_code"
+    assert entry["auth_type"] == "oauth"
+    assert entry["access_token"] == token
+    assert entry["refresh_token"] == "refresh-token"
+    assert entry["expires_at_ms"] == 1711234567000
+    assert not any(item["source"] == "manual:hermes_pkce" for item in entries)
+
+    from agent.credential_pool import load_pool
+
+    reloaded_pool = load_pool("anthropic")
+    assert any(entry.source == "manual:claude_code" for entry in reloaded_pool.entries())
 
 
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_mission_control_dashboard.py
+++ b/tests/hermes_cli/test_mission_control_dashboard.py
@@ -1,0 +1,173 @@
+"""Tests for Mission Control dashboard helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_read_mission_control_projects_groups_inventory(tmp_path: Path, monkeypatch):
+    from hermes_cli import web_server
+
+    projects = tmp_path / "projects"
+    (projects / "current").mkdir(parents=True)
+    (projects / "planning").mkdir()
+    (projects / "current" / "swiftpos.md").write_text("# SwiftPOS\n", encoding="utf-8")
+    (projects / "planning" / "mission.md").write_text("# Mission Control\n", encoding="utf-8")
+    (projects / "inventory.json").write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {
+                        "id": "swiftpos",
+                        "name": "SwiftPOS",
+                        "bucket": "current",
+                        "priority": "P0",
+                        "brief": "current/swiftpos.md",
+                    },
+                    {
+                        "id": "mission-control",
+                        "name": "Mission Control",
+                        "bucket": "planning",
+                        "priority": "P0",
+                        "brief": "planning/mission.md",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = web_server._read_mission_control_projects(projects)
+
+    assert result["total"] == 2
+    assert result["counts"]["current"] == 1
+    assert result["counts"]["planning"] == 1
+    assert result["buckets"]["current"][0]["name"] == "SwiftPOS"
+    assert result["buckets"]["planning"][0]["brief_path"].endswith("planning/mission.md")
+
+
+def test_read_mission_control_projects_falls_back_to_markdown(tmp_path: Path):
+    from hermes_cli import web_server
+
+    projects = tmp_path / "projects"
+    (projects / "future").mkdir(parents=True)
+    (projects / "future" / "home-ai-rack.md").write_text("# Home AI Rack\n\nPlan.", encoding="utf-8")
+
+    result = web_server._read_mission_control_projects(projects)
+
+    assert result["total"] == 1
+    assert result["counts"]["future"] == 1
+    assert result["buckets"]["future"][0]["name"] == "Home AI Rack"
+
+
+def test_parse_agent_process_line_detects_hermes_agent():
+    from hermes_cli import web_server
+
+    parsed = web_server._parse_agent_process_line(
+        "12345 00:01:22 python3 python3 -m hermes_cli.main chat -q build mission control --token SECRET_TOKEN_123"
+    )
+
+    assert parsed is not None
+    assert parsed["pid"] == 12345
+    assert parsed["agent_type"] == "hermes"
+    assert parsed["label"] == "Hermes Agent"
+    assert parsed["current_work"] == "Hermes Agent process detected"
+    assert "args" not in parsed
+    assert "SECRET_TOKEN" not in parsed["current_work"]
+
+
+def test_parse_agent_process_line_excludes_dashboard():
+    from hermes_cli import web_server
+
+    parsed = web_server._parse_agent_process_line(
+        "12345 00:01:22 python3 python3 -m hermes_cli.main dashboard --port 9119"
+    )
+
+    assert parsed is None
+
+
+def test_parse_agent_process_line_excludes_claude_desktop_helpers():
+    from hermes_cli import web_server
+
+    parsed = web_server._parse_agent_process_line(
+        "12345 03-05:14:19 /Applications/Claude.app/Contents/MacOS/Claude /Applications/Claude.app/Contents/MacOS/Claude"
+    )
+
+    assert parsed is None
+
+
+def test_parse_agent_process_line_keeps_claude_code():
+    from hermes_cli import web_server
+
+    parsed = web_server._parse_agent_process_line(
+        "12345 00:02:01 /Users/edison/Library/Application /Users/edison/Library/Application Support/Claude/claude-code/2.1.121/claude.app/Contents/MacOS/claude --model opus --output-format stream-json"
+    )
+
+    assert parsed is not None
+    assert parsed["agent_type"] == "claude"
+
+
+def test_mission_control_cron_excludes_paused_jobs_from_upcoming(monkeypatch):
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(cron_jobs, "list_jobs", lambda include_disabled=True: [
+        {"id": "enabled", "enabled": True, "next_run_at": "2026-01-01T09:00:00"},
+        {"id": "disabled", "enabled": False, "next_run_at": "2026-01-01T08:00:00"},
+        {"id": "paused-state", "enabled": True, "state": "paused", "next_run_at": "2026-01-01T07:00:00"},
+    ])
+
+    result = web_server._mission_control_cron()
+
+    assert result["total"] == 3
+    assert result["enabled"] == 1
+    assert result["paused"] == 2
+    assert [job["id"] for job in result["upcoming"]] == ["enabled"]
+
+
+def test_mission_control_skills_counts_disabled_without_undercounting(monkeypatch):
+    from hermes_cli import skills_config, web_server
+    from tools import skills_tool
+
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda skip_disabled=True: [
+        {"name": "enabled-one", "category": "dev"},
+        {"name": "enabled-two", "category": "dev"},
+        {"name": "disabled-one", "category": "ops"},
+    ])
+    monkeypatch.setattr(skills_config, "get_disabled_skills", lambda config: {"disabled-one", "missing-disabled"})
+
+    result = web_server._mission_control_skills()
+
+    assert result["total"] == 3
+    assert result["enabled"] == 2
+    assert result["disabled"] == 1
+    assert result["top_categories"] == [{"category": "dev", "count": 2}]
+
+
+def test_mission_control_overview_endpoint_is_read_only_snapshot(monkeypatch):
+    from fastapi.testclient import TestClient
+    from hermes_cli import web_server
+
+    async def fake_status():
+        return {"gateway_running": True, "version": "test"}
+
+    monkeypatch.setattr(web_server, "get_status", fake_status)
+    monkeypatch.setattr(web_server, "_mission_control_sessions", lambda: {"active": [{"id": "s1"}], "recent": [], "total": 1})
+    monkeypatch.setattr(web_server, "_scan_mission_control_agents", lambda: [{"pid": 42, "label": "Hermes Agent"}])
+    monkeypatch.setattr(web_server, "_mission_control_usage", lambda days=7: {"period_days": days, "period": {"total_tokens": 10}})
+    monkeypatch.setattr(web_server, "_read_mission_control_projects", lambda: {"total": 0, "counts": {}, "buckets": {}})
+    monkeypatch.setattr(web_server, "_mission_control_cron", lambda: {"total": 0, "enabled": 0, "paused": 0, "upcoming": []})
+    monkeypatch.setattr(web_server, "_mission_control_skills", lambda: {"total": 0, "enabled": 0, "disabled": 0, "top_categories": []})
+
+    response = TestClient(web_server.app).get(
+        "/api/mission-control/overview",
+        headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"]["gateway_running"] is True
+    assert body["usage"]["period"]["total_tokens"] == 10
+    assert body["agents"]["active_processes"] == 1
+    assert body["agents"]["active_sessions"] == 1

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,7 @@ import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
+import MissionControlPage from "@/pages/MissionControlPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -77,7 +78,7 @@ import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 
 function RootRedirect() {
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to="/mission-control" replace />;
 }
 
 const CHAT_NAV_ITEM: NavItem = {
@@ -98,6 +99,7 @@ const CHAT_NAV_ITEM: NavItem = {
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
+  "/mission-control": MissionControlPage,
   "/sessions": SessionsPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
@@ -120,6 +122,12 @@ function ChatRouteSink() {
 }
 
 const BUILTIN_NAV_REST: NavItem[] = [
+  {
+    path: "/mission-control",
+    labelKey: "missionControl",
+    label: "Mission Control",
+    icon: Activity,
+  },
   {
     path: "/sessions",
     labelKey: "sessions",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -65,6 +65,8 @@ export const api = {
     fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`),
   getModelsAnalytics: (days: number) =>
     fetchJSON<ModelsAnalyticsResponse>(`/api/analytics/models?days=${days}`),
+  getMissionControlOverview: () =>
+    fetchJSON<MissionControlOverviewResponse>("/api/mission-control/overview"),
   getConfig: () => fetchJSON<Record<string, unknown>>("/api/config"),
   getDefaults: () => fetchJSON<Record<string, unknown>>("/api/config/defaults"),
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
@@ -468,6 +470,78 @@ export interface AnalyticsResponse {
   skills: {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];
+  };
+}
+
+export interface MissionControlProject {
+  id: string;
+  name: string;
+  bucket: string;
+  priority: string;
+  brief: string;
+  brief_path: string | null;
+  updated_at: number | null;
+}
+
+export interface MissionControlUsageWindow {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_tokens?: number;
+  reasoning_tokens?: number;
+  total_tokens?: number;
+  estimated_cost?: number;
+  actual_cost?: number;
+  sessions?: number;
+  api_calls?: number;
+}
+
+export interface MissionControlAgentProcess {
+  pid: number;
+  agent_type: string;
+  label: string;
+  status: string;
+  elapsed: string;
+  command: string;
+  current_work: string;
+}
+
+export interface MissionControlOverviewResponse {
+  generated_at: number;
+  status: StatusResponse;
+  usage: {
+    today: MissionControlUsageWindow;
+    period_days: number;
+    period: MissionControlUsageWindow;
+    by_model: Array<AnalyticsModelEntry & { billing_provider?: string | null; actual_cost?: number }>;
+  };
+  projects: {
+    root: string;
+    inventory_path: string;
+    buckets: Record<string, MissionControlProject[]>;
+    counts: Record<string, number>;
+    total: number;
+  };
+  agents: {
+    processes: MissionControlAgentProcess[];
+    active_processes: number;
+    active_sessions: number;
+  };
+  sessions: {
+    active: SessionInfo[];
+    recent: SessionInfo[];
+    total: number;
+  };
+  cron: {
+    total: number;
+    enabled: number;
+    paused: number;
+    upcoming: CronJob[];
+  };
+  skills: {
+    total: number;
+    enabled: number;
+    disabled: number;
+    top_categories: Array<{ category: string; count: number }>;
   };
 }
 

--- a/web/src/pages/MissionControlPage.tsx
+++ b/web/src/pages/MissionControlPage.tsx
@@ -1,0 +1,362 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ComponentType } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Activity,
+  Bot,
+  CalendarClock,
+  FolderKanban,
+  MessageSquare,
+  Package,
+  RefreshCw,
+  Sparkles,
+  WalletCards,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import type {
+  MissionControlOverviewResponse,
+  MissionControlProject,
+  SessionInfo,
+} from "@/lib/api";
+import { timeAgo } from "@/lib/utils";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+
+function formatTokens(value?: number): string {
+  const n = value ?? 0;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatCost(value?: number): string {
+  const n = value ?? 0;
+  if (n === 0) return "$0.00";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function formatTimestamp(ts?: number | null): string {
+  if (!ts) return "Never";
+  return timeAgo(ts);
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+            <div className="mt-2 text-2xl font-semibold tabular-nums">{value}</div>
+            <div className="mt-1 text-xs text-muted-foreground">{detail}</div>
+          </div>
+          <div className="rounded-lg border border-border bg-muted/30 p-2">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ProjectBucket({
+  title,
+  projects,
+}: {
+  title: string;
+  projects: MissionControlProject[];
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-sm">{title}</CardTitle>
+          <Badge tone="secondary" className="text-xs tabular-nums">{projects.length}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {projects.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No projects tracked.</div>
+        ) : (
+          projects.slice(0, 6).map((project) => (
+            <div key={`${project.bucket}-${project.id}`} className="rounded-lg border border-border bg-background/60 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0 truncate text-sm font-medium">{project.name}</div>
+                {project.priority ? <Badge tone="secondary" className="text-[10px]">{project.priority}</Badge> : null}
+              </div>
+              <div className="mt-1 truncate text-xs text-muted-foreground">{project.brief || project.brief_path || "No brief linked"}</div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SessionRow({ session }: { session: SessionInfo }) {
+  return (
+    <div className="rounded-lg border border-border bg-background/60 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">{session.title || session.preview || session.id}</div>
+          <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span>{session.source || "unknown"}</span>
+            <span>•</span>
+            <span>{session.model || "no model"}</span>
+            <span>•</span>
+            <span>{formatTokens((session.input_tokens || 0) + (session.output_tokens || 0))} tokens</span>
+          </div>
+        </div>
+        <Badge tone={session.is_active ? "success" : "secondary"} className="shrink-0 text-xs">
+          {session.is_active ? "Live" : formatTimestamp(session.last_active)}
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+export default function MissionControlPage() {
+  const [overview, setOverview] = useState<MissionControlOverviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { setAfterTitle, setEnd } = usePageHeader();
+  const navigate = useNavigate();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.getMissionControlOverview();
+      setOverview(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load Mission Control");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <Badge tone={overview?.status.gateway_running ? "success" : "secondary"} className="text-xs">
+        Gateway {overview?.status.gateway_running ? "online" : "offline"}
+      </Badge>,
+    );
+    setEnd(
+      <Button outlined size="sm" onClick={load} disabled={loading}>
+        <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+        Refresh
+      </Button>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [load, loading, overview?.status.gateway_running, setAfterTitle, setEnd]);
+
+  const projectBuckets = overview?.projects.buckets ?? {};
+  const today = overview?.usage.today ?? {};
+  const period = overview?.usage.period ?? {};
+  const nextCron = overview?.cron.upcoming?.[0];
+
+  const topModel = useMemo(() => overview?.usage.by_model?.[0], [overview]);
+
+  if (loading && !overview) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
+
+  if (error && !overview) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-sm text-destructive">{error}</CardContent>
+      </Card>
+    );
+  }
+
+  if (!overview) return null;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          icon={WalletCards}
+          label="Today cost"
+          value={formatCost(today.actual_cost || today.estimated_cost)}
+          detail={`${formatTokens(today.total_tokens)} tokens · ${today.sessions ?? 0} sessions`}
+        />
+        <StatCard
+          icon={Activity}
+          label={`${overview.usage.period_days}d usage`}
+          value={formatTokens(period.total_tokens)}
+          detail={`${formatCost(period.actual_cost || period.estimated_cost)} · ${period.api_calls ?? 0} API calls`}
+        />
+        <StatCard
+          icon={Bot}
+          label="Active agents"
+          value={String(overview.agents.active_processes + overview.agents.active_sessions)}
+          detail={`${overview.agents.active_processes} processes · ${overview.agents.active_sessions} live sessions`}
+        />
+        <StatCard
+          icon={FolderKanban}
+          label="Tracked projects"
+          value={String(overview.projects.total)}
+          detail={`${overview.projects.counts.current ?? 0} current · ${overview.projects.counts.planning ?? 0} planning`}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Sparkles className="h-5 w-5 text-muted-foreground" />
+                  Command Center
+                </CardTitle>
+                <div className="mt-1 text-sm text-muted-foreground">
+                  Read-only mission snapshot generated {formatTimestamp(overview.generated_at)}.
+                </div>
+              </div>
+              <Button outlined size="sm" onClick={() => navigate("/chat")}>Open Chat</Button>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-lg border border-border bg-background/60 p-3">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Gateway</div>
+              <div className="mt-2 text-sm font-medium">{overview.status.gateway_state || (overview.status.gateway_running ? "running" : "stopped")}</div>
+              <div className="mt-1 text-xs text-muted-foreground">PID {overview.status.gateway_pid ?? "—"}</div>
+            </div>
+            <div className="rounded-lg border border-border bg-background/60 p-3">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Top model</div>
+              <div className="mt-2 truncate text-sm font-medium">{topModel?.model || "No model usage yet"}</div>
+              <div className="mt-1 text-xs text-muted-foreground">{formatTokens((topModel?.input_tokens || 0) + (topModel?.output_tokens || 0))} tokens</div>
+            </div>
+            <div className="rounded-lg border border-border bg-background/60 p-3">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Next scheduled job</div>
+              <div className="mt-2 truncate text-sm font-medium">{nextCron?.name || nextCron?.id || "None"}</div>
+              <div className="mt-1 text-xs text-muted-foreground">{nextCron?.next_run_at || "No upcoming run"}</div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Package className="h-5 w-5 text-muted-foreground" />
+              Skills
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-3 gap-2 text-center">
+              <div className="rounded-lg border border-border p-2"><div className="text-lg font-semibold">{overview.skills.total}</div><div className="text-[11px] text-muted-foreground">total</div></div>
+              <div className="rounded-lg border border-border p-2"><div className="text-lg font-semibold">{overview.skills.enabled}</div><div className="text-[11px] text-muted-foreground">enabled</div></div>
+              <div className="rounded-lg border border-border p-2"><div className="text-lg font-semibold">{overview.skills.disabled}</div><div className="text-[11px] text-muted-foreground">disabled</div></div>
+            </div>
+            <div className="space-y-1.5">
+              {overview.skills.top_categories.slice(0, 5).map((cat) => (
+                <div key={cat.category} className="flex items-center justify-between text-sm">
+                  <span className="truncate text-muted-foreground">{cat.category}</span>
+                  <Badge tone="secondary" className="text-xs">{cat.count}</Badge>
+                </div>
+              ))}
+            </div>
+            <Button outlined size="sm" className="w-full" onClick={() => navigate("/skills")}>Manage skills</Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-4">
+        <ProjectBucket title="Current" projects={projectBuckets.current ?? []} />
+        <ProjectBucket title="Planning" projects={projectBuckets.planning ?? []} />
+        <ProjectBucket title="Future" projects={projectBuckets.future ?? []} />
+        <ProjectBucket title="Archive" projects={projectBuckets.archive ?? []} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Bot className="h-5 w-5 text-muted-foreground" />
+              Agent activity
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {overview.agents.processes.length === 0 ? (
+              <div className="text-sm text-muted-foreground">No agent-like background processes detected.</div>
+            ) : overview.agents.processes.map((agent) => (
+              <div key={agent.pid} className="rounded-lg border border-border bg-background/60 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-sm font-medium">{agent.label}</div>
+                  <Badge tone="success" className="text-xs">PID {agent.pid}</Badge>
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">Running for {agent.elapsed}</div>
+                <div className="mt-2 truncate font-mono text-[11px] text-muted-foreground">{agent.current_work}</div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between gap-2">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <MessageSquare className="h-5 w-5 text-muted-foreground" />
+                Recent sessions
+              </CardTitle>
+              <Button ghost size="sm" onClick={() => navigate("/sessions")}>View all</Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {overview.sessions.recent.slice(0, 5).map((session) => <SessionRow key={session.id} session={session} />)}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <CalendarClock className="h-5 w-5 text-muted-foreground" />
+              Scheduled jobs
+            </CardTitle>
+            <Button ghost size="sm" onClick={() => navigate("/cron")}>Open Cron</Button>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+          {overview.cron.upcoming.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No scheduled jobs configured.</div>
+          ) : overview.cron.upcoming.slice(0, 8).map((job) => (
+            <div key={job.id} className="rounded-lg border border-border bg-background/60 p-3">
+              <div className="truncate text-sm font-medium">{job.name || job.id}</div>
+              <div className="mt-1 truncate text-xs text-muted-foreground">{job.schedule_display || job.schedule?.display || "No schedule"}</div>
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <Badge tone={job.enabled ? "success" : "secondary"} className="text-xs">{job.enabled ? "enabled" : "paused"}</Badge>
+                <span className="truncate text-xs text-muted-foreground">{job.next_run_at || "—"}</span>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add read-only Mission Control overview API and dashboard page
- aggregate Hermes status, usage, projects, sessions, cron, skills, and agent activity
- link existing Claude Code OAuth credentials for Anthropic auth and preserve Claude Code-backed refresh behavior

## Verification
- python -m pytest tests/hermes_cli/test_mission_control_dashboard.py tests/hermes_cli/test_auth_commands.py -q
- python -m compileall -q hermes_cli/web_server.py hermes_cli/auth_commands.py agent/credential_pool.py tests/hermes_cli/test_mission_control_dashboard.py tests/hermes_cli/test_auth_commands.py
- npm --prefix web run build
- git diff --check

## Notes
- Local push to origin was denied for edison-commits, so this is opened from the fork.