### PR TITLE
fix(weixin): simplify message delivery — send as single unit by default

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -763,42 +763,8 @@ def _split_markdown_blocks(content: str) -> List[str]:
 
 
 def _split_delivery_units_for_weixin(content: str) -> List[str]:
-    """Split formatted content into chat-friendly delivery units.
-
-    Weixin can render Markdown, but chat readability is better when top-level
-    line breaks become separate messages. Keep fenced code blocks intact and
-    attach indented continuation lines to the previous top-level line so nested
-    list items do not get torn apart.
-    """
-    units: List[str] = []
-
-    for block in _split_markdown_blocks(content):
-        if _FENCE_RE.match(block.splitlines()[0].strip()):
-            units.append(block)
-            continue
-
-        current: List[str] = []
-        for raw_line in block.splitlines():
-            line = raw_line.rstrip()
-            if not line.strip():
-                if current:
-                    units.append("\n".join(current).strip())
-                    current = []
-                continue
-
-            is_continuation = bool(current) and raw_line.startswith((" ", "\t"))
-            if is_continuation:
-                current.append(line)
-                continue
-
-            if current:
-                units.append("\n".join(current).strip())
-            current = [line]
-
-        if current:
-            units.append("\n".join(current).strip())
-
-    return [unit for unit in units if unit]
+    """Return content as a single unit; splitting is handled by length limits only."""
+    return [content] if content.strip() else []
 
 
 def _looks_like_chatty_line_for_weixin(line: str) -> bool:
@@ -829,6 +795,12 @@ def _looks_like_heading_line_for_weixin(line: str) -> bool:
     if _HEADER_RE.match(stripped):
         return True
     return len(stripped) <= 24 and stripped.endswith((":", "："))
+
+
+def _looks_like_chatty_block(block: str) -> bool:
+    """Return True when a block consists entirely of short chatty lines."""
+    lines = [l for l in block.splitlines() if l.strip()]
+    return bool(lines) and all(_looks_like_chatty_line_for_weixin(l) for l in lines)
 
 
 def _should_split_short_chat_block_for_weixin(block: str) -> bool:
