### PR TITLE
Add per-call image generation quality

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -63,6 +63,17 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 }
 
 DEFAULT_MODEL = "gpt-image-2-medium"
+_VALID_QUALITIES = {"low", "medium", "high"}
+
+
+def _model_for_quality(quality: Any) -> Optional[Tuple[str, Dict[str, Any]]]:
+    if not isinstance(quality, str):
+        return None
+    normalized = quality.strip().lower()
+    if normalized not in _VALID_QUALITIES:
+        return None
+    model_id = f"gpt-image-2-{normalized}"
+    return model_id, _MODELS[model_id]
 
 _SIZES = {
     "landscape": "1536x1024",
@@ -365,7 +376,8 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
+        quality_override = _model_for_quality(kwargs.get("quality"))
+        tier_id, meta = quality_override if quality_override is not None else _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
         token = _read_codex_access_token()

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -72,6 +72,17 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 }
 
 DEFAULT_MODEL = "gpt-image-2-medium"
+_VALID_QUALITIES = {"low", "medium", "high"}
+
+
+def _model_for_quality(quality: Any) -> Optional[Tuple[str, Dict[str, Any]]]:
+    if not isinstance(quality, str):
+        return None
+    normalized = quality.strip().lower()
+    if normalized not in _VALID_QUALITIES:
+        return None
+    model_id = f"gpt-image-2-{normalized}"
+    return model_id, _MODELS[model_id]
 
 _SIZES = {
     "landscape": "1536x1024",
@@ -210,7 +221,8 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
+        quality_override = _model_for_quality(kwargs.get("quality"))
+        tier_id, meta = quality_override if quality_override is not None else _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
         # gpt-image-2 returns b64_json unconditionally and REJECTS

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -168,6 +168,46 @@ class TestGenerate:
         }
         assert codex_plugin._extract_image_b64(payload) == _b64_png()
 
+    @pytest.mark.parametrize("quality,expected_tier", [
+        ("low", "gpt-image-2-low"),
+        ("medium", "gpt-image-2-medium"),
+        ("high", "gpt-image-2-high"),
+    ])
+    def test_per_call_quality_overrides_configured_tier(self, provider, monkeypatch, quality, expected_tier):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-medium")
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality):
+            captured.update({"token": token, "prompt": prompt, "size": size, "quality": quality})
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", quality=quality)
+
+        assert result["model"] == expected_tier
+        assert result["quality"] == quality
+        assert captured["quality"] == quality
+
+    def test_invalid_per_call_quality_falls_back_to_configured_tier(self, provider, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-high")
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality):
+            captured.update({"token": token, "prompt": prompt, "size": size, "quality": quality})
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", quality="ultra")
+
+        assert result["model"] == "gpt-image-2-high"
+        assert result["quality"] == "high"
+        assert captured["quality"] == "high"
+
+
     def test_sse_parser_handles_event_and_data_lines(self):
         class _Response:
             def iter_lines(self):

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -182,6 +182,36 @@ class TestGenerate:
         # Always the same underlying API model regardless of tier.
         assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
 
+
+    @pytest.mark.parametrize("quality,expected_tier", [
+        ("low", "gpt-image-2-low"),
+        ("medium", "gpt-image-2-medium"),
+        ("high", "gpt-image-2-high"),
+    ])
+    def test_per_call_quality_overrides_configured_tier(self, provider, monkeypatch, quality, expected_tier):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-medium")
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", quality=quality)
+
+        assert result["model"] == expected_tier
+        assert result["quality"] == quality
+        assert fake_client.images.generate.call_args.kwargs["quality"] == quality
+
+    def test_invalid_per_call_quality_falls_back_to_configured_tier(self, provider, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-high")
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", quality="ultra")
+
+        assert result["model"] == "gpt-image-2-high"
+        assert result["quality"] == "high"
+        assert fake_client.images.generate.call_args.kwargs["quality"] == "high"
+
     @pytest.mark.parametrize("aspect,expected_size", [
         ("landscape", "1536x1024"),
         ("square", "1024x1024"),

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -2,7 +2,7 @@
 
 Covers the pure logic of the new wrapper: catalog integrity, the three size
 families (image_size_preset / aspect_ratio / gpt_literal), the supports
-whitelist, default merging, GPT quality override, and model resolution
+whitelist, default merging, GPT quality override, per-call quality, and model resolution
 fallback. Does NOT exercise fal_client submission — that's covered by
 tests/tools/test_managed_media_gateways.py.
 """
@@ -253,16 +253,29 @@ class TestDefaults:
 
 
 # ---------------------------------------------------------------------------
-# GPT-Image quality is pinned to medium (not user-configurable)
+# GPT-Image quality defaults and per-call override
 # ---------------------------------------------------------------------------
 
-class TestGptQualityPinnedToMedium:
-    """GPT-Image quality is baked into the FAL_MODELS defaults at 'medium'
-    and cannot be overridden via config. Pinning keeps Nous Portal billing
-    predictable across all users."""
+class TestGptQualityDefaults:
+    """GPT-Image defaults to medium quality unless the image_generate call
+    explicitly asks for low/medium/high. Config-level quality knobs remain
+    ignored so billing stays predictable by default."""
 
-    def test_gpt_payload_always_has_medium_quality(self, image_tool):
+    def test_gpt_payload_defaults_to_medium_quality(self, image_tool):
         p = image_tool._build_fal_payload("fal-ai/gpt-image-1.5", "hi", "square")
+        assert p["quality"] == "medium"
+
+    @pytest.mark.parametrize("quality", ["low", "medium", "high"])
+    def test_gpt_payload_accepts_per_call_quality_override(self, image_tool, quality):
+        p = image_tool._build_fal_payload(
+            "fal-ai/gpt-image-2", "hi", "square", overrides={"quality": quality}
+        )
+        assert p["quality"] == quality
+
+    def test_invalid_gpt_quality_override_is_ignored(self, image_tool):
+        p = image_tool._build_fal_payload(
+            "fal-ai/gpt-image-2", "hi", "square", overrides={"quality": "ultra"}
+        )
         assert p["quality"] == "medium"
 
     def test_config_quality_setting_is_ignored(self, image_tool):
@@ -363,11 +376,15 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_prompt_aspect_ratio_and_quality_to_agent(self, image_tool):
+        """Agents may request low/medium/high quality per image, while provider
+        and model selection remain user-level config choices."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "quality"}
+
+    def test_quality_enum_is_three_values(self, image_tool):
+        enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["quality"]["enum"]
+        assert set(enum) == {"low", "medium", "high"}
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -27,6 +27,7 @@ class _FakeCodexProvider(ImageGenProvider):
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
             "provider": "codex",
+            "quality": kwargs.get("quality"),
         }
 
 
@@ -44,13 +45,14 @@ class TestPluginDispatch:
         monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
         monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
 
-        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "square")
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "square", quality="high")
         payload = json.loads(dispatched)
 
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+        assert payload["quality"] == "high"
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
@@ -62,7 +64,7 @@ class TestPluginDispatch:
         monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "missing-codex")
         monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
 
