### PR TITLE
fix(gateway): apply HOME_CHANNEL env vars to plugin platforms

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1601,5 +1601,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True
+
+            # Mirror the built-in pattern: {PREFIX}_HOME_CHANNEL env var
+            # populates the platform's home_channel so cross-platform
+            # send_message can route to a default destination.
+            prefix = entry.name.upper().replace("-", "_")
+            home_val = os.getenv(f"{prefix}_HOME_CHANNEL")
+            if home_val:
+                config.platforms[platform].home_channel = HomeChannel(
+                    platform=platform,
+                    chat_id=home_val,
+                    name=os.getenv(f"{prefix}_HOME_CHANNEL_NAME", "Home"),
+                    thread_id=os.getenv(f"{prefix}_HOME_CHANNEL_THREAD_ID") or None,
+                )
     except Exception as e:
         logger.debug("Plugin platform enable pass failed: %s", e)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -609,3 +609,80 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestPluginPlatformHomeChannelEnvOverride:
+    """Plugin platforms registered via the platform registry should pick up
+    ``{PREFIX}_HOME_CHANNEL`` env vars during ``_apply_env_overrides``,
+    matching the built-in pattern (regression for issue #19440)."""
+
+    def test_plugin_home_channel_env_var_populates_home_channel(self, monkeypatch):
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        original = dict(platform_registry._entries)
+        try:
+            platform_registry._entries.clear()
+            platform_registry.register(PlatformEntry(
+                name="xmpp",
+                label="XMPP",
+                adapter_factory=lambda cfg: None,
+                check_fn=lambda: True,
+                source="plugin",
+            ))
+
+            monkeypatch.setattr(
+                "hermes_cli.plugins.discover_plugins",
+                lambda: None,
+            )
+
+            config = GatewayConfig()
+            env = {
+                "XMPP_HOME_CHANNEL": "room@conference.example.org",
+                "XMPP_HOME_CHANNEL_NAME": "Lounge",
+                "XMPP_HOME_CHANNEL_THREAD_ID": "thread-1",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                _apply_env_overrides(config)
+
+            platform = Platform("xmpp")
+            assert platform in config.platforms
+            assert config.platforms[platform].enabled is True
+            home = config.platforms[platform].home_channel
+            assert home is not None
+            assert home.chat_id == "room@conference.example.org"
+            assert home.name == "Lounge"
+            assert home.thread_id == "thread-1"
+        finally:
+            platform_registry._entries.clear()
+            platform_registry._entries.update(original)
+
+    def test_plugin_without_home_channel_env_leaves_home_channel_unset(self, monkeypatch):
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        original = dict(platform_registry._entries)
+        try:
+            platform_registry._entries.clear()
+            platform_registry.register(PlatformEntry(
+                name="xmpp",
+                label="XMPP",
+                adapter_factory=lambda cfg: None,
+                check_fn=lambda: True,
+                source="plugin",
+            ))
+
+            monkeypatch.setattr(
+                "hermes_cli.plugins.discover_plugins",
+                lambda: None,
+            )
+
+            config = GatewayConfig()
+            with patch.dict(os.environ, {}, clear=True):
+                _apply_env_overrides(config)
+
+            platform = Platform("xmpp")
+            assert platform in config.platforms
+            assert config.platforms[platform].enabled is True
+            assert config.platforms[platform].home_channel is None
+        finally:
+            platform_registry._entries.clear()
+            platform_registry._entries.update(original)


### PR DESCRIPTION
Plugin platforms in `gateway/config.py::_apply_env_overrides()` now read their `{PREFIX}_HOME_CHANNEL` env vars instead of silently ignoring them.

## What changed and why
- The registry-driven plugin enable loop only set `enabled = True`, so plugin platforms (e.g. XMPP) ignored the documented `{PREFIX}_HOME_CHANNEL` env var. Cross-platform `send_message` calls then failed with `No home channel set for <platform> to determine where to send the message.`
- Added an env-driven `home_channel` setup in the plugin loop that mirrors the built-in pattern (`TELEGRAM_HOME_CHANNEL`, `DISCORD_HOME_CHANNEL`, etc.), including optional `_NAME` and `_THREAD_ID` companions.
- This is a generic fix that applies to every plugin platform — no per-plugin block required.

## How to test
- `pytest tests/gateway/test_config.py -q` (new `TestPluginPlatformHomeChannelEnvOverride` class covers the env-set and env-absent paths).
- Manual repro from the issue: install a plugin platform (e.g. XMPP), set `XMPP_HOME_CHANNEL=room@conference.example.org` in `.env`, then from another platform call `send_message(platform="xmpp", ...)` — the message now routes to the configured home channel instead of erroring.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #19440

<!-- autocontrib:worker-id=issue-new-697d75f7 kind=pr-open -->