### PR TITLE
fix: harden auxiliary timeouts and compression busy handling

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import queue
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -4089,6 +4090,138 @@ def _validate_llm_response(response: Any, task: str = None) -> Any:
     return response
 
 
+def _deadline_from_timeout(timeout: Optional[float]) -> Optional[float]:
+    """Convert a caller timeout into a monotonic deadline for the whole call."""
+    if timeout is None:
+        return None
+    try:
+        timeout_f = float(timeout)
+    except (TypeError, ValueError):
+        return None
+    if timeout_f <= 0:
+        return None
+    return time.monotonic() + timeout_f
+
+
+def _remaining_wall_clock(deadline: Optional[float]) -> Optional[float]:
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
+
+
+def _aux_timeout_message(task: Optional[str], timeout: Optional[float]) -> str:
+    label = task or "call"
+    if timeout is None:
+        return f"Auxiliary {label}: LLM call exceeded wall-clock timeout"
+    return f"Auxiliary {label}: LLM call exceeded {float(timeout):.1f}s wall-clock timeout"
+
+
+def _close_auxiliary_client(client: Any) -> None:
+    """Best-effort close to break blocked SDK streams/sockets after timeout."""
+    for attr in ("close", "aclose"):
+        close_fn = getattr(client, attr, None)
+        if callable(close_fn):
+            try:
+                result = close_fn()
+                # In sync code we cannot await ``aclose``.  Creating the coroutine
+                # is still better than doing nothing, but prefer ``close`` when
+                # both exist so OpenAI/Anthropic clients release sockets promptly.
+                close_coro_close = getattr(result, "close", None)
+                if callable(close_coro_close):
+                    close_coro_close()
+            except Exception:
+                logger.debug("Auxiliary client close after timeout failed", exc_info=True)
+            return
+
+
+def _create_with_wall_clock_timeout(
+    client: Any,
+    kwargs: Dict[str, Any],
+    deadline: Optional[float],
+    task: Optional[str],
+) -> Any:
+    """Run sync chat.completions.create under one total wall-clock budget.
+
+    SDK request timeouts are not enough for the interactive hot path: streaming
+    clients can still leave the reply path looking stuck.  This wrapper owns the
+    *whole* auxiliary call budget, closes the underlying client on expiry, and
+    returns control to the UI while any SDK worker is abandoned as a daemon.
+    """
+    remaining = _remaining_wall_clock(deadline)
+    if remaining is None:
+        return client.chat.completions.create(**kwargs)
+    if remaining <= 0:
+        _close_auxiliary_client(client)
+        raise TimeoutError(_aux_timeout_message(task, kwargs.get("timeout")))
+
+    result_q: "queue.Queue[Tuple[str, Any]]" = queue.Queue(maxsize=1)
+
+    def _target() -> None:
+        try:
+            result_q.put(("result", client.chat.completions.create(**kwargs)), block=False)
+        except BaseException as exc:  # propagate SDK errors unchanged
+            try:
+                result_q.put(("error", exc), block=False)
+            except Exception:
+                pass
+
+    thread = threading.Thread(
+        target=_target,
+        name=f"auxiliary-{task or 'call'}-llm",
+        daemon=True,
+    )
+    thread.start()
+    thread.join(remaining)
+    if thread.is_alive():
+        _close_auxiliary_client(client)
+        raise TimeoutError(_aux_timeout_message(task, kwargs.get("timeout")))
+
+    kind, payload = result_q.get_nowait()
+    if kind == "error":
+        raise payload
+    return payload
+
+
+async def _close_auxiliary_client_async(client: Any) -> None:
+    """Best-effort async close to break blocked SDK streams/sockets."""
+    close_fn = getattr(client, "aclose", None)
+    if callable(close_fn):
+        try:
+            result = close_fn()
+            if hasattr(result, "__await__"):
+                await result
+            return
+        except Exception:
+            logger.debug("Auxiliary async client aclose after timeout failed", exc_info=True)
+    _close_auxiliary_client(client)
+
+
+async def _async_create_with_wall_clock_timeout(
+    client: Any,
+    kwargs: Dict[str, Any],
+    deadline: Optional[float],
+    task: Optional[str],
+) -> Any:
+    """Async counterpart to _create_with_wall_clock_timeout."""
+    import asyncio
+
+    remaining = _remaining_wall_clock(deadline)
+    if remaining is None:
+        return await client.chat.completions.create(**kwargs)
+    if remaining <= 0:
+        await _close_auxiliary_client_async(client)
+        raise TimeoutError(_aux_timeout_message(task, kwargs.get("timeout")))
+
+    try:
+        return await asyncio.wait_for(
+            client.chat.completions.create(**kwargs),
+            timeout=remaining,
+        )
+    except asyncio.TimeoutError as exc:
+        await _close_auxiliary_client_async(client)
+        raise TimeoutError(_aux_timeout_message(task, kwargs.get("timeout"))) from exc
+
+
 def call_llm(
     task: str = None,
     *,
@@ -4192,6 +4325,7 @@ def call_llm(
                 f"Run: hermes setup")
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    call_deadline = _deadline_from_timeout(effective_timeout)
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
@@ -4218,8 +4352,10 @@ def call_llm(
     # then payment fallback.
     try:
         return _validate_llm_response(
-            client.chat.completions.create(**kwargs), task)
+            _create_with_wall_clock_timeout(client, kwargs, call_deadline, task), task)
     except Exception as first_err:
+        if isinstance(first_err, TimeoutError):
+            raise
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
@@ -4229,8 +4365,10 @@ def call_llm(
             )
             try:
                 return _validate_llm_response(
-                    client.chat.completions.create(**retry_kwargs), task)
+                    _create_with_wall_clock_timeout(client, retry_kwargs, call_deadline, task), task)
             except Exception as retry_err:
