### PR TITLE
feat(cli): add picker_mode config to restrict model picker

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -40,6 +40,16 @@ model:
   #
   # Can also be overridden with --provider flag or HERMES_INFERENCE_PROVIDER env var.
   provider: "auto"
+
+  # Model picker scope — controls which providers appear in `hermes model` picker.
+  #   "all"         — show all providers Hermes can detect via env vars, auth store,
+  #                    or credential pool (default). Discovery-oriented: shows providers
+  #                    you could switch to even if not yet explicitly configured.
+  #   "configured"  — only show providers that are explicitly configured (added via
+  #                    `hermes auth add` or present in auth.json credential pool).
+  #                    Use this to keep the picker focused on only the providers
+  #                    you have intentionally set up, hiding ambient detections.
+  # picker_mode: "all"
   
   # API configuration (falls back to OPENROUTER_API_KEY env var)
   # api_key: "your-key-here"  # Uncomment to set here instead of .env

--- a/cli.py
+++ b/cli.py
@@ -5636,6 +5636,12 @@ class HermesCLI:
             provider_display = get_label(self.provider) if self.provider else "unknown"
 
             try:
+                # Respect picker_mode: "configured" means only show providers that
+                # are explicitly configured (in auth.json / credential pool), not
+                # ambient env-var detections. "all" (default) shows everything.
+                model_cfg = cfg.get("model", {}) if cfg else {}
+                picker_mode = str(model_cfg.get("picker_mode", "all")).strip().lower()
+                configured_only = picker_mode == "configured"
                 providers = list_authenticated_providers(
                     current_provider=self.provider or "",
                     current_base_url=self.base_url or "",
@@ -5643,6 +5649,7 @@ class HermesCLI:
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=50,
+                    configured_only=configured_only,
                 )
             except Exception:
                 providers = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7454,6 +7454,8 @@ class GatewayRunner:
 
             if has_picker:
                 try:
+                    picker_mode = str(model_cfg.get("picker_mode", "all")).strip().lower()
+                    configured_only = picker_mode == "configured"
                     providers = list_authenticated_providers(
                         current_provider=current_provider,
                         current_base_url=current_base_url,
@@ -7461,6 +7463,7 @@ class GatewayRunner:
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
+                        configured_only=configured_only,
                     )
                 except Exception:
                     providers = []
@@ -7587,6 +7590,8 @@ class GatewayRunner:
             lines = [f"Current: `{current_model or 'unknown'}` on {provider_label}", ""]
 
             try:
+                picker_mode = str(model_cfg.get("picker_mode", "all")).strip().lower()
+                configured_only = picker_mode == "configured"
                 providers = list_authenticated_providers(
                     current_provider=current_provider,
                     current_base_url=current_base_url,
@@ -7594,6 +7599,7 @@ class GatewayRunner:
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=5,
+                    configured_only=configured_only,
                 )
                 for p in providers:
                     tag = " (current)" if p["is_current"] else ""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2092,6 +2092,7 @@ def _aux_select_for_task(task: str) -> None:
             current_provider=current_provider,
             current_model=current_model,
             current_base_url=current_base_url,
+            configured_only=True,  # aux picker: only explicitly configured
         )
     except Exception as exc:
         print(f"Could not detect authenticated providers: {exc}")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -992,6 +992,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
