### PR TITLE
fix(cli): handle kqueue EINVAL on macOS with uv-managed cPython

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11661,12 +11661,34 @@ class HermesCLI:
 
         # Validate stdin before launching prompt_toolkit — on macOS with
         # uv-managed Python, fd 0 can be invalid or unregisterable with the
-        # asyncio selector, causing "KeyError: '0 is not registered'" (#6393).
+        # asyncio selector, causing "KeyError: '0 is not registered'" (#6393)
+        # or OSError [Errno 22] Invalid argument from kqueue.
         try:
             os.fstat(0)
         except OSError:
             print(
                 "Error: stdin (fd 0) is not available.\n"
+                "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
+                "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
+            )
+            _run_cleanup()
+            self._print_exit_summary()
+            return
+
+        # Probe the selector to catch EINVAL before prompt_toolkit tries to
+        # register fd 0.  fstat() alone is insufficient — the selector can
+        # reject the fd even when fstat succeeds (kqueue EINVAL on macOS).
+        try:
+            import selectors as _sel
+            _s = _sel.DefaultSelector()
+            try:
+                _s.register(0, _sel.EVENT_READ)
+                _s.unregister(0)
+            finally:
+                _s.close()
+        except (KeyError, OSError) as _probe_err:
+            print(
+                f"Error: stdin is not usable by the async selector ({_probe_err}).\n"
                 "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
                 "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
             )
@@ -11692,7 +11714,14 @@ class HermesCLI:
             # and I/O errors from broken stdout during interrupt (#13710).
             if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:
                 pass  # suppress broken-stdout I/O errors on interrupt (#13710)
-            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            elif isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EINVAL:
+                # kqueue EINVAL on macOS with uv-managed cPython
+                print(
+                    f"\nError: stdin is not usable ({_stdin_err}).\n"
+                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
+                    "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
+                )
+            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err) or "Invalid argument" in str(_stdin_err):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"


### PR DESCRIPTION
## Summary

On macOS with uv-managed cPython (e.g. installed via `uv python install`), `hermes chat` crashes with an unhandled `OSError: [Errno 22] Invalid argument` from the kqueue selector when prompt_toolkit tries to register stdin (fd 0).

**Root cause**: The existing stdin validation (`os.fstat(0)`) passes successfully, but the kqueue selector still rejects fd 0 registration. The exception handler around `app.run()` only catches `errno.EIO` and the string `"is not registered"`, so `errno.EINVAL` (22) falls through to `raise`.

**Traceback** (abbreviated):
```
File "prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
File "asyncio/selector_events.py", line 344, in add_reader
    self._add_reader(fd, callback, *args)
File "selectors.py", line 523, in register
    self._selector.control([kev], 0, 0)
OSError: [Errno 22] Invalid argument
```

## Changes

1. **Selector probe** (before `app.run()`): After the existing `os.fstat(0)` check, actually attempt to `register`/`unregister` fd 0 with `selectors.DefaultSelector()`. This catches EINVAL before prompt_toolkit enters its event loop and prints an actionable error message instead of a traceback.

2. **Exception handler expansion**: Extend the `except (KeyError, OSError)` block around `app.run()` to also catch:
   - `errno.EINVAL` (explicit errno check)
   - `"Invalid argument"` (string match, matching existing pattern)

Related: #6393

## Testing

- Confirmed the crash reproduces on macOS with uv-managed cPython
- After the fix, the user sees a clear error message instead of a traceback:
  ```
  Error: stdin is not usable by the async selector ([Errno 22] Invalid argument).
  This can happen with certain Python installations (e.g. uv-managed cPython on macOS).
  Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup
  ```

## Notes

No formatting changes — the diff is purely functional (+31 lines, -2 lines).