### PR TITLE
fix(backup): floor keep to 1 in _prune_pre_migration_backups

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -874,9 +874,13 @@ def _prune_pre_migration_backups(backup_dir: Path, keep: int) -> int:
 
     Only touches files matching ``pre-migration-*.zip`` so other backups in
     the same directory are never touched.
+
+    ``keep`` is floored to 1 because this helper is only called immediately
+    after a fresh backup is written — same rationale as
+    :func:`_prune_pre_update_backups`.
     """
-    if keep < 0:
-        keep = 0
+    if keep < 1:
+        keep = 1
     if not backup_dir.exists():
         return 0
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1635,3 +1635,43 @@ class TestPreMigrationBackup:
             _t.sleep(1.05)
         # Update backup must still be there
         assert update_backup.exists(), "pre-migration rotation wrongly pruned the pre-update backup"
+
+    def test_keep_zero_does_not_delete_freshly_created_migration_backup(self, hermes_home):
+        """Regression: keep=0 triggered ``backups[0:]`` — wiping the just-written
+        zip and returning a path that no longer exists.  The floor (keep>=1)
+        preserves the new file regardless of the caller value.
+        """
+        from hermes_cli.backup import create_pre_migration_backup
+        out = create_pre_migration_backup(hermes_home=hermes_home, keep=0)
+        assert out is not None
+        assert out.exists(), (
+            "keep=0 silently deleted the freshly-created migration backup; "
+            "floor should preserve the just-written file."
+        )
+
+    def test_keep_negative_does_not_delete_freshly_created_migration_backup(self, hermes_home):
+        from hermes_cli.backup import create_pre_migration_backup
+        out = create_pre_migration_backup(hermes_home=hermes_home, keep=-3)
+        assert out is not None
+        assert out.exists()
+
+    def test_keep_zero_still_prunes_older_migration_backups(self, hermes_home):
+        """The floor preserves the newest backup but must still rotate older ones."""
+        import time as _t
+        from hermes_cli.backup import create_pre_migration_backup
+
+        first = create_pre_migration_backup(hermes_home=hermes_home, keep=5)
+        _t.sleep(1.05)
+        second = create_pre_migration_backup(hermes_home=hermes_home, keep=5)
+        _t.sleep(1.05)
+        third = create_pre_migration_backup(hermes_home=hermes_home, keep=0)
+
+        remaining = {
+            p.name for p in (hermes_home / "backups").iterdir()
+            if p.name.startswith("pre-migration-")
+        }
+        assert third.name in remaining, "Floor must preserve the newest migration backup"
+        assert first.name not in remaining and second.name not in remaining, (
+            f"keep=0 floored to 1 should still prune older migration backups; "
+            f"remaining={remaining}"
+        )


### PR DESCRIPTION
`_prune_pre_migration_backups` floored `keep` to 0 (via `if keep < 0`) instead of 1. Passing `keep=0` triggered `backups[0:]`, deleting all pre-migration zips — including the one written one line earlier. `create_pre_migration_backup()` then returned a path that no longer existed.

## Root cause

```python
# Before — wrong floor
if keep < 0:
    keep = 0          # keep=0 still deletes everything via backups[0:]

# After — correct floor  
if keep < 1:
    keep = 1
```

## Relation to prior work

Symmetric with the `_prune_pre_update_backups` fix (b46b0c988): that helper received the same `keep < 1` floor and docstring note explaining the rationale. `_prune_pre_migration_backups` is the direct sibling and was missed.

## Tests

Three regression cases added to `TestPreMigrationBackup`, mirroring the three cases from `TestPreUpdateBackup`:

| Test | Asserts |
|------|---------|
| `test_keep_zero_does_not_delete_freshly_created_migration_backup` | `keep=0` leaves the new zip on disk |
| `test_keep_negative_does_not_delete_freshly_created_migration_backup` | `keep=-3` same |
| `test_keep_zero_still_prunes_older_migration_backups` | floor of 1 still rotates older archives |