### PR TITLE
feat: Skill Evaluation Gate — universal skill loading (no keywords)

### DIFF
--- a/agent/skill_eval_gate.py
+++ b/agent/skill_eval_gate.py
@@ -1,0 +1,70 @@
+"""
+Skill Evaluation Gate — forces the agent to evaluate and load relevant skills
+before taking any action.
+
+This is a code-level enforcement mechanism. It does NOT use keyword matching.
+The agent sees all skill names and descriptions in the system prompt (via
+build_skills_system_prompt), and uses its own semantic understanding to decide
+which skills are relevant.
+
+Enforcement:
+  - Before the first action tool call, the agent MUST call skill_view() for
+    at least one relevant skill, OR explicitly acknowledge no skills are needed.
+  - If the agent skips this step, the tool call is blocked with a reminder.
+  - After skill_view() is called once, the gate opens and all tools proceed.
+
+This replaces the keyword-based auto_inject approach with a universal,
+language-agnostic mechanism that works for any task in any language.
+"""
+from __future__ import annotations
+import logging
+
+logger = logging.getLogger(__name__)
+
+# The mandatory instruction injected into the system prompt.
+SKILL_EVAL_INSTRUCTION = """## Mandatory Skill Evaluation
+
+Before your FIRST action (any tool call beyond read-only tools like read_file,
+search_files, browser_snapshot, or hindsight_recall), you MUST:
+
+1. Review the skill index in your system prompt (listed above)
+2. Call `skill_view()` for any skills whose description matches the user's task
+3. If no skills match, proceed without loading — but you MUST have considered them
+
+This is code-enforced. Skipping this step will cause your tool calls to be blocked.
+The skill index contains names and descriptions — use your understanding of the
+user's task to determine relevance. This applies to ALL languages and task types."""
+
+# Tools that are allowed before skill evaluation (read-only / info tools)
+_READ_ONLY_TOOLS = frozenset({
+    "read_file",
+    "search_files",
+    "browser_snapshot",
+    "browser_get_images",
+    "browser_console",
+    "hindsight_recall",
+    "hindsight_reflect",
+    "session_search",
+    "skills_list",
+    "skill_view",       # Allow skill_view itself (this is what we want!)
+    "clarify",          # Asking user a question is always OK
+    "todo",             # Planning is OK
+    "memory",           # Memory read is OK
+    "send_message",     # Messaging is OK (for gateway)
+    "cronjob",          # Cron management is OK
+})
+
+
+def get_skill_eval_instruction() -> str:
+    """Return the mandatory instruction to inject into system prompt."""
+    return SKILL_EVAL_INSTRUCTION
+
+
+def should_block_tool(tool_name: str) -> bool:
+    """Check if a tool should be blocked pending skill evaluation."""
+    return tool_name not in _READ_ONLY_TOOLS
+
+
+def is_skill_view_call(tool_name: str) -> bool:
+    """Check if this tool call satisfies the skill evaluation requirement."""
+    return tool_name == "skill_view"

--- a/run_agent.py
+++ b/run_agent.py
@@ -1702,6 +1702,7 @@ class AIAgent:
         self._memory_nudge_interval = 10
         self._turns_since_memory = 0
         self._iters_since_skill = 0
+        self._skill_eval_done = False   # Skill Evaluation Gate: set True after first skill_view
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -4989,6 +4990,12 @@ class AIAgent:
             skills_prompt = ""
         if skills_prompt:
             prompt_parts.append(skills_prompt)
+            # Skill Evaluation Gate: inject mandatory instruction after skill index
+            try:
+                from agent.skill_eval_gate import get_skill_eval_instruction
+                prompt_parts.append(get_skill_eval_instruction())
+            except ImportError:
+                pass
 
         if not self.skip_context_files:
             # Use TERMINAL_CWD for context file discovery when set (gateway
@@ -9306,6 +9313,21 @@ class AIAgent:
                 )
             except Exception:
                 pass
+        # Skill Evaluation Gate: mark skill_view calls, block non-read tools
+        if block_message is None:
+            try:
+                from agent.skill_eval_gate import should_block_tool, is_skill_view_call
+                if is_skill_view_call(function_name):
+                    self._skill_eval_done = True
+                elif not self._skill_eval_done and should_block_tool(function_name):
+                    block_message = (
+                        "SKILL EVALUATION REQUIRED: Before executing this tool, you MUST "
+                        "evaluate the skill index in your system prompt and call skill_view() "
+                        "for any skills relevant to this task. If no skills match, call "
+                        "skill_view(name='hermes-agent') as a minimal acknowledgment and proceed."
+                    )
+            except ImportError:
+                pass
         if block_message is not None:
             return json.dumps({"error": block_message}, ensure_ascii=False)
 
@@ -9815,6 +9837,22 @@ class AIAgent:
                 )
             except Exception:
                 pass
+
+            # Skill Evaluation Gate: mark skill_view calls, block non-read tools
+            if _block_msg is None:
+                try:
+                    from agent.skill_eval_gate import should_block_tool, is_skill_view_call
+                    if is_skill_view_call(function_name):
+                        self._skill_eval_done = True
+                    elif not self._skill_eval_done and should_block_tool(function_name):
+                        _block_msg = (
+                            "SKILL EVALUATION REQUIRED: Before executing this tool, you MUST "
+                            "evaluate the skill index in your system prompt and call skill_view() "
+                            "for any skills relevant to this task. If no skills match, call "
+                            "skill_view(name='hermes-agent') as a minimal acknowledgment and proceed."
+                        )
+                except ImportError:
+                    pass
 
             _guardrail_block_decision: ToolGuardrailDecision | None = None
             if _block_msg is None:
@@ -10482,6 +10520,9 @@ class AIAgent:
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
         self.iteration_budget = IterationBudget(self.max_iterations)
+        # Skill Evaluation Gate: reset per conversation so each new conversation
+        # requires skill evaluation (unlike nudge counters that persist).
+        self._skill_eval_done = False
 
         # Log conversation turn start for debugging/observability
         _preview_text = _summarize_user_message_for_log(user_message)


### PR DESCRIPTION
Closing — all changes merged into PR #18316 (feature/semantic-skill-retrieval). The Skill Evaluation Gate is now part of the unified solution with FTS5 + hybrid selector + gate enforcement.