### PR TITLE
fix(cli): use get_env_value for base_url resolution in auth and runtime provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3414,6 +3414,7 @@ def get_codex_auth_status() -> Dict[str, Any]:
 
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
+    from hermes_cli.config import get_env_value
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "api_key":
         return {"configured": False}
@@ -3424,7 +3425,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = get_env_value(pconfig.base_url_env_var, "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3445,6 +3446,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
+    from hermes_cli.config import get_env_value
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
@@ -3456,7 +3458,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = get_env_value(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -3507,6 +3509,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     Returns dict with: provider, api_key, base_url, source.
     """
+    from hermes_cli.config import get_env_value
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "api_key":
         raise AuthError(
@@ -3528,7 +3531,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = get_env_value(pconfig.base_url_env_var, "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3549,6 +3552,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
 def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str, Any]:
     """Resolve runtime details for local subprocess-backed providers."""
+    from hermes_cli.config import get_env_value
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         raise AuthError(
@@ -3557,7 +3561,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = get_env_value(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3425,7 +3425,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = get_env_value(pconfig.base_url_env_var, "").strip()
+        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3458,7 +3458,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = get_env_value(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = (get_env_value(pconfig.base_url_env_var) or "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
@@ -3531,7 +3531,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = get_env_value(pconfig.base_url_env_var, "").strip()
+        env_url = (get_env_value(pconfig.base_url_env_var) or "").strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3561,7 +3561,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = get_env_value(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    base_url = (get_env_value(pconfig.base_url_env_var) or "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -842,9 +842,11 @@ def _resolve_explicit_runtime(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
+        from hermes_cli.config import get_env_value
+
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+            env_url = get_env_value(pconfig.base_url_env_var, "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -846,7 +846,7 @@ def _resolve_explicit_runtime(
 
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = get_env_value(pconfig.base_url_env_var, "").strip().rstrip("/")
+            env_url = (get_env_value(pconfig.base_url_env_var) or "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:


### PR DESCRIPTION
## Summary

Fixes #18757

`resolve_api_key_provider_credentials()` and related functions used `os.getenv()` to read `base_url_env_var`, which only checks exported shell environment variables. This misses values stored in `~/.hermes/.env` (the user dotenv file).

Meanwhile, API key resolution in the same functions correctly uses `get_env_value()` which reads both shell env and `.env` files — creating an inconsistency where API keys are found but base URLs are not.

### Fix

Replaced `os.getenv(pconfig.base_url_env_var, ...)` with `get_env_value(pconfig.base_url_env_var, ...)` in:

- `hermes_cli/auth.py` — 4 occurrences across 4 functions:
  - `get_api_key_provider_status()`
  - `get_external_process_provider_status()`
  - `resolve_api_key_provider_credentials()`
  - `resolve_external_process_provider_credentials()`
- `hermes_cli/runtime_provider.py` — 1 occurrence in `_resolve_explicit_runtime()`

### Testing

- Providers with base URL stored only in `~/.hermes/.env` (not exported) now correctly resolve the custom endpoint
- Providers with base URL exported in shell continue to work (env vars take precedence per #19201)

Closes #18757