### PR TITLE
feat(dashboard): scope cron jobs by profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2287,73 +2287,135 @@ class CronJobUpdate(BaseModel):
     updates: dict
 
 
+_cron_profile_lock = threading.RLock()
+
+
+def _resolve_cron_profile(name: str) -> Tuple[str, Path]:
+    """Return canonical profile name and profile HERMES_HOME for cron APIs."""
+    from hermes_cli import profiles as profiles_mod
+
+    try:
+        canon = profiles_mod.normalize_profile_name(name or "default")
+        profiles_mod.validate_profile_name(canon)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not profiles_mod.profile_exists(canon):
+        raise HTTPException(status_code=404, detail=f"Profile '{canon}' does not exist.")
+    return canon, profiles_mod.get_profile_dir(canon)
+
+
+def _with_cron_profile(profile: str, operation):
+    """Run a cron.jobs operation against the selected profile's cron store.
+
+    cron.jobs keeps its storage paths as module-level constants resolved from
+    HERMES_HOME at import time. The dashboard can inspect multiple profiles in
+    one process, so API requests temporarily point those constants at the
+    selected profile under a process lock and restore them immediately after.
+    """
+    _, profile_home = _resolve_cron_profile(profile)
+    import cron.jobs as cron_jobs
+
+    cron_dir = profile_home / "cron"
+    output_dir = cron_dir / "output"
+    jobs_file = cron_dir / "jobs.json"
+
+    with _cron_profile_lock:
+        old_paths = (
+            cron_jobs.HERMES_DIR,
+            cron_jobs.CRON_DIR,
+            cron_jobs.JOBS_FILE,
+            cron_jobs.OUTPUT_DIR,
+        )
+        try:
+            cron_jobs.HERMES_DIR = profile_home.resolve()
+            cron_jobs.CRON_DIR = cron_dir
+            cron_jobs.JOBS_FILE = jobs_file
+            cron_jobs.OUTPUT_DIR = output_dir
+            return operation(cron_jobs)
+        finally:
+            (
+                cron_jobs.HERMES_DIR,
+                cron_jobs.CRON_DIR,
+                cron_jobs.JOBS_FILE,
+                cron_jobs.OUTPUT_DIR,
+            ) = old_paths
+
+
 @app.get("/api/cron/jobs")
-async def list_cron_jobs():
-    from cron.jobs import list_jobs
-    return list_jobs(include_disabled=True)
+async def list_cron_jobs(profile: str = "default"):
+    return _with_cron_profile(
+        profile,
+        lambda cron_jobs: cron_jobs.list_jobs(include_disabled=True),
+    )
 
 
 @app.get("/api/cron/jobs/{job_id}")
-async def get_cron_job(job_id: str):
-    from cron.jobs import get_job
-    job = get_job(job_id)
+async def get_cron_job(job_id: str, profile: str = "default"):
+    job = _with_cron_profile(profile, lambda cron_jobs: cron_jobs.get_job(job_id))
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
 
 
 @app.post("/api/cron/jobs")
-async def create_cron_job(body: CronJobCreate):
-    from cron.jobs import create_job
+async def create_cron_job(body: CronJobCreate, profile: str = "default"):
     try:
-        job = create_job(prompt=body.prompt, schedule=body.schedule,
-                         name=body.name, deliver=body.deliver)
+        job = _with_cron_profile(
+            profile,
+            lambda cron_jobs: cron_jobs.create_job(
+                prompt=body.prompt,
+                schedule=body.schedule,
+                name=body.name,
+                deliver=body.deliver,
+            ),
+        )
         return job
+    except HTTPException:
+        raise
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")
         raise HTTPException(status_code=400, detail=str(e))
 
 
 @app.put("/api/cron/jobs/{job_id}")
-async def update_cron_job(job_id: str, body: CronJobUpdate):
-    from cron.jobs import update_job
-    job = update_job(job_id, body.updates)
+async def update_cron_job(job_id: str, body: CronJobUpdate, profile: str = "default"):
+    job = _with_cron_profile(
+        profile,
+        lambda cron_jobs: cron_jobs.update_job(job_id, body.updates),
+    )
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
 
 
 @app.post("/api/cron/jobs/{job_id}/pause")
