### PR TITLE
fix(tui): declare nanostores direct dependency

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -12,6 +12,7 @@
         "@nanostores/react": "^1.1.0",
         "ink": "^6.8.0",
         "ink-text-input": "^6.0.0",
+        "nanostores": "^1.2.0",
         "react": "^19.2.4",
         "unicode-animations": "^1.0.3"
       },
@@ -5303,7 +5304,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -21,6 +21,7 @@
     "@nanostores/react": "^1.1.0",
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
+    "nanostores": "^1.2.0",
     "react": "^19.2.4",
     "unicode-animations": "^1.0.3"
   },


### PR DESCRIPTION
Salvage of #15468 onto current main.\n\n## Summary\nThe TUI imports from  directly, but only  was declared. Some installs miss the direct package during rebuilds. Declare nanostores explicitly (it's a peer dep of @nanostores/react).\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15468