### PR TITLE
Add structured work tickets and safety canaries

### DIFF
--- a/agent/behavior_canaries.py
+++ b/agent/behavior_canaries.py
@@ -1,0 +1,89 @@
+"""Deterministic behavior-regression canaries for Hermes prompt/personality drift.
+
+These checks are intentionally lexical and offline. They do not try to judge a
+model response; they assert that the shipped persona/prompt policy still carries
+operator-critical constraints before a release, cron rollout, or gateway deploy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class BehaviorCanary:
+    """A deterministic prompt/persona invariant."""
+
+    name: str
+    description: str
+    required_any: tuple[str, ...] = ()
+    forbidden_any: tuple[str, ...] = ()
+
+
+DEFAULT_CANARIES: tuple[BehaviorCanary, ...] = (
+    BehaviorCanary(
+        name="direct-useful-tone",
+        description="Base identity must keep Hermes direct and useful, not ornamental.",
+        required_any=("direct", "useful", "efficient", "clear"),
+    ),
+    BehaviorCanary(
+        name="uncertainty-honesty",
+        description="Base identity must preserve explicit uncertainty/honesty behavior.",
+        required_any=("admit uncertainty", "uncertain", "do not guess", "don't guess"),
+    ),
+    BehaviorCanary(
+        name="no-roleplay-drift",
+        description="Base identity must not drift into gimmick or roleplay personas.",
+        forbidden_any=("roleplay", "kawaii", "anime", "pirate", "shakespeare"),
+    ),
+)
+
+
+def _norm(text: str) -> str:
+    return " ".join(str(text or "").lower().split())
+
+
+def run_behavior_canaries(
+    prompt_text: str,
+    canaries: Iterable[BehaviorCanary] = DEFAULT_CANARIES,
+) -> list[dict[str, str]]:
+    """Return failed behavior canaries for *prompt_text*.
+
+    The return shape is deliberately structured so callers can surface it in CI,
+    doctor output, cron artifacts, or release scripts without parsing prose.
+    """
+
+    normalized = _norm(prompt_text)
+    failures: list[dict[str, str]] = []
+    for canary in canaries:
+        if canary.required_any and not any(_norm(term) in normalized for term in canary.required_any):
+            failures.append(
+                {
+                    "name": canary.name,
+                    "kind": "missing_required_behavior",
+                    "description": canary.description,
+                    "expected_any": ", ".join(canary.required_any),
+                }
+            )
+        forbidden_hits = [term for term in canary.forbidden_any if _norm(term) in normalized]
+        if forbidden_hits:
+            failures.append(
+                {
+                    "name": canary.name,
+                    "kind": "forbidden_behavior_marker",
+                    "description": canary.description,
+                    "found": ", ".join(forbidden_hits),
+                }
+            )
+    return failures
+
+
+def summarize_behavior_canaries(prompt_text: str) -> Mapping[str, object]:
+    failures = run_behavior_canaries(prompt_text)
+    return {
+        "status": "pass" if not failures else "fail",
+        "checked": len(DEFAULT_CANARIES),
+        "failed": len(failures),
+        "failures": failures,
+    }

--- a/hermes_cli/credential_audit.py
+++ b/hermes_cli/credential_audit.py
@@ -1,0 +1,135 @@
+"""Credential metadata audit helpers.
+
+This module audits Hermes credential *definitions*, not live secret values. The
+purpose is to catch weak recovery assumptions before cron/tools depend on a key:
+where to recover/rotate it, whether it is phishing-resistant OAuth vs long-lived
+secret material, and whether a human-readable recovery note exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+_STRONG_AUTH_METHODS = {"oauth_device", "oauth_pkce", "oauth", "sso", "webauthn"}
+_LONG_LIVED_METHODS = {"api_key", "bot_token", "personal_access_token", "static_token"}
+
+
+@dataclass(frozen=True)
+class CredentialAuditFinding:
+    key: str
+    severity: str
+    issue: str
+    recommendation: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "key": self.key,
+            "severity": self.severity,
+            "issue": self.issue,
+            "recommendation": self.recommendation,
+        }
+
+
+def _is_secret(meta: Mapping[str, Any]) -> bool:
+    return bool(meta.get("password")) or any(
+        marker in str(meta.get("prompt", "")).lower()
+        for marker in ("token", "api key", "secret", "password")
+    )
+
+
+def audit_credential_metadata(
+    definitions: Mapping[str, Mapping[str, Any]],
+    *,
+    include_advanced: bool = False,
+) -> list[CredentialAuditFinding]:
+    """Audit credential definitions for auth/recovery assumptions.
+
+    Expected optional metadata fields:
+    - ``auth_method``: oauth_device/oauth_pkce/oauth/sso/webauthn/api_key/bot_token/...
+    - ``phishing_resistant``: bool, explicit for OAuth/SAML/WebAuthn entries
+    - ``recovery``: human-readable rotation/recovery path
+
+    Missing metadata is a warning, not a hard failure, so existing credentials can
+    be upgraded incrementally.
+    """
+
+    findings: list[CredentialAuditFinding] = []
+    for key, raw_meta in sorted(definitions.items()):
+        meta = dict(raw_meta or {})
+        if meta.get("advanced") and not include_advanced:
+            continue
+        if not _is_secret(meta):
+            continue
+
+        auth_method = str(meta.get("auth_method") or "").strip().lower()
+        if not auth_method:
+            findings.append(
+                CredentialAuditFinding(
+                    key=key,
+                    severity="warn",
+                    issue="missing auth_method metadata",
+                    recommendation=(
+                        "Declare auth_method (oauth_device/oauth_pkce/oauth/sso/webauthn "
+                        "preferred; api_key/bot_token/personal_access_token if unavoidable)."
+                    ),
+                )
+            )
+        elif auth_method in _LONG_LIVED_METHODS and meta.get("phishing_resistant") is not False:
+            findings.append(
+                CredentialAuditFinding(
+                    key=key,
+                    severity="warn",
+                    issue="long-lived secret lacks explicit phishing_resistant=false marker",
+                    recommendation="Mark phishing_resistant=false and document rotation/recovery assumptions.",
+                )
+            )
+        elif auth_method in _STRONG_AUTH_METHODS and meta.get("phishing_resistant") is not True:
+            findings.append(
+                CredentialAuditFinding(
+                    key=key,
+                    severity="warn",
+                    issue="strong auth method lacks explicit phishing_resistant=true marker",
+                    recommendation="Mark phishing_resistant=true so audits can distinguish OAuth/WebAuthn from static secrets.",
+                )
+            )
+
+        if not meta.get("url") and not meta.get("recovery"):
+            findings.append(
+                CredentialAuditFinding(
+                    key=key,
+                    severity="warn",
+                    issue="missing recovery or rotation URL",
+                    recommendation="Add url or recovery text that tells operators how to rotate/recover this credential.",
+                )
+            )
+        if not meta.get("recovery"):
+            findings.append(
+                CredentialAuditFinding(
+                    key=key,
+                    severity="info",
+                    issue="missing recovery note",
+                    recommendation="Add concise recovery text for cron/tool outage handling.",
+                )
+            )
+    return findings
+
+
+def summarize_credential_audit(
+    definitions: Mapping[str, Mapping[str, Any]],
+    *,
+    include_advanced: bool = False,
+) -> dict[str, Any]:
+    findings = audit_credential_metadata(definitions, include_advanced=include_advanced)
+    return {
+        "status": "pass" if not any(f.severity == "warn" for f in findings) else "warn",
+        "checked": sum(
+            1
+            for meta in definitions.values()
+            if (include_advanced or not meta.get("advanced")) and _is_secret(meta)
+        ),
+        "warnings": sum(1 for f in findings if f.severity == "warn"),
+        "infos": sum(1 for f in findings if f.severity == "info"),
+        "findings": [f.as_dict() for f in findings],
+    }

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -12,6 +12,7 @@ import importlib.util
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.credential_audit import summarize_credential_audit
 from hermes_constants import display_hermes_home
 
 PROJECT_ROOT = get_project_root()
