### PR TITLE
docs(model-catalog): rename x-ai/grok-4.20-beta to x-ai/grok-4.20

### DIFF
--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-04-30T03:06:09Z",
+  "updated_at": "2026-05-04T09:41:25Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -232,7 +232,7 @@
           "id": "z-ai/glm-5-turbo"
         },
         {
-          "id": "x-ai/grok-4.20-beta"
+          "id": "x-ai/grok-4.20"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b"


### PR DESCRIPTION
## Summary
OpenRouter and Nous Portal dropped the `-beta` suffix on the Grok 4.20 slug. Update the online model catalog JSON to match.

## Changes
- `website/static/api/model-catalog.json`: Nous Portal entry `x-ai/grok-4.20-beta` -> `x-ai/grok-4.20`; `updated_at` bumped.

The OpenRouter section in the same file already used `x-ai/grok-4.20` (no change needed there).

Note: `hermes_cli/models.py` still has `x-ai/grok-4.20-beta` in the curated OpenRouter list — scoped out of this PR since the request was specifically for the online JSON.