### PR TITLE
feat(web): add loading-ui ring status primitive

### DIFF
--- a/web/components.json
+++ b/web/components.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {
+    "@loading-ui": "https://loading-ui.com/r/{name}.json"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,7 +46,7 @@ import {
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { SelectionSwitcher } from "@nous-research/ui/ui/components/selection-switcher";
-import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Ring } from "@/components/loading-ui/ring";
 import { Typography } from "@/components/NouiTypography";
 import { cn } from "@/lib/utils";
 import { Backdrop } from "@/components/Backdrop";
@@ -596,7 +596,7 @@ export default function App() {
                         aria-live="polite"
                       >
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <Spinner />
+                          <Ring className="h-4 w-4 shrink-0" aria-hidden />
                           <span>Loading chat…</span>
                         </div>
                       </div>
@@ -752,9 +752,9 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
                 )}
               >
                 {isPending ? (
-                  <Spinner className="shrink-0 text-[0.875rem]" />
+                  <Ring className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 ) : isActionRunning && spin ? (
-                  <Spinner className="shrink-0 text-[0.875rem]" />
+                  <Ring className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 ) : (
                   <Icon
                     className={cn(

--- a/web/src/components/loading-ui/ring.tsx
+++ b/web/src/components/loading-ui/ring.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+
+function Ring({ className, style, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <>
+      <style>{`
+        @keyframes loading-ui-ring-spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className={cn(className)}
+        style={{
+          animationName: "loading-ui-ring-spin",
+          animationDuration: "var(--duration, 1s)",
+          animationTimingFunction: "linear",
+          animationIterationCount: "infinite",
+          ...style,
+        }}
+        {...props}
+      >
+        <path
+          d="M21 12.0004C20.9999 13.901 20.3981 15.7528 19.2809 17.2904C18.1637 18.8279 16.5885 19.9723 14.7809 20.5596C12.9733 21.1469 11.0262 21.1468 9.21864 20.5594C7.41109 19.9721 5.83588 18.8276 4.71876 17.29C3.60165 15.7523 2.99999 13.9005 3 11.9999C3.00001 10.0993 3.60171 8.24755 4.71884 6.70994C5.83598 5.17233 7.4112 4.02785 9.21877 3.44052C11.0263 2.85319 12.9734 2.85316 14.781 3.44044"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </>
+  );
+}
+
+export { Ring };

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -7,6 +7,7 @@ import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@/hooks/useToast";
 import { useConfirmDelete } from "@/hooks/useConfirmDelete";
 import { Toast } from "@/components/Toast";
+import { Ring } from "@/components/loading-ui/ring";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -173,7 +174,7 @@ export default function ProfilesPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        <Ring className="h-6 w-6 text-primary" aria-hidden />
       </div>
     );
   }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,4 +1,10 @@
 {
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
## Summary

Adds a small shadcn-compatible loading primitive for the Hermes web dashboard.

- Adds `web/components.json` with the Loading UI registry.
- Mirrors the existing `@/*` alias into root `web/tsconfig.json` so shadcn resolves paths correctly.
- Adds `Ring` from `@loading-ui/ring`.
- Uses `Ring` for embedded chat loading, sidebar system-action pending/running states, and the Profiles page loading state.

## Verification

- `cd web && npm ci` — pass, 0 vulnerabilities reported
- `cd web && npm run build` — pass
- `cd web && npx eslint src/App.tsx src/pages/ProfilesPage.tsx src/components/loading-ui/ring.tsx` — pass
- `cd web && npx shadcn@latest add @loading-ui/ring --dry-run --yes` — pass, reports identical skipped component

Full `cd web && npm run lint` is not green on current `main`; it reports existing React hook/compiler lint errors in untouched files such as `OAuthProvidersCard.tsx`, `Toast.tsx`, `ConfigPage.tsx`, `SessionsPage.tsx`, and `PluginPage.tsx`. This PR keeps that out of scope and verifies the touched files directly.