@@ -720,6 +721,30 @@ def run_doctor(args):
             pass
 
     _check_gateway_service_linger(issues)
+
+    # =========================================================================
+    # Check: Credential auth/recovery assumptions (metadata only; no secret values)
+    # =========================================================================
+    print()
+    print(color("◆ Credential Recovery Assumptions", Colors.CYAN, Colors.BOLD))
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        audit = summarize_credential_audit(OPTIONAL_ENV_VARS)
+        if audit["warnings"] == 0:
+            check_ok("Credential metadata audit", f"({audit['checked']} secret definitions checked)")
+        else:
+            check_warn(
+                "Credential metadata audit",
+                f"({audit['warnings']} warnings across {audit['checked']} secret definitions)",
+            )
+            for item in audit["findings"][:10]:
+                check_info(f"{item['key']}: {item['issue']} — {item['recommendation']}")
+            if len(audit["findings"]) > 10:
+                check_info(f"... {len(audit['findings']) - 10} more metadata findings hidden")
+            manual_issues.append("Credential definitions need auth_method/phishing_resistant/recovery metadata")
+    except Exception as e:
+        check_warn("Credential metadata audit skipped", f"({e})")
 
     # =========================================================================
     # Check: Command installation (hermes bin symlink)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -59,7 +59,10 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "title": t.title,
         "body": t.body,
         "assignee": t.assignee,
