### PR TITLE
feat(kanban): prevent child task dispatch when parent is not done

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -527,6 +527,22 @@ def _set_status_direct(
         ).fetchone()
         if prev is None:
             return False
+
+        # Guard: don't allow promoting to 'ready' unless all parents are done.
+        # Prevents the dispatcher from spawning a child whose upstream work
+        # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
+        if new_status == "ready":
+            parent_statuses = conn.execute(
+                "SELECT t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            if parent_statuses and not all(
+                p["status"] == "done" for p in parent_statuses
+            ):
+                return False
+
         was_running = prev["status"] == "running"
 
         cur = conn.execute(

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -203,7 +203,10 @@ def test_patch_block_then_unblock(client):
 
 def test_patch_drag_drop_move_todo_to_ready(client):
     """Direct status write: the drag-drop path for statuses without a
-    dedicated verb (e.g. manually promoting todo -> ready)."""
+    dedicated verb (e.g. manually promoting todo -> ready).
+
+    Promoting a child whose parent is not done is rejected (409).
+    Promoting a child whose parent IS done is accepted (200)."""
     parent = client.post("/api/plugins/kanban/tasks", json={"title": "p"}).json()["task"]
     child = client.post(
         "/api/plugins/kanban/tasks",
@@ -211,12 +214,23 @@ def test_patch_drag_drop_move_todo_to_ready(client):
     ).json()["task"]
     assert child["status"] == "todo"
 
+    # Rejected: parent not done yet.
     r = client.patch(
         f"/api/plugins/kanban/tasks/{child['id']}",
         json={"status": "ready"},
     )
+    assert r.status_code == 409
+
+    # Complete the parent.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "done"},
+    )
     assert r.status_code == 200
-    assert r.json()["task"]["status"] == "ready"
+
+    # Now child auto-promoted by recompute_ready — already ready.
+    child_after = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+    assert child_after["status"] == "ready"
 
 
 def test_patch_reassign(client):
@@ -433,13 +447,17 @@ def test_board_progress_rollup(client):
         "/api/plugins/kanban/tasks",
         json={"title": "b", "parents": [parent["id"]]},
     ).json()["task"]
-    # Children start as "todo" because the parent isn't done yet; promote
-    # them to "ready" so complete_task will accept the transition.
+    # Children start as "todo" because the parent isn't done yet.  Set the
+    # parent to done so children auto-promote to ready via recompute_ready.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "done"},
+    )
+    assert r.status_code == 200
+    # Verify children are now ready.
     for cid in (child_a["id"], child_b["id"]):
-        r = client.patch(
-            f"/api/plugins/kanban/tasks/{cid}", json={"status": "ready"},
-        )
-        assert r.status_code == 200
+        t = client.get(f"/api/plugins/kanban/tasks/{cid}").json()["task"]
+        assert t["status"] == "ready", f"{cid} should be ready after parent done"
 
     # 0/2 done.
     r = client.get("/api/plugins/kanban/board")


### PR DESCRIPTION
## What does this PR do?

Prevents child Kanban tasks from being dispatched before their parent tasks are done. Adds a parent dependency guard to the `_set_status_direct` function so that manually setting a task's status to "ready" via the dashboard API (drag-drop or explicit PATCH) is rejected with 409 when the task's parents are not all completed.

Previously, the dependency guard only existed in `recompute_ready` (which handles auto-promotion from `todo` → `ready`). Direct status writes via the dashboard API bypassed this check entirely, allowing the dispatcher to spawn a child task whose upstream work hadn't finished yet.

**Root cause example:** After a dispatcher tick reclaimed stale workers and promoted tasks via `recompute_ready`, subsequent dashboard status writes set both a child and its grandchild to "ready" in quick succession. The writer (grandchild) was spawned and ran while the analyst (child) was blocked — upstream research wasn't complete.

## Related Issue

Fixes #19746

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py` — Added parent dependency check in `_set_status_direct()`: when transitioning to "ready", verify all parents are "done". Returns `False` (409) if not.
- `tests/plugins/test_kanban_dashboard_plugin.py` — Updated `test_board_progress_rollup` to complete the parent (trigger `recompute_ready`) instead of manually forcing children to "ready". Rewrote `test_patch_drag_drop_move_todo_to_ready` to verify both the rejection case (parent not done → 409) and the acceptance case (parent done → auto-promoted to ready).

## How to Test

1. Create parent task → create child task with `parents=[parent_id]`. Child starts as `todo`.
2. `PATCH /api/plugins/kanban/tasks/{child_id}` with `{"status":"ready"}` → expect **409 Conflict**
3. Complete the parent: `PATCH /api/plugins/kanban/tasks/{parent_id}` with `{"status":"done"}`
4. Verify child auto-promoted to `ready` by `recompute_ready`
5. Run `pytest tests/plugins/test_kanban_dashboard_plugin.py -v` — all 42 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] N/A (no doc/config/arch changes needed)
