### PR TITLE
fix(tui): close AIAgent on session teardown to prevent FD leak

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2440,6 +2440,12 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
     try:
+        agent = session.get("agent")
+        if agent and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
         worker = session.get("slash_worker")
         if worker:
             worker.close()


### PR DESCRIPTION
Salvage of #15693 by @el-analista onto current main.

## Summary
`session.close` in tui_gateway/server.py only closed the `slash_worker` subprocess and never called `agent.close()` on the AIAgent instance. In the long-lived TUI gateway process, httpx clients were left to be finalized by GC — when the OS recycled a closed file descriptor number for a new active connection, the stale reference in the old httpx client raised 'I/O operation on closed file' tracebacks.

## Changes
- tui_gateway/server.py: call `agent.close()` in session teardown (+6/-0)

## Validation
Manual review; diff is defensive cleanup.

Original PR: #15693