### PR TITLE
fix(anthropic): strip top-level oneOf/allOf/anyOf from tool input_schema

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1225,6 +1225,14 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     ``keep_nullable_hint=False`` because the Anthropic validator does not
     recognize the OpenAPI-style ``nullable: true`` extension and strict
     schema-to-grammar converters may reject unknown keywords.
+
+    Top-level ``oneOf``/``allOf``/``anyOf`` are also stripped here: the
+    Anthropic API rejects union keywords at the schema root with a generic
+    HTTP 400. Several upstream and plugin tools ship schemas with one of
+    these keywords at the top level (commonly for Pydantic discriminated
+    unions). If we land here with those keywords still present after
+    nullable-union stripping, drop them and fall back to a plain object
+    schema so the tool still validates at the Anthropic boundary.
     """
     if not schema:
         return {"type": "object", "properties": {}}
@@ -1234,6 +1242,12 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     normalized = strip_nullable_unions(schema, keep_nullable_hint=False)
     if not isinstance(normalized, dict):
         return {"type": "object", "properties": {}}
+    # Strip top-level union keywords that Anthropic's validator rejects.
+    banned = {"oneOf", "allOf", "anyOf"}
+    if banned & normalized.keys():
+        normalized = {k: v for k, v in normalized.items() if k not in banned}
+        if "type" not in normalized:
+            normalized["type"] = "object"
     if normalized.get("type") == "object" and not isinstance(normalized.get("properties"), dict):
         normalized = {**normalized, "properties": {}}
     return normalized


### PR DESCRIPTION
Salvage of #16471 by @Grey0202 onto current main.

## Summary
The Anthropic Messages API rejects tool `input_schema` definitions that contain JSON-Schema union keywords (`oneOf`, `allOf`, `anyOf`) at the top level, returning HTTP 400 with a generic validation error. Several upstream and plugin tools ship schemas with one of these keywords (common for Pydantic discriminated unions). The existing `strip_nullable_unions` sanitizer only collapses `anyOf`-with-null patterns; a non-null top-level union keyword passes through and hits the API.

## Adaptation during salvage
Main has refactored the sanitizer into a single `_normalize_tool_input_schema` helper that calls `strip_nullable_unions`. Rather than introducing the PR's parallel `_sanitize_input_schema` function (which would create two schema-munging code paths racing against the same input), I folded the oneOf/allOf/anyOf strip into the existing helper so there's one entry point that applies both passes.

## Changes
- agent/anthropic_adapter.py: extend `_normalize_tool_input_schema` to strip top-level union keywords after nullable-union collapse (+14/-0)

## Validation
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -k input_schema -> 1 passed

Original PR: #16471
