### PR TITLE
fix(telegram): fall back to document on any send_photo failure, not just dim errors

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2268,14 +2268,36 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             error_str = str(e)
-            # Check for dimension-related errors - fallback to document mode
-            if "Photo_invalid_dimensions" in error_str or "PHOTO_INVALID_DIMENSIONS" in error_str:
+            # Dimension-related errors are the expected case for valid image
+            # files that Telegram just refuses as photos (screenshots, extreme
+            # aspect ratios). Log at INFO because the document fallback is
+            # the correct path. Any other send_photo failure also falls back
+            # to document (rate limits, corrupt file markers, format edge
+            # cases), but at WARNING because it's unexpected and worth
+            # surfacing in logs.
+            is_dim_error = (
+                "Photo_invalid_dimensions" in error_str
+                or "PHOTO_INVALID_DIMENSIONS" in error_str
+            )
+            if is_dim_error:
                 logger.info(
-                    "[%s] Image dimensions exceed Telegram photo limits, sending as document: %s",
+                    "[%s] Image dimensions exceed Telegram photo limits, "
+                    "sending as document: %s",
                     self.name,
                     image_path,
                 )
-                # Fallback to sending as document (file) - no dimension limits, only 50MB size limit
+            else:
+                logger.warning(
+                    "[%s] Failed to send Telegram local image as photo, "
+                    "trying document fallback: %s",
+                    self.name,
+                    e,
+                    exc_info=True,
+                )
+            # Fallback to sending as document (file) — no dimension limit,
+            # only 50MB size limit. If even that fails, fall back to the
+            # base adapter's text-only "Image: /path" rendering.
+            try:
                 return await self.send_document(
                     chat_id=chat_id,
                     file_path=image_path,
@@ -2284,13 +2306,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to=reply_to,
                     metadata=metadata,
                 )
-            logger.error(
-                "[%s] Failed to send Telegram local image, falling back to base adapter: %s",
-                self.name,
-                e,
-                exc_info=True,
-            )
-            return await super().send_image_file(chat_id, image_path, caption, reply_to)
+            except Exception as doc_err:
+                logger.error(
+                    "[%s] Failed to send Telegram local image as document, "
+                    "falling back to base adapter: %s",
+                    self.name,
+                    doc_err,
+                    exc_info=True,
+                )
+                return await super().send_image_file(chat_id, image_path, caption, reply_to)
 
     async def send_document(
         self,


### PR DESCRIPTION
Salvage of #15837 by @QifengKuang onto current main, broadening the existing dimension-specific fallback.

## Summary
Earlier work (#19630) added document-fallback for the specific `Photo_invalid_dimensions` error on send_photo. #15837 correctly pointed out that other failures (rate limits on the photo endpoint, corrupt-looking image markers, format edge cases) also benefit from the same fallback — degrading to a text-only "Image: /path" from the base adapter is strictly worse for users than attempting a document send.

Broaden the fallback to fire on ANY send_photo exception. Keep the dimension case logging at INFO (document is the expected path for screenshots / tall images). Log all other failures at WARNING with exc_info so they stay visible. If send_document itself fails, still fall back to the base adapter as a last resort.

## Adaptation during salvage
Original PR unconditionally logged at WARNING. Kept the INFO-vs-WARNING split for known-benign dimension errors so log noise stays quiet for the expected case.

## Changes
- gateway/platforms/telegram.py: dimension-aware logging + try/except document fallback on any photo failure (+35/-11)

## Validation
scripts/run_tests.sh tests/gateway/ -k telegram → 379 passed

Original PR: #15837
