### PR TITLE
fix(gateway): detect stale sys.modules via expected exports (#17648 follow-up)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -133,6 +133,20 @@ def _compute_repo_mtime(repo_root: Path) -> float:
     return newest
 
 
+def _loaded_modules_missing_expected_exports() -> bool:
+    """Return True if loaded ``hermes_cli.config`` or ``utils`` lack expected attributes."""
+    cfg_mod = sys.modules.get("hermes_cli.config")
+    if cfg_mod is not None and not hasattr(cfg_mod, "cfg_get"):
+        return True
+    utils_mod = sys.modules.get("utils")
+    if utils_mod is not None:
+        if not hasattr(utils_mod, "atomic_replace"):
+            return True
+        if not hasattr(utils_mod, "base_url_host_matches"):
+            return True
+    return False
+
+
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
     """Best-effort conversion of stored gateway timestamps to epoch seconds.
 
@@ -1019,6 +1033,13 @@ class GatewayRunner:
             self._boot_repo_mtime: float = _compute_repo_mtime(
                 self._repo_root_for_staleness,
             )
+            if self._boot_repo_mtime <= 0.0 and self._boot_wall_time:
+                logger.warning(
+                    "Stale-code mtime baseline unavailable (no readable sentinel "
+                    "files under %s). Export-based detection still applies. "
+                    "See Issue #17648.",
+                    self._repo_root_for_staleness,
+                )
         except Exception:
             self._boot_wall_time = 0.0
             self._repo_root_for_staleness = Path(".")
@@ -2637,6 +2658,8 @@ class GatewayRunner:
         sentinel file is readable, to avoid false-positive restart loops
         in unusual checkouts (sparse clones, read-only filesystems).
         """
+        if _loaded_modules_missing_expected_exports():
+            return True
         if not self._boot_wall_time or not self._boot_repo_mtime:
             return False
         try:

--- a/tests/gateway/test_stale_code_self_check.py
+++ b/tests/gateway/test_stale_code_self_check.py
@@ -9,15 +9,15 @@ and ``_trigger_stale_code_restart()`` triggers a graceful restart.
 """
 
 import os
+import sys
 import time
+import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 from gateway.run import (
     GatewayRunner,
     _compute_repo_mtime,
+    _loaded_modules_missing_expected_exports,
     _STALE_CODE_SENTINELS,
 )
 
@@ -94,6 +94,33 @@ def test_detect_stale_code_false_when_files_unchanged(tmp_path):
 
     runner = _make_runner(repo, boot_mtime=baseline, boot_wall=baseline)
     assert runner._detect_stale_code() is False
+
+
+def test_loaded_modules_missing_expected_exports_detects_stale_config(monkeypatch):
+    stale_cfg = types.ModuleType("hermes_cli.config")
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", stale_cfg)
+    assert _loaded_modules_missing_expected_exports() is True
+
+
+def test_loaded_modules_missing_expected_exports_detects_stale_utils(monkeypatch):
+    stale_utils = types.ModuleType("utils")
+    monkeypatch.setitem(sys.modules, "utils", stale_utils)
+    assert _loaded_modules_missing_expected_exports() is True
+
+
+def test_detect_stale_code_true_when_sys_modules_config_lacks_cfg_get(
+    tmp_path, monkeypatch
+):
+    stale_cfg = types.ModuleType("hermes_cli.config")
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", stale_cfg)
+
+    repo = _make_tmp_repo(tmp_path)
+    baseline = time.time() - 100
+    for rel in _STALE_CODE_SENTINELS:
+        os.utime(repo / rel, (baseline, baseline))
+
+    runner = _make_runner(repo, boot_mtime=baseline, boot_wall=baseline)
+    assert runner._detect_stale_code() is True
 
 
 def test_detect_stale_code_true_after_update(tmp_path):


### PR DESCRIPTION
## What does this PR do?

After `hermes update`, a gateway can keep running with old modules still in `sys.modules` while tools on disk import newer symbols. Users see import errors; session commands do not reload Python.

[#18409](https://github.com/NousResearch/hermes-agent/pull/18409) restarts the gateway when key source files look newer than at startup (mtime check). This change adds a second condition: if `hermes_cli.config` or the project `utils` package is already loaded but is missing `cfg_get`, `atomic_replace`, or `base_url_host_matches`, treat the process as stale and use the same restart path. It does not add broad try/except import fallbacks ([#17935](https://github.com/NousResearch/hermes-agent/pull/17935)).

## Related Issue

Refs [#17648](https://github.com/NousResearch/hermes-agent/issues/17648). Follow-up to [#18409](https://github.com/NousResearch/hermes-agent/pull/18409).

## Source branch

Fork: [github.com/anuragbanerjee/hermes-agent](https://github.com/anuragbanerjee/hermes-agent), branch **`fix/gateway-stale-sys-modules-exports`**. To check out locally: `gh repo clone anuragbanerjee/hermes-agent -- -b fix/gateway-stale-sys-modules-exports` (or add the fork as a remote and fetch that branch).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: `_loaded_modules_missing_expected_exports()`; call from `_detect_stale_code()`; warn when boot mtime baseline is zero.
- `tests/gateway/test_stale_code_self_check.py`: tests for the export-based path.

## How to Test

1. `pytest tests/gateway/test_stale_code_self_check.py -v`
2. Optional: long-lived gateway + update without process exit; next message should restart or succeed, not fail importing `cfg_get`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A