### PR TITLE
fix(cli): suppress one-shot session transcripts

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -307,6 +307,8 @@ def _run_agent(
         #   - skill secret capture → returns gracefully when no callback set
         clarify_callback=_oneshot_clarify_callback,
     )
+    # `hermes -z` is a scripted one-shot path; leave no hidden session transcript.
+    agent._persist_session = lambda messages, conversation_history=None: None
 
     # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
     # display callbacks that would bypass our stdout capture.

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -308,6 +308,62 @@ def test_oneshot_distinguishes_disabled_mcp_from_unknown(monkeypatch, capsys):
     assert "mcp-off" in err
 
 
+def test_oneshot_agent_suppresses_session_persistence(monkeypatch):
+    from hermes_cli.oneshot import _run_agent
+
+    created = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.persist_called = False
+            created["agent"] = self
+
+            def persist_session(messages, conversation_history=None):
+                self.persist_called = True
+
+            self._persist_session = persist_session
+
+        def chat(self, prompt):
+            self._persist_session(
+                [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "OK"},
+                ],
+                None,
+            )
+            return "OK"
+
+    monkeypatch.setitem(sys.modules, "run_agent", types.SimpleNamespace(AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(load_config=lambda: {"model": {"default": "test-model"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        types.SimpleNamespace(detect_provider_for_model=lambda model, provider: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        types.SimpleNamespace(
+            resolve_runtime_provider=lambda **kwargs: {
+                "provider": "test-provider",
+                "api_mode": "chat_completions",
+            }
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        types.SimpleNamespace(_get_platform_tools=lambda cfg, platform: set()),
+    )
+
+    assert _run_agent("hello") == "OK"
+    assert created["agent"].persist_called is False
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None


### PR DESCRIPTION
## Summary
- prevent `hermes -z` from writing the hidden per-session JSON transcript during one-shot runs
- keep the behavior scoped to `hermes_cli.oneshot`; interactive CLI/gateway persistence is unchanged
- add a regression test that proves the one-shot agent's session persistence hook is suppressed

Fixes #19503.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_agent_suppresses_session_persistence tests/hermes_cli/test_tui_resume_flow.py::test_main_top_level_oneshot_accepts_toolsets tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_rejects_invalid_only_toolsets` -> 3 passed, 3 warnings
- `git diff --check` -> passed

Additional check:
- `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py::test_launch_tui_exports_model_provider_and_toolsets` currently fails independently because this shell has `NODE_ENV=development` while the existing test expects `production`. This reproduces when run alone and is outside this change's one-shot persistence path.