### PR TITLE
fix(anthropic): cap max_tokens at 65536 for Qwen models via DashScope

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -105,6 +105,9 @@ _ANTHROPIC_OUTPUT_LIMITS = {
     "claude-3-haiku":      4_096,
     # Third-party Anthropic-compatible providers
     "minimax":            131_072,
+    # Qwen models via DashScope Anthropic-compatible endpoint
+    # DashScope enforces max_tokens ∈ [1, 65536]
+    "qwen3":               65_536,
 }
 
 # For any model not in the table, assume the highest current limit.


### PR DESCRIPTION
Salvage of #15255 onto current main.\n\n## Summary\nDashScope's Anthropic-compatible endpoint enforces . Qwen models sent with higher max_tokens (e.g. 131072) immediately triggered context compression even on short messages (~4k tokens), shrinking the effective window from 1M to 64K. Add qwen3 to the model-ceiling table in .\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15255