-async def pause_cron_job(job_id: str):
-    from cron.jobs import pause_job
-    job = pause_job(job_id)
+async def pause_cron_job(job_id: str, profile: str = "default"):
+    job = _with_cron_profile(profile, lambda cron_jobs: cron_jobs.pause_job(job_id))
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
 
 
 @app.post("/api/cron/jobs/{job_id}/resume")
-async def resume_cron_job(job_id: str):
-    from cron.jobs import resume_job
-    job = resume_job(job_id)
+async def resume_cron_job(job_id: str, profile: str = "default"):
+    job = _with_cron_profile(profile, lambda cron_jobs: cron_jobs.resume_job(job_id))
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
 
 
 @app.post("/api/cron/jobs/{job_id}/trigger")
-async def trigger_cron_job(job_id: str):
-    from cron.jobs import trigger_job
-    job = trigger_job(job_id)
+async def trigger_cron_job(job_id: str, profile: str = "default"):
+    job = _with_cron_profile(profile, lambda cron_jobs: cron_jobs.trigger_job(job_id))
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
 
 
 @app.delete("/api/cron/jobs/{job_id}")
-async def delete_cron_job(job_id: str):
-    from cron.jobs import remove_job
-    if not remove_job(job_id):
+async def delete_cron_job(job_id: str, profile: str = "default"):
+    removed = _with_cron_profile(profile, lambda cron_jobs: cron_jobs.remove_job(job_id))
+    if not removed:
         raise HTTPException(status_code=404, detail="Job not found")
     return {"ok": True}
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,44 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+    def test_cron_jobs_can_be_scoped_by_profile(self):
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        (hermes_home / "profiles" / "coder").mkdir(parents=True)
+
+        default_resp = self.client.post(
+            "/api/cron/jobs?profile=default",
+            json={
+                "prompt": "default profile job",
+                "schedule": "every 1h",
+                "name": "default-job",
+                "deliver": "local",
+            },
+        )
+        coder_resp = self.client.post(
+            "/api/cron/jobs?profile=coder",
+            json={
+                "prompt": "coder profile job",
+                "schedule": "every 2h",
+                "name": "coder-job",
+                "deliver": "local",
+            },
+        )
+
+        assert default_resp.status_code == 200
+        assert coder_resp.status_code == 200
+
+        default_jobs = self.client.get("/api/cron/jobs?profile=default")
+        coder_jobs = self.client.get("/api/cron/jobs?profile=coder")
+
+        assert default_jobs.status_code == 200
+        assert coder_jobs.status_code == 200
+        assert [job["name"] for job in default_jobs.json()] == ["default-job"]
+        assert [job["name"] for job in coder_jobs.json()] == ["coder-job"]
+        assert (hermes_home / "cron" / "jobs.json").exists()
+        assert (hermes_home / "profiles" / "coder" / "cron" / "jobs.json").exists()
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -207,6 +207,7 @@ export const en: Translations = {
     namePlaceholder: "e.g. Daily summary",
     prompt: "Prompt",
     promptPlaceholder: "What should the agent do on each run?",
+    profile: "Profile",
     schedule: "Schedule (cron expression)",
     schedulePlaceholder: "0 9 * * *",
     deliverTo: "Deliver to",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -211,6 +211,7 @@ export interface Translations {
     namePlaceholder: string;
     prompt: string;
     promptPlaceholder: string;
+    profile: string;
     schedule: string;
     schedulePlaceholder: string;
     deliverTo: string;

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -204,6 +204,7 @@ export const zh: Translations = {
     namePlaceholder: "例如：每日总结",
     prompt: "提示词",
     promptPlaceholder: "代理每次运行时应执行什么操作？",
+    profile: "多Agent配置",
     schedule: "调度表达式（cron）",
     schedulePlaceholder: "0 9 * * *",
     deliverTo: "投递至",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,11 @@ declare global {
 let _sessionToken: string | null = null;
 const SESSION_HEADER = "X-Hermes-Session-Token";
 
+function profileQuery(profile?: string): string {
+  if (!profile) return "";
+  return `?${new URLSearchParams({ profile }).toString()}`;
+}
+
 function setSessionHeader(headers: Headers, token: string): void {
   if (!headers.has(SESSION_HEADER)) {
     headers.set(SESSION_HEADER, token);
@@ -116,21 +121,37 @@ export const api = {
   },
 
   // Cron jobs
-  getCronJobs: () => fetchJSON<CronJob[]>("/api/cron/jobs"),
-  createCronJob: (job: { prompt: string; schedule: string; name?: string; deliver?: string }) =>
-    fetchJSON<CronJob>("/api/cron/jobs", {
+  getCronJobs: (profile?: string) =>
+    fetchJSON<CronJob[]>(`/api/cron/jobs${profileQuery(profile)}`),
+  createCronJob: (
+    job: { prompt: string; schedule: string; name?: string; deliver?: string },
+    profile?: string,
+  ) =>
+    fetchJSON<CronJob>(`/api/cron/jobs${profileQuery(profile)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(job),
     }),
-  pauseCronJob: (id: string) =>
-    fetchJSON<{ ok: boolean }>(`/api/cron/jobs/${id}/pause`, { method: "POST" }),
-  resumeCronJob: (id: string) =>
-    fetchJSON<{ ok: boolean }>(`/api/cron/jobs/${id}/resume`, { method: "POST" }),
-  triggerCronJob: (id: string) =>
-    fetchJSON<{ ok: boolean }>(`/api/cron/jobs/${id}/trigger`, { method: "POST" }),
-  deleteCronJob: (id: string) =>
-    fetchJSON<{ ok: boolean }>(`/api/cron/jobs/${id}`, { method: "DELETE" }),
+  pauseCronJob: (id: string, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/cron/jobs/${id}/pause${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
+  resumeCronJob: (id: string, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/cron/jobs/${id}/resume${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
+  triggerCronJob: (id: string, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/cron/jobs/${id}/trigger${profileQuery(profile)}`,
+      { method: "POST" },
+    ),
+  deleteCronJob: (id: string, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/cron/jobs/${id}${profileQuery(profile)}`,
+      { method: "DELETE" },
+    ),
 
   // Profiles (minimal)
   getProfiles: () =>

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -6,7 +6,7 @@ import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { H2 } from "@/components/NouiTypography";
 import { api } from "@/lib/api";
-import type { CronJob } from "@/lib/api";
+import type { CronJob, ProfileInfo } from "@/lib/api";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@/hooks/useToast";
 import { useConfirmDelete } from "@/hooks/useConfirmDelete";
@@ -33,6 +33,8 @@ const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState("default");
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
@@ -46,11 +48,30 @@ export default function CronPage() {
 
   const loadJobs = useCallback(() => {
     api
-      .getCronJobs()
+      .getCronJobs(selectedProfile)
       .then(setJobs)
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
-  }, [showToast, t.common.loading]);
+  }, [selectedProfile, showToast, t.common.loading]);
+
+  useEffect(() => {
+    api
+      .getProfiles()
+      .then((res) => setProfiles(res.profiles))
+      .catch(() =>
+        setProfiles([
+          {
+            name: "default",
+            path: "",
+            is_default: true,
+            model: null,
+            provider: null,
+            has_env: false,
+            skill_count: 0,
+          },
+        ]),
+      );
+  }, []);
 
   useEffect(() => {
     loadJobs();
@@ -63,12 +84,15 @@ export default function CronPage() {
     }
     setCreating(true);
     try {
-      await api.createCronJob({
-        prompt: prompt.trim(),
-        schedule: schedule.trim(),
-        name: name.trim() || undefined,
-        deliver,
-      });
+      await api.createCronJob(
+        {
+          prompt: prompt.trim(),
+          schedule: schedule.trim(),
+          name: name.trim() || undefined,
+          deliver,
+        },
+        selectedProfile,
+      );
       showToast(t.common.create + " ✓", "success");
       setPrompt("");
       setSchedule("");
@@ -86,13 +110,13 @@ export default function CronPage() {
     try {
       const isPaused = job.state === "paused";
       if (isPaused) {
-        await api.resumeCronJob(job.id);
+        await api.resumeCronJob(job.id, selectedProfile);
         showToast(
           `${t.cron.resume}: "${job.name || job.prompt.slice(0, 30)}"`,
           "success",
         );
       } else {
-        await api.pauseCronJob(job.id);
+        await api.pauseCronJob(job.id, selectedProfile);
         showToast(
           `${t.cron.pause}: "${job.name || job.prompt.slice(0, 30)}"`,
           "success",
@@ -106,7 +130,7 @@ export default function CronPage() {
 
   const handleTrigger = async (job: CronJob) => {
     try {
-      await api.triggerCronJob(job.id);
+      await api.triggerCronJob(job.id, selectedProfile);
       showToast(
         `${t.cron.triggerNow}: "${job.name || job.prompt.slice(0, 30)}"`,
         "success",
@@ -122,7 +146,7 @@ export default function CronPage() {
       async (id: string) => {
         const job = jobs.find((j) => j.id === id);
         try {
-          await api.deleteCronJob(id);
+          await api.deleteCronJob(id, selectedProfile);
           showToast(
             `${t.common.delete}: "${job?.name || (job?.prompt ?? "").slice(0, 30) || id}"`,
             "success",
@@ -133,7 +157,14 @@ export default function CronPage() {
           throw e;
         }
       },
-      [jobs, loadJobs, showToast, t.common.delete, t.status.error],
+      [
+        jobs,
+        loadJobs,
+        selectedProfile,
+        showToast,
+        t.common.delete,
+        t.status.error,
+      ],
     ),
   });
 
@@ -166,6 +197,26 @@ export default function CronPage() {
         }
         loading={jobDelete.isDeleting}
       />
+
+      <div className="flex flex-col gap-2 sm:max-w-xs">
+        <Label htmlFor="cron-profile">{t.cron.profile}</Label>
+        <Select
+          id="cron-profile"
+          value={selectedProfile}
+          onValueChange={(value) => {
+            setLoading(true);
+            setSelectedProfile(value);
+          }}
+        >
+          {profiles.map((profile) => (
+            <SelectOption key={profile.name} value={profile.name}>
+              {profile.is_default
+                ? `${profile.name} (${t.profiles.defaultBadge})`
+                : profile.name}
+            </SelectOption>
+          ))}
+        </Select>
+      </div>
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
## What does this PR do?

Adds profile selection to the dashboard Cron tab so users can view and manage scheduled jobs for the default profile or any named Hermes profile. Previously the dashboard cron endpoints always used the dashboard process's active `HERMES_HOME`, so named-profile cron jobs were invisible from the Cron tab.

The backend now accepts a `profile` query parameter on cron job endpoints, validates the profile using the existing profile helpers, and runs cron job storage operations against that profile's `cron/jobs.json`. The React Cron page loads available profiles and passes the selected profile through list/create/pause/resume/trigger/delete actions.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added profile-scoped cron handling in `hermes_cli/web_server.py` for list/get/create/update/pause/resume/trigger/delete endpoints.
- Added a profile dropdown to `web/src/pages/CronPage.tsx`.
- Updated `web/src/lib/api.ts` so cron dashboard calls include the selected profile.
- Added English/Chinese i18n copy and translation typing for the Cron profile label.
- Added a dashboard API test proving default and named profile cron jobs are stored and listed separately.

## How to Test

1. Create at least one named profile, then add cron jobs under both the default profile and the named profile.
2. Run `hermes dashboard` and open the Cron tab.
3. Use the Profile dropdown to switch between profiles and verify each profile shows its own cron jobs; create/pause/resume/trigger/delete actions should affect only the selected profile.

Validation run locally on macOS:

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server.py
PATH=/Users/mike/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build
```

`npm run lint` still fails on existing dashboard lint debt outside this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Backend and dashboard build checks passed locally. Full lint currently has pre-existing dashboard failures unrelated to this PR.
