### PR TITLE
docs(kanban): document handoff evidence metadata

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -149,6 +149,40 @@ When the dispatcher spawns a worker, it sets `HERMES_KANBAN_TASK` in the child's
 
 The `kanban-worker` and `kanban-orchestrator` skills teach the model which tool to call when and in what order.
 
+### Recommended handoff evidence
+
+`kanban_complete(summary=..., metadata={...})` is intentionally flexible:
+the summary is the human-readable closeout, and `metadata` is the
+machine-readable handoff that downstream agents, reviewers, or dashboards can
+reuse without scraping prose.
+
+For engineering and review tasks, prefer this optional metadata shape:
+
+```json
+{
+  "changed_files": ["path/to/file.py"],
+  "verification": ["pytest tests/hermes_cli/test_kanban_db.py -q"],
+  "dependencies": ["parent task id or external issue, if any"],
+  "blocked_reason": null,
+  "retry_notes": "what failed before, if this was a retry",
+  "residual_risk": ["what was not tested or still needs human review"]
+}
+```
+
+These keys are a convention, not a schema requirement. The useful property is
+that every worker leaves enough evidence for the next reader to answer four
+questions quickly:
+
+1. What changed?
+2. How was it verified?
+3. What can unblock or retry this if it fails?
+4. What risk is still deliberately left open?
+
+Keep secrets, raw logs, tokens, OAuth material, and unrelated transcripts out of
+`metadata`. Store pointers and summaries instead. If a task has no files or
+tests, say so explicitly in `summary` and use `metadata` for the evidence that
+does exist, such as source URLs, issue ids, or manual review steps.
+
 ### The worker skill
 
 Any profile that should be able to work kanban tasks must load the `kanban-worker` skill. It teaches the worker the full lifecycle:


### PR DESCRIPTION
## What does this PR do?

Documents an optional `metadata` convention for Kanban worker handoffs so humans, downstream agents, and dashboards can read the same evidence packet without scraping prose.

This is intentionally docs-only. The runtime already accepts structured `metadata` through `kanban_complete(summary=..., metadata={...})`; this PR only describes a practical shape for engineering/review tasks.

## Related Issue

No issue yet; this is a docs-only clarification for existing Kanban behavior.

## Type of Change

- [x] Documentation update

## Changes Made

- `website/docs/user-guide/features/kanban.md`
  - Adds a "Recommended handoff evidence" section.
  - Suggests optional keys: `changed_files`, `verification`, `dependencies`, `blocked_reason`, `retry_notes`, and `residual_risk`.
  - Clarifies that these keys are a convention, not a schema requirement.
  - Calls out that secrets, raw logs, tokens, OAuth material, and unrelated transcripts should not be placed in task metadata.

## Evidence Checked

- Existing tool surface: `kanban_complete` already exposes `summary` and `metadata` as the structured completion handoff.
- Existing docs already describe Kanban as a durable queue where every handoff is a row any profile or human can read.
- PR hygiene check: #19507 was superseded by #19508 to keep an unrelated TUI change out of the branch; this PR keeps the diff to one docs file.
- Branch compare: 1 commit, 1 modified file, +34/-0.

## How to Test

1. Review the edited docs section in `website/docs/user-guide/features/kanban.md`.
2. Confirm the example metadata is valid JSON.
3. Confirm the wording does not imply required schema enforcement or runtime behavior changes.

Not run: full website build. This is a docs-only copy change with no code/runtime path touched.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open PRs for duplicate Kanban handoff/evidence metadata work.
- [x] My PR contains only changes related to this docs clarification.
- [x] N/A: `pytest tests/ -q` is not relevant for a docs-only copy change.
- [x] N/A: tests are not added because runtime behavior is unchanged.
- [x] Tested on my platform: macOS, docs diff review only.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] N/A: no config keys changed.
- [x] N/A: no architecture or workflow files changed.
- [x] N/A: no cross-platform runtime impact.
- [x] N/A: no tool behavior changed.

## Non-goals

- No database schema migration.
- No dispatcher/runtime behavior change.
- No dashboard rendering change.
- No mandatory metadata validation.

## Residual Risk

The exact field names may need maintainer vocabulary changes. Because this is docs-only and explicitly optional, the safe review path is to adjust naming here before any tests or runtime UI depend on it.
