### PR TITLE
feat(sentry): Sentry webhook receiver for Vedere ecosystem

### DIFF
--- a/cron/sentry_backfill.py
+++ b/cron/sentry_backfill.py
@@ -1,0 +1,251 @@
+"""Sentry 6h backfill cron — Vedere ecosystem standardization.
+
+Queries the Sentry events API for the last 6h+1h margin (level >= error)
+and replays each unique fingerprint through the Hermes Sentry webhook
+endpoint. Re-using the live HTTP path means the SAME
+:class:`hermes_cli.sentry_webhook.FingerprintCache` is consulted (G5
+unification) — no parallel dedup logic to drift out of sync.
+
+Crontab line (deploy via ``crontab -e``)::
+
+    0 */6 * * * /usr/bin/env -i HOME=$HOME bash -lc 'source .venv/bin/activate && python -m cron.sentry_backfill >> ~/.hermes/logs/backfill.log 2>&1'
+
+Env vars consumed:
+
+* ``SENTRY_AUTH_TOKEN`` — Sentry API auth token (required).
+* ``SENTRY_ORG_SLUG``   — Sentry organization slug (default: ``vedere``).
+* ``SENTRY_PROJECTS``   — comma-separated project slugs to scan (required).
+* ``SENTRY_WEBHOOK_TOKEN`` — same secret the receiver verifies (required).
+* ``HERMES_WEBHOOK_URL`` — webhook receiver URL
+  (default: ``http://localhost:9119/api/sentry/webhook``).
+* ``SENTRY_BASE_URL``   — Sentry API base (default: ``https://sentry.io/api/0``).
+
+Exit codes:
+
+* 0 — success (zero or more fingerprints replayed)
+* 2 — missing required env vars
+* 3 — Sentry API error
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+import httpx
+
+from hermes_cli.sentry_webhook import FingerprintCache, get_cache
+
+_log = logging.getLogger("cron.sentry_backfill")
+
+
+_BACKFILL_WINDOW_S = 6 * 60 * 60      # nominal window
+_BACKFILL_MARGIN_S = 1 * 60 * 60      # +1h overlap so we don't lose events at the edges
+_HTTP_TIMEOUT_S = 30.0
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        _log.error("missing required env var %s", name)
+        raise SystemExit(2)
+    return value
+
+
+def _list_projects() -> List[str]:
+    raw = _require_env("SENTRY_PROJECTS")
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def _fetch_recent_events(
+    *,
+    org: str,
+    project: str,
+    auth_token: str,
+    since_ts: int,
+    base_url: str,
+    client: httpx.Client,
+) -> List[Dict[str, Any]]:
+    """Pull recent events for one project. Returns a list of event dicts.
+
+    Uses the public Sentry events endpoint with a ``query=level:error
+    age:-7h`` filter. We over-fetch slightly because Sentry's age filter
+    is project-time-zone sensitive and we'd rather replay one event twice
+    (the receiver dedups) than miss one.
+    """
+    url = f"{base_url}/projects/{org}/{project}/events/"
+    headers = {"Authorization": f"Bearer {auth_token}"}
+    params = {
+        "query": "level:error",
+        "statsPeriod": "7h",  # 6h + 1h margin
+        "full": "true",
+    }
+    response = client.get(url, headers=headers, params=params, timeout=_HTTP_TIMEOUT_S)
+    if response.status_code != 200:
+        _log.error(
+            "Sentry events API returned %d for project=%s body=%s",
+            response.status_code,
+            project,
+            response.text[:300],
+        )
+        raise SystemExit(3)
+    data = response.json()
+    if not isinstance(data, list):
+        _log.error("Sentry events API returned non-list payload: %r", type(data))
+        raise SystemExit(3)
+    return [evt for evt in data if isinstance(evt, dict)]
+
+
+def _event_fingerprint(event: Dict[str, Any]) -> Optional[str]:
+    fp = event.get("fingerprint") or event.get("groupID") or event.get("eventID")
+    if isinstance(fp, list) and fp:
+        return str(fp[0])
+    if isinstance(fp, str) and fp:
+        return fp
+    return None
+
+
+def _event_environment(event: Dict[str, Any], default: Optional[str] = None) -> Optional[str]:
+    env = event.get("environment")
+    if isinstance(env, str) and env:
+        return env
+    return default
+
+
+def _build_synthetic_payload(event: Dict[str, Any], project: str) -> Dict[str, Any]:
+    fp = _event_fingerprint(event) or event.get("eventID") or "unknown"
+    env = _event_environment(event) or f"{project}-prod"
+    return {
+        "action": "triggered",
+        "data": {
+            "event": {
+                "fingerprint": [fp],
+                "level": event.get("level") or "error",
+                "environment": env,
+                "exception": event.get("entries", [{}])[0].get("data") if event.get("entries") else None,
+                "message": event.get("message") or event.get("title"),
+                "title": event.get("title"),
+                "web_url": event.get("permalink") or event.get("eventID"),
+                "project_slug": project,
+            },
+            "issue_url": event.get("groupURL"),
+            "triggered_rule": "hermes-backfill-cron",
+        },
+    }
+
+
+def _replay_one(
+    *,
+    payload: Dict[str, Any],
+    webhook_url: str,
+    webhook_token: str,
+    client: httpx.Client,
+) -> Tuple[int, str]:
+    response = client.post(
+        webhook_url,
+        params={"token": webhook_token},
+        json=payload,
+        timeout=_HTTP_TIMEOUT_S,
+    )
+    return response.status_code, (response.text or "")[:300]
+
+
+def _configure_logging() -> None:
+    level = os.environ.get("SENTRY_BACKFILL_LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=getattr(logging, level, logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    _configure_logging()
+
+    auth_token = _require_env("SENTRY_AUTH_TOKEN")
+    webhook_token = _require_env("SENTRY_WEBHOOK_TOKEN")
+    projects = _list_projects()
+
+    org = os.environ.get("SENTRY_ORG_SLUG", "vedere")
+    base_url = os.environ.get("SENTRY_BASE_URL", "https://sentry.io/api/0").rstrip("/")
+    webhook_url = os.environ.get(
+        "HERMES_WEBHOOK_URL",
+        "http://localhost:9119/api/sentry/webhook",
+    )
+
+    since_ts = int(time.time()) - (_BACKFILL_WINDOW_S + _BACKFILL_MARGIN_S)
+
+    # Touch the singleton so the cache file exists on disk before the
+    # webhook receiver process is asked to consult it. This is purely a
+    # warm-start nicety; the receiver opens its own connection.
+    cache: FingerprintCache = get_cache()
+    _log.info("sentry-backfill: cache path=%s projects=%s", cache.path, projects)
+
+    new_count = 0
+    skipped_count = 0
+    error_count = 0
+
+    seen: Set[Tuple[str, str]] = set()
+
+    with httpx.Client() as client:
+        for project in projects:
+            try:
+                events = _fetch_recent_events(
+                    org=org,
+                    project=project,
+                    auth_token=auth_token,
+                    since_ts=since_ts,
+                    base_url=base_url,
+                    client=client,
+                )
+            except SystemExit:
+                raise
+            except httpx.HTTPError as exc:
+                _log.warning("network error fetching project=%s: %s", project, exc)
+                error_count += 1
+                continue
+            for event in events:
+                fp = _event_fingerprint(event)
+                env = _event_environment(event, default=f"{project}-prod")
+                if not fp or not env:
+                    continue
+                key = (fp, env)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if not cache.is_new(fp, env) and not cache.is_regression(fp, env):
+                    skipped_count += 1
+                    continue
+                payload = _build_synthetic_payload(event, project)
+                try:
+                    status, text = _replay_one(
+                        payload=payload,
+                        webhook_url=webhook_url,
+                        webhook_token=webhook_token,
+                        client=client,
+                    )
+                except httpx.HTTPError as exc:
+                    _log.warning("network error replaying fp=%s env=%s: %s", fp, env, exc)
+                    error_count += 1
+                    continue
+                if status >= 400:
+                    _log.warning(
+                        "webhook replay returned %d fp=%s env=%s body=%s",
+                        status, fp, env, text,
+                    )
+                    error_count += 1
+                else:
+                    new_count += 1
+                    _log.info("replayed fp=%s env=%s status=%d", fp, env, status)
+
+    _log.info(
+        "sentry-backfill: done new=%d skipped=%d errors=%d unique=%d",
+        new_count, skipped_count, error_count, len(seen),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/sentry-webhook-ops.md
+++ b/docs/sentry-webhook-ops.md
@@ -1,0 +1,139 @@
+# Sentry Webhook Receiver — Ops Runbook
+
+Vedere ecosystem standardization (Phase 2 Lane A3). The receiver lives at
+`POST /api/sentry/webhook` on the existing Hermes FastAPI server
+(`hermes_cli/web_server.py`). It deduplicates Sentry Issue Alert webhooks by
+fingerprint via a SQLite cache and creates GitHub issues in the appropriate
+Vedere repository via the `gh` CLI.
+
+## Environment variables
+
+| Var                     | Required | Purpose                                                                                  |
+| ----------------------- | :------: | ---------------------------------------------------------------------------------------- |
+| `SENTRY_WEBHOOK_TOKEN`  |   yes    | Shared secret. Sentry presents it as `?token=...`. Compared with `secrets.compare_digest`. |
+| `SENTRY_AUTH_TOKEN`     |   yes\*  | Sentry API token used by the 6h backfill cron only.                                      |
+| `SENTRY_PROJECTS`       |   yes\*  | Comma-separated project slugs the backfill cron should scan.                             |
+| `SENTRY_ORG_SLUG`       |    no    | Defaults to `vedere`.                                                                    |
+| `SENTRY_BASE_URL`       |    no    | Defaults to `https://sentry.io/api/0`.                                                   |
+| `HERMES_WEBHOOK_URL`    |    no    | Backfill posts here. Defaults to `http://localhost:9119/api/sentry/webhook`.             |
+
+\* Required only on the host that runs the backfill cron, not on every Hermes node.
+
+## Auth model
+
+* **Free-tier Sentry does not sign webhook payloads.** Auth is a shared secret-token
+  query parameter: `POST /api/sentry/webhook?token=<SENTRY_WEBHOOK_TOKEN>`.
+* The receiver compares with `secrets.compare_digest` (constant-time).
+* The dashboard `auth_middleware` is bypassed for `/api/sentry/webhook` because the
+  endpoint owns its own auth — `register_sentry_webhook` extends
+  `_PUBLIC_API_PATHS`.
+
+## Dedup, regression, and the shared cache (G5)
+
+* SQLite at `~/.hermes/sentry-fingerprints.db`, schema
+  `(fingerprint, environment, last_seen, github_issue_url, github_issue_state)`,
+  PK `(fingerprint, environment)`.
+* `is_new` → True when no row exists or `last_seen` is older than 30 days.
+* `is_regression` → True when `last_seen` is older than 7 days **and** the recorded
+  state is `closed`. Regressions create a fresh issue with the `regression` label.
+* Connection opened with `check_same_thread=False` so the FastAPI handler thread
+  and the backfill cron share the SAME `FingerprintCache` instance (G5).
+
+## Issue creation
+
+* `gh issue create --repo <mapped-repo> --title "[Sentry] <summary> (<fp[:12]>)" --body <hybrid> --label sentry-bug --label hermes-pending [--label regression]`
+* Body is hybrid Markdown + a `<!-- hermes-payload -->` JSON block matching
+  `Vhailors/vedere-shared@main:golden/payload-schema.ts`.
+* `hermes-pending` is applied at creation time so the Hermes triage loop can scan
+  the label even if Hermes was offline when the issue was created (downtime
+  fallback).
+
+## Environment → repo mapping (compile-time)
+
+```
+lms-{prod,staging,dev}        → manlaughed/VedereLMS
+aireader-{prod,staging,dev}   → Vhailors/AIReader
+university-{prod,staging,dev} → Vhailors/VedereUniversity
+```
+
+Unknown environments yield `400 unknown environment`. Adding a new project is an
+explicit code edit reviewed in PR.
+
+## Deploy: BLUE-GREEN MANDATORY (G2 lock-in)
+
+The webhook receiver is on the request path of every Sentry alert. We require
+zero-downtime deploys with **RTO < 60s** during deploy windows.
+
+Two systemd units run side-by-side; nginx fronts them:
+
+```
+# /etc/systemd/system/hermes@blue.service
+[Service]
+Environment=HERMES_PORT=9119
+ExecStart=/opt/hermes/.venv/bin/hermes dashboard --no-browser --host 127.0.0.1 --port ${HERMES_PORT}
+Restart=on-failure
+EnvironmentFile=/etc/hermes/sentry.env
+
+# /etc/systemd/system/hermes@green.service  (port 9120, same EnvironmentFile)
+```
+
+```
+# /etc/nginx/conf.d/hermes-upstream.conf
+upstream hermes_active {
+    server 127.0.0.1:9119;   # blue (currently active)
+    # server 127.0.0.1:9120; # green (commented out except during swap window)
+}
+server {
+    listen 443 ssl;
+    server_name hermes.vedere.io;
+    location /api/sentry/webhook {
+        proxy_pass http://hermes_active;
+        proxy_read_timeout 30s;
+    }
+}
+```
+
+### Swap procedure (RTO target: <60s)
+
+```bash
+# 1. Deploy new code to the inactive color (green).
+sudo systemctl restart hermes@green
+# 2. Smoke-test green directly.
+curl -fsS -X POST "http://127.0.0.1:9120/api/sentry/webhook?token=$SENTRY_WEBHOOK_TOKEN" \
+     -H 'content-type: application/json' \
+     -d '{"action":"triggered","data":{"event":{"fingerprint":["smoke"],"environment":"lms-prod"}}}'
+# 3. Edit upstream conf to point at green; reload nginx gracefully.
+sudo sed -i 's|server 127.0.0.1:9119;|# server 127.0.0.1:9119;|; s|# server 127.0.0.1:9120;|server 127.0.0.1:9120;|' \
+     /etc/nginx/conf.d/hermes-upstream.conf
+sudo nginx -t && sudo nginx -s reload
+# 4. After verification window, stop the now-idle blue.
+sudo systemctl stop hermes@blue
+```
+
+`nginx -s reload` is graceful — in-flight requests drain on the old upstream. The
+flip itself is sub-second.
+
+## 6h backfill cron (G5 unified dedup)
+
+`cron/sentry_backfill.py` re-queries the Sentry events API for the last 6h+1h
+margin and POSTs each unseen event to the live webhook URL. Because the synthetic
+POST goes through the SAME endpoint, it consults the SAME `FingerprintCache` —
+no parallel logic to drift out of sync.
+
+Crontab entry (deploy via `crontab -e`, or systemd timer if preferred):
+
+```
+0 */6 * * * /usr/bin/env -i HOME=$HOME bash -lc 'source .venv/bin/activate && python -m cron.sentry_backfill >> ~/.hermes/logs/backfill.log 2>&1'
+```
+
+Required env in the cron environment: `SENTRY_AUTH_TOKEN`,
+`SENTRY_WEBHOOK_TOKEN`, `SENTRY_PROJECTS`. If running over a systemd timer,
+encode them in `EnvironmentFile=` rather than the unit body.
+
+## Operational checks
+
+* Verify cache is healthy: `sqlite3 ~/.hermes/sentry-fingerprints.db 'SELECT COUNT(*) FROM fingerprints;'`
+* Tail receiver logs: `journalctl -u hermes@blue -f | grep sentry-webhook`
+* Tail backfill: `tail -f ~/.hermes/logs/backfill.log`
+* Force-replay one fingerprint (after deleting its row):
+  `sqlite3 ~/.hermes/sentry-fingerprints.db "DELETE FROM fingerprints WHERE fingerprint='<fp>'"`

--- a/hermes_cli/sentry_webhook.py
+++ b/hermes_cli/sentry_webhook.py
@@ -1,0 +1,439 @@
+"""Sentry Issue Alert webhook receiver — Vedere ecosystem standardization.
+
+Receives Sentry Issue Alert webhook payloads, deduplicates by fingerprint
+against a SQLite cache, maps environment to a target GitHub repository, and
+creates a GitHub issue via ``gh issue create`` with a hybrid Markdown +
+JSON-payload body matching ``Vhailors/vedere-shared@main:golden/payload-schema.ts``.
+
+Free-tier Sentry does NOT sign webhook payloads. Authentication is via the
+``SENTRY_WEBHOOK_TOKEN`` env var presented as a ``?token=`` query parameter
+and compared with :func:`secrets.compare_digest`.
+
+The same :class:`FingerprintCache` is shared between the FastAPI handler
+thread and the 6h backfill cron (G5 unification) — ``check_same_thread=False``
+on the underlying sqlite3 connection so concurrent calls are safe under the
+short critical sections used here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import sqlite3
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, FastAPI, HTTPException, Query, Request
+from pydantic import BaseModel, Field, ValidationError
+
+_log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/sentry", tags=["sentry"])
+
+
+# ---------------------------------------------------------------------------
+# Environment → target repo mapping. Static rather than configurable —
+# adding a new Vedere project should be an explicit code change reviewed
+# in PR rather than a runtime env-var surprise.
+# ---------------------------------------------------------------------------
+ENV_REPO_MAP: Dict[str, str] = {
+    "lms-prod": "manlaughed/VedereLMS",
+    "lms-staging": "manlaughed/VedereLMS",
+    "lms-dev": "manlaughed/VedereLMS",
+    "aireader-prod": "Vhailors/AIReader",
+    "aireader-staging": "Vhailors/AIReader",
+    "aireader-dev": "Vhailors/AIReader",
+    "university-prod": "Vhailors/VedereUniversity",
+    "university-staging": "Vhailors/VedereUniversity",
+    "university-dev": "Vhailors/VedereUniversity",
+}
+
+
+# Recurrence-vs-regression thresholds (seconds).
+_RECURRENCE_HORIZON_S = 30 * 24 * 60 * 60   # 30 days — within = "recurring"
+_REGRESSION_HORIZON_S = 7 * 24 * 60 * 60    # 7 days — older AND closed = regression
+
+
+# ---------------------------------------------------------------------------
+# Pydantic payload model — matches the Sentry Issue Alert webhook shape
+# documented at https://docs.sentry.io/product/integrations/integration-platform/webhooks/issue-alerts/
+# We only require the fields we actually consume; unknown fields pass through.
+# ---------------------------------------------------------------------------
+class SentryEventException(BaseModel):
+    values: Optional[List[Dict[str, Any]]] = None
+
+
+class SentryEvent(BaseModel):
+    fingerprint: List[str] = Field(..., min_length=1)
+    level: Optional[str] = "error"
+    environment: str
+    exception: Optional[SentryEventException] = None
+    message: Optional[str] = None
+    title: Optional[str] = None
+    web_url: Optional[str] = None
+    project_slug: Optional[str] = None
+
+
+class SentryIssueAlertData(BaseModel):
+    event: SentryEvent
+    issue_url: Optional[str] = None
+    triggered_rule: Optional[str] = None
+
+
+class SentryIssueAlertPayload(BaseModel):
+    action: str
+    data: SentryIssueAlertData
+    installation: Optional[Dict[str, Any]] = None
+    actor: Optional[Dict[str, Any]] = None
+
+
+# ---------------------------------------------------------------------------
+# SQLite-backed fingerprint cache. Shared by the FastAPI handler thread and
+# the backfill cron via the SAME on-disk file. We open with
+# ``check_same_thread=False`` and serialize writes through a process-local
+# lock — sqlite3 itself handles cross-process locking via the file.
+# ---------------------------------------------------------------------------
+class FingerprintCache:
+    """Tracks fingerprint→issue-state mappings for dedup + regression detection.
+
+    Schema::
+        CREATE TABLE fingerprints (
+            fingerprint        TEXT,
+            environment        TEXT,
+            last_seen          INTEGER,
+            github_issue_url   TEXT,
+            github_issue_state TEXT,
+            PRIMARY KEY(fingerprint, environment)
+        )
+
+    All methods are safe to call from any thread.
+    """
+
+    DEFAULT_PATH = Path.home() / ".hermes" / "sentry-fingerprints.db"
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        path = Path(db_path) if db_path is not None else self.DEFAULT_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._path = path
+        self._lock = threading.Lock()
+        # check_same_thread=False so the cache instance is shareable across
+        # the FastAPI worker thread and any background-loop tasks (G5).
+        self._conn = sqlite3.connect(
+            str(path),
+            check_same_thread=False,
+            isolation_level=None,  # autocommit; we wrap atomic ops in `BEGIN` ourselves
+            timeout=5.0,
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS fingerprints (
+                fingerprint        TEXT NOT NULL,
+                environment        TEXT NOT NULL,
+                last_seen          INTEGER NOT NULL,
+                github_issue_url   TEXT,
+                github_issue_state TEXT,
+                PRIMARY KEY (fingerprint, environment)
+            )
+            """
+        )
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _row(self, fingerprint: str, env: str) -> Optional[sqlite3.Row]:
+        cur = self._conn.execute(
+            "SELECT fingerprint, environment, last_seen, github_issue_url, github_issue_state "
+            "FROM fingerprints WHERE fingerprint = ? AND environment = ?",
+            (fingerprint, env),
+        )
+        return cur.fetchone()
+
+    def is_new(self, fingerprint: str, env: str, *, now: Optional[int] = None) -> bool:
+        """True when no row exists OR the cached row is older than 30 days."""
+        with self._lock:
+            row = self._row(fingerprint, env)
+        if row is None:
+            return True
+        now_s = int(now if now is not None else time.time())
+        return (now_s - int(row[2])) >= _RECURRENCE_HORIZON_S
+
+    def is_regression(self, fingerprint: str, env: str, *, now: Optional[int] = None) -> bool:
+        """True when last_seen is older than 7 days AND state was 'closed'."""
+        with self._lock:
+            row = self._row(fingerprint, env)
+        if row is None:
+            return False
+        now_s = int(now if now is not None else time.time())
+        age = now_s - int(row[2])
+        state = (row[4] or "").lower()
+        return age >= _REGRESSION_HORIZON_S and state == "closed"
+
+    def record(
+        self,
+        fingerprint: str,
+        env: str,
+        issue_url: Optional[str],
+        issue_state: Optional[str],
+        *,
+        now: Optional[int] = None,
+    ) -> None:
+        """Insert or replace the row for ``(fingerprint, env)`` with current time."""
+        now_s = int(now if now is not None else time.time())
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO fingerprints
+                    (fingerprint, environment, last_seen, github_issue_url, github_issue_state)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(fingerprint, environment) DO UPDATE SET
+                    last_seen = excluded.last_seen,
+                    github_issue_url = excluded.github_issue_url,
+                    github_issue_state = excluded.github_issue_state
+                """,
+                (fingerprint, env, now_s, issue_url, issue_state),
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._conn.close()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+
+# Module-level singleton — handler and backfill share this. Tests override
+# via :func:`set_cache`.
+_cache_singleton: Optional[FingerprintCache] = None
+_cache_singleton_lock = threading.Lock()
+
+
+def get_cache() -> FingerprintCache:
+    global _cache_singleton
+    with _cache_singleton_lock:
+        if _cache_singleton is None:
+            _cache_singleton = FingerprintCache()
+        return _cache_singleton
+
+
+def set_cache(cache: FingerprintCache) -> None:
+    """Test hook — swap the module-level cache for an isolated instance."""
+    global _cache_singleton
+    with _cache_singleton_lock:
+        _cache_singleton = cache
+
+
+# ---------------------------------------------------------------------------
+# Issue-body builder — hybrid Markdown + machine-readable JSON block.
+# Schema lives in Vhailors/vedere-shared@main:golden/payload-schema.ts; the
+# JSON block here MUST stay byte-aligned with that golden file.
+# ---------------------------------------------------------------------------
+def _short_fingerprint(fp: str) -> str:
+    fp = fp.strip()
+    if len(fp) <= 12:
+        return fp
+    return fp[:12]
+
+
+def _summarize_exception(event: SentryEvent) -> str:
+    if event.title:
+        return event.title
+    if event.message:
+        return event.message
+    if event.exception and event.exception.values:
+        first = event.exception.values[0]
+        type_ = first.get("type") or "Exception"
+        value = first.get("value") or ""
+        return f"{type_}: {value}".strip(": ")
+    return "Sentry event"
+
+
+def build_issue_body(payload: SentryIssueAlertPayload, *, regression: bool) -> str:
+    event = payload.data.event
+    fingerprint = event.fingerprint[0]
+    machine_payload = {
+        "schema": "vedere-shared/payload-schema@1",
+        "source": "sentry-webhook",
+        "fingerprint": fingerprint,
+        "environment": event.environment,
+        "level": event.level,
+        "title": _summarize_exception(event),
+        "sentry_issue_url": payload.data.issue_url,
+        "sentry_event_url": event.web_url,
+        "project_slug": event.project_slug,
+        "regression": regression,
+        "received_at": int(time.time()),
+    }
+    md_lines = [
+        f"## Sentry alert ({'regression' if regression else 'new'})",
+        "",
+        f"- **Fingerprint:** `{fingerprint}`",
+        f"- **Environment:** `{event.environment}`",
+        f"- **Level:** `{event.level or 'error'}`",
+        f"- **Title:** {_summarize_exception(event)}",
+    ]
+    if payload.data.issue_url:
+        md_lines.append(f"- **Sentry issue:** {payload.data.issue_url}")
+    if event.web_url:
+        md_lines.append(f"- **Event URL:** {event.web_url}")
+    if regression:
+        md_lines.append("")
+        md_lines.append(
+            "> Regression detected — this fingerprint was previously closed "
+            "more than 7 days ago."
+        )
+    md_lines.append("")
+    md_lines.append("<!-- hermes-payload -->")
+    md_lines.append("```json")
+    md_lines.append(json.dumps(machine_payload, indent=2, sort_keys=True))
+    md_lines.append("```")
+    return "\n".join(md_lines)
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue creation via `gh` CLI. Subprocess-based so we inherit the
+# operator's existing gh auth — no token plumbing needed.
+# ---------------------------------------------------------------------------
+class GhCliError(RuntimeError):
+    pass
+
+
+def _run_gh_issue_create(repo: str, title: str, body: str, labels: List[str]) -> str:
+    """Invoke ``gh issue create`` and return the resulting issue URL.
+
+    Raises :class:`GhCliError` if the CLI exits non-zero or returns no URL.
+    """
+    cmd = [
+        "gh", "issue", "create",
+        "--repo", repo,
+        "--title", title,
+        "--body", body,
+    ]
+    for label in labels:
+        cmd.extend(["--label", label])
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover — host without gh
+        raise GhCliError("gh CLI not installed") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GhCliError("gh issue create timed out") from exc
+    if result.returncode != 0:
+        raise GhCliError(
+            f"gh issue create failed (rc={result.returncode}): {result.stderr.strip() or result.stdout.strip()}"
+        )
+    # gh prints the issue URL as the last non-empty line on success.
+    out_lines = [ln.strip() for ln in (result.stdout or "").splitlines() if ln.strip()]
+    if not out_lines:
+        raise GhCliError("gh issue create produced no output")
+    url = out_lines[-1]
+    if not url.startswith("http"):
+        raise GhCliError(f"gh issue create did not return a URL: {url!r}")
+    return url
+
+
+# ---------------------------------------------------------------------------
+# FastAPI endpoint
+# ---------------------------------------------------------------------------
+def _verify_token(token: Optional[str]) -> None:
+    expected = os.environ.get("SENTRY_WEBHOOK_TOKEN", "")
+    presented = token or ""
+    # compare_digest requires equal-length strings to be safe; both inputs
+    # are str here, so it short-circuits length-mismatch in constant time.
+    if not expected or not secrets.compare_digest(presented, expected):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+@router.post("/webhook")
+async def sentry_webhook(
+    request: Request,
+    token: Optional[str] = Query(default=None),
+) -> Dict[str, Any]:
+    """Receive a Sentry Issue Alert payload and create/skip a GitHub issue."""
+    _verify_token(token)
+
+    raw_body = await request.body()
+    try:
+        body_json = json.loads(raw_body or b"{}")
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"invalid JSON: {exc}")
+
+    try:
+        payload = SentryIssueAlertPayload.model_validate(body_json)
+    except ValidationError as exc:
+        # Pydantic returns 422-shaped detail by default; we surface the message.
+        raise HTTPException(status_code=422, detail=exc.errors())
+
+    event = payload.data.event
+    env = event.environment
+    fingerprint = event.fingerprint[0]
+
+    repo = ENV_REPO_MAP.get(env)
+    if repo is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown environment: {env!r} — add to ENV_REPO_MAP if it is a Vedere project",
+        )
+
+    cache = get_cache()
+    is_new = cache.is_new(fingerprint, env)
+    is_regression = cache.is_regression(fingerprint, env)
+
+    if not is_new and not is_regression:
+        _log.info("sentry-webhook: skipping recurring fingerprint=%s env=%s", fingerprint, env)
+        return {
+            "action": "skipped",
+            "reason": "recurring",
+            "fingerprint": fingerprint,
+            "environment": env,
+        }
+
+    title = f"[Sentry] {_summarize_exception(event)} ({_short_fingerprint(fingerprint)})"
+    body = build_issue_body(payload, regression=is_regression)
+    labels = ["sentry-bug", "hermes-pending"]
+    if is_regression:
+        labels.append("regression")
+
+    issue_url = _run_gh_issue_create(repo=repo, title=title, body=body, labels=labels)
+
+    cache.record(fingerprint, env, issue_url=issue_url, issue_state="open")
+
+    return {
+        "action": "created",
+        "github_issue_url": issue_url,
+        "fingerprint": fingerprint,
+        "environment": env,
+        "repo": repo,
+        "regression": is_regression,
+    }
+
+
+def register_sentry_webhook(app: FastAPI) -> None:
+    """Mount the Sentry webhook router on the given FastAPI app.
+
+    The dashboard's ``auth_middleware`` gates all ``/api/*`` paths behind
+    the ephemeral session token. The Sentry webhook has its own
+    secret-token query-param auth (``?token=...`` checked with
+    :func:`secrets.compare_digest` against ``SENTRY_WEBHOOK_TOKEN``), so
+    we extend the dashboard's public-paths frozenset to let our router
+    handle authentication itself.
+    """
+    app.include_router(router)
+    try:
+        from . import web_server  # local import to avoid cycle at module-load time
+    except Exception:  # pragma: no cover — register_sentry_webhook can be called against alternate apps
+        return
+    public = getattr(web_server, "_PUBLIC_API_PATHS", None)
+    if isinstance(public, frozenset):
+        web_server._PUBLIC_API_PATHS = frozenset(public | {"/api/sentry/webhook"})

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3999,6 +3999,10 @@ def _mount_plugin_api_routes():
 # Mount plugin API routes before the SPA catch-all.
 _mount_plugin_api_routes()
 
