### PR TITLE
fix(cli): remove dead 'q' check from quit command resolution

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6282,7 +6282,7 @@ class HermesCLI:
         _cmd_def = _resolve_cmd(_base_word)
         canonical = _cmd_def.name if _cmd_def else _base_word
         
-        if canonical in ("quit", "exit", "q"):
+        if canonical in ("quit", "exit"):
             return False
         elif canonical == "help":
             self.show_help()

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -123,6 +123,13 @@ class TestBusyInputMode:
         cli.process_command("/queue follow up")
         assert cli._pending_input.get_nowait() == "follow up"
 
+    def test_q_alias_queues_prompt(self):
+        """The /q alias should resolve to /queue, not /quit."""
+        cli = _make_cli()
+        cli._agent_running = False
+        assert cli.process_command("/q follow up") is True
+        assert cli._pending_input.get_nowait() == "follow up"
+
     def test_queue_mode_routes_busy_enter_to_pending(self):
         """In queue mode, Enter while busy should go to _pending_input, not _interrupt_queue."""
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})


### PR DESCRIPTION
Salvage of #16662 onto current main.

## Summary
`q` is registered as an alias for `/queue`, so `resolve_command('q')` returns the queue command — the `canonical in ('quit', 'exit', 'q')` check never matches `'q'` and the third entry is dead code. Remove it and add a regression test for `/q <prompt>` routing to queue, not quit.

## Validation
scripts/run_tests.sh tests/cli/test_cli_init.py -k q_alias -> passed

Original PR: #16662