### PR TITLE
fix(gateway): translate inbound cache paths to container paths for Docker backend

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5579,8 +5579,10 @@ class GatewayRunner:
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
+            from tools.credential_files import to_agent_visible_cache_path
 
             _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+            _terminal_backend = os.getenv("TERMINAL_ENV", "local")
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype in ("", "application/octet-stream"):
@@ -5599,16 +5601,21 @@ class GatewayRunner:
                 display_name = parts[2] if len(parts) >= 3 else basename
                 display_name = re.sub(r'[^\w.\- ]', '_', display_name)
 
+                # The agent runs in the terminal backend's filesystem view; under
+                # docker the host cache path is bind-mounted at a different
+                # container path, so rewrite before injecting into the prompt.
+                agent_path = to_agent_visible_cache_path(path, backend=_terminal_backend)
+
                 if mtype.startswith("text/"):
                     context_note = (
                         f"[The user sent a text document: '{display_name}'. "
                         f"Its content has been included below. "
-                        f"The file is also saved at: {path}]"
+                        f"The file is also saved at: {agent_path}]"
                     )
                 else:
                     context_note = (
                         f"[The user sent a document: '{display_name}'. "
-                        f"The file is saved at: {path}. "
+                        f"The file is saved at: {agent_path}. "
                         f"Ask the user what they'd like you to do with it.]"
                     )
                 message_text = f"{context_note}\n\n{message_text}"

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -16,6 +16,7 @@ from tools.credential_files import (
     iter_skills_files,
     register_credential_file,
     register_credential_files,
+    to_agent_visible_cache_path,
 )
 
 
