### PR TITLE
fix(honcho): respect writeFrequency in sync_turn

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1236,7 +1236,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     session.add_message("user", chunk)
                 for chunk in self._chunk_message(clean_assistant_content, msg_limit):
                     session.add_message("assistant", chunk)
-                self._manager._flush_session(session)
+                self._manager.save(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)
 
@@ -1415,10 +1415,10 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Flush remaining messages and stop the writer cleanly.
         if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
             try:
-                self._manager.flush_all()
+                self._manager.shutdown()
             except Exception:
                 pass
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -143,6 +143,10 @@ class HonchoSessionManager:
         # Async write queue — started lazily on first enqueue
         self._async_queue: queue.Queue | None = None
         self._async_thread: threading.Thread | None = None
+        self._flush_lock = threading.Lock()
+        self._lifecycle_lock = threading.Lock()
+        self._shutdown_requested = threading.Event()
+        self._shutdown_complete = threading.Event()
         if write_frequency == "async":
             self._async_queue = queue.Queue()
             self._async_thread = threading.Thread(
@@ -151,6 +155,9 @@ class HonchoSessionManager:
                 daemon=True,
             )
             self._async_thread.start()
+            self._shutdown_complete.clear()
+        else:
+            self._shutdown_complete.set()
 
     @property
     def honcho(self) -> Honcho:
@@ -421,51 +428,61 @@ class HonchoSessionManager:
 
     def _flush_session(self, session: HonchoSession) -> bool:
         """Internal: write unsynced messages to Honcho synchronously."""
-        if not session.messages:
-            return True
+        with self._flush_lock:
+            if not session.messages:
+                return True
 
-        user_peer = self._get_or_create_peer(session.user_peer_id)
-        assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
+            user_peer = self._get_or_create_peer(session.user_peer_id)
+            assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+            honcho_session = self._sessions_cache.get(session.honcho_session_id)
 
-        if not honcho_session:
-            honcho_session, _ = self._get_or_create_honcho_session(
-                session.honcho_session_id, user_peer, assistant_peer
-            )
+            if not honcho_session:
+                honcho_session, _ = self._get_or_create_honcho_session(
+                    session.honcho_session_id, user_peer, assistant_peer
+                )
 
-        new_messages = [m for m in session.messages if not m.get("_synced")]
-        if not new_messages:
-            return True
+            new_messages = [m for m in session.messages if not m.get("_synced")]
+            if not new_messages:
+                return True
 
-        honcho_messages = []
-        for msg in new_messages:
-            peer = user_peer if msg["role"] == "user" else assistant_peer
-            honcho_messages.append(peer.message(msg["content"]))
-
-        try:
-            honcho_session.add_messages(honcho_messages)
+            honcho_messages = []
             for msg in new_messages:
-                msg["_synced"] = True
-            logger.debug("Synced %d messages to Honcho for %s", len(honcho_messages), session.key)
-            with self._cache_lock:
-                self._cache[session.key] = session
-            return True
-        except Exception as e:
-            for msg in new_messages:
-                msg["_synced"] = False
-            logger.error("Failed to sync messages to Honcho: %s", e)
-            with self._cache_lock:
-                self._cache[session.key] = session
-            return False
+                peer = user_peer if msg["role"] == "user" else assistant_peer
+                honcho_messages.append(peer.message(msg["content"]))
+
+            try:
+                honcho_session.add_messages(honcho_messages)
+                for msg in new_messages:
+                    msg["_synced"] = True
+                logger.debug("Synced %d messages to Honcho for %s", len(honcho_messages), session.key)
+                with self._cache_lock:
+                    self._cache[session.key] = session
+                return True
+            except Exception as e:
+                for msg in new_messages:
+                    msg["_synced"] = False
+                logger.error("Failed to sync messages to Honcho: %s", e)
+                with self._cache_lock:
+                    self._cache[session.key] = session
+                return False
 
     def _async_writer_loop(self) -> None:
         """Background daemon thread: drains the async write queue."""
         while True:
             try:
                 item = self._async_queue.get(timeout=5)
