### PR TITLE
fix(update): avoid package-lock churn on npm fallback

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5293,12 +5293,14 @@ def _run_npm_install_deterministic(
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
-    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present;
-    falls back to ``npm install`` only if ``npm ci`` fails (e.g. lockfile out of
-    sync on a WIP checkout).  Without this, ``npm install`` on npm ≥ 10 silently
-    rewrites committed lockfiles (stripping ``"peer": true`` etc.), which leaves
-    the working tree dirty and causes the next ``hermes update`` to stash the
-    lockfile — repeatedly.
+    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present.
+    If ``npm ci`` fails (for example because a WIP checkout's lockfile is out of
+    sync), fall back to ``npm install --package-lock=false`` so the update can
+    still refresh ``node_modules`` without silently rewriting committed
+    lockfiles.  Plain ``npm install`` on npm ≥ 10 rewrites lockfiles (stripping
+    ``"peer": true`` and adding optional peer metadata), leaving the working
+    tree dirty and causing the next ``hermes update`` to stash the same lockfile
+    again.
     """
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
@@ -5312,9 +5314,10 @@ def _run_npm_install_deterministic(
         )
         if ci_result.returncode == 0:
             return ci_result
-        # Fall through to `npm install` — lockfile may be out of sync on a
-        # WIP fork/branch, or `npm ci` may not be available on very old npm.
-    install_cmd = [npm, "install", *extra_args]
+        # Fall through to `npm install --package-lock=false` — lockfile may be
+        # out of sync on a WIP fork/branch, or `npm ci` may not be available on
+        # very old npm, but update/install flows must not dirty the checkout.
+    install_cmd = [npm, "install", "--package-lock=false", *extra_args]
     return subprocess.run(
         install_cmd,
         cwd=cwd,

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -13,7 +13,11 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import _web_ui_build_needed, _build_web_ui
+from hermes_cli.main import (
+    _build_web_ui,
+    _run_npm_install_deterministic,
+    _web_ui_build_needed,
+)
 
 
 def _touch(path: Path, offset: float = 0.0) -> None:
@@ -94,6 +98,60 @@ class TestWebUIBuildNeeded:
         _touch(dist_dir / ".vite" / "manifest.json", offset=-10)
         _touch(web_dir / "dist" / "assets" / "index.js")
         assert _web_ui_build_needed(web_dir) is False
+
+
+class TestNpmInstallDeterministic:
+    def test_uses_npm_ci_when_lockfile_is_present(self, tmp_path):
+        (tmp_path / "package-lock.json").write_text("{}")
+        success = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+
+        with patch("hermes_cli.main.subprocess.run", return_value=success) as mock_run:
+            result = _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                tmp_path,
+                extra_args=("--silent", "--no-audit"),
+            )
+
+        assert result is success
+        mock_run.assert_called_once_with(
+            ["/usr/bin/npm", "ci", "--silent", "--no-audit"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_fallback_install_never_rewrites_lockfile(self, tmp_path):
+        (tmp_path / "package-lock.json").write_text("{}")
+        failed_ci = __import__("subprocess").CompletedProcess(
+            [], 1, stdout="", stderr="lockfile out of sync"
+        )
+        install_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+
+        with patch(
+            "hermes_cli.main.subprocess.run",
+            side_effect=[failed_ci, install_ok],
+        ) as mock_run:
+            result = _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                tmp_path,
+                extra_args=("--silent", "--no-audit"),
+            )
+
+        assert result is install_ok
+        assert mock_run.call_args_list[0].args[0] == [
+            "/usr/bin/npm",
+            "ci",
+            "--silent",
+            "--no-audit",
+        ]
+        assert mock_run.call_args_list[1].args[0] == [
+            "/usr/bin/npm",
+            "install",
+            "--package-lock=false",
+            "--silent",
+            "--no-audit",
+        ]
 
 
 class TestBuildWebUISkipsWhenFresh:


### PR DESCRIPTION
## Summary
- keep `hermes update` from rewriting committed npm lockfiles when the `npm ci` path fails
- fall back to `npm install --package-lock=false` instead of plain `npm install`
- add tests for both the normal `npm ci` path and the lockfile-preserving fallback

## Why
On npm 10, plain `npm install` can rewrite `package-lock.json` metadata even during an update flow that only needs to refresh `node_modules`. If `npm ci` fails because a lockfile is temporarily out of sync, the current fallback can leave the checkout dirty and make later updates stash the same lockfile repeatedly.

## Tests
- `python -m pytest tests/hermes_cli/test_web_ui_build.py -q -o 'addopts='`
- manual repro against `ui-tui` using `_run_npm_install_deterministic`; the fallback completed without changing `package-lock.json`
