### PR TITLE
fix(tui): prevent trailing space in picker-command completions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1126,6 +1126,12 @@ class SlashCommandCompleter(Completer):
         except Exception:
             return {}
 
+    # Commands that open pickers when run without arguments.
+    # These should NOT receive a trailing space in completions because:
+    # - The TUI's submit handler applies completions on Enter if input differs
+    # - Adding space makes "/model" → "/model " which blocks picker execution
+    _PICKER_COMMANDS = frozenset({"model", "skin", "personality"})
+
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
         """Return replacement text for a completion.
@@ -1134,8 +1140,17 @@ class SlashCommandCompleter(Completer):
         returning ``help`` would be a no-op and prompt_toolkit suppresses the
         menu. Appending a trailing space keeps the dropdown visible and makes
         backspacing retrigger it naturally.
+
+        However, commands that open pickers (model, skin, personality) should
+        NOT get a trailing space — the TUI would apply the completion on Enter
+        and block the picker from opening.
         """
-        return f"{cmd_name} " if cmd_name == word else cmd_name
+        if cmd_name != word:
+            return cmd_name
+        # Don't add space for picker commands — allows Enter to execute them
+        if cmd_name in SlashCommandCompleter._PICKER_COMMANDS:
+            return cmd_name
+        return f"{cmd_name} "
 
     @staticmethod
     def _extract_path_word(text: str) -> str | None:


### PR DESCRIPTION
Salvage of #15339 by @simplenamebox-ops onto current main.

## Summary
Commands that open pickers (`/model`, `/skin`, `/personality`) received a trailing space in completions. The TUI's submit handler applied the completion on Enter if input differed — so `/model` + space became `/model ` and the picker never opened. Picker commands now omit the trailing space.

## Changes
- hermes_cli/commands.py: `_PICKER_COMMANDS` frozenset + conditional space in `_completion_text` (+16/-1)

## Validation
Manual review; surgical conditional change.

Original PR: #15339