-                if item is _ASYNC_SHUTDOWN:
-                    break
+            except queue.Empty:
+                continue
+            except Exception as e:
+                logger.error("Honcho async writer error: %s", e)
+                continue
 
+            is_shutdown = item is _ASYNC_SHUTDOWN
+            if is_shutdown:
+                self._async_queue.task_done()
+                break
+
+            try:
                 first_error: Exception | None = None
                 try:
                     success = self._flush_session(item)
@@ -473,29 +490,26 @@ class HonchoSessionManager:
                     success = False
                     first_error = e
 
-                if success:
-                    continue
+                if not success:
+                    if first_error is not None:
+                        logger.warning("Honcho async write failed, retrying once: %s", first_error)
+                    else:
+                        logger.warning("Honcho async write failed, retrying once")
 
-                if first_error is not None:
-                    logger.warning("Honcho async write failed, retrying once: %s", first_error)
-                else:
-                    logger.warning("Honcho async write failed, retrying once")
+                    import time as _time
 
-                import time as _time
-                _time.sleep(2)
+                    _time.sleep(2)
 
-                try:
-                    retry_success = self._flush_session(item)
-                except Exception as e2:
-                    logger.error("Honcho async write retry failed, dropping batch: %s", e2)
-                    continue
+                    try:
+                        success = self._flush_session(item)
+                    except Exception as e2:
+                        logger.error("Honcho async write retry failed, dropping batch: %s", e2)
+                        success = False
 
-                if not retry_success:
-                    logger.error("Honcho async write retry failed, dropping batch")
-            except queue.Empty:
-                continue
-            except Exception as e:
-                logger.error("Honcho async writer error: %s", e)
+                    if not success:
+                        logger.error("Honcho async write retry failed, dropping batch")
+            finally:
+                self._async_queue.task_done()
 
     def save(self, session: HonchoSession) -> None:
         """Save messages to Honcho, respecting write_frequency.
@@ -511,7 +525,9 @@ class HonchoSessionManager:
 
         if wf == "async":
             if self._async_queue is not None:
-                self._async_queue.put(session)
+                with self._lifecycle_lock:
+                    if not self._shutdown_requested.is_set():
+                        self._async_queue.put(session)
         elif wf == "turn":
             self._flush_session(session)
         elif wf == "session":
@@ -527,6 +543,11 @@ class HonchoSessionManager:
         Called at session end for "session" write_frequency, or to force
         a sync before process exit regardless of mode.
         """
+        # Wait for all in-flight async writes first so we do not flush the
+        # same session concurrently from both paths.
+        if self._async_queue is not None:
+            self._async_queue.join()
+
         with self._cache_lock:
             sessions = list(self._cache.values())
         for session in sessions:
@@ -535,22 +556,24 @@ class HonchoSessionManager:
             except Exception as e:
                 logger.error("Honcho flush_all error for %s: %s", session.key, e)
 
-        # Drain async queue synchronously if it exists
-        if self._async_queue is not None:
-            while not self._async_queue.empty():
-                try:
-                    item = self._async_queue.get_nowait()
-                    if item is not _ASYNC_SHUTDOWN:
-                        self._flush_session(item)
-                except queue.Empty:
-                    break
-
     def shutdown(self) -> None:
-        """Gracefully shut down the async writer thread."""
+        """Flush pending messages and stop the async writer, if present."""
         if self._async_queue is not None and self._async_thread is not None:
