### PR TITLE
fix(auth): rewrite stale MiniMax OAuth verification_uri host

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -36,7 +36,7 @@ from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
 import yaml
@@ -4138,6 +4138,41 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
 # ==================== MiniMax Portal OAuth ====================
 
+# MiniMax's OAuth code endpoint returns a verification_uri pointing at
+# https://www.minimax.io/oauth-authorize?... but that page was retired and
+# 307-redirects to the marketing homepage, leaving users stranded. The live
+# approval UI is on https://platform.minimax.io. This rewrite is a defensive
+# client-side workaround; it can be removed once MiniMax updates the server
+# response. See issue #19337.
+_MINIMAX_STALE_AUTHORIZE_HOST = "www.minimax.io"
+_MINIMAX_LIVE_AUTHORIZE_HOST = "platform.minimax.io"
+
+
+def _minimax_normalize_verification_uri(url: str) -> str:
+    """Rewrite MiniMax's stale www.minimax.io/oauth-authorize host to the live
+    platform.minimax.io host. Returns the URL unchanged for any other host or
+    path.
+    """
+    try:
+        parts = urlparse(url)
+        # parts.hostname / parts.port are properties that re-parse netloc and
+        # can raise ValueError on malformed authority components (e.g. an
+        # out-of-range port). Touch them inside the try so any failure falls
+        # through to returning the input unchanged.
+        host = parts.hostname
+        port = parts.port
+    except (ValueError, TypeError):
+        return url
+    if host == _MINIMAX_STALE_AUTHORIZE_HOST and parts.path.startswith(
+        "/oauth-authorize"
+    ):
+        netloc = _MINIMAX_LIVE_AUTHORIZE_HOST
+        if port:
+            netloc = f"{netloc}:{port}"
+        return urlunparse(parts._replace(netloc=netloc))
+    return url
+
+
 def _minimax_pkce_pair() -> tuple:
     """Generate (code_verifier, code_challenge_S256, state) for MiniMax OAuth."""
     import secrets
@@ -4290,7 +4325,9 @@ def _minimax_oauth_login(
             client_id=pconfig.client_id,
             code_challenge=challenge, state=state,
         )
-        verification_url = str(code_data["verification_uri"])
+        verification_url = _minimax_normalize_verification_uri(
+            str(code_data["verification_uri"])
+        )
         user_code = str(code_data["user_code"])
 
         print()

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -29,6 +29,7 @@ from hermes_cli.auth import (
     MINIMAX_OAUTH_CN_BASE,
     MINIMAX_OAUTH_CN_INFERENCE,
     MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
+    _minimax_normalize_verification_uri,
     _minimax_pkce_pair,
     _minimax_request_user_code,
     _minimax_poll_token,
@@ -464,3 +465,46 @@ def test_get_minimax_oauth_auth_status_logged_in():
 
     assert status["logged_in"] is True
     assert status["region"] == "global"
+
+
+# ---------------------------------------------------------------------------
+# 16. test_normalize_verification_uri rewrites stale www.minimax.io host
+# ---------------------------------------------------------------------------
+
+def test_normalize_verification_uri_rewrites_stale_host():
+    # Real-world payload from issue #19337: server hands back www.minimax.io,
+    # which 307-redirects to the marketing homepage. Live UI is on
+    # platform.minimax.io.
+    stale = "https://www.minimax.io/oauth-authorize?user_code=ABCD&client=OpenClaw"
+    rewritten = _minimax_normalize_verification_uri(stale)
+
+    assert rewritten == (
+        "https://platform.minimax.io/oauth-authorize"
+        "?user_code=ABCD&client=OpenClaw"
+    )
+
+
+def test_normalize_verification_uri_preserves_unrelated_urls():
+    # Other hosts pass through unchanged so we don't accidentally rewrite
+    # a corrected server response or an unrelated URL.
+    untouched = [
+        "https://platform.minimax.io/oauth-authorize?user_code=X",
+        "https://api.minimax.io/oauth/code",
+        "https://www.minimax.io/about",  # different path, not authorize
+        "https://minimax.io/oauth-authorize?u=1",  # apex host, not www
+        "https://www.minimaxi.com/oauth-authorize",  # CN cousin, different brand
+    ]
+    for url in untouched:
+        assert _minimax_normalize_verification_uri(url) == url
+
+
+def test_normalize_verification_uri_handles_bad_input():
+    # Robust against odd inputs — empty, malformed, out-of-range port.
+    # A bad port causes urlparse().port to raise ValueError; the helper
+    # must catch that and return the original string unchanged.
+    assert _minimax_normalize_verification_uri("") == ""
+    assert _minimax_normalize_verification_uri("not a url") == "not a url"
+    assert (
+        _minimax_normalize_verification_uri("https://www.minimax.io:999999/oauth-authorize")
+        == "https://www.minimax.io:999999/oauth-authorize"
+    )


### PR DESCRIPTION
## What does this PR do?

MiniMax's OAuth `/oauth/code` endpoint returns a `verification_uri` of the form `https://www.minimax.io/oauth-authorize?user_code=...&client=OpenClaw`, but that path was retired and now 307-redirects to the marketing homepage `/`, leaving users with no way to approve the device code. The live approval UI is at `https://platform.minimax.io/oauth-authorize?...`.

This PR adds a defensive client-side rewrite in `_minimax_oauth_login`: when `verification_uri` host is exactly `www.minimax.io` and the path starts with `/oauth-authorize`, the host is rewritten to `platform.minimax.io` before the URL is printed or opened. Any other host or path passes through unchanged, so the rewrite auto-disables once MiniMax fixes the server response, and the CN portal (`api.minimaxi.com`) is unaffected (different brand domain entirely).

This is option (1) from the issue. The reporter flagged option (2) — escalating to MiniMax to fix the server-side `verification_uri` — as the cleaner long-term path, but unblocking users today is worth the small workaround.

## Related Issue

Fixes #19337

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — add `_minimax_normalize_verification_uri(url)` helper just above `_minimax_pkce_pair`; apply it at the call site in `_minimax_oauth_login` where `verification_uri` is read from `code_data`. A short comment block in the source records the workaround and its removal condition. `parts.hostname` and `parts.port` are accessed inside the `try` because both properties re-parse the netloc and can raise `ValueError` on malformed input (e.g. an out-of-range port).
- `tests/test_minimax_oauth.py` — add three unit tests covering: (a) the real-world stale URL gets rewritten with the query string preserved, (b) unrelated URLs (already-platform host, apex `minimax.io`, CN `minimaxi.com`, non-authorize paths) pass through unchanged, (c) malformed/empty/bad-port inputs are returned untouched.

## How to Test

1. Run \`pytest tests/test_minimax_oauth.py -q\` → 18 tests pass (3 new).
2. End-to-end (requires a MiniMax Plus account):
   - \`hermes model\` → choose \"MiniMax via OAuth browser login\".
   - Hermes prints \`Open: https://platform.minimax.io/oauth-authorize?user_code=...&client=OpenClaw\` (note the rewritten host).
   - The browser loads the live approval UI; approving completes the device-code flow.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run \`pytest tests/test_minimax_oauth.py -q\` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — N/A (workaround is internal; the in-source comment documents it)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python urllib.parse, no platform-specific behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A