### PR TITLE
feat(gateway): make Feishu processing status reactions configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -971,6 +971,12 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(feishu_cfg, dict):
                 if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
                     os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
+                if "reactions" in feishu_cfg and not os.getenv("FEISHU_REACTIONS"):
+                    os.environ["FEISHU_REACTIONS"] = str(feishu_cfg["reactions"]).lower()
+                if "reactions_in_progress" in feishu_cfg and not os.getenv("FEISHU_REACTION_IN_PROGRESS"):
+                    os.environ["FEISHU_REACTION_IN_PROGRESS"] = str(feishu_cfg["reactions_in_progress"])
+                if "reactions_failure" in feishu_cfg and not os.getenv("FEISHU_REACTION_FAILURE"):
+                    os.environ["FEISHU_REACTION_FAILURE"] = str(feishu_cfg["reactions_failure"])
 
     except Exception as e:
         logger.warning(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -229,9 +229,9 @@ _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withd
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
 # we only mark start (Typing) and failure (CrossMark); the reply itself is
-# the success signal.
-_FEISHU_REACTION_IN_PROGRESS = "Typing"
-_FEISHU_REACTION_FAILURE = "CrossMark"
+# the success signal. Emoji types are configurable via environment variables.
+_FEISHU_REACTION_IN_PROGRESS = os.getenv("FEISHU_REACTION_IN_PROGRESS", "Typing")
+_FEISHU_REACTION_FAILURE = os.getenv("FEISHU_REACTION_FAILURE", "CrossMark")
 # Bound on the (message_id → reaction_id) handle cache. Happy-path entries
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -363,9 +363,55 @@ Plain text messages (no markdown detected) are sent as the simple `text` message
 
 ## Processing Status Reactions
 
-While the agent is working, the bot shows a `Typing` reaction on your message. It's cleared when the reply arrives, or replaced with `CrossMark` if processing failed.
+While the agent is working, the bot adds a reaction emoji on your message to indicate processing status:
 
-Set `FEISHU_REACTIONS=false` to turn it off.
+| Stage | Default Emoji | Behavior |
+|-------|--------------|----------|
+| Processing | `Typing` 👆 | Added when the agent starts working |
+| Success | _(removed)_ | The `Typing` reaction is removed when the reply arrives — the reply itself is the success signal |
+| Failure | `CrossMark` ❌ | If processing fails, `Typing` is replaced with `CrossMark` |
+
+### Configuration
+
+All three aspects are configurable via `config.yaml` or environment variables:
+
+**Via `config.yaml`:**
+
+```yaml
+feishu:
+  reactions: true                         # Enable/disable reactions (default: true)
+  reactions_in_progress: "Typing"         # Emoji shown while processing
+  reactions_failure: "CrossMark"          # Emoji shown on failure
+```
+
+**Via environment variables (env vars take precedence):**
+
+```bash
+FEISHU_REACTIONS=true
+FEISHU_REACTION_IN_PROGRESS=Typing
+FEISHU_REACTION_FAILURE=CrossMark
+```
+
+Set `FEISHU_REACTIONS=false` (or `reactions: false`) to disable all status reactions.
+
+### Supported Emoji Types
+
+Feishu supports **200+ built-in reaction emoji types**. Below are some of the most commonly useful ones:
+
+```
+OK, THUMBSUP, MUSCLE, STRIVE, SMILE, LOVE, THINKING, ERROR, CLAP,
+LGTM, OnIt, Typing, CrossMark, CheckMark, MinusOne, Fire, BOMB,
+Trophy, HEART, ROSE, BEER, Coffee, REDPACKET, PARTY, XmasHat,
+FIRECRACKER, POOP, GeneralWorkFromHome, StatusReading, MoonRabbit
+```
+
+:::tip
+The full list of 200+ emoji types (with visual previews) is available in the [Feishu Open Platform documentation](https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce).
+:::
+
+:::note
+Feishu reactions render as prominent badges (unlike Discord/Telegram's small footer emoji), so adding a success badge on every message would add visual noise. That's why only start (processing) and failure reactions are shown — the reply itself is the success signal.
+:::
 
 ## Burst Protection and Batching
 
@@ -503,6 +549,9 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `HERMES_FEISHU_TEXT_BATCH_MAX_MESSAGES` | — | `8` | Max messages merged per text batch |
 | `HERMES_FEISHU_TEXT_BATCH_MAX_CHARS` | — | `4000` | Max characters merged per text batch |
 | `HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS` | — | `0.8` | Media burst debounce quiet period |
+| `FEISHU_REACTIONS` | — | `true` | Enable/disable processing status reactions |
+| `FEISHU_REACTION_IN_PROGRESS` | — | `Typing` | Emoji type shown while processing |
+| `FEISHU_REACTION_FAILURE` | — | `CrossMark` | Emoji type shown on processing failure |
 
 WebSocket and per-group ACL settings are configured via `config.yaml` under `platforms.feishu.extra` (see [WebSocket Tuning](#websocket-tuning) and [Per-Group Access Control](#per-group-access-control) above).
 


### PR DESCRIPTION
## Summary

Makes Feishu gateway's processing status reactions (the emoji badges shown on user messages while the agent is working) fully configurable via `config.yaml` or environment variables.

## Problem

The emoji types (`Typing` and `CrossMark`) were hardcoded in `gateway/platforms/feishu.py` with no way to customize them. The `reactions` enable/disable toggle was also only available via env var, unlike Slack/Discord/Telegram which all support `config.yaml` configuration.

## Changes

### `gateway/platforms/feishu.py`
- `_FEISHU_REACTION_IN_PROGRESS` and `_FEISHU_REACTION_FAILURE` now read from environment variables with defaults preserving backward compatibility

### `gateway/config.py`
- Added `feishu.reactions`, `feishu.reactions_in_progress`, and `feishu.reactions_failure` → env var mappings
- Follows the same pattern as existing Slack/Discord/Telegram config → env var bridging

### `website/docs/user-guide/messaging/feishu.md`
- Rewrote "Processing Status Reactions" section with full configuration docs
- Added common emoji types and linked to Feishu's official emoji documentation (200+ types)
- Added entries to the All Environment Variables table

## Configuration Examples

```yaml
feishu:
  reactions: true
  reactions_in_progress: "Typing"      # or any of 200+ Feishu emoji types
  reactions_failure: "CrossMark"
```

Or via environment variables:
```bash
FEISHU_REACTIONS=true
FEISHU_REACTION_IN_PROGRESS=Typing
FEISHU_REACTION_FAILURE=CrossMark
```

## Testing

- Backward compatible: default values unchanged (`Typing` / `CrossMark`)
- No new dependencies added
- Documentation updated