### PR TITLE
fix(ollama): fall back and bump num_ctx to model.context_length

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2121,6 +2121,25 @@ class AIAgent:
                     self._ollama_num_ctx = _detected
             except Exception as exc:
                 logger.debug("Ollama num_ctx detection failed: %s", exc)
+        # When /api/show detection fails (LAN latency timeout, model not found, or
+        # missing GGUF context_length metadata) and the user has explicitly set
+        # model.context_length in config.yaml, use that value as num_ctx.  Without
+        # this fallback Ollama defaults to 2048 tokens, which is smaller than
+        # hermes's system prompt alone and causes silent truncation that makes the
+        # model appear to forget earlier turns in the same session.  Refs #14420.
+        if (
+            self._ollama_num_ctx is None
+            and _config_context_length
+            and _ollama_num_ctx_override is None
+            and self.base_url
+            and is_local_endpoint(self.base_url)
+        ):
+            self._ollama_num_ctx = _config_context_length
+            logger.info(
+                "Ollama num_ctx: /api/show detection failed; using model.context_length=%d "
+                "from config. Set model.ollama_num_ctx in config.yaml to pin a specific value.",
+                _config_context_length,
+            )
         # Cap auto-detected ollama_num_ctx to the user's explicit context_length.
         # Without this, GGUF metadata can advertise 256K+ which Ollama honours
         # by allocating that much VRAM — blowing up small GPUs even though the
@@ -2138,7 +2157,7 @@ class AIAgent:
             self._ollama_num_ctx = _config_context_length
         if self._ollama_num_ctx and not self.quiet_mode:
             logger.info(
-                "Ollama num_ctx: will request %d tokens (model max from /api/show)",
+                "Ollama num_ctx: will request %d tokens",
                 self._ollama_num_ctx,
             )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2140,20 +2140,32 @@ class AIAgent:
                 "from config. Set model.ollama_num_ctx in config.yaml to pin a specific value.",
                 _config_context_length,
             )
-        # Cap auto-detected ollama_num_ctx to the user's explicit context_length.
-        # Without this, GGUF metadata can advertise 256K+ which Ollama honours
-        # by allocating that much VRAM — blowing up small GPUs even though the
-        # user explicitly set a smaller context_length in config.yaml.
+        # Cap or bump auto-detected ollama_num_ctx to match model.context_length.
+        # Cap: GGUF metadata can advertise 256K+, which Ollama honours by allocating
+        # that much VRAM — blowing up small GPUs.  Cap prevents that.
+        # Bump: the model's Modelfile may pin num_ctx to a value below what the user
+        # configured in context_length (e.g. Modelfile has num_ctx 32768 but the user
+        # wants 64K).  Without a bump, Ollama silently truncates conversation history
+        # once messages overflow the Modelfile's lower limit, making the model appear
+        # to forget earlier turns even though hermes is sending the full history.
+        # Refs #14420.
         if (
             self._ollama_num_ctx
             and _config_context_length
             and _ollama_num_ctx_override is None  # don't override explicit ollama_num_ctx
-            and self._ollama_num_ctx > _config_context_length
+            and self._ollama_num_ctx != _config_context_length
         ):
-            logger.info(
-                "Ollama num_ctx capped: %d -> %d (model.context_length override)",
-                self._ollama_num_ctx, _config_context_length,
-            )
+            if self._ollama_num_ctx > _config_context_length:
+                logger.info(
+                    "Ollama num_ctx capped: %d -> %d (model.context_length override)",
+                    self._ollama_num_ctx, _config_context_length,
+                )
+            else:
+                logger.info(
+                    "Ollama num_ctx bumped: %d -> %d (model.context_length override; "
+                    "Modelfile default is below requested context window)",
+                    self._ollama_num_ctx, _config_context_length,
+                )
             self._ollama_num_ctx = _config_context_length
         if self._ollama_num_ctx and not self.quiet_mode:
             logger.info(

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -133,3 +133,37 @@ class TestQueryOllamaNumCtx:
                 result = query_ollama_num_ctx("model", "http://localhost:11434")
 
         assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Level 2: run_agent.py fallback — model.context_length used when
+#           /api/show detection fails
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOllamaNumCtxFallback:
+    """Verify the run_agent.py fallback: when query_ollama_num_ctx() returns None
+    for a local endpoint, the user's model.context_length is used as num_ctx so
+    Ollama does not silently default to 2048 tokens and truncate conversation
+    history (issue #14420)."""
+
+    def test_context_length_fallback_on_detection_failure(self):
+        """query_ollama_num_ctx returning None → context_length used as num_ctx."""
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None):
+            # detect_local_server_type returning None causes query_ollama_num_ctx
+            # to return None immediately.  Simulate the same None return directly.
+            result = query_ollama_num_ctx("qwen3.5:9b", "http://192.168.21.205:11434/v1")
+
+        # query returns None; the caller (run_agent.py) should apply the fallback
+        # using model.context_length.  This test documents the None return that
+        # triggers the fallback, not the fallback itself (which lives in AIAgent.__init__).
+        assert result is None
+
+    def test_detection_failure_via_timeout(self):
+        """A connection timeout should also return None so the fallback kicks in."""
+        import httpx
+
+        with patch("agent.model_metadata.detect_local_server_type", side_effect=httpx.ConnectTimeout("timeout")):
+            result = query_ollama_num_ctx("qwen3.5:9b", "http://192.168.21.205:11434/v1")
+
+        assert result is None

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -167,3 +167,22 @@ class TestOllamaNumCtxFallback:
             result = query_ollama_num_ctx("qwen3.5:9b", "http://192.168.21.205:11434/v1")
 
         assert result is None
