### PR TITLE
fix(google_oauth): close TOCTOU window when saving credentials

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -489,16 +489,29 @@ def save_credentials(creds: GoogleCredentials) -> Path:
     """Atomically write creds to disk with 0o600 permissions."""
     path = _credentials_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Tighten parent dir to 0o700 so siblings can't traverse to the creds file.
+    # On Windows this is a no-op (POSIX mode bits aren't enforced); ignore failures.
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
     payload = json.dumps(creds.to_dict(), indent=2, sort_keys=True) + "\n"
 
     with _credentials_lock():
         tmp_path = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
         try:
-            with open(tmp_path, "w", encoding="utf-8") as fh:
+            # Create with 0o600 atomically to close the TOCTOU window where the
+            # default umask (often 0o644) would briefly expose tokens to other
+            # local users between open() and chmod().
+            fd = os.open(
+                str(tmp_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(payload)
                 fh.flush()
                 os.fsync(fh.fileno())
-            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
             atomic_replace(tmp_path, path)
         finally:
             try:


### PR DESCRIPTION
Salvage of #16718 by @CharlieKerfoot onto current main.

## Summary
`save_credentials` created the temp file via `open(tmp, "w")` and only chmod'd it to 0o600 afterward. Between create and chmod the file existed on disk at the process umask (commonly 0o644 = publicly readable). On a multi-user host, Google OAuth tokens were briefly exposed to other local users.

Use `os.open` with `O_EXCL | S_IRUSR | S_IWUSR` so the file is created atomically with restrictive mode. Also tighten the parent dir to 0o700 on POSIX (no-op on Windows) so siblings can't traverse to the creds file.

## Conflict resolution during salvage
Main has moved from `os.replace` to `atomic_replace`. Kept the newer `atomic_replace` call and dropped the now-redundant post-write `os.chmod(tmp_path, ...)` because O_EXCL creation already applies the 0o600 mode.

## Changes
- agent/google_oauth.py: O_EXCL atomic create + parent dir 0o700 (+15/-2)

## Validation
Manual review (no targeted google_oauth tests in tree).

Original PR: #16718
