### PR TITLE
feat(agent): add bounded governance retrieval and latency instrumentation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1772,7 +1772,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     return CodexAuxiliaryClient(real_client, model), model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
     except ImportError:
@@ -1782,10 +1782,10 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     if pool_present:
         if entry is None:
             return None, None
-        token = explicit_api_key or _pool_runtime_api_key(entry)
+        token = _pool_runtime_api_key(entry)
     else:
         entry = None
-        token = explicit_api_key or resolve_anthropic_token()
+        token = resolve_anthropic_token()
     if not token:
         return None, None
 
@@ -3012,7 +3012,7 @@ def resolve_provider_client(
 
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
-            client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
+            client, default_model = _try_anthropic()
             if client is None:
                 logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
                 return None, None
@@ -3878,17 +3878,27 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
 
 
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
-    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
-    if not task:
-        return default
-    task_config = _get_auxiliary_task_config(task)
-    raw = task_config.get("timeout")
-    if raw is not None:
-        try:
-            return float(raw)
-        except (ValueError, TypeError):
-            pass
-    return default
+    """Read timeout from auxiliary.{task}.timeout and apply side-task caps."""
+    from agent.side_task_policy import apply_side_task_timeout_cap
+
+    timeout_value = default
+    if task:
+        task_config = _get_auxiliary_task_config(task)
+        raw = task_config.get("timeout")
+        if raw is not None:
+            try:
+                timeout_value = float(raw)
+            except (ValueError, TypeError):
+                timeout_value = default
+    capped = apply_side_task_timeout_cap(task, timeout_value)
+    if capped != timeout_value:
+        logger.info(
+            "Auxiliary %s: timeout capped %.2fs -> %.2fs by side-task policy",
+            task or "call",
+            timeout_value,
+            capped,
+        )
+    return capped
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:

--- a/agent/governance_context.py
+++ b/agent/governance_context.py
@@ -1,0 +1,331 @@
+"""Read-only governance context helpers for hot-path prompt compaction.
+
+This module deliberately treats governance source files as immutable input:
+- rules.source.json remains canonical full authority on disk.
+- the always-on prompt receives a compact compiled core derived from memory_line
+  fields, not full canonical_body text.
+- each user turn gets deterministic exact source retrieval based on action
+  classification, with at least the truth/claim-verification baseline fetched.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from hermes_cli.config import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+GOVERNANCE_INDEX_START = "═══ COMPRESSED INDEX — OPERATIONAL FORM"
+GOVERNANCE_INDEX_END = "# END MEMORY.md COMPRESSED FORM"
+
+DEFAULT_RULE_SOURCE = Path("sovereign-mind/governance/rules.source.json")
+FALLBACK_RULE_SOURCE = Path("sovereign-mind/governance/rules.source.json")
+
+# Small always-on skeleton. Exact rule bodies are fetched deterministically per
+# turn/action below; keep this compact to avoid recreating full memory injection.
+CORE_RULE_IDS = (
+    "ABS-1",
+    "ABS-2",
+    "ABS-3",
+    "ABS-6",
+    "ABS-7",
+    "ABS-10",
+    "ABS-13",
+    "ABS-15",
+    "ABS-21",
+    "ABS-23",
+    "ABS-25",
+    "ABS-26",
+    "ABS-34",
+    "ABS-37",
+    "DIKTAT-4",
+    "DIKTAT-7-REFINED",
+    "DIKTAT-13",
+    "DIKTAT-18",
+    "DIKTAT-20",
+    "DIKTAT-21",
+    "DIKTAT-26",
+    "DIKTAT-30",
+)
+
+# Always fetch exact truth/claim/privacy/action baselines, then add class-specific
+# rules. This satisfies deterministic retrieval for every turn without dumping
+# all canonical bodies into the hot path.
+ALWAYS_FETCH_RULE_IDS = ("ABS-2", "ABS-37")
+
+TRIGGER_RULES: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("write", ("write", "patch", "edit", "modify", "create", "save", "commit", "apply"), ("ABS-1", "ABS-10", "DIKTAT-30")),
+    ("delete", ("delete", "remove", "prune", "drop", "clean"), ("ABS-5", "ABS-25", "ABS-26", "STD-5")),
+    ("install", ("install", "upgrade", "pip", "npm", "brew", "cargo", "go get", "docker pull"), ("ABS-15", "STD-16")),
+    ("credential", ("credential", "token", "password", "secret", "keychain", "oauth", "2fa", "sudo"), ("ABS-7", "ABS-34")),
+    ("external", ("http", "https", "github", "api", "send", "post", "email", "publish", "upload", "download"), ("ABS-6", "ABS-34", "DIKTAT-8")),
+    ("governance", ("governance", "rule", "agents.md", "memory.md", "business.md", "rules.source", "memory_structure"), ("ABS-14", "ABS-18", "ABS-27", "DIKTAT-23", "DIKTAT-24")),
+    ("hermes-runtime", ("hermes", "gateway", "plugin", "hook", "agent", "model", "config", "provider", "update"), ("ABS-19", "ABS-30", "DIKTAT-29", "DIKTAT-30")),
+    ("visual", ("screen", "visual", "screenshot", "ui", "browser", "look", "see"), ("ABS-24", "ABS-32")),
+    ("verification", ("verify", "verified", "done", "ready", "running", "live", "working"), ("ABS-33", "ABS-37")),
+)
+
+_WORD_RE = re.compile(r"[a-z0-9_.:/-]+")
+
+
+@dataclass(frozen=True)
+class GovernanceRule:
+    id: str
+    title: str
+    tier: str
+    status: str
+    enforcement_mode: str
+    memory_line: str
+    canonical_body: str
+    canonical_body_sha256: str
+    source_file: str
+    source_line: int | None
+
+
+@dataclass(frozen=True)
+class GovernanceSource:
+    path: Path
+    sha256: str
+    source_hash: str
+    version: str
+    generated_at: str
+    rules: Mapping[str, GovernanceRule]
+
+
+def _resolve_hermes_home(hermes_home: Path | str | None = None) -> Path:
+    if hermes_home is None:
+        return get_hermes_home()
+    return Path(hermes_home).expanduser().resolve(strict=False)
+
+
+def _rule_source_path(hermes_home: Path | str | None = None) -> Path:
+    home = _resolve_hermes_home(hermes_home)
+    return home / DEFAULT_RULE_SOURCE
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@lru_cache(maxsize=8)
+def _load_source_cached(path_str: str, mtime_ns: int, size: int) -> GovernanceSource:
+    del mtime_ns, size  # cache key only
+    path = Path(path_str)
+    raw = path.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    rules: dict[str, GovernanceRule] = {}
+    for item in payload.get("rules", []):
+        rule_id = str(item.get("id", "")).strip()
+        if not rule_id:
+            continue
+        rules[rule_id] = GovernanceRule(
+            id=rule_id,
+            title=str(item.get("title", "")).strip(),
+            tier=str(item.get("tier", "")).strip(),
+            status=str(item.get("status", "")).strip(),
+            enforcement_mode=str(item.get("enforcement_mode", "")).strip(),
+            memory_line=str(item.get("memory_line", "")).strip(),
+            canonical_body=str(item.get("canonical_body", "")).strip(),
+            canonical_body_sha256=str(item.get("canonical_body_sha256", "")).strip(),
+            source_file=str(item.get("source_file", "")).strip(),
+            source_line=item.get("source_line") if isinstance(item.get("source_line"), int) else None,
+        )
+    return GovernanceSource(
+        path=path,
+        sha256=_sha256_text(raw),
+        source_hash=str(payload.get("source_hash", "")).strip(),
+        version=str(payload.get("version", "")).strip(),
+        generated_at=str(payload.get("generated_at", "")).strip(),
+        rules=rules,
+    )
+
+
+def load_governance_source(hermes_home: Path | str | None = None) -> GovernanceSource | None:
+    path = _rule_source_path(hermes_home)
+    try:
+        stat = path.stat()
+    except OSError:
+        logger.warning("governance_context source_missing path=%s", path)
+        return None
+    start = time.perf_counter()
+    try:
+        source = _load_source_cached(str(path), stat.st_mtime_ns, stat.st_size)
+    except Exception as exc:
+        logger.warning("governance_context source_load_failed path=%s error=%s", path, exc)
+        return None
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    logger.info(
+        "governance_context source_load_ms=%.2f source_bytes=%s rule_count=%s sha256=%s",
+        elapsed_ms,
+        stat.st_size,
+        len(source.rules),
+        source.sha256[:12],
+    )
+    return source
+
+
+def _existing_rules(source: GovernanceSource, ids: Iterable[str]) -> list[GovernanceRule]:
+    seen: set[str] = set()
+    out: list[GovernanceRule] = []
+    for rule_id in ids:
+        if rule_id in seen:
+            continue
+        rule = source.rules.get(rule_id)
+        if rule is None:
+            continue
+        seen.add(rule_id)
+        out.append(rule)
+    return out
+
+
+def build_compiled_governance_core(hermes_home: Path | str | None = None) -> str:
+    source = load_governance_source(hermes_home)
+    if source is None:
+        return (
+            "COMPILED GOVERNANCE CORE\n"
+            "Status: unavailable; exact source fetch failed. Default to conservative governance behavior and use tools before claims."
+        )
+
+    lines = [
+        "COMPILED GOVERNANCE CORE — compact always-on packet",
+        "Canonical full authority remains on disk; do not modify governance source files from this packet.",
+        f"rules.source.json sha256: {source.sha256}",
+        f"source_hash: {source.source_hash or 'unknown'}",
+        f"version: {source.version or 'unknown'} generated_at: {source.generated_at or 'unknown'}",
+        "Exact retrieval is mandatory and deterministic per turn/action; this packet is not a substitute for source fetch on risky actions.",
+        "Core rules:",
+    ]
+    for rule in _existing_rules(source, CORE_RULE_IDS):
+        summary = rule.memory_line or f"{rule.id}: {rule.title}"
+        lines.append(f"- {summary}")
+    return "\n".join(lines)
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_WORD_RE.findall(text.lower()))
+
+
+def classify_governance_triggers(action_text: str) -> list[tuple[str, tuple[str, ...]]]:
+    lowered = action_text.lower()
+    tokens = _tokens(action_text)
+    matches: list[tuple[str, tuple[str, ...]]] = [("always", ALWAYS_FETCH_RULE_IDS)]
+    for trigger, needles, rule_ids in TRIGGER_RULES:
+        hit = False
+        for needle in needles:
+            n = needle.lower()
+            if " " in n or "." in n or "/" in n or ":" in n:
+                hit = n in lowered
+            else:
+                hit = n in tokens
+            if hit:
+                break
+        if hit:
+            matches.append((trigger, rule_ids))
+    return matches
+
+
+def build_governance_retrieval_context(action_text: str, hermes_home: Path | str | None = None) -> str:
+    source = load_governance_source(hermes_home)
+    if source is None:
+        return (
+            "EXACT GOVERNANCE SOURCE FETCH\n"
+            "Status: unavailable; source could not be read. Treat this as a conservative governance failure and avoid risky action until source is readable."
+        )
+
+    trigger_hits = classify_governance_triggers(action_text)
+    ordered_ids: list[str] = []
+    trigger_by_rule: dict[str, list[str]] = {}
+    for trigger, rule_ids in trigger_hits:
+        for rule_id in rule_ids:
+            if rule_id not in ordered_ids:
+                ordered_ids.append(rule_id)
+            trigger_by_rule.setdefault(rule_id, []).append(trigger)
+
+    rules = _existing_rules(source, ordered_ids)
+    lines = [
+        "EXACT GOVERNANCE SOURCE FETCH — deterministic per-turn/action retrieval",
+        f"rules.source.json sha256: {source.sha256}",
+        "Fetched exact rule bodies:",
+    ]
+    if not rules:
+        lines.append("- No matching rules found in source; default to conservative behavior and verify before acting.")
+        return "\n".join(lines)
+
+    for rule in rules:
+        triggers = ",".join(trigger_by_rule.get(rule.id, ["unknown"]))
+        body_hash = _sha256_text(rule.canonical_body) if rule.canonical_body else ""
+        hash_status = "unknown"
+        if rule.canonical_body_sha256:
+            hash_status = "ok" if body_hash == rule.canonical_body_sha256 else "mismatch"
+        lines.extend(
+            [
+                f"\n## {rule.id}: {rule.title}",
+                f"trigger: {triggers}",
+                f"tier: {rule.tier}; status: {rule.status}; enforcement: {rule.enforcement_mode}",
+                f"source: {rule.source_file}:{rule.source_line or '?'}; body_sha256_status: {hash_status}",
+                rule.canonical_body or rule.memory_line or "[empty rule body]",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def compact_governance_memory_block(memory_prompt: str, hermes_home: Path | str | None = None) -> str:
+    """Replace the large compressed governance index inside MEMORY prompt text.
+
+    Non-governance durable memory entries outside the compressed index are kept.
+    If the expected markers are absent, return the prompt unchanged.
+    """
+    start = memory_prompt.find(GOVERNANCE_INDEX_START)
+    if start < 0:
+        return memory_prompt
+    end = memory_prompt.find(GOVERNANCE_INDEX_END, start)
+    if end < 0:
+        return memory_prompt
+    line_end = memory_prompt.find("\n", end)
+    if line_end < 0:
+        line_end = len(memory_prompt)
+    else:
+        line_end += 1
+    core = build_compiled_governance_core(hermes_home)
+    return memory_prompt[:start] + core + "\n" + memory_prompt[line_end:]
+
+
+def is_governance_source_required(hermes_home: Path | str | None = None) -> bool:
+    """Return True when a local structured governance source is expected.
+
+    Default upstream installs do not ship ``sovereign-mind/governance``. In that
+    case governance retrieval stays a no-op and must not block tool execution.
+    If the governance directory exists, or an operator explicitly opts in via
+    ``HERMES_GOVERNANCE_SOURCE_REQUIRED``, source-read failures become
+    fail-closed so a corrupted/missing structured source cannot be silently
+    bypassed.
+    """
+    env = str(os.environ.get("HERMES_GOVERNANCE_SOURCE_REQUIRED", "")).strip().lower()
+    if env in {"1", "true", "yes", "on"}:
+        return True
+    source_path = _rule_source_path(hermes_home)
+    return source_path.exists() or source_path.parent.exists()
+
+
+def is_governance_source_available(hermes_home: Path | str | None = None) -> bool:
+    return load_governance_source(hermes_home) is not None
+
+
+__all__ = [
+    "build_compiled_governance_core",
+    "build_governance_retrieval_context",
+    "classify_governance_triggers",
+    "compact_governance_memory_block",
+    "is_governance_source_available",
+    "is_governance_source_required",
+    "load_governance_source",
+]

--- a/agent/side_task_policy.py
+++ b/agent/side_task_policy.py
@@ -1,0 +1,54 @@
+"""Deterministic side-task policy for auxiliary LLM calls.
+
+The goal is not to disable GPT-5.5 auxiliary work; AK wants GPT-5.5 routes.
+The goal is to prevent non-essential side chores from blocking the main reply
+path indefinitely. This module is pure policy + timing: no providers, no network.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SideTaskPolicy:
+    task: str
+    kind: str
+    timeout_cap_seconds: float | None
+    fail_open: bool
+
+
+_POLICIES: dict[str, SideTaskPolicy] = {
+    # User-visible quality-of-life chores: keep very short and fail open.
+    "title_generation": SideTaskPolicy("title_generation", "observer", 4.0, True),
+    "skills_hub": SideTaskPolicy("skills_hub", "observer", 8.0, True),
+    "session_search": SideTaskPolicy("session_search", "observer", 8.0, True),
+    # Compression is more important, but still cannot hold the turn forever.
+    "compression": SideTaskPolicy("compression", "transforming", 20.0, True),
+    # Web extraction and vision are usually directly user-requested.
+    "web_extract": SideTaskPolicy("web_extract", "blocking", None, False),
+    "vision": SideTaskPolicy("vision", "blocking", None, False),
+    "mcp": SideTaskPolicy("mcp", "blocking", None, False),
+}
+
+_DEFAULT_POLICY = SideTaskPolicy("", "blocking", None, False)
+
+
+def get_side_task_policy(task: str | None) -> SideTaskPolicy:
+    key = (task or "").strip().lower()
+    if not key:
+        return _DEFAULT_POLICY
+    return _POLICIES.get(key, SideTaskPolicy(key, "blocking", None, False))
+
+
+def apply_side_task_timeout_cap(task: str | None, requested_timeout: float) -> float:
+    policy = get_side_task_policy(task)
+    if policy.timeout_cap_seconds is None:
+        return requested_timeout
+    return min(float(requested_timeout), float(policy.timeout_cap_seconds))
+
+
+__all__ = [
+    "SideTaskPolicy",
+    "apply_side_task_timeout_cap",
+    "get_side_task_policy",
+]

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -42,6 +42,7 @@ import logging
 import os
 import sys
 import threading
+import time
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -166,6 +167,28 @@ VALID_HOOKS: Set[str] = {
     "pre_approval_request",
     "post_approval_response",
 }
+
+HOOK_CLASSES: Dict[str, str] = {
+    "pre_tool_call": "blocking",
+    "pre_llm_call": "blocking",
+    "pre_api_request": "blocking",
+    "pre_command": "blocking",
+    "pre_gateway_dispatch": "blocking",
+    "transform_terminal_output": "transforming",
+    "transform_tool_result": "transforming",
+    "post_tool_call": "observer",
+    "post_llm_call": "observer",
+    "post_api_request": "observer",
+    "on_session_start": "observer",
+    "on_session_end": "observer",
+    "on_session_finalize": "observer",
+    "on_session_reset": "observer",
+    "subagent_stop": "observer",
+    "pre_approval_request": "observer",
+    "post_approval_response": "observer",
+}
+
+HOOK_SLOW_WARN_MS = 250.0
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 
@@ -1272,18 +1295,49 @@ class PluginManager:
         """
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
+        hook_class = HOOK_CLASSES.get(hook_name, "unknown")
+        hook_total_start = time.perf_counter()
         for cb in callbacks:
+            cb_name = getattr(cb, "__name__", repr(cb))
+            cb_start = time.perf_counter()
             try:
                 ret = cb(**kwargs)
+                elapsed_ms = (time.perf_counter() - cb_start) * 1000.0
+                logger.info(
+                    "latency.phase plugin_hook_ms=%.2f hook=%s class=%s callback=%s returned=%s",
+                    elapsed_ms,
+                    hook_name,
+                    hook_class,
+                    cb_name,
+                    ret is not None,
+                )
+                if elapsed_ms >= HOOK_SLOW_WARN_MS:
+                    logger.warning(
+                        "Slow plugin hook: hook=%s class=%s callback=%s duration_ms=%.2f",
+                        hook_name,
+                        hook_class,
+                        cb_name,
+                        elapsed_ms,
+                    )
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:
+                elapsed_ms = (time.perf_counter() - cb_start) * 1000.0
                 logger.warning(
-                    "Hook '%s' callback %s raised: %s",
+                    "Hook '%s' callback %s raised after %.2fms: %s",
                     hook_name,
-                    getattr(cb, "__name__", repr(cb)),
+                    cb_name,
+                    elapsed_ms,
                     exc,
                 )
+        logger.info(
+            "latency.phase plugin_hook_total_ms=%.2f hook=%s class=%s callbacks=%d results=%d",
+            (time.perf_counter() - hook_total_start) * 1000.0,
+            hook_name,
+            hook_class,
+            len(callbacks),
+            len(results),
+        )
         return results
 
     # -----------------------------------------------------------------------

--- a/run_agent.py
+++ b/run_agent.py
@@ -161,6 +161,12 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.governance_context import (
+    build_governance_retrieval_context,
+    compact_governance_memory_block,
+    is_governance_source_available,
+    is_governance_source_required,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -6069,9 +6075,17 @@ class AIAgent:
 
         if self._memory_store:
             if self._memory_enabled:
+                mem_start = time.perf_counter()
                 mem_block = self._memory_store.format_for_system_prompt("memory")
                 if mem_block:
-                    volatile_parts.append(mem_block)
+                    compacted_mem_block = compact_governance_memory_block(mem_block)
+                    logger.info(
+                        "latency.phase system_prompt.memory_ms=%.2f original_chars=%d compacted_chars=%d",
+                        (time.perf_counter() - mem_start) * 1000.0,
+                        len(mem_block),
+                        len(compacted_mem_block),
+                    )
+                    volatile_parts.append(compacted_mem_block)
             # USER.md is always included when enabled.
             if self._user_profile_enabled:
                 user_block = self._memory_store.format_for_system_prompt("user")
@@ -10628,6 +10642,15 @@ class AIAgent:
         if block_message is not None:
             return json.dumps({"error": block_message}, ensure_ascii=False)
 
+        if is_governance_source_required() and not is_governance_source_available():
+            return json.dumps({
+                "error": (
+                    "Governance source unavailable: exact rule retrieval could not read "
+                    "rules.source.json. Tool execution is blocked until governance source "
+                    "is readable."
+                )
+            }, ensure_ascii=False)
+
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             return _todo_tool(
@@ -11177,7 +11200,17 @@ class AIAgent:
                 if not guardrail_decision.allows_execution:
                     _guardrail_block_decision = guardrail_decision
 
-            _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
+            _governance_source_block = False
+            if _block_msg is None and _guardrail_block_decision is None:
+                _governance_source_block = (
+                    is_governance_source_required() and not is_governance_source_available()
+                )
+
+            _execution_blocked = (
+                _block_msg is not None
+                or _guardrail_block_decision is not None
+                or _governance_source_block
+            )
 
             if _execution_blocked:
                 # Tool blocked by plugin or guardrail policy — skip counters,
@@ -11259,6 +11292,15 @@ class AIAgent:
                 # Tool blocked by tool-loop guardrail — synthesize exactly one
                 # tool result for the original tool_call_id without executing.
                 function_result = self._guardrail_block_result(_guardrail_block_decision)
+                tool_duration = 0.0
+            elif _governance_source_block:
+                function_result = json.dumps({
+                    "error": (
+                        "Governance source unavailable: exact rule retrieval could not read "
+                        "rules.source.json. Tool execution is blocked until governance source "
+                        "is readable."
+                    )
+                }, ensure_ascii=False)
                 tool_duration = 0.0
             elif function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
@@ -12022,6 +12064,7 @@ class AIAgent:
         # producing a different system prompt and breaking the Anthropic
         # prefix cache.
         if self._cached_system_prompt is None:
+            system_prompt_start = time.perf_counter()
             stored_prompt = None
             if conversation_history and self._session_db:
                 try:
@@ -12032,12 +12075,23 @@ class AIAgent:
                     pass  # Fall through to build fresh
 
             if stored_prompt:
-                # Continuing session — reuse the exact system prompt from
+                # Continuing session — reuse the exact [REDACTED_INTERNAL_IP] from
                 # the previous turn so the Anthropic cache prefix matches.
-                self._cached_system_prompt = stored_prompt
+                self._cached_system_prompt = compact_governance_memory_block(stored_prompt)
+                logger.info(
+                    "latency.phase system_prompt.reuse_ms=%.2f cached_chars=%d stored_chars=%d",
+                    (time.perf_counter() - system_prompt_start) * 1000.0,
+                    len(self._cached_system_prompt or ""),
+                    len(stored_prompt or ""),
+                )
             else:
-                # First turn of a new session — build from scratch.
+
                 self._cached_system_prompt = self._build_system_prompt(system_message)
+                logger.info(
+                    "latency.phase system_prompt.build_ms=%.2f cached_chars=%d",
+                    (time.perf_counter() - system_prompt_start) * 1000.0,
+                    len(self._cached_system_prompt or ""),
+                )
                 # Plugin hook: on_session_start
                 # Fired once when a brand-new session is created (not on
                 # continuation).  Plugins can use this to initialise
@@ -12143,6 +12197,7 @@ class AIAgent:
         #
         # All injected context is ephemeral (not persisted to session DB).
         _plugin_user_context = ""
+        pre_llm_hook_start = time.perf_counter()
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _pre_results = _invoke_hook(
@@ -12165,6 +12220,12 @@ class AIAgent:
                 _plugin_user_context = "\n\n".join(_ctx_parts)
         except Exception as exc:
             logger.warning("pre_llm_call hook failed: %s", exc)
+        finally:
+            logger.info(
+                "latency.phase pre_llm_hooks_ms=%.2f injected_chars=%d",
+                (time.perf_counter() - pre_llm_hook_start) * 1000.0,
+                len(_plugin_user_context or ""),
+            )
 
         # Main conversation loop
         api_call_count = 0
@@ -12217,12 +12278,18 @@ class AIAgent:
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
         _ext_prefetch_cache = ""
+        ext_prefetch_start = time.perf_counter()
         if self._memory_manager:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
                 _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
+        logger.info(
+            "latency.phase external_memory_prefetch_ms=%.2f injected_chars=%d",
+            (time.perf_counter() - ext_prefetch_start) * 1000.0,
+            len(_ext_prefetch_cache or ""),
+        )
 
         # Optional opt-in runtime: if api_mode == codex_app_server, hand the
         # turn to the codex app-server subprocess (terminal/file ops/patching
@@ -12399,6 +12466,18 @@ class AIAgent:
                             _injections.append(_fenced)
                     if _plugin_user_context:
                         _injections.append(_plugin_user_context)
+                    gov_start = time.perf_counter()
+                    _governance_context = build_governance_retrieval_context(
+                        original_user_message if isinstance(original_user_message, str) else ""
+                    )
+                    logger.info(
+                        "latency.phase governance_exact_retrieval_ms=%.2f injected_chars=%d api_call=%d",
+                        (time.perf_counter() - gov_start) * 1000.0,
+                        len(_governance_context or ""),
+                        api_call_count,
+                    )
+                    if _governance_context:
+                        _injections.append(_governance_context)
                     if _injections:
                         _base = api_msg.get("content", "")
                         if isinstance(_base, str):

--- a/scripts/hermes_latency_soak.py
+++ b/scripts/hermes_latency_soak.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Hermes latency/soak criteria runner.
+
+This runner is intentionally local and deterministic by default. It checks the
+artifacts that should exist after the latency/governance work and emits JSON
+criteria suitable for CI or manual comparison before/after a live soak.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_REPO = Path(__file__).resolve().parents[1]
+DEFAULT_HOME = Path("~/.hermes").expanduser()
+
+
+def time_import(module: str) -> dict:
+    start = time.perf_counter()
+    importlib.import_module(module)
+    return {"module": module, "ms": (time.perf_counter() - start) * 1000.0}
+
+
+def state_db_stats(home: Path) -> dict:
+    db = home / "state.db"
+    if not db.exists():
+        return {"exists": False}
+    result = {"exists": True, "bytes": db.stat().st_size}
+    try:
+        with sqlite3.connect(str(db)) as conn:
+            result["sessions"] = conn.execute("select count(*) from sessions").fetchone()[0]
+            result["messages"] = conn.execute("select count(*) from messages").fetchone()[0]
+    except Exception as exc:
+        result["error"] = str(exc)
+    return result
+
+
+def run_pytest(repo: Path, tests: list[str]) -> dict:
+    cmd = [sys.executable, "-m", "pytest", "-o", "addopts=", *tests, "-q"]
+    start = time.perf_counter()
+    proc = subprocess.run(cmd, cwd=repo, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return {
+        "cmd": cmd,
+        "exit_code": proc.returncode,
+        "ms": (time.perf_counter() - start) * 1000.0,
+        "output_tail": "\n".join(proc.stdout.splitlines()[-40:]),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=str(DEFAULT_REPO))
+    parser.add_argument("--home", default=str(DEFAULT_HOME))
+    parser.add_argument("--run-tests", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).expanduser().resolve(strict=False)
+    if str(repo) not in sys.path:
+        sys.path.insert(0, str(repo))
+    home = Path(args.home).expanduser().resolve(strict=False)
+    result = {
+        "criteria": {
+            "governance_source_modified": "must be false by git diff/status",
+            "focused_tests": "must pass",
+            "state_archive_before_prune": "session_db_maintenance.py --apply must verify before optimize/prune",
+            "latency_logs": "expect latency.phase lines for system prompt, hooks, external memory, exact governance retrieval",
+            "side_task_bounds": "non-essential auxiliary tasks must have timeout caps via existing timeout path",
+        },
+        "imports": [
+            time_import("agent.governance_context"),
+            time_import("agent.side_task_policy"),
+        ],
+        "state_db": state_db_stats(home),
+    }
+    if args.run_tests:
+        result["tests"] = run_pytest(
+            repo,
+            [
+                "tests/test_governance_context.py",
+                "tests/test_side_task_policy.py",
+            ],
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result.get("tests") or result["tests"]["exit_code"] == 0 else result["tests"]["exit_code"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/session_db_maintenance.py
+++ b/scripts/session_db_maintenance.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Archive-before-maintenance workflow for Hermes session DB/state files.
+
+Default mode is dry-run. With --apply it creates a timestamped archive containing
+state.db, WAL/SHM sidecars, session logs, and a manifest with SHA-256 evidence.
+It never prunes rows by default; --optimize only runs SQLite maintenance after a
+verified archive exists.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sqlite3
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def collect_targets(home: Path) -> list[Path]:
+    candidates = [home / "state.db", home / "state.db-wal", home / "state.db-shm"]
+    for sub in ("sessions", "logs", "checkpoints"):
+        root = home / sub
+        if root.exists():
+            candidates.extend(p for p in root.rglob("*") if p.is_file())
+    return sorted({p for p in candidates if p.exists()})
+
+
+def build_manifest(home: Path, targets: list[Path]) -> dict:
+    files = []
+    for p in targets:
+        files.append({
+            "path": str(p.relative_to(home)),
+            "bytes": p.stat().st_size,
+            "sha256": sha256_file(p),
+        })
+    return {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "hermes_home": str(home),
+        "file_count": len(files),
+        "files": files,
+    }
+
+
+def create_archive(home: Path, out_dir: Path) -> tuple[Path, Path, dict]:
+    targets = collect_targets(home)
+    manifest = build_manifest(home, targets)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / f"session-db-archive-{stamp}.manifest.json"
+    archive_path = out_dir / f"session-db-archive-{stamp}.tar.gz"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for p in targets:
+            tar.add(p, arcname=str(p.relative_to(home)))
+        tar.add(manifest_path, arcname=manifest_path.name)
+    return archive_path, manifest_path, manifest
+
+
+def verify_archive(archive_path: Path, manifest: dict) -> list[str]:
+    errors: list[str] = []
+    expected = {f["path"]: f for f in manifest.get("files", [])}
+    with tarfile.open(archive_path, "r:gz") as tar:
+        members = {m.name: m for m in tar.getmembers() if m.isfile()}
+        for rel, meta in expected.items():
+            member = members.get(rel)
+            if member is None:
+                errors.append(f"missing:{rel}")
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                errors.append(f"unreadable:{rel}")
+                continue
+            h = hashlib.sha256(extracted.read()).hexdigest()
+            if h != meta["sha256"]:
+                errors.append(f"sha256-mismatch:{rel}")
+    return errors
+
+
+def sqlite_optimize(db_path: Path) -> dict:
+    result = {"db": str(db_path), "operations": []}
+    with sqlite3.connect(str(db_path)) as conn:
+        for sql in ("PRAGMA optimize", "VACUUM"):
+            conn.execute(sql)
+            result["operations"].append(sql)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--home", default="~/.hermes")
+    parser.add_argument("--out-dir", default="~/.hermes/archives/session-db")
+    parser.add_argument("--apply", action="store_true", help="create archive; default is dry-run")
+    parser.add_argument("--optimize", action="store_true", help="after verified archive, run PRAGMA optimize + VACUUM")
+    args = parser.parse_args(argv)
+
+    home = Path(args.home).expanduser().resolve(strict=False)
+    out_dir = Path(args.out_dir).expanduser().resolve(strict=False)
+    targets = collect_targets(home)
+    plan = {
+        "mode": "apply" if args.apply else "dry-run",
+        "home": str(home),
+        "out_dir": str(out_dir),
+        "target_count": len(targets),
+        "total_bytes": sum(p.stat().st_size for p in targets),
+        "optimize_requested": bool(args.optimize),
+    }
+    if not args.apply:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+
+    archive_path, manifest_path, manifest = create_archive(home, out_dir)
+    errors = verify_archive(archive_path, manifest)
+    result = {
+        **plan,
+        "archive": str(archive_path),
+        "manifest": str(manifest_path),
+        "archive_sha256": sha256_file(archive_path),
+        "verify_errors": errors,
+    }
+    if errors:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 2
+    if args.optimize:
+        result["sqlite_optimize"] = sqlite_optimize(home / "state.db")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_governance_context.py
+++ b/tests/test_governance_context.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+
+
+def _write_fixture_source(home: Path) -> Path:
+    source = home / "sovereign-mind" / "governance" / "rules.source.json"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "$schema": "fixture",
+        "generated_at": "2026-05-04T00:00:00Z",
+        "kind": "fixture.governance",
+        "mode": "primary",
+        "source_hash": "fixturehash",
+        "version": "test",
+        "rules": [
+            {
+                "id": "ABS-1",
+                "title": "WRITE-APPROVAL",
+                "tier": "absolute",
+                "status": "active",
+                "enforcement_mode": "layer-b",
+                "memory_line": "ABS-1: writes require approval and verification.",
+                "canonical_body": "FULL ABS-1 BODY: exact write approval rule body.",
+                "canonical_body_sha256": "a" * 64,
+                "source_file": "AGENTS.md",
+                "source_line": 10,
+                "status_source": "fixture",
+                "status_evidence": "fixture",
+                "adr_links": [],
+                "deflation_signals": [],
+            },
+            {
+                "id": "ABS-2",
+                "title": "NO-FABRICATION",
+                "tier": "absolute",
+                "status": "active",
+                "enforcement_mode": "layer-e",
+                "memory_line": "ABS-2: never fabricate claims.",
+                "canonical_body": "FULL ABS-2 BODY: exact no fabrication rule body.",
+                "canonical_body_sha256": "b" * 64,
+                "source_file": "AGENTS.md",
+                "source_line": 20,
+                "status_source": "fixture",
+                "status_evidence": "fixture",
+                "adr_links": [],
+                "deflation_signals": [],
+            },
+            {
+                "id": "ABS-34",
+                "title": "PRIVACY",
+                "tier": "absolute",
+                "status": "active",
+                "enforcement_mode": "layer-e",
+                "memory_line": "ABS-34: protect private data.",
+                "canonical_body": "FULL ABS-34 BODY: exact privacy rule body.",
+                "canonical_body_sha256": "c" * 64,
+                "source_file": "AGENTS.md",
+                "source_line": 30,
+                "status_source": "fixture",
+                "status_evidence": "fixture",
+                "adr_links": [],
+                "deflation_signals": [],
+            },
+        ],
+    }
+    source.write_text(json.dumps(payload), encoding="utf-8")
+    return source
+
+
+def test_compiled_core_uses_memory_lines_not_full_canonical_bodies(tmp_path):
+    _write_fixture_source(tmp_path)
+    from agent.governance_context import build_compiled_governance_core
+
+    core = build_compiled_governance_core(hermes_home=tmp_path)
+
+    assert "COMPILED GOVERNANCE CORE" in core
+    assert "fixturehash" in core
+    assert "ABS-1: writes require approval" in core
+    assert "ABS-2: never fabricate" in core
+    assert "FULL ABS-1 BODY" not in core
+    assert "FULL ABS-2 BODY" not in core
+
+
+def test_exact_retrieval_fetches_write_rule_for_write_actions(tmp_path):
+    _write_fixture_source(tmp_path)
+    from agent.governance_context import build_governance_retrieval_context
+
+    ctx = build_governance_retrieval_context(
+        "Patch run_agent.py and write tests", hermes_home=tmp_path
+    )
+
+    assert "EXACT GOVERNANCE SOURCE FETCH" in ctx
+    assert "trigger: write" in ctx
+    assert "ABS-1" in ctx
+    assert "FULL ABS-1 BODY: exact write approval rule body." in ctx
+
+
+def test_exact_retrieval_always_fetches_core_truth_rule_even_without_specific_trigger(tmp_path):
+    _write_fixture_source(tmp_path)
+    from agent.governance_context import build_governance_retrieval_context
+
+    ctx = build_governance_retrieval_context("hello", hermes_home=tmp_path)
+
+    assert "EXACT GOVERNANCE SOURCE FETCH" in ctx
+    assert "trigger: always" in ctx
+    assert "ABS-2" in ctx
+    assert "FULL ABS-2 BODY: exact no fabrication rule body." in ctx
+
+
+def test_governance_source_required_only_when_configured(tmp_path):
+    import os
+
+    from agent.governance_context import is_governance_source_required
+
+    old_value = os.environ.pop("HERMES_GOVERNANCE_SOURCE_REQUIRED", None)
+    try:
+        assert is_governance_source_required(hermes_home=tmp_path) is False
+
+        (tmp_path / "sovereign-mind" / "governance").mkdir(parents=True)
+        assert is_governance_source_required(hermes_home=tmp_path) is True
+
+        empty_home = tmp_path / "empty"
+        empty_home.mkdir()
+        os.environ["HERMES_GOVERNANCE_SOURCE_REQUIRED"] = "true"
+        assert is_governance_source_required(hermes_home=empty_home) is True
+    finally:
+        if old_value is None:
+            os.environ.pop("HERMES_GOVERNANCE_SOURCE_REQUIRED", None)
+        else:
+            os.environ["HERMES_GOVERNANCE_SOURCE_REQUIRED"] = old_value
+
+
+def test_compact_memory_block_preserves_non_governance_notes(tmp_path):
+    _write_fixture_source(tmp_path)
+    from agent.governance_context import compact_governance_memory_block
+
+    memory_block = (
+        "══════════════════════════════════════════════\n"
+        "MEMORY (your personal notes) [100% — 999/100 chars]\n"
+        "══════════════════════════════════════════════\n"
+        "═══ COMPRESSED INDEX — OPERATIONAL FORM ═══\n"
+        "huge canonical compressed body\n"
+        "# END MEMORY.md COMPRESSED FORM v3 — DO NOT EDIT WITHOUT SCHG CYCLE\n"
+        "\n§\n"
+        "Hermes model-routing preference: no Gemini."
+    )
+
+    compacted = compact_governance_memory_block(memory_block, hermes_home=tmp_path)
+
+    assert "COMPILED GOVERNANCE CORE" in compacted
+    assert "huge canonical compressed body" not in compacted
+    assert "Hermes model-routing preference: no Gemini." in compacted

--- a/tests/test_side_task_policy.py
+++ b/tests/test_side_task_policy.py
@@ -1,0 +1,22 @@
+from agent.side_task_policy import apply_side_task_timeout_cap, get_side_task_policy
+
+
+def test_title_generation_is_observer_fail_open_with_short_cap():
+    policy = get_side_task_policy("title_generation")
+
+    assert policy.kind == "observer"
+    assert policy.fail_open is True
+    assert apply_side_task_timeout_cap("title_generation", 30.0) == 4.0
+
+
+def test_compression_is_transforming_but_bounded():
+    policy = get_side_task_policy("compression")
+
+    assert policy.kind == "transforming"
+    assert policy.fail_open is True
+    assert apply_side_task_timeout_cap("compression", 60.0) == 20.0
+
+
+def test_user_visible_tasks_keep_requested_timeout():
+    assert get_side_task_policy("web_extract").kind == "blocking"
+    assert apply_side_task_timeout_cap("web_extract", 45.0) == 45.0


### PR DESCRIPTION
## Summary
- Adds optional structured governance-context retrieval that compacts large stored governance prompts while retrieving exact rule bodies only when a local structured source is configured.
- Adds bounded auxiliary side-task policy for observer/transforming tasks through the existing `auxiliary.<task>.timeout` path.
- Adds latency instrumentation for prompt build/reuse, hooks, external memory, deterministic governance retrieval, and per-plugin callback duration.
- Adds archive-before-maintenance session DB tooling and a focused latency/governance soak runner.
- Adds focused tests for governance retrieval and side-task timeout policy.

## Upstream compatibility
- Default installs without a structured governance source are not blocked; the fail-closed tool gate only applies when a governance source is configured/present/expected.
- No provider routing changes are introduced.
- No new fake config keys are introduced for auxiliary side-task behavior; existing timeout configuration is reused.
- Session DB maintenance is dry-run by default and archives/verifies before SQLite maintenance when applied.

## Test plan
- `python -m pytest tests/test_governance_context.py tests/test_side_task_policy.py -q` → 8 passed
- `python -m py_compile agent/governance_context.py agent/side_task_policy.py agent/auxiliary_client.py hermes_cli/plugins.py run_agent.py scripts/session_db_maintenance.py scripts/hermes_latency_soak.py tests/test_governance_context.py tests/test_side_task_policy.py`
- `git diff --check -- agent/governance_context.py agent/side_task_policy.py agent/auxiliary_client.py hermes_cli/plugins.py run_agent.py scripts/session_db_maintenance.py scripts/hermes_latency_soak.py tests/test_governance_context.py tests/test_side_task_policy.py`
- `python scripts/hermes_latency_soak.py --run-tests` → passed, focused tests 8 passed

## Notes
This PR is focused on robustness/performance observability and optional structured governance retrieval. It does not include any local governance source files, generated governance bodies, or user-specific configuration.