### PR TITLE
fix(discord): trigger auto-TTS in voice-linked text channels

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3832,6 +3832,10 @@ class DiscordAdapter(BasePlatformAdapter):
                             msg_type = MessageType.DOCUMENT
                     break
 
+        # Voice-linked channels: treat as VOICE so auto-TTS triggers in base.py.
+        if is_voice_linked_channel and msg_type == MessageType.TEXT:
+            msg_type = MessageType.VOICE
+
         # When auto-threading kicked in, route responses to the new thread
         effective_channel = auto_threaded_channel or message.channel
 

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -718,3 +718,77 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+def _make_discord_message(*, channel_id=123, content="hello", mentions=None):
+    channel = SimpleNamespace(
+        id=channel_id,
+        name=f"chan-{channel_id}",
+        guild=SimpleNamespace(id=456, name="Test Guild"),
+        topic=None,
+    )
+    return SimpleNamespace(
+        id=789,
+        content=content,
+        channel=channel,
+        guild=channel.guild,
+        author=SimpleNamespace(id=111, name="Alice", display_name="Alice", bot=False),
+        mentions=mentions or [],
+        attachments=[],
+        reference=None,
+        created_at=None,
+        type=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_message_marks_voice_linked_text_channel_as_voice(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    bot_user = SimpleNamespace(id=999, name="Hermes")
+    adapter._client = SimpleNamespace(user=bot_user)
+    adapter._voice_text_channels = {"voice-channel": "123"}
+    adapter._text_batch_delay_seconds = 0
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "*")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["event"] = event
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+    message = _make_discord_message(channel_id=123, content="hello from voice text")
+    await adapter._handle_message(message)
+
+    assert captured["event"].message_type == discord_platform.MessageType.VOICE
+
+
+@pytest.mark.asyncio
+async def test_handle_message_keeps_non_voice_linked_text_channel_as_text(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    bot_user = SimpleNamespace(id=999, name="Hermes")
+    adapter._client = SimpleNamespace(user=bot_user)
+    adapter._voice_text_channels = {"voice-channel": "123"}
+    adapter._text_batch_delay_seconds = 0
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "*")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["event"] = event
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+    message = _make_discord_message(
+        channel_id=124,
+        content="<@999> hello from regular text",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    assert captured["event"].message_type == discord_platform.MessageType.TEXT


### PR DESCRIPTION
## Summary
- Treat plain text messages in Discord voice-linked text channels as `MessageType.VOICE` so auto-TTS reply playback can trigger.
- Preserve existing behavior for non voice-linked text channels and non-text message types.
- Add regression coverage for both voice-linked and regular text channels.

## Reproduction
1. Use `/voice channel` to join a Discord voice channel.
2. Set `/voice mode all`.
3. Send a text message in the bound text channel.
4. The bot replies with text, but no TTS generation/playback path runs.

## Root cause
`_handle_message()` classified messages from the voice-linked text channel as `MessageType.TEXT`. The base platform auto-TTS branch only runs for `MessageType.VOICE`, so `_should_send_voice_reply()` never allowed voice playback for this path.

## Test Plan
- `python -m pytest tests/gateway/test_discord_connect.py -q`
- `python -m py_compile gateway/platforms/discord.py tests/gateway/test_discord_connect.py`
