### PR TITLE
fix(bedrock): strip top-level oneOf/allOf/anyOf from tool inputSchema

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -415,6 +415,19 @@ def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
         name = fn.get("name", "")
         description = fn.get("description", "")
         parameters = fn.get("parameters", {"type": "object", "properties": {}})
+        # Bedrock Converse rejects top-level oneOf/allOf/anyOf with a
+        # ValidationException — same constraint as the Anthropic native API.
+        # Pydantic discriminated unions and some MCP tools ship schemas with
+        # one of these keywords at the root; strip them and fall back to a
+        # plain object schema so the tool still validates at the AWS boundary.
+        if isinstance(parameters, dict):
+            banned = {"oneOf", "allOf", "anyOf"}
+            if banned & parameters.keys():
+                parameters = {k: v for k, v in parameters.items() if k not in banned}
+                if "type" not in parameters:
+                    parameters["type"] = "object"
+                if not isinstance(parameters.get("properties"), dict):
+                    parameters = {**parameters, "properties": {}}
         result.append({
             "toolSpec": {
                 "name": name,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -695,6 +695,19 @@ def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
         name = fn.get("name", "")
         description = fn.get("description", "")
         parameters = fn.get("parameters", {"type": "object", "properties": {}})
+        # Bedrock Converse rejects top-level oneOf/allOf/anyOf with a
+        # ValidationException — same constraint as the Anthropic native API.
+        # Pydantic discriminated unions and some MCP tools ship schemas with
+        # one of these keywords at the root; strip them and fall back to a
+        # plain object schema so the tool still validates at the AWS boundary.
+        if isinstance(parameters, dict):
+            banned = {"oneOf", "allOf", "anyOf"}
+            if banned & parameters.keys():
+                parameters = {k: v for k, v in parameters.items() if k not in banned}
+                if "type" not in parameters:
+                    parameters["type"] = "object"
+                if not isinstance(parameters.get("properties"), dict):
+                    parameters = {**parameters, "properties": {}}
         result.append({
             "toolSpec": {
                 "name": name,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -192,6 +192,69 @@ class TestConvertToolsToConverse:
         schema = result[0]["toolSpec"]["inputSchema"]["json"]
         assert schema == {"type": "object", "properties": {}}
 
+    def test_strips_top_level_oneof_from_schema(self):
+        # Pydantic discriminated unions emit a root-level oneOf that Bedrock
+        # Converse rejects with ValidationException — must be stripped.
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "classify",
+                "description": "Classify input",
+                "parameters": {
+                    "oneOf": [
+                        {"type": "object", "properties": {"text": {"type": "string"}}},
+                        {"type": "object", "properties": {"items": {"type": "array", "items": {"type": "string"}}}},
+                    ]
+                },
+            },
+        }]
+        result = convert_tools_to_converse(tools)
+        schema = result[0]["toolSpec"]["inputSchema"]["json"]
+        assert "oneOf" not in schema
+        assert schema["type"] == "object"
+        assert isinstance(schema["properties"], dict)
+
+    def test_strips_top_level_allof_preserves_sibling_keys(self):
+        # allOf alongside type/description — only allOf must be removed.
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search",
+                "parameters": {
+                    "type": "object",
+                    "description": "Search params",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                    "allOf": [{"properties": {"query": {"type": "string"}}}],
+                },
+            },
+        }]
+        result = convert_tools_to_converse(tools)
+        schema = result[0]["toolSpec"]["inputSchema"]["json"]
+        assert "allOf" not in schema
+        assert schema["type"] == "object"
+        assert schema["description"] == "Search params"
+        assert "query" in schema["properties"]
+        assert schema["required"] == ["query"]
+
+    def test_schema_without_banned_keys_passes_through_unchanged(self):
+        # Normal schemas must not be altered.
+        from agent.bedrock_adapter import convert_tools_to_converse
+        original = {
+            "type": "object",
+            "properties": {"path": {"type": "string", "description": "File path"}},
+            "required": ["path"],
+        }
+        tools = [{
+            "type": "function",
+            "function": {"name": "read_file", "description": "Read file", "parameters": original},
+        }]
+        result = convert_tools_to_converse(tools)
+        assert result[0]["toolSpec"]["inputSchema"]["json"] == original
+
 
 # ---------------------------------------------------------------------------
 # Message conversion: OpenAI → Converse

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -182,6 +182,68 @@ class TestConvertToolsToConverse:
         assert convert_tools_to_converse([]) == []
         assert convert_tools_to_converse(None) == []
 
