### PR TITLE
fix(terminal): bridge docker_env config through to TERMINAL_DOCKER_ENV

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -495,6 +495,7 @@ def load_cli_config() -> Dict[str, Any]:
         "container_disk": "TERMINAL_CONTAINER_DISK",
         "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+        "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
@@ -518,7 +519,7 @@ def load_cli_config() -> Dict[str, Any]:
                 continue
             if _file_has_terminal_config or env_var not in os.environ:
                 val = terminal_config[config_key]
-                if isinstance(val, list):
+                if isinstance(val, (list, dict)):
                     os.environ[env_var] = json.dumps(val)
                 else:
                     os.environ[env_var] = str(val)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -380,6 +380,7 @@ if _config_path.exists():
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+                "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
@@ -398,7 +399,7 @@ if _config_path.exists():
                     # receives a literal "~/" which the kernel rejects.
                     if _cfg_key == "cwd" and isinstance(_val, str):
                         _val = os.path.expanduser(_val)
-                    if isinstance(_val, list):
+                    if isinstance(_val, (list, dict)):
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1085,6 +1085,7 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in ("true", "1", "yes"),
     }
 


### PR DESCRIPTION
## Problem

`terminal.docker_env` from `config.yaml` is silently ignored at runtime. Setting it has no effect on container env vars.

## Root cause

Three places in the config bridge omit `docker_env`:

1. `gateway/run.py:_terminal_env_map` — no `docker_env` entry, so the value never reaches `os.environ` as `TERMINAL_DOCKER_ENV`
2. `cli.py:env_mappings` — same omission for the standalone CLI path
3. `tools/terminal_tool.py:_get_env_config` — return dict missing `docker_env`, so even if `TERMINAL_DOCKER_ENV` were set the runtime config dict wouldn't carry it

The downstream container_config builder at `terminal_tool.py:1792` does call `config.get(\"docker_env\", {})` (added in db86ed19), but that always returned `{}` due to the upstream bridge gap. db86ed19 fixed the symptom; this PR closes the upstream cause.

## Fix

- Add `\"docker_env\": \"TERMINAL_DOCKER_ENV\"` to both env_var mapping tables (`gateway/run.py`, `cli.py`)
- Extend list-only `json.dumps` serialization to also handle `dict` (since `docker_env` is dict-valued)
- Add `docker_env` to `_get_env_config` return dict, parsing `TERMINAL_DOCKER_ENV` as JSON with `{}` default

5 lines added, 2 lines modified across 3 files.

## Test

Verified on a production deployment of Hermes 0.12.0 (fork main) + this patch:

- `config.yaml` with \`terminal.docker_env: {EMAIL_MCP_SERVER: email-general, GIT_REPOS_PATH: /repo}\`
- After restart, container started by sandbox now has those env vars: \`exec('echo \$EMAIL_MCP_SERVER')\` returns \`email-general\`
- Confirmed across 7 instances (different docker_env per agent)

## Behavioral compatibility

- No new config keys (uses already-documented \`docker_env\`)
- No new env var conventions (follows existing \`TERMINAL_DOCKER_VOLUMES\` pattern)
- List/string serialization unchanged; only added dict branch