### PR TITLE
Fix: browser_vision unconditionally passes --full, producing unreadable screenshots on long pages (#19620)

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2344,7 +2344,7 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         }, ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
+def browser_vision(question: str, annotate: bool = False, full_page: bool = True, task_id: Optional[str] = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
     
@@ -2359,6 +2359,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     Args:
         question: What you want to know about the page visually
         annotate: If True, overlay numbered [N] labels on interactive elements
+        full_page: If True, capture the entire page. If False, capture only the viewport.
         task_id: Task identifier for session isolation
         
     Returns:
@@ -2387,7 +2388,8 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         screenshot_args = []
         if annotate:
             screenshot_args.append("--annotate")
-        screenshot_args.append("--full")
+        if full_page:
+            screenshot_args.append("--full")
         screenshot_args.append(str(screenshot_path))
         result = _run_browser_command(
             effective_task_id, 


### PR DESCRIPTION
## What
The `browser_vision` function unconditionally took full-page screenshots. On long web pages, this produced excessively large and unreadable images, causing vision analysis to fail. This change introduces a `full_page` parameter to the function, which defaults to `True` to maintain backward compatibility. The screenshot command now only includes the `--full` flag when `full_page` is `True`, enabling callers to request a viewport-only screenshot.

## Changes
- `tools/browser_tool.py`:
  - Added a `full_page: bool = True` parameter to the `browser_vision` function signature.
  - Conditionally added the `--full` flag to the screenshot command based on the `full_page` parameter.
  - Updated the function docstring to reflect the new parameter.

## How to verify
1. Call `browser_vision` on a long web page with `full_page=False`.
2. Verify the resulting screenshot captures only the visible viewport.
3. Call `browser_vision` with `full_page=True` (or without the argument).
4. Verify the screenshot captures the full page,

---
_Opened via [Open Issue Fixer](https://github.com) · AI-assisted. Please review carefully before merging._