### PR TITLE
fix(cron): skip AI call when prerun script produces no output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -706,10 +706,8 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     f"{prompt}"
                 )
             else:
-                prompt = (
-                    "[Script ran successfully but produced no output.]\n\n"
-                    f"{prompt}"
-                )
+                # Script produced no output — nothing to report, skip AI call.
+                return None
         else:
             prompt = (
                 "## Script Error\n"
@@ -869,6 +867,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             return True, silent_doc, SILENT_MARKER, None
 
     prompt = _build_job_prompt(job, prerun_script=prerun_script)
+    if prompt is None:
+        logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 


### PR DESCRIPTION
Salvage of #15223 onto current main.\n\n## Summary\nWhen a cron pre-run script runs successfully but produces no output (e.g. an email checker with an empty inbox), the scheduler injected 'Script ran successfully but produced no output' and still called the AI model \u2014 288 wasted API calls/day for a 5-minute interval job. Return None from  and short-circuit with a SILENT_MARKER in that case.\n\n## Validation\nManual review; diff scope self-contained.\n\nOriginal PR: #15223