### PR TITLE
fix(self-improvement-loop): give bg review 16 iters and hide mid-review status leaks

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3611,7 +3611,7 @@ class AIAgent:
                     _parent_runtime = self._current_main_runtime()
                     review_agent = AIAgent(
                         model=self.model,
-                        max_iterations=8,
+                        max_iterations=16,
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
@@ -3629,6 +3629,14 @@ class AIAgent:
                     review_agent._user_profile_enabled = self._user_profile_enabled
                     review_agent._memory_nudge_interval = 0
                     review_agent._skill_nudge_interval = 0
+                    # Suppress all status/warning emits from the fork so the
+                    # user only sees the final successful-action summary.
+                    # Without this, mid-review "Iteration budget exhausted",
+                    # rate-limit retries, compression warnings, and other
+                    # lifecycle messages bubble up through _emit_status ->
+                    # _vprint and leak past the stdout redirect (they go via
+                    # _print_fn/status_callback, which bypass sys.stdout).
+                    review_agent.suppress_status_output = True
 
                     review_agent.run_conversation(
                         user_message=prompt,


### PR DESCRIPTION
## Summary
The background memory/skill review fork no longer trips its own iteration-budget warning on multi-step reviews, and no longer leaks mid-review lifecycle messages into the user's terminal. Only the final `💾 Self-improvement review: ...` summary reaches the user.

## Changes
- `run_agent.py` `_spawn_background_review`: bump fork `max_iterations` 8 → 16
- `run_agent.py` `_spawn_background_review`: set `review_agent.suppress_status_output = True` on the fork

## Why
Two user-visible issues showed up during a long CLI session that triggered a combined memory+skill review:

1. **Budget too tight.** 8 iterations isn't enough for a review that does `skill_view` on a couple of candidate skills, adds a memory entry, and patches a skill. The review would hit `Iteration budget exhausted (8/8)` and leave work half-done.
2. **Status leaks past the stdout redirect.** The fork already runs under `quiet_mode=True` + `contextlib.redirect_stdout(devnull)` + `redirect_stderr(devnull)`. But `_emit_status` / `_emit_warning` route through `_vprint(force=True)` → `_print_fn` / `status_callback`, which bypass `sys.stdout` entirely. So mid-review `⚠️ Iteration budget exhausted`, rate-limit retries, compression warnings, etc. all bubbled up to the user. `suppress_status_output` is the existing (already-wired) flag that short-circuits `_vprint` unconditionally — repurposing it here is the cleanest fix.

The summary filter was already correct — `_summarize_background_review_actions` already gates on `data.get('success')` so failed attempts and reasoning text never reach the summary line. The leak was from the fork's own lifecycle emits, not the summarizer.

## Validation
| | Before | After |
|---|---|---|
| Review budget | 8 iters | 16 iters |
| User sees mid-review `Iteration budget exhausted` | Yes | No |
| User sees rate-limit / compression / retry emits | Yes | No |
| User sees final `💾 Self-improvement review: ...` summary | Yes | Yes |
| Summary contents | success-only (unchanged) | success-only (unchanged) |

`py_compile` passes. Skill reference doc (`references/self-improvement-loop.md`) updated separately to reflect the new invariants.