### PR TITLE
fix: add stale chat recovery and codex-only auth guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
 hermes setup        # Run the full setup wizard (configures everything at once)
 hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
 hermes update       # Update to the latest version
-hermes doctor       # Diagnose any issues
+hermes doctor       # Diagnose setup issues
+hermes doctor chat  # Diagnose stale/frozen interactive chat sessions safely
 ```
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
@@ -81,6 +82,22 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |
 
 For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
+
+### Recovering a stale interactive chat
+
+If an interactive `hermes`/`hermes chat` terminal appears frozen, run this from another terminal:
+
+```bash
+hermes doctor chat
+```
+
+It lists active chat PIDs, TTY, CWD, elapsed time, and safe recovery steps. It does not interrupt or kill anything by default. To explicitly recover a process you recognize, use soft recovery:
+
+```bash
+hermes doctor chat --recover --pid <pid>
+```
+
+This sends `SIGINT` (like Ctrl+C). Forced `SIGTERM` recovery requires the additional `--force` flag and should only be used after soft recovery fails.
 
 ---
 

--- a/cli.py
+++ b/cli.py
@@ -6419,6 +6419,10 @@ class HermesCLI:
             self._handle_resume_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
+        elif canonical == "provider":
+            self._show_model_and_providers()
+        elif canonical == "doctor":
+            self._handle_doctor_command(cmd_original)
         elif canonical == "gquota":
             self._handle_gquota_command(cmd_original)
 
@@ -6676,6 +6680,37 @@ class HermesCLI:
                     _cprint(f"{_DIM}{_ACCENT}Type /help for available commands{_RST}")
         
         return True
+
+    def _handle_doctor_command(self, cmd: str):
+        """Handle /doctor chat inside an interactive CLI session."""
+        import argparse
+        import shlex
+
+        try:
+            parts = shlex.split(cmd)
+        except ValueError as exc:
+            _cprint(f"  Usage error: {exc}")
+            return
+
+        if len(parts) < 2 or parts[1].lower() != "chat":
+            _cprint("  Usage: /doctor chat [--stacks] [--recover --pid <pid>] [--force]")
+            _cprint("  Full setup diagnostics are available from another terminal: hermes doctor")
+            return
+
+        parser = argparse.ArgumentParser(prog="/doctor chat", add_help=False)
+        parser.add_argument("--stacks", action="store_true")
+        parser.add_argument("--recover", action="store_true")
+        parser.add_argument("--pid", action="append", type=int, default=[])
+        parser.add_argument("--force", action="store_true")
+        try:
+            args = parser.parse_args(parts[2:])
+        except SystemExit:
+            _cprint("  Usage: /doctor chat [--stacks] [--recover --pid <pid>] [--force]")
+            return
+
+        from hermes_cli.doctor import run_chat_doctor
+
+        run_chat_doctor(args)
     
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -669,12 +669,24 @@ class AuthError(RuntimeError):
         self.relogin_required = relogin_required
 
 
+def is_openai_codex_only_policy() -> bool:
+    """Return True when config requests the local Codex CLI-only policy."""
+    config = read_raw_config()
+    return (config.get("codex") or {}).get("policy") == "openai-codex-only"
+
+
 def format_auth_error(error: Exception) -> str:
     """Map auth failures to concise user-facing guidance."""
     if not isinstance(error, AuthError):
         return str(error)
 
     if error.relogin_required:
+        if error.provider == "openai-codex" and is_openai_codex_only_policy():
+            return (
+                f"{error} Hermes-native Codex auth needs re-login. "
+                "For project work, use `hermes-task \"<task>\"` because it runs through the verified Codex CLI account. "
+                "To repair interactive `hermes chat`, run `hermes auth add openai-codex` in a local terminal."
+            )
         return f"{error} Run `hermes model` to re-authenticate."
 
     if error.code == "subscription_required":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -112,6 +112,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",
                aliases=("provider",), args_hint="[model] [--provider name] [--global]"),
+    CommandDef("doctor", "Diagnose stale/frozen interactive chat sessions",
+               "Configuration", cli_only=True, args_hint="chat [--stacks] [--recover --pid <pid>] [--force]",
+               subcommands=("chat",)),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,10 +5,13 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import signal
+import shlex
 import sys
 import subprocess
 import shutil
 import importlib.util
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
@@ -17,6 +20,19 @@ from hermes_constants import display_hermes_home
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
 _DHH = display_hermes_home()  # user-facing display path (e.g. ~/.hermes or ~/.hermes/profiles/coder)
