### PR TITLE
fix(api_server): emit run.failed when run_conversation returns failed=True

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2578,21 +2578,39 @@ class APIServerAdapter(BasePlatformAdapter):
                     return r, u
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
-                final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                q.put_nowait({
-                    "event": "run.completed",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "output": final_response,
-                    "usage": usage,
-                })
-                self._set_run_status(
-                    run_id,
-                    "completed",
-                    output=final_response,
-                    usage=usage,
-                    last_event="run.completed",
-                )
+                # Check for structured failure (non-retryable client errors like
+                # 401/400 return failed=True instead of raising, so the except
+                # block below never fires — issue #15561).
+                if isinstance(result, dict) and result.get("failed"):
+                    error_msg = result.get("error") or "agent run failed"
+                    q.put_nowait({
+                        "event": "run.failed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "error": error_msg,
+                    })
+                    self._set_run_status(
+                        run_id,
+                        "failed",
+                        error=error_msg,
+                        last_event="run.failed",
+                    )
+                else:
+                    final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    q.put_nowait({
+                        "event": "run.completed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "output": final_response,
+                        "usage": usage,
+                    })
+                    self._set_run_status(
+                        run_id,
+                        "completed",
+                        output=final_response,
+                        usage=usage,
+                        last_event="run.completed",
+                    )
             except asyncio.CancelledError:
                 self._set_run_status(
                     run_id,


### PR DESCRIPTION
Salvage of #15564 by @ygd58 onto current main.

## Summary
When `run_conversation` hits a non-retryable client error (401, 400, etc.), it returns `{failed: True, error: ...}` instead of raising. The gateway's `_run_sync` branch only handled the exception path, so failed runs were serialized as `run.completed` with empty output. Detect structured failure and emit `run.failed` with the error message.

## Conflict resolution during salvage
Main has added run-status state tracking (`_set_run_status`, cancellation handling) around this block. The failed-path check now also calls `self._set_run_status(run_id, "failed", error=..., last_event="run.failed")` so the API-server run-status cache stays consistent with the emitted event.

## Changes
- gateway/platforms/api_server.py: branch on `result.get("failed")` → emit run.failed + mark status (+33/-15)

## Validation
scripts/run_tests.sh tests/gateway/test_api_server.py -> 126 passed

Original PR: #15564
