### PR TITLE
fix(gateway): read api_key from model config in /model command handler

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7473,6 +7473,7 @@ class GatewayRunner:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    current_api_key = model_cfg.get("api_key", "")
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers


### PR DESCRIPTION
## Summary

Fixes #18681

The `/model` command handler in the messaging gateway reads `model.default`, `model.provider`, and `model.base_url` from `config.yaml`, but **did not read `model.api_key`**. This caused `probe_api_models()` to send unauthenticated requests to custom endpoints that require bearer tokens, resulting in 401 errors.

### Fix

Added one line after the `current_base_url` assignment:

```python
current_api_key = model_cfg.get("api_key", "")
```

This matches the pattern already used in `tui_gateway/server.py` which correctly reads the API key from the agent object.

### Testing

Verified that the `/model` command now correctly passes the API key when probing custom endpoints with authentication.

Closes #18681