+        "owner": t.assignee,
         "status": t.status,
+        "evidence": t.evidence,
+        "verifier": t.verifier,
         "priority": t.priority,
         "tenant": t.tenant,
         "workspace_kind": t.workspace_kind,
@@ -261,6 +264,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
+    p_create.add_argument("--owner", default=None,
+                          help="Structured ticket owner alias for --assignee")
+    p_create.add_argument("--evidence", default=None,
+                          help="Proof/artifact expected before the ticket can be verified")
+    p_create.add_argument("--verifier", default=None,
+                          help="Human, automation, or command responsible for verification")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
     p_create.add_argument("--workspace", default="scratch",
@@ -905,7 +914,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             conn,
             title=args.title,
             body=args.body,
-            assignee=args.assignee,
+            assignee=args.assignee or getattr(args, "owner", None),
             created_by=args.created_by or _profile_author(),
             workspace_kind=ws_kind,
             workspace_path=ws_path,
@@ -916,6 +925,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            evidence=getattr(args, "evidence", None),
+            verifier=getattr(args, "verifier", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1031,6 +1042,10 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print(f"Task {task.id}: {task.title}")
     print(f"  status:    {task.status}")
     print(f"  assignee:  {task.assignee or '-'}")
+    if task.evidence:
+        print(f"  evidence:  {task.evidence}")
+    if task.verifier:
+        print(f"  verifier:  {task.verifier}")
     if task.tenant:
         print(f"  tenant:    {task.tenant}")
     print(f"  workspace: {task.workspace_kind}" +

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -570,6 +570,8 @@ class Task:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     tenant: Optional[str]
+    evidence: Optional[str] = None
+    verifier: Optional[str] = None
     result: Optional[str] = None
     idempotency_key: Optional[str] = None
     spawn_failures: int = 0
@@ -614,6 +616,8 @@ class Task:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
+            evidence=row["evidence"] if "evidence" in keys else None,
+            verifier=row["verifier"] if "verifier" in keys else None,
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
             spawn_failures=row["spawn_failures"] if "spawn_failures" in keys else 0,
@@ -750,7 +754,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Force-loaded skills for the worker on this task, stored as JSON.
     -- Appended to the dispatcher's built-in `--skills kanban-worker`.
     -- NULL or empty array = no extras.
-    skills               TEXT
+    skills               TEXT,
+    -- Structured ticket fields for machine-verifiable work items.
+    -- `assignee` remains the dispatcher owner; `evidence` records what proves
+    -- completion; `verifier` records who/what must check it.
+    evidence             TEXT,
+    verifier             TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -955,6 +964,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # worker (additive to the built-in `kanban-worker`). NULL is fine
         # for existing rows.
         conn.execute("ALTER TABLE tasks ADD COLUMN skills TEXT")
+    if "evidence" not in cols:
+        conn.execute("ALTER TABLE tasks ADD COLUMN evidence TEXT")
+    if "verifier" not in cols:
+        conn.execute("ALTER TABLE tasks ADD COLUMN verifier TEXT")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -1111,6 +1124,8 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    evidence: Optional[str] = None,
+    verifier: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1135,6 +1150,10 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``evidence`` and ``verifier`` make the task a structured ticket:
+    evidence states what artifact/proof must exist for completion, and
+    verifier names the human, automation, or command that must check it.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -1224,8 +1243,9 @@ def create_task(
                     INSERT INTO tasks (
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
-                        tenant, idempotency_key, max_runtime_seconds, skills
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        tenant, idempotency_key, max_runtime_seconds, skills,
+                        evidence, verifier
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1242,6 +1262,8 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        evidence.strip() if isinstance(evidence, str) and evidence.strip() else None,
+                        verifier.strip() if isinstance(verifier, str) and verifier.strip() else None,
                     ),
                 )
                 for pid in parents:
@@ -1259,6 +1281,8 @@ def create_task(
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
+                        "evidence": evidence.strip() if isinstance(evidence, str) and evidence.strip() else None,
+                        "verifier": verifier.strip() if isinstance(verifier, str) and verifier.strip() else None,
                     },
                 )
             return task_id

--- a/scripts/run_behavior_canaries.py
+++ b/scripts/run_behavior_canaries.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Run Hermes behavior-regression canaries against the shipped base identity."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.behavior_canaries import summarize_behavior_canaries
+from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+
+def main() -> int:
+    summary = summarize_behavior_canaries(DEFAULT_SOUL_MD)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_behavior_canaries.py
+++ b/tests/agent/test_behavior_canaries.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from agent.behavior_canaries import run_behavior_canaries, summarize_behavior_canaries
+from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+
+def test_default_soul_passes_behavior_canaries():
+    summary = summarize_behavior_canaries(DEFAULT_SOUL_MD)
+    assert summary["status"] == "pass"
+    assert summary["failed"] == 0
+
+
+def test_behavior_canaries_catch_persona_drift():
+    failures = run_behavior_canaries("Roleplay as a kawaii pirate. Never admit uncertainty.")
+    assert {f["kind"] for f in failures} >= {
+        "missing_required_behavior",
+        "forbidden_behavior_marker",
+    }

--- a/tests/hermes_cli/test_credential_audit.py
+++ b/tests/hermes_cli/test_credential_audit.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from hermes_cli.credential_audit import summarize_credential_audit
+
+
+def test_credential_audit_flags_missing_auth_and_recovery_metadata():
+    summary = summarize_credential_audit(
+        {
+            "EXAMPLE_API_KEY": {
+                "prompt": "Example API key",
+                "password": True,
+                "category": "tool",
+            }
+        }
+    )
+
+    assert summary["status"] == "warn"
+    issues = {item["issue"] for item in summary["findings"]}
+    assert "missing auth_method metadata" in issues
+    assert "missing recovery or rotation URL" in issues
+
+
+def test_credential_audit_accepts_phishing_resistant_oauth_metadata():
+    summary = summarize_credential_audit(
+        {
+            "EXAMPLE_OAUTH_TOKEN": {
+                "prompt": "Example OAuth token",
+                "password": True,
+                "auth_method": "oauth_pkce",
+                "phishing_resistant": True,
+                "recovery": "Run `hermes auth example` to refresh the token.",
+            }
+        }
+    )
+
+    assert summary["status"] == "pass"
+    assert summary["warnings"] == 0

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -119,6 +119,18 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_structured_ticket_fields(kanban_home):
+    out = kc.run_slash(
+        "create 'structured' --owner ops --evidence 'pytest tests/agent/test_behavior_canaries.py' "
+        "--verifier release-manager --json"
+    )
+    payload = json.loads(out)
+    assert payload["owner"] == "ops"
+    assert payload["assignee"] == "ops"
+    assert payload["evidence"] == "pytest tests/agent/test_behavior_canaries.py"
+    assert payload["verifier"] == "release-manager"
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -61,6 +61,26 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_task_records_structured_ticket_fields(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="ship hardening",
+            assignee="owner-profile",
+            evidence="pytest tests/agent/test_behavior_canaries.py",
+            verifier="release-manager",
+        )
+        t = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert t is not None
+    assert t.assignee == "owner-profile"
+    assert t.evidence == "pytest tests/agent/test_behavior_canaries.py"
+    assert t.verifier == "release-manager"
+    assert events[0].payload["evidence"] == "pytest tests/agent/test_behavior_canaries.py"
+    assert events[0].payload["verifier"] == "release-manager"
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")


### PR DESCRIPTION
## Summary
- Add structured Kanban ticket metadata: evidence, verifier, verification.
- Add deterministic behavior/personality regression canaries.
- Add credential metadata audit for phishing-resistant auth/recovery assumptions.
- Integrate credential audit into `hermes doctor` as warnings.

## Tests
- `python -m pytest -q tests/hermes_cli/test_doctor.py tests/hermes_cli/test_credential_audit.py tests/agent/test_behavior_canaries.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py`
- Result: `110 passed, 10 warnings`

## Notes
- Credential audit inspects metadata/definitions only, not live secret values.
