### PR TITLE
fix(test): add skip marker for transcription tests requiring faster_whisper

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -414,6 +414,10 @@ class TestTranscribeLocalCommand:
 # _transcribe_local — additional tests
 # ============================================================================
 
+@pytest.mark.skipif(
+    not __import__("importlib").util.find_spec("faster_whisper"),
+    reason="faster_whisper not installed",
+)
 class TestTranscribeLocalExtended:
     def test_model_reuse_on_second_call(self, tmp_path):
         """Second call with same model should NOT reload the model."""


### PR DESCRIPTION
Salvage of #16045 onto current main.

## Summary
`TestTranscribeLocalExtended` patches `faster_whisper.WhisperModel`, which triggers `ModuleNotFoundError` when `faster_whisper` is not installed. Gate the class on `importlib.util.find_spec('faster_whisper')` via `pytest.mark.skipif` so the 8 tests in that class skip cleanly on environments without the optional dep.

## Validation
scripts/run_tests.sh tests/tools/test_transcription_tools.py -> passed

Original PR: #16045