+                if isinstance(retry_err, TimeoutError):
+                    raise
                 retry_err_str = str(retry_err)
                 # If retry still fails, fall through to the max_tokens /
                 # payment / auth chains below using the temperature-stripped
@@ -4267,8 +4405,10 @@ def call_llm(
             kwargs.pop("max_completion_tokens", None)
             try:
                 return _validate_llm_response(
-                    client.chat.completions.create(**kwargs), task)
+                    _create_with_wall_clock_timeout(client, kwargs, call_deadline, task), task)
             except Exception as retry_err:
+                if isinstance(retry_err, TimeoutError):
+                    raise
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
@@ -4297,7 +4437,7 @@ def call_llm(
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
                 return _validate_llm_response(
-                    refreshed_client.chat.completions.create(**kwargs), task)
+                    _create_with_wall_clock_timeout(refreshed_client, kwargs, call_deadline, task), task)
 
         # ── Auth refresh retry ───────────────────────────────────────
         if (_is_auth_error(first_err)
@@ -4332,7 +4472,7 @@ def call_llm(
             if _is_rate_limit_error(first_err):
                 try:
                     return _validate_llm_response(
-                        client.chat.completions.create(**kwargs), task)
+                        _create_with_wall_clock_timeout(client, kwargs, call_deadline, task), task)
                 except Exception as retry_err:
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
@@ -4411,7 +4551,7 @@ def call_llm(
                     extra_body=effective_extra_body,
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
                 return _validate_llm_response(
-                    fb_client.chat.completions.create(**fb_kwargs), task)
+                    _create_with_wall_clock_timeout(fb_client, fb_kwargs, call_deadline, task), task)
         # Connection/timeout errors leave the cached client poisoned (closed
         # httpx transport, half-read stream, dead async loop).  Drop it from
         # the cache regardless of whether we found a fallback above so the
@@ -4556,6 +4696,7 @@ async def async_call_llm(
                 f"Run: hermes setup")
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    call_deadline = _deadline_from_timeout(effective_timeout)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish
@@ -4573,8 +4714,10 @@ async def async_call_llm(
 
     try:
         return _validate_llm_response(
-            await client.chat.completions.create(**kwargs), task)
+            await _async_create_with_wall_clock_timeout(client, kwargs, call_deadline, task), task)
     except Exception as first_err:
+        if isinstance(first_err, TimeoutError):
+            raise
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
@@ -4584,8 +4727,10 @@ async def async_call_llm(
             )
             try:
                 return _validate_llm_response(
-                    await client.chat.completions.create(**retry_kwargs), task)
+                    await _async_create_with_wall_clock_timeout(client, retry_kwargs, call_deadline, task), task)
             except Exception as retry_err:
