### PR TITLE
fix(file-tools): cap read_file result size at 100k to match other file tools

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -516,12 +516,25 @@ class TestPerToolThresholds:
         except ImportError:
             pytest.skip("terminal_tool not importable in test env")
 
-    def test_read_file_never_persisted(self):
+    def test_read_file_result_size_cap(self):
         from tools.registry import registry
         try:
             import tools.file_tools  # noqa: F401
             val = registry.get_max_result_size("read_file")
-            assert val == float("inf")
+            assert val == 100_000
+        except ImportError:
+            pytest.skip("file_tools not importable in test env")
+
+    def test_read_file_registry_cap_is_100k(self):
+        """Regression test: read_file must have a 100_000 char registry cap (Layer 2 safety net)."""
+        from tools.registry import registry
+        try:
+            import tools.file_tools  # noqa: F401
+            val = registry.get_max_result_size("read_file")
+            assert val == 100_000, (
+                f"read_file registry cap must be 100_000, got {val!r}. "
+                "float('inf') is not allowed — it disables the Layer 2 result-size guard."
+            )
         except ImportError:
             pytest.skip("file_tools not importable in test env")
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1137,7 +1137,7 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=float('inf'))
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
 registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)


### PR DESCRIPTION
Salvage of #16508 by @chinadbo onto current main.

## Summary
`read_file` was registered with `max_result_size_chars=float('inf')`, skipping the Layer 2 registry-level result-size guard that every other file tool enforces. The tool's own paginated read logic already bounds output to ~100K chars, but the registry-layer guard is the defense-in-depth fallback when the internal cap is bypassed. Set the registry cap to 100_000 to match.

## Changes
- tools/file_tools.py: `max_result_size_chars=100_000` for read_file
- tests: regression covering registry cap value

## Validation
scripts/run_tests.sh tests/tools/test_tool_result_storage.py -k read_file -> 3 passed

Original PR: #16508
