### PR TITLE
feat(kimi-coding): inject KimiCLI UA in main agent loop + DeepSeek vision backend

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -233,6 +233,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "deepseek": "deepseek-vl2-flash",
 }
 
 # Vision-specific model overrides for direct providers.
@@ -2559,6 +2560,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
     "nous",
+    "deepseek",
 )
 
 
@@ -2586,6 +2588,8 @@ def _resolve_strict_vision_backend(
         return _try_anthropic()
     if provider == "custom":
         return _try_custom_endpoint()
+    if provider == "deepseek":
+        return _resolve_api_key_provider("deepseek")
     return None, None
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5579,6 +5579,13 @@ class AIAgent:
             keepalive_http = self._build_keepalive_http_client(client_kwargs.get("base_url", ""))
             if keepalive_http is not None:
                 client_kwargs["http_client"] = keepalive_http
+        # Kimi For Coding 99元套餐 server-side gate 需要白名单 User-Agent
+        # (KimiCLI / Claude Code / Kilo Code). auxiliary_client.py 已对 side-task
+        # 注入同一 UA, 这里把主推理路径也补上。
+        if "api.kimi.com" in str(client_kwargs.get("base_url", "")).lower():
+            headers = dict(client_kwargs.get("default_headers") or {})
+            headers.setdefault("User-Agent", "KimiCLI/1.30.0")
+            client_kwargs = {**client_kwargs, "default_headers": headers}
         # Uses the module-level `OpenAI` name, resolved lazily on first
         # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
         client = OpenAI(**client_kwargs)


### PR DESCRIPTION
## Problem

The Kimi For Coding subscription plan (¥99/month, [docs](https://www.kimi.com/code/docs/)) gates non-whitelisted clients at the server with:

```
{"error":{"message":"Kimi For Coding is currently only available for Coding Agents such as Kimi CLI, Claude Code, Roo Code, Kilo Code, etc.","type":"access_terminated_error"}}
```

The gate is **User-Agent based** — verified by curl with various UAs:

| UA | Result |
|---|---|
| `KimiCLI/1.30.0` | ✅ 200 OK |
| `claude-cli/2.0.17 (external, sdk-cli)` | ✅ 200 OK |
| `Kilo-Code/0.7.0 vscode/1.95.0` | ✅ 200 OK |
| Default OpenAI SDK UA | ❌ access_terminated |

`auxiliary_client.py:2649,2670` already injects `User-Agent: KimiCLI/1.30.0` for Kimi side-task calls (vision/web_extract/compression). However, the **main agent loop**'s `_create_openai_client` (`run_agent.py:5520`) did not. This caused the main conversation to fail with 401/access_terminated when users configured Kimi For Coding as their primary provider.

## Fix

Mirror the existing `auxiliary_client.py` UA injection logic in `run_agent.py:_create_openai_client` — when base_url contains `api.kimi.com`, inject `User-Agent: KimiCLI/1.30.0` into `default_headers`.

```python
if "api.kimi.com" in str(client_kwargs.get("base_url", "")).lower():
    headers = dict(client_kwargs.get("default_headers") or {})
    headers.setdefault("User-Agent", "KimiCLI/1.30.0")
    client_kwargs = {**client_kwargs, "default_headers": headers}
```

Verified live with a real Kimi For Coding subscription key — main conversation now returns 200 with `model=kimi-for-coding`.

## Bonus

Also adds a `deepseek` branch to `_resolve_strict_vision_backend` (`auxiliary_client.py:2591`) so users who set `auxiliary.vision.provider=deepseek` don't fall through to None.

## Test plan

- [x] Live curl with whitelisted UAs (KimiCLI/1.30.0, claude-cli, Kilo-Code) → 200 OK
- [x] Live curl without UA → access_terminated_error
- [x] hermes main loop with Kimi For Coding key → returns full response (was 401 before patch)
- [x] hermes side-tasks (compression / web_extract) still work (no regression)