### PR TITLE
feat(models): add Alibaba qwen3.6-flash

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -185,6 +185,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "llama": 131072,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
+    "qwen3.6-flash": 1_000_000,  # 1M context
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -403,6 +403,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
         "qwen3.6-plus",
+        "qwen3.6-flash",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -485,6 +485,12 @@ class TestGetModelContextLength:
         assert get_model_context_length("qwen3-coder-plus") == 1000000
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    def test_qwen36_flash_context_length(self, mock_fetch):
+        """qwen3.6-flash has a 1M context window, not the generic 128K Qwen default."""
+        mock_fetch.return_value = {}
+        assert get_model_context_length("qwen3.6-flash") == 1000000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_qwen3_coder_context_length(self, mock_fetch):
         """qwen3-coder has a 256K context window, not the generic 128K Qwen default."""
         mock_fetch.return_value = {}

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
     is_nous_free_tier, partition_nous_models_by_tier,
-    check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    check_nous_free_tier, _FREE_TIER_CACHE_TTL, _PROVIDER_MODELS,
 )
 import hermes_cli.models as _models_mod
 
@@ -56,6 +56,12 @@ class TestOpenRouterModels:
     def test_at_least_5_models(self):
         """Sanity check that the models list hasn't been accidentally truncated."""
         assert len(OPENROUTER_MODELS) >= 5
+
+
+class TestAlibabaModels:
+    def test_qwen36_flash_is_in_static_catalog(self):
+        """Alibaba's documented qwen3.6-flash model is available offline."""
+        assert "qwen3.6-flash" in _PROVIDER_MODELS["alibaba"]
 
 
 class TestFetchOpenRouterModels:


### PR DESCRIPTION
## Summary
- add `qwen3.6-flash` to the static Alibaba provider model catalog
- add the documented 1M context fallback for `qwen3.6-flash`
- add regression tests for the catalog entry and context metadata

## Basis
Alibaba Cloud Model Studio lists `qwen3.6-flash` under Qwen3.6 with 1M context, 64k max output, function calling, built-in tools, structured output, and batch calling support:
https://www.alibabacloud.com/help/doc-detail/3026903.html

Issue #19128 also notes the DeepSeek entries are already present; this PR intentionally scopes to the net-new Alibaba/Qwen model.

Fixes #19128

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_models.py::TestAlibabaModels::test_qwen36_flash_is_in_static_catalog tests/agent/test_model_metadata.py::TestGetModelContextLength::test_qwen36_flash_context_length` — 2 passed, 2 warnings
- `git diff --check`