### PR TITLE
fix(tools): scope tool caches by session context

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -23,6 +23,7 @@ Public API (signatures preserved from the original 2,400-line version):
 import json
 import asyncio
 import logging
+import os
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
@@ -261,6 +262,26 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def _session_tool_cache_fingerprint() -> tuple:
+    """Return session context that can affect tool availability/schema output."""
+    names = (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_SESSION_KEY",
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+    )
+    try:
+        from gateway.session_context import get_session_env
+
+        return tuple((name, get_session_env(name, "")) for name in names)
+    except Exception:
+        return tuple((name, os.getenv(name, "")) for name in names)
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -307,6 +328,7 @@ def get_tool_definitions(
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
+            _session_tool_cache_fingerprint(),
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -422,6 +422,43 @@ def test_startup_runtime_does_not_call_network_detector(monkeypatch):
     assert provider in {None, "anthropic"}
 
 
+def test_tool_definitions_cache_is_session_context_aware(monkeypatch):
+    """TUI/gateway sessions must not share stale quiet-mode tool schemas."""
+    import model_tools
+
+    session_env = {"HERMES_SESSION_PLATFORM": ""}
+    calls = []
+
+    def fake_get_session_env(name, default=""):
+        return session_env.get(name, default)
+
+    def fake_compute(enabled_toolsets=None, disabled_toolsets=None, quiet_mode=False):
+        calls.append(session_env["HERMES_SESSION_PLATFORM"])
+        tool_name = (
+            "send_message"
+            if session_env["HERMES_SESSION_PLATFORM"]
+            else "plain_chat"
+        )
+        return [{"type": "function", "function": {"name": tool_name}}]
+
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env", fake_get_session_env
+    )
+    monkeypatch.setattr(model_tools, "_compute_tool_definitions", fake_compute)
+    model_tools._clear_tool_defs_cache()
+
+    try:
+        first = model_tools.get_tool_definitions(["hermes-cli"], quiet_mode=True)
+        session_env["HERMES_SESSION_PLATFORM"] = "telegram"
+        second = model_tools.get_tool_definitions(["hermes-cli"], quiet_mode=True)
+    finally:
+        model_tools._clear_tool_defs_cache()
+
+    assert [t["function"]["name"] for t in first] == ["plain_chat"]
+    assert [t["function"]["name"] for t in second] == ["send_message"]
+    assert calls == ["", "telegram"]
+
+
 def _session(agent=None, **extra):
     return {
         "agent": agent if agent is not None else types.SimpleNamespace(),

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -5,7 +5,11 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
-from tools.registry import ToolRegistry, discover_builtin_tools
+from tools.registry import (
+    ToolRegistry,
+    discover_builtin_tools,
+    invalidate_check_fn_cache,
+)
 
 
 def _dummy_handler(args, **kwargs):
@@ -110,6 +114,42 @@ class TestGetDefinitions:
         defs = reg.get_definitions({"first", "second"})
         assert len(defs) == 2
         assert calls["count"] == 1
+
+    def test_check_fn_cache_is_session_context_aware(self, monkeypatch):
+        """A CLI false result must not hide a tool in a later gateway session."""
+        reg = ToolRegistry()
+        calls = {"count": 0}
+        session_env = {"HERMES_SESSION_PLATFORM": ""}
+
+        def fake_get_session_env(name, default=""):
+            return session_env.get(name, default)
+
+        monkeypatch.setattr(
+            "gateway.session_context.get_session_env", fake_get_session_env
+        )
+        invalidate_check_fn_cache()
+
+        def session_check():
+            calls["count"] += 1
+            from gateway.session_context import get_session_env
+
+            return bool(get_session_env("HERMES_SESSION_PLATFORM", ""))
+
+        reg.register(
+            name="send_message",
+            toolset="messaging",
+            schema=_make_schema("send_message"),
+            handler=_dummy_handler,
+            check_fn=session_check,
+        )
+
+        assert reg.get_definitions({"send_message"}) == []
+
+        session_env["HERMES_SESSION_PLATFORM"] = "telegram"
+        defs = reg.get_definitions({"send_message"})
+
+        assert [d["function"]["name"] for d in defs] == ["send_message"]
+        assert calls["count"] == 2
 
 
 class TestUnknownToolDispatch:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -111,15 +111,45 @@ class ToolEntry:
 # ---------------------------------------------------------------------------
 
 _CHECK_FN_TTL_SECONDS = 30.0
-_check_fn_cache: Dict[Callable, tuple[float, bool]] = {}
+_check_fn_cache: Dict[tuple[Callable, tuple], tuple[float, bool]] = {}
 _check_fn_cache_lock = threading.Lock()
+
+
+def _session_cache_fingerprint() -> tuple:
+    """Return session context that can affect tool availability checks.
+
+    Some check_fn callables intentionally read gateway session context (for
+    example, send_message is always available inside messaging sessions). A
+    process-wide cache keyed only by callable can otherwise let an early CLI
+    or not-yet-contextualized false result hide tools from later TUI/gateway
+    sessions in the same long-lived process.
+    """
+    names = (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_SESSION_KEY",
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+    )
+    try:
+        from gateway.session_context import get_session_env
+
+        return tuple((name, get_session_env(name, "")) for name in names)
+    except Exception:
+        import os
+
+        return tuple((name, os.getenv(name, "")) for name in names)
 
 
 def _check_fn_cached(fn: Callable) -> bool:
     """Return bool(fn()), TTL-cached across calls. Swallows exceptions as False."""
     now = time.monotonic()
+    cache_key = (fn, _session_cache_fingerprint())
     with _check_fn_cache_lock:
-        cached = _check_fn_cache.get(fn)
+        cached = _check_fn_cache.get(cache_key)
         if cached is not None:
             ts, value = cached
             if now - ts < _CHECK_FN_TTL_SECONDS:
@@ -129,7 +159,7 @@ def _check_fn_cached(fn: Callable) -> bool:
     except Exception:
         value = False
     with _check_fn_cache_lock:
-        _check_fn_cache[fn] = (now, value)
+        _check_fn_cache[cache_key] = (now, value)
     return value
 
 


### PR DESCRIPTION
## Summary
- include gateway/TUI session context in the quiet-mode tool-definition cache key
- include the same session context in registry check_fn TTL cache keys
- add regressions so a CLI/no-platform false result cannot hide messaging tools from a later gateway/TUI session

Fixes #17777.

## Verification
- scripts/run_tests.sh tests/tools/test_registry.py::TestGetDefinitions::test_check_fn_cache_is_session_context_aware tests/test_tui_gateway_server.py::test_tool_definitions_cache_is_session_context_aware
- git diff --check