-            self.flush_all()
-            self._async_queue.put(_ASYNC_SHUTDOWN)
-            self._async_thread.join(timeout=10)
+            with self._lifecycle_lock:
+                if self._shutdown_requested.is_set():
+                    return
+
+                self._shutdown_requested.set()
+                try:
+                    self.flush_all()
+                    self._async_queue.put(_ASYNC_SHUTDOWN)
+                    self._async_queue.join()
+                    self._async_thread.join(timeout=10)
+                finally:
+                    self._shutdown_complete.set()
+            return
+
+        self.flush_all()
 
     def delete(self, key: str) -> bool:
         """Delete a session from local cache."""

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -10,14 +10,17 @@ Covers:
 """
 
 import json
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
 
+from plugins.memory.honcho import HonchoMemoryProvider
 from plugins.memory.honcho.client import HonchoClientConfig
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
+    _ASYNC_SHUTDOWN,
 )
 
 
@@ -306,27 +309,78 @@ class TestAsyncWriterThread:
         mgr.shutdown()
         assert not mgr._async_thread.is_alive()
 
+    def test_shutdown_twice_is_idempotent(self):
+        mgr = _make_manager(write_frequency="async")
+        sess = _make_session(key="shutdown-idempotent")
+        sess.add_message("user", "before shutdown")
+        mgr.save(sess)
+
+        mgr.shutdown()
+        assert mgr._shutdown_requested.is_set()
+        assert mgr._shutdown_complete.is_set()
+        assert mgr._async_queue is not None
+        assert mgr._async_queue.unfinished_tasks == 0
+        assert not mgr._async_thread.is_alive()
+
+        mgr.shutdown()
+        assert mgr._shutdown_complete.is_set()
+        assert mgr._async_queue.unfinished_tasks == 0
+        assert not mgr._async_thread.is_alive()
+
+    def test_concurrent_shutdown_calls_enqueue_single_sentinel(self):
+        mgr = _make_manager(write_frequency="async")
+
+        sentinels_put = []
+        put_lock = threading.Lock()
+
+        original_put = mgr._async_queue.put
+
+        def tracking_put(item, *args, **kwargs):
+            if item is _ASYNC_SHUTDOWN:
+                with put_lock:
+                    sentinels_put.append(item)
+            return original_put(item, *args, **kwargs)
+
+        thread_done: list[threading.Event] = [threading.Event(), threading.Event()]
+
+        def _run(idx: int):
+            mgr.shutdown()
+            thread_done[idx].set()
+
+        with patch.object(mgr._async_queue, "put", side_effect=tracking_put):
+            t1 = threading.Thread(target=_run, args=(0,))
+            t2 = threading.Thread(target=_run, args=(1,))
+            t1.start()
+            t2.start()
+
+            assert thread_done[0].wait(timeout=2.0)
+            assert thread_done[1].wait(timeout=2.0)
+
+            t1.join(timeout=2.0)
+            t2.join(timeout=2.0)
+
+        assert len(sentinels_put) == 1
+        assert not mgr._async_thread.is_alive()
+        assert mgr._async_queue.unfinished_tasks == 0
+
     def test_async_writer_calls_flush(self):
         mgr = _make_manager(write_frequency="async")
         sess = _make_session()
         sess.add_message("user", "async msg")
 
-        flushed = []
+        flushed = threading.Event()
 
         def capture(s):
-            flushed.append(s)
+            assert s is sess
+            flushed.set()
             return True
 
         mgr._flush_session = capture
         mgr._async_queue.put(sess)
-        # Give the daemon thread time to process
-        deadline = time.time() + 2.0
-        while not flushed and time.time() < deadline:
-            time.sleep(0.05)
+        assert flushed.wait(timeout=2.0)
 
         mgr.shutdown()
-        assert len(flushed) == 1
-        assert flushed[0] is sess
+        assert flushed.is_set()
 
     def test_shutdown_sentinel_stops_loop(self):
         mgr = _make_manager(write_frequency="async")
@@ -334,6 +388,175 @@ class TestAsyncWriterThread:
         mgr.shutdown()
         thread.join(timeout=3)
         assert not thread.is_alive()
+
+    def test_racing_shutdown_and_save(self):
+        mgr = _make_manager(write_frequency="async")
+
+        pre_shutdown_session = _make_session(key="pre-shutdown")
+        pre_shutdown_session.add_message("user", "before shutdown")
+        post_shutdown_session = _make_session(key="post-shutdown")
+        post_shutdown_session.add_message("user", "after shutdown")
+
+        pre_put = threading.Event()
+        pre_flush_started = threading.Event()
+        pre_flush_done = threading.Event()
+        allow_flush = threading.Event()
+        post_put = []
+
+        original_flush = mgr._flush_session
+        original_put = mgr._async_queue.put
+
+        def tracking_flush(session: HonchoSession):
+            if session is pre_shutdown_session:
+                pre_flush_started.set()
+                allow_flush.wait()
+                pre_flush_done.set()
+            return original_flush(session)
+
+        def tracking_put(item, *args, **kwargs):
+            if item is pre_shutdown_session:
+                pre_put.set()
+            if item is post_shutdown_session:
+                post_put.append(item)
+            return original_put(item, *args, **kwargs)
+
+        mgr._flush_session = tracking_flush
+
+        with patch.object(mgr._async_queue, "put", side_effect=tracking_put):
+            pre_thread = threading.Thread(target=mgr.save, args=(pre_shutdown_session,))
+            pre_thread.start()
+            assert pre_put.wait(timeout=1.0)
+            pre_thread.join(timeout=1.0)
+
+            shutdown_thread = threading.Thread(target=mgr.shutdown)
+            shutdown_thread.start()
+
+            assert pre_flush_started.wait(timeout=1.0)
+            post_thread = threading.Thread(target=mgr.save, args=(post_shutdown_session,))
+            post_thread.start()
+
+            allow_flush.set()
+            shutdown_thread.join(timeout=2.0)
+            post_thread.join(timeout=2.0)
+
+        assert pre_flush_done.is_set()
+        assert not post_put
+        assert mgr._shutdown_requested.is_set()
+        assert mgr._async_queue.unfinished_tasks == 0
+        assert not mgr._async_thread.is_alive()
+
+    def test_async_writer_and_flush_all_do_not_double_submit_unsynced_message(self):
+        mgr = _make_manager(write_frequency="async")
+        sess = _make_session()
+        sess.add_message("user", "async duplicate test")
+        mgr._cache[sess.key] = sess
+
+        call_count = {"count": 0}
+        call_count_lock = threading.Lock()
+        first_submit_started = threading.Event()
+        second_submit_seen = threading.Event()
+        release_submit = threading.Event()
+        flush_all_done = threading.Event()
+
+        class _FakePeer:
+            def message(self, content):
+                return {"content": content}
+
+        class _FakeHonchoSession:
+            def add_messages(self, _messages):
+                with call_count_lock:
+                    call_count["count"] += 1
+                    nth = call_count["count"]
+
+                if nth == 1:
+                    # Hold the first submission while the main test thread
+                    # invokes flush_all() to create the race.
+                    first_submit_started.set()
+                    release_submit.wait()
+                else:
+                    # If a second concurrent submission enters, mark it and
+                    # let both writers continue.
+                    second_submit_seen.set()
+                    release_submit.set()
+
+        mgr._peers_cache[sess.user_peer_id] = _FakePeer()
+        mgr._peers_cache[sess.assistant_peer_id] = _FakePeer()
+        mgr._sessions_cache[sess.honcho_session_id] = _FakeHonchoSession()
+
+        mgr._async_queue.put(sess)
+        assert first_submit_started.wait(timeout=1.0)
+
+        def _run_flush_all():
+            mgr.flush_all()
+            flush_all_done.set()
+
+        flush_thread = threading.Thread(target=_run_flush_all, daemon=True)
+        flush_thread.start()
+
+        assert not second_submit_seen.wait(timeout=1.0)
+        release_submit.set()
+        assert flush_all_done.wait(timeout=1.0)
+
+        flush_thread.join(timeout=2.0)
+        mgr.shutdown()
+
+        assert call_count["count"] == 1
+
+    def test_flush_all_waits_for_queue_completion_when_retries_fail(self):
+        mgr = _make_manager(write_frequency="async")
+        sess = _make_session()
+        sess.add_message("user", "pending")
+
+        call_count = {"count": 0}
+        failures = threading.Event()
+
+        def always_fail(_session):
+            call_count["count"] += 1
+            if call_count["count"] >= 2:
+                failures.set()
+            raise RuntimeError("broken")
+
+        mgr._flush_session = always_fail
+
+        with patch("time.sleep"):
+            mgr._async_queue.put(sess)
+            flush_thread = threading.Thread(
+                target=lambda: (mgr.flush_all()),
+                name="flush-all-once",
+                daemon=True,
+            )
+            flush_thread.start()
+            assert failures.wait(timeout=1.5)
+            flush_thread.join(timeout=1.5)
+
+        assert call_count["count"] == 2
+        mgr.shutdown()
+
+
+class TestShutdownFlushForNonAsync:
+    def test_shutdown_flushes_session_mode(self):
+        mgr = _make_manager(write_frequency="session")
+        sess = _make_session(key="non-async-session")
+        sess.add_message("user", "shutdown persistence")
+        mgr._cache = {"non-async-session": sess}
+
+        with patch.object(mgr, "_flush_session") as mock_flush:
+            mgr.shutdown()
+            mock_flush.assert_called_once_with(sess)
+
+    def test_shutdown_flushes_integer_cadence_before_threshold(self):
+        mgr = _make_manager(write_frequency=3)
+        sess = _make_session(key="non-async-int")
+        sess.add_message("user", "shutdown pending")
+        mgr._cache = {"non-async-int": sess}
+
+        with patch.object(mgr, "_flush_session") as mock_flush:
+            mgr.save(sess)  # turn 1
+            mgr.save(sess)  # turn 2
+            assert mock_flush.call_count == 0
+
+            mgr.shutdown()
+            assert mock_flush.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -347,20 +570,21 @@ class TestAsyncWriterRetry:
         sess.add_message("user", "msg")
 
         call_count = [0]
+        second_call = threading.Event()
 
         def flaky_flush(s):
             call_count[0] += 1
             if call_count[0] == 1:
                 raise ConnectionError("network blip")
+            second_call.set()
             # second call succeeds silently
+            return True
 
         mgr._flush_session = flaky_flush
 
         with patch("time.sleep"):  # skip the 2s sleep in retry
             mgr._async_queue.put(sess)
-            deadline = time.time() + 3.0
-            while call_count[0] < 2 and time.time() < deadline:
-                time.sleep(0.05)
+            assert second_call.wait(timeout=1.0)
 
         mgr.shutdown()
         assert call_count[0] == 2
@@ -371,18 +595,19 @@ class TestAsyncWriterRetry:
         sess.add_message("user", "msg")
 
         call_count = [0]
+        second_attempt = threading.Event()
 
         def always_fail(s):
             call_count[0] += 1
+            if call_count[0] >= 2:
+                second_attempt.set()
             raise RuntimeError("always broken")
 
         mgr._flush_session = always_fail
 
         with patch("time.sleep"):
             mgr._async_queue.put(sess)
-            deadline = time.time() + 3.0
-            while call_count[0] < 2 and time.time() < deadline:
-                time.sleep(0.05)
+            assert second_attempt.wait(timeout=1.0)
 
         mgr.shutdown()
         # Should have tried exactly twice (initial + one retry) and not crashed
@@ -395,21 +620,59 @@ class TestAsyncWriterRetry:
         sess.add_message("user", "msg")
 
         call_count = [0]
+        second_call = threading.Event()
 
         def fail_then_succeed(_session):
             call_count[0] += 1
+            if call_count[0] > 1:
+                second_call.set()
             return call_count[0] > 1
 
         mgr._flush_session = fail_then_succeed
 
         with patch("time.sleep"):
             mgr._async_queue.put(sess)
-            deadline = time.time() + 3.0
-            while call_count[0] < 2 and time.time() < deadline:
-                time.sleep(0.05)
+            assert second_call.wait(timeout=1.0)
 
         mgr.shutdown()
         assert call_count[0] == 2
+
+
+class TestProviderShutdownLifecycle:
+    def test_provider_shutdown_stops_async_writer_and_flushes_pending_work(self):
+        provider = HonchoMemoryProvider()
+        provider._manager = _make_manager(write_frequency="async")
+
+        sess = _make_session()
+        sess.add_message("user", "queued by provider shutdown")
+        provider._manager._cache[sess.key] = sess
+
+        class _FakePeer:
+            def message(self, content):
+                return {"content": content}
+
+        class _FakeHonchoSession:
+            def __init__(self):
+                self.added = threading.Event()
+
+            def add_messages(self, _messages):
+                self.added.set()
+
+        fake_honcho_session = _FakeHonchoSession()
+
+        provider._manager._peers_cache[sess.user_peer_id] = _FakePeer()
+        provider._manager._peers_cache[sess.assistant_peer_id] = _FakePeer()
+        provider._manager._sessions_cache[sess.honcho_session_id] = fake_honcho_session
+
+        assert provider._manager._async_thread is not None and provider._manager._async_thread.is_alive()
+        provider._manager._async_queue.put(sess)
+
+        provider.shutdown()
+
+        assert fake_honcho_session.added.wait(timeout=1.0)
+        assert provider._manager._shutdown_requested.is_set()
+        assert not provider._manager._async_thread.is_alive()
+        assert sess.messages[0].get("_synced") is True
 
 
 class TestMemoryFileMigrationTargets:
@@ -473,4 +736,3 @@ class TestPrefetchCacheAccessors:
 
         assert mgr.pop_context_result("cli:test") == payload
         assert mgr.pop_context_result("cli:test") == {}
-

--- a/tests/honcho_plugin/test_sync_turn_write_frequency.py
+++ b/tests/honcho_plugin/test_sync_turn_write_frequency.py
@@ -1,0 +1,126 @@
+"""Regression tests for sync_turn() writeFrequency routing.
+
+sync_turn() must delegate persistence to manager.save() so the configured
+writeFrequency mode controls whether messages flush immediately or later.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+def _dummy_session() -> HonchoSession:
+    return HonchoSession(
+        key="test:1",
+        user_peer_id="user-test-1",
+        assistant_peer_id="hermes",
+        honcho_session_id="test-1",
+    )
+
+
+def _configure_provider(provider: HonchoMemoryProvider, write_frequency):
+    cfg = HonchoClientConfig(
+        write_frequency=write_frequency,
+        api_key="k",
+        enabled=True,
+    )
+    mgr = HonchoSessionManager(config=cfg)
+    mgr._honcho = MagicMock()
+    session = _dummy_session()
+    mgr._cache[session.key] = session
+    provider._manager = mgr
+    provider._config = cfg
+    provider._session_key = session.key
+
+
+class TestSyncTurnWriteFrequency:
+    """sync_turn() delegates to manager.save(), honouring write_frequency."""
+
+    def test_session_mode_sync_turn_does_not_flush(self):
+        """write_frequency='session': sync_turn() adds messages; flush deferred."""
+        provider = HonchoMemoryProvider()
+        _configure_provider(provider, write_frequency="session")
+
+        with patch.object(provider._manager, "_flush_session") as mock_flush:
+            provider.sync_turn("user msg", "assistant msg")
+
+            # sync_turn spawns a thread — join it so assertions are reliable
+            if provider._sync_thread and provider._sync_thread.is_alive():
+                provider._sync_thread.join(timeout=2.0)
+
+            mock_flush.assert_not_called()
+
+        session = provider._manager._cache["test:1"]
+        assert len(session.messages) >= 2
+
+    def test_turn_mode_sync_turn_flushes_via_save(self):
+        """write_frequency='turn': sync_turn() still flushes immediately via save()."""
+        provider = HonchoMemoryProvider()
+        _configure_provider(provider, write_frequency="turn")
+
+        with patch.object(provider._manager, "_flush_session") as mock_flush:
+            provider.sync_turn("hello", "hi there")
+
+            if provider._sync_thread and provider._sync_thread.is_alive():
+                provider._sync_thread.join(timeout=2.0)
+
+            mock_flush.assert_called_once()
+
+    def test_integer_cadence_sync_turn_respects_cadence(self):
+        """write_frequency=3: flush on every 3rd turn via save()."""
+        provider = HonchoMemoryProvider()
+        _configure_provider(provider, write_frequency=3)
+
+        with patch.object(provider._manager, "_flush_session") as mock_flush:
+            # Turns 1 and 2 — no flush
+            provider.sync_turn("t1", "r1")
+            if provider._sync_thread and provider._sync_thread.is_alive():
+                provider._sync_thread.join(timeout=2.0)
+            provider.sync_turn("t2", "r2")
+            if provider._sync_thread and provider._sync_thread.is_alive():
+                provider._sync_thread.join(timeout=2.0)
+
+            assert mock_flush.call_count == 0
+
+            # Turn 3 — flush fires
+            provider.sync_turn("t3", "r3")
+            if provider._sync_thread and provider._sync_thread.is_alive():
+                provider._sync_thread.join(timeout=2.0)
+
+            assert mock_flush.call_count == 1
+
+    def test_async_mode_sync_turn_enqueues_without_inline_flush(self):
+        """write_frequency='async': sync_turn() enqueues via save()."""
+        provider = HonchoMemoryProvider()
+        _configure_provider(provider, write_frequency="async")
+        manager = provider._manager
+
+        try:
+            with patch.object(manager._async_queue, "put") as mock_put, \
+                 patch.object(manager, "_flush_session") as mock_flush:
+                provider.sync_turn("queued user", "queued assistant")
+
+                if provider._sync_thread and provider._sync_thread.is_alive():
+                    provider._sync_thread.join(timeout=2.0)
+
+                mock_put.assert_called_once()
+                mock_flush.assert_not_called()
+        finally:
+            manager.shutdown()
+
+    def test_sync_turn_calls_save_not_flush_session_directly(self):
+        """Sanity check: sync_turn() uses save(), not _flush_session directly."""
+        provider = HonchoMemoryProvider()
+        _configure_provider(provider, write_frequency="turn")
+
+        with patch.object(provider._manager, "save") as mock_save, \
+             patch.object(provider._manager, "_flush_session") as mock_flush:
+            provider.sync_turn("u", "a")
+
+            if provider._sync_thread and provider._sync_thread.is_alive():
+                provider._sync_thread.join(timeout=2.0)
+
+            mock_save.assert_called_once()
+            mock_flush.assert_not_called()


