### PR TITLE
feat: make context compaction decision-oriented

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5,9 +5,10 @@ Uses auxiliary model (cheap/fast) to summarize middle turns while
 protecting head and tail context.
 
 Improvements over v2:
-  - Structured summary template with Resolved/Pending question tracking
+  - Decision-packet summary template with evidence, risks, and next verification gate
   - Summarizer preamble: "Do not respond to any questions" (from OpenCode)
   - Handoff framing: "different assistant" (from Codex) to create separation
+  - Compress for continuity, not chronology: keep facts that change future behavior
   - "Remaining Work" replaces "Next Steps" to avoid reading as active instructions
   - Clear separator when summary merges into tail message
   - Iterative summary updates (preserves info across multiple compactions)
@@ -314,6 +315,141 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         sv = str(v)[:40]
         first_arg += f" {k}={sv}"
     return f"[{tool_name}]{first_arg} ({content_len:,} chars result)"
+
+
+def _build_summary_prompt(
+    *,
+    previous_summary: Optional[str],
+    content_to_summarize: str,
+    summary_budget: int,
+    focus_topic: Optional[str] = None,
+) -> str:
+    """Build the shared prompt used by manual and automatic compaction.
+
+    Manual ``/compress`` and threshold-triggered auto compression both flow
+    through ``ContextCompressor._generate_summary()``, so keeping the prompt
+    builder in one place prevents the two paths from drifting apart.
+    """
+    # Preamble shared by both first-compaction and iterative-update prompts.
+    # Inspired by OpenCode's "do not respond to any questions" instruction
+    # and Codex's "another language model" framing.
+    summarizer_preamble = (
+        "You are a context compaction agent creating a decision-quality "
+        "handoff checkpoint. Your output will be injected as reference "
+        "material for a DIFFERENT assistant that continues the conversation. "
+        "Do NOT respond to any questions or requests in the conversation — "
+        "only output the structured summary. Do NOT include any preamble, "
+        "greeting, or prefix. Compress for continuity, not chronology: "
+        "preserve facts, constraints, decisions, evidence, and open risk that "
+        "change what the next assistant should do; discard social filler, "
+        "repeated tool chatter, raw logs, and dead branches unless they explain "
+        "the current state. Be explicit about uncertainty: label unverified "
+        "claims, failed checks, and assumptions instead of smoothing them over. "
+        "Write the summary in the same language the user was using in the "
+        "conversation — do not translate or switch to English. NEVER include "
+        "API keys, tokens, passwords, secrets, credentials, or connection "
+        "strings in the summary — replace any that appear with [REDACTED]. "
+        "Note that credentials may have been present, but do not preserve their values."
+    )
+
+    # Shared structured template (used by both paths).  The headings are kept
+    # stable for downstream readers; the content rules bias the model toward a
+    # Workbench-style decision packet rather than a chronological run log.
+    template_sections = f"""## Active Task
+[THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent unfulfilled request or task assignment verbatim — the exact words they used. If multiple tasks were requested and only some are done, list only the ones NOT yet completed. If no outstanding task exists, write "None." Do not resurrect already completed asks.]
+
+## Goal
+[What the user is trying to accomplish overall, including the intent behind the work when clear.]
+
+## Constraints & Preferences
+[Durable operating contract: user preferences, coding style, safety boundaries, repo conventions, tool/provider constraints, and any explicit non-goals. Preserve only items that should affect future behavior.]
+
+## Completed Actions
+[Numbered list of durable actions taken — include tool used, target, and outcome.
+Format each as: N. ACTION target — outcome [tool: name]
+Prefer state-changing edits, verified discoveries, decisions, and failed checks that affect the next move. Omit mechanical lookup/scroll/poll chatter unless it is the only evidence for a claim.
+Example:
+1. READ config.py:45 — found `==` should be `!=` [tool: read_file]
+2. PATCH config.py:45 — changed `==` to `!=` [tool: patch]
+3. TEST `pytest tests/` — 3/50 failed: test_parse, test_validate, test_edge [tool: terminal]
+Be specific with file paths, commands, line numbers, and results.]
+
+## Evidence & Verification
+[Ground truth the next assistant can trust: tests run, command outputs, file paths, URLs, IDs, status codes, screenshots, and exact errors. Mark anything inferred, stale, or unverified. If no verification was run, say so plainly.]
+
+## Active State
+[Current working state — include:
+- Working directory and branch (if applicable)
+- Modified/created files with brief note on each
+- Test status (X/Y passing)
+- Any running processes or servers
+- Environment details that matter]
+
+## In Progress
+[Work currently underway — what was being done when compaction fired. Keep this factual, not motivational.]
+
+## Blocked
+[Any blockers, errors, risks, or unresolved contradictions. Include exact error messages and whether they are verified.]
+
+## Key Decisions
+[Important decisions and WHY they were made. Include rejected alternatives only when knowing them prevents backtracking.]
+
+## Resolved Questions
+[Questions the user asked that were ALREADY answered — include the answer so the next assistant does not re-answer them.]
+
+## Pending User Asks
+[Questions or requests from the user that have NOT yet been answered or fulfilled. If none, write "None."]
+
+## Relevant Files
+[Files read, modified, or created — with brief note on each. Prefer absolute paths when known.]
+
+## Remaining Work
+[What remains to be done — framed as context, not instructions. Include the smallest next verification gate needed to continue safely.]
+
+## Critical Context
+[Any specific values, error messages, configuration details, assumptions, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
+
+Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed. Keep the packet dense: enough to decide and continue, not enough to replay the whole transcript.
+
+Write only the summary body. Do not include any preamble or prefix."""
+
+    if previous_summary:
+        # Iterative update: preserve existing info, add new progress.
+        prompt = f"""{summarizer_preamble}
+
+You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+
+PREVIOUS SUMMARY:
+{previous_summary}
+
+NEW TURNS TO INCORPORATE:
+{content_to_summarize}
+
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State", "Evidence & Verification", blockers, and remaining work to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
+
+{template_sections}"""
+    else:
+        # First compaction: summarize from scratch.
+        prompt = f"""{summarizer_preamble}
+
+Create a structured handoff summary for a different assistant that will continue this conversation after earlier turns are compacted. The next assistant should be able to understand what happened without re-reading the original turns.
+
+TURNS TO SUMMARIZE:
+{content_to_summarize}
+
+Use this exact structure:
+
+{template_sections}"""
+
+    # Inject focus topic guidance when the user provides one via /compress <focus>.
+    # This goes at the end of the prompt so it takes precedence.
+    if focus_topic:
+        prompt += f"""
+
+FOCUS TOPIC: "{focus_topic}"
+The user has requested that this compaction PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, decisions, and verification evidence. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+
+    return prompt
 
 
 class ContextCompressor(ContextEngine):
@@ -739,119 +875,12 @@ class ContextCompressor(ContextEngine):
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
 
-        # Preamble shared by both first-compaction and iterative-update prompts.
-        # Inspired by OpenCode's "do not respond to any questions" instruction
-        # and Codex's "another language model" framing.
-        _summarizer_preamble = (
-            "You are a summarization agent creating a context checkpoint. "
-            "Your output will be injected as reference material for a DIFFERENT "
-            "assistant that continues the conversation. "
-            "Do NOT respond to any questions or requests in the conversation — "
-            "only output the structured summary. "
-            "Do NOT include any preamble, greeting, or prefix. "
-            "Write the summary in the same language the user was using in the "
-            "conversation — do not translate or switch to English. "
-            "NEVER include API keys, tokens, passwords, secrets, credentials, "
-            "or connection strings in the summary — replace any that appear "
-            "with [REDACTED]. Note that the user had credentials present, but "
-            "do not preserve their values."
+        prompt = _build_summary_prompt(
+            previous_summary=self._previous_summary,
+            content_to_summarize=content_to_summarize,
+            summary_budget=summary_budget,
+            focus_topic=focus_topic,
         )
-
-        # Shared structured template (used by both paths).
-        _template_sections = f"""## Active Task
-[THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent request or
-task assignment verbatim — the exact words they used. If multiple tasks
-were requested and only some are done, list only the ones NOT yet completed.
-The next assistant must pick up exactly here. Example:
-"User asked: 'Now refactor the auth module to use JWT instead of sessions'"
-If no outstanding task exists, write "None."]
-
-## Goal
-[What the user is trying to accomplish overall]
-
-## Constraints & Preferences
-[User preferences, coding style, constraints, important decisions]
-
-## Completed Actions
-[Numbered list of concrete actions taken — include tool used, target, and outcome.
-Format each as: N. ACTION target — outcome [tool: name]
-Example:
-1. READ config.py:45 — found `==` should be `!=` [tool: read_file]
-2. PATCH config.py:45 — changed `==` to `!=` [tool: patch]
-3. TEST `pytest tests/` — 3/50 failed: test_parse, test_validate, test_edge [tool: terminal]
-Be specific with file paths, commands, line numbers, and results.]
-
-## Active State
-[Current working state — include:
-- Working directory and branch (if applicable)
-- Modified/created files with brief note on each
-- Test status (X/Y passing)
-- Any running processes or servers
-- Environment details that matter]
-
-## In Progress
-[Work currently underway — what was being done when compaction fired]
-
-## Blocked
-[Any blockers, errors, or issues not yet resolved. Include exact error messages.]
-
-## Key Decisions
-[Important technical decisions and WHY they were made]
-
-## Resolved Questions
-[Questions the user asked that were ALREADY answered — include the answer so the next assistant does not re-answer them]
-
-## Pending User Asks
-[Questions or requests from the user that have NOT yet been answered or fulfilled. If none, write "None."]
-
-## Relevant Files
-[Files read, modified, or created — with brief note on each]
-
-## Remaining Work
-[What remains to be done — framed as context, not instructions]
-
-## Critical Context
-[Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
-
-Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
-
-Write only the summary body. Do not include any preamble or prefix."""
-
-        if self._previous_summary:
-            # Iterative update: preserve existing info, add new progress
-            prompt = f"""{_summarizer_preamble}
-
-You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
-
-PREVIOUS SUMMARY:
-{self._previous_summary}
-
-NEW TURNS TO INCORPORATE:
-{content_to_summarize}
-
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
-
-{_template_sections}"""
-        else:
-            # First compaction: summarize from scratch
-            prompt = f"""{_summarizer_preamble}
-
-Create a structured handoff summary for a different assistant that will continue this conversation after earlier turns are compacted. The next assistant should be able to understand what happened without re-reading the original turns.
-
-TURNS TO SUMMARIZE:
-{content_to_summarize}
-
-Use this exact structure:
-
-{_template_sections}"""
-
-        # Inject focus topic guidance when the user provides one via /compress <focus>.
-        # This goes at the end of the prompt so it takes precedence.
-        if focus_topic:
-            prompt += f"""
-
-FOCUS TOPIC: "{focus_topic}"
-The user has requested that this compaction PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
         try:
             call_kwargs = {

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3,7 +3,11 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _build_summary_prompt,
+)
 
 
 @pytest.fixture()
@@ -18,6 +22,48 @@ def compressor():
             quiet_mode=True,
         )
         return c
