### PR TITLE
fix(compressor): trigger fallback on timeout errors alongside model-unavailable errors

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -906,15 +906,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 or "does not exist" in _err_str
                 or "no available channel" in _err_str
             )
+            _is_timeout = (
+                _status in (408, 429, 502, 504)
+                or "timeout" in _err_str
+            )
             if (
-                _is_model_not_found
+                (_is_model_not_found or _is_timeout)
                 and self.summary_model
                 and self.summary_model != self.model
                 and not getattr(self, "_summary_model_fallen_back", False)
             ):
                 self._summary_model_fallen_back = True
                 logging.warning(
-                    "Summary model '%s' not available (%s). "
+                    "Summary model '%s' unavailable (%s). "
                     "Falling back to main model '%s' for compression.",
                     self.summary_model, e, self.model,
                 )


### PR DESCRIPTION
Salvage of #16126 onto current main.

## Summary
Only HTTP 404/503 and specific model-not-found error strings triggered the compression summary model to fall back to the main model. Timeout errors (408/429/502/504, or strings containing 'timeout') left the compressor in a cooldown, so subsequent compressions failed silently. Add timeout detection to the fallback trigger.

## Validation
Manual review of diff against current main.

Original PR: #16126