### PR TITLE
fix(subprocess): block /proc/environ env-blocklist bypass (#4427)

### DIFF
--- a/tests/test_subprocess_proc_environ_hardening.py
+++ b/tests/test_subprocess_proc_environ_hardening.py
@@ -20,31 +20,38 @@ _LINUX_ONLY = pytest.mark.skipif(
 )
 
 
+def _prctl_or_skip():
+    """Resolve libc.prctl via the same path production uses, or skip the test.
+
+    Production routes through `ctypes.util.find_library("c")` with a
+    `CDLL(None)` fallback so musl-based distros (Alpine) work; mirroring that
+    here keeps the test from spuriously failing on hosts where `libc.so.6`
+    doesn't exist.
+    """
+    from tools.environments.local import _resolve_prctl
+    prctl = _resolve_prctl()
+    if prctl is None:
+        pytest.skip("libc.prctl unavailable on this host")
+    return prctl
+
+
+_PR_GET_DUMPABLE = 3
+_PR_SET_DUMPABLE = 4
+
+
 def _get_dumpable() -> int:
-    import ctypes
-    libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    PR_GET_DUMPABLE = 3
-    return libc.prctl(PR_GET_DUMPABLE, 0, 0, 0, 0)
+    return _prctl_or_skip()(_PR_GET_DUMPABLE, 0, 0, 0, 0)
 
 
 def _set_dumpable(value: int) -> None:
-    import ctypes
-    libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    PR_SET_DUMPABLE = 4
-    libc.prctl(PR_SET_DUMPABLE, value, 0, 0, 0)
+    _prctl_or_skip()(_PR_SET_DUMPABLE, value, 0, 0, 0)
 
 
 @pytest.fixture
 def restore_dumpable():
-    import tools.environments.local as _local
     original = _get_dumpable()
-    original_flag = getattr(_local, "_PROC_ENVIRON_HARDENED", None)
-    if original_flag is not None:
-        _local._PROC_ENVIRON_HARDENED = False
     _set_dumpable(1)
     yield
-    if original_flag is not None:
-        _local._PROC_ENVIRON_HARDENED = original_flag
     _set_dumpable(original)
 
 

--- a/tests/test_subprocess_proc_environ_hardening.py
+++ b/tests/test_subprocess_proc_environ_hardening.py
@@ -1,0 +1,97 @@
+"""Tests for /proc/<ppid>/environ leak hardening (#4427).
+
+Verifies that constructing a subprocess env via _sanitize_subprocess_env() or
+_make_run_env() drops the PR_SET_DUMPABLE flag on the parent process so a
+same-UID child cannot recover the parent's initial environment by reading
+/proc/<ppid>/environ.
+
+See: https://github.com/NousResearch/hermes-agent/issues/4427
+"""
+
+import os
+import platform
+
+import pytest
+
+
+_LINUX_ONLY = pytest.mark.skipif(
+    platform.system() != "Linux",
+    reason="/proc/<pid>/environ leak is Linux-specific",
+)
+
+
+def _get_dumpable() -> int:
+    import ctypes
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    PR_GET_DUMPABLE = 3
+    return libc.prctl(PR_GET_DUMPABLE, 0, 0, 0, 0)
+
+
+def _set_dumpable(value: int) -> None:
+    import ctypes
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    PR_SET_DUMPABLE = 4
+    libc.prctl(PR_SET_DUMPABLE, value, 0, 0, 0)
+
+
+@pytest.fixture
+def restore_dumpable():
+    original = _get_dumpable()
+    _set_dumpable(1)
+    import tools.environments.local as _local
+    original_flag = getattr(_local, "_PROC_ENVIRON_HARDENED", None)
+    if original_flag is not None:
+        _local._PROC_ENVIRON_HARDENED = False
+    yield
+    if original_flag is not None:
+        _local._PROC_ENVIRON_HARDENED = original_flag
+    _set_dumpable(original)
+
+
+@_LINUX_ONLY
+class TestProcEnvironHardening:
+    """Verify subprocess env construction clears PR_SET_DUMPABLE."""
+
+    def test_sanitize_subprocess_env_clears_dumpable(self, restore_dumpable):
+        assert _get_dumpable() == 1
+        from tools.environments.local import _sanitize_subprocess_env
+        _sanitize_subprocess_env({"PATH": "/usr/bin"})
+        assert _get_dumpable() == 0
+
+    def test_make_run_env_clears_dumpable(self, restore_dumpable):
+        assert _get_dumpable() == 1
+        from tools.environments.local import _make_run_env
+        _make_run_env({"PATH": "/usr/bin"})
+        assert _get_dumpable() == 0
+
+    def test_hardening_runs_only_once(self, restore_dumpable):
+        from tools.environments.local import _sanitize_subprocess_env
+        _sanitize_subprocess_env({})
+        assert _get_dumpable() == 0
+        _set_dumpable(1)
+        _sanitize_subprocess_env({})
+        assert _get_dumpable() == 1
+
+    @pytest.mark.skipif(
+        os.geteuid() == 0,
+        reason="root bypasses PR_SET_DUMPABLE=0; security property only verifiable as non-root",
+    )
+    def test_child_cannot_read_parent_environ_after_hardening(self, restore_dumpable):
+        import subprocess
+        import sys
+        from tools.environments.local import _harden_against_proc_environ_leak
+
+        _harden_against_proc_environ_leak()
+        assert _get_dumpable() == 0
+
+        ppid = os.getpid()
+        child = subprocess.run(
+            [sys.executable, "-c", f"open('/proc/{ppid}/environ', 'rb').read()"],
+            capture_output=True,
+            text=True,
+        )
+        assert child.returncode != 0, (
+            f"child unexpectedly read /proc/{ppid}/environ; "
+            f"stdout={child.stdout!r} stderr={child.stderr!r}"
+        )
+        assert "Permission denied" in child.stderr or "EACCES" in child.stderr

--- a/tests/test_subprocess_proc_environ_hardening.py
+++ b/tests/test_subprocess_proc_environ_hardening.py
@@ -36,12 +36,12 @@ def _set_dumpable(value: int) -> None:
 
 @pytest.fixture
 def restore_dumpable():
-    original = _get_dumpable()
-    _set_dumpable(1)
     import tools.environments.local as _local
+    original = _get_dumpable()
     original_flag = getattr(_local, "_PROC_ENVIRON_HARDENED", None)
     if original_flag is not None:
         _local._PROC_ENVIRON_HARDENED = False
+    _set_dumpable(1)
     yield
     if original_flag is not None:
         _local._PROC_ENVIRON_HARDENED = original_flag
@@ -64,13 +64,19 @@ class TestProcEnvironHardening:
         _make_run_env({"PATH": "/usr/bin"})
         assert _get_dumpable() == 0
 
-    def test_hardening_runs_only_once(self, restore_dumpable):
+    def test_hardening_reapplies_when_dumpable_resets(self, restore_dumpable):
         from tools.environments.local import _sanitize_subprocess_env
         _sanitize_subprocess_env({})
         assert _get_dumpable() == 0
         _set_dumpable(1)
         _sanitize_subprocess_env({})
+        assert _get_dumpable() == 0
+
+    def test_mcp_build_safe_env_clears_dumpable(self, restore_dumpable):
         assert _get_dumpable() == 1
+        from tools.mcp_tool import _build_safe_env
+        _build_safe_env(None)
+        assert _get_dumpable() == 0
 
     @pytest.mark.skipif(
         os.geteuid() == 0,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1230,6 +1230,9 @@ def execute_code(
         _child_cwd = _resolve_child_cwd(_mode, tmpdir)
         _script_path = os.path.join(tmpdir, "script.py")
 
+        from tools.environments.local import _harden_against_proc_environ_leak
+        _harden_against_proc_environ_leak()
+
         proc = subprocess.Popen(
             [_child_python, _script_path],
             cwd=_child_cwd,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -17,8 +17,6 @@ logger = logging.getLogger(__name__)
 
 _IS_WINDOWS = platform.system() == "Windows"
 
-logger = logging.getLogger(__name__)
-
 
 def _resolve_safe_cwd(cwd: str) -> str:
     """Return ``cwd`` if it exists as a directory, else the nearest existing
@@ -146,8 +144,13 @@ def _build_provider_env_blocklist() -> frozenset:
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 
-_PROC_ENVIRON_HARDENED = False
+_PRCTL = None
+_PRCTL_UNAVAILABLE = False
+_CTYPES_MOD = None
 _HARDEN_WARNED = False
+
+_PR_GET_DUMPABLE = 3
+_PR_SET_DUMPABLE = 4
 
 
 def _warn_harden_failed(reason: str) -> None:
@@ -162,23 +165,20 @@ def _warn_harden_failed(reason: str) -> None:
     )
 
 
-def _harden_against_proc_environ_leak() -> None:
-    """Drop the PR_SET_DUMPABLE flag so /proc/<pid>/environ is owned root:root.
+def _resolve_prctl():
+    """Resolve libc.prctl once and cache it.  Returns the bound function or None.
 
-    Subprocesses inherit the same UID and can otherwise read the parent's
-    initial environment via /proc/<ppid>/environ — bypassing the env=
-    sanitization done at Popen time.  Dropping dumpable changes the ownership
-    of the /proc files to root:root with mode 400, which blocks same-UID
-    readers on Linux.  No-op on non-Linux platforms.
-
-    Privileged bypass paths still exist (CAP_SYS_PTRACE in the target's user
-    namespace, ptrace-mode FSCREDS overrides) and are out of scope for this
-    function; pair with /proc hidepid=2 mount option for defense in depth.
+    On musl-based distros (Alpine) `libc.so.6` does not exist, so we go through
+    `ctypes.util.find_library("c")` and fall back to `CDLL(None)` (the current
+    process's symbols).  After the first failed resolution we set a sentinel
+    and stop retrying, so a non-Linux or broken-libc host doesn't pay the
+    resolution cost on every spawn.
     """
-    global _PROC_ENVIRON_HARDENED
-    if platform.system() != "Linux":
-        _PROC_ENVIRON_HARDENED = True
-        return
+    global _PRCTL, _PRCTL_UNAVAILABLE, _CTYPES_MOD
+    if _PRCTL is not None:
+        return _PRCTL
+    if _PRCTL_UNAVAILABLE:
+        return None
     try:
         import ctypes
         import ctypes.util
@@ -192,22 +192,43 @@ def _harden_against_proc_environ_leak() -> None:
             ctypes.c_ulong, ctypes.c_ulong,
         ]
         libc.prctl.restype = ctypes.c_int
-        PR_GET_DUMPABLE = 3
-        PR_SET_DUMPABLE = 4
-        if libc.prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0:
-            _PROC_ENVIRON_HARDENED = True
-            return
-        rc = libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)
     except Exception as exc:
+        _PRCTL_UNAVAILABLE = True
         _warn_harden_failed(f"libc/prctl unavailable: {type(exc).__name__}")
+        return None
+    _CTYPES_MOD = ctypes
+    _PRCTL = libc.prctl
+    return _PRCTL
+
+
+def _harden_against_proc_environ_leak() -> None:
+    """Drop the PR_SET_DUMPABLE flag so /proc/<pid>/environ is owned root:root.
+
+    Subprocesses inherit the same UID and can otherwise read the parent's
+    initial environment via /proc/<ppid>/environ — bypassing the env=
+    sanitization done at Popen time.  Dropping dumpable changes the ownership
+    of the /proc files to root:root with mode 400, which blocks same-UID
+    readers on Linux.  No-op on non-Linux platforms.
+
+    Re-reads PR_GET_DUMPABLE on every call so the helper self-corrects when
+    the flag is reset by a fork / extension / multiprocessing path.  libc
+    resolution is cached after the first success, so the steady-state cost is
+    one prctl syscall.
+
+    Privileged bypass paths still exist (CAP_SYS_PTRACE in the target's user
+    namespace, ptrace-mode FSCREDS overrides) and are out of scope for this
+    function; pair with /proc hidepid=2 mount option for defense in depth.
+    """
+    if platform.system() != "Linux":
         return
+    prctl = _resolve_prctl()
+    if prctl is None:
+        return
+    if prctl(_PR_GET_DUMPABLE, 0, 0, 0, 0) == 0:
+        return
+    rc = prctl(_PR_SET_DUMPABLE, 0, 0, 0, 0)
     if rc != 0:
-        _warn_harden_failed(f"prctl returned {rc}, errno={ctypes.get_errno()}")
-        return
-    _PROC_ENVIRON_HARDENED = True
-
-
-_harden_against_proc_environ_leak()
+        _warn_harden_failed(f"prctl returned {rc}, errno={_CTYPES_MOD.get_errno()}")
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
+logger = logging.getLogger(__name__)
+
 _IS_WINDOWS = platform.system() == "Windows"
 
 logger = logging.getLogger(__name__)
@@ -144,8 +146,62 @@ def _build_provider_env_blocklist() -> frozenset:
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 
+_PROC_ENVIRON_HARDENED = False
+_HARDEN_WARNED = False
+
+
+def _warn_harden_failed(reason: str) -> None:
+    global _HARDEN_WARNED
+    if _HARDEN_WARNED:
+        return
+    _HARDEN_WARNED = True
+    logger.warning(
+        "PR_SET_DUMPABLE could not be cleared (%s); /proc/<pid>/environ leak protection inactive — "
+        "subprocess children may recover stripped credentials. See issue #4427.",
+        reason,
+    )
+
+
+def _harden_against_proc_environ_leak() -> None:
+    """Drop the PR_SET_DUMPABLE flag so /proc/<pid>/environ is owned root:root.
+
+    Subprocesses inherit the same UID and can otherwise read the parent's
+    initial environment via /proc/<ppid>/environ — bypassing the env=
+    sanitization done at Popen time.  Dropping dumpable changes the ownership
+    of the /proc files to root:root with mode 400, which blocks same-UID
+    readers on Linux.  No-op on non-Linux platforms.
+    """
+    global _PROC_ENVIRON_HARDENED
+    if _PROC_ENVIRON_HARDENED:
+        return
+    if platform.system() != "Linux":
+        _PROC_ENVIRON_HARDENED = True
+        return
+    try:
+        import ctypes
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        libc.prctl.argtypes = [
+            ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong,
+            ctypes.c_ulong, ctypes.c_ulong,
+        ]
+        libc.prctl.restype = ctypes.c_int
+        PR_SET_DUMPABLE = 4
+        rc = libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)
+    except Exception as exc:
+        _warn_harden_failed(f"libc/prctl unavailable: {type(exc).__name__}")
+        return
+    if rc != 0:
+        _warn_harden_failed(f"prctl returned {rc}, errno={ctypes.get_errno()}")
+        return
+    _PROC_ENVIRON_HARDENED = True
+
+
+_harden_against_proc_environ_leak()
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
+    _harden_against_proc_environ_leak()
     try:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:
@@ -241,6 +297,7 @@ _SANE_PATH = (
 
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
+    _harden_against_proc_environ_leak()
     try:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -170,22 +170,33 @@ def _harden_against_proc_environ_leak() -> None:
     sanitization done at Popen time.  Dropping dumpable changes the ownership
     of the /proc files to root:root with mode 400, which blocks same-UID
     readers on Linux.  No-op on non-Linux platforms.
+
+    Privileged bypass paths still exist (CAP_SYS_PTRACE in the target's user
+    namespace, ptrace-mode FSCREDS overrides) and are out of scope for this
+    function; pair with /proc hidepid=2 mount option for defense in depth.
     """
     global _PROC_ENVIRON_HARDENED
-    if _PROC_ENVIRON_HARDENED:
-        return
     if platform.system() != "Linux":
         _PROC_ENVIRON_HARDENED = True
         return
     try:
         import ctypes
-        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        import ctypes.util
+        libc_name = ctypes.util.find_library("c")
+        try:
+            libc = ctypes.CDLL(libc_name or "libc.so.6", use_errno=True)
+        except OSError:
+            libc = ctypes.CDLL(None, use_errno=True)
         libc.prctl.argtypes = [
             ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong,
             ctypes.c_ulong, ctypes.c_ulong,
         ]
         libc.prctl.restype = ctypes.c_int
+        PR_GET_DUMPABLE = 3
         PR_SET_DUMPABLE = 4
+        if libc.prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0:
+            _PROC_ENVIRON_HARDENED = True
+            return
         rc = libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)
     except Exception as exc:
         _warn_harden_failed(f"libc/prctl unavailable: {type(exc).__name__}")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -292,8 +292,13 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
     explicitly specified by the user in the server config.
 
     This prevents accidentally leaking secrets like API keys, tokens, or
-    credentials to MCP server subprocesses.
+    credentials to MCP server subprocesses. PR_SET_DUMPABLE is also cleared
+    here so an MCP stdio child can't recover the stripped vars by reading
+    /proc/<ppid>/environ — see issue #4427.
     """
+    from tools.environments.local import _harden_against_proc_environ_leak
+    _harden_against_proc_environ_leak()
+
     env = {}
     for key, value in os.environ.items():
         if key in _SAFE_ENV_KEYS or key.startswith("XDG_"):


### PR DESCRIPTION
## What

Closes #4427. On Linux a same-UID child can recover the parent's stripped
env vars by reading `/proc/<ppid>/environ` even when the spawn used a
filtered `env=` dict, because `dumpable=1` leaves `/proc/<self>/environ`
world-readable to same-UID processes. Clear `PR_SET_DUMPABLE` on the parent
across the secret-stripping spawn sites so the kernel marks the file
`0400 root:root`. Hardening is best-effort: a one-shot `logger.warning`
fires if `prctl` is unavailable.

## Related Issue

Fixes #4427

## Related work

PR #4609 fixes a different layer (the `read_file` tool's own guard against
reading other processes' environ); the two are complementary and neither
subsumes the other.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- Clear `PR_SET_DUMPABLE` via a `ctypes` `prctl(2)` call, wired into every
  secret-stripping spawn path: the helpers in `tools/environments/local.py`,
  the inline `child_env` builder in `tools/code_execution_tool.py`, and
  `_build_safe_env()` in `tools/mcp_tool.py` (MCP stdio servers).
- Resolve libc via `ctypes.util.find_library("c")` with a `CDLL(None)`
  fallback so musl-based distros (Alpine) don't silently skip the
  protection.
- Read `PR_GET_DUMPABLE` before every set so the helper self-corrects when
  the flag is reset by a fork / extension / multiprocessing path.
- One-shot `logger.warning` if `prctl` is unavailable; the spawn still
  proceeds.

## How to Test

- Linux only — the hardening is a no-op on macOS/Windows where
  `/proc/<pid>/environ` doesn't exist.
- `python -m pytest tests/test_subprocess_proc_environ_hardening.py -v`
- `test_child_cannot_read_parent_environ_after_hardening` is skipped under
  root (root bypasses `dumpable=0`); the upstream CI runner is non-root so
  this test executes there.
- Manual repro: before the fix, a child spawned from
  `tools/environments/local.py` could read `/proc/<ppid>/environ` and
  recover stripped secrets; after the fix, the same `open()` raises
  `PermissionError`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — #4609 covers a different layer (read_file tool), not the subprocess-launch layer this PR targets
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/test_subprocess_proc_environ_hardening.py -q` and the new tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8)

### Documentation & Housekeeping

- [x] N/A — internal hardening, no user-facing config or tool-schema change
- [x] N/A — no new config keys
- [x] N/A — no architecture change
- [x] Considered cross-platform impact: prctl call is gated behind
  `sys.platform == "linux"`; on other platforms the function is a no-op.
- [x] N/A — no tool-behavior change
