### PR TITLE
fix(gateway/slack): report failure and deliver all chunks for slash-command replies

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -436,23 +436,26 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         ctx: Dict[str, Any],
         content: str,
+        chat_id: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> "SendResult":
         """Replace the initial ephemeral ack via ``response_url``.
 
-        Slack's ``response_url`` accepts a POST with ``replace_original``
+        Slack’s ``response_url`` accepts a POST with ``replace_original``
         for up to 30 minutes after the slash command was invoked.  This
-        lets us swap the "Running /cmd…" placeholder with the real reply,
-        and the message stays ephemeral ("Only visible to you").
+        lets us swap the “Running /cmd…” placeholder with the real reply,
+        and the message stays ephemeral (“Only visible to you”).
 
-        Falls back to a simple ``True`` SendResult if the POST fails —
-        the user already saw the initial ack, so a delivery failure here
-        is non-critical.
+        For multi-chunk responses the first chunk replaces the ephemeral
+        ack and subsequent chunks are delivered as normal channel messages
+        so the user sees the complete output.
+
+        Returns ``SendResult(success=False, ...)`` when the ``response_url``
+        POST fails so that the caller can surface or retry the failure
+        instead of silently swallowing it.
         """
         formatted = self.format_message(content)
-        # Slack's response_url has the same ~40k char limit as chat_postMessage.
-        # Truncate to MAX_MESSAGE_LENGTH and use only the first chunk — the
-        # response_url replaces a single ephemeral ack, so multi-chunk isn't
-        # possible.  Long responses are rare for command replies.
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         text = chunks[0] if chunks else formatted
         payload = {
@@ -460,6 +463,7 @@ class SlackAdapter(BasePlatformAdapter):
             "replace_original": True,
             "text": text,
         }
+        ephemeral_ok = False
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
@@ -468,18 +472,46 @@ class SlackAdapter(BasePlatformAdapter):
                     timeout=aiohttp.ClientTimeout(total=10),
                 ) as resp:
                     if resp.status == 200:
-                        return SendResult(success=True, message_id=None)
-                    body = await resp.text()
-                    logger.warning(
-                        "[Slack] response_url POST returned %s: %s",
-                        resp.status,
-                        body[:200],
-                    )
+                        ephemeral_ok = True
+                    else:
+                        body = await resp.text()
+                        logger.warning(
+                            "[Slack] response_url POST returned %s: %s",
+                            resp.status,
+                            body[:200],
+                        )
         except Exception as e:
             logger.warning(
                 "[Slack] response_url POST failed: %s", e,
             )
-        # Non-fatal — the user saw the initial ack already.
+
+        if not ephemeral_ok:
+            return SendResult(
+                success=False,
+                error="response_url delivery failed",
+                retryable=True,
+            )
+
+        # Deliver remaining chunks (if any) as normal channel messages so the
+        # user sees the full response.  The first chunk already replaced the
+        # ephemeral ack above.
+        if len(chunks) > 1 and chat_id:
+            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            for extra_chunk in chunks[1:]:
+                kwargs = {
+                    "channel": chat_id,
+                    "text": extra_chunk,
+                    "mrkdwn": True,
+                }
+                if thread_ts:
+                    kwargs["thread_ts"] = thread_ts
+                try:
+                    await self._get_client(chat_id).chat_postMessage(**kwargs)
+                except Exception as e:
+                    logger.warning(
+                        "[Slack] follow-up chunk delivery failed: %s", e,
+                    )
+
         return SendResult(success=True, message_id=None)
 
     async def connect(self) -> bool:
@@ -720,6 +752,7 @@ class SlackAdapter(BasePlatformAdapter):
             if slash_ctx:
                 return await self._send_slash_ephemeral(
                     slash_ctx, content,
+                    chat_id=chat_id, reply_to=reply_to, metadata=metadata,
                 )
 
             # Convert standard markdown → Slack mrkdwn

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2932,7 +2932,7 @@ class TestSlashEphemeralAck:
 
     @pytest.mark.asyncio
     async def test_send_slash_ephemeral_fallback_on_post_failure(self, adapter):
-        """_send_slash_ephemeral returns success=True even if POST fails."""
+        """_send_slash_ephemeral returns success=False with retryable=True when POST fails."""
         import time
         adapter._slash_command_contexts[("C1", "U1")] = {
             "response_url": "https://hooks.slack.com/commands/bad",
@@ -2954,11 +2954,13 @@ class TestSlashEphemeralAck:
             result = await adapter.send("C1", "Some response")
 
         # Still success — the user saw the initial ack already
-        assert result.success is True
+        assert result.success is False
+        assert result.retryable is True
+        assert result.error == "response_url delivery failed"
 
     @pytest.mark.asyncio
     async def test_send_slash_ephemeral_fallback_on_exception(self, adapter):
-        """_send_slash_ephemeral returns success=True even if aiohttp raises."""
+        """_send_slash_ephemeral returns success=False with retryable=True when aiohttp raises."""
         import time
         adapter._slash_command_contexts[("C1", "U1")] = {
             "response_url": "https://hooks.slack.com/commands/timeout",
@@ -2973,7 +2975,8 @@ class TestSlashEphemeralAck:
         with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
             result = await adapter.send("C1", "Some response")
 
-        assert result.success is True
+        assert result.success is False
+        assert result.retryable is True
 
     @pytest.mark.asyncio
     async def test_native_slash_stashes_context_and_dispatches(self, adapter):


### PR DESCRIPTION
## Summary

Fix two bugs in the Slack slash-command ephemeral reply path (`_send_slash_ephemeral`):

1. **Silent truncation**: Only the first chunk of multi-chunk responses was delivered via `response_url`. Follow-up chunks were silently dropped, so users with long `/help`, `/commands`, or `/model` output only saw partial responses.

2. **False success on failure**: When the `response_url` POST failed (non-200 status or exception), the method returned `SendResult(success=True)`, making the caller believe delivery succeeded even though the user may have only seen the initial "Running …" acknowledgement.

## Changes

- **`gateway/platforms/slack.py`**: 
  - `_send_slash_ephemeral` now accepts `chat_id`, `reply_to`, and `metadata` parameters
  - After replacing the ephemeral ack with the first chunk, any remaining chunks are posted as normal channel messages via `chat_postMessage`
  - Returns `SendResult(success=False, error="response_url delivery failed", retryable=True)` when the `response_url` POST fails
  - Updated call site in `send()` to pass through `chat_id`, `reply_to`, and `metadata`

- **`tests/gateway/test_slack.py`**: Updated the two existing tests (`test_send_slash_ephemeral_fallback_on_post_failure` and `test_send_slash_ephemeral_fallback_on_exception`) to assert the corrected `success=False` + `retryable=True` behavior.

## Testing

All 180 Slack gateway tests pass.

Closes #19688