### PR TITLE
fix(agent): thread custom_providers into compression feasibility check (#19539)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1946,6 +1946,11 @@ class AIAgent:
         # Persist for reuse on switch_model / fallback activation. Must come
         # AFTER the custom_providers branch so per-model overrides aren't lost.
         self._config_context_length = _config_context_length
+        # Persist custom_providers so _check_compression_model_feasibility can
+        # thread the list into get_model_context_length for the auxiliary
+        # compression model — otherwise per-model context_length overrides
+        # declared in custom_providers are silently ignored there. (#19539)
+        self._custom_providers = _custom_providers
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
 
@@ -2659,6 +2664,7 @@ class AIAgent:
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
                 provider=getattr(self, "provider", ""),
+                custom_providers=getattr(self, "_custom_providers", None),
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -205,6 +206,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -258,6 +260,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=getattr(agent, "_custom_providers", None),
     )
 
 
@@ -442,3 +445,65 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
         agent._compression_warning = None
 
     assert len(callback_events) == 0
+
+
+# ── custom_providers context_length override (#19539) ───────────────
+
+
+@patch("agent.auxiliary_client._resolve_task_provider_model")
+@patch("agent.model_metadata.get_model_context_length")
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_custom_providers_context_length_passed_to_feasibility_check(
+    mock_get_client, mock_ctx_len, mock_resolve
+):
+    """custom_providers per-model context_length must be threaded into the
+    compression feasibility check.  Without the fix, get_model_context_length
+    is called without custom_providers and ignores the user's override, causing
+    a spurious low-context warning / auto-threshold-lowering.  (#19539)"""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+
+    # Simulate a custom provider override of 500_000 tokens for the aux model.
+    custom_providers_cfg = [
+        {
+            "name": "my-openai-compatible",
+            "base_url": "https://custom.example.com/v1",
+            "models": {
+                "my-local-llm": {"context_length": 500_000},
+            },
+        }
+    ]
+    agent._custom_providers = custom_providers_cfg
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://custom.example.com/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "my-local-llm")
+    mock_resolve.return_value = ("my-openai-compatible", None, None, None, None)
+
+    # Return 256_000 when custom_providers is NOT passed (old behaviour) so we
+    # can assert that the patched call received the list.
+    captured_calls = []
+
+    def _side_effect(*args, **kwargs):
+        captured_calls.append(kwargs)
+        cp = kwargs.get("custom_providers")
+        if cp:
+            # Simulate get_model_context_length honouring the override.
+            return 500_000
+        return 256_000  # old behaviour — no custom_providers forwarded
+
+    mock_ctx_len.side_effect = _side_effect
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    # The feasibility call must have forwarded _custom_providers.
+    assert any(
+        call.get("custom_providers") == custom_providers_cfg
+        for call in captured_calls
+    ), "get_model_context_length was not called with custom_providers — fix not applied"
+
+    # With the override respected (500K > 100K threshold) no warning should fire.
+    assert len(messages) == 0, f"Unexpected warning: {messages}"
+    assert agent._compression_warning is None


### PR DESCRIPTION
## Problem

`_check_compression_model_feasibility()` called `get_model_context_length()` for the auxiliary compression model without passing the `custom_providers` list that was already resolved earlier in `__init__`. Any per-model `context_length` declared under `custom_providers[].models.<model>` was silently ignored, causing:

- A spurious "compression model context too small" warning
- An incorrect auto-threshold lowering for users whose auxiliary model lives on a custom-provider endpoint with a large context override

Reported in #19539.

## Root cause

`_custom_providers` was a local variable in `__init__` — it was never stored as `self._custom_providers`, so `_check_compression_model_feasibility()` had no way to access it.

## Fix

1. Persist the already-resolved list as `self._custom_providers` immediately after it is built in `__init__` (alongside the existing `self._config_context_length` store).
2. Pass `custom_providers=getattr(self, '_custom_providers', None)` to `get_model_context_length` inside `_check_compression_model_feasibility`.

## Tests

- Updated three existing `assert_called_once_with` assertions that now include the new keyword argument.
- Added `test_custom_providers_context_length_passed_to_feasibility_check`: verifies that `get_model_context_length` is invoked with the `custom_providers` list **and** that no spurious warning fires when the per-model override makes the aux context sufficient.

All 17 compression feasibility tests pass.