### PR TITLE
fix(cron): make job model source explicit

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -43,6 +43,25 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+MODEL_SOURCE_GLOBAL = "global"
+MODEL_SOURCE_PINNED = "pinned"
+
+
+def _normalize_model_source(value: Optional[str], *, has_override: bool) -> str:
+    """Normalize how a cron job resolves its model at run time.
+
+    ``global`` means the job follows the active global config whenever it runs.
+    ``pinned`` means the job uses its stored model/provider/base_url override.
+
+    When callers omit the field, infer the legacy-compatible behavior:
+    jobs with an override are pinned; jobs without one inherit the global model.
+    """
+    text = str(value or "").strip().lower().replace("-", "_")
+    if text in {"global", "inherit", "inherited", "default", "auto"}:
+        return MODEL_SOURCE_GLOBAL
+    if text in {"pinned", "pin", "fixed", "override"}:
+        return MODEL_SOURCE_PINNED
+    return MODEL_SOURCE_PINNED if has_override else MODEL_SOURCE_GLOBAL
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -431,6 +450,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    model_source: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
@@ -451,6 +471,8 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        model_source: "global" to follow the global model at run time, or
+                      "pinned" to use the per-job model/provider override.
         script: Optional path to a Python script whose stdout is injected into the
                 prompt each run.  The script runs before the agent turn, and its output
                 is prepended as context.  Useful for data collection / change detection.