@@ -885,11 +857,18 @@ def _split_text_for_weixin_delivery(
     if not content:
         return []
     if split_per_line:
-        # Legacy: one message per top-level delivery unit.
+        # Legacy: one top-level line → one bubble.
         if len(content) <= max_length and "\n" not in content:
             return [content]
         chunks: List[str] = []
-        for unit in _split_delivery_units_for_weixin(content):
+        for unit in _split_markdown_blocks(content):
+            # Short chatty blocks: split into individual lines.
+            if _looks_like_chatty_block(unit):
+                for line in unit.splitlines():
+                    line = line.strip()
+                    if line:
+                        chunks.append(line)
+                continue
             if len(unit) <= max_length:
                 chunks.append(unit)
                 continue
@@ -900,11 +879,9 @@ def _split_text_for_weixin_delivery(
     # content looks like a short chatty exchange, in which case split into
     # separate bubbles for a more natural chat feel.
     if len(content) <= max_length:
-        return (
-            [u for u in _split_delivery_units_for_weixin(content) if u]
-            if _should_split_short_chat_block_for_weixin(content)
-            else [content]
-        )
+        if _should_split_short_chat_block_for_weixin(content):
+            return [line.strip() for line in content.splitlines() if line.strip()]
+        return [content]
     return _pack_markdown_blocks_for_weixin(content, max_length) or [content]
 
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -762,11 +762,6 @@ def _split_markdown_blocks(content: str) -> List[str]:
     return [block for block in blocks if block]
 
 
-def _split_delivery_units_for_weixin(content: str) -> List[str]:
-    """Return content as a single unit; splitting is handled by length limits only."""
-    return [content] if content.strip() else []
-
-
 def _looks_like_chatty_line_for_weixin(line: str) -> bool:
     """Return True when a line looks like a standalone chat utterance."""
     stripped = line.strip()
@@ -797,20 +792,25 @@ def _looks_like_heading_line_for_weixin(line: str) -> bool:
     return len(stripped) <= 24 and stripped.endswith((":", "："))
 
 
-def _looks_like_chatty_block(block: str) -> bool:
-    """Return True when a block consists entirely of short chatty lines."""
+def _is_chatty_block(block: str, *, check_length: bool = True) -> bool:
+    """Return True when a block looks like a short chatty exchange.
+
+    When *check_length* is True (default for the compact path), also
+    require 2–6 non-empty lines and reject blocks whose first line
+    looks like a heading — this preserves the original
+    ``_should_split_short_chat_block_for_weixin`` guard rails.
+    When False (used in the per-line path), any non-empty all-chatty
+    block qualifies regardless of line count or heading.
+    """
     lines = [l for l in block.splitlines() if l.strip()]
-    return bool(lines) and all(_looks_like_chatty_line_for_weixin(l) for l in lines)
-
-
-def _should_split_short_chat_block_for_weixin(block: str) -> bool:
-    """Split only chat-like multiline blocks into separate bubbles."""
-    lines = [line for line in block.splitlines() if line.strip()]
-    if not 2 <= len(lines) <= 6:
+    if not lines:
         return False
-    if _looks_like_heading_line_for_weixin(lines[0]):
-        return False
-    return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
+    if check_length:
+        if not 2 <= len(lines) <= 6:
+            return False
+        if _looks_like_heading_line_for_weixin(lines[0]):
+            return False
+    return all(_looks_like_chatty_line_for_weixin(l) for l in lines)
 
 
 def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:
@@ -863,7 +863,7 @@ def _split_text_for_weixin_delivery(
         chunks: List[str] = []
         for unit in _split_markdown_blocks(content):
             # Short chatty blocks: split into individual lines.
-            if _looks_like_chatty_block(unit):
+            if _is_chatty_block(unit, check_length=False):
                 for line in unit.splitlines():
                     line = line.strip()
                     if line:
@@ -879,7 +879,7 @@ def _split_text_for_weixin_delivery(
     # content looks like a short chatty exchange, in which case split into
     # separate bubbles for a more natural chat feel.
     if len(content) <= max_length:
-        if _should_split_short_chat_block_for_weixin(content):
+        if _is_chatty_block(content):
             return [line.strip() for line in content.splitlines() if line.strip()]
         return [content]
     return _pack_markdown_blocks_for_weixin(content, max_length) or [content]


### PR DESCRIPTION
## Summary

Weixin message delivery was over-segmented: headings separated from body text, Markdown symbols appearing as isolated bubbles, structured content broken into fragments. Root cause: `_split_delivery_units_for_weixin` applied an overly aggressive line-level splitting heuristic. This PR removes it, sends messages as a single unit by default, splits only in two well-defined scenarios, and cleans up the dead code and overlapping helpers this exposes.

**Net change:** +30 / −53 lines (`gateway/platforms/weixin.py`)

## Technical Changes

### 1. Remove `_split_delivery_units_for_weixin` (−39 lines)

The original 40-line function handled line-level splitting, continuation-line detection, and code-block preservation. When called from the `split_per_line` path it then applied length checks and packing to each unit, causing headings to detach from body text and short lines to be sent as individual bubbles.

After simplification to a single-unit return it still had two call sites; further refactoring reduced callers to zero, so it was deleted outright.

### 2. Refactor `_split_text_for_weixin_delivery` — both paths

#### Compact mode (default, `split_per_line=False`)

**Before:**
```python
if len(content) <= max_length:
    return (
        [u for u in _split_delivery_units_for_weixin(content) if u]
        if _should_split_short_chat_block_for_weixin(content)
        else [content]
    )
```

**After:**
```python
if len(content) <= max_length:
    if _is_chatty_block(content):
        return [line.strip() for line in content.splitlines() if line.strip()]
    return [content]
```

- Short chatty exchanges (e.g. "line1\nline2\nline3") are split into individual bubbles directly via `splitlines()`, no longer routed through the removed heuristic.
- Non-chatty content is sent as a single message.

#### Per-line mode (`split_per_line=True`, legacy behavior)

**Before:**
```python
for unit in _split_delivery_units_for_weixin(content):
    if len(unit) <= max_length:
        chunks.append(unit)
        continue
```

**After:**
```python
for unit in _split_markdown_blocks(content):
    if _is_chatty_block(unit, check_length=False):
        for line in unit.splitlines():
            line = line.strip()
            if line:
                chunks.append(line)
        continue
    if len(unit) <= max_length:
        chunks.append(unit)
        continue
```

- Uses `_split_markdown_blocks` directly instead of the deleted `_split_delivery_units_for_weixin`.
- Pure-chatty blocks are split line-by-line (`check_length=False` skips the line-count/heading restrictions).

### 3. Merge `_looks_like_chatty_block` + `_should_split_short_chat_block_for_weixin` → `_is_chatty_block`

The two functions shared 90% identical logic — both check "all lines are chatty". The only difference:
- `_should_split_short_chat_block_for_weixin` additionally required 2–6 lines and a non-heading first line.
- `_looks_like_chatty_block` had no line-count or heading restrictions.

Merged into a single function with a `check_length` keyword toggle:

```python
def _is_chatty_block(block: str, *, check_length: bool = True) -> bool:
    lines = [l for l in block.splitlines() if l.strip()]
    if not lines:
        return False
    if check_length:
        if not 2 <= len(lines) <= 6:
            return False
        if _looks_like_heading_line_for_weixin(lines[0]):
            return False
    return all(_looks_like_chatty_line_for_weixin(l) for l in lines)
```

| Call site | Before | After | `check_length` |
|-----------|--------|-------|----------------|
| compact path | `_should_split_short_chat_block_for_weixin(content)` | `_is_chatty_block(content)` | `True` (default) |
| per-line path | `_looks_like_chatty_block(unit)` | `_is_chatty_block(unit, check_length=False)` | `False` |

### Function changes summary

| Function | Change |
|----------|--------|
| `_split_delivery_units_for_weixin` | **Deleted** (40-line heuristic → single-line wrapper → zero callers) |
| `_looks_like_chatty_block` | **Deleted** (merged into `_is_chatty_block`) |
| `_should_split_short_chat_block_for_weixin` | **Deleted** (merged into `_is_chatty_block`) |
| `_is_chatty_block` | **Added** (`check_length` param unifies both paths) |

## Test Results

- **51/51 passed** — no test modifications needed
- `TestWeixinChunking` all pass: chatty-split, table-keep-together, code-block integrity, heading-with-body

## References

- Related: #9612