@@ -476,3 +477,120 @@ class TestIterCacheFiles:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert iter_cache_files() == []
+
+
+class TestToAgentVisibleCachePath:
+    """Translate host cache paths to container paths for the Docker backend.
+
+    Inbound documents from messaging platforms are saved to host paths under
+    ``~/.hermes/cache/<subdir>``. Under the Docker terminal backend those
+    directories are bind-mounted at ``{container_base}/cache/<subdir>``
+    via :func:`get_cache_directory_mounts`. This helper produces the
+    container-visible path the agent will see.
+    """
+
+    def test_docker_translates_documents_path(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        docs = hermes_home / "cache" / "documents"
+        docs.mkdir(parents=True)
+        host_file = docs / "report.docx"
+        host_file.write_bytes(b"DOCX")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = to_agent_visible_cache_path(str(host_file), backend="docker")
+        assert result == "/root/.hermes/cache/documents/report.docx"
+
+    def test_docker_translates_nested_subpath(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        sub = hermes_home / "cache" / "documents" / "session_abc"
+        sub.mkdir(parents=True)
+        host_file = sub / "memo.pdf"
+        host_file.write_bytes(b"PDF")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = to_agent_visible_cache_path(str(host_file), backend="docker")
+        assert result == "/root/.hermes/cache/documents/session_abc/memo.pdf"
+
+    def test_docker_translates_each_cache_subdir(self, tmp_path, monkeypatch):
+        """Translation works for documents, images, audio, screenshots."""
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        for subdir, fname in [
+            ("documents", "a.pdf"),
+            ("images", "b.png"),
+            ("audio", "c.ogg"),
+            ("screenshots", "d.png"),
+        ]:
+            cache_dir = hermes_home / "cache" / subdir
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            f = cache_dir / fname
+            f.write_bytes(b"x")
+            assert to_agent_visible_cache_path(str(f), backend="docker") == (
+                f"/root/.hermes/cache/{subdir}/{fname}"
+            )
+
+    def test_non_docker_backend_passes_through(self, tmp_path, monkeypatch):
+        """Local/SSH/Modal/etc. don't bind-mount cache the same way — no-op."""
+        hermes_home = tmp_path / ".hermes"
+        docs = hermes_home / "cache" / "documents"
+        docs.mkdir(parents=True)
+        host_file = docs / "report.docx"
+        host_file.write_bytes(b"DOCX")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        for backend in ("local", "ssh", "modal", "daytona", "vercel", ""):
+            assert to_agent_visible_cache_path(
+                str(host_file), backend=backend
+            ) == str(host_file)
+
+    def test_path_outside_cache_passes_through(self, tmp_path, monkeypatch):
+        """Paths not under any cache subdir are returned unchanged."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        outside = tmp_path / "elsewhere" / "foo.docx"
+        outside.parent.mkdir()
+        outside.write_bytes(b"x")
+
+        assert to_agent_visible_cache_path(str(outside), backend="docker") == str(outside)
+
+    def test_already_translated_container_path_passes_through(self, tmp_path, monkeypatch):
+        """Calling with an already-container path is a no-op (idempotent)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        already = "/root/.hermes/cache/documents/report.docx"
+        assert to_agent_visible_cache_path(already, backend="docker") == already
+
+    def test_backend_case_insensitive(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        docs = hermes_home / "cache" / "documents"
+        docs.mkdir(parents=True)
+        host_file = docs / "x.pdf"
+        host_file.write_bytes(b"x")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        for variant in ("docker", "DOCKER", "Docker", "  docker  "):
+            assert to_agent_visible_cache_path(
+                str(host_file), backend=variant
+            ) == "/root/.hermes/cache/documents/x.pdf"
+
+    def test_custom_container_base(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        docs = hermes_home / "cache" / "documents"
+        docs.mkdir(parents=True)
+        host_file = docs / "x.pdf"
+        host_file.write_bytes(b"x")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = to_agent_visible_cache_path(
+            str(host_file), backend="docker", container_base="/opt/hermes"
+        )
+        assert result == "/opt/hermes/cache/documents/x.pdf"
+
+    def test_invalid_path_returns_unchanged(self):
+        """Empty or non-path-like inputs are returned as-is."""
+        assert to_agent_visible_cache_path("", backend="docker") == ""

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -401,6 +401,58 @@ def iter_cache_files(
     return result
 
 
+def to_agent_visible_cache_path(
+    host_path: str,
+    *,
+    backend: str,
+    container_base: str = "/root/.hermes",
+) -> str:
+    """Translate a host cache path to the path the agent will see.
+
+    Inbound documents from messaging platforms are saved under
+    ``~/.hermes/cache/<subdir>`` on the host. Under the Docker terminal
+    backend those subdirectories are bind-mounted at
+    ``{container_base}/cache/<subdir>`` via :func:`get_cache_directory_mounts`,
+    so any host path the gateway injects into the agent's prompt must be
+    rewritten or the agent will fail to open the file.
+
+    Pass-through cases (returns ``host_path`` unchanged):
+      * ``backend`` is anything other than ``docker`` (case/space-insensitive).
+        Other backends use different mount semantics — Modal uploads files
+        individually via :func:`iter_cache_files`, SSH/local share the host
+        filesystem — so this rewrite does not apply.
+      * The path does not lie under any known cache subdirectory.
+      * The path is unparseable.
+
+    The translation is idempotent: an already-container path under
+    ``container_base`` is unchanged because it doesn't match any host cache
+    root.
+    """
+    if backend.strip().lower() != "docker":
+        return host_path
+
+    from hermes_constants import get_hermes_dir
+
+    try:
+        host_resolved = Path(host_path).resolve()
+    except (OSError, ValueError, RuntimeError):
+        return host_path
+
+    for new_subpath, old_name in _CACHE_DIRS:
+        try:
+            host_root = get_hermes_dir(new_subpath, old_name).resolve()
+        except (OSError, ValueError, RuntimeError):
+            continue
+        try:
+            rel = host_resolved.relative_to(host_root)
+        except ValueError:
+            continue
+        container_root = f"{container_base.rstrip('/')}/{new_subpath}"
+        return f"{container_root}/{rel.as_posix()}"
+
+    return host_path
+
+
 def clear_credential_files() -> None:
     """Reset the skill-scoped registry (e.g. on session reset)."""
     _get_registered().clear()

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -300,6 +300,8 @@ docker compose up -d
 
 When using Docker as the execution environment (not the methods above, but when the agent runs commands inside a Docker sandbox), Hermes automatically bind-mounts the skills directory (`~/.hermes/skills/`) and any credential files declared by skills into the container as read-only volumes. This means skill scripts, templates, and references are available inside the sandbox without manual configuration.
 
+Inbound media from messaging platforms (documents, images, audio, screenshots) is cached under `~/.hermes/cache/<subdir>/` on the host and bind-mounted into the container at `/root/.hermes/cache/<subdir>/`. When the gateway tells the agent that a user-sent file is "saved at &lt;path&gt;", the path is rewritten to the container view so the agent can open it directly.
+
 The same syncing happens for SSH and Modal backends — skills and credential files are uploaded via rsync or the Modal mount API before each command.
 
 ## Troubleshooting


### PR DESCRIPTION
## What does this PR do?

When `terminal.backend: docker`, inbound documents (`.docx`/`.pdf`/etc.) from messaging platforms are saved at host paths under `~/.hermes/cache/documents/` and `_prepare_inbound_message_text` injects those raw host paths into the agent's prompt:

```
[The user sent a document: 'report.docx'. The file is saved at: /home/hermes/.hermes/cache/documents/abc_123_report.docx. ...]
```

The agent runs inside the Docker container where that host path doesn't exist; the cache directories are bind-mounted at `/root/.hermes/cache/documents/` via `get_cache_directory_mounts()` (added in #4846), but the path translation step was missing — so reads of user-sent docs fail.

This adds `to_agent_visible_cache_path()` in `tools/credential_files.py` next to `get_cache_directory_mounts`, and calls it at the two doc-injection sites in `gateway/run.py`. Pass-through for non-Docker backends keeps existing behavior unchanged. Mirrors the pattern from #14990 (vision sandbox path resolution).

Out of scope (intentionally, to keep the diff focused):
- **Audio**: `_enrich_message_with_transcription` injects the transcript text, not the file path.
- **Native-vision images**: attached as multimodal content blocks, not text-injected paths.
- **Modal / Daytona / Vercel**: different mount semantics (per-file upload, etc.). The helper signature accepts a `backend` arg so they can opt in later if needed.

## Related Issue

Fixes #18787

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/credential_files.py`: add `to_agent_visible_cache_path(host_path, *, backend, container_base='/root/.hermes')` that maps host cache paths to their container-side mount points by walking `_CACHE_DIRS`. Idempotent (already-translated paths pass through). Gated on `backend == "docker"` (case/space-insensitive).
- `gateway/run.py`: call the helper inside the `event.message_type == MessageType.DOCUMENT` block before injecting the path into both the text-document and binary-document context notes. Backend resolved once via `os.getenv("TERMINAL_ENV", "local")`.
- `tests/tools/test_credential_files.py`: add `TestToAgentVisibleCachePath` (9 tests) — translation for each cache subdir, nested subpaths, non-docker pass-through, paths outside cache, idempotence, case/space-insensitive backend, custom container_base, empty input.
- `website/docs/user-guide/docker.md`: brief note in "Skills and credential files" about the cache bind-mount and path rewrite, where the analogous skills/credential-file mount behavior is already documented.

## How to Test

Repro (before fix):

1. Configure `terminal.backend: docker` and run the gateway.
2. Send a `.docx` or `.pdf` to the bot from Telegram (or any messaging platform with document support).
3. Ask the agent to read or summarise the file.
4. The agent calls `read_file` / `terminal cat` with the host path it was given (e.g. `/home/<user>/.hermes/cache/documents/...`) and gets `No such file or directory` from inside the container.

After fix:

1. Same flow.
2. The agent receives the container-visible path (`/root/.hermes/cache/documents/...`), which is the bind-mount target, and the read succeeds.

Unit-test verification:

```
pytest tests/tools/test_credential_files.py -v
```

All 38 tests pass (9 new + 29 existing). Re-ran `tests/tools/` and `tests/gateway/` for regression — no new failures from this change. There are 14 pre-existing failures in unrelated platform adapters (dingtalk/feishu/teams/whatsapp) that fail on `main` without this patch as well.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (Darwin 25.4)
- [ ] I've run `pytest tests/ -q` and all tests pass — partial: ran `tests/tools/` and `tests/gateway/` (4322 passed, 14 unrelated pre-existing failures in dingtalk/feishu/teams/whatsapp, confirmed on clean `main`).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/docker.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses `pathlib.Path.relative_to`/`.resolve()` which are cross-platform; container paths are forward-slash POSIX (correct for the Linux container target regardless of host OS).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Open considerations (from #18787 triage questions)

1. **Scope**: Docker-only for this PR, matching the `backend/docker` label. Helper signature takes a `backend` kwarg so other backends can opt in without breaking callers.
2. **Helper location**: placed in `tools/credential_files.py` next to `get_cache_directory_mounts` — same `_CACHE_DIRS` constant, same module that owns the mount mapping. Open to moving it to `gateway/platforms/base.py` if maintainers prefer the platform layer.
3. **Translation site**: single call site in `_prepare_inbound_message_text` (the only place doc host paths get injected into prompt text). Did not translate `_build_media_placeholder` (line 646), since queued events re-enter `_prepare_inbound_message_text` on requeue and get translated there.
4. **Cross-platform**: uses `Path.resolve()` + `relative_to`, which canonicalise on each platform. Container paths are emitted as forward-slash POSIX strings (`as_posix()`) since the container target is always Linux.