@@ -494,6 +516,10 @@ def create_job(
     normalized_model = normalized_model or None
     normalized_provider = normalized_provider or None
     normalized_base_url = normalized_base_url or None
+    normalized_model_source = _normalize_model_source(
+        model_source,
+        has_override=bool(normalized_model or normalized_provider or normalized_base_url),
+    )
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
@@ -518,6 +544,7 @@ def create_job(
         "model": normalized_model,
         "provider": normalized_provider,
         "base_url": normalized_base_url,
+        "model_source": normalized_model_source,
         "script": normalized_script,
         "context_from": context_from,
         "schedule": parsed_schedule,
@@ -584,6 +611,18 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["workdir"] = _normalize_workdir(_wd)
 
         updated = _apply_skill_fields({**job, **updates})
+
+        if "model_source" in updates:
+            updated["model_source"] = _normalize_model_source(
+                updates.get("model_source"),
+                has_override=bool(updated.get("model") or updated.get("provider") or updated.get("base_url")),
+            )
+        elif any(key in updates for key in ("model", "provider", "base_url")):
+            updated["model_source"] = _normalize_model_source(
+                None,
+                has_override=bool(updated.get("model") or updated.get("provider") or updated.get("base_url")),
+            )
+
         schedule_changed = "schedule" in updates
 
         if "skills" in updates or "skill" in updates:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -41,6 +41,21 @@ from hermes_time import now as _hermes_now
 logger = logging.getLogger(__name__)
 
 
+def _job_uses_pinned_model(job: dict) -> bool:
+    """Return whether a cron job should use its stored model override.
+
+    New jobs persist ``model_source`` explicitly. Legacy jobs do not, so keep
+    the historical behavior: if a model/provider/base_url is stored, treat it as
+    pinned; otherwise inherit the global config at run time.
+    """
+    source = str((job or {}).get("model_source") or "").strip().lower().replace("-", "_")
+    if source in {"global", "inherit", "inherited", "default", "auto"}:
+        return False
+    if source in {"pinned", "pin", "fixed", "override"}:
+        return True
+    return bool((job or {}).get("model") or (job or {}).get("provider") or (job or {}).get("base_url"))
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -942,7 +957,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        use_pinned_model = _job_uses_pinned_model(job)
+        model = (job.get("model") if use_pinned_model else None) or os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -953,7 +969,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 with open(_cfg_path) as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
-                if not job.get("model"):
+                if not use_pinned_model:
                     if isinstance(_model_cfg, str):
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
@@ -1005,9 +1021,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         from hermes_cli.auth import AuthError
         try:
             runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                "requested": (job.get("provider") if use_pinned_model else None) or os.getenv("HERMES_INFERENCE_PROVIDER"),
             }
-            if job.get("base_url"):
+            if use_pinned_model and job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except AuthError as auth_exc:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2281,6 +2281,10 @@ class CronJobCreate(BaseModel):
     schedule: str
     name: str = ""
     deliver: str = "local"
+    model: str | None = None
+    provider: str | None = None
+    base_url: str | None = None
+    model_source: str | None = None
 
 
 class CronJobUpdate(BaseModel):
@@ -2307,7 +2311,10 @@ async def create_cron_job(body: CronJobCreate):
     from cron.jobs import create_job
     try:
         job = create_job(prompt=body.prompt, schedule=body.schedule,
-                         name=body.name, deliver=body.deliver)
+                         name=body.name, deliver=body.deliver,
+                         model=body.model, provider=body.provider,
+                         base_url=body.base_url,
+                         model_source=body.model_source)
         return job
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -233,6 +233,35 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_default_model_source_inherits_global_model(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["model"] is None
+        assert job["provider"] is None
+        assert job["model_source"] == "global"
+
+    def test_model_override_pins_job_model(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Test",
+            schedule="30m",
+            model="mimo-v2.5-pro",
+            provider="xiaomi-mimo-cn",
+        )
+        assert job["model"] == "mimo-v2.5-pro"
+        assert job["provider"] == "xiaomi-mimo-cn"
+        assert job["model_source"] == "pinned"
+
+    def test_explicit_global_model_source_does_not_pin_override(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Test",
+            schedule="30m",
+            model="old-model",
+            provider="old-provider",
+            model_source="global",
+        )
+        assert job["model"] == "old-model"
+        assert job["provider"] == "old-provider"
+        assert job["model_source"] == "global"
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -249,6 +278,33 @@ class TestUpdateJob:
         # Verify persisted to disk
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
+
+    def test_updating_model_pins_model_source(self, tmp_cron_dir):
+        job = create_job(prompt="Check server status", schedule="every 1h")
+        assert job["model_source"] == "global"
+
+        updated = update_job(
+            job["id"],
+            {"model": "qwen3.6-plus", "provider": "alibaba-coding-plan"},
+        )
+
+        assert updated["model"] == "qwen3.6-plus"
+        assert updated["provider"] == "alibaba-coding-plan"
+        assert updated["model_source"] == "pinned"
+
+    def test_explicit_global_update_keeps_inheritance(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Check server status",
+            schedule="every 1h",
+            model="mimo-v2.5-pro",
+            provider="xiaomi-mimo-cn",
+        )
+
+        updated = update_job(job["id"], {"model_source": "global"})
+
+        assert updated["model"] == "mimo-v2.5-pro"
+        assert updated["provider"] == "xiaomi-mimo-cn"
+        assert updated["model_source"] == "global"
 
     def test_update_schedule(self, tmp_cron_dir):
         job = create_job(prompt="Daily report", schedule="every 1h")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _job_uses_pinned_model
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -68,6 +68,31 @@ class TestResolveOrigin:
         """
         job = {"origin": non_dict_origin}
         assert _resolve_origin(job) is None
+
+
+class TestModelSource:
+    def test_global_model_source_inherits_runtime_config(self):
+        assert _job_uses_pinned_model({
+            "model_source": "global",
+            "model": "mimo-v2.5-pro",
+            "provider": "xiaomi-mimo-cn",
+        }) is False
+
+    def test_pinned_model_source_uses_job_override(self):
+        assert _job_uses_pinned_model({
+            "model_source": "pinned",
+            "model": "mimo-v2.5-pro",
+            "provider": "xiaomi-mimo-cn",
+        }) is True
+
+    def test_legacy_job_with_model_remains_pinned(self):
+        assert _job_uses_pinned_model({
+            "model": "mimo-v2.5-pro",
+            "provider": "xiaomi-mimo-cn",
+        }) is True
+
+    def test_legacy_job_without_model_inherits_global(self):
+        assert _job_uses_pinned_model({}) is False
 
 
 class TestResolveDeliveryTarget:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -117,15 +117,18 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
 
 
 def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
-    """Resolve a model override object into (provider, model) for job storage.
+    """Resolve a model override object into (provider, model, model_source).
 
     If provider is omitted, pins the current main provider from config so the
     job doesn't drift when the user later changes their default via hermes model.
 
-    Returns (provider_str_or_none, model_str_or_none).
+    Returns (provider_str_or_none, model_str_or_none, model_source_or_none).
     """
     if not model_obj or not isinstance(model_obj, dict):
-        return (None, None)
+        return (None, None, None)
+    source = str(model_obj.get("source") or model_obj.get("model_source") or "").strip().lower()
+    if source in {"global", "inherit", "inherited", "default", "auto"}:
+        return (None, None, "global")
     model_name = (model_obj.get("model") or "").strip() or None
     provider_name = (model_obj.get("provider") or "").strip() or None
     if model_name and not provider_name:
@@ -138,7 +141,7 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
                 provider_name = model_cfg.get("provider") or None
         except Exception:
             pass  # Best-effort; provider stays None
-    return (provider_name, model_name)
+    return (provider_name, model_name, "pinned" if model_name or provider_name else None)
 
 
 def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash: bool = False) -> Optional[str]:
