### PR TITLE
fix(cron): drop stale env-var override of persisted provider

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1004,8 +1004,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         from hermes_cli.auth import AuthError
         try:
+            # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
+            # already prefers persisted config over stale shell/env overrides when
+            # no explicit provider is requested. Passing the env var here short-
+            # circuits that precedence and can resurrect old providers (for
+            # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
+                "requested": job.get("provider"),
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")


### PR DESCRIPTION
Salvage of #15769 onto current main.\n\n## Summary\nCron jobs were passing  as  to , short-circuiting the resolver's own precedence (explicit arg \u2192 persisted config \u2192 env). Long-lived cron daemons inherit env from their launching shell, so a since-changed env var could resurrect an old provider.\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15769