### PR TITLE
fix(tests): tolerate ps ancestor-walk in find_gateway_pids fallback test

### DIFF
--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -310,6 +310,10 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     def fake_run(cmd, **kwargs):
         if cmd[:4] == ["ps", "-A", "eww", "-o"]:
             return SimpleNamespace(returncode=1, stdout="", stderr="ps failed")
+        if cmd[:3] == ["ps", "-o", "ppid="]:
+            # _get_ancestor_pids() walks up the tree; return "no parent" so
+            # the loop terminates cleanly.
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
         raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)


### PR DESCRIPTION
Follow-up to #19586 (@cixuuz salvage): `_get_ancestor_pids()` walks `ps -o ppid=` up the process tree, which the pre-existing mock in `test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails` didn't expect. Return empty stdout so the ancestor loop terminates cleanly and the original fallback assertion still passes.

## Validation
scripts/run_tests.sh tests/hermes_cli/test_gateway.py -k pid -> 3 passed