### PR TITLE
feat(cli): surface model aliases for discoverability

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4738,6 +4738,34 @@ class HermesCLI:
         print("  Tip: Use 'all' or '*' to enable all toolsets")
         print("  Example: python cli.py --toolsets web,terminal")
         print()
+
+    def _handle_aliases(self) -> None:
+        """Handle /aliases command — list all model shortcuts and aliases."""
+        from hermes_cli.model_switch import list_all_aliases
+
+        aliases = list_all_aliases()
+        if not aliases:
+            _cprint("  No model aliases available.")
+            return
+
+        builtin = [(name, resolved) for name, resolved, source in aliases if source == "builtin"]
+        user = [(name, resolved) for name, resolved, source in aliases if source == "user"]
+
+        print()
+        if builtin:
+            _cprint(f"  {_BOLD}Built-in shortcuts:{_RST}")
+            for name, resolved in builtin:
+                _cprint(f"    {name:<12} → {resolved}")
+        if user:
+            if builtin:
+                print()
+            _cprint(f"  {_BOLD}User-defined aliases:{_RST}")
+            for name, resolved in user:
+                _cprint(f"    {name:<12} → {resolved}")
+        if not user:
+            print()
+            _cprint(f"  {_DIM}Add custom aliases under model_aliases: in config.yaml{_RST}")
+        print()
     
     def _handle_profile_command(self):
         """Display active profile name and home directory."""
@@ -5486,6 +5514,8 @@ class HermesCLI:
         provider_label = result.provider_label or result.target_provider
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
+        if result.resolved_via_alias:
+            _cprint(f"    Alias: {result.resolved_via_alias}")
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
@@ -5714,6 +5744,8 @@ class HermesCLI:
         provider_label = result.provider_label or result.target_provider
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
+        if result.resolved_via_alias:
+            _cprint(f"    Alias: {result.resolved_via_alias}")
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
@@ -6447,6 +6479,8 @@ class HermesCLI:
                 self._handle_skills_command(cmd_original)
         elif canonical == "platforms":
             self._show_gateway_status()
+        elif canonical == "aliases":
+            self._handle_aliases()
         elif canonical == "status":
             self._show_session_status()
         elif canonical == "statusbar":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5235,6 +5235,9 @@ class GatewayRunner:
         if canonical == "model":
             return await self._handle_model_command(event)
 
+        if canonical == "aliases":
+            return await self._handle_aliases(event)
+
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
@@ -7541,6 +7544,8 @@ class GatewayRunner:
                         plabel = result.provider_label or result.target_provider
                         lines = [f"Model switched to `{result.new_model}`"]
                         lines.append(f"Provider: {plabel}")
+                        if result.resolved_via_alias:
+                            lines.append(f"Alias: `{result.resolved_via_alias}`")
                         mi = result.model_info
                         from hermes_cli.model_switch import resolve_display_context_length
                         _sw_config_ctx = None
@@ -7698,6 +7703,8 @@ class GatewayRunner:
         provider_label = result.provider_label or result.target_provider
         lines = [f"Model switched to `{result.new_model}`"]
         lines.append(f"Provider: {provider_label}")
+        if result.resolved_via_alias:
+            lines.append(f"Alias: `{result.resolved_via_alias}`")
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry.
@@ -7746,6 +7753,34 @@ class GatewayRunner:
             lines.append("Saved to config.yaml (`--global`)")
         else:
             lines.append("_(session only -- add `--global` to persist)_")
+
+        return "\n".join(lines)
+
+    async def _handle_aliases(self, event: MessageEvent) -> str:
+        """Handle /aliases command - list model shortcuts and aliases."""
+        from hermes_cli.model_switch import list_all_aliases
+
+        aliases = list_all_aliases()
+        if not aliases:
+            return "No model aliases available."
+
+        builtin = [(name, resolved) for name, resolved, source in aliases if source == "builtin"]
+        user = [(name, resolved) for name, resolved, source in aliases if source == "user"]
+
+        lines = []
+        if builtin:
+            lines.append("**Built-in shortcuts:**")
+            for name, resolved in builtin:
+                lines.append(f"  `{name}` → `{resolved}`")
+        if user:
+            if builtin:
+                lines.append("")
+            lines.append("**User-defined aliases:**")
+            for name, resolved in user:
+                lines.append(f"  `{name}` → `{resolved}`")
+        if not user:
+            lines.append("")
+            lines.append("_Add custom aliases under `model_aliases:` in `config.yaml`._")
 
         return "\n".join(lines)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -178,6 +178,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),
