### PR TITLE
fix(model-picker): exclude providers with empty credential pool entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1264,11 +1264,7 @@ def list_authenticated_providers(
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
                 providers_store = store.get("providers", {})
-                pool_store = store.get("credential_pool", {})
-                if store and (
-                    pid in providers_store or hermes_slug in providers_store
-                    or pid in pool_store or hermes_slug in pool_store
-                ):
+                if store and (pid in providers_store or hermes_slug in providers_store):
                     has_creds = True
             except Exception as exc:
                 logger.debug("Auth store check failed for %s: %s", pid, exc)
@@ -1364,11 +1360,7 @@ def list_authenticated_providers(
                 from hermes_cli.auth import _load_auth_store
                 _cp_store = _load_auth_store()
                 _cp_providers_store = _cp_store.get("providers", {})
-                _cp_pool_store = _cp_store.get("credential_pool", {})
-                if _cp_store and (
-                    _cp.slug in _cp_providers_store
-                    or _cp.slug in _cp_pool_store
-                ):
+                if _cp_store and _cp.slug in _cp_providers_store:
                     _cp_has_creds = True
             except Exception:
                 pass


### PR DESCRIPTION
Salvage of #15950 onto current main.

## Summary
`list_authenticated_providers` checked `slug in credential_pool` to decide authentication status, but an empty pool entry without actual keys/tokens isn't a credential. Providers with ghost credential_pool entries (e.g. `ollama-cloud` seeded but not yet configured) showed as authenticated in the `/model` picker and selecting one produced a 401. Only count providers with entries in `auth.providers` as authenticated.

## Validation
Manual review of diff against current main.

Original PR: #15950