### PR TITLE
fix(cli): omit empty api_mode when probing custom models

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3413,10 +3413,10 @@ def _model_flow_named_custom(config, provider_info):
     print()
 
     print("Fetching available models...")
-    models = fetch_api_models(
-        api_key, base_url, timeout=8.0,
-        api_mode=api_mode or None,
-    )
+    fetch_kwargs = {"timeout": 8.0}
+    if api_mode:
+        fetch_kwargs["api_mode"] = api_mode
+    models = fetch_api_models(api_key, base_url, **fetch_kwargs)
 
     if models:
         default_idx = 0

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -56,7 +56,6 @@ class TestCustomProviderModelSwitch:
             "sk-test",
             "https://vllm.example.com/v1",
             timeout=8.0,
-            api_mode=None,
         )
 
     def test_can_switch_to_different_model(self, config_home):
@@ -141,12 +140,18 @@ class TestCustomProviderModelSwitch:
             "api_mode": "anthropic_messages",
         }
 
-        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3"]), \
+        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3"]) as mock_fetch, \
              patch.dict("sys.modules", {"simple_term_menu": None}), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
+        mock_fetch.assert_called_once_with(
+            "***",
+            "https://proxy.example.com/anthropic",
+            timeout=8.0,
+            api_mode="anthropic_messages",
+        )
         config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
         model = config.get("model")
         assert isinstance(model, dict)
@@ -215,7 +220,6 @@ class TestCustomProviderModelSwitch:
             "sk-live-example-provider",
             "https://api.example-provider.test/v1",
             timeout=8.0,
-            api_mode=None,
         )
         config = yaml.safe_load(config_path.read_text()) or {}
         assert config["model"]["api_key"] == "${EXAMPLE_PROVIDER_API_KEY}"


### PR DESCRIPTION
Salvage of #15256 by @LeonSGP43 onto current main, with two pre-existing tests updated to match the new call shape.

## Summary
`_model_flow_named_custom` was passing `api_mode=None` to `fetch_api_models` for custom providers without a declared api_mode. Only include api_mode in kwargs when it's set.

## Changes
- hermes_cli/main.py: conditional kwarg inclusion
- tests: updated two existing call assertions that expected the old shape (api_mode=None) to the new shape (kwarg omitted)

## Validation
scripts/run_tests.sh tests/hermes_cli/test_custom_provider_model_switch.py -> 11 passed

Original PR: #15256