### PR TITLE
[codex] Support OpenClaudeCode SDK requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,6 +107,13 @@ from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_
 logger = logging.getLogger(__name__)
 
 
+def _openclaudecode_headers(base_url: str) -> Dict[str, str]:
+    """Headers for OpenClaudeCode's gateway, which blocks SDK fingerprints."""
+    if base_url_host_matches(base_url, "openclaudecode.cn"):
+        return {"User-Agent": "curl/8.7.1", "Accept": "*/*"}
+    return {}
+
+
 def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
     """Return False instead of raising when a patched symbol is not a type."""
     try:
@@ -1459,6 +1466,9 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
     _clean_base, _dq = _extract_url_query_params(custom_base)
     _extra = {"default_query": _dq} if _dq else {}
+    _headers = _openclaudecode_headers(_clean_base)
+    if _headers:
+        _extra["default_headers"] = _headers
     if custom_mode == "codex_responses":
         real_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
         return CodexAuxiliaryClient(real_client, model), model
@@ -1975,6 +1985,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+    elif _openclaudecode_headers(sync_base_url):
+        async_kwargs["default_headers"] = _openclaudecode_headers(sync_base_url)
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -2202,6 +2214,8 @@ def resolve_provider_client(
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
                 )
+            elif _openclaudecode_headers(custom_base):
+                extra["default_headers"] = _openclaudecode_headers(custom_base)
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -2267,6 +2281,9 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                _headers2 = _openclaudecode_headers(_clean_base2)
+                if _headers2:
+                    _extra2["default_headers"] = _headers2
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")
@@ -2390,6 +2407,8 @@ def resolve_provider_client(
             headers.update(copilot_request_headers(
                 is_agent_turn=True, is_vision=is_vision
             ))
+        elif _openclaudecode_headers(base_url):
+            headers.update(_openclaudecode_headers(base_url))
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -346,6 +346,44 @@ def _try_resolve_from_custom_pool(
         return None
 
 
+def _try_resolve_from_named_custom_pool(
+    custom_provider: Dict[str, Any],
+    base_url: str,
+    provider_label: str,
+    api_mode_override: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve a custom provider pool by its explicit name before base_url."""
+    names = [
+        str(custom_provider.get("provider_key", "") or "").strip(),
+        str(custom_provider.get("name", "") or "").strip(),
+    ]
+    for name in names:
+        if not name:
+            continue
+        pool_key = f"custom:{_normalize_custom_provider_name(name)}"
+        try:
+            pool = load_pool(pool_key)
+            if not pool.has_credentials():
+                continue
+            entry = pool.select()
+            if entry is None:
+                continue
+            pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
+            if not pool_api_key:
+                continue
+            return {
+                "provider": provider_label,
+                "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
+                "base_url": base_url,
+                "api_key": pool_api_key,
+                "source": f"pool:{pool_key}",
+                "credential_pool": pool,
+            }
+        except Exception:
+            continue
+    return None
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm or requested_norm == "custom":
@@ -520,8 +558,15 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
-    # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    # Prefer the exact named custom provider pool before falling back to
+    # base_url matching. Multiple providers can share one gateway URL while
+    # using different keys/groups upstream.
+    pool_result = (
+        _try_resolve_from_named_custom_pool(
+            custom_provider, base_url, "custom", custom_provider.get("api_mode")
+        )
+        or _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.

--- a/run_agent.py
+++ b/run_agent.py
@@ -832,6 +832,13 @@ def _routermint_headers() -> dict:
     }
 
 
+def _openclaudecode_headers(base_url: str) -> dict:
+    """Headers for OpenClaudeCode's gateway, which blocks SDK fingerprints."""
+    if base_url_host_matches(base_url, "openclaudecode.cn"):
+        return {"User-Agent": "curl/8.7.1", "Accept": "*/*"}
+    return {}
+
+
 def _pool_may_recover_from_rate_limit(pool) -> bool:
     """Decide whether to wait for credential-pool rotation instead of falling back.
 
@@ -1437,6 +1444,8 @@ class AIAgent:
                     client_kwargs["default_headers"] = {
                         "User-Agent": "claude-code/0.1.0",
                     }
+                elif _openclaudecode_headers(effective_base):
+                    client_kwargs["default_headers"] = _openclaudecode_headers(effective_base)
                 elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                     client_kwargs["default_headers"] = _qwen_portal_headers()
                 elif base_url_host_matches(effective_base, "chatgpt.com"):
@@ -5575,6 +5584,12 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
+        if "default_headers" not in client_kwargs:
+            openclaudecode_headers = _openclaudecode_headers(
+                str(client_kwargs.get("base_url", "") or "")
+            )
+            if openclaudecode_headers:
+                client_kwargs["default_headers"] = openclaudecode_headers
         if "http_client" not in client_kwargs:
             keepalive_http = self._build_keepalive_http_client(client_kwargs.get("base_url", ""))
             if keepalive_http is not None:
@@ -6194,6 +6209,8 @@ class AIAgent:
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
             self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        elif _openclaudecode_headers(base_url):
+            self._client_kwargs["default_headers"] = _openclaudecode_headers(base_url)
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):


### PR DESCRIPTION
## Summary

Fixes two related issues found while using multiple OpenClaudeCode-backed custom providers in Hermes:

1. OpenClaudeCode rejects OpenAI SDK/httpx default client fingerprints even though the same key/model/body works via `curl`.
2. Multiple named custom providers that share the same gateway `base_url` can resolve the wrong credential pool, causing Hermes to send a model request with another provider's key/group.

## Root Cause

For the first failure, a custom OpenClaudeCode provider configured as OpenAI-compatible was reachable with the same key, base URL, model, and request body via `curl`, but failed from Hermes with HTTP 403 `Your request was blocked.` Reproducing with the Hermes virtualenv showed the minimal OpenAI Python SDK request was also blocked, while adding a curl-like `User-Agent` allowed the request through.

For the second failure, Hermes resolved named custom provider credentials through `get_custom_provider_pool_key(base_url)`. When two custom providers share one distributor gateway URL but use different API keys/groups, base URL matching returns the first matching provider. In the observed case, switching from a DeepSeek key/group to a GPT key/group still selected `pool:custom:deep`, so the GPT model request was sent under the DeepSeek group and failed with `No available channel for model ... under group vip_4_ds_pro`.

## Changes

- Add OpenClaudeCode-specific default headers for main-agent OpenAI client construction.
- Add the same header handling for auxiliary/custom provider resolution, including sync and async client paths.
- Scope the compatibility headers only to hosts matching `openclaudecode.cn`.
- Resolve named custom provider credential pools by explicit provider name/provider_key before falling back to base URL matching.
- Preserve the existing base URL fallback for older custom provider configs.

## Validation

- `venv/bin/python3 -m py_compile agent/auxiliary_client.py run_agent.py hermes_cli/runtime_provider.py`
- `resolve_runtime_provider(requested='got')` now resolves `source: pool:custom:got`.
- `resolve_runtime_provider(requested='deep')` still resolves `source: pool:custom:deep`.
- `hermes chat -Q --accept-hooks --max-turns 1 -q "请只回复 OK"` returned `OK` against `https://www.openclaudecode.cn/v1` with model `gpt-5.5-openai-compact`.
