### PR TITLE
fix: preserve launchd gateway env on restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -24,6 +24,7 @@ from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
     is_managed,
+    load_env,
     managed_error,
     read_raw_config,
     save_env_value,
@@ -934,6 +935,103 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     )
 
 
+def _launchd_extra_env_vars() -> dict[str, str]:
+    """Return gateway-relevant env vars that should be embedded in launchd."""
+    env_vars = load_env()
+    keys: set[str] = set()
+    prefixes = (
+        "TELEGRAM_",
+        "DISCORD_",
+        "SLACK_",
+        "MATRIX_",
+        "MATTERMOST_",
+        "WHATSAPP_",
+        "SIGNAL_",
+        "EMAIL_",
+        "SMS_",
+        "TWILIO_",
+        "DINGTALK_",
+        "FEISHU_",
+        "WECOM_",
+        "WEIXIN_",
+        "BLUEBUBBLES_",
+        "QQ_",
+        "HERMES_GATEWAY_",
+    )
+    explicit_keys = {
+        "GATEWAY_ALLOW_ALL_USERS",
+        "HERMES_AGENT_TIMEOUT",
+        "HERMES_AGENT_TIMEOUT_WARNING",
+        "HERMES_AGENT_NOTIFY_INTERVAL",
+        "HERMES_RESTART_DRAIN_TIMEOUT",
+        "HERMES_TIMEZONE",
+    }
+
+    for key in set(env_vars) | set(os.environ):
+        if key in explicit_keys or key.startswith(prefixes):
+            keys.add(key)
+
+    return {
+        key: value
+        for key in sorted(keys)
+        if (value := get_env_value(key))
+    }
+
+
+def _launchd_env_vars_xml(env_vars: dict[str, str]) -> str:
+    from xml.sax.saxutils import escape
+
+    lines = []
+    for key, value in env_vars.items():
+        lines.append(f"        <key>{escape(key)}</key>")
+        lines.append(f"        <string>{escape(str(value))}</string>")
+    return "\n".join(lines)
+
+
+def _launchd_target(label: str | None = None) -> str:
+    return f"{_launchd_domain()}/{label or get_launchd_label()}"
+
+
+def _launchd_job_is_loaded(label: str | None = None) -> bool:
+    result = subprocess.run(
+        ["launchctl", "print", _launchd_target(label)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _launchd_bootstrap(
+    plist_path: Path,
+    *,
+    label: str | None = None,
+    check: bool = True,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess:
+    """Bootstrap a launchd job, tolerating rc=5 when the job is already loaded."""
+    result = subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode == 0:
+        return result
+    if result.returncode == 5 and _launchd_job_is_loaded(label):
+        return result
+    if check:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            result.args,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+    return result
+
+
 def systemd_unit_is_current(system: bool = False) -> bool:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
@@ -1250,6 +1348,14 @@ def generate_launchd_plist() -> str:
         dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
     )
 
+    env_vars = {
+        "PATH": sane_path,
+        "VIRTUAL_ENV": venv_dir,
+        "HERMES_HOME": hermes_home,
+        **_launchd_extra_env_vars(),
+    }
+    env_vars_xml = _launchd_env_vars_xml(env_vars)
+
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
         f"<string>{python_path}</string>",
@@ -1283,12 +1389,7 @@ def generate_launchd_plist() -> str:
     
     <key>EnvironmentVariables</key>
     <dict>
-        <key>PATH</key>
-        <string>{sane_path}</string>
-        <key>VIRTUAL_ENV</key>
-        <string>{venv_dir}</string>
-        <key>HERMES_HOME</key>
-        <string>{hermes_home}</string>
+{env_vars_xml}
     </dict>
     
     <key>RunAtLoad</key>
@@ -1334,8 +1435,8 @@ def refresh_launchd_plist_if_needed() -> bool:
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
     # Bootout/bootstrap so launchd picks up the new definition
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)
+    subprocess.run(["launchctl", "bootout", _launchd_target(label)], check=False, timeout=90)
+    _launchd_bootstrap(plist_path, label=label, check=False, timeout=30)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
@@ -1355,9 +1456,9 @@ def launchd_install(force: bool = False):
     
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     print(f"Installing launchd service to: {plist_path}")
-    plist_path.write_text(generate_launchd_plist())
+    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+    _launchd_bootstrap(plist_path, label=get_launchd_label(), check=True, timeout=30)
     
     print()
     print("✓ Service installed and loaded!")
@@ -1387,20 +1488,20 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        _launchd_bootstrap(plist_path, label=label, check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
-        if e.returncode not in (3, 113):
+        if e.returncode not in (3, 5, 113):
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        _launchd_bootstrap(plist_path, label=label, check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
     print("✓ Service started")
 
 def launchd_stop():
@@ -1464,7 +1565,7 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    target = _launchd_target(label)
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
@@ -1485,12 +1586,12 @@ def launchd_restart():
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
-        if e.returncode not in (3, 113):
+        if e.returncode not in (3, 5, 113):
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+        _launchd_bootstrap(plist_path, label=label, check=True, timeout=30)
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -268,6 +268,37 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_tolerates_bootstrap_io_error_when_job_is_loaded(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        calls = []
+
+        def fake_run(cmd, check=False, capture_output=False, text=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
+                raise gateway_cli.subprocess.CalledProcessError(5, cmd, stderr="Bootstrap failed: 5: Input/output error")
+            if cmd == ["launchctl", "bootstrap", domain, str(plist_path)]:
+                return SimpleNamespace(returncode=5, stdout="", stderr="Bootstrap failed: 5: Input/output error", args=cmd)
+            if cmd == ["launchctl", "print", target]:
+                return SimpleNamespace(returncode=0, stdout="loaded", stderr="", args=cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="", args=cmd)
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        assert calls == [
+            ["launchctl", "kickstart", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "print", target],
+            ["launchctl", "kickstart", target],
+        ]
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -136,6 +136,17 @@ class TestLaunchdPlistPath:
         assert "<key>VIRTUAL_ENV</key>" in plist
         assert "<key>HERMES_HOME</key>" in plist
 
+    def test_plist_embeds_gateway_env_vars_from_runtime_or_dotenv(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:abc")
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "42")
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>TELEGRAM_BOT_TOKEN</key>" in plist
+        assert "<string>123:abc</string>" in plist
+        assert "<key>TELEGRAM_ALLOWED_USERS</key>" in plist
+        assert "<string>42</string>" in plist
+
     def test_plist_path_includes_venv_bin(self):
         plist = gateway_cli.generate_launchd_plist()
         detected = gateway_cli._detect_venv_dir()


### PR DESCRIPTION
- embed messaging env vars in generated launchd plist
- tolerate launchctl bootstrap rc=5 when job is already loaded
- add regression coverage for launchd plist env persistence and bootstrap recovery

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

PR title
fix: preserve launchd gateway env on restart

PR body
## Summary
- preserve messaging/gateway environment variables in the generated macOS launchd plist
- fix Hermes gateway restarts that dropped Telegram config and came back with no active messaging platform
- tolerate `launchctl bootstrap` exit code 5 when the launchd job is already loaded
- add regression tests for plist env persistence and launchd bootstrap recovery

## Problem
On macOS, `hermes gateway start` could rewrite the launch agent plist without Telegram environment settings like:
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_ALLOWED_USERS`

That left the gateway loaded but effectively offline, showing behavior like:
- `No messaging platforms enabled`
- service appears started, but bot is unreachable

There was also a launchd edge case where `launchctl bootstrap` could return:
- `Bootstrap failed: 5: Input/output error`

even when the job was already loaded.

## Fix
- embed gateway/messaging env vars from Hermes config env into the generated launchd plist
- add helper logic for safer launchd bootstrap handling
- treat bootstrap rc=5 as non-fatal when launchd confirms the job is already loaded
- update launchd install/start/restart refresh paths to use the safer bootstrap flow

## Tests
Added/updated regression coverage for:
- launchd plist includes Telegram env vars
- launchd start tolerates bootstrap rc=5 when the job is already loaded

## Verification
- targeted tests passed:
  - `tests/hermes_cli/test_gateway_service.py`
  - `tests/hermes_cli/test_update_gateway_restart.py`
- local result:
  - `106 passed`

## Real-world validation
- ran `hermes gateway start`
- confirmed service definition matched current install
- confirmed gateway loaded successfully
- confirmed plist retained:
  - `TELEGRAM_ALLOWED_USERS`
  - `TELEGRAM_BOT_TOKEN`
- confirmed live established connections to `api.telegram.org:443`