### PR TITLE
fix(compression): pass custom_providers to feasibility check context lookup

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1947,6 +1947,7 @@ class AIAgent:
         # Persist for reuse on switch_model / fallback activation. Must come
         # AFTER the custom_providers branch so per-model overrides aren't lost.
         self._config_context_length = _config_context_length
+        self._custom_providers = _custom_providers
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
 
@@ -2659,6 +2660,7 @@ class AIAgent:
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                custom_providers=getattr(self, "_custom_providers", None),
                 provider=getattr(self, "provider", ""),
             )
 

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -181,6 +181,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        custom_providers=None,
         provider="openrouter",
     )
 
@@ -204,6 +205,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
+        custom_providers=None,
         provider="openrouter",
     )
 
@@ -257,6 +259,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        custom_providers=[],
         provider="",
     )
 


### PR DESCRIPTION
## Summary

The compression feasibility check in `_check_compression_model_feasibility()` calls `get_model_context_length()` without passing `custom_providers`, so per-model `context_length` overrides from `custom_providers` config are ignored. The check falls back to the auxiliary compression model's detected context window (e.g. 256K) instead of the user's configured override (e.g. 1M), causing spurious warnings and auto-lowered compression thresholds.

## Root Cause

`get_model_context_length()` supports a `custom_providers` parameter (added in #15779) that checks per-model `context_length` overrides before probing endpoints. However, the feasibility check at `run_agent.py:2657` was not passing this parameter.

The `_custom_providers` list was resolved during `__init__` but only used for the main model's context length resolution, not stored on `self` for the feasibility check to access.

## Fix

1. Store `_custom_providers` on `self` alongside `_config_context_length` (line 1949).
2. Pass `custom_providers=getattr(self, '_custom_providers', None)` to `get_model_context_length()` in `_check_compression_model_feasibility()`.
3. Update existing test assertions to include the new parameter.

## Testing

- All 243 compression-related tests pass (`pytest -k compress`).
- Updated `test_compression_feasibility.py` assertions to verify the new parameter is forwarded.

## Scope

- `run_agent.py`: 2 lines added
- `tests/run_agent/test_compression_feasibility.py`: 3 assertion updates

Closes #19539