### PR TITLE
fix(agent): preserve dots in model names for Xiaomi MiMo provider

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8203,6 +8203,7 @@ class AIAgent:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
+        Xiaomi MiMo keeps dots (e.g. mimo-v2.5, mimo-v2.5-pro).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
         AWS Bedrock uses dotted inference-profile IDs
@@ -8216,6 +8217,7 @@ class AIAgent:
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",
             "zai", "bedrock",
+            "xiaomi",
         }:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
@@ -8225,6 +8227,7 @@ class AIAgent:
             or "minimax" in base
             or "opencode.ai/zen/" in base
             or "bigmodel.cn" in base
+            or "xiaomimimo.com" in base
             # AWS Bedrock runtime endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
             or "bedrock-runtime." in base


### PR DESCRIPTION
Salvage of #16157 onto current main.

## Summary
Without this fix, `normalize_model_name()` in `agent/anthropic_adapter.py` converts `mimo-v2.5-pro` to `mimo-v2-5-pro` for Xiaomi's Anthropic-compatible endpoint, producing a 404. Add `xiaomi` to the provider whitelist and `xiaomimimo.com` to the URL-based fallback check.

## Validation
Manual review of diff against current main.

Original PR: #16157