### PR TITLE
test: cover run_tests venv fallback message

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,7 +35,7 @@ for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agen
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  echo "error: no virtualenv found in $REPO_ROOT/.venv, $REPO_ROOT/venv, or $HOME/.hermes/hermes-agent/venv" >&2
   exit 1
 fi
 

--- a/tests/test_run_tests_script.py
+++ b/tests/test_run_tests_script.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_TESTS = REPO_ROOT / "scripts" / "run_tests.sh"
+
+
+def test_missing_virtualenv_error_mentions_shared_worktree_fallback():
+    script = RUN_TESTS.read_text(encoding="utf-8")
+    expected = "$HOME/.hermes/hermes-agent/venv"
+
+    assert expected in script
+
+    error_lines = [line for line in script.splitlines() if "error: no virtualenv found" in line]
+    assert error_lines, "run_tests.sh should emit a clear missing-virtualenv error"
+    assert expected in error_lines[0]


### PR DESCRIPTION
## Summary
- Add a regression test for the `scripts/run_tests.sh` missing-virtualenv error message.
- Update the error message to include the shared worktree fallback venv path that the script already probes.

## Test Plan
- `bash -n scripts/run_tests.sh`
- `PYTHONDONTWRITEBYTECODE=1 /Users/meow/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_run_tests_script.py -q -p no:cacheprovider -o 'addopts=' --tb=short`
- `PYTHONDONTWRITEBYTECODE=1 /Users/meow/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_commands.py tests/test_run_tests_script.py -q -p no:cacheprovider --ignore=tests/integration --ignore=tests/e2e -m 'not integration' -o 'addopts=' --tb=short`

## Notes
Small test-runner clarity fix. No behavior change beyond a more accurate error message.