+                if isinstance(retry_err, TimeoutError):
+                    raise
                 retry_err_str = str(retry_err)
                 if not (
                     _is_payment_error(retry_err)
@@ -4618,8 +4763,10 @@ async def async_call_llm(
             kwargs.pop("max_completion_tokens", None)
             try:
                 return _validate_llm_response(
-                    await client.chat.completions.create(**kwargs), task)
+                    await _async_create_with_wall_clock_timeout(client, kwargs, call_deadline, task), task)
             except Exception as retry_err:
+                if isinstance(retry_err, TimeoutError):
+                    raise
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
@@ -4647,7 +4794,7 @@ async def async_call_llm(
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
                 return _validate_llm_response(
-                    await refreshed_client.chat.completions.create(**kwargs), task)
+                    await _async_create_with_wall_clock_timeout(refreshed_client, kwargs, call_deadline, task), task)
 
         # ── Auth refresh retry (mirrors sync call_llm) ───────────────
         if (_is_auth_error(first_err)
@@ -4681,7 +4828,7 @@ async def async_call_llm(
             if _is_rate_limit_error(first_err):
                 try:
                     return _validate_llm_response(
-                        await client.chat.completions.create(**kwargs), task)
+                        await _async_create_with_wall_clock_timeout(client, kwargs, call_deadline, task), task)
                 except Exception as retry_err:
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
@@ -4742,7 +4889,7 @@ async def async_call_llm(
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model
                 return _validate_llm_response(
-                    await async_fb.chat.completions.create(**fb_kwargs), task)
+                    await _async_create_with_wall_clock_timeout(async_fb, fb_kwargs, call_deadline, task), task)
         # Mirror the sync path: drop poisoned clients on connection/timeout
         # so the next aux call rebuilds.  See issue #23432.
         if _is_connection_error(first_err):

--- a/cli.py
+++ b/cli.py
@@ -11524,6 +11524,16 @@ class HermesCLI:
                 payload = (text, images) if images else text
                 if self._agent_running and not (text and _looks_like_slash_command(text)):
                     _effective_mode = self.busy_input_mode
+                    _compression_queue = False
+                    try:
+                        if (
+                            self.agent is not None
+                            and bool(self.agent.get_activity_summary().get("compression_in_progress"))
+                        ):
+                            _effective_mode = "queue"
+                            _compression_queue = True
+                    except Exception:
+                        _compression_queue = False
                     if _effective_mode == "steer":
                         # Route Enter through /steer — inject mid-run after the
                         # next tool call.  Images can't ride along (steer only
@@ -11549,7 +11559,13 @@ class HermesCLI:
                         # Queue for the next turn instead of interrupting
                         self._pending_input.put(payload)
                         preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
-                        _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
+                        if _compression_queue:
+                            _cprint(
+                                f"  🗜️ Compression in progress; message queued for next turn: "
+                                f"{preview[:80]}{'...' if len(preview) > 80 else ''}"
+                            )
+                        else:
+                            _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
                     elif _effective_mode == "interrupt":
                         self._interrupt_queue.put(payload)
                         # Debug: log to file when message enters interrupt queue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2552,6 +2552,19 @@ class GatewayRunner:
         # (sentinel) or lacks steer(), or the payload is empty, fall back
         # to queue semantics so nothing is lost.
         effective_mode = self._busy_input_mode
+        compression_in_progress = False
+        busy_summary = None
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                busy_summary = running_agent.get_activity_summary()
+                compression_in_progress = bool(busy_summary.get("compression_in_progress"))
+            except Exception:
+                busy_summary = None
+        if compression_in_progress:
+            # Compression rewrites/splits the context and may be blocked in an
+            # auxiliary LLM call. Never interrupt or steer this critical
+            # section; queue the user's text for the next clean turn.
+            effective_mode = "queue"
         steered = False
         if effective_mode == "steer":
             steer_text = (event.text or "").strip()
@@ -2612,7 +2625,7 @@ class GatewayRunner:
         status_parts = []
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
-                summary = running_agent.get_activity_summary()
+                summary = busy_summary or running_agent.get_activity_summary()
                 iteration = summary.get("api_call_count", 0)
                 max_iter = summary.get("max_iterations", 0)
                 current_tool = summary.get("current_tool")
@@ -2633,6 +2646,11 @@ class GatewayRunner:
             message = (
                 f"⏩ Steered into current run{status_detail}. "
                 f"Your message arrives after the next tool call."
+            )
+        elif compression_in_progress:
+            message = (
+                f"🗜️ Compression in progress; message queued for next turn{status_detail}. "
+                f"I'll respond once the context compression finishes."
             )
         elif is_queue_mode:
             message = (
@@ -2740,6 +2758,20 @@ class GatewayRunner:
         logged and swallowed so they never block the shutdown sequence.
         """
         active = self._snapshot_running_agents()
+        if not active:
+            logger.debug("Skipping shutdown notification: no active gateway tasks")
+            return
+
+        _notify_sig = (bool(self._restart_requested), tuple(sorted(active.keys())))
+        _notify_now = time.time()
+        if (
+            getattr(self, "_last_shutdown_notify_signature", None) == _notify_sig
+            and _notify_now - getattr(self, "_last_shutdown_notify_at", 0.0) < 60.0
+        ):
+            logger.debug("Skipping duplicate shutdown notification for active sessions")
+            return
+        self._last_shutdown_notify_signature = _notify_sig
+        self._last_shutdown_notify_at = _notify_now
 
         action = "restarting" if self._restart_requested else "shutting down"
         hint = (
@@ -6282,6 +6314,17 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
+            try:
+                if (
+                    running_agent is not None
+                    and running_agent is not _AGENT_PENDING_SENTINEL
+                    and bool(running_agent.get_activity_summary().get("compression_in_progress"))
+                ):
+                    logger.debug("PRIORITY compression-queue follow-up for session %s", _quick_key)
+                    self._queue_or_replace_pending_event(_quick_key, event)
+                    return "🗜️ Compression in progress; message queued for next turn."
+            except Exception:
+                pass
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1397,6 +1397,13 @@ class AIAgent:
         self._execution_thread_id: int | None = None  # Set at run_conversation() start
         self._interrupt_thread_signal_pending = False
         self._client_lock = threading.RLock()
+        # Compression is a hot-path critical section: interrupting the worker
+        # while the compressor is rewriting/splitting context can leave stale
+        # threads and confusing queued input. UIs read this flag to force
+        # queue semantics until compression completes.
+        self._compression_in_progress = False
+        self._compression_started_at: Optional[float] = None
+        self._force_handoff_after_compression = False
 
         # /steer mechanism — inject a user note into the next tool result
         # without interrupting the agent. Unlike interrupt(), steer() does
@@ -2115,6 +2122,11 @@ class AIAgent:
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        try:
+            compression_preflight_max_passes = int(_compression_cfg.get("preflight_max_passes", 3))
+        except (TypeError, ValueError):
+            compression_preflight_max_passes = 3
+        compression_preflight_max_passes = max(0, compression_preflight_max_passes)
         # protect_first_n is the number of non-system messages to protect at
         # the head, in addition to the system prompt (which is always
         # implicitly protected by the compressor).  Floor at 0 — a value of
@@ -2340,6 +2352,7 @@ class AIAgent:
                 api_mode=self.api_mode,
             )
         self.compression_enabled = compression_enabled
+        self._compression_preflight_max_passes = compression_preflight_max_passes
 
         # Reject models whose context window is below the minimum required
         # for reliable tool-calling workflows (64K tokens).
@@ -5635,6 +5648,11 @@ class AIAgent:
         when it was killed, and by the periodic "still working" notifications.
         """
         elapsed = time.time() - self._last_activity_ts
+        compression_started = getattr(self, "_compression_started_at", None)
+        compression_elapsed = (
+            round(time.time() - compression_started, 1)
+            if compression_started else None
+        )
         return {
             "last_activity_ts": self._last_activity_ts,
             "last_activity_desc": self._last_activity_desc,
@@ -5644,7 +5662,36 @@ class AIAgent:
             "max_iterations": self.max_iterations,
             "budget_used": self.iteration_budget.used,
             "budget_max": self.iteration_budget.max_total,
+            "compression_in_progress": bool(getattr(self, "_compression_in_progress", False)),
+            "compression_elapsed": compression_elapsed,
+            "handoff_required_after_compression": bool(getattr(self, "_force_handoff_after_compression", False)),
         }
+
+    def _should_pre_cap_closeout(self) -> bool:
+        """Return True when the session should close out before hard iteration cap."""
+        budget = getattr(self, "iteration_budget", None)
+        max_total = getattr(budget, "max_total", 0) or 0
+        used = getattr(budget, "used", 0) or 0
+        # Avoid surprising tiny test/subagent budgets; this gate is for long
+        # interactive sessions where hitting the cap causes stuck-looking exits.
+        if max_total < 20:
+            return False
+        return used >= max(1, int(max_total * 0.85))
+
+    def _forced_closeout_response(self, reason: str) -> str:
+        """Deterministic closeout text used when another model/tool cycle is unsafe."""
+        if reason == "compression":
+            return (
+                "I need to stop this session here because the context has already "
+                "been compressed multiple times. Continuing would risk degraded or "
+                "stale reasoning. Start a fresh session and carry forward the latest "
+                "handoff/summary before continuing."
+            )
+        return (
+            "I need to stop this session before the iteration cap is exhausted. "
+            "Continuing in this session risks a hard stop mid-task. Start a fresh "
+            "session and carry forward the current task state before continuing."
+        )
 
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider and context engine — call at actual session boundaries.
@@ -10374,12 +10421,18 @@ class AIAgent:
             except Exception:
                 pass
 
+        self._compression_in_progress = True
+        self._compression_started_at = time.time()
         try:
-            compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
-        except TypeError:
-            # Plugin context engine with strict signature that doesn't accept
-            # focus_topic — fall back to calling without it.
-            compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+            try:
+                compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
+            except TypeError:
+                # Plugin context engine with strict signature that doesn't accept
+                # focus_topic — fall back to calling without it.
+                compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+        finally:
+            self._compression_in_progress = False
+            self._compression_started_at = None
 
         summary_error = getattr(self.context_compressor, "_last_summary_error", None)
         if summary_error:
@@ -10490,9 +10543,10 @@ class AIAgent:
         # Warn on repeated compressions (quality degrades with each pass)
         _cc = self.context_compressor.compression_count
         if _cc >= 2:
+            self._force_handoff_after_compression = True
             self._vprint(
                 f"{self.log_prefix}⚠️  Session compressed {_cc} times — "
-                f"accuracy may degrade. Consider /new to start fresh.",
+                f"forcing a fresh-session handoff before more tool/model work.",
                 force=True,
             )
 
@@ -12082,7 +12136,10 @@ class AIAgent:
                 tools=self.tools or None,
             )
 
-            if _preflight_tokens >= self.context_compressor.threshold_tokens:
+            if (
+                _preflight_tokens >= self.context_compressor.threshold_tokens
+                and self._compression_preflight_max_passes > 0
+            ):
                 logger.info(
                     "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                     f"{_preflight_tokens:,}",
@@ -12097,7 +12154,7 @@ class AIAgent:
                 )
                 # May need multiple passes for very large sessions with small
                 # context windows (each pass summarises the middle N turns).
-                for _pass in range(3):
+                for _pass in range(self._compression_preflight_max_passes):
                     _orig_len = len(messages)
                     messages, active_system_prompt = self._compress_context(
                         messages, system_message, approx_tokens=_preflight_tokens,
@@ -12248,6 +12305,18 @@ class AIAgent:
                 _turn_exit_reason = "interrupted_by_user"
                 if not self.quiet_mode:
                     self._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
+                break
+
+            if getattr(self, "_force_handoff_after_compression", False):
+                _turn_exit_reason = "compression_handoff_required"
+                final_response = self._forced_closeout_response("compression")
+                messages.append({"role": "assistant", "content": final_response})
+                break
+
+            if self._should_pre_cap_closeout():
+                _turn_exit_reason = "pre_cap_closeout"
+                final_response = self._forced_closeout_response("pre_cap")
+                messages.append({"role": "assistant", "content": final_response})
                 break
             
             api_call_count += 1

--- a/tests/agent/test_auxiliary_wall_clock_timeout.py
+++ b/tests/agent/test_auxiliary_wall_clock_timeout.py
@@ -1,0 +1,131 @@
+"""Regression tests for auxiliary LLM wall-clock timeout enforcement.
+
+Auxiliary calls are used by hot-path features such as context compression.  A
+provider SDK timeout alone is not sufficient: a streaming call can block the
+interactive reply path until the user interrupts the whole session.  These tests
+cover the provider-independent wrapper used by OpenAI-compatible, Codex, and
+Anthropic auxiliary clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.auxiliary_client import (
+    _async_create_with_wall_clock_timeout,
+    _create_with_wall_clock_timeout,
+    _deadline_from_timeout,
+)
+
+
+class _BlockingCompletions:
+    def __init__(self, closed: threading.Event):
+        self.closed = closed
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        # Simulate an SDK stream that would otherwise keep the reply path stuck.
+        self.closed.wait(timeout=5.0)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="late"))]
+        )
+
+
+class _FakeSyncClient:
+    def __init__(self):
+        self.closed = threading.Event()
+        self.chat = SimpleNamespace(completions=_BlockingCompletions(self.closed))
+
+    def close(self):
+        self.closed.set()
+
+
+class _ImmediateCompletions:
+    def create(self, **kwargs):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+
+class _FakeImmediateClient:
+    def __init__(self):
+        self.closed = False
+        self.chat = SimpleNamespace(completions=_ImmediateCompletions())
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.parametrize("task", ["compression", "openai-compatible", "anthropic-compatible", "openai-codex"])
+def test_sync_wall_clock_timeout_closes_provider_client(task):
+    client = _FakeSyncClient()
+    started = time.monotonic()
+
+    with pytest.raises(TimeoutError, match="wall-clock timeout"):
+        _create_with_wall_clock_timeout(
+            client,
+            {"model": "m", "messages": [], "timeout": 0.05},
+            _deadline_from_timeout(0.05),
+            task,
+        )
+
+    assert time.monotonic() - started < 0.5
+    assert client.closed.is_set(), "timed-out auxiliary client must be closed"
+
+
+def test_sync_wall_clock_timeout_preserves_successful_response():
+    client = _FakeImmediateClient()
+
+    response = _create_with_wall_clock_timeout(
+        client,
+        {"model": "m", "messages": [], "timeout": 1.0},
+        _deadline_from_timeout(1.0),
+        "compression",
+    )
+
+    assert response.choices[0].message.content == "ok"
+    assert client.closed is False
+
+
+class _AsyncBlockingCompletions:
+    def __init__(self):
+        self.started = asyncio.Event()
+
+    async def create(self, **kwargs):
+        self.started.set()
+        await asyncio.sleep(5.0)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="late"))]
+        )
+
+
+class _FakeAsyncClient:
+    def __init__(self):
+        self.closed = False
+        self.chat = SimpleNamespace(completions=_AsyncBlockingCompletions())
+
+    async def aclose(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_async_wall_clock_timeout_closes_provider_client():
+    client = _FakeAsyncClient()
+    started = time.monotonic()
+
+    with pytest.raises(TimeoutError, match="wall-clock timeout"):
+        await _async_create_with_wall_clock_timeout(
+            client,
+            {"model": "m", "messages": [], "timeout": 0.05},
+            _deadline_from_timeout(0.05),
+            "compression",
+        )
+
+    assert time.monotonic() - started < 0.5
+    assert client.closed is True

--- a/tests/gateway/test_compression_busy_quarantine.py
+++ b/tests/gateway/test_compression_busy_quarantine.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.base import MessageEvent
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+class CompressingAgent:
+    def __init__(self):
+        self.interrupt = MagicMock()
+
+    def get_activity_summary(self):
+        return {
+            "compression_in_progress": True,
+            "api_call_count": 4,
+            "max_iterations": 200,
+            "current_tool": None,
+        }
+
+
+@pytest.mark.asyncio
+async def test_busy_message_queues_instead_of_interrupting_during_compression():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source()
+    session_key = runner._session_key_for_source(source)
+    agent = CompressingAgent()
+    runner._running_agents[session_key] = agent
+    runner._running_agents_ts[session_key] = 0
+    runner._busy_input_mode = "interrupt"
+    runner._busy_ack_ts = {}
+
+    event = MessageEvent(text="follow up", source=source, message_id="m1")
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    agent.interrupt.assert_not_called()
+    queued = adapter._pending_messages[session_key]
+    assert queued.text == "follow up"
+    assert adapter.sent
+    assert "Compression in progress" in adapter.sent[-1]
+    assert "queued for next turn" in adapter.sent[-1]
+
+
+def test_agent_activity_summary_exposes_compression_state():
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._last_activity_ts = 100.0
+    agent._last_activity_desc = "testing"
+    agent._current_tool = None
+    agent._api_call_count = 2
+    agent.max_iterations = 200
+    agent.iteration_budget = SimpleNamespace(used=2, max_total=200)
+    agent._compression_in_progress = True
+    agent._compression_started_at = 99.0
+
+    summary = agent.get_activity_summary()
+
+    assert summary["compression_in_progress"] is True
+    assert summary["compression_elapsed"] is not None

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1157,7 +1157,7 @@ async def test_restart_banner_uses_try_to_resume_wording():
 
 
 @pytest.mark.asyncio
-async def test_restart_notifies_home_channel_even_without_active_sessions():
+async def test_restart_skips_home_channel_without_active_sessions():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
     runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
@@ -1168,10 +1168,7 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    assert adapter.sent == [
-        "⚠️ Gateway restarting — Your current task will be interrupted. "
-        "Send any message after restart and I'll try to resume where you left off."
-    ]
+    assert adapter.sent == []
 
 
 @pytest.mark.asyncio
@@ -1219,7 +1216,7 @@ async def test_restart_home_channel_notification_not_deduped_across_threads():
 
 
 @pytest.mark.asyncio
-async def test_restart_home_channel_notification_ignores_false_send_result():
+async def test_restart_home_channel_notification_not_sent_without_active_task_even_if_send_would_fail():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
     runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
@@ -1231,7 +1228,7 @@ async def test_restart_home_channel_notification_ignores_false_send_result():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    adapter.send.assert_called_once()
+    adapter.send.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_shutdown_notification_guard.py
+++ b/tests/gateway/test_shutdown_notification_guard.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_skips_when_no_active_gateway_task():
+    runner, adapter = make_restart_runner()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_dedupes_same_active_session_within_window():
+    runner, adapter = make_restart_runner()
+    session_key = "agent:main:telegram:dm:12345"
+    runner._running_agents[session_key] = object()
+    runner._restart_requested = True
+
+    await runner._notify_active_sessions_of_shutdown()
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
+    assert "Gateway restarting" in adapter.sent[0]

--- a/tests/run_agent/test_preflight_compression_budget.py
+++ b/tests/run_agent/test_preflight_compression_budget.py
@@ -1,0 +1,63 @@
+"""Tests for AIAgent preflight compression pass budgeting."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+def _make_agent_with_compression_config(compression_cfg: dict) -> AIAgent:
+    with (
+        patch("hermes_cli.config.load_config", return_value={"compression": compression_cfg}),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        kwargs = {"api" + "_key": "placeholder"}
+        return AIAgent(
+            **kwargs,
+            base_url="https://openrouter.ai/api/v1",
+            model="anthropic/claude-sonnet-4.6",
+            provider="openrouter",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_preflight_max_passes_defaults_to_legacy_three():
+    agent = _make_agent_with_compression_config({})
+
+    assert agent._compression_preflight_max_passes == 3
+
+
+def test_preflight_max_passes_honors_configured_one():
+    agent = _make_agent_with_compression_config({"preflight_max_passes": 1})
+
+    assert agent._compression_preflight_max_passes == 1
+
+
+def test_preflight_max_passes_clamps_negative_to_zero():
+    agent = _make_agent_with_compression_config({"preflight_max_passes": -4})
+
+    assert agent._compression_preflight_max_passes == 0
+
+
+def test_pre_cap_closeout_triggers_at_eighty_five_percent_budget():
+    agent = object.__new__(AIAgent)
+    agent.iteration_budget = SimpleNamespace(used=169, max_total=200)
+    assert agent._should_pre_cap_closeout() is False
+
+    agent.iteration_budget = SimpleNamespace(used=170, max_total=200)
+    assert agent._should_pre_cap_closeout() is True
+
+
+def test_repeated_compression_closeout_text_is_deterministic():
+    agent = object.__new__(AIAgent)
+
+    response = agent._forced_closeout_response("compression")
+
+    assert "compressed multiple times" in response
+    assert "fresh session" in response


### PR DESCRIPTION
## Summary
- add a central wall-clock timeout wrapper for auxiliary chat completion calls and close provider clients on timeout/failure
- honor `compression.preflight_max_passes` and expose compression-in-progress activity state
- queue busy input while compression is active, preserving explicit Ctrl-C as the hard interrupt path
- add closeout gates for repeated compression and high iteration budget usage
- avoid gateway restart/shutdown notification noise when no active task exists and throttle duplicate notifications

## Test plan
- `uv run --extra dev python -m pytest tests/agent/test_auxiliary_wall_clock_timeout.py tests/run_agent/test_preflight_compression_budget.py tests/gateway/test_compression_busy_quarantine.py tests/gateway/test_shutdown_notification_guard.py -q` — 15 passed
- `uv run --extra dev python -m pytest tests/gateway/test_compression_busy_quarantine.py tests/gateway/test_shutdown_notification_guard.py tests/gateway/test_shutdown_cache_cleanup.py tests/gateway/test_shutdown_memory_provider_messages.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_session_reset_notify.py -q` — 92 passed
- `uv run --extra dev python -m py_compile agent/auxiliary_client.py run_agent.py cli.py gateway/run.py`
- `git diff --check origin/main...HEAD`