### PR TITLE
fix(file): flag redacted read_file output

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -561,6 +561,46 @@ class TestLargeFileHint(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Redaction hint
+# ---------------------------------------------------------------------------
+
+class TestReadFileRedactionHint(unittest.TestCase):
+    """Reads that redact secrets should tell the model the file was masked."""
+
+    def setUp(self):
+        _read_tracker.clear()
+
+    def tearDown(self):
+        _read_tracker.clear()
+
+    @patch("tools.file_tools._get_file_ops")
+    @patch("tools.file_tools.redact_sensitive_text")
+    def test_redacted_read_gets_hint(self, mock_redact, mock_ops):
+        original = "     1|SECRET_KEY=os.environ.get('SECRET_KEY', 'value')\n"
+        redacted = "     1|SECRET_KEY=os.env...EY', 'value')\n"
+        mock_ops.return_value = _make_fake_ops(content=original, file_size=len(original))
+        mock_redact.return_value = redacted
+
+        result = json.loads(read_file_tool("/tmp/config.py", task_id="redact_hint"))
+
+        self.assertEqual(result["content"], redacted)
+        self.assertIn("_hint", result)
+        self.assertIn("Secret redaction", result["_hint"])
+        self.assertIn("not literal file corruption", result["_hint"])
+
+    @patch("tools.file_tools._get_file_ops")
+    @patch("tools.file_tools.redact_sensitive_text")
+    def test_unredacted_read_has_no_redaction_hint(self, mock_redact, mock_ops):
+        content = "     1|DEBUG=True\n"
+        mock_ops.return_value = _make_fake_ops(content=content, file_size=len(content))
+        mock_redact.return_value = content
+
+        result = json.loads(read_file_tool("/tmp/config.py", task_id="no_redact_hint"))
+
+        self.assertNotIn("_hint", result)
+
+
+# ---------------------------------------------------------------------------
 # Config override
 # ---------------------------------------------------------------------------
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -570,8 +570,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
+            original_content = result.content
             result.content = redact_sensitive_text(result.content)
             result_dict["content"] = result.content
+            if result.content != original_content:
+                result_dict.setdefault("_hint", (
+                    "Secret redaction was applied to this read_file output. "
+                    "Masked substrings are not literal file corruption or "
+                    "line truncation; inspect surrounding non-sensitive text "
+                    "or ask the user before editing redacted values."
+                ))
 
         # Large-file hint: if the file is big and the caller didn't ask
         # for a narrow window, nudge toward targeted reads.


### PR DESCRIPTION
## Summary
- Fixes #16520
- Add a structured read_file hint when secret redaction changes returned file content
- Clarify that masked substrings are not literal file corruption or line truncation, complementing the line-length PR #16596

## Verification
- scripts/run_tests.sh tests/tools/test_file_read_guards.py::TestReadFileRedactionHint tests/tools/test_file_read_guards.py::TestLargeFileHint::test_large_truncated_file_gets_hint
- git diff --check

## Notes
- The full tests/tools/test_file_read_guards.py suite currently has unrelated macOS temp-path write-safety failures in existing tests; the focused touched behavior passes.