@@ -257,6 +260,7 @@ def cronjob(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    model_source: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
@@ -310,6 +314,7 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                model_source=_normalize_optional_job_value(model_source),
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
@@ -396,6 +401,8 @@ def cronjob(
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            if model_source is not None:
+                updates["model_source"] = _normalize_optional_job_value(model_source)
             if script is not None:
                 # Pass empty string to clear an existing script
                 if script:
@@ -509,8 +516,12 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "model": {
                 "type": "object",
-                "description": "Optional per-job model override. If provider is omitted, the current main provider is pinned at creation time so the job stays stable.",
+                "description": "Optional per-job model setting. Omit to inherit the global model. Set {\"source\":\"global\"} to explicitly follow the global model, or include model/provider to pin a fixed override. If provider is omitted with a pinned model, the current main provider is pinned at creation time.",
                 "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Optional: 'global'/'inherit' to follow the global model, or 'pinned' to use this object's model/provider override."
+                    },
                     "provider": {
                         "type": "string",
                         "description": "Provider name (e.g. 'openrouter', 'anthropic'). Omit to use and pin the current provider."
@@ -520,7 +531,6 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                         "description": "Model name (e.g. 'anthropic/claude-sonnet-4', 'claude-sonnet-4')"
                     }
                 },
-                "required": ["model"]
             },
             "script": {
                 "type": "string",
@@ -589,6 +599,7 @@ registry.register(
         skills=args.get("skills"),
         model=_mo[1],
         provider=_mo[0] or args.get("provider"),
+        model_source=_mo[2] or args.get("model_source"),
         base_url=args.get("base_url"),
         reason=args.get("reason"),
         script=args.get("script"),


### PR DESCRIPTION
## Summary

Fixes #19615.

Cron jobs now persist an explicit `model_source` field so scheduled jobs can distinguish between:

- `global`: inherit the active global model/provider from `config.yaml` at run time
- `pinned`: use the stored per-job `model` / `provider` / `base_url` override

Legacy jobs remain backward-compatible: jobs without `model_source` still behave exactly as before, where stored model/provider/base_url implies a pinned job and missing model config inherits the global default.

## Root cause

Cron job execution previously inferred model behavior only from the presence of `job.model`. If a job record contained a model from creation time, the scheduler kept using that model even after the user switched the global Hermes model. This made scheduled jobs brittle when a provider quota or token plan was exhausted.

## Changes

- Add `model_source` normalization to cron job creation and updates.
- Teach the scheduler to ignore stored model/provider/base_url when `model_source=global`.
- Preserve legacy pinned behavior for old jobs that have stored model/provider/base_url but no `model_source`.
- Expose the new model-source semantics through the cronjob tool schema and built-in web server cron create endpoint.
- Add regression coverage for global vs pinned model behavior.

## Validation

```bash
/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_jobs.py tests/cron/test_scheduler.py tests/tools/test_cronjob_tools.py -q -n0
# 213 passed

/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m py_compile cron/jobs.py cron/scheduler.py tools/cronjob_tools.py hermes_cli/web_server.py

git diff --check
```

Note: the same pytest selection under the repo's default parallel mode showed unrelated cron tick lock interference in existing delivery tests; running the cron suite single-process passed.
