### PR TITLE
fix(pty): default TERM to xterm-256color for resize probes

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -108,9 +108,14 @@ class PtyBridge:
                     "(or pip install -e '.[pty]')."
                 )
             raise PtyUnavailableError("Pseudo-terminals are unavailable.")
-        # Let caller-supplied env fully override inheritance; if they pass
-        # None we inherit the server's env (same semantics as subprocess).
-        spawn_env = os.environ.copy() if env is None else env
+        # PTY-hosted programs expect TERM to describe the terminal type.
+        # CI often runs without TERM in the parent process, which makes
+        # simple terminal probes like `tput cols` fail before winsize reads.
+        # Preserve explicit caller overrides, but backfill a sensible default
+        # when TERM is missing or blank.
+        spawn_env = (os.environ.copy() if env is None else env.copy())
+        if not spawn_env.get("TERM"):
+            spawn_env["TERM"] = "xterm-256color"
         proc = ptyprocess.PtyProcess.spawn(  # type: ignore[union-attr]
             list(argv),
             cwd=cwd,


### PR DESCRIPTION
Salvage of #15278 by @LeonSGP43 onto current main (core code only; test refactors on main now exercise TIOCGWINSZ directly, making PR-15278's test changes obsolete).

## Summary
PTY-hosted programs expect TERM to describe the terminal type. CI often runs without TERM in the parent process, which makes terminal probes like `tput cols` fail before winsize reads. Preserve explicit caller overrides, but backfill `TERM=xterm-256color` when missing or blank.

## Changes
- hermes_cli/pty_bridge.py: TERM default backfill (+8/-3)

## Validation
scripts/run_tests.sh tests/hermes_cli/test_pty_bridge.py -> 12 passed

Original PR: #15278