### PR TITLE
fix(transport): add default max_tokens for custom providers with tools

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -287,6 +287,11 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.update(max_tokens_fn(32000))
         elif anthropic_max_out is not None:
             api_kwargs["max_tokens"] = anthropic_max_out
+        elif is_custom_provider and tools and max_tokens_fn:
+            # Custom proxies forwarding to Anthropic need max_tokens when
+            # tools are present — Anthropic's Messages API rejects requests
+            # without max_tokens when tool schemas are included (#19360).
+            api_kwargs.update(max_tokens_fn(4096))
 
         # Kimi: top-level reasoning_effort (unless thinking disabled)
         if is_kimi:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -272,6 +272,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
         is_tokenhub = params.get("is_tokenhub", False)
+        is_custom_provider = params.get("is_custom_provider", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:


### PR DESCRIPTION
## Summary

Fixes #19360

When Hermes Agent is configured with a custom OpenAI-compatible proxy that forwards to Anthropic models, all API requests fail with HTTP 400 when tools are present but `max_tokens` is not set.

### Root Cause

Anthropic's Messages API requires `max_tokens` when tool schemas are included. The chat_completions transport already has provider-specific defaults for NVIDIA NIM (16384), Qwen (65536), and Kimi (32000), but custom providers had no fallback.

### Fix

Added a fallback in `agent/transports/chat_completions.py`: when the provider is custom, tools are present, and no `max_tokens` is configured, default to 4096. This matches the existing Bedrock transport pattern (`self.max_tokens or 4096`).

### Behavior

- Custom provider **with** tools and **no** configured `max_tokens` → sends `max_tokens: 4096`
- Custom provider **without** tools → no `max_tokens` sent (unchanged)
- Custom provider **with** configured `max_tokens` → uses configured value (unchanged)
- Non-custom providers → unchanged (existing provider-specific defaults)

Closes #19360