### PR TITLE
fix(kanban-dashboard): widen drawer, bump body fonts, fix code-block contrast

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -268,7 +268,7 @@
 }
 
 .hermes-kanban-drawer {
-  width: min(480px, 92vw);
+  width: min(var(--hermes-kanban-drawer-width, 640px), 92vw);
   height: 100vh;
   background: var(--color-card);
   border-left: 1px solid var(--color-border);
@@ -334,7 +334,7 @@
 .hermes-kanban-meta-row {
   display: flex;
   gap: 0.5rem;
-  font-size: 0.72rem;
+  font-size: 0.8rem;
 }
 .hermes-kanban-meta-label {
   width: 92px;
@@ -367,14 +367,15 @@
 
 .hermes-kanban-pre {
   margin: 0;
-  padding: 0.45rem 0.55rem;
+  padding: 0.5rem 0.6rem;
   white-space: pre-wrap;
   word-break: break-word;
   background: color-mix(in srgb, var(--color-foreground) 4%, transparent);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 0.25rem);
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 0.72rem;
+  font-size: 0.8rem;
+  line-height: 1.5;
   color: var(--color-foreground);
 }
 
@@ -605,8 +606,8 @@
 /* ---- Markdown rendering -------------------------------------------- */
 
 .hermes-kanban-md {
-  font-size: 0.8rem;
-  line-height: 1.55;
+  font-size: 0.85rem;
+  line-height: 1.6;
   color: var(--color-foreground);
 }
 .hermes-kanban-md p  { margin: 0.25rem 0; }
@@ -632,15 +633,22 @@
 }
 .hermes-kanban-md code {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   padding: 0.05rem 0.3rem;
   background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
   border-radius: 3px;
+  color: inherit;
 }
+/* Fenced code block. Set a visible background even when --color-foreground
+ * is empty (color-mix falls through to transparent in that case), and force
+ * color: inherit so the text tracks the drawer foreground rather than the
+ * UA default on <code> elements — otherwise themes that don't set
+ * --color-foreground leave code text rendering near-black on dark themes
+ * (see issue #18576). */
 .hermes-kanban-md-code {
   margin: 0.35rem 0;
   padding: 0.5rem 0.6rem;
-  background: color-mix(in srgb, var(--color-foreground) 5%, transparent);
+  background: color-mix(in srgb, currentColor 6%, transparent);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 0.25rem);
   overflow-x: auto;
@@ -648,8 +656,9 @@
 .hermes-kanban-md-code code {
   background: transparent;
   padding: 0;
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   white-space: pre;
+  color: inherit;
 }
 .hermes-kanban-md strong { font-weight: 600; }
 
@@ -684,11 +693,11 @@
 /* ---- Worker log pane ------------------------------------------------ */
 
 .hermes-kanban-log {
-  max-height: 340px;
+  max-height: 360px;
   overflow: auto;
   white-space: pre;
-  font-size: 0.7rem;
-  line-height: 1.45;
+  font-size: 0.78rem;
+  line-height: 1.5;
 }
 
 
@@ -739,7 +748,8 @@
   color: var(--color-muted-foreground);
 }
 .hermes-kanban-run-summary {
-  font-size: 0.75rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
   padding: 0.2rem 0 0;
   color: var(--color-foreground);
 }
@@ -751,7 +761,8 @@
 }
 .hermes-kanban-run-meta {
   display: block;
-  font-size: 0.65rem;
+  font-size: 0.72rem;
+  line-height: 1.5;
   padding: 0.15rem 0 0;
   color: var(--color-muted-foreground);
   white-space: pre-wrap;


### PR DESCRIPTION
Closes #18576.

## Summary
Three of four drawer-readability complaints in #18576 are now fixed; the fourth (resize handle + live log viewer) is left as follow-up because the plugin ships build-artifacts only (no `src/` in-tree to safely extend the JS).

## Changes (CSS only, `plugins/kanban/dashboard/dist/style.css`)

| | Before | After |
|---|---|---|
| Drawer width | `min(480px, 92vw)` | `min(var(--hermes-kanban-drawer-width, 640px), 92vw)` |
| `.hermes-kanban-pre` | 0.72rem / 1.45 | 0.8rem / 1.5 |
| `.hermes-kanban-md` | 0.8rem / 1.55 | 0.85rem / 1.6 |
| `.hermes-kanban-md code` | 0.75rem, no color | 0.8rem, `color: inherit` |
| `.hermes-kanban-md-code` bg | `color-mix(var(--color-foreground) 5%)` | `color-mix(currentColor 6%)` (survives missing theme var) |
| `.hermes-kanban-md-code code` | 0.75rem, no color | 0.8rem, `color: inherit` |
| `.hermes-kanban-log` | 0.7rem / 1.45 | 0.78rem / 1.5 |
| `.hermes-kanban-meta-row` | 0.72rem | 0.8rem |
| `.hermes-kanban-run-summary` | 0.75rem | 0.82rem / 1.5 |
| `.hermes-kanban-run-meta` | 0.65rem | 0.72rem / 1.5 |

## Black-text-on-dark root cause
Themes that don't define `--color-foreground` (Hermes' NERV theme is the one that surfaced this) leave `color: var(--color-foreground)` on `<code>` elements resolving to empty, which falls back to the UA default — near-black — instead of inheriting from the drawer's light body color. Worse, `color-mix(in srgb, var(--color-foreground) 5%, transparent)` on the fenced-code background also collapses to transparent, so the code block has no visible card at all. Fix: force `color: inherit` on both inline and fenced code, and switch the fenced-code background to `color-mix(currentColor 6%, transparent)` so it tracks whatever the ambient text color is.

## Validation
Live-tested in an isolated dashboard pointed at the worktree (`hermes dashboard --port 9122`) against a seeded kanban task with body markdown, a comment, events, worker log, and run history. All computed styles verified via DevTools before and after each patch; vision model confirmed the fenced code block went from dark-on-dark (invisible) to readable light-on-dark.

`tests/plugins/test_kanban_dashboard_plugin.py` — 42/42 pass.

## Out of scope (filed as follow-up in #18576 comment)
- Draggable resize handle for drawer width (needs JS work; requires plugin source restored to repo).
- Live worker-log viewer for in-progress tasks (backend WS endpoint + React component).
- Sibling fix: Hermes themes should define `--color-foreground`. This PR makes the drawer robust to themes that don't, but the root fix belongs in the theme layer.