### PR TITLE
fix(kanban): allow orchestrator profiles to see kanban tools via toolsets config

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -467,8 +467,8 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
         skip_memory=True,
     )
     prompt = a._build_system_prompt()
-    # Header phrase
-    assert "You are a Kanban worker" in prompt
+    # Header phrase (identity-free — SOUL.md owns identity, layer 3 is protocol)
+    assert "Kanban task execution protocol" in prompt
     # Lifecycle signals
     assert "kanban_show()" in prompt
     assert "kanban_complete" in prompt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -40,13 +40,31 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _check_kanban_mode() -> bool:
-    """Tools are available iff the current process has ``HERMES_KANBAN_TASK``
-    set in its env, which the dispatcher sets when spawning a worker.
+    """Tools are available when:
 
-    Humans running ``hermes chat`` see zero kanban tools. Workers spawned
-    by the kanban dispatcher (gateway-embedded by default) see all seven.
+    1. ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), OR
+    2. The current profile has ``kanban`` in its toolsets config
+       (orchestrator profiles like techlead that route work via Kanban).
+
+    Humans running ``hermes chat`` without the kanban toolset see zero
+    kanban tools. Workers spawned by the kanban dispatcher (gateway-
+    embedded by default) and orchestrator profiles with the kanban
+    toolset enabled see all seven.
     """
-    return bool(os.environ.get("HERMES_KANBAN_TASK"))
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+
+    # Check if the current profile has the kanban toolset enabled.
+    # Uses load_config() which has mtime-based caching, so this adds
+    # negligible overhead. The check_fn results are further TTL-cached
+    # (~30s) by the tool registry.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        toolsets = cfg.get("toolsets", [])
+        return "kanban" in toolsets
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Salvage of #18970 onto current main + test fixup for #19427.

Closes #18968.

## Summary
`_check_kanban_mode()` now enables kanban tools for any profile that has `kanban` in its `toolsets` config, not just dispatcher-spawned workers (`HERMES_KANBAN_TASK` env). Orchestrator profiles like `techlead` can now actually call `kanban_create` / `kanban_link` to route work — previously their SOUL.md told them to use kanban tools that were never registered into their schema, which fueled hallucination.

## Changes
- `tools/kanban_tools.py`: gate returns True when HERMES_KANBAN_TASK is set OR `kanban` ∈ config.toolsets. Worker fast-path unchanged.
- `tests/tools/test_kanban_tools.py`: update `test_kanban_guidance_in_worker_prompt` header assertion — #19427 replaced `"You are a Kanban worker"` with `"Kanban task execution protocol"`, the old assertion was stale.

## Validation
E2E tested all four gate cases against current main:

| scenario | expected | actual |
|---|---|---|
| no toolsets config | False | False |
| `toolsets: [kanban, ...]` | True | True |
| `toolsets: [terminal, web]` (no kanban) | False | False |
| `HERMES_KANBAN_TASK` set | True | True |

`tests/tools/test_kanban_tools.py` — 31/31 pass.

## Duplicates closed with credit
- #18970 @pdonizete — reporter, first-submitted, this PR cherry-picks their commit
- #18971 @shellybotmoyer — same fix shape
- #18991 @shellybotmoyer — same fix shape