### PR TITLE
fix(vision): preserve ZAI credential resolution with custom base_url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2648,8 +2648,11 @@ def resolve_vision_provider_client(
         return resolved_provider, sync_client, final_model
 
     if resolved_base_url:
+        provider_for_base_override = (
+            requested if requested and requested not in ("", "auto") else "custom"
+        )
         client, final_model = resolve_provider_client(
-            "custom",
+            provider_for_base_override,
             model=resolved_model,
             async_mode=async_mode,
             explicit_base_url=resolved_base_url,
@@ -2657,8 +2660,8 @@ def resolve_vision_provider_client(
             api_mode=resolved_api_mode,
         )
         if client is None:
-            return "custom", None, None
-        return "custom", client, final_model
+            return provider_for_base_override, None, None
+        return provider_for_base_override, client, final_model
 
     if requested == "auto":
         # Vision auto-detection order:

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -13,16 +13,13 @@ def test_vision_call_uses_resolved_provider_args():
         usage=MagicMock(prompt_tokens=10, completion_tokens=5),
     )
 
-    with (
-        patch(
-            "agent.auxiliary_client._resolve_task_provider_model",
-            return_value=("my-resolved-provider", "my-resolved-model", "http://resolved", "resolved-key", "chat_completions"),
-        ),
-        patch(
-            "agent.auxiliary_client.resolve_vision_provider_client",
-            return_value=("my-resolved-provider", fake_client, "my-resolved-model"),
-        ) as mock_vision,
-    ):
+    with patch(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        return_value=("my-resolved-provider", "my-resolved-model", "http://resolved", "resolved-key", "chat_completions"),
+    ), patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("my-resolved-provider", fake_client, "my-resolved-model"),
+    ) as mock_vision:
         call_llm(
             "vision",
             provider="raw-provider",
@@ -38,3 +35,30 @@ def test_vision_call_uses_resolved_provider_args():
     assert call_args.kwargs["model"] == "my-resolved-model"
     assert call_args.kwargs["base_url"] == "http://resolved"
     assert call_args.kwargs["api_key"] == "resolved-key"
+
+
+def test_vision_base_url_override_keeps_explicit_provider():
+    """Explicit provider should still drive credential resolution with custom base_url."""
+    from agent.auxiliary_client import resolve_vision_provider_client
+
+    fake_client = MagicMock()
+    with patch(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        return_value=(
+            "zai",
+            "glm-4v",
+            "https://open.bigmodel.cn/api/paas/v4",
+            None,
+            "chat_completions",
+        ),
+    ), patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(fake_client, "glm-4v"),
+    ) as mock_resolve:
+        provider, client, model = resolve_vision_provider_client()
+
+    assert provider == "zai"
+    assert client is fake_client
+    assert model == "glm-4v"
+    assert mock_resolve.call_args.args[0] == "zai"
+    assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://open.bigmodel.cn/api/paas/v4"


### PR DESCRIPTION
Salvage of #16317 onto current main.

## Summary
`resolve_vision_provider_client` forced `provider='custom'` when `auxiliary.vision.base_url` was set, dropping the provider-specific credential pool lookup (`ZAI_API_KEY` etc.) and falling back to generic custom-provider resolution. Preserve the original `requested` provider when it's explicit so provider-scoped credentials continue to resolve.

## Validation
Manual review of diff.

Original PR: #16317