+    configured_only: bool = False,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1009,6 +1010,12 @@ def list_authenticated_providers(
       - source: str — "built-in", "models.dev", "user-config"
 
     Only includes providers that have API keys set or are user-defined endpoints.
+
+    When *configured_only* is True, providers are only included if they have
+    credentials stored in the auth store / credential pool.  Environment-variable
+    detection (``os.environ.get``) is skipped so that ambient detections of
+    potentially invalid keys do not pollute the picker.  User-defined providers
+    (from ``providers:`` and ``custom_providers:`` in config) are always shown.
     """
     import os
     from agent.models_dev import (
@@ -1163,8 +1170,12 @@ def list_authenticated_providers(
             if not isinstance(env_vars, list):
                 continue
 
-        # Check if any env var is set
-        has_creds = any(os.environ.get(ev) for ev in env_vars)
+        # Check if any env var is set (skip when configured_only — env vars
+        # may be leftover / invalid; we only want explicit auth-store creds).
+        if configured_only:
+            has_creds = False
+        else:
+            has_creds = any(os.environ.get(ev) for ev in env_vars)
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store
@@ -1225,16 +1236,19 @@ def list_authenticated_providers(
         has_creds = False
         if overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
-        elif overlay.extra_env_vars:
+        elif not configured_only and overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
-            for _key in (pid, hermes_slug):
-                pcfg = _auth_registry.get(_key)
-                if pcfg and pcfg.api_key_env_vars:
-                    if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
-                        has_creds = True
-                        break
+            if configured_only:
+                pass  # skip env-var check in configured_only mode
+            else:
+                for _key in (pid, hermes_slug):
+                    pcfg = _auth_registry.get(_key)
+                    if pcfg and pcfg.api_key_env_vars:
+                        if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
+                            has_creds = True
+                            break
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code
@@ -1337,7 +1351,10 @@ def list_authenticated_providers(
         _cp_config = _auth_registry.get(_cp.slug)
         _cp_has_creds = False
         if _cp_config and _cp_config.api_key_env_vars:
-            _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
+            if configured_only:
+                _cp_has_creds = False
+            else:
+                _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
         # Also check auth store and credential pool
         if not _cp_has_creds:
             try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -994,6 +994,8 @@ def get_model_options():
             user_providers=user_providers,
             custom_providers=custom_providers,
             max_models=50,
+            configured_only=str(model_cfg.get("picker_mode", "all")).strip().lower() == "configured"
+                if isinstance(model_cfg, dict) else False,
         )
         return {
             "providers": providers,

--- a/tests/hermes_cli/test_model_picker_configured_mode.py
+++ b/tests/hermes_cli/test_model_picker_configured_mode.py
@@ -1,0 +1,157 @@
+"""Regression tests for model picker ``configured_only`` mode.
+
+When ``picker_mode: "configured"`` is set, the model picker should only
+show providers that are explicitly configured (in auth.json credential pool
+or config.yaml providers section), not ambient env-var detections.
+"""
+
+import pytest
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_configured_only_skips_env_var_detection(monkeypatch):
+    """With configured_only=True, env vars alone must not surface a provider.
+
+    Section 1 of list_authenticated_providers checks PROVIDER_TO_MODELS_DEV
+    entries.  An env-var like OPENAI_API_KEY would normally surface the
+    ``openai`` provider.  With configured_only=True and no credential pool
+    entry, it must not appear.
+    """
+    import hermes_cli.providers as _pmod
+    # Prevent HERMES_OVERLAYS from adding providers we don't control.
+    monkeypatch.setattr(_pmod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        # Simulate a models.dev entry for openai so section 1 processes it.
+        "openai": {"name": "OpenAI", "env": ["OPENAI_API_KEY"]},
+    })
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    # Make sure openai has env vars registered so section 1 checks them.
+    monkeypatch.setattr(
+        "hermes_cli.auth.PROVIDER_REGISTRY",
+        {**PROVIDER_REGISTRY, "openai": type("P", (), {
+            "api_key_env_vars": ["OPENAI_API_KEY"],
+            "auth_type": "api_key",
+        })()},
+    )
+    # No auth store / credential pool — configured_only should skip env var.
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+    providers = list_authenticated_providers(
+        user_providers={},
+        custom_providers=[],
+        configured_only=True,
+    )
+
+    assert not any(p["slug"] == "openai" for p in providers), (
+        "openai should not appear when only env var is set and configured_only=True"
+    )
+
+
+def test_configured_only_false_includes_env_var_provider(monkeypatch):
+    """With configured_only=False (default), a provider with a non-empty env var appears."""
+    import hermes_cli.providers as _pmod
+    monkeypatch.setattr(_pmod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openai": {"name": "OpenAI", "env": ["OPENAI_API_KEY"]},
+    })
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    monkeypatch.setattr(
+        "hermes_cli.auth.PROVIDER_REGISTRY",
+        {**PROVIDER_REGISTRY, "openai": type("P", (), {
+            "api_key_env_vars": ["OPENAI_API_KEY"],
+            "auth_type": "api_key",
+        })()},
+    )
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-key")
+
+    providers = list_authenticated_providers(
+        user_providers={},
+        custom_providers=[],
+        configured_only=False,
+    )
+
+    assert any(p["slug"] == "openai" for p in providers), (
+        "openai should appear when OPENAI_API_KEY is set and configured_only=False"
+    )
+
+
+def test_configured_only_respects_auth_store(monkeypatch):
+    """With configured_only=True, a provider in the credential pool must appear.
+
+    Even without env vars set, a credential pool entry in auth.json should
+    still cause the provider to show up.
+    """
+    import hermes_cli.providers as _pmod
+    monkeypatch.setattr(_pmod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openai": {"name": "OpenAI", "env": ["OPENAI_API_KEY"]},
+    })
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    monkeypatch.setattr(
+        "hermes_cli.auth.PROVIDER_REGISTRY",
+        {**PROVIDER_REGISTRY, "openai": type("P", (), {
+            "api_key_env_vars": ["OPENAI_API_KEY"],
+            "auth_type": "api_key",
+        })()},
+    )
+    # No env var, but credential pool has an entry for openai.
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    from unittest.mock import MagicMock
+    fake_store = MagicMock()
+    fake_store.get.side_effect = lambda k, d=None: {
+        "credential_pool": {"openai": [{"access_token": "***"}]},
+    }.get(k, d)
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: fake_store)
+
+    providers = list_authenticated_providers(
+        user_providers={},
+        custom_providers=[],
+        configured_only=True,
+    )
+
+    assert any(p["slug"] == "openai" for p in providers), (
+        "openai should appear when in credential pool even without env var"
+    )
+
+
+def test_configured_only_always_shows_user_defined(monkeypatch):
+    """User-defined providers from config should always appear regardless of configured_only."""
+    import hermes_cli.providers as _pmod
+    monkeypatch.setattr(_pmod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: None)
+    # No env vars at all.
+    for ev in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GROQ_API_KEY"):
+        monkeypatch.setenv(ev, "")
+
+    user_providers = {
+        "my-endpoint": {
+            "name": "My Custom Endpoint",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-my-key",
+            "model": "my-model-v1",
+        }
+    }
+
+    providers_default = list_authenticated_providers(
+        user_providers=user_providers,
+        custom_providers=[],
+        configured_only=False,
+    )
+    providers_configured = list_authenticated_providers(
+        user_providers=user_providers,
+        custom_providers=[],
+        configured_only=True,
+    )
+
+    assert any(p["slug"] == "my-endpoint" for p in providers_default)
+    assert any(p["slug"] == "my-endpoint" for p in providers_configured), (
+        "user-defined providers should appear in configured_only mode too"
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4902,6 +4902,9 @@ def _(rid, params: dict) -> dict:
             if isinstance(cfg.get("custom_providers"), list)
             else []
         )
+        model_cfg = cfg.get("model", {}) if cfg else {}
+        picker_mode = str(model_cfg.get("picker_mode", "all")).strip().lower()
+        configured_only = picker_mode == "configured"
         authenticated = list_authenticated_providers(
             current_provider=current_provider,
             current_base_url=current_base_url,
@@ -4909,6 +4912,7 @@ def _(rid, params: dict) -> dict:
             user_providers=user_provs,
             custom_providers=custom_provs,
             max_models=50,
+            configured_only=configured_only,
         )
 
         # Mark authenticated providers and build lookup by slug
@@ -5028,6 +5032,7 @@ def _(rid, params: dict) -> dict:
                 else []
             ),
             max_models=50,
+            configured_only=False,  # model switch: always show all for discovery
         )
 
         # Find the newly-authenticated provider


### PR DESCRIPTION
## Problem

The `/mode` model picker shows every provider Hermes can detect via environment variables — even if those keys are leftover, invalid, or belong to services the user never intentionally configured. For example, a stale `OPENROUTER_API_KEY` or `GROQ_API_KEY` in the shell profile will surface those providers in the picker, causing confusion.

## Solution

Add a `model.picker_mode` config option with two values:

| Value | Behavior |
|---|---|
| `"all"` (default) | Discovery-oriented — show all providers detectable via env vars, auth store, or credential pool. **No behavior change.** |
| `"configured"` | Only show providers explicitly configured in `auth.json` / credential pool. Skips ambient env-var detection. User-defined providers (`providers:` and `custom_providers:` in config) are always shown. |

## Changes

- **`hermes_cli/model_switch.py`**: Add `configured_only` param to `list_authenticated_providers()`. When True, skip all `os.environ.get()` credential checks in sections 1, 2, and 2b — only auth store / credential pool entries count.
- **`cli.py`**, **`gateway/run.py`**, **`tui_gateway/server.py`**, **`hermes_cli/web_server.py`**: Read `model.picker_mode` from config and pass `configured_only` flag.
- **`hermes_cli/main.py`**: Aux picker always uses `configured_only=True` (matches its existing intent).
- **`cli-config.yaml.example`**: Document the new option.
- **Tests**: 4 regression tests covering both modes, auth store respect, and user-defined providers always showing.

## Usage

```yaml
# ~/.hermes/config.yaml
model:
  picker_mode: "configured"
```

## Backward Compatibility

Fully backward-compatible. Default is `"all"` — existing behavior is unchanged unless the user explicitly sets `picker_mode: "configured"`.