### PR TITLE
fix(delegate): guard _load_config() against delegation: null in config.yaml

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2337,7 +2337,7 @@ def _load_config() -> dict:
     try:
         from cli import CLI_CONFIG
 
-        cfg = CLI_CONFIG.get("delegation", {})
+        cfg = CLI_CONFIG.get("delegation") or {}
         if cfg:
             return cfg
     except Exception:
@@ -2346,7 +2346,7 @@ def _load_config() -> dict:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation", {})
+        return full.get("delegation") or {}
     except Exception:
         return {}
 


### PR DESCRIPTION
Salvage of #16345 onto current main.

## Summary
`delegation: null` in config.yaml causes `NoneType object has no attribute 'get'` on every API call that triggers the delegation path, because `dict.get('delegation', {})` returns the explicit `None` when the key is present-but-null. Use `... or {}` so both missing-key and present-null fall back to the default empty config.

## Validation
Manual review of diff against current main.

Original PR: #16345