### PR TITLE
fix(chat): sanitize empty text content blocks

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -115,6 +115,8 @@ class ChatCompletionsTransport(ProviderTransport):
         Strips Codex Responses API fields (``codex_reasoning_items`` /
         ``codex_message_items`` on the message, ``call_id``/``response_item_id``
         on tool_calls) that strict chat-completions providers reject with 400/422.
+        Also replaces empty text content blocks with a single space because some
+        OpenAI-compatible gateways reject ``{"type": "text", "text": ""}``.
         """
         needs_sanitize = False
         for msg in messages:
@@ -127,6 +129,18 @@ class ChatCompletionsTransport(ProviderTransport):
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
                     if isinstance(tc, dict) and ("call_id" in tc or "response_item_id" in tc):
+                        needs_sanitize = True
+                        break
+                if needs_sanitize:
+                    break
+            content = msg.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") in {"text", "input_text"}
+                        and not str(part.get("text") or "").strip()
+                    ):
                         needs_sanitize = True
                         break
                 if needs_sanitize:
@@ -147,6 +161,15 @@ class ChatCompletionsTransport(ProviderTransport):
                     if isinstance(tc, dict):
                         tc.pop("call_id", None)
                         tc.pop("response_item_id", None)
+            content = msg.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") in {"text", "input_text"}
+                        and not str(part.get("text") or "").strip()
+                    ):
+                        part["text"] = " "
         return sanitized
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,34 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_replaces_empty_text_blocks(self, transport):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                    {"type": "input_text", "text": "   "},
+                ],
+            }
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert result is not msgs
+        assert result[0]["content"][0]["text"] == " "
+        assert result[0]["content"][1]["type"] == "image_url"
+        assert result[0]["content"][2]["text"] == " "
+        assert msgs[0]["content"][0]["text"] == ""
+        assert msgs[0]["content"][2]["text"] == "   "
+
+    def test_convert_messages_preserves_non_empty_text_blocks(self, transport):
+        msgs = [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+
+        result = transport.convert_messages(msgs)
+
+        assert result is msgs
+
 
 class TestChatCompletionsBuildKwargs:
 


### PR DESCRIPTION
## Summary
- Fixes #19309
- Replace empty OpenAI-compatible chat text content blocks with a single-space placeholder before sending requests
- Preserve copy-on-demand behavior so stored conversation messages are not mutated

## Verification
- scripts/run_tests.sh tests/agent/transports/test_chat_completions.py
- git diff --check