### PR TITLE
fix(agent): honor model.max_tokens in config.yaml

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1884,6 +1884,36 @@ class AIAgent:
                 )
                 _config_context_length = None
 
+        # Read explicit max_tokens override from model config. Needed when
+        # routing to Anthropic via an OpenAI-compatible proxy with tools
+        # enabled — Anthropic's Messages API rejects those requests with
+        # HTTP 400 unless max_tokens is present. See issue #19360.
+        if isinstance(_model_cfg, dict):
+            _config_max_tokens = _model_cfg.get("max_tokens")
+        else:
+            _config_max_tokens = None
+        if _config_max_tokens is not None:
+            try:
+                _config_max_tokens = int(_config_max_tokens)
+                if _config_max_tokens <= 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid model.max_tokens in config.yaml: %r — "
+                    "must be a positive integer (e.g. 4096). "
+                    "Falling back to model default.",
+                    _config_max_tokens,
+                )
+                print(
+                    f"\n⚠ Invalid model.max_tokens in config.yaml: {_config_max_tokens!r}\n"
+                    f"  Must be a positive integer (e.g. 4096).\n"
+                    f"  Falling back to model default.\n",
+                    file=sys.stderr,
+                )
+                _config_max_tokens = None
+            if _config_max_tokens is not None:
+                self.max_tokens = _config_max_tokens
+
         # Resolve custom_providers list once for reuse below (startup
         # context-length override and plugin context-engine init).
         try:

--- a/tests/run_agent/test_max_tokens_config.py
+++ b/tests/run_agent/test_max_tokens_config.py
@@ -1,0 +1,107 @@
+"""Tests that model.max_tokens config is honored and validated.
+
+Regression for issue #19360: when routing to Anthropic via an
+OpenAI-compatible proxy with tools enabled, Anthropic's Messages API
+requires ``max_tokens`` in the request body. Previously there was no
+way to set it from config.yaml — the AIAgent constructor accepted
+``max_tokens`` but no caller ever passed it, so ``self.max_tokens``
+was always ``None`` and the OpenAI SDK omitted the field.
+"""
+
+from unittest.mock import patch
+
+
+def _build_agent(model_cfg, model="anthropic/claude-opus-4.6"):
+    cfg = {"model": model_cfg}
+    base_url = model_cfg.get("base_url", "")
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return agent
+
+
+def test_valid_integer_max_tokens_applied():
+    """Plain integer max_tokens should land on self.max_tokens."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4-6",
+            "provider": "custom",
+            "base_url": "http://localhost:8045/v1",
+            "max_tokens": 16384,
+        })
+    assert agent.max_tokens == 16384
+    for c in mock_logger.warning.call_args_list:
+        assert "max_tokens" not in str(c) or "Invalid" not in str(c)
+
+
+def test_string_numeric_max_tokens_parses():
+    """max_tokens: '4096' (string) should parse via int()."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4-6",
+            "provider": "custom",
+            "base_url": "http://localhost:8045/v1",
+            "max_tokens": "4096",
+        })
+    assert agent.max_tokens == 4096
+    for c in mock_logger.warning.call_args_list:
+        assert "Invalid" not in str(c) or "max_tokens" not in str(c)
+
+
+def test_invalid_k_suffix_max_tokens_warns():
+    """max_tokens: '4K' is not a plain integer — warn and fall back."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4-6",
+            "provider": "custom",
+            "base_url": "http://localhost:8045/v1",
+            "max_tokens": "4K",
+        })
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "max_tokens" in str(c) and "Invalid" in str(c)]
+    assert len(warning_calls) == 1
+    assert "4K" in str(warning_calls[0])
+
+
+def test_nonpositive_max_tokens_warns():
+    """max_tokens: 0 or negative is not a usable value — warn and fall back."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4-6",
+            "provider": "custom",
+            "base_url": "http://localhost:8045/v1",
+            "max_tokens": 0,
+        })
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "max_tokens" in str(c) and "Invalid" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_missing_max_tokens_leaves_default():
+    """No max_tokens key → self.max_tokens stays at the constructor default (None)."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "claude-opus-4-6",
+            "provider": "custom",
+            "base_url": "http://localhost:8045/v1",
+        })
+    assert agent.max_tokens is None
+    for c in mock_logger.warning.call_args_list:
+        assert "max_tokens" not in str(c) or "Invalid" not in str(c)


### PR DESCRIPTION
## Summary

Fixes #19360 — all tool-using agents fail with HTTP 400 when routed through an OpenAI-compatible proxy to Anthropic models, because Hermes sends chat completion requests without `max_tokens`, which Anthropic's Messages API requires when `tools` is present.

- `AIAgent.__init__` accepts `max_tokens` but no caller ever passes it — so `self.max_tokens` was always `None` and the OpenAI SDK omitted the field entirely.
- This PR lets users set it via `config.yaml` → `model.max_tokens`, mirroring the existing `model.context_length` block right above the new code in `run_agent.py`.
- Validation: non-int / `"4K"` / non-positive values log a clear warning and fall back to the model default (same shape as the `context_length` warning) rather than crashing.

## Config usage

```yaml
model:
  default: claude-opus-4-6-thinking
  provider: custom
  base_url: http://192.168.1.13:8045/v1
  api_key: sk-xxx
  max_tokens: 16384   # new
```

## Test plan

- [x] New regression suite `tests/run_agent/test_max_tokens_config.py` (5 cases: valid int, numeric string, `"4K"` warn, `0` warn, absent → default `None`).
- [x] Verified the new tests fail on `main` without the fix (4/5 fail — only the `None`-default case passes, which is the pre-existing behavior) and all pass with it.
- [x] Sibling suite `test_invalid_context_length_warning.py` still green — the new block only reuses `_model_cfg`, doesn't alter the existing `_config_context_length` flow.
