### PR TITLE
fix(gateway): exclude ancestor PIDs from gateway process scan

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -237,6 +237,26 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     return False
 
 
+def _get_ancestor_pids() -> set[int]:
+    """Return the set of PIDs in the current process's ancestor chain.
+
+    Walks from the current PID up to PID 1 (init) so that process-table scans
+    never match the calling CLI process or any of its parents.  This prevents
+    ``hermes gateway status`` from falsely counting the ``hermes`` CLI that
+    invoked it as a running gateway instance (see #13242).
+    """
+    ancestors: set[int] = set()
+    pid = os.getpid()
+    # Cap iterations to avoid infinite loops on exotic platforms.
+    for _ in range(64):
+        ancestors.add(pid)
+        parent = _get_parent_pid(pid)
+        if parent is None or parent <= 0 or parent in ancestors:
+            break
+        pid = parent
+    return ancestors
+
+
 def _append_unique_pid(pids: list[int], pid: int | None, exclude_pids: set[int]) -> None:
     if pid is None or pid <= 0:
         return
@@ -252,6 +272,10 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
     a live gateway when the PID file is stale/missing, and ``--all`` sweeps can
     discover gateways outside the current profile.
     """
+    # Exclude the entire ancestor chain so the CLI process that invoked this
+    # scan (e.g. ``hermes gateway status``) is never mistaken for a running
+    # gateway.  See #13242.
+    exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
     patterns = [
         "hermes_cli.main gateway",


### PR DESCRIPTION
Salvage of #19146 onto current main.\n\n## Summary\n● hermes-gateway.service - Hermes Agent Gateway - Messaging Platform Integration
     Loaded: loaded (/home/teknium/.config/systemd/user/hermes-gateway.service; enabled; preset: enabled)
     Active: active (running) since Sun 2026-05-03 00:48:57 PDT; 24h ago
 Invocation: 0164d4e1e1b94f48a04a2df6beb4a6ff
   Main PID: 2304773 (python)
      Tasks: 19 (limit: 76757)
     Memory: 81.4M (peak: 990.7M, swap: 304.3M, swap peak: 305.4M)
        CPU: 2min 10.664s
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service
             ├─2304773 /home/teknium/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace
             └─2305068 node /home/teknium/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js --port 3000 --session /home/teknium/.hermes/whatsapp/session --mode self-chat

May 03 00:48:58 teknium-dev python[2304773]:   Then remove the old entries from /home/teknium/.hermes/.env
May 03 06:40:05 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 5947288074 (:)) on telegram
May 03 06:41:03 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 5947288074 (:)) on telegram
May 03 06:41:44 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 5947288074 (:)) on telegram
May 03 10:24:53 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 684405948 (blackvas) on telegram
May 03 10:24:57 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 684405948 (blackvas) on telegram
May 03 10:27:06 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 684405948 (blackvas) on telegram
May 03 14:45:27 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 206415579 (A) on telegram
May 03 14:45:42 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 206415579 (A) on telegram
May 03 14:52:35 teknium-dev python[2304773]: WARNING gateway.run: Unauthorized user: 206415579 (A) on telegram
⚠ Installed gateway service definition is outdated
  Run: hermes gateway restart  # auto-refreshes the unit

✓ User gateway service is running
✓ Systemd linger is enabled (service survives logout) could falsely count the 























╭──────────── Hermes Agent v0.12.0 (2026.4.30) · upstream 8a4fe80f ────────────╮
│                                   Available Tools                            │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀⠀⢀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   browser: browser_back, browser_click, ...  │
│  ⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣇⠸⣿⣿⠇⣸⣿⣿⣷⣦⣄⡀⠀⠀⠀⠀⠀⠀   browser-cdp: browser_cdp, browser_dialog   │
│  ⠀⢀⣠⣴⣶⠿⠋⣩⡿⣿⡿⠻⣿⡇⢠⡄⢸⣿⠟⢿⣿⢿⣍⠙⠿⣶⣦⣄⡀⠀   clarify: clarify                           │
│  ⠀⠀⠉⠉⠁⠶⠟⠋⠀⠉⠀⢀⣈⣁⡈⢁⣈⣁⡀⠀⠉⠀⠙⠻⠶⠈⠉⠉⠀⠀   code_execution: execute_code               │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⣿⡿⠛⢁⡈⠛⢿⣿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   cronjob: cronjob                           │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⣿⣦⣤⣈⠁⢠⣴⣿⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   delegation: delegate_task                  │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠻⢿⣿⣦⡉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   file: patch, read_file, search_files,      │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⢷⣦⣈⠛⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   write_file                                 │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣴⠦⠈⠙⠿⣦⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   hermes-yuanbao: yb_query_group_info, ...   │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿⣤⡈⠁⢤⣿⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   (and 12 more toolsets...)                  │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠷⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀                                              │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠑⢶⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   Available Skills                           │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠁⢰⡆⠈⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   autonomous-ai-agents: claude-code, codex,  │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠳⠈⣡⠞⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   hermes-agent, kanban-multia...             │
│  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀   creative: architecture-diagram,            │
│                                   ascii-art, ascii-video, b...               │
│  claude-opus-4.7 · Nous Research  data-science: jupyter-live-kernel          │
│                 .                 devops: browser-backend-work,              │
│  Session: 20260504_013834_316595  bug-triage-work, claw3d-h...               │
│                                   email: himalaya                            │
│                                   games: allthemons10-ops                    │
│                                   gaming: minecraft-modpack-server           │
│                                   general: dogfood, ocr-and-documents,       │
│                                   yuanbao                                    │
│                                   gifs: gif-search                           │
│                                   github: codebase-audit-work,               │
│                                   gateway-platform-integrati...              │
│                                   market-data: polymarket                    │
│                                   mcp: fastmcp, native-mcp                   │
│                                   media: spotify, youtube-content            │
│                                   mlops: audiocraft-audio-generation,        │
│                                   gguf-quantization,...                      │
│                                   music-creation: heartmula, songsee         │
│                                   note-taking: obsidian                      │
│                                   productivity: airtable, google-workspace,  │
│                                   latex-pdf-report, m...                     │
│                                   red-teaming: godmode                       │
│                                   research: agentic-research-ideas,          │
│                                   ai-funding-daily-report...                 │
│                                   social-media: discoverhermes-submission,   │
│                                   linkedin, xitter, xurl                     │
│                                   software-development:                      │
│                                   feature-design-work, hermes-pr-review,     │
│                                   node-ins...                                │
│                                                                              │
│                                   31 tools · 112 skills · /help for          │
│                                   commands                                   │
│                                   ⚠ 73 commits behind — run hermes update    │
│                                   to update                                  │
╰──────────────────────────────────────────────────────────────────────────────╯

Welcome to Hermes Agent! Type your message or /help for commands.
✦ Tip: Corrections you give the agent ("no, do it this way") are often 
auto-saved to memory.


Goodbye! ⚕ CLI process that invoked it as a running gateway because  didn't exclude the scan process's ancestor chain. Walk up to PID 1 and exclude. Fixes #13242.\n\n## Validation\nscripts/run_tests.sh tests/hermes_cli/test_gateway.py -k pid -> passed\n\nOriginal PR: #19146