### PR TITLE
fix(gateway): filter status PIDs by profile

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -67,13 +67,17 @@ class ProfileGatewayProcess:
     path: Path
     pid: int
 
-def _get_service_pids() -> set:
+def _get_service_pids(all_profiles: bool = False) -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
     Used to avoid killing freshly-restarted service processes when sweeping
     for stale manual gateway processes after a service restart.  Relies on the
     service manager having committed the new PID before the restart command
     returns (true for both systemd and launchd in practice).
+
+    Args:
+        all_profiles: When true, include every ``hermes-gateway*`` service.
+            Otherwise only include the service for the current HERMES_HOME.
     """
     pids: set = set()
 
@@ -81,8 +85,9 @@ def _get_service_pids() -> set:
     if supports_systemd_services():
         for scope_args in [["systemctl", "--user"], ["systemctl"]]:
             try:
+                unit_pattern = "hermes-gateway*" if all_profiles else f"{get_service_name()}.service"
                 result = subprocess.run(
-                    scope_args + ["list-units", "hermes-gateway*",
+                    scope_args + ["list-units", unit_pattern,
                                   "--plain", "--no-legend", "--no-pager"],
                     capture_output=True, text=True, timeout=5,
                 )
@@ -91,6 +96,8 @@ def _get_service_pids() -> set:
                     if not parts or not parts[0].endswith(".service"):
                         continue
                     svc = parts[0]
+                    if not all_profiles and svc != f"{get_service_name()}.service":
+                        continue
                     try:
                         show = subprocess.run(
                             scope_args + ["show", svc,
@@ -127,6 +134,26 @@ def _get_service_pids() -> set:
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
+    return pids
+
+
+def _other_profile_gateway_pids(exclude_pids: set[int]) -> set[int]:
+    """Return live gateway PIDs recorded by profiles other than this one."""
+    try:
+        current_home = get_hermes_home().resolve()
+        processes = find_profile_gateway_processes(exclude_pids=exclude_pids)
+    except Exception:
+        return set()
+
+    pids: set[int] = set()
+    for process in processes:
+        try:
+            if process.path.resolve() == current_home:
+                continue
+        except OSError:
+            continue
+        if process.pid > 0:
+            pids.add(process.pid)
     return pids
 
 
@@ -372,7 +399,10 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
+    if not all_profiles:
+        _exclude.update(_other_profile_gateway_pids(_exclude))
+    service_pids = _get_service_pids(all_profiles=True) if all_profiles else _get_service_pids()
+    for pid in service_pids:
         _append_unique_pid(pids, pid, _exclude)
     for pid in _scan_gateway_pids(_exclude, all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -317,6 +317,76 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     assert gateway.find_gateway_pids() == [321]
 
 
+def test_find_gateway_pids_excludes_pid_files_from_other_profiles(monkeypatch, tmp_path):
+    default_home = tmp_path / ".hermes"
+    other_home = default_home / "profiles" / "wx1"
+    other_home.mkdir(parents=True)
+
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: default_home)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        gateway,
+        "find_profile_gateway_processes",
+        lambda exclude_pids=None: [
+            gateway.ProfileGatewayProcess(profile="wx1", path=other_home, pid=222),
+        ],
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["ps", "-A", "eww", "-o"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "111 python -m hermes_cli.main gateway run --replace\n"
+                    "222 python -m hermes_cli.main gateway run --replace\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    monkeypatch.setattr("os.getpid", lambda: 999)
+
+    assert gateway.find_gateway_pids() == [111]
+
+
+def test_find_gateway_pids_all_profiles_keeps_other_profile_pid_files(monkeypatch, tmp_path):
+    default_home = tmp_path / ".hermes"
+    other_home = default_home / "profiles" / "wx1"
+    other_home.mkdir(parents=True)
+
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda all_profiles=False: set())
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: default_home)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        gateway,
+        "find_profile_gateway_processes",
+        lambda exclude_pids=None: [
+            gateway.ProfileGatewayProcess(profile="wx1", path=other_home, pid=222),
+        ],
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["ps", "-A", "eww", "-o"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "111 python -m hermes_cli.main gateway run --replace\n"
+                    "222 python -m hermes_cli.main gateway run --replace\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    monkeypatch.setattr("os.getpid", lambda: 999)
+
+    assert gateway.find_gateway_pids(all_profiles=True) == [111, 222]
+
+
 # ---------------------------------------------------------------------------
 # _wait_for_gateway_exit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #19113
- Exclude PIDs recorded by other Hermes profile PID files before the current-profile manual process scan
- Scope service PID discovery to the current profile service by default, while preserving all-profile discovery for update/restart sweeps
- Add regression tests for ambiguous process-table rows where another profile's gateway would otherwise be reported as current-profile running

## Verification
- scripts/run_tests.sh tests/hermes_cli/test_gateway.py tests/hermes_cli/test_update_gateway_restart.py::TestGetServicePids
- git diff --check