### PR TITLE
feat: add codebase map skill and AI PR review workflow

### DIFF
--- a/.github/workflows/hermes-ai-pr-check.yml
+++ b/.github/workflows/hermes-ai-pr-check.yml
@@ -1,0 +1,92 @@
+name: Hermes AI PR Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  hermes-ai-review:
+    name: Hermes AI Review
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Hermes Agent
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[mcp]
+
+      - name: Build PR context
+        run: |
+          git diff --stat origin/${{ github.base_ref }}...HEAD > /tmp/pr-diff-stat.txt
+          git diff --name-only origin/${{ github.base_ref }}...HEAD > /tmp/pr-files.txt
+          git diff --unified=80 origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
+
+      - name: Run Hermes PR review
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          HERMES_PROVIDER: ${{ vars.HERMES_PROVIDER || 'openai' }}
+          HERMES_MODEL: ${{ vars.HERMES_MODEL || 'gpt-4o-mini' }}
+        run: |
+          cat > /tmp/hermes-pr-prompt.txt <<'PROMPT'
+          You are reviewing a GitHub pull request for Hermes Agent.
+
+          Produce a concise markdown review with:
+          1. Summary of the change.
+          2. Security concerns.
+          3. Test/build risks.
+          4. Documentation or migration notes.
+          5. Concrete requested changes, if any.
+
+          Prefer actionable findings over style nits. If the diff is safe, say so.
+          Use the provided diff/stat files. Do not modify files.
+          PROMPT
+
+          {
+            cat /tmp/hermes-pr-prompt.txt
+            echo
+            echo '## Changed files'
+            cat /tmp/pr-files.txt
+            echo
+            echo '## Diff stat'
+            cat /tmp/pr-diff-stat.txt
+            echo
+            echo '## Diff'
+            cat /tmp/pr.diff
+          } > /tmp/hermes-pr-review-input.txt
+
+          hermes -z "$(cat /tmp/hermes-pr-review-input.txt)" --provider "$HERMES_PROVIDER" -m "$HERMES_MODEL" > hermes-pr-review.md
+
+      - name: Upload review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-pr-review
+          path: hermes-pr-review.md
+
+      - name: Comment review on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('hermes-pr-review.md', 'utf8').slice(0, 60000);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Hermes AI PR Review\n\n${body}`
+            });

--- a/skills/software-development/codebase-map/SKILL.md
+++ b/skills/software-development/codebase-map/SKILL.md
@@ -1,0 +1,94 @@
+# Codebase Map
+
+Create a compact, durable map of a repository before editing, reviewing, or delegating work. Use this skill when a task touches an unfamiliar or large codebase, when context is tight, or when handing work to subagents.
+
+## When to Use
+
+- Starting work in a repo you have not recently inspected.
+- Preparing a subagent prompt that needs repo orientation without dumping files.
+- Reviewing a PR and needing likely impact areas.
+- Debugging where entry points, tests, or ownership are unclear.
+
+## Outputs
+
+Write the map to `CODEBASE_MAP.md` at the repository root or to a task-specific file under `.plans/` when the repo should not be modified.
+
+A useful map includes:
+
+1. **Purpose** — one paragraph summarizing what the project does.
+2. **Primary languages and package managers** — from lockfiles and manifests.
+3. **Entrypoints** — CLIs, servers, jobs, web apps, extension hosts.
+4. **Important directories** — one-line responsibility for each.
+5. **Test/build commands** — exact commands discovered from project files.
+6. **Dependency seams** — model providers, databases, network clients, tool adapters.
+7. **Likely change targets** — files/modules relevant to the current task.
+8. **Risks** — security, migrations, generated files, side effects.
+9. **Open questions** — only if the repository itself does not answer them.
+
+## Fast Mapping Procedure
+
+1. Inspect root files: `README*`, `AGENTS.md`, `CONTRIBUTING*`, `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `.github/workflows/*`.
+2. List top-level directories and identify source, tests, docs, examples, scripts, generated assets, and vendored code.
+3. Search for entrypoints:
+   - Python: `[project.scripts]`, `if __name__ == "__main__"`, `click`, `typer`, `fire`, `argparse`.
+   - Node/TS: `package.json` scripts, `bin`, framework configs, extension manifests.
+   - Go: `cmd/*`, `main.go`.
+4. Search for tests and quality gates: `pytest`, `vitest`, `jest`, `ruff`, `ty`, `mypy`, `go test`, `cargo test`, `prettier`, `biome`.
+5. Search for integration seams: `OpenAI`, `Anthropic`, `MCP`, `GitHub`, `Docker`, `SQLite`, `Postgres`, `Redis`, `VNC`, `browser`, `cron`.
+6. Summarize. Do not paste massive file trees; prefer high-signal bullets.
+
+## Subagent Prompt Template
+
+```text
+You are mapping this repository for future agents.
+Repository: <path or URL>
+Task focus: <feature/bug/review area>
+Produce CODEBASE_MAP.md with: purpose, languages, entrypoints, key dirs, tests/build commands, dependency seams, likely change targets, risks, and open questions.
+Keep it concise and cite file paths.
+Do not modify functional code.
+```
+
+## Quality Bar
+
+- Every claim names at least one supporting file path.
+- Commands are copied from manifests or verified by running `--help`/dry-run where safe.
+- Generated/vendor/build directories are excluded unless they are the subject of the task.
+- The map is small enough to paste into a subagent prompt.
+
+## Example Skeleton
+
+```markdown
+# Codebase Map
+
+## Purpose
+
+...
+
+## Languages and Tooling
+
+- Python package: `pyproject.toml`
+- Node app: `website/package.json`
+
+## Entrypoints
+
+- CLI: `hermes_cli/main.py`
+- Dashboard: `dashboard/` ...
+
+## Key Directories
+
+- `agent/` — ...
+- `tools/` — ...
+
+## Commands
+
+- Tests: `pytest ...`
+- Type checks: `ty check ...`
+
+## Task-Relevant Targets
+
+...
+
+## Risks
+
+...
+```


### PR DESCRIPTION
## Summary

Adds two self-improvement capabilities for Hermes Agent:

- `skills/software-development/codebase-map/SKILL.md`: a repeatable workflow for mapping unfamiliar repositories before editing, reviewing, or delegating work.
- `.github/workflows/hermes-ai-pr-check.yml`: a GitHub Actions workflow that runs Hermes on pull requests, uploads the review artifact, and comments a concise AI review.

## Verification

- `git diff --check`
- Parsed workflow YAML with Python/PyYAML inside the Hermes Docker image
- Sanity checked the skill markdown starts with `# Codebase Map`

## Notes

The PR review workflow uses repository secrets/vars for provider selection and API keys.