+
+
+class TestSummaryPromptBuilder:
+    def test_prompt_is_decision_packet_not_chronological_run_log(self):
+        prompt = _build_summary_prompt(
+            previous_summary=None,
+            content_to_summarize="USER: fix the cache bug\nASSISTANT: read files",
+            summary_budget=1200,
+        )
+
+        assert "decision-quality handoff checkpoint" in prompt
+        assert "Compress for continuity, not chronology" in prompt
+        assert "## Evidence & Verification" in prompt
+        assert "Omit mechanical lookup/scroll/poll chatter" in prompt
+        assert "Keep the packet dense" in prompt
+        assert "TURNS TO SUMMARIZE" in prompt
+        assert "PREVIOUS SUMMARY" not in prompt
+
+    def test_iterative_prompt_uses_same_packet_structure(self):
+        prompt = _build_summary_prompt(
+            previous_summary="## Active Task\nOld task",
+            content_to_summarize="USER: new request",
+            summary_budget=900,
+        )
+
+        assert "PREVIOUS SUMMARY" in prompt
+        assert "NEW TURNS TO INCORPORATE" in prompt
+        assert "## Evidence & Verification" in prompt
+        assert "decision-quality handoff checkpoint" in prompt
+        assert "Update \"Active State\", \"Evidence & Verification\"" in prompt
+
+    def test_focus_topic_prioritizes_verification_evidence(self):
+        prompt = _build_summary_prompt(
+            previous_summary=None,
+            content_to_summarize="USER: compress around database migration",
+            summary_budget=900,
+            focus_topic="database migration",
+        )
+
+        assert 'FOCUS TOPIC: "database migration"' in prompt
+        assert "verification evidence" in prompt
+        assert "NEVER preserve API keys" in prompt
 
 
 class TestShouldCompress:
