### PR TITLE
fix(tui): use --outdir instead of --outfile in hermes-ink build

### DIFF
--- a/ui-tui/packages/hermes-ink/index.js
+++ b/ui-tui/packages/hermes-ink/index.js
@@ -1,1 +1,1 @@
-export * from './dist/ink-bundle.js'
+export * from './dist/entry-exports.js'

--- a/ui-tui/packages/hermes-ink/package.json
+++ b/ui-tui/packages/hermes-ink/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "esbuild src/entry-exports.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/ink-bundle.js"
+    "build": "esbuild src/entry-exports.ts --bundle --platform=node --format=esm --packages=external --outdir=dist"
   },
   "sideEffects": true,
   "main": "./index.js",


### PR DESCRIPTION
Salvage of #16119 onto current main.

## Summary
On Android/Termux ARM64 with esbuild >=0.25, the hermes-ink build script fails with `Must use "outdir" when there are multiple input files` because the TypeScript source now has multiple inputs. Switch the build command to `--outdir=dist` and update the package entry to point at `entry-exports.js` which matches the new output layout. Dashboard --tui works again.

## Validation
Manual review of diff against current main.

Original PR: #16119