### PR TITLE
fix(redact): add code_file param to skip false-positive ENV/JSON patterns

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -305,13 +305,18 @@ def _redact_form_body(text: str) -> str:
     return _redact_query_string(text.strip())
 
 
-def redact_sensitive_text(text: str, *, force: bool = False) -> str:
+def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
     """Apply all redaction patterns to a block of text.
 
     Safe to call on any string -- non-matching text passes through unchanged.
     Disabled by default — enable via security.redact_secrets: true in config.yaml.
     Set force=True for safety boundaries that must never return raw secrets
     regardless of the user's global logging redaction preference.
+
+    Set code_file=True to skip the ENV-assignment and JSON-field regex
+    patterns when the text is known to be source code (e.g. MAX_TOKENS=***
+    constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
+    private keys, DB connstrings, JWTs, and URL secrets are still redacted.
     """
     if text is None:
         return None
@@ -325,17 +330,18 @@ def redact_sensitive_text(text: str, *, force: bool = False) -> str:
     # Known prefixes (sk-, ghp_, etc.)
     text = _PREFIX_RE.sub(lambda m: _mask_token(m.group(1)), text)
 
-    # ENV assignments: OPENAI_API_KEY=sk-abc...
-    def _redact_env(m):
-        name, quote, value = m.group(1), m.group(2), m.group(3)
-        return f"{name}={quote}{_mask_token(value)}{quote}"
-    text = _ENV_ASSIGN_RE.sub(_redact_env, text)
+    # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
+    if not code_file:
+        def _redact_env(m):
+            name, quote, value = m.group(1), m.group(2), m.group(3)
+            return f"{name}={quote}{_mask_token(value)}{quote}"
+        text = _ENV_ASSIGN_RE.sub(_redact_env, text)
 
-    # JSON fields: "apiKey": "value"
-    def _redact_json(m):
-        key, value = m.group(1), m.group(2)
-        return f'{key}: "{_mask_token(value)}"'
-    text = _JSON_FIELD_RE.sub(_redact_json, text)
+        # JSON fields: "apiKey": "***"  (skip for code files — false positives)
+        def _redact_json(m):
+            key, value = m.group(1), m.group(2)
+            return f'{key}: "{_mask_token(value)}"'
+        text = _JSON_FIELD_RE.sub(_redact_json, text)
 
     # Authorization headers
     text = _AUTH_HEADER_RE.sub(

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -570,7 +570,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
-            result.content = redact_sensitive_text(result.content)
+            result.content = redact_sensitive_text(result.content, code_file=True)
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
@@ -993,7 +993,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
-                    m.content = redact_sensitive_text(m.content)
+                    m.content = redact_sensitive_text(m.content, code_file=True)
         result_dict = result.to_dict()
 
         if count >= 3:


### PR DESCRIPTION
Salvage of #16127 by @ms-alan onto current main.

## Summary
`ENV_ASSIGN` and `JSON_FIELD` regex patterns in `redact_sensitive_text()` cause false positives when reading source code files — `MAX_TOKENS=***` triggers the ENV-assignment pattern even though it's a constant definition, and `"apiKey": "test"` in test fixtures matches the JSON-field pattern. Both are safe content in that context. Add a `code_file=True` flag that skips those two patterns while keeping prefix patterns, auth headers, private keys, DB connstrings, JWTs, and URL secrets always redacted.

## Conflict resolution during salvage
Main has since added a `force: bool = False` keyword-only param to the signature. Merged signatures to accept both kwargs: `redact_sensitive_text(text, *, force=False, code_file=False)`. Docstring updated to explain both flags.

## Note on authorship
The contributor's original commit had an empty author email (`pander <>`, local git-config quirk). Re-attributed to `ms-alan <chenb19870707@gmail.com>` (GitHub public email) during salvage so the commit passes AUTHOR_MAP validation.

## Changes
- agent/redact.py: `code_file=True` skips ENV/JSON patterns (+20/-14)

## Validation
scripts/run_tests.sh tests/agent/ -k redact -> 78 passed

Original PR: #16127
Fixes: #15934