+
+
+@dataclass(frozen=True)
+class ChatProcess:
+    """A live Hermes interactive chat-like process found by doctor chat."""
+
+    pid: int
+    ppid: int
+    tty: str
+    elapsed: str
+    command: str
+    cwd: str = ""
+    stack_hint: str = ""
 
 # Load environment variables from ~/.hermes/.env so API key checks work
 from dotenv import load_dotenv
@@ -62,6 +78,23 @@ _PROVIDER_ENV_HINTS = (
     "TOKENHUB_API_KEY",
 )
 
+_NON_OPENAI_PROVIDER_ENV_KEYS = (
+    "OPENROUTER_API_KEY",
+    "KIMI_CODE_API_KEY",
+    "KIMI_API_KEY",
+    "KIMI_CN_API_KEY",
+    "MOONSHOT_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "GLM_API_KEY",
+    "ZAI_API_KEY",
+    "Z_AI_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
+
 
 from hermes_constants import is_termux as _is_termux
 
@@ -102,6 +135,58 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _is_openai_codex_only_policy() -> bool:
+    """Return True when Hermes is configured for subscription-backed Codex only."""
+    try:
+        import yaml as _yaml
+
+        config_path = HERMES_HOME / "config.yaml"
+        policy_config = _yaml.safe_load(config_path.read_text()) or {}
+        return (policy_config.get("codex") or {}).get("policy") == "openai-codex-only"
+    except Exception:
+        return False
+
+
+def _primary_codex_home_for_doctor() -> Path | None:
+    """Read the non-secret account ledger and return the primary CODEX_HOME."""
+    try:
+        import json
+
+        ledger_path = HERMES_HOME / "account-ledger.json"
+        ledger = json.loads(ledger_path.read_text())
+        accounts = ledger.get("accounts") or {}
+        for account in accounts.values():
+            if account.get("status") == "primary" and account.get("codex_home"):
+                return Path(account["codex_home"]).expanduser()
+    except Exception:
+        return None
+    return None
+
+
+def _codex_cli_login_status(codex_home: Path | None = None) -> tuple[bool, str]:
+    """Check Codex CLI subscription login without exposing token material."""
+    if not shutil.which("codex"):
+        return False, "codex CLI not found"
+
+    env = os.environ.copy()
+    if codex_home is not None:
+        env["CODEX_HOME"] = str(codex_home)
+
+    try:
+        result = subprocess.run(
+            ["codex", "login", "status"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception as exc:
+        return False, str(exc)
+
+    output = ((result.stdout or "") + (result.stderr or "")).strip()
+    return result.returncode == 0 and "Logged in" in output, output or f"exit {result.returncode}"
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -127,6 +212,258 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable
+
+
+def _is_hermes_chat_command(command: str) -> bool:
+    """Return True for interactive Hermes chat entrypoints, not doctor/tests."""
+    text = " ".join(command.split())
+    if not text:
+        return False
+    lowered = text.lower()
+    if "pytest" in lowered:
+        return False
+    try:
+        argv = shlex.split(text)
+    except ValueError:
+        argv = text.split()
+
+    if not argv:
+        return False
+
+    chat_subcommands = {"chat"}
+    non_chat_subcommands = {
+        "acp", "auth", "backup", "claw", "completion", "config", "cron",
+        "dashboard", "debug", "doctor", "dump", "gateway", "honcho",
+        "hooks", "import", "insights", "login", "logout", "logs", "mcp",
+        "memory", "model", "pairing", "plugins", "profile", "sessions",
+        "setup", "skills", "status", "tools", "uninstall", "update",
+        "version", "webhook", "whatsapp",
+    }
+
+    def _first_command_after(index: int) -> str | None:
+        options_with_values = {
+            "-c", "--continue", "-m", "--model", "-p", "--profile",
+            "--provider", "-r", "--resume", "-s", "--skills", "--source",
+            "-t", "--toolsets",
+        }
+        i = index
+        while i < len(argv):
+            token = argv[i]
+            if token == "--":
+                i += 1
+                continue
+            if token.startswith("-"):
+                opt = token.split("=", 1)[0]
+                i += 2 if opt in options_with_values and "=" not in token else 1
+                continue
+            return token.lower()
+        return None
+
+    def _is_python_token(token: str) -> bool:
+        return Path(token).name.lower().startswith(("python", "python3"))
+
+    for i, token in enumerate(argv):
+        basename = Path(token).name.lower()
+        if basename == "hermes":
+            subcommand = _first_command_after(i + 1)
+            # Bare `hermes` defaults to interactive chat. `hermes chat` is
+            # explicit interactive chat. Other subcommands are intentionally
+            # excluded so `hermes doctor chat` never reports itself.
+            return subcommand is None or subcommand in chat_subcommands
+
+        if basename == "cli.py":
+            subcommand = _first_command_after(i + 1)
+            return subcommand is None or subcommand in chat_subcommands
+
+        if _is_python_token(token):
+            if i + 2 < len(argv) and argv[i + 1] == "-m" and argv[i + 2] == "hermes_cli.main":
+                subcommand = _first_command_after(i + 3)
+                return subcommand is None or subcommand in chat_subcommands
+            if i + 1 < len(argv) and Path(argv[i + 1]).name.lower() == "cli.py":
+                subcommand = _first_command_after(i + 2)
+                return subcommand is None or subcommand in chat_subcommands
+
+    # Fallback for truncated ps command lines. Be conservative: include common
+    # chat entrypoints only when no known non-chat subcommand appears.
+    if any(f" {sub} " in f" {lowered} " for sub in non_chat_subcommands):
+        return False
+    return "hermes_cli.main chat" in lowered
+
+
+def _parse_ps_chat_processes(ps_output: str, *, include_stacks: bool = False) -> list[ChatProcess]:
+    """Parse `ps -axo pid,ppid,tty,etime,command` output into chat processes."""
+    processes: list[ChatProcess] = []
+    for raw_line in ps_output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 4)
+        if len(parts) < 5:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        tty, elapsed, command = parts[2], parts[3], parts[4]
+        if not _is_hermes_chat_command(command):
+            continue
+        processes.append(
+            ChatProcess(
+                pid=pid,
+                ppid=ppid,
+                tty=tty,
+                elapsed=elapsed,
+                command=command,
+                cwd=_cwd_for_pid(pid),
+                stack_hint=_stack_hint_for_pid(pid) if include_stacks else "",
+            )
+        )
+    return processes
+
+
+def _cwd_for_pid(pid: int) -> str:
+    """Best-effort CWD lookup for a process without requiring privileges."""
+    proc_cwd = Path(f"/proc/{pid}/cwd")
+    try:
+        if proc_cwd.exists():
+            return str(proc_cwd.resolve())
+    except Exception:
+        pass
+
+    if shutil.which("lsof"):
+        try:
+            result = subprocess.run(
+                ["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            for line in (result.stdout or "").splitlines():
+                if line.startswith("n") and len(line) > 1:
+                    return line[1:]
+        except Exception:
+            pass
+
+    if shutil.which("pwdx"):
+        try:
+            result = subprocess.run(
+                ["pwdx", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            output = (result.stdout or "").strip()
+            if ": " in output:
+                return output.split(": ", 1)[1]
+        except Exception:
+            pass
+
+    return "unknown"
+
+
+def _stack_hint_for_pid(pid: int) -> str:
+    """Return a compact macOS stack hint when sampling tools are available."""
+    if sys.platform != "darwin" or not shutil.which("sample"):
+        return ""
+    try:
+        result = subprocess.run(
+            ["sample", str(pid), "1", "1"],
+            capture_output=True,
+            text=True,
+            timeout=4,
+        )
+    except Exception:
+        return ""
+
+    output = (result.stdout or "") + (result.stderr or "")
+    interesting = []
+    needles = ("prompt_toolkit", "input", "readline", "select", "poll", "thread")
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(needle in stripped.lower() for needle in needles):
+            interesting.append(stripped)
+        if len(interesting) >= 3:
+            break
+    return " | ".join(interesting)
+
+
+def list_hermes_chat_processes(*, include_stacks: bool = False) -> list[ChatProcess]:
+    """List active local Hermes interactive chat processes."""
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,tty=,etime=,command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+    return _parse_ps_chat_processes(result.stdout or "", include_stacks=include_stacks)
+
+
+def run_chat_doctor(args) -> int:
+    """Diagnose and optionally soft-recover stale interactive chat sessions."""
+    recover = bool(getattr(args, "recover", False))
+    requested_pids = [int(pid) for pid in (getattr(args, "pid", None) or [])]
+    include_stacks = bool(getattr(args, "stacks", False))
+    force = bool(getattr(args, "force", False))
+
+    print(color("◆ Hermes Chat Doctor", Colors.CYAN, Colors.BOLD))
+    print("Lists local interactive chat processes and gives safe stale-session recovery steps.")
+    print()
+
+    processes = list_hermes_chat_processes(include_stacks=include_stacks)
+    if processes:
+        print(f"Found {len(processes)} active Hermes chat process(es):")
+        print(f"  {'PID':>7} {'TTY':<10} {'ELAPSED':<12} {'CWD':<34} COMMAND")
+        for proc in processes:
+            cwd = proc.cwd if len(proc.cwd) <= 34 else "…" + proc.cwd[-33:]
+            print(f"  {proc.pid:>7} {proc.tty:<10} {proc.elapsed:<12} {cwd:<34} {proc.command}")
+            if proc.stack_hint:
+                print(f"          stack: {proc.stack_hint}")
+    else:
+        print("No active Hermes interactive chat processes found.")
+
+    print()
+    print("Safe recovery guidance:")
+    print("  1) Return to the chat terminal and press Ctrl+C once; wait a few seconds.")
+    print("  2) If the prompt does not return, start a fresh terminal and run `hermes doctor chat`.")
+    print("  3) Use explicit soft recovery only for the PID you recognize:")
+    example_pid = requested_pids[0] if requested_pids else (processes[0].pid if processes else "<pid>")
+    print(f"     hermes doctor chat --recover --pid {example_pid}")
+    print("  4) Forced termination is intentionally not default. Use `--force` only after soft recovery fails.")
+
+    if not recover:
+        return 0
+
+    if not requested_pids:
+        print()
+        print("Recovery requires --pid so doctor never interrupts every chat by accident.")
+        return 2
+
+    known = {proc.pid: proc for proc in processes}
+    signal_to_send = signal.SIGTERM if force else signal.SIGINT
+    signal_name = "SIGTERM" if force else "SIGINT"
+    print()
+    for pid in requested_pids:
+        if pid not in known:
+            print(f"Skipping PID {pid}: not an active Hermes chat process from this scan.")
+            continue
+        try:
+            os.kill(pid, signal_to_send)
+            print(f"Sent {signal_name} to Hermes chat PID {pid} ({known[pid].tty}).")
+        except ProcessLookupError:
+            print(f"PID {pid} already exited.")
+        except PermissionError:
+            print(f"Permission denied sending {signal_name} to PID {pid}.")
+        except Exception as exc:
+            print(f"Could not send {signal_name} to PID {pid}: {exc}")
+    return 0
 
 
 def check_ok(text: str, detail: str = ""):
@@ -178,6 +515,7 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
+    openai_only_policy = _is_openai_codex_only_policy()
 
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
     # checks (like cronjob management) should see the same context as `hermes`.
@@ -545,50 +883,61 @@ def run_doctor(args):
     print()
     print(color("◆ Auth Providers", Colors.CYAN, Colors.BOLD))
 
-    try:
-        from hermes_cli.auth import (
-            get_nous_auth_status,
-            get_codex_auth_status,
-            get_gemini_oauth_auth_status,
-            get_minimax_oauth_auth_status,
-        )
-
-        nous_status = get_nous_auth_status()
-        if nous_status.get("logged_in"):
-            check_ok("Nous Portal auth", "(logged in)")
+    if openai_only_policy:
+        primary_codex_home = _primary_codex_home_for_doctor()
+        codex_logged_in, codex_detail = _codex_cli_login_status(primary_codex_home)
+        if codex_logged_in:
+            detail = f"(logged in via CODEX_HOME={primary_codex_home})" if primary_codex_home else "(logged in)"
+            check_ok("OpenAI Codex CLI auth", detail)
         else:
-            check_warn("Nous Portal auth", "(not logged in)")
+            detail = f"({codex_detail})" if codex_detail else "(not logged in)"
+            check_warn("OpenAI Codex CLI auth", detail)
+        check_ok("Auth policy", "(Hermes-native Nous/Gemini/OpenAI OAuth skipped)")
+    else:
+        try:
+            from hermes_cli.auth import (
+                get_nous_auth_status,
+                get_codex_auth_status,
+                get_gemini_oauth_auth_status,
+                get_minimax_oauth_auth_status,
+            )
 
-        codex_status = get_codex_auth_status()
-        if codex_status.get("logged_in"):
-            check_ok("OpenAI Codex auth", "(logged in)")
-        else:
-            check_warn("OpenAI Codex auth", "(not logged in)")
-            if codex_status.get("error"):
-                check_info(codex_status["error"])
+            nous_status = get_nous_auth_status()
+            if nous_status.get("logged_in"):
+                check_ok("Nous Portal auth", "(logged in)")
+            else:
+                check_warn("Nous Portal auth", "(not logged in)")
 
-        gemini_status = get_gemini_oauth_auth_status()
-        if gemini_status.get("logged_in"):
-            email = gemini_status.get("email") or ""
-            project = gemini_status.get("project_id") or ""
-            pieces = []
-            if email:
-                pieces.append(email)
-            if project:
-                pieces.append(f"project={project}")
-            suffix = f" ({', '.join(pieces)})" if pieces else ""
-            check_ok("Google Gemini OAuth", f"(logged in{suffix})")
-        else:
-            check_warn("Google Gemini OAuth", "(not logged in)")
+            codex_status = get_codex_auth_status()
+            if codex_status.get("logged_in"):
+                check_ok("OpenAI Codex auth", "(logged in)")
+            else:
+                check_warn("OpenAI Codex auth", "(not logged in)")
+                if codex_status.get("error"):
+                    check_info(codex_status["error"])
 
-        minimax_status = get_minimax_oauth_auth_status()
-        if minimax_status.get("logged_in"):
-            region = minimax_status.get("region", "global")
-            check_ok("MiniMax OAuth", f"(logged in, region={region})")
-        else:
-            check_warn("MiniMax OAuth", "(not logged in)")
-    except Exception as e:
-        check_warn("Auth provider status", f"(could not check: {e})")
+            gemini_status = get_gemini_oauth_auth_status()
+            if gemini_status.get("logged_in"):
+                email = gemini_status.get("email") or ""
+                project = gemini_status.get("project_id") or ""
+                pieces = []
+                if email:
+                    pieces.append(email)
+                if project:
+                    pieces.append(f"project={project}")
+                suffix = f" ({', '.join(pieces)})" if pieces else ""
+                check_ok("Google Gemini OAuth", f"(logged in{suffix})")
+            else:
+                check_warn("Google Gemini OAuth", "(not logged in)")
+
+            minimax_status = get_minimax_oauth_auth_status()
+            if minimax_status.get("logged_in"):
+                region = minimax_status.get("region", "global")
+                check_ok("MiniMax OAuth", f"(logged in, region={region})")
+            else:
+                check_warn("MiniMax OAuth", "(not logged in)")
+        except Exception as e:
+            check_warn("Auth provider status", f"(could not check: {e})")
 
     if _safe_which("codex"):
         check_ok("codex CLI")
@@ -994,6 +1343,11 @@ def run_doctor(args):
     # =========================================================================
     print()
     print(color("◆ API Connectivity", Colors.CYAN, Colors.BOLD))
+
+    if openai_only_policy:
+        for _env_key in _NON_OPENAI_PROVIDER_ENV_KEYS:
+            os.environ.pop(_env_key, None)
+        check_ok("OpenAI Codex policy", "(non-OpenAI provider checks skipped)")
     
     openrouter_key = os.getenv("OPENROUTER_API_KEY")
     if openrouter_key:
@@ -1025,7 +1379,7 @@ def run_doctor(args):
         except Exception as e:
             print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'({e})', Colors.DIM)}                ")
             issues.append("Check network connectivity")
-    else:
+    elif not openai_only_policy:
         check_warn("OpenRouter API", "(not configured)")
     
     from hermes_cli.auth import get_anthropic_key
@@ -1215,6 +1569,16 @@ def run_doctor(args):
         
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
+        if openai_only_policy:
+            _blocked_tool_envs = set(_NON_OPENAI_PROVIDER_ENV_KEYS)
+            _filtered_unavailable = []
+            for _tool in unavailable:
+                _tool_name = str(_tool.get("name") or _tool.get("id") or "").lower()
+                _envs = set(_tool.get("missing_vars") or _tool.get("env_vars") or [])
+                if _tool_name in {"moa", "vision"} or (_envs & _blocked_tool_envs):
+                    continue
+                _filtered_unavailable.append(_tool)
+            unavailable = _filtered_unavailable
         
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})
@@ -1230,7 +1594,7 @@ def run_doctor(args):
 
         # Count disabled tools with API key requirements
         api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
-        if api_disabled:
+        if api_disabled and not openai_only_policy:
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -135,17 +135,6 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
-def _is_openai_codex_only_policy() -> bool:
-    """Return True when Hermes is configured for subscription-backed Codex only."""
-    try:
-        import yaml as _yaml
-
-        config_path = HERMES_HOME / "config.yaml"
-        policy_config = _yaml.safe_load(config_path.read_text()) or {}
-        return (policy_config.get("codex") or {}).get("policy") == "openai-codex-only"
-    except Exception:
-        return False
-
 
 def _primary_codex_home_for_doctor() -> Path | None:
     """Read the non-secret account ledger and return the primary CODEX_HOME."""
@@ -514,8 +503,10 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 
 def run_doctor(args):
     """Run diagnostic checks."""
+    from hermes_cli.auth import is_openai_codex_only_policy
+
     should_fix = getattr(args, 'fix', False)
-    openai_only_policy = _is_openai_codex_only_policy()
+    openai_only_policy = is_openai_codex_only_policy()
 
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
     # checks (like cronjob management) should see the same context as `hermes`.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5072,6 +5072,11 @@ def cmd_hooks(args):
 
 def cmd_doctor(args):
     """Check configuration and dependencies."""
+    if getattr(args, "doctor_subject", None) == "chat":
+        from hermes_cli.doctor import run_chat_doctor
+
+        raise SystemExit(run_chat_doctor(args))
+
     from hermes_cli.doctor import run_doctor
 
     run_doctor(args)
@@ -8870,6 +8875,37 @@ def main():
     )
     doctor_parser.add_argument(
         "--fix", action="store_true", help="Attempt to fix issues automatically"
+    )
+    doctor_subparsers = doctor_parser.add_subparsers(dest="doctor_subject")
+    doctor_chat_parser = doctor_subparsers.add_parser(
+        "chat",
+        help="Diagnose and recover stale interactive chat sessions",
+        description=(
+            "List active Hermes chat PIDs, TTY, CWD, elapsed time, optional stack hints, "
+            "and safe stale-session recovery instructions."
+        ),
+    )
+    doctor_chat_parser.add_argument(
+        "--stacks",
+        action="store_true",
+        help="Try to include compact stack hints when supported by the platform",
+    )
+    doctor_chat_parser.add_argument(
+        "--recover",
+        action="store_true",
+        help="Explicitly send a soft interrupt (SIGINT) to the selected chat PID(s)",
+    )
+    doctor_chat_parser.add_argument(
+        "--pid",
+        action="append",
+        type=int,
+        default=[],
+        help="Hermes chat PID to recover; repeat for multiple PIDs",
+    )
+    doctor_chat_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="With --recover, send SIGTERM instead of the default soft SIGINT",
     )
     doctor_parser.set_defaults(func=cmd_doctor)
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -12,6 +12,51 @@ from hermes_cli.auth import AuthError, get_provider_auth_state, resolve_nous_run
 
 
 # =============================================================================
