### PR TITLE
fix(browser): inject --no-sandbox for root and AppArmor userns restrictions

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1482,6 +1482,34 @@ def _run_browser_command(
         if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
             idle_ms = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
             browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = idle_ms
+
+        # Inject --no-sandbox when needed (issue #15765):
+        # - Running as root: Chromium always refuses to start without it
+        # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
+        #   are restricted, causing Chromium to exit with "No usable sandbox"
+        #   even for non-root users running under systemd or containers.
+        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+            _needs_sandbox_bypass = False
+            if hasattr(os, "geteuid") and os.geteuid() == 0:
+                _needs_sandbox_bypass = True
+                logger.debug("browser: running as root — injecting --no-sandbox")
+            else:
+                # Detect AppArmor user namespace restrictions (Ubuntu 23.10+)
+                _userns_restrict = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+                try:
+                    with open(_userns_restrict) as _f:
+                        if _f.read().strip() == "1":
+                            _needs_sandbox_bypass = True
+                            logger.debug(
+                                "browser: AppArmor userns restrictions detected — "
+                                "injecting --no-sandbox"
+                            )
+                except OSError:
+                    pass
+            if _needs_sandbox_bypass:
+                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
+                    "--no-sandbox --disable-dev-shm-usage"
+                )
         
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
Salvage of #15771 by @ygd58 — core browser fix only.

## Summary
On VPS/Docker deployments and some Ubuntu 23.10+ hosts, Chromium refuses to start without `--no-sandbox`:
- **uid=0 (root):** hard requirement, common on Hetzner/DigitalOcean/Docker
- **AppArmor `apparmor_restrict_unprivileged_userns=1`:** Ubuntu 23.10+ also restricts non-root users under systemd or unprivileged containers

Detect both conditions and inject `AGENT_BROWSER_CHROME_FLAGS="--no-sandbox --disable-dev-shm-usage"` when the user hasn't already set the flags themselves. Without this fix, `browser_navigate` hangs until the command timeout fires (~30s) before surfacing an obscure error.

## Adaptation during salvage
The original PR also added a Playwright MCP preset with matching root-safe flags. That's a net-new feature surface, not a bug fix, so it was dropped from this salvage — the underlying browser fix stands on its own and helps every agent-browser user on affected systems.

## Changes
- tools/browser_tool.py: root + AppArmor userns detection, inject CHROME_FLAGS when needed (+28/-0)

## Validation
Pre-existing failures in `test_browser_chromium_check.py` on main are unrelated to this change (same failures with or without it).

Original PR: #15771
Fixes: #15765
