### PR TITLE
fix(cronjob): advertise 'custom:<name>' provider format in tool schema

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -513,7 +513,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "properties": {
                     "provider": {
                         "type": "string",
-                        "description": "Provider name (e.g. 'openrouter', 'anthropic'). Omit to use and pin the current provider."
+                        "description": "Provider name (e.g. 'openrouter', 'anthropic', or 'custom:<name>' for a provider defined in custom_providers config — always include the ':<name>' suffix, never pass the bare 'custom'). Omit to use and pin the current provider."
                     },
                     "model": {
                         "type": "string",


### PR DESCRIPTION
Salvage of #15477 onto current main.

## Summary
The `provider` field in the `cronjob` tool schema advertised `'openrouter'` and `'anthropic'` but not the canonical `'custom:<name>'` form that custom_providers entries require. Paired with #15480's runtime guard against bare `'custom'`, this teaches the schema what shape to emit so the model gets it right on first try.

## Validation
Manual review of diff against current main.

Original PR: #15477