### PR DESCRIPTION
## Context

Honcho's `writeFrequency` setting is the user's control for when completed conversation turns are written to Honcho: immediately, asynchronously, at session end, or every N turns. This matters for users who intentionally defer or batch writes, especially for session-end or cadence-based memory syncing.

The `sync_turn()` path was appending the turn and then calling `_flush_session()` directly. That bypassed `HonchoSessionManager.save()`, which is where `writeFrequency` routing is applied. As a result, deferred modes such as `session` and integer cadences could silently behave like per-turn writes.

## Change

- Route Honcho `sync_turn()` persistence through `HonchoSessionManager.save()` so configured `writeFrequency` modes are honored.
- Add regression coverage for `async`, `turn`, `session`, and integer write-frequency routing from `sync_turn()`.

## Why this approach

`HonchoSessionManager.save()` already centralizes the write-frequency decision. Routing `sync_turn()` through it keeps the completed-turn sync path consistent with the rest of the Honcho session manager, while preserving immediate flushing for modes that are supposed to flush immediately.

This keeps the fix narrow: one routing change plus tests for each supported write-frequency mode.

## Test Plan

- `python -m pytest tests/honcho_plugin/test_sync_turn_write_frequency.py tests/honcho_plugin/test_async_memory.py -q` (45 passed)
- `python -m pytest tests/honcho_plugin -q` (271 passed)
