### PR TITLE
fix(setup): back up config.yaml before setup modifies it

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3003,6 +3003,21 @@ def run_setup_wizard(args):
     config = load_config()
     hermes_home = get_hermes_home()
 
+    # Back up existing config before setup modifies it (#3522)
+    config_path = get_config_path()
+    if config_path.exists():
+        from datetime import datetime as _dt
+        _backup_path = config_path.with_suffix(
+            f".yaml.bak.{_dt.now().strftime('%Y%m%d_%H%M%S')}"
+        )
+        try:
+            import shutil
+            shutil.copy2(config_path, _backup_path)
+        except Exception:
+            _backup_path = None
+    else:
+        _backup_path = None
+
     # Detect non-interactive environments (headless SSH, Docker, CI/CD)
     non_interactive = getattr(args, 'non_interactive', False)
     if not non_interactive and not is_interactive_stdin():
@@ -3172,6 +3187,10 @@ def run_setup_wizard(args):
 
     # Save and show summary
     save_config(config)
+    if _backup_path and _backup_path.exists():
+        print_info(f"Previous config backed up to: {_backup_path}")
+        print_info("If setup changed a value you customized, restore it with:")
+        print_info(f"  cp {_backup_path} {config_path}")
     _print_setup_summary(config, hermes_home)
 
     _offer_launch_chat()


### PR DESCRIPTION
Salvage of #19383 onto current main.\n\n## Summary\n
⚕ Hermes Setup — Non-interactive mode

  Running in a non-interactive environment (no TTY detected).
  The interactive wizard cannot be used here.

  Configure Hermes using environment variables or config commands:
    hermes config set model.provider custom
    hermes config set model.base_url http://localhost:8080/v1
    hermes config set model.default your-model-name

  Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.
  Run 'hermes setup' in an interactive terminal to use the full wizard. modifies  in place with no rollback. Back it up to  before saving and tell the user where it went so they can restore customizations the wizard might have reset.\n\n## Validation\nscripts/run_tests.sh tests/hermes_cli/test_setup.py -> passed\n\nOriginal PR: #19383