### PR TITLE
fix: surface Codex CLI-only models

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -78,8 +78,10 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         if not isinstance(slug, str) or not slug.strip():
             continue
         slug = slug.strip()
-        if item.get("supported_in_api") is False:
-            continue
+        # Codex CLI's catalog uses ``supported_in_api`` for the public OpenAI
+        # API, not for the OAuth-backed Codex backend that this provider uses.
+        # Some valid Codex CLI models (for example gpt-5.3-codex-spark) are
+        # marked false here but are still accepted by the Codex route.
         visibility = item.get("visibility", "")
         if isinstance(visibility, str) and visibility.strip().lower() in ("hide", "hidden"):
             continue
@@ -128,8 +130,9 @@ def _read_cache_models(codex_home: Path) -> List[str]:
             if not isinstance(slug, str) or not slug.strip():
                 continue
             slug = slug.strip()
-            if item.get("supported_in_api") is False:
-                continue
+            # Do not filter on ``supported_in_api`` here.  It describes the
+            # public OpenAI API, while Hermes openai-codex talks to the same
+            # OAuth-backed Codex backend as Codex CLI.
             visibility = item.get("visibility")
             if isinstance(visibility, str) and visibility.strip().lower() in ("hide", "hidden"):
                 continue

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1287,7 +1287,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"copilot", "copilot-acp"}:
+        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
             model_ids = provider_model_ids(hermes_slug)
         # For aws_sdk providers (bedrock), use live discovery so the list
         # reflects the active region (eu.*, ap.*) not the static us.* list.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,6 +83,8 @@ AUTHOR_MAP = {
     "thomasjhon6666@gmail.com": "ThomassJonax",
     "focusflow.app.help@gmail.com": "yes999zc",
     "rob@atlas.lan": "rmoen",
+    # Vesper automation (May 2026)
+    "vesper@askclaw.dev": "askclaw-vesper",
     # Slack ephemeral slash-ack salvage (May 2026)
     "probepark@users.noreply.github.com": "probepark",
     # Slack batch salvage (May 2026)

--- a/tests/hermes_cli/test_codex_cli_model_picker.py
+++ b/tests/hermes_cli/test_codex_cli_model_picker.py
@@ -75,6 +75,30 @@ def test_normal_path_still_works(hermes_auth_only_env):
     assert "openai-codex" in slugs
 
 
