### PR TITLE
fix(status): add missing popular provider API keys to hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -122,11 +122,16 @@ def show_status(args):
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
 
-    keys = {
+    # Values may be a single env var name (str) or a tuple of alternates (first found wins).
+    keys: dict[str, str | tuple[str, ...]] = {
         "OpenRouter": "OPENROUTER_API_KEY",
         "OpenAI": "OPENAI_API_KEY",
-        "NVIDIA": "NVIDIA_API_KEY",
-        "Z.AI/GLM": "GLM_API_KEY",
+        "Anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"),
+        "Google / Gemini": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+        "DeepSeek": "DEEPSEEK_API_KEY",
+        "xAI / Grok": "XAI_API_KEY",
+        "NVIDIA NIM": "NVIDIA_API_KEY",
+        "Z.AI / GLM": "GLM_API_KEY",
         "Kimi": "KIMI_API_KEY",
         "StepFun Step Plan": "STEPFUN_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
@@ -140,11 +145,25 @@ def show_status(args):
         "WandB": "WANDB_API_KEY",
         "ElevenLabs": "ELEVENLABS_API_KEY",
         "GitHub": "GITHUB_TOKEN",
-        "NVIDIA NIM":      "NVIDIA_API_KEY",
     }
 
-    for name, env_var in keys.items():
-        value = get_env_value(env_var) or ""
+    def _resolve_env(env_ref) -> str:
+        """Return first non-empty env var value from a str or tuple of names."""
+        if isinstance(env_ref, tuple):
+            for candidate in env_ref:
+                v = get_env_value(candidate) or ""
+                if v:
+                    return v
+            return ""
+        return get_env_value(env_ref) or ""
+
+    for name, env_ref in keys.items():
+        # Anthropic already has a dedicated lookup below; keep that as the
+        # single source of truth (it also resolves OAuth tokens), skip here
+        # so we don't print two "Anthropic" rows.
+        if name == "Anthropic":
+            continue
+        value = _resolve_env(env_ref)
         has_key = bool(value)
         display = redact_key(value) if not show_all else value
         print(f"  {name:<12}  {check_mark(has_key)} {display}")


### PR DESCRIPTION
Salvage of #16159 by @briandevans onto current main.

## Summary
`hermes status` silently omitted four widely-used LLM providers (Google/Gemini, DeepSeek, xAI/Grok, NVIDIA NIM) from both its API Keys and API-Key Providers sections, even though all four are fully registered in `PROVIDER_REGISTRY`.

Also support tuple-valued env var lookups (first found wins) so Google can accept either `GOOGLE_API_KEY` or `GEMINI_API_KEY`.

## Adaptation during salvage
Main had picked up a duplicate "NVIDIA" / "NVIDIA NIM" row pointing at the same env var (from an earlier separate merge). The salvage deduplicates that while applying the broader provider list + tuple support.

## Changes
- hermes_cli/status.py: broader key table + tuple-env support + NVIDIA dedup (+25/-6)

## Validation
Manual review; syntax check passes, key resolution logic is straightforward.

Original PR: #16159
Fixes: #16082
