### PR TITLE
fix(wecom): split long outbound markdown instead of silent truncation

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1211,7 +1211,7 @@ class WeComAdapter(BasePlatformAdapter):
             reply_req_id,
             {
                 "msgtype": "markdown",
-                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                "markdown": {"content": content},
             },
         )
         self._raise_for_wecom_error(response, "send reply markdown")
@@ -1343,36 +1343,45 @@ class WeComAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="chat_id is required")
 
         try:
+            chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+
             reply_req_id = self._reply_req_id_for_message(reply_to)
 
             if not reply_req_id and chat_id in self._last_chat_req_ids:
                 reply_req_id = self._last_chat_req_ids[chat_id]
 
-            if reply_req_id:
-                response = await self._send_reply_markdown(reply_req_id, content)
-            else:
-                response = await self._send_request(
-                    APP_CMD_SEND,
-                    {
-                        "chatid": chat_id,
-                        "msgtype": "markdown",
-                        "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-                    },
-                )
+            last_response = None
+            for i, chunk in enumerate(chunks):
+                if i == 0 and reply_req_id:
+                    last_response = await self._send_reply_markdown(
+                        reply_req_id, chunk,
+                    )
+                else:
+                    last_response = await self._send_request(
+                        APP_CMD_SEND,
+                        {
+                            "chatid": chat_id,
+                            "msgtype": "markdown",
+                            "markdown": {"content": chunk},
+                        },
+                    )
+                    self._raise_for_wecom_error(
+                        last_response, "send markdown chunk",
+                    )
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
             logger.error("[%s] Send failed: %s", self.name, exc)
             return SendResult(success=False, error=str(exc))
 
-        error = self._response_error(response)
+        error = self._response_error(last_response)
         if error:
             return SendResult(success=False, error=error)
 
         return SendResult(
             success=True,
-            message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
-            raw_response=response,
+            message_id=self._payload_req_id(last_response) or uuid.uuid4().hex[:12],
+            raw_response=last_response,
         )
 
     async def send_image(

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -789,3 +789,63 @@ class TestWeComZombieSessionFix:
         cmd = adapter._send_request.await_args.args[0]
         assert cmd == APP_CMD_SEND
 
+
+
+class TestSendLongMessageSplitting:
+    """Verify that send() splits long markdown into multiple WeCom messages."""
+
+    @pytest.mark.asyncio
+    async def test_send_splits_long_message_into_chunks(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0},
+        )
+
+        long_content = "A" * 6000  # exceeds MAX_MESSAGE_LENGTH (4000)
+        result = await adapter.send("chat-123", long_content)
+
+        assert result.success is True
+        # Should have been called more than once (content was split)
+        assert adapter._send_request.await_count >= 2
+        # All sent chunks should be within the limit
+        for call in adapter._send_request.call_args_list:
+            payload = call[0][1]
+            assert len(payload["markdown"]["content"]) <= adapter.MAX_MESSAGE_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_send_short_message_not_split(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0},
+        )
+
+        result = await adapter.send("chat-123", "short message")
+
+        assert result.success is True
+        adapter._send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_reply_first_chunk_uses_reply_rest_proactive(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_id_for_message = lambda _: "reply-req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0},
+        )
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-2"}, "errcode": 0},
+        )
+
+        long_content = "B" * 6000
+        result = await adapter.send("chat-123", long_content, reply_to="msg-orig")
+
+        assert result.success is True
+        # First chunk sent via reply
+        assert adapter._send_reply_request.await_count == 1
+        # Remaining chunk(s) sent via proactive
+        assert adapter._send_request.await_count >= 1


### PR DESCRIPTION
## Summary

Fixes #19689 — WeCom outbound markdown responses were silently truncated at 4000 characters. Everything beyond `MAX_MESSAGE_LENGTH` was dropped with no indication to the user.

## Changes

- **`gateway/platforms/wecom.py`**: Replace `content[:self.MAX_MESSAGE_LENGTH]` with `self.truncate_message()` (inherited from `BasePlatformAdapter`) which splits long content into multiple chunks preserving code block boundaries and adding chunk indicators (e.g. `(1/2)`).
  - In `send()`: iterate over chunks — first chunk uses passive reply path if available, remaining chunks use proactive `APP_CMD_SEND`.
  - In `_send_reply_markdown()`: remove inline truncation (caller now pre-chunks).
- **`tests/gateway/test_wecom.py`**: Add `TestSendLongMessageSplitting` with 3 tests:
  - Long message is split into multiple API calls, each within limit
  - Short message is sent as single call (no regression)
  - Reply path: first chunk uses reply, overflow uses proactive send

## Testing

All 44 existing WeCom tests pass + 3 new tests pass.

## Root Cause

Both `_send_reply_markdown()` and the proactive path in `send()` used `content[:self.MAX_MESSAGE_LENGTH]` to enforce the WeCom 4000-char limit. Since the WeCom API accepts truncated payloads without error, Hermes reported success while the user lost all content beyond 4000 chars.