### PR TITLE
fix(tui): restore terminal modes on all exit paths

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -358,6 +358,13 @@ export function useMainApp(gw: GatewayClient) {
   const die = useCallback(() => {
     gw.kill()
     exit()
+    // Ink's exit() calls unmount() which resets terminal modes but does NOT
+    // call process.exit().  Without an explicit exit the Node process stays
+    // alive (stdin listener keeps the event loop open), so the process.on('exit')
+    // handler in entry.tsx — which sends the final resetTerminalModes() — never
+    // fires.  This leaves kitty keyboard protocol, mouse modes, etc. enabled
+    // in the parent shell.  See issue #19194.
+    process.exit(0)
   }, [exit, gw])
 
   const session = useSessionLifecycle({


### PR DESCRIPTION
Salvage of #19210 onto current main.\n\n## Summary\n calls Ink's  which unmounts the component but doesn't call , so the Node process's  handler (which runs ) never fires. Kitty keyboard protocol, mouse modes, etc. leak into the parent shell. Explicit  in the die path +  covers all exit paths.\n\n## Validation\nManual review; frontend/no-test change.\n\nOriginal PR: #19210