### PR TITLE
fix: refresh systemd unit on gateway boot (not just start/restart)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2492,6 +2492,20 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
                  hasn't fully exited yet.
     """
     sys.path.insert(0, str(PROJECT_ROOT))
+
+    # Refresh the systemd unit definition on every boot so that restart
+    # settings (RestartSec, StartLimitIntervalSec, etc.) stay current even
+    # when the process was respawned via exit-code-75 (stale-code or
+    # /restart) rather than through `hermes gateway restart` which already
+    # calls refresh_systemd_unit_if_needed().  Without this, a code update
+    # that ships new unit settings won't take effect until the next manual
+    # `hermes gateway start/restart` — leaving the gateway vulnerable to
+    # the exact failure mode the new settings were meant to prevent.
+    if supports_systemd_services():
+        try:
+            refresh_systemd_unit_if_needed(system=False)
+        except Exception:
+            pass  # best-effort; don't block gateway startup
     
     from gateway.run import start_gateway
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -107,6 +107,40 @@ class TestSystemdServiceRefresh:
         ]
 
 
+    def test_run_gateway_refreshes_outdated_unit_on_boot(self, tmp_path, monkeypatch):
+        """run_gateway() should refresh the systemd unit on boot so that
+        restart settings take effect even when the process was respawned
+        via exit-code-75 (bypassing `hermes gateway restart`)."""
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        # Prevent run_gateway from actually starting the gateway
+        def fake_start_gateway(**kwargs):
+            import asyncio
+            f = asyncio.Future()
+            f.set_result(True)
+            return f
+
+        monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+
+        gateway_cli.run_gateway()
+
+        assert unit_path.read_text(encoding="utf-8") == "new unit\n"
+        assert ["systemctl", "--user", "daemon-reload"] in calls
+
+
 class TestGeneratedSystemdUnits:
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=False)


### PR DESCRIPTION
## Problem

PR #18639 shipped resilient restart settings (`StartLimitIntervalSec=0`, `RestartSec=60`, exponential backoff) but they only took effect when the gateway was cold-started via `hermes gateway start` or explicitly restarted via `hermes gateway restart`. Both paths call `refresh_systemd_unit_if_needed()` which rewrites the unit file and runs `daemon-reload`.

**This is a broader issue that affects all users.** The standard update flow is:

1. User runs `hermes update`
2. `cmd_update()` pulls code, reinstalls deps
3. Sends USR1 to the running gateway → gateway drains → exits with code 75
4. systemd sees `RestartForceExitStatus=75` → respawns the process
5. New Python code runs ✓
6. **systemd unit file is never refreshed** ✗ — no `daemon-reload`, no unit rewrite

`cmd_update()` in `hermes_cli/main.py` (line ~7340) uses `_graceful_restart_via_sigusr1()` to restart all gateway services. This never goes through `systemd_restart()` or `systemd_start()` — it's purely signal-based, so `refresh_systemd_unit_if_needed()` is never called.

**This means no systemd unit changes have ever propagated through the normal update path.** Every unit-level fix shipped since the gateway service was introduced — restart limits, timeout changes, `After=` targets, `KillMode` settings — was silently ignored for users who updated normally and never ran `hermes gateway restart` manually.

### The discrepancy

The gateway has two layers that need to stay in sync:
- **Python code** (the running process) — updated automatically via stale-code detection + exit-75
- **systemd unit** (restart behavior, limits, dependencies) — only updated by explicit `hermes gateway start/restart` CLI commands

After every `hermes update`, the Python code is always current but the systemd unit can be arbitrarily stale. The update flow appears seamless (gateway restarts, new code runs) so users have no reason to suspect the unit is outdated.

## Fix

Call `refresh_systemd_unit_if_needed()` at the top of `run_gateway()` — the foreground entry point that systemd's `ExecStart` invokes on every boot. This ensures the unit definition is current regardless of how the process was spawned:

- `hermes gateway start` → runs `run_gateway()` → unit refreshed ✓
- `hermes gateway restart` → already refreshed in `systemd_restart()` + redundantly in `run_gateway()` ✓  
- `hermes update` → USR1 → exit 75 → systemd respawns → runs `run_gateway()` → **unit now refreshed** ✓
- Stale-code auto-restart → exit 75 → systemd respawns → runs `run_gateway()` → **unit now refreshed** ✓

Properties:
- **Best-effort**: exceptions are caught so a daemon-reload failure can't block gateway startup
- **No-op when current**: one `stat()` + string compare, zero overhead in the common case
- **Idempotent**: safe to call alongside the existing refresh in `systemd_start()`/`systemd_restart()`

## Test

Added `test_run_gateway_refreshes_outdated_unit_on_boot` — verifies that `run_gateway()` rewrites a stale unit and triggers daemon-reload before starting the gateway.

## Timeline of Today's Incident

| Time (UTC) | Event |
|---|---|
| May 2, 03:21 | PR #18639 merged |
| May 2, ~03:30 | `hermes update` pulled new code, sent USR1 to gateway |
| May 2, 07:42 | Stale-code detector triggered exit-75 respawn. New Python code running. **No daemon-reload — unit still has old settings.** |
| May 4, 08:41 | Telegram API outage begins |
| May 4, 08:41–08:46 | Gateway crash-loops with **30s** intervals (old `RestartSec`), counter reaches 12 |
| May 4, 08:46:44 | systemd: "Start request repeated too quickly" — permanently dead (old `StartLimitBurst=5` still in effect) |
| May 4, 10:43 | Manual `reset-failed` + `gateway start` → unit finally refreshed, gateway back |
