### PR TITLE
fix(nix): update npmDepsHash for hermes-tui

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -4,7 +4,7 @@ let
   src = ../ui-tui;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-a/HGI9OgVcTnZrMXA7xFMGnFoVxyHe95fulVz+WNYB0=";
+    hash = "sha256-tmKv51gGIHzfT6HqB3zR3mrRIfkmngrW1ad3Gg6n2aE=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "ui-tui"; attr = "tui"; pname = "hermes-tui"; };


### PR DESCRIPTION
## What does this PR do?

This PR updates the `npmDepsHash` in `nix/tui.nix` to match the current `package-lock.json` inside the `ui-tui` directory. 

The previous hash was causing a fixed-output derivation hash mismatch during the Nix flake build due to recent dependency updates (`nanostores`, etc.). I have verified that the `web` component still builds correctly and does not require a hash update.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #19760 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated the hardcoded `hash` value in the `npmDeps` derivation inside `nix/tui.nix` to correctly match the updated `package-lock.json` in the `ui-tui` directory.

## How to Test

1. Checkout the `main` branch and attempt to build the TUI component using Nix: `nix build .#tui`. It will fail with an `ERROR: npmDepsHash is out of date`.
2. Checkout this PR's branch.
3. Run `nix build .#tui` again. Observe that the build now successfully completes.
4. Run `nix build .#web` to verify that the web component still builds successfully and was not affected by this change.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow[Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(N/A for Nix builds)*
- [x] I've added tests for my changes *(N/A, the Nix flake evaluation and build itself acts as the test)*
- [x] I've tested on my platform: NixOS unstable (x86_64-linux)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Error log on `main` before this fix:**
```text
> Validating consistency between /build/ui-tui/package-lock.json and /nix/store/...-npm-deps/package-lock.json
> 15d14
> <         "nanostores": "^1.2.0",
> 5306a5306
> >       "peer": true,
> 
> ERROR: npmDepsHash is out of date