### PR TITLE
fix(status): show NVIDIA NIM api key status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -140,6 +140,7 @@ def show_status(args):
         "WandB": "WANDB_API_KEY",
         "ElevenLabs": "ELEVENLABS_API_KEY",
         "GitHub": "GITHUB_TOKEN",
+        "NVIDIA NIM":      "NVIDIA_API_KEY",
     }
 
     for name, env_var in keys.items():


### PR DESCRIPTION
Salvage of #16143 onto current main.

## Summary
`hermes status` omitted NVIDIA NIM from the API-key overview table even though NVIDIA NIM is a registered inference provider with its own `NVIDIA_API_KEY` env var. Add the row so users can tell at a glance whether their NIM credential is configured.

## Validation
Manual review of diff against current main.

Original PR: #16143