### PR TITLE
fix(cli): defer Enter during rapid text input to prevent multiline paste splitting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10068,6 +10068,13 @@ class HermesCLI:
                 return
 
             # --- Normal input routing ---
+            # Defer during rapid text input (paste without bracketed-paste support).
+            # When newlines arrive as individual Enter events, _on_text_changed fires
+            # for each character. If the last text change was < 50 ms ago, text is
+            # still arriving — skip submission and let the buffer accumulate.
+            if _last_text_change[0] and (time.monotonic() - _last_text_change[0]) < 0.05:
+                return
+
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
@@ -10717,6 +10724,7 @@ class HermesCLI:
         _prev_newline_count = [0]
         _paste_just_collapsed = [False]
         self._skip_paste_collapse = False
+        _last_text_change = [None]
 
         def _on_text_changed(buf):
             """Detect large pastes and collapse them to a file reference.
@@ -10733,6 +10741,7 @@ class HermesCLI:
                still batch newlines.  Alt+Enter only adds 1 newline per
                event so it never triggers this.
             """
+            _last_text_change[0] = time.monotonic()
             text = _strip_leaked_bracketed_paste_wrappers(buf.text)
             text, _had_mouse_reports = _strip_leaked_terminal_responses_with_meta(text)
             if _had_mouse_reports:


### PR DESCRIPTION
## Problem

Pasting multiline text into the Hermes CLI without bracketed paste support (Windows Terminal, tmux) sends each line as a separate steering message instead of one complete input.

## Root Cause

Without bracketed paste, pasted newlines are received as individual Enter key events. The @kb.add('enter') handler submits each line independently.

## Fix: 50ms Timing Guard

Three changes in cli.py (9 lines):

1. **Tracker** — 
2. **Timestamp update** —  in 
3. **Defer guard** in handle_enter:


50ms cleanly separates paste (<1ms between chars) from human typing (>50ms).

## Tested

- Windows Terminal — multiline pastes buffer correctly, submit only on physical Enter
- Large pastes (731+ lines) accumulate fully as one message
- No impact on normal or fast manual typing
- Verified across multiple sessions

Closes #10994