### PR TITLE
fix(kanban): reject direct status transition to 'running' via dashboard API (salvage of #19554)

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -449,7 +449,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     ok = _set_status_direct(conn, task_id, "ready")
             elif s == "archived":
                 ok = kanban_db.archive_task(conn, task_id)
-            elif s in ("todo", "running", "triage"):
+            elif s == "running":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
+                )
+            elif s in ("todo", "triage"):
                 ok = _set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -253,6 +253,33 @@ def test_patch_invalid_status(client):
     assert r.status_code == 400
 
 
+def test_patch_status_running_rejected(client):
+    """Dashboard PATCH cannot transition a task directly to 'running'.
+
+    The only legitimate path into 'running' is through the dispatcher's
+    ``claim_task`` — which atomically creates a ``task_runs`` row,
+    claim_lock, expiry, and worker-PID metadata. Allowing a direct set
+    creates orphaned 'running' tasks with no run row or claim, which
+    violate the board's run-history invariants. See issue #19535.
+    """
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "running"},
+    )
+    assert r.status_code == 400
+    assert "running" in r.json()["detail"]
+    # Task's status should still be its pre-request value — the direct-set
+    # was rejected before any mutation.
+    board = client.get("/api/plugins/kanban/board").json()
+    statuses = {
+        tt["id"]: col["name"]
+        for col in board["columns"]
+        for tt in col["tasks"]
+    }
+    assert statuses.get(t["id"]) != "running"
+
+
 # ---------------------------------------------------------------------------
 # Comments + Links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #19535. Salvage of @luyao618's PR #19554 onto current main with a regression test the reporter asked for.

## Summary
Dashboard `PATCH /tasks/:id` now returns HTTP 400 for `status=running` instead of silently bypassing the dispatcher. The only legitimate path into `running` is the dispatcher's `claim_task`, which atomically creates the `task_runs` row, claim_lock, expiry, and worker-PID metadata that the rest of the kanban lifecycle depends on.

## Root cause
`plugins/kanban/dashboard/plugin_api.py` line 417 lumped `running` in with `todo`/`triage` in the `_set_status_direct` branch of the status-PATCH handler. A dashboard or API caller could transition any task to `running` with no active worker, no claim lock, and no run row — creating orphaned tasks stuck in `running` state with no recovery path short of manual DB surgery.

## Changes
- **Commit 1 (@luyao618's cherry-pick):** Rejects `status=running` via PATCH with HTTP 400, splits the `("todo", "triage")` tuple out into its own `_set_status_direct` branch.
- **Commit 2 (follow-up):** Adds `test_patch_status_running_rejected` in `tests/plugins/test_kanban_dashboard_plugin.py` — asserts both the 400 response and that the task's pre-request status is preserved (no partial mutation). This was explicitly requested in the issue body ("Add regression tests ensuring PATCH /tasks/{id} with status='running' is rejected") but skipped in the original PR.

## Validation
`tests/plugins/test_kanban_dashboard_plugin.py` — 43/43 pass (42 existing + 1 new).

Manual verification against a running dashboard would require seeding a task and hitting the endpoint; the regression test covers that path with the FastAPI TestClient.