### PR TITLE
fix: replace print() with logger.debug() in WhatsApp media cache handlers

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1017,42 +1017,42 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         cached_path = await cache_image_from_url(url, ext=".jpg")
                         cached_urls.append(cached_path)
                         media_types.append("image/jpeg")
-                        print(f"[{self.name}] Cached user image: {cached_path}", flush=True)
+                        logger.debug("[%s] Cached user image: %s", self.name, cached_path)
                     except Exception as e:
-                        print(f"[{self.name}] Failed to cache image: {e}", flush=True)
+                        logger.debug("[%s] Failed to cache image: %s", self.name, e)
                         cached_urls.append(url)
                         media_types.append("image/jpeg")
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
                     # Local file path — bridge already downloaded the image
                     cached_urls.append(url)
                     media_types.append("image/jpeg")
-                    print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached image: %s", self.name, url)
                 elif msg_type == MessageType.VOICE and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_audio_from_url(url, ext=".ogg")
                         cached_urls.append(cached_path)
                         media_types.append("audio/ogg")
-                        print(f"[{self.name}] Cached user voice: {cached_path}", flush=True)
+                        logger.debug("[%s] Cached user voice: %s", self.name, cached_path)
                     except Exception as e:
-                        print(f"[{self.name}] Failed to cache voice: {e}", flush=True)
+                        logger.debug("[%s] Failed to cache voice: %s", self.name, e)
                         cached_urls.append(url)
                         media_types.append("audio/ogg")
                 elif msg_type == MessageType.VOICE and os.path.isabs(url):
                     # Local file path — bridge already downloaded the audio
                     cached_urls.append(url)
                     media_types.append("audio/ogg")
-                    print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached audio: %s", self.name, url)
                 elif msg_type == MessageType.DOCUMENT and os.path.isabs(url):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
                     mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
                     media_types.append(mime)
-                    print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached document: %s", self.name, url)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):
                     cached_urls.append(url)
                     media_types.append("video/mp4")
-                    print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached video: %s", self.name, url)
                 else:
                     cached_urls.append(url)
                     media_types.append("unknown")


### PR DESCRIPTION
## Problem

The media caching handlers in `gateway/platforms/whatsapp.py` use bare `print()` statements when caching voice notes, images, videos, and documents received via WhatsApp.

On gateway platforms, stdout is captured and included in the agent's response context. This causes spurious debug strings like:

```
[Whatsapp] Using bridge-cached audio: /opt/data/cache/audio/abc123.ogg
[Whatsapp] Cached user voice: /opt/data/cache/audio/abc123.ogg
```

...to appear verbatim in the agent's replies to the user.

## Fix

Replace all `print()` calls in the media URL caching loop with `logger.debug()`. The messages are still accessible via `gateway.log` at DEBUG level but will never reach the conversation.

Affected cases:
- Image (remote URL cache)
- Image (bridge-cached local path)
- Voice/audio (remote URL cache)
- Voice/audio (bridge-cached local path)
- Document (bridge-cached local path)
- Video (bridge-cached local path)