### PR TITLE
fix: handle multimodal supermemory captures

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -250,7 +250,39 @@ def _format_prefetch_context(static_facts: list, dynamic_facts: list, search_res
     return f"<supermemory-context>\n{intro}\n\n{body}\n</supermemory-context>"
 
 
-def _clean_text_for_capture(text: str) -> str:
+def _stringify_message_content(value: Any) -> str:
+    """Convert OpenAI-style message content into safe text for capture.
+
+    Gateway turns may include multimodal content as a list of parts. Keep user
+    text, omit raw image/data payloads, and avoid passing non-strings to regexes.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = []
+        for item in value:
+            rendered = _stringify_message_content(item).strip()
+            if rendered:
+                parts.append(rendered)
+        return "\n".join(parts)
+    if isinstance(value, dict):
+        part_type = str(value.get("type") or "").strip()
+        if part_type == "text":
+            return _stringify_message_content(value.get("text"))
+        if part_type in ("image_url", "input_image"):
+            return "[image omitted from memory capture]"
+        if "content" in value:
+            return _stringify_message_content(value.get("content"))
+        if "text" in value:
+            return _stringify_message_content(value.get("text"))
+        return ""
+    return str(value)
+
+
+def _clean_text_for_capture(text: Any) -> str:
+    text = _stringify_message_content(text)
     text = _CONTEXT_STRIP_RE.sub("", text or "")
     text = _CONTAINERS_STRIP_RE.sub("", text)
     return text.strip()

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -97,6 +97,33 @@ def test_clean_text_for_capture_strips_injected_context():
     assert _clean_text_for_capture(text) == "hello\nworld"
 
 
+def test_clean_text_for_capture_handles_multimodal_parts():
+    content = [
+        {"type": "text", "text": "remember this"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,secret-ish-bulk"}},
+    ]
+    cleaned = _clean_text_for_capture(content)
+    assert "remember this" in cleaned
+    assert "image omitted" in cleaned
+    assert "secret-ish-bulk" not in cleaned
+
+
+def test_sync_turn_accepts_multimodal_user_content(provider):
+    provider.sync_turn(
+        [
+            {"type": "text", "text": "Please remember this multimodal request"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,raw-image"}},
+        ],
+        "I will store the text safely without raw image data.",
+        session_id="session-1",
+    )
+    provider._sync_thread.join(timeout=1)
+    assert len(provider._client.add_calls) == 1
+    content = provider._client.add_calls[0]["content"]
+    assert "Please remember this multimodal request" in content
+    assert "raw-image" not in content
+
+
 def test_format_prefetch_context_deduplicates_overlap():
     result = _format_prefetch_context(
         static_facts=["Jordan prefers short answers"],


### PR DESCRIPTION
## Summary
- Handle structured/multimodal message content before Supermemory capture cleaning
- Preserve text parts while omitting raw image payloads
- Add regression coverage for multimodal capture cleaning and `sync_turn`

## Test Plan
- `./venv/bin/python -m pytest tests/plugins/memory/test_supermemory_provider.py -q -o 'addopts='`

## Notes
Gateway turns can include OpenAI-style list/dict content when messages contain images or other parts. The previous cleaner passed that list into regex substitution and raised `expected string or bytes-like object, got 'list'`. This change normalizes content to safe text first.
