### PR TITLE
test(kanban): assert metadata handoff round-trip

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -133,6 +133,32 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_metadata_round_trips_through_show(worker_env):
+    """Structured completion metadata should be visible to downstream agents."""
+    from tools import kanban_tools as kt
+
+    handoff = {
+        "changed_files": ["hermes_cli/kanban.py"],
+        "verification": ["pytest tests/tools/test_kanban_tools.py -q"],
+        "dependencies": [],
+        "blocked_reason": None,
+        "retry_notes": "none",
+        "residual_risk": ["dashboard rendering not exercised"],
+    }
+
+    complete_out = kt._handle_complete({
+        "summary": "finished with structured evidence",
+        "metadata": handoff,
+    })
+    assert json.loads(complete_out)["ok"] is True
+
+    show_out = kt._handle_show({"task_id": worker_env})
+    shown = json.loads(show_out)
+    assert shown["task"]["status"] == "done"
+    assert shown["runs"][-1]["summary"] == "finished with structured evidence"
+    assert shown["runs"][-1]["metadata"] == handoff
+
+
 def test_complete_with_result_only(worker_env):
     """`result` alone (without summary) is accepted for legacy compat."""
     from tools import kanban_tools as kt
@@ -468,7 +494,7 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     )
     prompt = a._build_system_prompt()
     # Header phrase
-    assert "You are a Kanban worker" in prompt
+    assert "# Kanban task execution protocol" in prompt
     # Lifecycle signals
     assert "kanban_show()" in prompt
     assert "kanban_complete" in prompt


### PR DESCRIPTION
## What does this PR do?

Adds a focused Kanban tool test proving that structured completion metadata written through `kanban_complete(...)` is visible again through `kanban_show(...)`.

This supports the existing Kanban handoff model: `summary` stays human-readable, while `metadata` remains machine-readable for downstream workers, reviewers, or dashboards.

This PR also updates one stale worker-prompt assertion in the same test file from the old header text to the current `# Kanban task execution protocol` header so the focused Kanban tool test file passes locally.

## Related Issue

No issue yet; this is a test-only clarification for existing Kanban behavior.

Follow-up to the docs convention proposed in #19512, but this PR does not depend on that PR.

## Type of Change

- [x] Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_kanban_tools.py`
  - Adds `test_complete_metadata_round_trips_through_show`.
  - Completes a worker task with a structured evidence-style metadata object.
  - Reads the task back through `kanban_show` and asserts the latest run preserves both `summary` and `metadata`.
  - Aligns the worker guidance prompt assertion with the current `KANBAN_GUIDANCE` header.

## Evidence Checked

- Existing code already stores completion metadata on `task_runs`.
- Existing `kanban_show` response already includes `runs[].metadata`.
- Branch refreshed onto latest `main`.
- Branch compare: 1 commit, 1 modified file, +27/-1.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_kanban_tools.py -q`
2. Confirm the new test fails if `kanban_show` stops returning `runs[].metadata`.

Local validation performed:

```text
scripts/run_tests.sh tests/tools/test_kanban_tools.py -q
32 passed, 4 warnings in 18.88s
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open PRs for duplicate Kanban metadata round-trip test work.
- [x] My PR contains only changes related to this Kanban test file.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [x] I've run the focused Kanban tool test file.
- [x] I've added tests for my changes.
- [x] Tested on my platform: macOS, focused pytest via `scripts/run_tests.sh`.

### Documentation & Housekeeping

- [x] N/A: docs are covered separately in #19512.
- [x] N/A: no config keys changed.
- [x] N/A: no architecture or workflow files changed.
- [x] N/A: no runtime cross-platform behavior changed.
- [x] N/A: no tool behavior changed.

## Non-goals

- No runtime behavior change.
- No schema migration.
- No dashboard rendering change.
- No mandatory metadata validation.

## Residual Risk

Full `pytest tests/ -q` was not run locally. The focused Kanban tool file passes, and this PR only changes that one test file.
