### PR TITLE
fix(wecom): mark adapter as non-editable to prevent broken streaming edits

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -142,6 +142,7 @@ class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    SUPPORTS_MESSAGE_EDITING = False
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -36,6 +36,11 @@ class TestWeComRequirements:
 
 
 class TestWeComAdapterInit:
+    def test_declares_non_editable_message_capability(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
+
     def test_reads_config_from_extra(self):
         from gateway.platforms.wecom import WeComAdapter
 


### PR DESCRIPTION
Salvage of #16092 onto current main.

## Summary
WeCom does not reliably support message edits via its WebSocket API — streaming updates via edit fail or produce duplicate messages. Set `WeComAdapter.SUPPORTS_MESSAGE_EDITING = False` so gateway streaming/progress paths avoid edit-based updates and fall back to new-message semantics.

## Validation
scripts/run_tests.sh tests/gateway/test_wecom.py -k editing -> passed

Original PR: #16092