### PR TITLE
fix(mattermost): honor proxy env vars for WebSocket connection

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -201,7 +201,8 @@ class MattermostAdapter(BasePlatformAdapter):
             return False
 
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         )
         self._closing = False
 
@@ -634,7 +635,15 @@ class MattermostAdapter(BasePlatformAdapter):
         ws_url = re.sub(r"^http", "ws", self._base_url) + "/api/v4/websocket"
         logger.info("Mattermost: connecting to %s", ws_url)
 
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0)
+        ws_proxy = (
+            os.getenv("WSS_PROXY")
+            or os.getenv("wss_proxy")
+            or os.getenv("HTTPS_PROXY")
+            or os.getenv("https_proxy")
+            or os.getenv("ALL_PROXY")
+            or os.getenv("all_proxy")
+        )
+        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0, proxy=ws_proxy)
 
         # Authenticate via the WebSocket.
         auth_msg = {

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -618,6 +618,75 @@ class TestMattermostDedup:
 
 
 # ---------------------------------------------------------------------------
+# WebSocket proxy handling
+# ---------------------------------------------------------------------------
+
+class TestMattermostWebSocketProxy:
+    @pytest.mark.asyncio
+    async def test_connect_creates_session_with_trust_env(self, monkeypatch):
+        """ClientSession must be created with trust_env=True so all requests
+        (REST and WebSocket) honor HTTP_PROXY / HTTPS_PROXY / NO_PROXY."""
+        seen_session_kwargs: dict = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                seen_session_kwargs.update(kwargs)
+                self.closed = False
+
+            async def close(self): self.closed = True
+
+            def get(self, *a, **kw):
+                class _R:
+                    status = 200
+                    async def json(self): return {"id": "bot1", "username": "hermes"}
+                    async def __aenter__(self): return self
+                    async def __aexit__(self, *a): pass
+                return _R()
+
+        adapter = _make_adapter()
+        with patch("gateway.platforms.mattermost.aiohttp.ClientSession", side_effect=FakeSession):
+            result = await adapter.connect()
+            # Cancel background ws_task so the test doesn't hang.
+            if adapter._ws_task:
+                adapter._ws_task.cancel()
+                try:
+                    await adapter._ws_task
+                except asyncio.CancelledError:
+                    pass
+
+        assert result is True
+        assert seen_session_kwargs.get("trust_env") is True
+
+    @pytest.mark.asyncio
+    async def test_ws_connect_passes_proxy_env(self, monkeypatch):
+        """_ws_connect_and_listen must read HTTPS_PROXY and pass it to ws_connect."""
+        for key in ("WSS_PROXY", "wss_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+
+        adapter = _make_adapter()
+        seen_ws_kwargs: dict = {}
+
+        class FakeWs:
+            closed = False
+            async def send_json(self, *a, **kw): pass
+            def __aiter__(self): return self
+            async def __anext__(self): raise StopAsyncIteration
+
+        class FakeSession:
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return FakeWs()
+
+        # Inject a pre-built session — bypasses connect() so we isolate
+        # the proxy-resolution logic inside _ws_connect_and_listen().
+        adapter._session = FakeSession()
+        await adapter._ws_connect_and_listen()
+
+        assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
+
+
+# ---------------------------------------------------------------------------
 # Requirements check
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`aiohttp.ClientSession` was created without `trust_env=True` and `ws_connect()` was called without a `proxy` argument, so Mattermost users behind a corporate or network proxy received a silent connection timeout — `HTTPS_PROXY`, `ALL_PROXY`, and related env vars were ignored for both REST and WebSocket traffic.

## What changed

`gateway/platforms/mattermost.py`:

1. `connect()`: add `trust_env=True` to `ClientSession(...)` so all REST calls (`_api_get`, `_api_post`, file uploads) also honor `HTTPS_PROXY` / `NO_PROXY`.
2. `_ws_connect_and_listen()`: resolve `WSS_PROXY` → `HTTPS_PROXY` → `ALL_PROXY` (case-insensitive, first found wins) and pass it as `proxy=` to `ws_connect()`. `None` when no proxy is configured — no behavior change for direct connections.

## Relation to prior work

Symmetric with the QQBot fix (044348411, "fix(qqbot): honor proxy env vars for websocket"). Mattermost is a parallel adapter using the same aiohttp `ws_connect()` pattern that was missing the same two changes.

## Tests

Two new cases in `TestMattermostWebSocketProxy`:

| Test | What it verifies |
|------|-----------------|
| `test_connect_creates_session_with_trust_env` | `ClientSession` receives `trust_env=True` |
| `test_ws_connect_passes_proxy_env` | `HTTPS_PROXY` is forwarded to `ws_connect(proxy=...)` |