### PR TITLE
fix(docker): exclude compose/profile runtime state from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,7 @@ ui-tui/packages/hermes-ink/dist/
 
 # Runtime data (bind-mounted at /opt/data; must not leak into build context)
 data/
+
+# Compose/profile runtime state (bind-mounted; avoid ownership/secret issues)
+hermes-config/
+runtime/


### PR DESCRIPTION
Salvage of #15263 onto current main.\n\n## Summary\nAdd  and  to .dockerignore. Compose/profile setups keep runtime state outside the image via bind mounts; including those dirs in the build context slows builds, risks ownership issues, and can leak local secrets.\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15263