@@ -190,6 +236,28 @@ class TestNonStringContent:
 
         kwargs = mock_call.call_args.kwargs
         assert "temperature" not in kwargs
+
+    def test_generate_summary_sends_decision_packet_prompt_to_aux_llm(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "fix the cache bug"},
+            {"role": "assistant", "content": "I inspected cache.py"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            c._generate_summary(messages, focus_topic="cache bug")
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert "decision-quality handoff checkpoint" in prompt
+        assert "## Evidence & Verification" in prompt
+        assert 'FOCUS TOPIC: "cache bug"' in prompt
+        assert "fix the cache bug" in prompt
 
     def test_summary_call_passes_live_main_runtime(self):
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary

This changes context compaction from a chronological chat recap into a decision-quality handoff packet.

The practical premise is simple: compaction is not just token reduction. It is the state transition between context windows. Once older turns are removed, the generated summary becomes the next assistant's operating memory. If that memory over-preserves chronology, raw tool chatter, repeated lookups, and social filler, the continuation inherits noise. If it preserves task intent, constraints, decisions, evidence, blockers, active state, and the smallest next verification gate, the continuation is much less likely to repeat work or drift.

Concretely, this PR:

- extracts a shared `_build_summary_prompt()` used by both manual `/compress` and automatic threshold-triggered compaction;
- keeps the existing stable handoff headings, but makes the instructions more decision-oriented;
- adds `## Evidence & Verification` so tests, command outputs, exact errors, paths, URLs, status codes, and unverified assumptions survive compaction explicitly;
- tells the summarizer to "compress for continuity, not chronology";
- biases `Completed Actions` toward durable state changes, verified discoveries, decisions, and failed checks that affect the next move;
- tells the summarizer to omit mechanical lookup/scroll/poll chatter unless it is the only evidence for a claim;
- keeps the existing protections around active-task handling, same-language output, and secret redaction.

## Why this matters

Long agent sessions usually fail after compaction in boring ways:

1. the agent repeats already-completed work because the summary kept the activity but not the verified outcome;
2. the agent loses a user constraint because it was buried inside a long exchange;
3. the agent treats an assumption as fact because the summary removed the uncertainty marker;
4. the agent preserves a raw log but drops the conclusion the log supported;
5. the agent resumes with a vague "next steps" list instead of knowing the smallest safe verification gate.

This PR tries to improve that handoff quality without changing the compressor algorithm, session splitting, token budgeting, or public command behavior. It is prompt-level and test-covered, so the risk surface is intentionally small.

The mental model is: a compressed summary should be closer to an engineering handoff / decision packet than to a meeting transcript. The next assistant should not be able to replay the whole conversation, but it should be able to continue safely and know which facts are grounded.

## Implementation notes

Manual and automatic compaction already flow through `ContextCompressor._generate_summary()`. This PR keeps that route and moves the prompt construction into one helper:

```python
_build_summary_prompt(
    previous_summary=...,
    content_to_summarize=...,
    summary_budget=...,
    focus_topic=...,
)
```

That means `/compress`, focus-topic compaction, iterative compaction, and threshold-triggered auto compaction share the same instruction style instead of drifting.

The output headings remain familiar:

- `## Active Task`
- `## Goal`
- `## Constraints & Preferences`
- `## Completed Actions`
- `## Evidence & Verification` (new)
- `## Active State`
- `## In Progress`
- `## Blocked`
- `## Key Decisions`
- `## Resolved Questions`
- `## Pending User Asks`
- `## Relevant Files`
- `## Remaining Work`
- `## Critical Context`

## Test plan

- `venv/bin/python -m pytest tests/agent/test_context_compressor.py -q -o 'addopts='`
  - 70 passed

- Compress-related regression set:

```bash
venv/bin/python -m pytest \
  tests/gateway/test_compress_command.py \
  tests/cli/test_manual_compress.py \
  tests/agent/test_context_compressor.py \
  tests/test_cli_manual_compress.py \
  tests/run_agent/test_compression_feasibility.py \
  tests/run_agent/test_compression_boundary_hook.py \
  tests/run_agent/test_compress_focus_plugin_fallback.py \
  tests/gateway/test_compress_plugin_engine.py \
  tests/gateway/test_compress_focus.py \
  tests/agent/test_compressor_image_tokens.py \
  tests/test_trajectory_compressor_async.py \
  tests/test_trajectory_compressor.py \
  tests/run_agent/test_compression_trigger_excludes_reasoning.py \
  tests/run_agent/test_compression_persistence.py \
  tests/run_agent/test_413_compression.py \
  tests/cli/test_compress_focus.py \
  tests/agent/test_compress_focus.py \
  tests/run_agent/test_compressor_fallback_update.py \
  tests/run_agent/test_compression_boundary.py \
  -q -o 'addopts='
```

Result: 194 passed, 2 unrelated deprecation warnings from `websockets` / `lark_oapi`.

Additional local checks:

- `venv/bin/python -m py_compile agent/context_compressor.py tests/agent/test_context_compressor.py`
- `git diff --check -- agent/context_compressor.py tests/agent/test_context_compressor.py`
- secret-like pattern scan over the touched files

## Compatibility / risk

This does not change:

- the compression trigger threshold;
- token budgeting;
- session splitting;
- fallback behavior when the auxiliary compression model fails;
- secret redaction behavior;
- the active-task guard in `SUMMARY_PREFIX`.

The main behavioral change is the summarizer instruction style and one added section in the structured handoff.