### PR TITLE
fix(compressor): skip non-string tool content in summarization pass

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -590,6 +590,8 @@ class ContextCompressor(ContextEngine):
             # Skip multimodal content (list of content blocks)
             if isinstance(content, list):
                 continue
+            if not isinstance(content, str):
+                continue
             if not content or content == _PRUNED_TOOL_PLACEHOLDER:
                 continue
             # Skip already-deduplicated or previously-summarized results


### PR DESCRIPTION
## Summary

Follow-up to 408dd8aa which added a `isinstance(content, str)` guard in Pass 1 (dedup), but missed the same pattern in Pass 2 (summarization/pruning).

Pass 2 calls `content.startswith()` and `len()` on tool message content without checking type first. When a provider returns non-string tool content (e.g. `dict` from llama.cpp), this crashes with `AttributeError`.

## Changes

- Add `if not isinstance(content, str): continue` to Pass 2 loop (mirrors the existing Pass 1 guard)

## Test plan

- [x] 66/66 existing `test_context_compressor` tests pass
- [x] Verified both passes now have identical type guards