### PR TITLE
fix(cli): sync credential_pool entries after Codex token refresh

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2353,8 +2353,9 @@ def _refresh_codex_auth_tokens(
     timeout_seconds: float,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
-    
-    Saves the new tokens to Hermes auth store automatically.
+
+    Saves the new tokens to Hermes auth store and mirrors them into any
+    matching ``credential_pool`` entries for ``openai-codex``.
     """
     refreshed = refresh_codex_oauth_pure(
         str(tokens.get("access_token", "") or ""),
@@ -2366,6 +2367,32 @@ def _refresh_codex_auth_tokens(
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
     _save_codex_tokens(updated_tokens)
+
+    # Mirror rotated tokens into credential_pool. OpenAI uses single-use
+    # rotating refresh tokens, so any pool entry still holding the previous
+    # refresh_token will fail with invalid_grant the next time pool.select()
+    # routes a request to it. Failure here must not break refresh — the new
+    # tokens are already persisted to the active provider state above.
+    try:
+        pool_entries = read_credential_pool("openai-codex")
+        pool_changed = False
+        for entry in pool_entries:
+            if not isinstance(entry, dict) or entry.get("auth_type") != "oauth":
+                continue
+            if (
+                entry.get("access_token") == updated_tokens["access_token"]
+                and entry.get("refresh_token") == updated_tokens["refresh_token"]
+            ):
+                continue
+            entry["access_token"] = updated_tokens["access_token"]
+            entry["refresh_token"] = updated_tokens["refresh_token"]
+            entry["last_refresh"] = refreshed.get("last_refresh")
+            pool_changed = True
+        if pool_changed:
+            write_credential_pool("openai-codex", pool_entries)
+    except Exception as exc:
+        logger.warning("Failed to sync credential_pool after Codex refresh: %s", exc)
+
     return updated_tokens
 
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -14,14 +14,17 @@ from hermes_cli.auth import (
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
     _read_codex_tokens,
+    _refresh_codex_auth_tokens,
     _save_codex_tokens,
     _import_codex_cli_tokens,
     _login_openai_codex,
     get_codex_auth_status,
     get_provider_auth_state,
+    read_credential_pool,
     refresh_codex_oauth_pure,
     resolve_codex_runtime_credentials,
     resolve_provider,
+    write_credential_pool,
 )
 
 
@@ -351,3 +354,107 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
 
     assert called["device_login"] == 1
     assert called["tokens"]["access_token"] == "fresh-at"
+
+
+def _seed_pool_entry(hermes_home: Path, *, access_token: str, refresh_token: str, auth_type: str = "oauth"):
+    """Add one credential_pool entry for openai-codex inside an existing auth.json."""
+    auth_file = hermes_home / "auth.json"
+    store = json.loads(auth_file.read_text())
+    store.setdefault("credential_pool", {})["openai-codex"] = [
+        {
+            "id": "test01",
+            "label": "device_code",
+            "auth_type": auth_type,
+            "priority": 0,
+            "source": "device_code",
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "last_status": None,
+            "last_refresh": "2026-02-26T00:00:00Z",
+        }
+    ]
+    auth_file.write_text(json.dumps(store, indent=2))
+
+
+def test_refresh_codex_auth_tokens_syncs_credential_pool(tmp_path, monkeypatch):
+    """After token rotation, credential_pool entries should hold the new tokens."""
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="access-old", refresh_token="refresh-old")
+    _seed_pool_entry(hermes_home, access_token="access-old", refresh_token="refresh-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda *_a, **_kw: {
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-05-04T08:41:03Z",
+        },
+    )
+
+    _refresh_codex_auth_tokens({"access_token": "access-old", "refresh_token": "refresh-old"}, 20.0)
+
+    entries = read_credential_pool("openai-codex")
+    assert len(entries) == 1
+    assert entries[0]["access_token"] == "access-new"
+    assert entries[0]["refresh_token"] == "refresh-new"
+    assert entries[0]["last_refresh"] == "2026-05-04T08:41:03Z"
+
+
+def test_refresh_codex_auth_tokens_pool_sync_skips_non_oauth_entries(tmp_path, monkeypatch):
+    """API-key (non-oauth) pool entries must not be touched by OAuth refresh."""
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="access-old", refresh_token="refresh-old")
+    _seed_pool_entry(
+        hermes_home,
+        access_token="sk-static-key",
+        refresh_token="",
+        auth_type="api_key",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda *_a, **_kw: {
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-05-04T08:41:03Z",
+        },
+    )
+
+    _refresh_codex_auth_tokens({"access_token": "access-old", "refresh_token": "refresh-old"}, 20.0)
+
+    entries = read_credential_pool("openai-codex")
+    assert entries[0]["access_token"] == "sk-static-key"
+    assert entries[0]["refresh_token"] == ""
+
+
+def test_refresh_codex_auth_tokens_pool_write_failure_does_not_break_refresh(tmp_path, monkeypatch):
+    """If credential_pool write fails, refresh must still return new tokens (provider state already persisted)."""
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="access-old", refresh_token="refresh-old")
+    _seed_pool_entry(hermes_home, access_token="access-old", refresh_token="refresh-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda *_a, **_kw: {
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-05-04T08:41:03Z",
+        },
+    )
+
+    def _boom(*_a, **_kw):
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr("hermes_cli.auth.write_credential_pool", _boom)
+
+    result = _refresh_codex_auth_tokens(
+        {"access_token": "access-old", "refresh_token": "refresh-old"}, 20.0
+    )
+
+    assert result["access_token"] == "access-new"
+    assert result["refresh_token"] == "refresh-new"
+    state = get_provider_auth_state("openai-codex")
+    assert state["tokens"]["access_token"] == "access-new"


### PR DESCRIPTION
## What

After `_refresh_codex_auth_tokens` rotates Codex OAuth tokens, mirror the new `access_token` and `refresh_token` into matching `credential_pool["openai-codex"]` entries.

Fixes #19611

## Why

OpenAI uses single-use rotating refresh tokens. Today `_refresh_codex_auth_tokens` only persists to `providers.openai-codex.tokens`, so the `credential_pool` entry retains the previous `refresh_token`, which OpenAI invalidates as soon as the new pair is minted. The next time `pool.select()` routes a request to that entry, refresh fails with `invalid_grant` and the entry is marked exhausted — even though the active provider state has a valid token pair.

## How

In `hermes_cli/auth.py`, after `_save_codex_tokens(updated_tokens)`:

- Read `credential_pool["openai-codex"]`.
- For each entry with `auth_type == "oauth"`, update `access_token`, `refresh_token`, `last_refresh` to match the rotated pair.
- Skip non-OAuth entries (api_key seeds).
- Skip entries already in sync (no-op write).
- Wrap the whole block in `try/except` — pool write failure is logged at WARNING level but does not break refresh, since the new tokens are already persisted to the active provider state.
- `last_status` and other exhaustion/error fields are deliberately preserved. Token rotation does not imply quota status has cleared.

## How to test

```bash
pytest tests/hermes_cli/test_auth_codex_provider.py -v
```

Three new tests:
- `test_refresh_codex_auth_tokens_syncs_credential_pool` — pool entry receives rotated tokens
- `test_refresh_codex_auth_tokens_pool_sync_skips_non_oauth_entries` — `api_key` entries are untouched
- `test_refresh_codex_auth_tokens_pool_write_failure_does_not_break_refresh` — pool write failure is logged; refresh still returns the new tokens

Wider regression check:

```bash
pytest tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py tests/hermes_cli/test_anthropic_model_flow_stale_oauth.py -v
```

All 66 tests pass (16 existing codex + 3 new + 47 pool/OAuth-flow).

## Platforms tested

- Linux / Python 3.11.14 (uv venv)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)