### PR TITLE
fix(setup): skip AUXILIARY_VISION_MODEL write when input is blank

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -964,7 +964,8 @@ def setup_model_provider(config: dict, *, quick: bool = False):
                     )
                 else:
                     _selected_vision_model = prompt("  Vision model (blank = use main/custom default)").strip()
-                save_env_value("AUXILIARY_VISION_MODEL", _selected_vision_model)
+                if _selected_vision_model:
+                    save_env_value("AUXILIARY_VISION_MODEL", _selected_vision_model)
                 print_success(
                     f"Vision configured with {_base_url}"
                     + (f" ({_selected_vision_model})" if _selected_vision_model else "")


### PR DESCRIPTION
Salvage of #15504 by @alt-glitch (core fix only; contributor's test collided with subsequent test refactors on main).

## Summary
The non-native-OpenAI vision setup path unconditionally called `save_env_value('AUXILIARY_VISION_MODEL', ...)` with the prompt result. Blank input (user wants to use default) nuked existing .env values. Guard with `if _selected_vision_model:`.

## Changes
- hermes_cli/setup.py: guard blank input from overwriting .env (+2/-1)

Original PR: #15504