### PR TITLE
feat(acp): auto-detect OpenCode ACP command syntax

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -39,11 +39,16 @@ def _resolve_command() -> str:
     )
 
 
-def _resolve_args() -> list[str]:
+def _resolve_args(command: str = "") -> list[str]:
     raw = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    if not raw:
-        return ["--acp", "--stdio"]
-    return shlex.split(raw)
+    if raw:
+        return shlex.split(raw)
+    # Copilot CLI uses flag-style: copilot --acp --stdio
+    # OpenCode uses subcommand-style: opencode acp
+    cmd_name = os.path.basename(command) if command else _resolve_command()
+    if cmd_name == "opencode":
+        return ["acp"]
+    return ["--acp", "--stdio"]
 
 
 def _resolve_home_dir() -> str:
@@ -329,7 +334,7 @@ class CopilotACPClient:
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_args = list(acp_args or args or _resolve_args(self._acp_command))
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -205,3 +205,33 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+# ── _resolve_args() tests (OpenCode ACP auto-detection) ─────────────
+
+from agent.copilot_acp_client import _resolve_args
+
+
+def test_resolve_args_defaults_to_copilot_flags(monkeypatch):
+    """No command, no env var → returns Copilot CLI style flags."""
+    monkeypatch.delenv("HERMES_COPILOT_ACP_ARGS", raising=False)
+    assert _resolve_args() == ["--acp", "--stdio"]
+
+
+def test_resolve_args_detects_opencode(monkeypatch):
+    """opencode command → returns subcommand-style args."""
+    monkeypatch.delenv("HERMES_COPILOT_ACP_ARGS", raising=False)
+    assert _resolve_args(command="opencode") == ["acp"]
+    assert _resolve_args(command="/usr/local/bin/opencode") == ["acp"]
+
+
+def test_resolve_args_env_var_overrides(monkeypatch):
+    """HERMES_COPILOT_ACP_ARGS takes priority over auto-detection."""
+    monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--acp --stdio --model claude-sonnet-4")
+    assert _resolve_args(command="opencode") == ["--acp", "--stdio", "--model", "claude-sonnet-4"]
+
+
+def test_resolve_args_copilot_explicit(monkeypatch):
+    """Explicit copilot command still returns flag-style args."""
+    monkeypatch.delenv("HERMES_COPILOT_ACP_ARGS", raising=False)
+    assert _resolve_args(command="copilot") == ["--acp", "--stdio"]


### PR DESCRIPTION
## What does this PR do?

Makes `delegate_task` detect OpenCode's ACP command syntax automatically. Currently, only Copilot CLI works out of the box because `_resolve_args()` hardcodes `copilot --acp --stdio`. OpenCode uses `opencode acp` (subcommand-style), requiring users to manually pass `acp_args: ["acp"]`. This PR makes the detection automatic based on the command name.

## Related Issue

Fixes #19493

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/copilot_acp_client.py`: `_resolve_args()` now accepts an optional `command` parameter and returns `["acp"]` when the command is `opencode` (vs `["--acp", "--stdio"]` for copilot)
- `agent/copilot_acp_client.py`: `CopilotACPClient.__init__` passes the resolved command to `_resolve_args()`

## How to Test

1. Install OpenCode CLI (`npm install -g opencode`)
2. Verify OpenCode ACP is available: `opencode acp --help`
3. Start Hermes Agent and run:
   ```
   delegate_task(acp_command="opencode", toolsets=["terminal"], goal="Run: echo 'test ok'")
   ```
4. Confirm:
   - No "process exited early" error (args are now correct)
   - Subagent returns text output (ACP handshake + tool dispatch working)
   - `tokens: {"input": 0, "output": 0}` in the result (ACP path confirmed)
5. Verify copilot path is unaffected: regular copilot ACP delegation still works

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (minor internal change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, Linux)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
