### PR TITLE
fix(weixin): skip invalid/empty media paths to prevent EISDIR error

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1903,7 +1903,10 @@ class BasePlatformAdapter(ABC):
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+                expanded = os.path.expanduser(path)
+                if os.path.isdir(expanded):
+                    continue
+                media.append((expanded, has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:
@@ -2902,6 +2905,9 @@ class BasePlatformAdapter(ABC):
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
                 for media_path, is_voice in _non_image_media:
+                    if not media_path or not os.path.isfile(media_path):
+                        logger.warning('[%s] Skipping invalid media path: %r', self.name, media_path)
+                        continue
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
@@ -2932,6 +2938,9 @@ class BasePlatformAdapter(ABC):
 
                 # Send auto-detected local non-image files as native attachments
                 for file_path in _non_image_local:
+                    if not file_path or not os.path.isfile(file_path):
+                        logger.warning('[%s] Skipping invalid local file path: %r', self.name, file_path)
+                        continue
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1632,6 +1632,9 @@ class WeixinAdapter(BasePlatformAdapter):
         _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 
         async def _deliver_media(path: str, is_voice: bool = False) -> None:
+            if not path or not os.path.isfile(path):
+                logger.warning('[%s] Skipping invalid media path: %r', self.name, path)
+                return
             ext = Path(path).suffix.lower()
             if is_voice or ext in _AUDIO_EXTS:
                 await self.send_voice(chat_id=chat_id, audio_path=path, metadata=metadata)


### PR DESCRIPTION
## Summary

Fixes #19510

The Weixin gateway was calling `send_document` with an empty or directory path (`/`) after every text response, causing:
```
ERROR [Weixin] send_document failed to=o9cq803o: [Errno 21] Is a directory: '/'
WARNING [Weixin] Failed to send media (): [Errno 21] Is a directory: '/'
```

## Root Cause

`extract_media()` in `gateway/platforms/base.py` could return paths that expand to directories (e.g. `/` from a malformed or empty `MEDIA:` tag). The media delivery loops in both `base.py` and `weixin.py` had no validation guards, so these invalid paths were passed directly to `send_document()`.

## Changes

- **`gateway/platforms/base.py`**:
  - `extract_media()`: Skip paths that resolve to directories after `os.path.expanduser()`
  - `handle_message()` media delivery loop: Validate `media_path` is an existing file before attempting delivery
  - `handle_message()` local files loop: Same validation for auto-detected local file paths
- **`gateway/platforms/weixin.py`**:
  - `send()` / `_deliver_media()`: Validate path is an existing file before dispatching to `send_document`/`send_voice`/etc.

All invalid paths are logged at WARNING level for debugging.

## Testing

- All existing `extract_media` and `weixin` tests pass (57 passed)
- Changes are defensive guards only — no behavioral change for valid paths