### PR TITLE
fix(cli): reject invalid argv values from -p/--profile before profile resolver

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -114,6 +114,16 @@ def _apply_profile_override() -> None:
             consume = 1
             break
 
+    # 1b. Reject values that can't be valid profile names (e.g. pytest's
+    # "-p no:xdist" would be misread as profile "no:xdist" otherwise).
+    # Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never call
+    # resolve_profile_env() with a value it must reject + sys.exit on.
+    if profile_name is not None and consume == 2:
+        import re as _re
+        if not _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile_name):
+            profile_name = None
+            consume = 0
+
     # 1.5 If HERMES_HOME is already set and no explicit flag was given, trust it.
     # This lets child processes (relaunch, subprocess) inherit the parent's
     # profile choice without having to pass --profile again.


### PR DESCRIPTION
Salvage of #15997 onto current main.

## Summary
`_apply_profile_override()` in `hermes_cli/main.py` scans `sys.argv` for `-p`/`--profile` at module import time. When `hermes_cli.main` is imported inside pytest with `-p no:xdist` on the command line, `'no:xdist'` is picked up as a profile name and `resolve_profile_env()` raises + sys.exits the whole test session. Mirror `hermes_cli.profiles._PROFILE_ID_RE` locally so malformed values are ignored before resolver entry.

## Validation
Manual review of diff against current main.

Original PR: #15997