### PR TITLE
fix(acp): bypass streaming for copilot shim

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11165,10 +11165,17 @@ class AIAgent:
                             self.thinking_callback("")
 
                     _use_streaming = True
+                    # ACP subprocess shims (copilot-acp, including Gemini CLI ACP)
+                    # currently expose a non-streaming OpenAI-compatible facade.
+                    # If we pass stream=True, the shim still returns a regular
+                    # SimpleNamespace response; the streaming path then tries to
+                    # iterate it and raises: 'types.SimpleNamespace' object is not iterable.
+                    if self.provider == "copilot-acp":
+                        _use_streaming = False
                     # Provider signaled "stream not supported" on a previous
                     # attempt — switch to non-streaming for the rest of this
                     # session instead of re-failing every retry.
-                    if getattr(self, "_disable_streaming", False):
+                    elif getattr(self, "_disable_streaming", False):
                         _use_streaming = False
                     # CopilotACPClient communicates via subprocess stdio and
                     # returns a plain SimpleNamespace — not an iterable

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2326,6 +2326,29 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_copilot_acp_uses_non_streaming_path_even_with_stream_consumer(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "copilot-acp"
+        agent.stream_delta_callback = lambda _delta: None
+        resp = _mock_response(content="ACP final answer", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", return_value=resp) as mock_api_call,
+            patch.object(
+                agent,
+                "_interruptible_streaming_api_call",
+                side_effect=AssertionError("copilot-acp must not use streaming path"),
+            ) as mock_streaming_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "ACP final answer"
+        mock_api_call.assert_called_once()
+        mock_streaming_call.assert_not_called()
+
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")


### PR DESCRIPTION
## Summary
- bypass streaming for copilot-acp subprocess shims, which return non-streaming OpenAI-compatible SimpleNamespace responses
- force-redact ACP fs/read_text_file output at the file-read safety boundary
- add regression coverage for copilot-acp non-streaming path even when stream consumers are registered

## Tests
- venv/bin/python -m py_compile run_agent.py tests/run_agent/test_run_agent.py agent/redact.py agent/copilot_acp_client.py tests/agent/test_copilot_acp_client.py
- venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_copilot_acp_uses_non_streaming_path_even_with_stream_consumer -q
- venv/bin/python -m pytest tests/agent/test_copilot_acp_client.py -q
- venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_stop_finish_reason_returns_response tests/run_agent/test_run_agent.py::TestRunConversation::test_copilot_acp_uses_non_streaming_path_even_with_stream_consumer tests/run_agent/test_run_agent.py::TestRunConversation::test_tool_calls_then_stop tests/agent/test_copilot_acp_client.py tests/agent/test_redact.py -q