-        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "landscape")
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "landscape", quality="medium")
         payload = json.loads(dispatched)
 
         assert payload["success"] is False
@@ -90,10 +92,11 @@ class TestPluginDispatch:
         monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", fake_ensure_plugins_discovered)
         monkeypatch.setattr(registry_module, "get_provider", lambda name: provider_state["provider"])
 
-        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw hammy", "portrait")
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw hammy", "portrait", quality="low")
         payload = json.loads(dispatched)
 
         assert calls == [False, True]
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+        assert payload["quality"] == "low"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -373,6 +373,8 @@ DEFAULT_MODEL = "fal-ai/flux-2/klein/9b"
 
 DEFAULT_ASPECT_RATIO = "landscape"
 VALID_ASPECT_RATIOS = ("landscape", "square", "portrait")
+DEFAULT_IMAGE_QUALITY = "medium"
+VALID_IMAGE_QUALITIES = ("low", "medium", "high")
 
 
 # ---------------------------------------------------------------------------
@@ -547,7 +549,14 @@ def _build_fal_payload(
 
     if overrides:
         for k, v in overrides.items():
-            if v is not None:
+            if v is None:
+                continue
+            if k == "quality" and isinstance(v, str):
+                quality = v.strip().lower()
+                if quality not in VALID_IMAGE_QUALITIES:
+                    continue
+                payload[k] = quality
+            else:
                 payload[k] = v
 
     supports = meta["supports"]
@@ -609,6 +618,7 @@ def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, A
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    quality: Optional[str] = None,
     num_inference_steps: Optional[int] = None,
     guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None,
@@ -617,8 +627,8 @@ def image_generate_tool(
 ) -> str:
     """Generate an image from a text prompt using the configured FAL model.
 
-    The agent-facing schema exposes only ``prompt`` and ``aspect_ratio``; the
-    remaining kwargs are overrides for direct Python callers and are filtered
+    The agent-facing schema exposes ``prompt``, ``aspect_ratio``, and optional
+    ``quality``. Remaining kwargs are overrides for direct Python callers and are filtered
     per-model via the ``supports`` whitelist (unsupported overrides are
     silently dropped so legacy callers don't break when switching models).
 
@@ -632,6 +642,7 @@ def image_generate_tool(
         "parameters": {
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
+            "quality": quality,
             "num_inference_steps": num_inference_steps,
             "guidance_scale": guidance_scale,
             "num_images": num_images,
@@ -662,6 +673,8 @@ def image_generate_tool(
             aspect_lc = DEFAULT_ASPECT_RATIO
 
         overrides: Dict[str, Any] = {}
+        if quality is not None:
+            overrides["quality"] = quality
         if num_inference_steps is not None:
             overrides["num_inference_steps"] = num_inference_steps
         if guidance_scale is not None:
@@ -906,6 +919,12 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "quality": {
+                "type": "string",
+                "enum": list(VALID_IMAGE_QUALITIES),
+                "description": "Optional generation quality. Use low for drafts, medium for normal/default work, and high only for final/high-stakes images. Unsupported providers ignore it.",
+                "default": DEFAULT_IMAGE_QUALITY,
+            },
         },
         "required": ["prompt"],
     },
@@ -951,7 +970,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, quality: Optional[str] = None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -1008,6 +1027,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if quality is not None:
+            kwargs["quality"] = quality
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -1035,16 +1056,18 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    quality = args.get("quality")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, quality=quality)
     if dispatched is not None:
         return dispatched
 
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=aspect_ratio,
+        quality=quality,
     )
 
 


### PR DESCRIPTION
## Summary
- expose optional `quality` (`low`, `medium`, `high`) on the `image_generate` tool schema
- pass per-call quality through plugin dispatch and FAL payload building, with invalid values ignored/falling back to configured defaults
- let OpenAI API-key and OpenAI Codex image providers map per-call quality to the existing `gpt-image-2-{quality}` tiers

## Tests
- `python -m compileall -q tools/image_generation_tool.py plugins/image_gen/openai/__init__.py plugins/image_gen/openai-codex/__init__.py`
- `pytest -q tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_openai_provider.py tests/plugins/image_gen/test_openai_codex_provider.py`

## Notes
- Gateway not restarted. The new tool schema will require a gateway/session restart before live agents see the `quality` argument.
- Full `pytest -q` currently has unrelated baseline/environment failures in Discord/Vercel/TUI/etc.; touched image generation tests pass.
