### PR TITLE
fix(config): respect env vars over .env file for 12-factor precedence

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -165,7 +165,7 @@ def load_hermes_dotenv(
         _sanitize_env_file_if_needed(project_env_path)
 
     if user_env.exists():
-        _load_dotenv_with_fallback(user_env, override=True)
+        _load_dotenv_with_fallback(user_env, override=False)
         loaded.append(user_env)
 
     if project_env_path and project_env_path.exists():


### PR DESCRIPTION
## Summary

Fixes #19201

Changed `override=True` to `override=False` in `hermes_cli/env_loader.py` line 168 for user-level `.env` file loading.

### Problem
When `load_dotenv()` is called with `override=True`, values from `~/.hermes/.env` (user-level dotenv) **overwrite** environment variables that were already set. This violates the [12-factor app](https://12factor.net/config) configuration precedence:

> Environment variables > dotenv files

Users who set env vars (e.g., `export OPENAI_API_KEY=...` in `.bashrc`) expected them to take precedence over `.hermes/.env`, but they were being silently overridden.

### Fix
Changed `override=True` to `override=False` in the user-env loading path (`load_hermes_dotenv()`), so that:
- **Env vars set by the user** (shell, systemd, Docker) always win
- **`.hermes/.env`** serves as fallback defaults (not overrides)

### Scope
Only affects the **user-level** `.env` file path (`~/.hermes/.env`). Project-level `.env` and system-level loading are unaffected (they already use `override=False` or have separate precedence logic).

### Testing
- Set `OPENAI_API_KEY=env-value` in shell
- Set `OPENAI_API_KEY=file-value` in `~/.hermes/.env`
- Verify `os.environ['OPENAI_API_KEY']` returns `env-value` (not `file-value`)

Closes #19201