### PR TITLE
fix(delegation): increase heartbeat stale thresholds for slow LLM providers

### DIFF
--- a/tests/tools/test_heartbeat_stale_thresholds.py
+++ b/tests/tools/test_heartbeat_stale_thresholds.py
@@ -1,0 +1,35 @@
+"""Tests for delegate heartbeat stale threshold configuration."""
+
+import pytest
+
+
+class TestHeartbeatStaleThresholds:
+    """Verify the heartbeat stale threshold constants are correct."""
+
+    def test_idle_cycles_value(self):
+        """IDLE stale cycles should be 15 (15 * 30s = 450s)."""
+        from tools.delegate_tool import _HEARTBEAT_STALE_CYCLES_IDLE
+        assert _HEARTBEAT_STALE_CYCLES_IDLE == 15
+
+    def test_in_tool_cycles_value(self):
+        """IN_TOOL stale cycles should be 40 (40 * 30s = 1200s)."""
+        from tools.delegate_tool import _HEARTBEAT_STALE_CYCLES_IN_TOOL
+        assert _HEARTBEAT_STALE_CYCLES_IN_TOOL == 40
+
+    def test_idle_timeout_seconds(self):
+        """Effective idle stale timeout: 15 * 30 = 450s (> typical LLM response time)."""
+        from tools.delegate_tool import _HEARTBEAT_STALE_CYCLES_IDLE, _HEARTBEAT_INTERVAL
+        effective = _HEARTBEAT_STALE_CYCLES_IDLE * _HEARTBEAT_INTERVAL
+        assert effective == 450
+        assert effective > 300  # Must be > 5 minutes for slow LLM responses
+
+    def test_in_tool_timeout_seconds(self):
+        """Effective in-tool stale timeout: 40 * 30 = 1200s (= 20 minutes)."""
+        from tools.delegate_tool import _HEARTBEAT_STALE_CYCLES_IN_TOOL, _HEARTBEAT_INTERVAL
+        effective = _HEARTBEAT_STALE_CYCLES_IN_TOOL * _HEARTBEAT_INTERVAL
+        assert effective == 1200
+
+    def test_interval_unchanged(self):
+        """Heartbeat interval should remain 30s."""
+        from tools.delegate_tool import _HEARTBEAT_INTERVAL
+        assert _HEARTBEAT_INTERVAL == 30

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -483,8 +483,8 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 # The idle ceiling stays tight so genuinely stuck children don't mask the gateway
 # timeout. The in-tool ceiling is much higher so legit long-running tools get
 # time to finish; child_timeout_seconds (default 600s) is still the hard cap.
-_HEARTBEAT_STALE_CYCLES_IDLE = 5  # 5 * 30s = 150s idle between turns → stale
-_HEARTBEAT_STALE_CYCLES_IN_TOOL = 20  # 20 * 30s = 600s stuck on same tool → stale
+_HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
+_HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
 
 


### PR DESCRIPTION
Salvage of #15921 by @zons-zhaozhy onto current main.

## Summary
Child-agent delegation heartbeat stale detection was too aggressive and terminated heartbeats prematurely when LLM providers had response times in the 30s+ range. Defaults of 5 idle cycles × 30s = 150s were shorter than many reasoning-model turns; 20 in-tool cycles × 30s = 600s wasn't enough for legitimately long-running tool calls.

Raise to:
- `_HEARTBEAT_STALE_CYCLES_IDLE = 15` → 450s (7.5 minutes) idle ceiling
- `_HEARTBEAT_STALE_CYCLES_IN_TOOL = 40` → 1200s (20 minutes) in-tool ceiling

Hard cap is still `child_timeout_seconds` (default 600s), so runaway children are still bounded.

## Changes
- tools/delegate_tool.py: bump heartbeat cycle constants (+2/-2)
- tests: verify constant values and effective timeouts

## Validation
scripts/run_tests.sh tests/tools/test_heartbeat_stale_thresholds.py -> 5 passed

Original PR: #15921