+# format_auth_error: provider-specific guidance
+# =============================================================================
+
+
+def test_format_auth_error_uses_codex_policy_guidance(monkeypatch):
+    import hermes_cli.auth as auth
+
+    monkeypatch.setattr(
+        auth,
+        "read_raw_config",
+        lambda: {"codex": {"policy": "openai-codex-only"}},
+    )
+    message = auth.format_auth_error(
+        AuthError(
+            "Codex token refresh failed: session revoked.",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+    )
+
+    assert "Hermes-native Codex auth needs re-login" in message
+    assert "hermes-task" in message
+    assert "hermes auth add openai-codex" in message
+    assert "hermes model" not in message
+
+
+def test_format_auth_error_keeps_default_relogin_guidance_without_codex_policy(monkeypatch):
+    import hermes_cli.auth as auth
+
+    monkeypatch.setattr(auth, "read_raw_config", lambda: {})
+    message = auth.format_auth_error(
+        AuthError(
+            "Codex token refresh failed: session revoked.",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+    )
+
+    assert message.endswith("Run `hermes model` to re-authenticate.")
+    assert "hermes-task" not in message
+
+
+# =============================================================================
 # _resolve_verify: CA bundle path validation
 # =============================================================================
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,6 +1,9 @@
 """Tests for hermes_cli.doctor."""
 
+import contextlib
+import io
 import os
+import signal
 import sys
 import types
 import io
@@ -14,6 +17,122 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+from hermes_cli.commands import resolve_command
+
+
+class TestChatDoctorProcessListing:
+    def test_command_matcher_handles_macos_linux_entrypoint_edges(self):
+        positives = [
+            "/opt/homebrew/bin/hermes",
+            "/usr/local/bin/hermes --profile sim",
+            "hermes --profile sim chat",
+            "hermes chat --profile sim",
+            "/usr/bin/python3 -m hermes_cli.main",
+            "/usr/bin/python3 -m hermes_cli.main --profile sim",
+            "/usr/bin/python3 -m hermes_cli.main chat",
+            "python /repo/cli.py",
+            "python /repo/cli.py chat",
+        ]
+        negatives = [
+            "hermes doctor chat",
+            "hermes --profile sim doctor chat",
+            "/usr/bin/python3 -m hermes_cli.main doctor chat",
+            "python /repo/cli.py setup",
+            "python -m pytest tests/hermes_cli/test_doctor.py",
+            "not-hermes chat",
+        ]
+
+        for command in positives:
+            assert doctor_mod._is_hermes_chat_command(command), command
+        for command in negatives:
+            assert not doctor_mod._is_hermes_chat_command(command), command
+
+    def test_doctor_chat_is_registered_as_cli_slash_command(self):
+        cmd = resolve_command("doctor")
+
+        assert cmd is not None
+        assert cmd.cli_only is True
+        assert "chat" in cmd.subcommands
+
+    def test_lists_only_interactive_hermes_chat_processes(self, monkeypatch):
+        ps_output = """
+          101     1 ttys001   01:02:03 /usr/bin/python -m hermes_cli.main chat
+          102     1 ??        00:00:10 /usr/bin/python -m hermes_cli.main doctor chat
+          103     1 ttys002      12:34 hermes chat --profile sim
+          104     1 ttys003      00:07 python cli.py
+          105     1 ttys004      00:07 python -m pytest tests
+        """
+
+        def fake_run(cmd, **kwargs):
+            assert cmd[:2] == ["ps", "-axo"]
+            return SimpleNamespace(returncode=0, stdout=ps_output, stderr="")
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(doctor_mod, "_cwd_for_pid", lambda pid: f"/tmp/p{pid}")
+        monkeypatch.setattr(doctor_mod, "_stack_hint_for_pid", lambda pid: "prompt_toolkit/input wait" if pid == 101 else "")
+
+        processes = doctor_mod.list_hermes_chat_processes(include_stacks=True)
+
+        assert [p.pid for p in processes] == [101, 103, 104]
+        assert processes[0].tty == "ttys001"
+        assert processes[0].cwd == "/tmp/p101"
+        assert processes[0].stack_hint == "prompt_toolkit/input wait"
+
+    def test_chat_doctor_default_prints_instructions_without_recovery(self, monkeypatch):
+        sent = []
+        monkeypatch.setattr(
+            doctor_mod,
+            "list_hermes_chat_processes",
+            lambda include_stacks=False: [
+                doctor_mod.ChatProcess(
+                    pid=123,
+                    ppid=1,
+                    tty="ttys001",
+                    elapsed="00:05",
+                    command="hermes chat",
+                    cwd="/Users/me/project",
+                    stack_hint="",
+                )
+            ],
+        )
+        monkeypatch.setattr(doctor_mod.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = doctor_mod.run_chat_doctor(Namespace(recover=False, pid=[], stacks=False, force=False))
+
+        out = buf.getvalue()
+        assert code == 0
+        assert "123" in out
+        assert "hermes doctor chat --recover --pid 123" in out
+        assert sent == []
+
+    def test_chat_doctor_recover_requires_explicit_pid(self, monkeypatch):
+        monkeypatch.setattr(doctor_mod, "list_hermes_chat_processes", lambda include_stacks=False: [])
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = doctor_mod.run_chat_doctor(Namespace(recover=True, pid=[], stacks=False, force=False))
+
+        assert code == 2
+        assert "requires --pid" in buf.getvalue()
+
+    def test_chat_doctor_recover_sends_soft_interrupt_only_to_requested_pid(self, monkeypatch):
+        sent = []
+        monkeypatch.setattr(
+            doctor_mod,
+            "list_hermes_chat_processes",
+            lambda include_stacks=False: [
+                doctor_mod.ChatProcess(123, 1, "ttys001", "00:05", "hermes chat", "/tmp", ""),
+                doctor_mod.ChatProcess(456, 1, "ttys002", "00:06", "hermes chat", "/tmp", ""),
+            ],
+        )
+        monkeypatch.setattr(doctor_mod.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+
+        code = doctor_mod.run_chat_doctor(Namespace(recover=True, pid=[123], stacks=False, force=False))
+
+        assert code == 0
+        assert sent == [(123, signal.SIGINT)]
 
 
 class TestDoctorPlatformHints:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -589,6 +589,14 @@ class TestFullCommandAlwaysShown:
             result = prompt_dangerous_approval(short_cmd, "recursive delete")
         assert result == "deny"
 
+    def test_interactive_chat_without_callback_denies_without_raw_input(self):
+        """prompt_toolkit owns stdin in Hermes chat; fallback input() must not steal it."""
+        for env_name in ("HERMES_INTERACTIVE", "HERMESINTERACTIVE"):
+            with mock_patch.dict("os.environ", {env_name: "1"}, clear=True):
+                with mock_patch("builtins.input", side_effect=AssertionError("input() should not be called")):
+                    result = prompt_dangerous_approval("rm -rf /tmp", "recursive delete")
+            assert result == "deny"
+
 
 class TestForkBombDetection:
     """The fork bomb regex must match the classic :(){ :|:& };: pattern."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -640,6 +640,15 @@ def prompt_dangerous_approval(command: str, description: str,
             print()
             sys.stdout.flush()
 
+            # In interactive Hermes chat, prompt_toolkit owns stdin.  If the
+            # CLI approval callback is missing/failed, falling back to a raw
+            # input() thread races prompt_toolkit for fd 0 and can leave the
+            # chat apparently frozen/stale.  Fail closed instead of stealing
+            # the terminal.
+            if os.environ.get("HERMES_INTERACTIVE") == "1" or os.environ.get("HERMESINTERACTIVE") == "1":
+                print("      ✗ Approval UI unavailable in interactive chat - denying command")
+                return "deny"
+
             result = {"choice": ""}
 
             def get_input():


### PR DESCRIPTION
## Summary
- add ◆ Hermes Chat Doctor
Lists local interactive chat processes and gives safe stale-session recovery steps.

Found 3 active Hermes chat process(es):
      PID TTY        ELAPSED      CWD                                COMMAND
    52260 ttys010    01:17:51     …sers/christiankrag/Desktop/cursiv /Users/christiankrag/.hermes/hermes-agent/venv/bin/python3 /Users/christiankrag/.local/bin/hermes chat
    76921 ttys011    30:37        /Users/christiankrag/Desktop/sim   /Users/christiankrag/.hermes/hermes-agent/venv/bin/python3 /Users/christiankrag/.local/bin/hermes chat
    68450 ttys012    47:49        /Users/christiankrag/Desktop/vault /Users/christiankrag/.hermes/hermes-agent/venv/bin/python3 /Users/christiankrag/.local/bin/hermes chat

Safe recovery guidance:
  1) Return to the chat terminal and press Ctrl+C once; wait a few seconds.
  2) If the prompt does not return, start a fresh terminal and run `hermes doctor chat`.
  3) Use explicit soft recovery only for the PID you recognize:
     hermes doctor chat --recover --pid 52260
  4) Forced termination is intentionally not default. Use `--force` only after soft recovery fails. stale/frozen interactive session detection and soft recovery
- clarify Codex-only auth relogin guidance to prefer the verified Codex CLI task route
- consolidate Codex-only policy detection through the auth helper so doctor/auth do not drift

## Test plan
- ........................................................................ [ 36%]
........................................................................ [ 72%]
........................................................                 [100%]
=============================== warnings summary ===============================
tests/hermes_cli/test_auth_nous_provider.py::test_format_auth_error_uses_codex_policy_guidance
  /Users/christiankrag/.hermes/hermes-agent/tests/conftest.py:492: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop_policy().get_event_loop()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
200 passed, 1 warning in 3.36s
- 
- 