### PR TITLE
Add worker verification harness

### DIFF
--- a/.hermes/plans/2026-05-04_183955-verification-harness.md
+++ b/.hermes/plans/2026-05-04_183955-verification-harness.md
@@ -1,0 +1,338 @@
+# Hermes Worker Verification Harness Implementation Plan
+
+> For Hermes: Use subagent-driven-development skill to implement this plan task-by-task after Callum approves scope.
+
+Goal: Build a lightweight verification harness so coding workers cannot honestly report success without machine-readable evidence: tests run, UI/browser/simulator evidence captured where relevant, artifacts stored, and summary visible to Hermes/UI.
+
+Architecture: Start as a local CLI/library inside Hermes Agent, not a giant new service. The harness should accept a repo path plus task type, discover repo verification commands, run checks, capture evidence artifacts, and write a JSON + markdown verification report. Hermes/Codex prompts can then require workers to call it before final response.
+
+Tech Stack: Python for harness CLI/library, pytest for unit tests, existing Hermes web/API later for visibility, Playwright/browser tooling only once the core report format is stable.
+
+---
+
+## Current context / assumptions
+
+- Brain source: `/Users/cal/dev/brain/research/x-bookmarks-agent-orchestration.md`
+- Strongest bookmark signal: agents improve when they have durable context, a harness, and real verification loops.
+- Repo routing source: `/Users/cal/dev/orca/hermes/repo-families.yaml`
+- Main reference architecture: `program-mobile-backend` family.
+- Callum wants honest verification, not workers judging taste.
+- Callum remains final authority on whether UI/product work is satisfactory.
+- Existing Hermes repo: `/Users/cal/.hermes/hermes-agent`
+- Existing Orca repo: `/Users/cal/dev/orca`
+
+## Non-goals for v1
+
+- Do not build a full CI replacement.
+- Do not make monitor agents decide taste.
+- Do not add a huge dashboard first.
+- Do not require every repo to adopt new config before basic verification works.
+- Do not restart Hermes gateway as part of implementation unless Callum explicitly approves.
+
+## Acceptance criteria for v1
+
+A worker can run one command like:
+
+```bash
+hermes verify --repo /path/to/repo --task-type web-ui --output /tmp/verification
+```
+
+And get:
+
+- `verification.json` with status, repo path, git SHA/branch, commands run, exit codes, artifact paths, and honest limitations.
+- `verification.md` with a short human-readable summary.
+- test/lint command evidence when repo conventions are known.
+- screenshot/browser evidence for web UI when a URL is provided.
+- explicit `not_run` entries when evidence was expected but unavailable.
+- non-zero exit if required checks fail.
+
+## Proposed v1 check types
+
+1. repo_state
+   - git branch
+   - git SHA
+   - dirty diff summary
+   - changed files
+
+2. command_checks
+   - discover from repo config or repo-family map
+   - run fast verification commands only by default
+   - record command, cwd, exit code, duration, stdout/stderr tail
+
+3. web_ui_evidence
+   - optional in v1 behind `--url`
+   - load page with Playwright or existing browser tooling if available
+   - capture screenshot
+   - optionally collect console errors
+
+4. mobile_evidence
+   - v1: report `not_run` unless repo provides command
+   - v1.5: Expo/iOS simulator/Maestro integration
+
+5. final_report
+   - machine-readable JSON
+   - markdown summary
+   - status: `passed`, `failed`, `partial`, `not_run`
+
+---
+
+# Task 1: Add verification report data model
+
+Objective: Create stable Python objects for verification reports before adding runners.
+
+Files:
+- Create: `hermes_cli/verification/__init__.py`
+- Create: `hermes_cli/verification/report.py`
+- Test: `tests/verification/test_report.py`
+
+Steps:
+1. Write failing pytest for constructing a report with one passed command check.
+2. Verify failure with:
+   `./venv/bin/python -m pytest tests/verification/test_report.py -q -o 'addopts='`
+3. Implement dataclasses or pydantic-free plain Python structures:
+   - `VerificationReport`
+   - `VerificationCheck`
+   - `VerificationArtifact`
+4. Add JSON serialization.
+5. Add markdown serialization.
+6. Run the test and verify pass.
+
+Expected behavior:
+- JSON includes `status`, `repo`, `branch`, `sha`, `checks`, `artifacts`, `limitations`.
+- Markdown is short and readable in terminal.
+
+# Task 2: Add repo state collector
+
+Objective: Capture git state so verification evidence is tied to exact code.
+
+Files:
+- Create: `hermes_cli/verification/repo_state.py`
+- Test: `tests/verification/test_repo_state.py`
+
+Steps:
+1. Write failing tests using a temp git repo.
+2. Collect branch, SHA, dirty flag, and changed files.
+3. Handle non-git dirs gracefully as `partial` with limitation.
+4. Verify with pytest.
+
+Commands:
+- `git rev-parse --abbrev-ref HEAD`
+- `git rev-parse HEAD`
+- `git status --short`
+
+# Task 3: Add command runner with evidence capture
+
+Objective: Run verification commands and preserve outputs without flooding final responses.
+
+Files:
+- Create: `hermes_cli/verification/commands.py`
+- Test: `tests/verification/test_commands.py`
+
+Steps:
+1. Write failing test for a passing command.
+2. Write failing test for a failing command.
+3. Implement command runner with timeout, cwd, stdout/stderr tail, full log artifact path.
+4. Mark report failed if required command fails.
+5. Verify with pytest.
+
+Design constraints:
+- Default timeout should be explicit and configurable.
+- No shell injection from config: command list preferred, shell string only when intentionally accepted.
+- Store full command output under output directory.
+
+# Task 4: Discover repo verification commands
+
+Objective: Reuse existing project conventions before inventing new workflow layers.
+
+Files:
+- Create: `hermes_cli/verification/discovery.py`
+- Test: `tests/verification/test_discovery.py`
+
+Sources in priority order:
+1. Explicit CLI `--command` flags.
+2. Repo-local config, if present later: `.hermes/verification.yaml`.
+3. Known repo family map: `/Users/cal/dev/orca/hermes/repo-families.yaml`.
+4. Makefile/package fallback suggestions, marked `not_run` unless explicit.
+
+For v1:
+- Implement explicit `--command` first.
+- Implement family map lookup for exact repo or similar repo paths.
+- Do not add repo-local config until the first two paths work.
+
+# Task 5: Add `hermes verify` CLI
+
+Objective: Give workers one stable command to call.
+
+Files:
+- Modify: likely `hermes_cli/main.py` or CLI command registration file after inspection.
+- Create: `hermes_cli/verification/cli.py`
+- Test: `tests/verification/test_cli.py`
+
+CLI sketch:
+
+```bash
+hermes verify \
+  --repo /Users/cal/dev/program \
+  --task-type mobile-ui \
+  --command 'make test-mobile' \
+  --command 'make test-backend' \
+  --output /tmp/hermes-verification/program-task
+```
+
+Output:
+- prints path to `verification.md`
+- exits 0 only when required checks pass
+- exits non-zero when required checks fail
+- exits with partial status if evidence couldn't be collected but commands passed
+
+# Task 6: Add web UI evidence behind `--url`
+
+Objective: For web tasks, capture proof the page loads and screenshots exist.
+
+Files:
+- Create: `hermes_cli/verification/web_ui.py`
+- Test: `tests/verification/test_web_ui.py`
+
+Behavior:
+- If `--url` supplied, launch browser check.
+- Capture screenshot into output artifacts.
+- Capture title, HTTP-ish load result, console errors if feasible.
+- If browser dependencies are missing, mark `not_run` with a limitation instead of lying.
+
+Implementation note:
+- Prefer Playwright if already present or cheap to add.
+- If dependency addition is annoying, v1 can use existing Hermes browser tooling only in agent flow and leave CLI browser evidence as v1.5.
+
+# Task 7: Integrate harness into worker prompts
+
+Objective: Make verification mandatory in delegated coding workflows.
+
+Files likely to modify:
+- Hermes skill: `subagent-driven-development`
+- Hermes skill: `codex`
+- Hermes skill: `claude-code`
+- Possibly Orca prompts/docs if worker orchestration lives there.
+
+Prompt rule:
+- Worker final response must include verification report path.
+- If no report path exists, parent treats completion as unverified.
+- Worker must list limitations honestly.
+
+Important:
+- The harness reports evidence.
+- Callum judges taste.
+- Monitor/review agents can check spec compliance and code quality, but not override Callum's taste.
+
+# Task 8: Show verification summaries in Hermes UI
+
+Objective: Make evidence inspectable without reading logs.
+
+Files likely to inspect/change:
+- `hermes_cli/web_server.py`
+- `web/src/pages/*`
+- `web/src/lib/api.ts`
+
+Minimal UI v1:
+- Add a Verification page or attach latest verification reports to job/session details.
+- Show status, repo, branch/SHA, checks, artifacts, and markdown summary.
+- Auto-refresh if a verification run is active.
+
+Do this after CLI/report format is stable. Do not start here.
+
+# Task 9: Add mobile/simulator support
+
+Objective: Bring the harness to Callum's main app shape.
+
+Possible integrations:
+- Expo start + iOS simulator screenshot.
+- Maestro flow if repo has flows.
+- `make test-mobile` plus optional simulator evidence.
+
+Start with `program` family and do not generalize too early.
+
+# Task 10: Dogfood on a real task
+
+Objective: Prove it catches bullshit.
+
+Candidate dogfood task:
+- A small Hermes UI tweak or `program` mobile screen tweak.
+
+Required evidence:
+- report JSON/markdown
+- test command output
+- screenshot artifact if UI
+- final response includes exact report path
+
+Then ask Callum to accept/reject the quality. If rejected, log the behavioral incident in Orca, not Brain.
+
+---
+
+## Suggested build order
+
+Phase 1: Core CLI evidence
+1. report model
+2. repo state
+3. command runner
+4. CLI
+5. discovery via explicit commands and repo-family map
+
+Phase 2: Visual evidence
+6. web URL screenshot evidence
+7. UI page for reports
+
+Phase 3: Mobile evidence
+8. Expo/iOS simulator path for `program` family
+9. Maestro support if useful
+
+Phase 4: Workflow enforcement
+10. Update worker skills/prompts so workers must return a report path.
+11. Dogfood and refine.
+
+## Testing / validation
+
+Focused tests:
+
+```bash
+./venv/bin/python -m pytest tests/verification -q -o 'addopts='
+```
+
+Regression tests:
+
+```bash
+./venv/bin/python -m pytest tests/cron/test_jobs.py::TestJobRunState -q -o 'addopts='
+```
+
+Web build only after UI integration:
+
+```bash
+cd web && npm run build
+```
+
+Manual dogfood command:
+
+```bash
+hermes verify --repo /Users/cal/.hermes/hermes-agent --command './venv/bin/python -m pytest tests/verification -q -o addopts=' --output /tmp/hermes-verification/dogfood
+```
+
+Expected final proof:
+- `/tmp/hermes-verification/dogfood/verification.json`
+- `/tmp/hermes-verification/dogfood/verification.md`
+- command log artifacts
+- non-zero exit on failing checks
+
+## Risks / tradeoffs
+
+- Biggest risk: building a fancy framework before one boring CLI works. Avoid that.
+- Browser/simulator automation can be flaky. Treat visual evidence as artifact capture, not absolute correctness.
+- If report format is unstable, UI integration will churn. Keep UI after core reports.
+- Do not let verification become taste judgment. It proves what ran and what was observed.
+- Avoid per-repo custom hacks until `program` and Hermes dogfooding prove the base shape.
+
+## Open questions for Callum
+
+1. Should v1 live in Hermes Agent, Orca, or a small separate repo?
+   - My vote: Hermes Agent, because this is a control-plane feature.
+2. Should first dogfood target be Hermes web UI or `program` mobile?
+   - My vote: Hermes web UI first because browser evidence is simpler than iOS simulator.
+3. How strict should worker final-response enforcement be?
+   - My vote: harsh. No verification report path = unverified, no matter how confident the worker sounds.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -675,6 +675,24 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
+def mark_job_started(job_id: str) -> bool:
+    """Mark a job as actively running so dashboards can show manual triggers immediately."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] == job_id:
+                now = _hermes_now().isoformat()
+                job["state"] = "running"
+                job["last_status"] = "running"
+                job["last_error"] = None
+                job["last_delivery_error"] = None
+                job["current_run_started_at"] = now
+                save_jobs(jobs)
+                return True
+        logger.warning("mark_job_started: job_id %s not found, skipping save", job_id)
+        return False
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
@@ -694,6 +712,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
+                job.pop("current_run_started_at", None)
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
                 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1302,6 +1302,8 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
+            from cron.jobs import mark_job_started
+            mark_job_started(job["id"])
             try:
                 success, output, final_response, error = run_job(job)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -17,6 +17,7 @@ Usage:
     hermes cron                # Manage cron jobs
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
+    hermes verify              # Run verification checks and write evidence reports
     hermes doctor              # Check configuration and dependencies
     hermes honcho setup                    # Configure Honcho AI memory integration
     hermes honcho status                   # Show Honcho config and connection status
@@ -10003,6 +10004,13 @@ Examples:
             sys.exit(1)
 
     acp_parser.set_defaults(func=cmd_acp)
+
+    # =========================================================================
+    # verify command
+    # =========================================================================
+    from hermes_cli.verification.cli import add_verify_parser
+
+    add_verify_parser(subparsers)
 
     # =========================================================================
     # profile command

--- a/hermes_cli/verification/__init__.py
+++ b/hermes_cli/verification/__init__.py
@@ -1,0 +1,16 @@
+"""Verification harness for collecting evidence from worker runs."""
+
+from hermes_cli.verification.report import (
+    VerificationArtifact,
+    VerificationCheck,
+    VerificationReport,
+)
+from hermes_cli.verification.repo_state import RepoState, collect_repo_state
+
+__all__ = [
+    "RepoState",
+    "VerificationArtifact",
+    "VerificationCheck",
+    "VerificationReport",
+    "collect_repo_state",
+]

--- a/hermes_cli/verification/cli.py
+++ b/hermes_cli/verification/cli.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from hermes_cli.verification.commands import run_command_check
+from hermes_cli.verification.discovery import DEFAULT_FAMILY_MAP, discover_commands
+from hermes_cli.verification.repo_state import collect_repo_state
+from hermes_cli.verification.report import VerificationCheck, VerificationReport
+
+
+def build_report(
+    *,
+    repo: str | Path,
+    task_type: str | None,
+    commands: list[str],
+    output: str | Path,
+    timeout_seconds: float,
+    family_map_path: str | Path | None = DEFAULT_FAMILY_MAP,
+) -> VerificationReport:
+    repo_path = Path(repo).expanduser().resolve()
+    output_path = Path(output).expanduser().resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    repo_state = collect_repo_state(repo_path)
+    report = VerificationReport(
+        repo=repo_state.repo,
+        task_type=task_type,
+        branch=repo_state.branch,
+        sha=repo_state.sha,
+        dirty=repo_state.dirty,
+        changed_files=repo_state.changed_files,
+    )
+    for limitation in repo_state.limitations:
+        report.add_limitation(limitation)
+
+    discovered = discover_commands(
+        repo=repo_path,
+        explicit_commands=commands,
+        family_map_path=family_map_path,
+    )
+    if not discovered:
+        report.add_check(
+            VerificationCheck(
+                name="command checks",
+                kind="command",
+                status="not_run",
+                message="No verification commands supplied or discovered",
+            )
+        )
+        report.add_limitation("No verification commands ran")
+        return report
+
+    command_logs_dir = output_path / "logs"
+    for discovered_command in discovered:
+        check, artifact = run_command_check(
+            name=discovered_command.name,
+            command=discovered_command.command,
+            cwd=repo_path,
+            output_dir=command_logs_dir,
+            timeout_seconds=timeout_seconds,
+        )
+        check.message = (
+            f"source={discovered_command.source}"
+            if check.message is None
+            else f"{check.message}; source={discovered_command.source}"
+        )
+        report.add_check(check)
+        report.add_artifact(artifact)
+    return report
+
+
+def write_report(report: VerificationReport, output: str | Path) -> tuple[Path, Path]:
+    output_path = Path(output).expanduser().resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+    json_path = output_path / "verification.json"
+    markdown_path = output_path / "verification.md"
+    json_path.write_text(json.dumps(report.to_dict(), indent=2) + "\n", encoding="utf-8")
+    markdown_path.write_text(report.to_markdown(), encoding="utf-8")
+    return json_path, markdown_path
+
+
+def run_verify(
+    *,
+    repo: str | Path,
+    task_type: str | None = None,
+    commands: list[str] | None = None,
+    output: str | Path,
+    timeout_seconds: float = 300,
+    family_map_path: str | Path | None = DEFAULT_FAMILY_MAP,
+) -> int:
+    report = build_report(
+        repo=repo,
+        task_type=task_type,
+        commands=commands or [],
+        output=output,
+        timeout_seconds=timeout_seconds,
+        family_map_path=family_map_path,
+    )
+    _, markdown_path = write_report(report, output)
+    print(markdown_path)
+    return 1 if report.status == "failed" else 0
+
+
+def add_verify_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "verify",
+        help="Run verification checks and write evidence reports",
+        description="Run repo verification checks and write verification.json/verification.md artifacts.",
+    )
+    parser.add_argument("--repo", required=True, help="Repository path to verify")
+    parser.add_argument("--task-type", default=None, help="Task type label, e.g. web-ui or mobile-ui")
+    parser.add_argument(
+        "--command",
+        dest="verify_commands",
+        action="append",
+        default=[],
+        help="Verification command to run. May be supplied multiple times.",
+    )
+    parser.add_argument("--output", required=True, help="Output directory for verification artifacts")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300,
+        help="Timeout per command in seconds (default: 300)",
+    )
+    parser.set_defaults(func=cmd_verify)
+
+
+def cmd_verify(args: argparse.Namespace) -> None:
+    raise SystemExit(
+        run_verify(
+            repo=args.repo,
+            task_type=args.task_type,
+            commands=args.verify_commands,
+            output=args.output,
+            timeout_seconds=args.timeout,
+        )
+    )

--- a/hermes_cli/verification/commands.py
+++ b/hermes_cli/verification/commands.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from pathlib import Path
+
+from hermes_cli.verification.report import VerificationArtifact, VerificationCheck
+
+TAIL_CHARS = 4000
+
+
+def _safe_name(name: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", name.strip().lower()).strip("-")
+    return safe or "command"
+
+
+def _tail(text: str, limit: int = TAIL_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def run_command_check(
+    *,
+    name: str,
+    command: str,
+    cwd: str | Path,
+    output_dir: str | Path,
+    timeout_seconds: float = 300,
+) -> tuple[VerificationCheck, VerificationArtifact]:
+    output_path = Path(output_dir).expanduser().resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+    log_path = output_path / f"{_safe_name(name)}.log"
+
+    started = time.monotonic()
+    stdout = ""
+    stderr = ""
+    exit_code: int | None = None
+    message: str | None = None
+    status = "failed"
+
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=Path(cwd).expanduser().resolve(),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        exit_code = completed.returncode
+        status = "passed" if completed.returncode == 0 else "failed"
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        message = f"Command timed out after {timeout_seconds:g}s"
+        status = "failed"
+    duration = time.monotonic() - started
+
+    log_path.write_text(
+        "\n".join(
+            [
+                f"$ {command}",
+                f"cwd: {Path(cwd).expanduser().resolve()}",
+                f"exit_code: {exit_code}",
+                f"duration_seconds: {duration:.3f}",
+                "",
+                "--- stdout ---",
+                stdout,
+                "",
+                "--- stderr ---",
+                stderr,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    artifact = VerificationArtifact(kind="log", path=str(log_path), description=f"Output for {name}")
+    check = VerificationCheck(
+        name=name,
+        kind="command",
+        status=status,  # type: ignore[arg-type]
+        command=command,
+        exit_code=exit_code,
+        duration_seconds=duration,
+        stdout_tail=_tail(stdout),
+        stderr_tail=_tail(stderr),
+        message=message,
+        artifacts=[str(log_path)],
+    )
+    return check, artifact

--- a/hermes_cli/verification/discovery.py
+++ b/hermes_cli/verification/discovery.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+DEFAULT_FAMILY_MAP = Path("/Users/cal/dev/orca/hermes/repo-families.yaml")
+
+
+@dataclass(frozen=True)
+class DiscoveredCommand:
+    name: str
+    command: str
+    source: str
+
+
+def _resolve(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _matches_repo(repo: Path, family: dict) -> bool:
+    candidates: list[str] = []
+    reference_repo = family.get("reference_repo")
+    if reference_repo:
+        candidates.append(str(reference_repo))
+    candidates.extend(str(item) for item in family.get("similar_repos") or [])
+    return any(_resolve(candidate) == repo for candidate in candidates)
+
+
+def discover_commands(
+    *,
+    repo: str | Path,
+    explicit_commands: Iterable[str] | None = None,
+    family_map_path: str | Path | None = DEFAULT_FAMILY_MAP,
+) -> list[DiscoveredCommand]:
+    explicit = [command for command in (explicit_commands or []) if command]
+    if explicit:
+        return [
+            DiscoveredCommand(name=f"command {index}", command=command, source="explicit")
+            for index, command in enumerate(explicit, start=1)
+        ]
+
+    if family_map_path is None:
+        return []
+
+    map_path = Path(family_map_path).expanduser()
+    if not map_path.exists():
+        return []
+
+    data = yaml.safe_load(map_path.read_text(encoding="utf-8")) or {}
+    families = data.get("families") or {}
+    repo_path = _resolve(repo)
+    for family_name, family in families.items():
+        if not isinstance(family, dict) or not _matches_repo(repo_path, family):
+            continue
+        commands = ((family.get("command_surface") or {}).get("fast_verify") or [])
+        return [
+            DiscoveredCommand(
+                name=f"fast verify {index}",
+                command=str(command),
+                source=f"repo-family:{family_name}",
+            )
+            for index, command in enumerate(commands, start=1)
+        ]
+    return []

--- a/hermes_cli/verification/repo_state.py
+++ b/hermes_cli/verification/repo_state.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class RepoState:
+    repo: str
+    branch: str | None = None
+    sha: str | None = None
+    dirty: bool | None = None
+    changed_files: list[str] = field(default_factory=list)
+    limitations: list[str] = field(default_factory=list)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
+def collect_repo_state(repo: str | Path) -> RepoState:
+    repo_path = Path(repo).expanduser().resolve()
+    state = RepoState(repo=str(repo_path))
+
+    inside = _git(repo_path, "rev-parse", "--is-inside-work-tree")
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        state.limitations.append("Repository state not collected: path is not inside a git work tree")
+        return state
+
+    branch = _git(repo_path, "rev-parse", "--abbrev-ref", "HEAD")
+    if branch.returncode == 0:
+        state.branch = branch.stdout.strip()
+    else:
+        state.limitations.append(f"Git branch not collected: {branch.stderr.strip()}")
+
+    sha = _git(repo_path, "rev-parse", "HEAD")
+    if sha.returncode == 0:
+        state.sha = sha.stdout.strip()
+    else:
+        state.limitations.append(f"Git SHA not collected: {sha.stderr.strip()}")
+
+    status = _git(repo_path, "status", "--short")
+    if status.returncode == 0:
+        state.changed_files = [line.strip() for line in status.stdout.splitlines() if line.strip()]
+        state.dirty = bool(state.changed_files)
+    else:
+        state.limitations.append(f"Git status not collected: {status.stderr.strip()}")
+
+    return state

--- a/hermes_cli/verification/report.py
+++ b/hermes_cli/verification/report.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+CheckStatus = Literal["passed", "failed", "partial", "not_run"]
+ReportStatus = Literal["passed", "failed", "partial", "not_run"]
+
+
+@dataclass
+class VerificationArtifact:
+    kind: str
+    path: str
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class VerificationCheck:
+    name: str
+    kind: str
+    status: CheckStatus
+    command: str | None = None
+    exit_code: int | None = None
+    duration_seconds: float | None = None
+    stdout_tail: str | None = None
+    stderr_tail: str | None = None
+    message: str | None = None
+    artifacts: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class VerificationReport:
+    repo: str
+    task_type: str | None = None
+    branch: str | None = None
+    sha: str | None = None
+    dirty: bool | None = None
+    changed_files: list[str] = field(default_factory=list)
+    checks: list[VerificationCheck] = field(default_factory=list)
+    artifacts: list[VerificationArtifact] = field(default_factory=list)
+    limitations: list[str] = field(default_factory=list)
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    @property
+    def status(self) -> ReportStatus:
+        if not self.checks:
+            return "not_run"
+        statuses = {check.status for check in self.checks}
+        if "failed" in statuses:
+            return "failed"
+        if statuses & {"partial", "not_run"}:
+            return "partial"
+        if self.limitations:
+            return "partial"
+        return "passed"
+
+    def add_check(self, check: VerificationCheck) -> None:
+        self.checks.append(check)
+
+    def add_artifact(self, artifact: VerificationArtifact) -> None:
+        self.artifacts.append(artifact)
+
+    def add_limitation(self, limitation: str) -> None:
+        if limitation not in self.limitations:
+            self.limitations.append(limitation)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "repo": self.repo,
+            "task_type": self.task_type,
+            "branch": self.branch,
+            "sha": self.sha,
+            "dirty": self.dirty,
+            "changed_files": self.changed_files,
+            "generated_at": self.generated_at,
+            "checks": [check.to_dict() for check in self.checks],
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "limitations": self.limitations,
+        }
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# Verification Report",
+            "",
+            f"Status: {self.status}",
+            f"Repo: `{self.repo}`",
+        ]
+        if self.task_type:
+            lines.append(f"Task type: `{self.task_type}`")
+        if self.branch or self.sha:
+            lines.append(f"Git: `{self.branch or 'unknown'}` @ `{self.sha or 'unknown'}`")
+        if self.dirty is not None:
+            lines.append(f"Dirty: {str(self.dirty).lower()}")
+        if self.changed_files:
+            lines.extend(["", "## Changed files", ""])
+            lines.extend(f"- `{path}`" for path in self.changed_files)
+        if self.checks:
+            lines.extend(["", "## Checks", ""])
+            for check in self.checks:
+                detail = f"- {check.status}: {check.name} ({check.kind})"
+                if check.command:
+                    detail += f" — `{check.command}`"
+                if check.exit_code is not None:
+                    detail += f" exit={check.exit_code}"
+                if check.message:
+                    detail += f" — {check.message}"
+                lines.append(detail)
+        if self.artifacts:
+            lines.extend(["", "## Artifacts", ""])
+            for artifact in self.artifacts:
+                desc = f" — {artifact.description}" if artifact.description else ""
+                lines.append(f"- {artifact.kind}: `{artifact.path}`{desc}")
+        if self.limitations:
+            lines.extend(["", "## Limitations", ""])
+            lines.extend(f"- {limitation}" for limitation in self.limitations)
+        lines.append("")
+        return "\n".join(lines)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -20,6 +20,7 @@ from cron.jobs import (
     resume_job,
     remove_job,
     mark_job_run,
+    mark_job_started,
     advance_next_run,
     get_due_jobs,
     save_job_output,
@@ -675,6 +676,30 @@ class TestEnabledToolsets:
         update_job(job["id"], {"enabled_toolsets": ["web", "delegation"]})
         fetched = get_job(job["id"])
         assert fetched["enabled_toolsets"] == ["web", "delegation"]
+
+
+class TestJobRunState:
+    def test_mark_job_started_makes_running_state_visible(self, tmp_cron_dir):
+        job = create_job(prompt="Visible run", schedule="every 1h")
+
+        assert mark_job_started(job["id"]) is True
+
+        fetched = get_job(job["id"])
+        assert fetched["state"] == "running"
+        assert fetched["current_run_started_at"]
+        assert fetched["last_status"] == "running"
+        assert fetched["last_error"] is None
+
+    def test_mark_job_run_clears_running_state(self, tmp_cron_dir):
+        job = create_job(prompt="Visible run", schedule="every 1h")
+        mark_job_started(job["id"])
+
+        mark_job_run(job["id"], True)
+
+        fetched = get_job(job["id"])
+        assert fetched["state"] == "scheduled"
+        assert fetched["last_status"] == "ok"
+        assert "current_run_started_at" not in fetched
 
 
 class TestSaveJobOutput:

--- a/tests/verification/test_cli.py
+++ b/tests/verification/test_cli.py
@@ -1,0 +1,46 @@
+import json
+import sys
+
+from hermes_cli.verification.cli import run_verify
+
+
+def test_run_verify_writes_reports_for_passing_command(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output = tmp_path / "out"
+
+    code = run_verify(
+        repo=repo,
+        task_type="cli-test",
+        commands=[f"{sys.executable} -c \"print('ok')\""],
+        output=output,
+        timeout_seconds=10,
+        family_map_path=None,
+    )
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert str(output / "verification.md") in captured.out
+    data = json.loads((output / "verification.json").read_text())
+    assert data["status"] == "partial"  # non-git repo limitation is honest
+    assert data["checks"][0]["status"] == "passed"
+    assert (output / "verification.md").exists()
+
+
+def test_run_verify_returns_nonzero_for_failing_command(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output = tmp_path / "out"
+
+    code = run_verify(
+        repo=repo,
+        task_type="cli-test",
+        commands=[f"{sys.executable} -c \"import sys; sys.exit(4)\""],
+        output=output,
+        timeout_seconds=10,
+        family_map_path=None,
+    )
+
+    data = json.loads((output / "verification.json").read_text())
+    assert code == 1
+    assert data["status"] == "failed"

--- a/tests/verification/test_commands.py
+++ b/tests/verification/test_commands.py
@@ -1,0 +1,48 @@
+import sys
+
+from hermes_cli.verification.commands import run_command_check
+
+
+def test_run_command_check_records_passing_command(tmp_path):
+    check, artifact = run_command_check(
+        name="hello",
+        command=f"{sys.executable} -c \"print('hi')\"",
+        cwd=tmp_path,
+        output_dir=tmp_path / "out",
+        timeout_seconds=10,
+    )
+
+    assert check.status == "passed"
+    assert check.exit_code == 0
+    assert "hi" in check.stdout_tail
+    assert artifact.path.endswith("hello.log")
+
+
+def test_run_command_check_records_failing_command(tmp_path):
+    check, artifact = run_command_check(
+        name="fail",
+        command=f"{sys.executable} -c \"import sys; print('bad'); sys.exit(7)\"",
+        cwd=tmp_path,
+        output_dir=tmp_path / "out",
+        timeout_seconds=10,
+    )
+
+    assert check.status == "failed"
+    assert check.exit_code == 7
+    assert "bad" in check.stdout_tail
+    assert artifact.kind == "log"
+
+
+def test_run_command_check_records_timeout(tmp_path):
+    check, artifact = run_command_check(
+        name="slow",
+        command=f"{sys.executable} -c \"import time; time.sleep(2)\"",
+        cwd=tmp_path,
+        output_dir=tmp_path / "out",
+        timeout_seconds=0.1,
+    )
+
+    assert check.status == "failed"
+    assert check.exit_code is None
+    assert "timed out" in check.message.lower()
+    assert artifact.path.endswith("slow.log")

--- a/tests/verification/test_discovery.py
+++ b/tests/verification/test_discovery.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from hermes_cli.verification.discovery import discover_commands
+
+
+def test_discover_commands_prefers_explicit_commands(tmp_path):
+    commands = discover_commands(repo=tmp_path, explicit_commands=["pytest -q"], family_map_path=None)
+
+    assert [command.command for command in commands] == ["pytest -q"]
+    assert commands[0].name == "command 1"
+    assert commands[0].source == "explicit"
+
+
+def test_discover_commands_uses_repo_family_fast_verify(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    family_map = tmp_path / "families.yaml"
+    family_map.write_text(
+        f"""
+families:
+  test-family:
+    reference_repo: {repo}
+    command_surface:
+      fast_verify:
+        - make test
+        - make lint
+""".strip()
+    )
+
+    commands = discover_commands(repo=repo, explicit_commands=[], family_map_path=family_map)
+
+    assert [command.command for command in commands] == ["make test", "make lint"]
+    assert commands[0].source == "repo-family:test-family"
+
+
+def test_discover_commands_returns_empty_when_no_source(tmp_path):
+    commands = discover_commands(repo=tmp_path, explicit_commands=[], family_map_path=None)
+
+    assert commands == []

--- a/tests/verification/test_repo_state.py
+++ b/tests/verification/test_repo_state.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from hermes_cli.verification.repo_state import collect_repo_state
+
+
+def run(cmd, cwd):
+    import subprocess
+
+    subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def test_collect_repo_state_from_git_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(["git", "init"], repo)
+    run(["git", "config", "user.email", "test@example.com"], repo)
+    run(["git", "config", "user.name", "Test User"], repo)
+    (repo / "README.md").write_text("hello\n")
+    run(["git", "add", "README.md"], repo)
+    run(["git", "commit", "-m", "init"], repo)
+    (repo / "README.md").write_text("hello changed\n")
+
+    state = collect_repo_state(repo)
+
+    assert state.repo == str(repo)
+    assert state.branch in {"main", "master"}
+    assert len(state.sha) >= 7
+    assert state.dirty is True
+    assert "README.md" in state.changed_files[0]
+    assert state.limitations == []
+
+
+def test_collect_repo_state_handles_non_git_directory(tmp_path):
+    state = collect_repo_state(tmp_path)
+
+    assert state.repo == str(tmp_path)
+    assert state.branch is None
+    assert state.sha is None
+    assert state.dirty is None
+    assert state.limitations

--- a/tests/verification/test_report.py
+++ b/tests/verification/test_report.py
@@ -1,0 +1,69 @@
+from hermes_cli.verification.report import (
+    VerificationArtifact,
+    VerificationCheck,
+    VerificationReport,
+)
+
+
+def test_report_serializes_json_and_markdown():
+    report = VerificationReport(
+        repo="/tmp/repo",
+        task_type="web-ui",
+        branch="main",
+        sha="abc123",
+    )
+    report.add_check(
+        VerificationCheck(
+            name="unit tests",
+            kind="command",
+            status="passed",
+            command="pytest -q",
+            exit_code=0,
+            duration_seconds=1.23,
+        )
+    )
+    report.add_artifact(
+        VerificationArtifact(kind="log", path="/tmp/repo/test.log", description="pytest output")
+    )
+
+    data = report.to_dict()
+
+    assert data["status"] == "passed"
+    assert data["repo"] == "/tmp/repo"
+    assert data["task_type"] == "web-ui"
+    assert data["checks"][0]["name"] == "unit tests"
+    assert data["artifacts"][0]["path"] == "/tmp/repo/test.log"
+
+    markdown = report.to_markdown()
+    assert "# Verification Report" in markdown
+    assert "Status: passed" in markdown
+    assert "unit tests" in markdown
+
+
+def test_report_failed_check_sets_failed_status():
+    report = VerificationReport(repo="/tmp/repo")
+    report.add_check(
+        VerificationCheck(
+            name="lint",
+            kind="command",
+            status="failed",
+            command="npm run lint",
+            exit_code=1,
+        )
+    )
+
+    assert report.status == "failed"
+
+
+def test_report_not_run_without_failures_is_partial():
+    report = VerificationReport(repo="/tmp/repo")
+    report.add_check(
+        VerificationCheck(
+            name="screenshot",
+            kind="web_ui",
+            status="not_run",
+            message="No URL supplied",
+        )
+    )
+
+    assert report.status == "partial"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -381,6 +381,8 @@ export interface CronJob {
   deliver?: string;
   last_run_at?: string | null;
   next_run_at?: string | null;
+  current_run_started_at?: string | null;
+  last_status?: string | null;
   last_error?: string | null;
 }
 

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -22,10 +22,26 @@ function formatTime(iso?: string | null): string {
 const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
   enabled: "success",
   scheduled: "success",
+  running: "warning",
   paused: "warning",
   error: "destructive",
   completed: "destructive",
 };
+
+function jobSortTime(job: CronJob): number {
+  const primary = job.current_run_started_at || job.last_run_at || job.next_run_at;
+  if (!primary) return 0;
+  const ms = new Date(primary).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function sortCronJobs(jobs: CronJob[]): CronJob[] {
+  return [...jobs].sort((a, b) => {
+    if (a.state === "running" && b.state !== "running") return -1;
+    if (b.state === "running" && a.state !== "running") return 1;
+    return jobSortTime(b) - jobSortTime(a);
+  });
+}
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
@@ -43,13 +59,15 @@ export default function CronPage() {
   const loadJobs = useCallback(() => {
     api
       .getCronJobs()
-      .then(setJobs)
+      .then((nextJobs) => setJobs(sortCronJobs(nextJobs)))
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
   }, [showToast, t.common.loading]);
 
   useEffect(() => {
     loadJobs();
+    const intervalId = window.setInterval(loadJobs, 3000);
+    return () => window.clearInterval(intervalId);
   }, [loadJobs]);
 
   const handleCreate = async () => {
@@ -286,6 +304,11 @@ export default function CronPage() {
                 )}
                 <div className="flex items-center gap-4 text-xs text-muted-foreground">
                   <span className="font-mono">{job.schedule_display}</span>
+                  {job.current_run_started_at && (
+                    <span>
+                      Running since: {formatTime(job.current_run_started_at)}
+                    </span>
+                  )}
                   <span>
                     {t.cron.last}: {formatTime(job.last_run_at)}
                   </span>


### PR DESCRIPTION
## Summary\n- add hermes verify CLI that writes verification.json and verification.md evidence reports\n- collect repo state, run verification commands, preserve log artifacts, and report honest limitations\n- surface cron running state in the web UI so manual cron triggers become visible and auto-refresh\n\n## Verification\n- ./venv/bin/python -m pytest tests/verification tests/cron/test_jobs.py::TestJobRunState -q -o 'addopts='\n- cd web && npm run build\n- ./venv/bin/python -m hermes_cli.main verify --repo /Users/cal/.hermes/hermes-agent --task-type dogfood --command './venv/bin/python -m pytest tests/verification -q -o addopts=' --output /tmp/hermes-verification/dogfood-v1-final --timeout 120\n\nDogfood report: /tmp/hermes-verification/dogfood-v1-final/verification.md\n