### PR TITLE
fix(discord): clamp limit to [1, 100] in _search_members and _fetch_messages

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -332,7 +332,7 @@ def _search_members(token: str, guild_id: str, query: str, limit: int = 20, **_k
         limit = int(limit)
     except (TypeError, ValueError):
         limit = 20
-    params = {"query": query, "limit": str(min(limit, 100))}
+    params = {"query": query, "limit": str(max(1, min(limit, 100)))}
     members = _discord_request("GET", f"/guilds/{guild_id}/members/search", token, params=params)
     result = []
     for m in members:
@@ -358,7 +358,7 @@ def _fetch_messages(
         limit = int(limit)
     except (TypeError, ValueError):
         limit = 50
-    params: Dict[str, str] = {"limit": str(min(limit, 100))}
+    params: Dict[str, str] = {"limit": str(max(1, min(limit, 100)))}
     if before:
         params["before"] = before
     if after:


### PR DESCRIPTION
## What does this PR do?
Clamps the `limit` parameter to a valid range `[1, 100]` in two Discord tool functions. Previously only an upper bound of 100 was enforced via `min(limit, 100)`, allowing zero or negative values to be sent to the Discord API.

## Type of Change
- [x] Bug fix

## Changes Made
- `_search_members`: `min(limit, 100)` → `max(1, min(limit, 100))`
- `_fetch_messages`: `min(limit, 100)` → `max(1, min(limit, 100))`

## How to Test
Pass `limit=0` or `limit=-5` to either function — previously would send invalid value to Discord API, now clamps to 1.

## Checklist
- [x] Follows existing code style
- [x] No secrets or sensitive data
- [x] Minimal, focused change