### PR TITLE
fix(delegation): pass target_model to resolve_runtime_provider in _resolve_delegation_credentials

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2299,7 +2299,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider)
+        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
Salvage of #15320 onto current main.\n\n## Summary\nWhen  differs from  on providers like opencode-go or opencode-zen, delegate_task fails with 404.  calls  without a , so api_mode is computed from the MAIN model instead of the delegation model. Pass  so api_mode reflects the delegation target.\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15320