### PR TITLE
fix(gateway): show other profiles in 'gateway status' to prevent confusion

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -690,6 +690,32 @@ def _print_gateway_process_mismatch(snapshot: GatewayRuntimeSnapshot) -> None:
     print("  can refuse to start another copy until this process stops.")
 
 
+def _print_other_profiles_gateway_status() -> None:
+    """Print a summary of gateway status across all profiles.
+
+    Shown at the bottom of ``hermes gateway status`` output so users with
+    multiple profiles can tell at a glance which gateways are running and
+    avoid confusing another profile's process with the current one.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        current = get_active_profile_name()
+        other_processes = [
+            p for p in find_profile_gateway_processes()
+            if p.profile != current
+        ]
+        if not other_processes:
+            return
+
+        print()
+        print("Other profiles:")
+        for proc in other_processes:
+            print(f"  ✓ {proc.profile:<16s} — PID {proc.pid}")
+    except Exception:
+        pass
+
+
 def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None,
                            all_profiles: bool = False) -> int:
     """Kill any running gateway processes. Returns count killed.
@@ -4455,6 +4481,9 @@ def _gateway_command_inner(args):
                 else:
                     print("  hermes gateway install  # Install as user service")
                     print("  sudo hermes gateway install --system  # Install as boot-time system service")
+
+        # Show other profiles' gateway status for multi-profile awareness
+        _print_other_profiles_gateway_status()
 
     elif subcmd == "migrate-legacy":
         # Stop, disable, and remove legacy Hermes gateway unit files from


### PR DESCRIPTION
Salvage of #19115 onto current main.\n\n## Summary\nWhen running ● hermes-gateway.service - Hermes Agent Gateway - Messaging Platform Integration
     Loaded: loaded (/home/teknium/.config/systemd/user/hermes-gateway.service; enabled; preset: enabled)
     Active: active (running) since Sun 2026-05-03 00:48:57 PDT; 24h ago
 Invocation: 0164d4e1e1b94f48a04a2df6beb4a6ff
   Main PID: 2304773 (python)
      Tasks: 19 (limit: 76757)
     Memory: 81.6M (peak: 990.7M, swap: 304.4M, swap peak: 305.4M)
        CPU: 2min 10.545s
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service
             ├─2304773 /home/teknium/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace
             └─2305068 node /home/teknium/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js --port 3000 --session /home/teknium/.hermes/whatsapp/session --mode self-chat

May 03 00:48:58 teknium-dev python[2304773]:   Then remove the old entries from /home/teknium/.hermes/.env
May 03 06:40:05 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 5947288074 (:)) on telegram
May 03 06:41:03 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 5947288074 (:)) on telegram
May 03 06:41:44 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 5947288074 (:)) on telegram
May 03 10:24:53 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 684405948 (blackvas) on telegram
May 03 10:24:57 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 684405948 (blackvas) on telegram
May 03 10:27:06 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 684405948 (blackvas) on telegram
May 03 14:45:27 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 206415579 (A) on telegram
May 03 14:45:42 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 206415579 (A) on telegram
May 03 14:52:35 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 206415579 (A) on telegram
⚠ Installed gateway service definition is outdated
  Run: hermes gateway restart  # auto-refreshes the unit

✓ User gateway service is running
✓ Systemd linger is enabled (service survives logout) on a multi-profile install, add a summary of gateway processes belonging to OTHER profiles so users can tell at a glance which gateways are running. Error-swallowed, display-only.\n\n## Validation\nscripts/run_tests.sh tests/hermes_cli/test_gateway.py \u2192 passed\n\nOriginal PR: #19115