### PR TITLE
feat: add --mode flag and /mode slash command for ephemeral system prompts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5116,6 +5116,31 @@ class HermesCLI:
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 
+    def _handle_mode_command(self, cmd_original: str) -> None:
+        """Handle /mode <name> — load a mode file as the ephemeral system prompt."""
+        parts = cmd_original.split(None, 1)
+        target = parts[1].strip() if len(parts) > 1 else ""
+
+        if not target or target == "off":
+            if self.agent:
+                self.agent.system_prompt = ""
+                self.agent._invalidate_system_prompt()
+            _cprint("  Mode cleared.")
+            return
+
+        from hermes_constants import get_hermes_home
+        mode_path = get_hermes_home() / "modes" / f"{target}.md"
+        if not mode_path.exists():
+            _cprint(f"  Mode not found: {target}")
+            return
+
+        content = mode_path.read_text(encoding="utf-8")
+        if self.agent:
+            self.agent.system_prompt = content
+            self.agent._invalidate_system_prompt()
+        os.environ["HERMES_EPHEMERAL_SYSTEM_PROMPT"] = content
+        _cprint(f"  Loaded mode: {target} ({len(content)} chars, never compacted)")
+    
     def _handle_branch_command(self, cmd_original: str) -> None:
         """Handle /branch [name] — fork the current session into a new independent copy.
 
@@ -6417,6 +6442,8 @@ class HermesCLI:
             self.new_session()
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "mode":
+            self._handle_mode_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "gquota":

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -202,6 +202,13 @@ def build_top_level_parser():
     )
     _inherited_flag(
         parser,
+        "--mode",
+        default=None,
+        metavar="MODE",
+        help="Load a mode file from ~/.hermes/modes/<name>.md as an ephemeral system prompt. Injected into every LLM turn, never compacted. Combine with --resume / -c to apply a mode to an existingsession.",
+    )
+    _inherited_flag(
+        parser,
         "--ignore-rules",
         action="store_true",
         default=False,
@@ -353,6 +360,13 @@ def build_top_level_parser():
         "--source",
         default=None,
         help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--mode",
+        default=None,
+        metavar="MODE",
+        help="Load a mode file from ~/.hermes/modes/<name>.md as an ephemeral system prompt. Injected into every LLM turn,never compacted. Combine with --resume / -c to apply a mode to an existing session.",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -86,6 +86,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
                cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]"),
     CommandDef("stop", "Kill all running background processes", "Session"),
+    CommandDef("mode", "Load a mode file from ~/.hermes/modes/<name>.md. Injected as ephemeral system prompt. Use /mode off to clear.", 
+               "Session", args_hint="[name]"),
     CommandDef("approve", "Approve a pending dangerous command", "Session",
                gateway_only=True, args_hint="[session|always]"),
     CommandDef("deny", "Deny a pending dangerous command", "Session",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1314,6 +1314,23 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # --mode: load a mode file as an ephemeral system prompt
+    mode_name = getattr(args, "mode", None)
+    if mode_name:
+        from hermes_constants import get_hermes_home
+        mode_path = get_hermes_home() / "modes" / f"{mode_name}.md"
+        if mode_path.exists():
+            os.environ["HERMES_EPHEMERAL_SYSTEM_PROMPT"] = mode_path.read_text(encoding="utf-8")
+        else:
+            print(f"Mode not found: {mode_name}")
+            print(f"Create {mode_path} with your instructions, or choose from:")
+            modes_dir = mode_path.parent
+            if modes_dir.exists():
+                available = sorted(p.stem for p in modes_dir.glob("*.md") if p.stem != "README")
+                if available:
+                    print(f"Available modes: {', '.join(available)}")
+            sys.exit(1)
+    
     if use_tui:
         _launch_tui(
             getattr(args, "resume", None),


### PR DESCRIPTION
Adds a `--mode` flag and `/mode` slash command that load a markdown file from `~/.hermes/modes/<name>.md` as an `ephemeral_system_prompt`.

The mechanism (`HERMES_EPHEMERAL_SYSTEM_PROMPT` env var) already exists natively in Hermes — this wraps it in a user-facing CLI flag and slash command.

Works with:
- `hermes --mode companion` (fresh session with companion behavior)
- `hermes --mode orchestrator -c` (resume last session in orchestrator mode)
- `hermes chat --mode email-sender --resume <id>` (resume specific session with mode)
- `/mode email-sender` in-session (swap behavior mid-conversation)
- `/mode off` (clear the mode)

Four files changed:
- `hermes_cli/_parser.py` — top-level and chat `--mode` flag definitions
- `hermes_cli/main.py` — mode file loading logic
- `hermes_cli/commands.py` — `/mode` CommandDef entry
- `cli.py` — `/mode` command handler and dispatch wiring