+    def test_strips_top_level_oneof_from_schema(self):
+        # Pydantic discriminated unions emit a root-level oneOf that Bedrock
+        # Converse rejects with ValidationException — must be stripped.
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "classify",
+                "description": "Classify input",
+                "parameters": {
+                    "oneOf": [
+                        {"type": "object", "properties": {"text": {"type": "string"}}},
+                        {"type": "object", "properties": {"items": {"type": "array", "items": {"type": "string"}}}},
+                    ]
+                },
+            },
+        }]
+        result = convert_tools_to_converse(tools)
+        schema = result[0]["toolSpec"]["inputSchema"]["json"]
+        assert "oneOf" not in schema
+        assert schema["type"] == "object"
+        assert isinstance(schema["properties"], dict)
+
+    def test_strips_top_level_allof_preserves_sibling_keys(self):
+        # allOf alongside type/description — only allOf must be removed.
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search",
+                "parameters": {
+                    "type": "object",
+                    "description": "Search params",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                    "allOf": [{"properties": {"query": {"type": "string"}}}],
+                },
+            },
+        }]
+        result = convert_tools_to_converse(tools)
+        schema = result[0]["toolSpec"]["inputSchema"]["json"]
+        assert "allOf" not in schema
+        assert schema["type"] == "object"
+        assert schema["description"] == "Search params"
+        assert "query" in schema["properties"]
+        assert schema["required"] == ["query"]
+
+    def test_schema_without_banned_keys_passes_through_unchanged(self):
+        # Normal schemas must not be altered.
+        from agent.bedrock_adapter import convert_tools_to_converse
+        original = {
+            "type": "object",
+            "properties": {"path": {"type": "string", "description": "File path"}},
+            "required": ["path"],
+        }
+        tools = [{
+            "type": "function",
+            "function": {"name": "read_file", "description": "Read file", "parameters": original},
+        }]
+        result = convert_tools_to_converse(tools)
+        assert result[0]["toolSpec"]["inputSchema"]["json"] == original
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Bedrock Converse rejects tool schemas with a top-level `oneOf`/`allOf`/`anyOf` union keyword with a `ValidationException`. Several upstream and plugin tools (Pydantic discriminated unions, some MCP schemas) ship a schema root with one of these keywords, causing an unrecoverable API error when the tool list is sent to AWS.

## What changed

`convert_tools_to_converse()` in `agent/bedrock_adapter.py` now strips the three banned union keywords from the top-level of each tool's `parameters` schema before placing it into `inputSchema.json`, exactly mirroring the fix applied to the Anthropic adapter in a219a0a4:

- If banned keys are present, they are removed; sibling keys (`type`, `description`, `properties`, `required`, …) are preserved.
- If `type` is absent after stripping, `"type": "object"` is added.
- If `properties` is absent (or non-dict) after stripping, `"properties": {}` is added.
- Schemas without banned keys pass through unchanged — no behavior change for existing configs.

## Tests

Three new cases in `TestConvertToolsToConverse`:

| Test | Input | Expected |
|------|-------|----------|
| `test_strips_top_level_oneof_from_schema` | `{"oneOf": [...]}` | `{"type": "object", "properties": {}}` |
| `test_strips_top_level_allof_preserves_sibling_keys` | `{"type": "object", "allOf": [...], "properties": {...}, ...}` | `allOf` removed, siblings preserved |
| `test_schema_without_banned_keys_passes_through_unchanged` | normal schema | unchanged |

## Relation to prior work

Symmetric with the Anthropic adapter fix (a219a0a4, "fix(anthropic): strip top-level oneOf/allOf/anyOf from tool input_schema"). The Bedrock `convert_tools_to_converse()` is a parallel implementation that was not updated at the same time.