+    CommandDef("aliases", "List all available model shortcuts and aliases", "Info",
+               aliases=("als",)),
     CommandDef("help", "Show available commands", "Info"),
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -224,6 +224,56 @@ def _ensure_direct_aliases() -> None:
         DIRECT_ALIASES.update(_load_direct_aliases())
 
 
+def _resolve_builtin_alias_target(name: str, identity: ModelIdentity) -> str:
+    """Best-effort concrete model ID for a built-in alias.
+
+    Prefers an OpenRouter vendor/model slug because it is unambiguous across
+    providers. Falls back to a broader models.dev search, then finally to the
+    unresolved ``vendor/family`` prefix when the catalog is unavailable.
+    """
+    try:
+        alias_result = resolve_alias(name, "openrouter")
+        if alias_result is not None:
+            return alias_result[1]
+    except Exception:
+        pass
+
+    vendor_prefix = f"{identity.vendor}/{identity.family}".lower()
+    family_prefix = identity.family.lower()
+
+    try:
+        for match in list_provider_models("openrouter"):
+            model_lower = match.lower()
+            if model_lower.startswith(vendor_prefix) or model_lower.startswith(family_prefix):
+                return match
+    except Exception:
+        pass
+
+    return f"{identity.vendor}/{identity.family}"
+
+
+def list_all_aliases() -> list[tuple[str, str, str]]:
+    """Return every discoverable model alias as ``(name, resolved_model, source)``.
+
+    User-configured direct aliases shadow built-in aliases with the same name,
+    matching the runtime resolution order in :func:`resolve_alias`.
+    """
+    _ensure_direct_aliases()
+
+    aliases: list[tuple[str, str, str]] = []
+    user_alias_names = set(DIRECT_ALIASES)
+
+    for name, direct in sorted(DIRECT_ALIASES.items()):
+        aliases.append((name, direct.model, "user"))
+
+    for name, identity in sorted(MODEL_ALIASES.items()):
+        if name in user_alias_names:
+            continue
+        aliases.append((name, _resolve_builtin_alias_target(name, identity), "builtin"))
+
+    return aliases
+
+
 # ---------------------------------------------------------------------------
 # Result dataclasses
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_alias_discovery.py
+++ b/tests/hermes_cli/test_alias_discovery.py
@@ -1,0 +1,147 @@
+"""Tests for model alias discoverability — list_all_aliases and /aliases command."""
+
+from __future__ import annotations
+
+import pytest
+
+import hermes_cli.model_switch as ms
+from hermes_cli.model_switch import (
+    MODEL_ALIASES,
+    DirectAlias,
+    _resolve_builtin_alias_target,
+    list_all_aliases,
+)
+from hermes_cli.commands import COMMAND_REGISTRY, resolve_command
+
+
+# ---------------------------------------------------------------------------
+# list_all_aliases unit tests
+# ---------------------------------------------------------------------------
+
+class TestListAllAliases:
+    """Test list_all_aliases() output structure and correctness."""
+
+    def test_returns_list_of_tuples(self, monkeypatch):
+        """list_all_aliases returns list of (name, resolved_model, source) tuples."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        result = list_all_aliases()
+        assert isinstance(result, list)
+        for entry in result:
+            assert isinstance(entry, tuple)
+            assert len(entry) == 3
+            name, resolved, source = entry
+            assert isinstance(name, str)
+            assert isinstance(resolved, str)
+            assert source in ("builtin", "user")
+
+    def test_builtin_aliases_present(self, monkeypatch):
+        """Built-in aliases like 'sonnet', 'opus', 'gpt5' are included."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        result = list_all_aliases()
+        names = {name for name, _, _ in result}
+        # All MODEL_ALIASES keys should be present (with no DIRECT_ALIASES to shadow)
+        for expected in ("sonnet", "opus", "haiku", "gpt5", "gemini", "grok"):
+            assert expected in names, f"Missing built-in alias: {expected}"
+
+    def test_user_aliases_override_builtins(self, monkeypatch):
+        """User-defined aliases shadow built-in aliases with the same name."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {
+            "sonnet": DirectAlias(model="custom-sonnet-v1", provider="custom", base_url=""),
+        })
+        result = list_all_aliases()
+        sonnet_entries = [(n, r, s) for n, r, s in result if n == "sonnet"]
+        assert len(sonnet_entries) == 1
+        name, resolved, source = sonnet_entries[0]
+        assert source == "user"
+        assert resolved == "custom-sonnet-v1"
+
+    def test_user_aliases_listed_as_user_source(self, monkeypatch):
+        """User-defined direct aliases appear with source='user'."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {
+            "my-model": DirectAlias(model="custom/v1", provider="custom", base_url=""),
+        })
+        result = list_all_aliases()
+        user_entries = [(n, r, s) for n, r, s in result if s == "user"]
+        user_names = {n for n, _, _ in user_entries}
+        assert "my-model" in user_names
+
+    def test_no_duplicates_when_user_shadows_builtin(self, monkeypatch):
+        """A user alias that shadows a builtin should not produce duplicate entries."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {
+            "grok": DirectAlias(model="my-grok", provider="custom", base_url=""),
+        })
+        result = list_all_aliases()
+        grok_entries = [n for n, _, _ in result if n == "grok"]
+        assert len(grok_entries) == 1
+
+    def test_empty_direct_aliases_gives_only_builtins(self, monkeypatch):
+        """With no user aliases, only builtins are returned."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        result = list_all_aliases()
+        sources = {s for _, _, s in result}
+        assert sources == {"builtin"}
+
+    def test_sorted_within_each_source(self, monkeypatch):
+        """User and builtin aliases are each sorted by name."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {
+            "zzz-custom": DirectAlias(model="custom-z", provider="custom", base_url=""),
+            "aaa-custom": DirectAlias(model="custom-a", provider="custom", base_url=""),
+        })
+        result = list_all_aliases()
+        user_names = [n for n, _, s in result if s == "user"]
+        builtin_names = [n for n, _, s in result if s == "builtin"]
+        assert user_names == sorted(user_names)
+        assert builtin_names == sorted(builtin_names)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_builtin_alias_target unit tests
+# ---------------------------------------------------------------------------
+
+class TestResolveBuiltinAliasTarget:
+    """Test _resolve_builtin_alias_target produces a reasonable model string."""
+
+    def test_returns_string(self, monkeypatch):
+        """_resolve_builtin_alias_target always returns a string."""
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        for name, identity in list(MODEL_ALIASES.items())[:5]:
+            result = _resolve_builtin_alias_target(name, identity)
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+    def test_fallback_format(self, monkeypatch):
+        """When resolve_alias and catalog fail, returns vendor/family fallback."""
+        monkeypatch.setattr(ms, "resolve_alias", lambda *a, **kw: None)
+        monkeypatch.setattr(ms, "list_provider_models", lambda *a, **kw: [])
+        identity = ms.ModelIdentity("test-vendor", "test-family")
+        result = _resolve_builtin_alias_target("test", identity)
+        assert result == "test-vendor/test-family"
+
+
+# ---------------------------------------------------------------------------
+# /aliases command registration
+# ---------------------------------------------------------------------------
+
+class TestAliasesCommandRegistration:
+    """Verify /aliases is registered in the command registry."""
+
+    def test_aliases_command_exists(self):
+        cmd = resolve_command("aliases")
+        assert cmd is not None
+        assert cmd.name == "aliases"
+        assert cmd.category == "Info"
+
+    def test_aliases_command_has_als_alias(self):
+        cmd = resolve_command("als")
+        assert cmd is not None
+        assert cmd.name == "aliases"
+
+    def test_aliases_in_registry(self):
+        names = [cmd.name for cmd in COMMAND_REGISTRY]
+        assert "aliases" in names
+
+    def test_aliases_not_cli_only_not_gateway_only(self):
+        """aliases command should be available in both CLI and gateway."""
+        cmd = resolve_command("aliases")
+        assert cmd.cli_only is False
+        assert cmd.gateway_only is False


### PR DESCRIPTION
## Summary
Model aliases already work in Hermes, but today they are hard to discover and mostly invisible in the user experience. If someone defines a shortcut in `config.yaml` or relies on the built-in aliases, there is no dedicated way to see what aliases exist or what they resolve to.

This PR makes aliases visible where users actually need them:
- add a new `/aliases` command in both CLI and gateway
- list built-in shortcuts alongside user-defined aliases from `model_aliases:`
- show the alias name in model-switch confirmations when a switch resolved through a shortcut

## Why this matters
Discoverability is the missing piece that makes model aliases usable in practice. Without it, aliases exist as hidden configuration and users have to remember them or inspect code/config manually. With `/aliases` and switch confirmation, aliases become self-explanatory and much easier to adopt.

## Non-goals
This PR is only about alias discoverability. Using aliases to assign different models to delegated agents can be layered on in a follow-up PR once the core UX is visible and test-covered.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_alias_discovery.py tests/hermes_cli/test_ollama_cloud_auth.py tests/hermes_cli/test_regression_16767.py -q -o "addopts="`
- [x] `47 passed, 1 warning`
