### PR TITLE
fix(compressor): reset _summary_failure_cooldown_until on session reset

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -344,6 +344,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
 
     def update_model(
         self,


### PR DESCRIPTION
Salvage of #15548 onto current main.\n\n## Summary\n clears , , and  but leaves  intact. A transient summary error sets a 60s cooldown (600s when no auxiliary provider is configured); if the user immediately runs  or , the cooldown carries over and blocks summarization in the fresh session. Clear it alongside the other failure state.\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15548