### PR TITLE
fix(env): pass -- to cd for hyphen-prefixed workdirs

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -30,7 +30,7 @@ class TestWrapCommand:
         wrapped = env._wrap_command("echo hello", "/tmp")
 
         assert "source" in wrapped
-        assert "cd /tmp" in wrapped or "cd '/tmp'" in wrapped
+        assert "cd -- /tmp" in wrapped or "cd -- '/tmp'" in wrapped
         assert "eval 'echo hello'" in wrapped
         assert "__hermes_ec=$?" in wrapped
         assert "export -p >" in wrapped
@@ -57,24 +57,31 @@ class TestWrapCommand:
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "~")
 
-        assert "cd ~" in wrapped
-        assert "cd '~'" not in wrapped
+        assert "cd -- ~" in wrapped
+        assert "cd -- '~'" not in wrapped
 
     def test_tilde_subpath_with_spaces_uses_home_and_quotes_suffix(self):
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "~/my repo")
 
-        assert "cd $HOME/'my repo'" in wrapped
-        assert "cd ~/my repo" not in wrapped
+        assert "cd -- $HOME/'my repo'" in wrapped
+        assert "cd -- ~/my repo" not in wrapped
 
     def test_tilde_slash_maps_to_home(self):
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("ls", "~/")
 
-        assert "cd $HOME" in wrapped
-        assert "cd ~/" not in wrapped
+        assert "cd -- $HOME" in wrapped
+        assert "cd -- ~/" not in wrapped
+
+    def test_hyphen_prefixed_workdir_is_passed_after_double_dash(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("pwd", "-demo")
+
+        assert "builtin cd -- -demo || exit 126" in wrapped
 
     def test_cd_failure_exit_126(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -405,7 +405,8 @@ class BaseEnvironment(ABC):
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
         quoted_cwd = self._quote_cwd_for_cd(cwd)
-        parts.append(f"builtin cd {quoted_cwd} || exit 126")
+        # ``--`` keeps hyphen-prefixed directory names from being parsed as options.
+        parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")


### PR DESCRIPTION
Salvage of #15513 by @Yoimex onto current main, with one follow-up test update.

## Summary
The command wrapper in `tools/environments/base.py` built `cd <workdir>` shell commands. Work directories starting with `-` were interpreted as options by the `cd` builtin, causing the whole subprocess invocation to fail. Insert the POSIX end-of-options separator `--` before the workdir so any remaining arg is treated as a path.

## Salvage-time update
One pre-existing test (`test_basic_shape`) asserted the old `cd /tmp` shape and broke after the change. Updated it to the new `cd -- /tmp` shape so the full wrap-command test suite still passes.

## Changes
- tools/environments/base.py: `cd -- <workdir>` (+2/-2)
- tests/tools/test_base_environment.py: update existing assertions + add regression test for hyphen-prefixed workdir (+14/-6)

## Validation
scripts/run_tests.sh tests/tools/test_base_environment.py -> 18 passed

Original PR: #15513
