### PR TITLE
fix(package): include TUI runtime assets in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 graft skills
 graft optional-skills
+graft ui-tui
+graft scripts
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,10 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_manifest_includes_tui_runtime_assets():
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "graft ui-tui" in manifest
+    assert "graft scripts" in manifest


### PR DESCRIPTION
Fixes #19514.

## Summary
- add `ui-tui/` to MANIFEST.in so packaged installs include the TUI runtime tree
- add `scripts/` to MANIFEST.in so the Node bootstrap helper referenced by the TUI launcher is included
- cover both manifest entries in packaging metadata tests

## Verification
- scripts/run_tests.sh tests/test_packaging_metadata.py
- git diff --check