### PR TITLE
fix(browser): allow explicit CDP override without local agent-browser

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -209,6 +209,13 @@ class TestFindAgentBrowser:
 
 
 class TestBrowserRequirements:
+    def test_cdp_override_does_not_require_agent_browser_cli(self, monkeypatch):
+        monkeypatch.setenv("BROWSER_CDP_URL", "ws://127.0.0.1:9222/devtools/browser/test")
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: (_ for _ in ()).throw(FileNotFoundError("not found")))
+
+        assert check_browser_requirements() is True
+
     def test_termux_requires_real_agent_browser_install_not_npx_fallback(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2840,7 +2840,12 @@ def check_browser_requirements() -> bool:
     if _is_camofox_mode():
         return True
 
-    # The agent-browser CLI is always required
+    # CDP override mode can connect to an existing remote/local browser endpoint
+    # without requiring the local agent-browser binary on PATH.
+    if _get_cdp_override():
+        return True
+
+    # The agent-browser CLI is required for local launch and cloud-provider flows.
     try:
         browser_cmd = _find_agent_browser()
     except FileNotFoundError:


### PR DESCRIPTION
Salvage of #16070 onto current main.

## Summary
`check_browser_requirements()` always required a local `agent-browser` binary even when `BROWSER_CDP_URL` was set, producing a false negative for users who connect to a remote CDP endpoint directly (e.g. a sidecar Chrome, a pre-configured CDP tunnel). Treat `_get_cdp_override()` the same way as Camofox mode: valid backend, skip the local binary check.

## Validation
scripts/run_tests.sh tests/tools/test_browser_homebrew_paths.py -k cdp_override -> passed

Original PR: #16070