### PR TITLE
fix(cronjob): treat bare 'custom' provider as unspecified in model override

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -128,6 +128,15 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
         return (None, None)
     model_name = (model_obj.get("model") or "").strip() or None
     provider_name = (model_obj.get("provider") or "").strip() or None
+    # Bare "custom" is an incomplete spec — the canonical form is
+    # "custom:<name>" matching a custom_providers entry. LLMs frequently
+    # supply the bare type because the schema does not advertise the
+    # ":<name>" suffix, which used to bypass the pinning path below and
+    # leave the job stored with an unresolvable "custom" provider. Treat
+    # the bare value as "no provider supplied" so the current main
+    # provider gets pinned instead.
+    if provider_name == "custom":
+        provider_name = None
     if model_name and not provider_name:
         # Pin to the current main provider so the job is stable
         try:


### PR DESCRIPTION
Salvage of #15480 onto current main.

## Summary
`_resolve_model_override` in `tools/cronjob_tools.py` treated any non-empty `provider` string the LLM emitted as user-specified and skipped the pin-to-current-provider fallback. When the LLM wrote the bare type name `'custom'` (instead of the canonical `'custom:<name>'`), the job was stored with an unresolvable `'custom'` provider and failed on every fire. Treat bare `'custom'` as 'no provider supplied' so the current main provider gets pinned instead.

## Validation
Manual review of diff against current main.

Original PR: #15480