+
+    def test_modelfile_num_ctx_below_context_length_returns_modelfile_value(self):
+        """query_ollama_num_ctx returns the Modelfile num_ctx even if it is below
+        the user's context_length.  run_agent.py is responsible for bumping it up
+        to match context_length (issue #14420 follow-up)."""
+        show_data = {
+            "model_info": {"qwen2.context_length": 131072},
+            "parameters": "num_ctx 32768\ntemperature 0.6",
+        }
+        mock_ctx, _ = _mock_httpx_client(show_data)
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="ollama"):
+            import httpx
+            with patch.object(httpx, "Client", return_value=mock_ctx):
+                result = query_ollama_num_ctx("qwen3.5:9b", "http://192.168.21.205:11434/v1")
+
+        # The function returns the Modelfile's explicit num_ctx (32768).
+        # run_agent.py will bump this up to model.context_length (64000) if needed.
+        assert result == 32768


### PR DESCRIPTION
## What changed and why

### Fix 1 — Fallback when `/api/show` detection fails

When `query_ollama_num_ctx()` cannot reach the Ollama `/api/show` endpoint — due to LAN latency timeouts, missing GGUF `context_length` metadata, or a transiently unreachable server — `self._ollama_num_ctx` stayed `None`. Ollama then silently defaults to its built-in **2,048-token** context window.

This window is smaller than hermes's system prompt alone. Every API call therefore had conversation history silently truncated server-side by Ollama, making the model appear to "forget" what the user said in the previous turn of the **same** interactive session.

Fix: if detection fails **and** the user has explicitly set `model.context_length` in `config.yaml`, use that value as the `num_ctx` fallback.

### Fix 2 — Bump when Modelfile `num_ctx` is below `context_length`

Per reporter follow-up (@okynos, 2026-05-04): `/api/show` can succeed but return the model's **Modelfile** `num_ctx` (e.g. 32,768 for `qwen3.5:9b`) even when the user has set `model.context_length: 64000`. Without a bump, hermes would pass 32K as `num_ctx` to Ollama — still causing silent truncation once conversation history overflows the Modelfile's lower limit.

Fix: when the auto-detected `num_ctx < model.context_length` (and no explicit `model.ollama_num_ctx` override is set), hermes now bumps `num_ctx` up to `context_length`.

The `_ollama_num_ctx_override` guard ensures an explicit `model.ollama_num_ctx` entry always wins; both fixes only fire when no override is present.

## How to test

1. Configure hermes with `provider: custom`, a LAN Ollama endpoint (`base_url: http://192.168.x.x:11434/v1`), and `context_length: 64000`.
2. **Fallback path**: block the `/api/show` probe (firewall or mock) so detection returns `None`. Start `hermes chat` — the log should show `Ollama num_ctx: /api/show detection failed; using model.context_length=64000 from config.`
3. **Bump path**: use a model whose Modelfile pins `num_ctx` below `context_length` (e.g. `qwen3.5:9b` with `num_ctx 32768` vs `context_length: 64000`). Start `hermes chat` — the log should show `Ollama num_ctx bumped: 32768 -> 64000`.
4. In both cases: tell the agent your name, then ask in the next turn — it should remember.

Unit tests: `pytest tests/test_ollama_num_ctx.py -v`

## What platforms tested on

- macOS 14 (unit tests only; Ollama behaviour verified by code inspection)

Fixes #14420