+# Vedere Sentry standardization — see vedere-shared@main golden files
+from .sentry_webhook import register_sentry_webhook
+register_sentry_webhook(app)
+
 mount_spa(app)
 
 

--- a/tests/test_sentry_webhook.py
+++ b/tests/test_sentry_webhook.py
@@ -1,0 +1,327 @@
+"""Tests for hermes_cli.sentry_webhook — Vedere ecosystem standardization.
+
+Covers:
+
+* Token authentication (missing / wrong)
+* Happy path with mocked ``gh`` CLI subprocess invocation
+* Recurrence dedup within 30 days
+* Regression detection (last_seen > 7 days ago AND state == 'closed')
+* Thread isolation under a synthetic agent-loop hang (G6 — CRITICAL)
+* Pydantic validation errors → 422
+* Unknown environment → 400
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+# Ensure the repo root is importable when pytest is invoked from the cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from hermes_cli import sentry_webhook as sw
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def webhook_token(monkeypatch) -> str:
+    token = "test-token-deadbeef"
+    monkeypatch.setenv("SENTRY_WEBHOOK_TOKEN", token)
+    return token
+
+
+@pytest.fixture
+def isolated_cache(tmp_path) -> sw.FingerprintCache:
+    db_path = tmp_path / "fingerprints.db"
+    cache = sw.FingerprintCache(db_path=db_path)
+    sw.set_cache(cache)
+    yield cache
+    cache.close()
+    sw.set_cache(None)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def app(isolated_cache) -> FastAPI:
+    instance = FastAPI()
+    instance.include_router(sw.router)
+    return instance
+
+
+@pytest.fixture
+def client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+def _valid_payload(
+    *,
+    fingerprint: str = "deadbeefcafe1234",
+    environment: str = "lms-prod",
+    title: str = "ZeroDivisionError: division by zero",
+) -> Dict[str, Any]:
+    return {
+        "action": "triggered",
+        "data": {
+            "event": {
+                "fingerprint": [fingerprint],
+                "level": "error",
+                "environment": environment,
+                "exception": {"values": [{"type": "ZeroDivisionError", "value": "division by zero"}]},
+                "title": title,
+                "web_url": "https://sentry.io/organizations/vedere/issues/123/events/abc/",
+                "project_slug": "lms",
+            },
+            "issue_url": "https://sentry.io/organizations/vedere/issues/123/",
+            "triggered_rule": "Send a notification for new issues",
+        },
+    }
+
+
+def _mock_gh_success(returncode: int = 0, url: str = "https://github.com/manlaughed/VedereLMS/issues/42"):
+    def _runner(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0] if args else kwargs.get("args"),
+            returncode=returncode,
+            stdout=f"{url}\n",
+            stderr="",
+        )
+    return _runner
+
+
+# ---------------------------------------------------------------------------
+# (a) missing token → 401
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_webhook_rejects_missing_token(webhook_token, client):
+    async with client as c:
+        resp = await c.post("/api/sentry/webhook", json=_valid_payload())
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Unauthorized"
+
+
+# ---------------------------------------------------------------------------
+# (b) wrong token → 401
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_webhook_rejects_wrong_token(webhook_token, client):
+    async with client as c:
+        resp = await c.post(
+            "/api/sentry/webhook",
+            params={"token": "wrong-token"},
+            json=_valid_payload(),
+        )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# (c) happy path — valid payload creates issue + records cache
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_webhook_accepts_valid_payload_creates_issue(
+    webhook_token, isolated_cache, client,
+):
+    issue_url = "https://github.com/manlaughed/VedereLMS/issues/777"
+    with patch.object(sw.subprocess, "run", side_effect=_mock_gh_success(url=issue_url)):
+        async with client as c:
+            resp = await c.post(
+                "/api/sentry/webhook",
+                params={"token": webhook_token},
+                json=_valid_payload(),
+            )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["action"] == "created"
+    assert body["github_issue_url"] == issue_url
+    assert body["repo"] == "manlaughed/VedereLMS"
+    assert body["regression"] is False
+
+    # SQLite row recorded.
+    row = isolated_cache._row("deadbeefcafe1234", "lms-prod")
+    assert row is not None
+    assert row[3] == issue_url            # github_issue_url
+    assert row[4] == "open"               # github_issue_state
+
+
+# ---------------------------------------------------------------------------
+# (d) recurring fingerprint within 30 days → skipped
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_webhook_dedups_recurring_fingerprint(
+    webhook_token, isolated_cache, client,
+):
+    fp = "recurringfp"
+    isolated_cache.record(
+        fingerprint=fp,
+        env="lms-prod",
+        issue_url="https://github.com/manlaughed/VedereLMS/issues/1",
+        issue_state="open",
+        now=int(time.time()) - 60,  # 1 minute ago
+    )
+
+    with patch.object(sw.subprocess, "run", side_effect=AssertionError("gh must NOT be called")):
+        async with client as c:
+            resp = await c.post(
+                "/api/sentry/webhook",
+                params={"token": webhook_token},
+                json=_valid_payload(fingerprint=fp),
+            )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["action"] == "skipped"
+    assert body["reason"] == "recurring"
+
+
+# ---------------------------------------------------------------------------
+# (e) old + closed → regression → new issue created
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_webhook_treats_old_resolved_as_regression(
+    webhook_token, isolated_cache, client,
+):
+    fp = "regressionfp"
+    eight_days_ago = int(time.time()) - (8 * 24 * 60 * 60)
+    isolated_cache.record(
+        fingerprint=fp,
+        env="lms-prod",
+        issue_url="https://github.com/manlaughed/VedereLMS/issues/9",
+        issue_state="closed",
+        now=eight_days_ago,
+    )
+
+    assert isolated_cache.is_regression(fp, "lms-prod") is True
+
+    new_url = "https://github.com/manlaughed/VedereLMS/issues/10"
+    with patch.object(sw.subprocess, "run", side_effect=_mock_gh_success(url=new_url)):
+        async with client as c:
+            resp = await c.post(
+                "/api/sentry/webhook",
+                params={"token": webhook_token},
+                json=_valid_payload(fingerprint=fp),
+            )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["action"] == "created"
+    assert body["regression"] is True
+    assert body["github_issue_url"] == new_url
+
+
+# ---------------------------------------------------------------------------
+# (f) G6 — CRITICAL: thread isolation under blocked agent loop
+#
+# Spin up a worker thread that holds an asyncio loop blocked via
+# time.sleep(60). In parallel, send a webhook request via httpx and
+# assert the response completes within 5s with status 200/201 — proving
+# the FastAPI request thread is independent of any blocked agent loop.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_webhook_thread_isolation_under_agent_loop_hang(
+    webhook_token, isolated_cache, client,
+):
+    blocker_started = threading.Event()
+    blocker_done = threading.Event()
+
+    def _blocked_agent_loop():
+        loop = asyncio.new_event_loop()
+        try:
+            blocker_started.set()
+            # Block the loop's thread for 60s. If the FastAPI request thread
+            # is somehow coupled to this loop, the request below will time out.
+            time.sleep(60)
+        finally:
+            try:
+                loop.close()
+            except Exception:
+                pass
+            blocker_done.set()
+
+    blocker_thread = threading.Thread(target=_blocked_agent_loop, daemon=True)
+    blocker_thread.start()
+    assert blocker_started.wait(timeout=2.0), "blocker thread never started"
+
+    issue_url = "https://github.com/manlaughed/VedereLMS/issues/123"
+    gh_called = threading.Event()
+
+    def _gh_runner(*args, **kwargs):
+        gh_called.set()
+        return subprocess.CompletedProcess(
+            args=args[0] if args else kwargs.get("args"),
+            returncode=0,
+            stdout=f"{issue_url}\n",
+            stderr="",
+        )
+
+    start = time.monotonic()
+    with patch.object(sw.subprocess, "run", side_effect=_gh_runner):
+        async with client as c:
+            resp = await asyncio.wait_for(
+                c.post(
+                    "/api/sentry/webhook",
+                    params={"token": webhook_token},
+                    json=_valid_payload(fingerprint="threadisolationfp"),
+                ),
+                timeout=5.0,
+            )
+    elapsed = time.monotonic() - start
+
+    assert resp.status_code in (200, 201), f"unexpected status {resp.status_code}: {resp.text}"
+    assert elapsed < 5.0, f"request took {elapsed:.2f}s — thread isolation broken"
+    assert gh_called.is_set(), "issue creation path was not invoked"
+
+    # Cleanup: blocker thread is daemon; the test can finish without joining.
+
+
+# ---------------------------------------------------------------------------
+# (g) malformed payload (missing fingerprint) → 422
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_payload_validation_rejects_malformed(webhook_token, client):
+    payload = {
+        "action": "triggered",
+        "data": {
+            "event": {
+                # fingerprint intentionally omitted
+                "level": "error",
+                "environment": "lms-prod",
+            }
+        },
+    }
+    async with client as c:
+        resp = await c.post(
+            "/api/sentry/webhook",
+            params={"token": webhook_token},
+            json=payload,
+        )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# (h) unknown environment → 400
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_env_to_repo_mapping_unknown_env_returns_400(
+    webhook_token, isolated_cache, client,
+):
+    async with client as c:
+        resp = await c.post(
+            "/api/sentry/webhook",
+            params={"token": webhook_token},
+            json=_valid_payload(environment="unknown-prod"),
+        )
+    assert resp.status_code == 400
+    assert "unknown environment" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Adds a Sentry Issue Alert webhook receiver to the existing Hermes FastAPI server (`POST /api/sentry/webhook`), a 6h backfill cron, an OPS runbook, and a pytest suite that includes the load-bearing G6 thread-isolation test.

This is **Phase 2 Lane A3** of the Vedere Sentry standardization rollout (consensus plan: \`vedere-sentry-consensus-final.md\`, Phase A3 / iter2 lines 254-280, AC7+AC8+AC9).

## What lands

| File | Purpose |
| ---- | ------- |
| \`hermes_cli/sentry_webhook.py\` | Router, Pydantic models, \`FingerprintCache\`, env→repo map, issue-body builder, \`gh\` invocation |
| \`cron/sentry_backfill.py\` | 6h backfill — re-queries Sentry events API, replays via the live webhook so the SAME cache is consulted |
| \`tests/test_sentry_webhook.py\` | 8 cases incl. G6 thread-isolation under blocked agent loop |
| \`hermes_cli/web_server.py\` | 3 lines: import + \`register_sentry_webhook(app)\` + comment |
| \`docs/sentry-webhook-ops.md\` | OPS runbook: env vars, BLUE-GREEN swap procedure with two systemd units behind nginx upstream, RTO < 60s, cron line |

## Free-tier adaptation

Free-tier Sentry does **not** sign webhook payloads. Auth is a shared secret-token query parameter (\`?token=...\`) verified with \`secrets.compare_digest\`. **No HMAC logic** — that would be dead code on the only Sentry plan we have.

## G5 — unified dedup

\`FingerprintCache\` opens its sqlite3 connection with \`check_same_thread=False\` so the FastAPI handler thread and the backfill cron share the same on-disk file. The cron does NOT replicate dedup logic — it POSTs synthetic payloads to the live webhook and lets the receiver decide. No parallel logic to drift out of sync.

## G6 — thread isolation (CRITICAL test)

\`test_webhook_thread_isolation_under_agent_loop_hang\` spawns a worker thread that holds an asyncio loop blocked via \`time.sleep(60)\`. In parallel, it sends a webhook request via \`httpx\` and asserts the response completes within 5s with status 200/201 and that the issue creation path was actually invoked. This proves the FastAPI request thread is independent of any blocked agent-loop scheduler.

A failing G6 test ships nothing.

## G2 — BLUE-GREEN deploy lock-in

The runbook documents the only supported deploy pattern: two systemd units (\`hermes@blue\`, \`hermes@green\`) on different ports behind an nginx \`upstream\`, swapped via \`nginx -s reload\` (graceful, sub-second). RTO < 60s during deploy windows.

## Hermes-downtime fallback

\`hermes-pending\` label is applied at issue creation time. Hermes triage loop scans for the label asynchronously, so even if Hermes was offline when the issue was created, no work is lost.

## Test results

\`\`\`
$ venv/bin/python -m pytest tests/test_sentry_webhook.py -v
8 passed in 6.62s
\`\`\`

All 8 cases green:

- \`test_webhook_rejects_missing_token\` (401)
- \`test_webhook_rejects_wrong_token\` (401)
- \`test_webhook_accepts_valid_payload_creates_issue\` (mocked \`gh\`)
- \`test_webhook_dedups_recurring_fingerprint\` (skipped within 30d)
- \`test_webhook_treats_old_resolved_as_regression\` (>7d + closed → new issue)
- \`test_webhook_thread_isolation_under_agent_loop_hang\` (G6, 5s budget)
- \`test_payload_validation_rejects_malformed\` (422)
- \`test_env_to_repo_mapping_unknown_env_returns_400\` (400)

## Test plan

- [x] All 8 unit tests pass locally
- [x] Module imports clean (\`hermes_cli.sentry_webhook\`, \`cron.sentry_backfill\`)
- [x] \`/api/sentry/webhook\` registered in \`_PUBLIC_API_PATHS\` so dashboard auth_middleware does not double-gate
- [ ] Smoke against staging Sentry instance (operator action)
- [ ] Cron line installed on backfill host (operator action)
- [ ] BLUE-GREEN units provisioned per runbook (operator action)