+def test_codex_picker_uses_live_codex_catalog(hermes_auth_only_env, tmp_path, monkeypatch):
+    """The gateway /model picker should surface Codex CLI-only listed models."""
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "models_cache.json").write_text(json.dumps({
+        "models": [
+            {"slug": "gpt-5.5", "priority": 0, "supported_in_api": True},
+            {"slug": "gpt-5.3-codex-spark", "priority": 7, "supported_in_api": False},
+        ]
+    }))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        max_models=10,
+    )
+
+    codex = next(p for p in providers if p["slug"] == "openai-codex")
+    assert "gpt-5.3-codex-spark" in codex["models"]
+    assert codex["total_models"] == len(codex["models"])
+
+
 @pytest.fixture()
 def claude_code_only_env(tmp_path, monkeypatch):
     """Set up an environment where Anthropic credentials only exist in

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -1,9 +1,5 @@
 import json
-import os
-import sys
 from unittest.mock import patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
 
@@ -17,6 +13,7 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
             {
                 "models": [
                     {"slug": "gpt-5.3-codex", "priority": 20, "supported_in_api": True},
+                    {"slug": "gpt-5.3-codex-spark", "priority": 6, "supported_in_api": False},
                     {"slug": "gpt-5.1-codex", "priority": 5, "supported_in_api": True},
                     {"slug": "gpt-5.4", "priority": 1, "supported_in_api": True},
                     {"slug": "gpt-5-hidden-codex", "priority": 2, "visibility": "hidden"},
@@ -31,6 +28,9 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
     assert models[0] == "gpt-5.2-codex"
     assert "gpt-5.1-codex" in models
     assert "gpt-5.3-codex" in models
+    # Codex CLI marks Spark unsupported in the public API, but the Codex
+    # backend still accepts it via the OAuth-backed CLI/Hermes route.
+    assert "gpt-5.3-codex-spark" in models
     # Non-codex-suffixed models are included when the cache says they're available
     assert "gpt-5.4" in models
     assert "gpt-5.4-mini" in models


### PR DESCRIPTION
## Summary

This fixes the OpenAI Codex model picker so Hermes shows the models available through the user's Codex CLI/OAuth account, instead of hiding them only because cached OpenAI API metadata says `supported_in_api: false`.

The main user-visible fix is that `gpt-5.3-codex-spark` can appear in `/model` for accounts that have access to it.

## Context

User report / thread:

- Root post: https://x.com/GetAskClaw/status/2051118103694868698
- After-fix reply: https://x.com/GetAskClaw/status/2051118115875074228

The root post says:

> Using `gpt-5.5` for English learning is overkill.  
> Open Hermes `/model` and look.

The root screenshots show Hermes `/model` under **OpenAI Codex** listing only 7 models:

- `gpt-5.5`
- `gpt-5.4-mini`
- `gpt-5.4`
- `gpt-5.3-codex`
- `gpt-5.2-codex`
- `gpt-5.1-codex-max`
- `gpt-5.1-codex-mini`

`gpt-5.3-codex-spark` was missing from that picker.

Related replies in the same thread add the important detail:

> On the same VPS, Codex has `gpt-5.3-codex-spark`,  
> but Hermes `/model` does not.

Another reply says:

> Hermes (`gpt-5.5`) checked the source code and fixed the bug.

The after-fix reply says:

> /model gpt-5.3-codex-spark

The after-fix screenshots show:

- Hermes `/model` now shows **OpenAI Codex (1–8 of 9)**.
- `gpt-5.3-codex-spark` is visible in the model picker.
- Hermes can switch to `gpt-5.3-codex-spark`.
- The selected model shows:
  - Provider: OpenAI Codex
  - Context: 128,000 tokens
  - Max output: 32,000 tokens
  - Capabilities: reasoning, tools, vision, PDF, structured output

Important note: `gpt-5.3-codex-spark` availability can depend on the user's Codex/ChatGPT account entitlement. In this report, the user is a ChatGPT Pro subscriber, which is why Spark is available to their Codex CLI/OAuth account. This PR does not make Spark universal; it makes Hermes stop hiding Codex models that the authenticated Codex backend already exposes.

## Root cause

Hermes treated `supported_in_api: false` from cached OpenAI API metadata as a reason to hide a model from the OpenAI Codex provider list.

That is too strict for `openai-codex`. The Codex CLI/OAuth backend can expose account-entitled models that are not public OpenAI API models.

So Hermes' `/model` picker could be out of sync with what Codex CLI could actually run.

## Fix

- Use the Codex live/cache catalog for the `openai-codex` provider model picker.
- Do not exclude Codex CLI/OAuth-backed models only because `supported_in_api` is false.
- Keep validation in place so Hermes still rejects model names that the authenticated backend cannot use.
- Add tests for Codex catalog and model picker behavior.

## Validation

Before the patch:

- `gpt-5.3-codex-spark` existed in the Codex model cache / Codex CLI path.
- Hermes `/model` did not show it.
- The picker showed only 7 OpenAI Codex models.

After the patch:

- Hermes `/model` shows 9 OpenAI Codex models for this authenticated account.
- `gpt-5.3-codex-spark` appears in the picker.
- Hermes can switch to `gpt-5.3-codex-spark`.

Manual checks also confirmed:

- `codex exec -m gpt-5.3-codex-spark ...` returned `SPARK_OK`
- `hermes chat --provider openai-codex --model gpt-5.3-codex-spark ...` returned `HERMES_SPARK_OK`

## Testing

- `python -m pytest tests/hermes_cli/test_codex_models.py tests/hermes_cli/test_codex_cli_model_picker.py`
- 22 passed
