### PR TITLE
fix(web): add missing icons for config page category sidebar

### DIFF
--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -27,6 +27,15 @@ import {
   Wrench,
   FileQuestion,
   Filter,
+  Cloud,
+  Sparkles,
+  LayoutDashboard,
+  BookOpen,
+  Route,
+  History,
+  Shield,
+  FileOutput,
+  RefreshCw,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { getNestedValue, setNestedValue } from "@/lib/nested";
@@ -66,6 +75,15 @@ const CATEGORY_ICONS: Record<
   logging: ClipboardList,
   discord: MessageCircle,
   auxiliary: Wrench,
+  bedrock: Cloud,
+  curator: Sparkles,
+  kanban: LayoutDashboard,
+  model_catalog: BookOpen,
+  openrouter: Route,
+  sessions: History,
+  tool_loop_guardrails: Shield,
+  tool_output: FileOutput,
+  updates: RefreshCw,
 };
 
 function CategoryIcon({


### PR DESCRIPTION
Salvage of #19219 onto current main.\n\n## Summary\nCosmetic: several config page categories (bedrock, curator, kanban, openrouter, sessions, etc.) were rendering without icons in the dashboard sidebar. Map them to appropriate Lucide icons.\n\n## Validation\nManual review; scope is documentation/frontend/no-test.\n\nOriginal PR: #19219