### PR TITLE
fix(agent): resolve credential pool key ambiguity for shared base_url

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -305,11 +305,29 @@ def _iter_custom_providers(config: Optional[dict] = None):
         yield _normalize_custom_pool_name(name), entry
 
 
-def get_custom_provider_pool_key(base_url: str) -> Optional[str]:
-    """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching base_url.
+def get_custom_provider_pool_key(base_url: str, provider_name: Optional[str] = None) -> Optional[str]:
+    """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching provider.
+
+    When *provider_name* is given (and is not bare ``"custom"``), the lookup
+    matches by provider name first — this disambiguates when multiple
+    ``custom_providers`` share the same ``base_url``.
+
+    Falls back to *base_url*-only matching when *provider_name* is ``None``
+    or ``"custom"`` (the generic label the config layer uses).
 
     Returns None if no match is found.
     """
+    if not base_url and not provider_name:
+        return None
+
+    # --- Fast path: match by name when we have a specific provider name ---
+    if provider_name and provider_name.strip().lower() not in ("custom", ""):
+        target_norm = _normalize_custom_pool_name(provider_name)
+        for norm_name, entry in _iter_custom_providers():
+            if norm_name == target_norm:
+                return f"{CUSTOM_POOL_PREFIX}{norm_name}"
+
+    # --- Fallback: match by base_url ---
     if not base_url:
         return None
     normalized_url = base_url.strip().rstrip("/")
@@ -1535,9 +1553,12 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                     model_api_key = v.strip()
                     break
             if model_provider == "custom" and model_base_url and model_api_key:
-                # Check if this model's base_url matches our custom provider
-                matched_key = get_custom_provider_pool_key(model_base_url)
-                if matched_key == pool_key:
+                # Check if this model's base_url matches THIS custom provider
+                # (use the pool_key's own config to avoid first-match ambiguity
+                # when multiple providers share the same base_url — #19083)
+                cp_cfg = _get_custom_provider_config(pool_key)
+                cp_url = str((cp_cfg or {}).get("base_url") or "").strip().rstrip("/") if cp_cfg else ""
+                if cp_url and cp_url == model_base_url:
                     source = "model_config"
                     if not _is_suppressed(pool_key, source):
                         active_sources.add(source)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -319,9 +319,10 @@ def _try_resolve_from_custom_pool(
     base_url: str,
     provider_label: str,
     api_mode_override: Optional[str] = None,
+    provider_name: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
-    pool_key = get_custom_provider_pool_key(base_url)
+    pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
         return None
     try:
@@ -521,7 +522,7 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=requested_provider)
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.


### PR DESCRIPTION
## Summary

Fixes #19083

When multiple `custom_providers` share the same `base_url` but have different `api_key` values, `get_custom_provider_pool_key()` previously returned the pool key for the **first** match in iteration order. This caused the wrong credential pool to be loaded, resulting in 401 Unauthorized errors.

### Root Cause

`get_custom_provider_pool_key(base_url)` only matched by `base_url`, ignoring which provider name was actually requested. Two providers with the same `base_url` always resolved to the first one's pool key.

### Fix

Three targeted changes:

1. **`agent/credential_pool.py` — `get_custom_provider_pool_key()`**: Added optional `provider_name` parameter. When provided (and not bare `"custom"`), matches by provider name first for disambiguation. Falls back to `base_url` matching when name is not available.

2. **`hermes_cli/runtime_provider.py` — `_try_resolve_from_custom_pool()`**: Passes `provider_name` through to `get_custom_provider_pool_key()` so named provider lookups are unambiguous.

3. **`agent/credential_pool.py` — `_seed_custom_pool()`**: Replaced indirect `get_custom_provider_pool_key(model_base_url)` call with direct comparison against the current pool_key's own config entry, eliminating first-match ambiguity entirely for this path.

### Testing

- All 41 existing `test_credential_pool.py` tests pass
- All 109 existing `test_runtime_provider_resolution.py` tests pass

Closes #19083