### PR TITLE
fix: drop legacy async flag from Hindsight batch retain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1333,14 +1333,17 @@ class HindsightMemoryProvider(MemoryProvider):
             )
             item.pop("bank_id", None)
             item.pop("retain_async", None)
-            logger.debug("Hindsight retain: bank=%s, doc=%s, async=%s, content_len=%d, num_turns=%d",
+            logger.debug("Hindsight retain: bank=%s, doc=%s, async_config=%s, content_len=%d, num_turns=%d",
                          bank_id, document_id, retain_async_flag, len(content), num_turns)
+            # Do not forward retain_async to aretain_batch. Current Hindsight
+            # servers treat batch retains as asynchronous already and log
+            # "Unknown parameters ignored: [async]" when the client sends the
+            # legacy async flag through the /memories endpoint.
             self._run_hindsight_operation(
                 lambda client: client.aretain_batch(
                     bank_id=bank_id,
                     items=[item],
                     document_id=document_id,
-                    retain_async=retain_async_flag,
                 )
             )
             logger.debug("Hindsight retain succeeded")
@@ -1504,7 +1507,6 @@ class HindsightMemoryProvider(MemoryProvider):
                             bank_id=self._bank_id,
                             items=[item],
                             document_id=old_document_id,
-                            retain_async=self._retain_async,
                         )
                     )
                 except Exception as e:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -56,8 +56,10 @@ def _make_mock_client():
         entities=None,
         tags=None,
         update_mode=None,
-        retain_async=None,
     ):
+        return SimpleNamespace(ok=True)
+
+    async def _aretain_batch(bank_id, items, document_id=None):
         return SimpleNamespace(ok=True)
 
     client = MagicMock()
@@ -73,7 +75,7 @@ def _make_mock_client():
     client.areflect = AsyncMock(
         return_value=SimpleNamespace(text="Synthesized answer")
     )
-    client.aretain_batch = AsyncMock()
+    client.aretain_batch = AsyncMock(side_effect=_aretain_batch)
     client.aclose = AsyncMock()
     return client
 
@@ -675,7 +677,7 @@ class TestSyncTurn:
         call_kwargs = p._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
         assert call_kwargs["document_id"].startswith("session-1-")
-        assert call_kwargs["retain_async"] is True
+        assert "retain_async" not in call_kwargs
         assert len(call_kwargs["items"]) == 1
         item = call_kwargs["items"][0]
         assert item["context"] == "conversation between Hermes Agent and the User"
@@ -716,14 +718,14 @@ class TestSyncTurn:
         assert "session1" in item["tags"]
         assert "session:test-session" in item["tags"]
 
-    def test_sync_turn_uses_aretain_batch(self, provider):
-        """sync_turn should use aretain_batch with retain_async."""
+    def test_sync_turn_uses_aretain_batch_without_legacy_async_param(self, provider):
+        """sync_turn should use aretain_batch without the legacy async kwarg."""
         provider.sync_turn("hello", "hi")
         provider._retain_queue.join()
         provider._client.aretain_batch.assert_called_once()
         call_kwargs = provider._client.aretain_batch.call_args.kwargs
         assert call_kwargs["document_id"].startswith("test-session-")
-        assert call_kwargs["retain_async"] is True
+        assert "retain_async" not in call_kwargs
         assert len(call_kwargs["items"]) == 1
         assert call_kwargs["items"][0]["context"] == "conversation between Hermes Agent and the User"
 
@@ -745,7 +747,7 @@ class TestSyncTurn:
         p._client.aretain_batch.assert_called_once()
         call_kwargs = p._client.aretain_batch.call_args.kwargs
         assert call_kwargs["document_id"].startswith("test-session-")
-        assert call_kwargs["retain_async"] is False
+        assert "retain_async" not in call_kwargs
         item = call_kwargs["items"][0]
         content = json.loads(item["content"])
         assert len(content) == 3


### PR DESCRIPTION
## Summary
- stop forwarding the legacy `retain_async` kwarg to Hindsight `aretain_batch`
- keep the retain config value for compatibility/logging, but avoid sending the unsupported `async` parameter to current Hindsight servers
- tighten Hindsight provider tests so the mock batch-retain client rejects unexpected async kwargs

## Test Plan
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`
- `python -m pytest tests/plugins/memory -q -o 'addopts='`
- manual strict-client smoke: `aretain_batch` accepted only `bank_id`, `items`, and `document_id`
