### PR TITLE
fix(doctor): check global agent-browser when local install not found

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -935,6 +935,8 @@ def run_doctor(args):
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
         if agent_browser_path.exists():
             check_ok("agent-browser (Node.js)", "(browser automation)")
+        elif shutil.which("agent-browser"):
+            check_ok("agent-browser", "(browser automation)")
         else:
             if _is_termux():
                 check_info("agent-browser is not installed (expected in the tested Termux path)")


### PR DESCRIPTION
Salvage of #16125 by @ms-alan onto current main.

## Summary
When `agent-browser` is installed globally via `npm install -g agent-browser` but not present in the local `node_modules`, `hermes doctor` falsely warned that it wasn't installed. Check `shutil.which("agent-browser")` as a fallback after the local install check.

## Note on authorship
The contributor's original commit was authored with an empty email (`pander <>`) due to a local git-config quirk. Re-attributed to `ms-alan <chenb19870707@gmail.com>` (the PR opener's public GitHub email) during salvage so the commit passes AUTHOR_MAP validation.

## Changes
- hermes_cli/doctor.py: shutil.which fallback for global agent-browser install (+2/-0)

## Validation
Manual review; surgical fallback check.

Original PR: #16125
Fixes: #15951
