### PR TITLE
feat: add structured langmem memory lanes and evals

### DIFF
--- a/docs/plans/2026-04-24-langmem-eval-rubric.md
+++ b/docs/plans/2026-04-24-langmem-eval-rubric.md
@@ -1,0 +1,93 @@
+# LangMem eval rubric for Hermes
+
+## Goal
+
+Score Hermes' LangMem behavior in separable layers so failures do not collapse into one vague pass or fail.
+
+The eval harness should report four dimensions per scenario:
+
+- `extraction_score`
+- `reconciliation_score`
+- `retrieval_score`
+- `injection_usefulness_score`
+
+It should also write a machine-readable artifact to `tmp/langmem-eval/latest.json` for quick diffing and human review.
+
+## Scenario families
+
+The first harness covers four deterministic families:
+
+1. **Explicit preference writes**
+   - direct `langmem_conclude` writes
+   - verifies storage shape and basic recall
+2. **Preference correction / supersession**
+   - old fact should be retired conservatively and the new fact should dominate recall
+3. **Cross-session recall**
+   - memory written in one session should remain retrievable in a later session for the same user
+4. **Retrieval under lexical ambiguity**
+   - when multiple memories partially match the same query, the better-confirmed memory should rank first
+
+## Dimension definitions
+
+### Extraction score
+
+Measures whether the relevant durable fact or episode was actually created in storage.
+
+Count this as a failure when:
+- the expected row is missing
+- the expected content was not persisted
+- the stored shape is malformed enough that later stages cannot trust it
+
+### Reconciliation score
+
+Measures whether Hermes merged or retired memory state correctly.
+
+Count this as a failure when:
+- superseded facts remain live when the scenario expects them retired
+- metadata needed for later reasoning is missing or wrong
+- confirmation counts or session provenance do not reflect repeated evidence
+
+### Retrieval score
+
+Measures whether search or direct lookup returns the right memory for the scenario.
+
+Count this as a failure when:
+- the right memory is absent from results
+- a stale or irrelevant memory outranks the intended one
+- user scoping leaks the wrong user's memory into results
+
+### Injection usefulness score
+
+Measures whether the retrieved output is actually useful for the next turn.
+
+Count this as a failure when:
+- the provider returns the wrong fact even if the store contains the right row
+- the output contains stale contradictions that would mislead the assistant
+- the retrieved result is technically present but not usable as a clean prompt injection
+
+## Failure interpretation
+
+Use this table when reading `latest.json`:
+
+| Failure pattern | Likely cause |
+|---|---|
+| extraction low, others low | write path or row creation broken |
+| extraction high, reconciliation low | merge/delete/session metadata logic broken |
+| extraction + reconciliation high, retrieval low | search ranking or lookup path broken |
+| retrieval high, injection usefulness low | provider formatting or direct/fallback presentation broken |
+
+## Important guardrails
+
+- Keep this harness deterministic. Do not rely on live LLM calls for the baseline eval.
+- Prefer direct store/provider assertions over fuzzy judgments.
+- Use this harness to localize failures before considering embeddings or backend changes.
+- Do not treat profile lookup as a search problem when the typed profile lane can answer directly.
+
+## Next expansion ideas
+
+Later versions can add:
+- typed profile extraction quality checks
+- episode-lane usefulness checks
+- adversarial lexical collisions
+- human-reviewed prompt-injection usefulness samples
+- regression snapshots across provider versions

--- a/docs/plans/2026-04-24-langmem-procedural-memory-loop.md
+++ b/docs/plans/2026-04-24-langmem-procedural-memory-loop.md
@@ -1,0 +1,85 @@
+# Reviewed procedural-memory loop for Hermes LangMem
+
+## Goal
+
+Turn prompt optimization into a formal review loop for Hermes without auto-patching the live system prompt.
+
+## What counts as a prompt-worthy failure
+
+A failure is prompt-worthy when:
+- the agent had the right tools available but consistently framed or prioritized the task badly
+- the failure reflects reusable instruction gaps rather than one-off user context
+- the problem survives across multiple trajectories or reviewers can clearly articulate the missing guidance
+
+A failure is **not** prompt-worthy when it is mainly:
+- missing retrieval
+- bad ranking
+- tool breakage
+- auth or environment problems
+- temporary project-specific state
+- user-specific data that belongs in memory, not policy
+
+## Workflow
+
+1. Collect failed trajectories into a JSON review set.
+2. Run `scripts/langmem_prompt_review.py` to emit a review packet under `tmp/langmem-prompt-review/`.
+3. Inspect whether the failures are really prompt-shaped.
+4. If they are, use the review packet as the handoff surface for a human-reviewed optimization pass.
+5. Review candidate prompt deltas manually.
+6. Apply approved deltas in the actual prompt source, not in an automatic background patcher.
+7. Re-run the relevant evals before shipping the prompt change.
+
+## Who reviews optimized prompt text
+
+Human review is mandatory before any prompt delta lands.
+
+The reviewer should check:
+- whether the change generalizes
+- whether it duplicates an existing instruction
+- whether it overfits to a single user or one weird session
+- whether the change would create broader regressions or verbosity bloat
+
+## Where approved prompt deltas are applied
+
+Approved prompt deltas should be applied in the real Hermes prompt sources and code review flow.
+
+They should **not** be:
+- auto-written into the current system prompt
+- silently injected into memory stores
+- merged without a human-readable diff
+
+## What should never be auto-learned
+
+Never auto-learn:
+- user-specific temporary task state
+- secrets, credentials, or security-sensitive instructions
+- one-off exceptions that are not stable policy
+- prompt text inferred from broken tools or missing auth
+- irreversible behavioral policy changes without review
+
+## Script stub boundary
+
+`scripts/langmem_prompt_review.py` is intentionally a scaffold.
+
+It currently:
+- loads sample trajectories from JSON
+- builds a review packet
+- marks where `create_prompt_optimizer` would fit later
+- writes `tmp/langmem-prompt-review/latest.json`
+
+It does **not**:
+- call the optimizer yet
+- patch prompts automatically
+- modify Hermes runtime behavior
+
+## Review packet expectations
+
+A useful packet should include:
+- failure counts by category
+- representative sample trajectories
+- explicit TODOs for optimizer integration
+- a reviewer checklist separating prompt failures from retrieval or tooling failures
+
+## Success condition
+
+Hermes can improve prompt policy through a deliberate human-reviewed loop without turning prompt learning into an opaque self-modifying system.

--- a/plugins/memory/langmem/__init__.py
+++ b/plugins/memory/langmem/__init__.py
@@ -1,0 +1,721 @@
+"""LangMem memory plugin — MemoryProvider interface.
+
+LLM-powered memory extraction and consolidation via the LangMem library,
+with Hermes-managed local SQLite persistence and FTS5 retrieval.
+
+LangMem handles: extraction, update decisions, delete decisions.
+Hermes handles: persistence, retrieval, user scoping.
+
+Config (via env vars or $HERMES_HOME/langmem.json):
+  LANGMEM_MODEL        — LLM for extraction (default: anthropic:claude-3-5-haiku-latest)
+  LANGMEM_ENABLE_DELETES — Allow delete decisions during consolidation (default: true)
+  LANGMEM_MAX_EXISTING — Max existing memories passed into extraction (default: 50)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def _build_metadata(
+    *,
+    lane: str,
+    source_type: str,
+    session_id: str,
+    tags: Optional[List[str]] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Build a standard metadata payload for persisted LangMem rows."""
+    payload = {
+        "lane": lane,
+        "source_type": source_type,
+        "first_seen_session_id": session_id,
+        "last_seen_session_id": session_id,
+        "confirmation_count": 1,
+        "tags": tags or [],
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+class HermesUserProfile(BaseModel):
+    """Stable per-user profile Hermes can inject directly without search."""
+
+    name: Optional[str] = None
+    preferred_name: Optional[str] = None
+    timezone: Optional[str] = None
+    communication_style: Optional[str] = None
+    verbosity_preference: Optional[str] = None
+    preferred_tools: List[str] = Field(default_factory=list)
+    active_projects: List[str] = Field(default_factory=list)
+    dislikes: List[str] = Field(default_factory=list)
+    correction_patterns: List[str] = Field(default_factory=list)
+    recurring_workflows: List[str] = Field(default_factory=list)
+
+
+class HermesEpisode(BaseModel):
+    """Reusable successful interaction pattern extracted from a turn."""
+
+    observation: str
+    thoughts: str
+    action: str
+    result: str
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    """Load config from env vars, with $HERMES_HOME/langmem.json overrides."""
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "model": os.environ.get("LANGMEM_MODEL", "anthropic:claude-3-5-haiku-latest"),
+        "enable_deletes": os.environ.get("LANGMEM_ENABLE_DELETES", "true").lower() == "true",
+        "max_existing": int(os.environ.get("LANGMEM_MAX_EXISTING", "50")),
+        "debounce_seconds": float(os.environ.get("LANGMEM_DEBOUNCE_SECONDS", "20")),
+    }
+
+    config_path = get_hermes_home() / "langmem.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            for k, v in file_cfg.items():
+                if v is None or v == "":
+                    continue
+                if k == "enable_deletes":
+                    config[k] = str(v).lower() in ("true", "1", "yes")
+                elif k == "max_existing":
+                    config[k] = int(v)
+                elif k == "debounce_seconds":
+                    config[k] = float(v)
+                else:
+                    config[k] = v
+        except Exception:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Normalizer — isolate LangMem API shape changes to one function
+# ---------------------------------------------------------------------------
+
+def _normalize_memory(mem: Any) -> dict:
+    """Normalize a LangMem memory object into a plain dict.
+
+    LangMem's internal object shape has changed across versions — keep
+    all version-specific access here so the rest of the provider is stable.
+    """
+    mem_id = getattr(mem, "id", None)
+    action = getattr(mem, "action", None)
+
+    # Some versions use .type or .op instead of .action
+    if action is None:
+        action = getattr(mem, "type", None) or getattr(mem, "op", None)
+
+    # Try to extract content — LangMem wraps it in various ways
+    content_attr = getattr(mem, "content", None)
+    if hasattr(content_attr, "content"):
+        # Older versions: content is an object with a .content str
+        text = content_attr.content
+    elif isinstance(content_attr, str):
+        text = content_attr
+    elif isinstance(content_attr, dict):
+        # Some versions return content as a dict — pull "content" key or skip.
+        # Dicts with only "json_doc_id" are internal LangMem metadata — skip them.
+        if "json_doc_id" in content_attr and len(content_attr) == 1:
+            text = ""
+        else:
+            text = content_attr.get("content") or content_attr.get("text") or ""
+    elif content_attr is not None:
+        text = str(content_attr)
+    else:
+        text = str(mem)
+
+    # Filter out LangMem internal metadata artifacts.
+    # These appear as strings like "json_doc_id='<uuid>'" and carry no user-facing value.
+    _stripped = text.strip()
+    if (not _stripped
+            or _stripped.startswith("json_doc_id=")
+            or _stripped.startswith("json_doc_id =")):
+        text = ""
+
+    return {
+        "id": mem_id,
+        "content": text,
+        "action": action,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+PROFILE_SCHEMA = {
+    "name": "langmem_profile",
+    "description": (
+        "Retrieve all stored memories about the user — preferences, facts, "
+        "project context. Use at conversation start for a full overview."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+SEARCH_SCHEMA = {
+    "name": "langmem_search",
+    "description": (
+        "Search durable memories by keyword. Returns relevant facts ranked by "
+        "FTS relevance. Use to find specific remembered facts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "top_k": {"type": "integer", "description": "Max results (default: 10)."},
+        },
+        "required": ["query"],
+    },
+}
+
+CONCLUDE_SCHEMA = {
+    "name": "langmem_conclude",
+    "description": (
+        "Store a durable fact about the user verbatim — bypasses LLM extraction. "
+        "Use for explicit preferences, corrections, or decisions the user stated directly."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conclusion": {"type": "string", "description": "The fact to store."},
+        },
+        "required": ["conclusion"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class LangMemMemoryProvider(MemoryProvider):
+    """LangMem extraction + Hermes SQLite persistence."""
+
+    def __init__(self):
+        self._config: Optional[dict] = None
+        self._store = None          # LangMemStore
+        self._store_path = None     # Path to langmem.sqlite3
+        self._manager = None        # LangMem memory manager
+        self._profile_manager = None
+        self._episode_manager = None
+        self._manager_lock = threading.Lock()
+        self._user_id = "hermes-user"
+        self._session_id = ""
+        self._model = "anthropic:claude-3-5-haiku-latest"
+        self._enable_deletes = True
+        self._max_existing = 50
+        self._debounce_seconds = 20.0
+        self._sync_thread: Optional[threading.Thread] = None
+        self._pending_sync_payload: Optional[Dict[str, Any]] = None
+        self._pending_sync_deadline = 0.0
+        self._pending_sync_lock = threading.Lock()
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+
+    @property
+    def name(self) -> str:
+        return "langmem"
+
+    def is_available(self) -> bool:
+        try:
+            import langmem  # noqa: F401
+            return True
+        except Exception:
+            return False
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "model",
+                "description": "LangMem extraction model",
+                "default": "anthropic:claude-3-5-haiku-latest",
+            },
+            {
+                "key": "enable_deletes",
+                "description": "Allow delete decisions during consolidation",
+                "default": "true",
+                "choices": ["true", "false"],
+            },
+            {
+                "key": "max_existing",
+                "description": "Max existing memories to pass into extraction",
+                "default": "50",
+            },
+            {
+                "key": "debounce_seconds",
+                "description": "Seconds to wait before processing background memory sync",
+                "default": "20",
+            },
+        ]
+
+    def save_config(self, values: dict, hermes_home: str) -> None:
+        """Write config to $HERMES_HOME/langmem.json."""
+        from pathlib import Path
+        config_path = Path(hermes_home) / "langmem.json"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2))
+
+    def _get_manager(self):
+        """Thread-safe lazy manager accessor."""
+        with self._manager_lock:
+            if self._manager is not None:
+                return self._manager
+            try:
+                from langmem import create_memory_manager
+                self._manager = create_memory_manager(
+                    self._model,
+                    enable_inserts=True,
+                    enable_updates=True,
+                    enable_deletes=self._enable_deletes,
+                )
+                return self._manager
+            except ImportError:
+                raise RuntimeError(
+                    "langmem package not installed. Run: "
+                    "uv pip install langmem==0.0.30 langgraph==1.1.9"
+                )
+
+    def _get_profile_manager(self):
+        """Thread-safe lazy profile manager accessor."""
+        with self._manager_lock:
+            if self._profile_manager is not None:
+                return self._profile_manager
+            try:
+                from langmem import create_memory_manager
+                self._profile_manager = create_memory_manager(
+                    self._model,
+                    schemas=[HermesUserProfile],
+                    instructions="Extract durable user profile information for Hermes.",
+                    enable_inserts=False,
+                    enable_updates=True,
+                    enable_deletes=False,
+                )
+                return self._profile_manager
+            except ImportError:
+                raise RuntimeError(
+                    "langmem package not installed. Run: "
+                    "uv pip install langmem==0.0.30 langgraph==1.1.9"
+                )
+
+    def _get_episode_manager(self):
+        """Thread-safe lazy episodic manager accessor."""
+        with self._manager_lock:
+            if self._episode_manager is not None:
+                return self._episode_manager
+            try:
+                from langmem import create_memory_manager
+                self._episode_manager = create_memory_manager(
+                    self._model,
+                    schemas=[HermesEpisode],
+                    instructions="Extract successful reusable interaction patterns for Hermes.",
+                    enable_inserts=True,
+                    enable_updates=False,
+                    enable_deletes=False,
+                )
+                return self._episode_manager
+            except ImportError:
+                raise RuntimeError(
+                    "langmem package not installed. Run: "
+                    "uv pip install langmem==0.0.30 langgraph==1.1.9"
+                )
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._session_id = session_id
+        # Prefer gateway-provided user_id for per-user scoping;
+        # fall back to config default for CLI (single-user) sessions.
+        self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
+        self._model = self._config.get("model", "anthropic:claude-3-5-haiku-latest")
+        self._enable_deletes = self._config.get("enable_deletes", True)
+        self._max_existing = int(self._config.get("max_existing", 50))
+        self._debounce_seconds = float(self._config.get("debounce_seconds", 20.0))
+
+        # Open the local store
+        try:
+            from hermes_constants import get_hermes_home
+            from plugins.memory.langmem.store import LangMemStore
+            self._store_path = get_hermes_home() / "langmem.sqlite3"
+            self._store = LangMemStore(self._store_path)
+        except Exception as e:
+            logger.warning("LangMem store init failed: %s", e)
+            self._store = None
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# LangMem Memory\n"
+            f"Active. User: {self._user_id}.\n"
+            "Use langmem_search to search durable memories, "
+            "langmem_profile for a full snapshot, and langmem_conclude for explicit facts."
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if self._store is None:
+            return tool_error("LangMem store not initialized.")
+
+        if tool_name == "langmem_profile":
+            try:
+                profile = self._store.get_profile(self._user_id)
+                if profile:
+                    return json.dumps({"result": profile, "kind": "profile"})
+                rows = self._store.list_memories(self._user_id, limit=200)
+                if not rows:
+                    return json.dumps({"result": "No memories stored yet."})
+                lines = [r["content"] for r in rows if r.get("content")]
+                return json.dumps({"result": "\n".join(f"- {l}" for l in lines), "count": len(lines)})
+            except Exception as e:
+                return tool_error(f"Failed to fetch profile: {e}")
+
+        elif tool_name == "langmem_search":
+            query = args.get("query", "")
+            if not query:
+                return tool_error("Missing required parameter: query")
+            top_k = int(args.get("top_k", 10))
+            try:
+                rows = self._store.search_memories(self._user_id, query, limit=top_k)
+                if not rows:
+                    return json.dumps({"result": "No relevant memories found."})
+                items = [{"memory": r["content"], "id": r["id"]} for r in rows]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as e:
+                return tool_error(f"Search failed: {e}")
+
+        elif tool_name == "langmem_conclude":
+            conclusion = args.get("conclusion", "")
+            if not conclusion:
+                return tool_error("Missing required parameter: conclusion")
+            try:
+                mem_id = str(uuid.uuid4())
+                self._store.upsert_many(
+                    self._user_id,
+                    [{
+                        "id": mem_id,
+                        "content": conclusion,
+                        "source": "conclude",
+                        "metadata": _build_metadata(
+                            lane="preferences",
+                            source_type="conclude",
+                            session_id=self._session_id,
+                            tags=["explicit", "user-stated"],
+                        ),
+                    }],
+                    session_id=self._session_id,
+                )
+                return json.dumps({"result": "Fact stored.", "id": mem_id})
+            except Exception as e:
+                return tool_error(f"Failed to store conclusion: {e}")
+
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    def _should_extract_episode(self, user_content: str, assistant_content: str) -> bool:
+        """Return True when the turn looks like a reusable successful pattern."""
+        user_text = (user_content or "").strip()
+        assistant_text = (assistant_content or "").strip()
+        if not user_text or not assistant_text:
+            return False
+        if len(user_text) < 12:
+            return False
+        if user_text.lower() in {"ok", "thanks", "thank you", "proceed", "continue"}:
+            return False
+        assistant_lower = assistant_text.lower()
+        failure_markers = (
+            "error",
+            "failed",
+            "failure",
+            "unable",
+            "cannot",
+            "can't",
+            "refuse",
+            "refused",
+            "missing dependency",
+            "tool_error",
+        )
+        return not any(marker in assistant_lower for marker in failure_markers)
+
+    def _normalize_episode(self, episode: Any) -> Optional[dict]:
+        """Normalize a LangMem episode object into a plain dict payload."""
+        payload = getattr(episode, "content", episode)
+        if hasattr(payload, "model_dump"):
+            payload = payload.model_dump()
+        if not isinstance(payload, dict):
+            return None
+        required = ("observation", "thoughts", "action", "result")
+        if not all(payload.get(key) for key in required):
+            return None
+        return {key: str(payload[key]) for key in required}
+
+    def _run_single_sync(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Run one LangMem sync pass immediately."""
+        try:
+            manager = self._get_manager()
+
+            existing_rows = self._store.list_memories(self._user_id, limit=self._max_existing)
+            existing = [(row["id"], row["content"]) for row in existing_rows]
+
+            result = manager.invoke(
+                {
+                    "messages": [
+                        {"role": "user", "content": user_content},
+                        {"role": "assistant", "content": assistant_content},
+                    ],
+                    "existing": existing,
+                }
+            )
+
+            upserts: List[Dict[str, Any]] = []
+            delete_ids: List[str] = []
+
+            if isinstance(result, dict):
+                memories = result.get("memories") or result.get("results") or []
+            elif isinstance(result, list):
+                memories = result
+            else:
+                memories = []
+
+            logger.debug(
+                "LangMem raw result type=%s keys=%s len=%s",
+                type(result).__name__,
+                list(result.keys()) if isinstance(result, dict) else "n/a",
+                len(memories),
+            )
+
+            for mem in memories:
+                try:
+                    normalized = _normalize_memory(mem)
+                except Exception as e:
+                    logger.debug("LangMem normalize failed: %s", e)
+                    continue
+
+                action = (normalized.get("action") or "").lower()
+                content = normalized.get("content", "")
+                mem_id = normalized.get("id")
+
+                if not content or content.strip().startswith("json_doc_id="):
+                    continue
+
+                if action in ("delete", "remove"):
+                    if mem_id:
+                        delete_ids.append(mem_id)
+                else:
+                    upserts.append({
+                        "id": mem_id or str(uuid.uuid4()),
+                        "content": content,
+                        "metadata": _build_metadata(
+                            lane="preferences",
+                            source_type="sync_turn",
+                            session_id=session_id or self._session_id,
+                            tags=["background"],
+                        ),
+                    })
+
+            self._store.reconcile_many(
+                self._user_id,
+                upserts,
+                delete_ids,
+                session_id=session_id or self._session_id,
+            )
+
+            try:
+                profile_manager = self._get_profile_manager()
+                profile_result = profile_manager.invoke(
+                    {
+                        "messages": [
+                            {"role": "user", "content": user_content},
+                            {"role": "assistant", "content": assistant_content},
+                        ]
+                    }
+                )
+                if profile_result:
+                    first = profile_result[0]
+                    profile_content = getattr(first, "content", first)
+                    if hasattr(profile_content, "model_dump"):
+                        self._store.upsert_profile(
+                            self._user_id,
+                            profile_content.model_dump(),
+                            session_id=session_id or self._session_id,
+                        )
+            except Exception as e:
+                logger.debug("LangMem profile sync failed: %s", e)
+
+            try:
+                if self._should_extract_episode(user_content, assistant_content):
+                    episode_manager = self._get_episode_manager()
+                    episode_result = episode_manager.invoke(
+                        {
+                            "messages": [
+                                {"role": "user", "content": user_content},
+                                {"role": "assistant", "content": assistant_content},
+                            ]
+                        }
+                    )
+                    episode_upserts: List[Dict[str, Any]] = []
+                    for episode in episode_result or []:
+                        payload = self._normalize_episode(episode)
+                        if not payload:
+                            continue
+                        episode_upserts.append(
+                            {
+                                "id": str(uuid.uuid4()),
+                                "kind": "episode",
+                                "content": json.dumps(payload, sort_keys=True),
+                                "source": "langmem-episode",
+                                "metadata": _build_metadata(
+                                    lane="episodes",
+                                    source_type="episode_sync",
+                                    session_id=session_id or self._session_id,
+                                    tags=["episode", "background"],
+                                ),
+                            }
+                        )
+                    if episode_upserts:
+                        self._store.upsert_many(
+                            self._user_id,
+                            episode_upserts,
+                            session_id=session_id or self._session_id,
+                        )
+            except Exception as e:
+                logger.debug("LangMem episode sync failed: %s", e)
+
+            logger.debug(
+                "LangMem sync_turn: %d upserts, %d deletes for user %s",
+                len(upserts), len(delete_ids), self._user_id,
+            )
+
+        except Exception as e:
+            logger.warning("LangMem sync_turn failed: %s", e)
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Extract and consolidate memories from the completed turn (debounced, non-blocking)."""
+        if self._store is None:
+            return
+
+        payload = {
+            "user_content": user_content,
+            "assistant_content": assistant_content,
+            "session_id": session_id,
+        }
+
+        with self._pending_sync_lock:
+            self._pending_sync_payload = payload
+            self._pending_sync_deadline = time.time() + max(0.0, float(self._debounce_seconds))
+            already_running = self._sync_thread is not None and self._sync_thread.is_alive()
+
+        if already_running:
+            return
+
+        def _runner():
+            while True:
+                with self._pending_sync_lock:
+                    deadline = self._pending_sync_deadline
+                remaining = deadline - time.time()
+                if remaining > 0:
+                    time.sleep(min(remaining, 0.05))
+                    continue
+
+                with self._pending_sync_lock:
+                    current = self._pending_sync_payload
+                    self._pending_sync_payload = None
+                    self._pending_sync_deadline = 0.0
+
+                if current is None:
+                    return
+
+                self._run_single_sync(
+                    current["user_content"],
+                    current["assistant_content"],
+                    session_id=current.get("session_id", ""),
+                )
+
+                with self._pending_sync_lock:
+                    if self._pending_sync_payload is None:
+                        return
+
+        self._sync_thread = threading.Thread(target=_runner, daemon=True, name="langmem-sync")
+        self._sync_thread.start()
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return prefetched memories for this turn's query."""
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## LangMem Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Fire a background FTS search so results are ready for the next turn."""
+        if self._store is None or not query:
+            return
+
+        def _run():
+            try:
+                rows = self._store.search_memories(self._user_id, query, limit=5)
+                if rows:
+                    lines = [r["content"] for r in rows if r.get("content")]
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(f"- {l}" for l in lines)
+            except Exception as e:
+                logger.debug("LangMem prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="langmem-prefetch")
+        self._prefetch_thread.start()
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Wait for any pending sync before session closes."""
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=15.0)
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+        if self._store:
+            self._store.close()
+        with self._manager_lock:
+            self._manager = None
+            self._profile_manager = None
+            self._episode_manager = None
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register LangMem as a memory provider plugin."""
+    ctx.register_memory_provider(LangMemMemoryProvider())

--- a/plugins/memory/langmem/plugin.yaml
+++ b/plugins/memory/langmem/plugin.yaml
@@ -1,0 +1,5 @@
+name: langmem
+version: 0.1.0
+description: "LangMem-backed local memory provider with Hermes-managed SQLite persistence and FTS search."
+pip_dependencies:
+  - langmem==0.0.30

--- a/plugins/memory/langmem/store.py
+++ b/plugins/memory/langmem/store.py
@@ -1,0 +1,371 @@
+"""Local SQLite backing store for the LangMem memory provider.
+
+Hermes owns persistence; LangMem only does extraction/consolidation.
+
+Schema:
+  memories      — primary row store, soft-delete via ``deleted_at``
+  memories_fts  — FTS5 virtual table mirroring ``content`` column
+
+Conservative reconciliation rules:
+  - upsert whatever LangMem returns as inserts/updates
+  - only soft-delete rows when LangMem explicitly marks them for deletion
+  - NEVER infer deletion from omission (no replace_all)
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _score_row(row: dict) -> float:
+    """Score a retrieved memory row using lightweight local metadata."""
+    try:
+        meta = json.loads(row.get("metadata_json") or "{}")
+    except Exception:
+        meta = {}
+    try:
+        confirmations = float(meta.get("confirmation_count", 1))
+    except Exception:
+        confirmations = 1.0
+    try:
+        updated_at = float(row.get("updated_at") or 0)
+    except Exception:
+        updated_at = 0.0
+    recency_hours = max((time.time() - updated_at) / 3600.0, 0.0)
+    recency_bonus = max(0.0, 48.0 - recency_hours) / 48.0
+    return confirmations + recency_bonus
+
+
+def _merge_metadata(existing_json: Optional[str], incoming: dict, *, session_id: Optional[str]) -> dict:
+    """Merge provenance metadata conservatively across updates."""
+    try:
+        existing = json.loads(existing_json) if existing_json else {}
+    except Exception:
+        existing = {}
+
+    merged = dict(existing)
+    merged.update(incoming or {})
+
+    first_seen = existing.get("first_seen_session_id") or session_id
+    if first_seen:
+        merged["first_seen_session_id"] = first_seen
+
+    if session_id:
+        merged["last_seen_session_id"] = session_id
+
+    prior_count = existing.get("confirmation_count", 0)
+    try:
+        prior_count = int(prior_count)
+    except Exception:
+        prior_count = 0
+    merged["confirmation_count"] = max(prior_count, 0) + 1
+
+    return merged
+
+
+class LangMemStore:
+    """Thread-compatible SQLite store for durable memories.
+
+    Uses WAL mode for concurrent readers.  All operations are synchronous
+    (called from background threads by the provider).
+    """
+
+    # DDL split into individual statements — triggers use BEGIN...END
+    # which contain semicolons, so we can't do a simple split(";").
+    _DDL_STATEMENTS = [
+        """
+        CREATE TABLE IF NOT EXISTS memories (
+            id            TEXT PRIMARY KEY,
+            user_id       TEXT NOT NULL,
+            kind          TEXT NOT NULL DEFAULT 'memory',
+            content       TEXT NOT NULL,
+            source        TEXT NOT NULL DEFAULT 'langmem',
+            created_at    REAL NOT NULL,
+            updated_at    REAL NOT NULL,
+            deleted_at    REAL,
+            last_session_id TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """,
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+            content,
+            content=memories,
+            content_rowid=rowid
+        )
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+            INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content)
+                VALUES ('delete', old.rowid, old.content);
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content)
+                VALUES ('delete', old.rowid, old.content);
+            INSERT INTO memories_fts(rowid, content) VALUES (new.rowid, new.content);
+        END
+        """,
+    ]
+
+    def __init__(self, db_path: Path):
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        for stmt in self._DDL_STATEMENTS:
+            self._conn.execute(stmt)
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def upsert_many(
+        self,
+        user_id: str,
+        items: List[Dict[str, Any]],
+        *,
+        session_id: Optional[str] = None,
+    ) -> None:
+        """Insert or update memory rows.
+
+        Each item must have at minimum a ``content`` key.
+        If ``id`` is absent, a new UUID is generated.
+        """
+        now = time.time()
+        for item in items:
+            mem_id = item.get("id") or str(uuid.uuid4())
+            content = item.get("content", "")
+            kind = item.get("kind", "memory")
+            source = item.get("source", "langmem")
+            existing_row = self.get_memory(user_id, mem_id)
+            merged_metadata = _merge_metadata(
+                existing_row.get("metadata_json") if existing_row else None,
+                item.get("metadata", {}),
+                session_id=session_id,
+            )
+            metadata = json.dumps(merged_metadata, sort_keys=True)
+
+            self._conn.execute(
+                """
+                INSERT INTO memories
+                    (id, user_id, kind, content, source,
+                     created_at, updated_at, deleted_at, last_session_id, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    content         = excluded.content,
+                    kind            = excluded.kind,
+                    updated_at      = excluded.updated_at,
+                    deleted_at      = NULL,
+                    last_session_id = excluded.last_session_id,
+                    metadata_json   = excluded.metadata_json
+                """,
+                (mem_id, user_id, kind, content, source, now, now, session_id, metadata),
+            )
+        self._conn.commit()
+
+    def delete_memory(self, user_id: str, memory_id: str) -> bool:
+        """Soft-delete a single memory row by ID (user-scoped)."""
+        now = time.time()
+        cur = self._conn.execute(
+            "UPDATE memories SET deleted_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+            (now, memory_id, user_id),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def reconcile_many(
+        self,
+        user_id: str,
+        upserts: List[Dict[str, Any]],
+        delete_ids: List[str],
+        *,
+        session_id: Optional[str] = None,
+    ) -> None:
+        """Apply a set of LangMem extraction decisions conservatively.
+
+        - upserts: rows to insert or update (from LangMem insert/update actions)
+        - delete_ids: IDs to soft-delete (from LangMem explicit delete actions ONLY)
+
+        Never infers deletion from omission — only rows in ``delete_ids`` are
+        soft-deleted.  This preserves memories from older sessions even when
+        LangMem doesn't echo them back.
+        """
+        if upserts:
+            self.upsert_many(user_id, upserts, session_id=session_id)
+        now = time.time()
+        for mem_id in delete_ids:
+            self._conn.execute(
+                "UPDATE memories SET deleted_at = ? "
+                "WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+                (now, mem_id, user_id),
+            )
+        if delete_ids:
+            self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def list_memories(
+        self,
+        user_id: str,
+        *,
+        limit: int = 200,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Return all (non-deleted) memories for a user, newest-first."""
+        if include_deleted:
+            cur = self._conn.execute(
+                "SELECT * FROM memories WHERE user_id = ? "
+                "ORDER BY updated_at DESC LIMIT ?",
+                (user_id, limit),
+            )
+        else:
+            cur = self._conn.execute(
+                "SELECT * FROM memories WHERE user_id = ? AND deleted_at IS NULL "
+                "ORDER BY updated_at DESC LIMIT ?",
+                (user_id, limit),
+            )
+        return [dict(row) for row in cur.fetchall()]
+
+    def search_memories(
+        self,
+        user_id: str,
+        query: str,
+        *,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """FTS5 search over non-deleted memories for a user.
+
+        Falls back to LIKE if the FTS query cannot be tokenized safely
+        (e.g. single-character queries or special-character terms).
+        """
+        if not query or not query.strip():
+            return []
+
+        # Sanitize for FTS5 — remove characters that cause parse errors
+        fts_query = _sanitize_fts_query(query)
+
+        if fts_query:
+            try:
+                cur = self._conn.execute(
+                    """
+                    SELECT m.*
+                    FROM memories m
+                    JOIN memories_fts f ON m.rowid = f.rowid
+                    WHERE f.content MATCH ?
+                      AND m.user_id = ?
+                      AND m.deleted_at IS NULL
+                    ORDER BY rank
+                    LIMIT ?
+                    """,
+                    (fts_query, user_id, limit),
+                )
+                rows = [dict(row) for row in cur.fetchall()]
+                rows.sort(key=_score_row, reverse=True)
+                if rows:
+                    return rows[:limit]
+            except sqlite3.OperationalError:
+                pass  # fall through to LIKE
+
+        # LIKE fallback
+        pattern = f"%{query}%"
+        cur = self._conn.execute(
+            "SELECT * FROM memories "
+            "WHERE user_id = ? AND deleted_at IS NULL AND content LIKE ? "
+            "ORDER BY updated_at DESC LIMIT ?",
+            (user_id, pattern, limit),
+        )
+        rows = [dict(row) for row in cur.fetchall()]
+        rows.sort(key=_score_row, reverse=True)
+        return rows[:limit]
+
+    def get_memory(self, user_id: str, memory_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a single memory row (non-deleted) by ID."""
+        cur = self._conn.execute(
+            "SELECT * FROM memories WHERE id = ? AND user_id = ? AND deleted_at IS NULL",
+            (memory_id, user_id),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+    def get_profile(self, user_id: str) -> Optional[dict]:
+        """Fetch the structured per-user profile if present."""
+        row = self.get_memory(user_id, f"profile:{user_id}")
+        if not row:
+            return None
+        try:
+            return json.loads(row["content"])
+        except Exception:
+            return None
+
+    def upsert_profile(self, user_id: str, profile: dict, *, session_id: str = "") -> None:
+        """Store a single structured profile document for a user."""
+        self.upsert_many(
+            user_id,
+            [{
+                "id": f"profile:{user_id}",
+                "kind": "profile",
+                "content": json.dumps(profile, sort_keys=True),
+                "source": "langmem-profile",
+                "metadata": {
+                    "lane": "profile",
+                    "source_type": "profile_sync",
+                    "first_seen_session_id": session_id,
+                    "last_seen_session_id": session_id,
+                    "confirmation_count": 1,
+                    "tags": ["profile"],
+                },
+            }],
+            session_id=session_id,
+        )
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sanitize_fts_query(query: str) -> str:
+    """Return an FTS5-safe query string, or empty string if not usable.
+
+    FTS5 is finicky about: single characters, special chars, leading AND/OR/NOT,
+    mismatched quotes.  We keep it simple: strip obvious special chars and bail
+    if what's left is too short.
+    """
+    import re
+    # Remove FTS5 special characters except spaces
+    cleaned = re.sub(r'["\'^*(){}[\]<>=!|&]', " ", query).strip()
+    # Collapse whitespace
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    # If only 1 char or empty, FTS5 won't help
+    if len(cleaned) < 2:
+        return ""
+    # Multi-word: use AND so all terms must appear (avoids single-common-word false positives)
+    if " " in cleaned:
+        terms = [t for t in cleaned.split() if len(t) >= 2]
+        if not terms:
+            return ""
+        return " AND ".join(terms)
+    return cleaned

--- a/scripts/langmem_prompt_review.py
+++ b/scripts/langmem_prompt_review.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Reviewed procedural-memory scaffold for Hermes LangMem.
+
+Loads failed trajectories from JSON, prepares a review packet, and makes the
+optimizer hook explicit without auto-patching any prompt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OUTPUT_DIR = Path("tmp/langmem-prompt-review")
+
+
+def _load_trajectories(input_path: str | None) -> list[dict[str, Any]]:
+    if not input_path:
+        return []
+    path = Path(input_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        items = payload.get("trajectories")
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    raise ValueError(f"Unsupported trajectory payload shape in {path}")
+
+
+def _failure_summary(trajectories: list[dict[str, Any]]) -> dict[str, Any]:
+    categories: dict[str, int] = {}
+    for item in trajectories:
+        reason = str(item.get("failure_type") or item.get("category") or "uncategorized")
+        categories[reason] = categories.get(reason, 0) + 1
+    return {
+        "total_trajectories": len(trajectories),
+        "categories": categories,
+    }
+
+
+def _build_review_packet(trajectories: list[dict[str, Any]], input_path: str | None) -> dict[str, Any]:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "input_path": input_path,
+        "summary": _failure_summary(trajectories),
+        "sample_trajectories": trajectories[:10],
+        "optimizer_stub": {
+            "status": "scaffold_only",
+            "note": "This is where LangMem create_prompt_optimizer would run after human review prep.",
+            "auto_apply_enabled": False,
+            "todo": [
+                "Load approved failure trajectories only",
+                "Generate candidate prompt deltas for reviewer inspection",
+                "Keep optimizer output separate from the live system prompt",
+                "Require explicit human approval before any prompt patch lands",
+            ],
+        },
+        "review_checklist": [
+            "Is the failure actually prompt-worthy rather than a tool, retrieval, or environment issue?",
+            "Would the proposed prompt delta generalize without overfitting to one conversation?",
+            "Does the change avoid storing user-specific temporary task state as policy?",
+            "Is a human reviewer explicitly approving or rejecting the change?",
+        ],
+    }
+
+
+def write_review_packet(packet: dict[str, Any], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / "latest.json"
+    out_path.write_text(json.dumps(packet, indent=2, sort_keys=True), encoding="utf-8")
+    return out_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare a reviewed LangMem prompt-optimization packet without auto-patching prompts.",
+    )
+    parser.add_argument(
+        "--input",
+        help="Path to a JSON file containing failed trajectories or {\"trajectories\": [...]}.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Directory for review packets (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    args = parser.parse_args()
+
+    trajectories = _load_trajectories(args.input)
+    packet = _build_review_packet(trajectories, args.input)
+    out_path = write_review_packet(packet, Path(args.output_dir))
+    print(json.dumps({"result": "review packet written", "path": str(out_path), "count": len(trajectories)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_langmem_episodic_lane.py
+++ b/tests/agent/test_langmem_episodic_lane.py
@@ -1,0 +1,86 @@
+"""Tests for the LangMem episodic memory lane."""
+
+import json
+from unittest.mock import MagicMock
+
+
+def _make_provider(tmp_path, user_id="nick"):
+    from plugins.memory.langmem import LangMemMemoryProvider
+    from plugins.memory.langmem.store import LangMemStore
+
+    provider = LangMemMemoryProvider()
+    provider._store = LangMemStore(tmp_path / "langmem.sqlite3")
+    provider._store_path = tmp_path / "langmem.sqlite3"
+    provider._user_id = user_id
+    provider._session_id = "sess-episode"
+    provider._model = "anthropic:claude-3-5-haiku-latest"
+    provider._enable_deletes = True
+    provider._max_existing = 50
+    provider._debounce_seconds = 0.0
+    provider._manager = MagicMock()
+    provider._manager.invoke.return_value = []
+    provider._profile_manager = MagicMock()
+    provider._profile_manager.invoke.return_value = []
+    return provider
+
+
+def _fake_episode(payload):
+    return type("FakeEpisode", (), {"content": payload})()
+
+
+def test_episode_lane_stores_success_patterns_separately(tmp_path):
+    provider = _make_provider(tmp_path)
+    provider._episode_manager = MagicMock()
+    provider._episode_manager.invoke.return_value = [
+        _fake_episode(
+            {
+                "observation": "User asked to continue the LangMem plan",
+                "thoughts": "Task 5 should preserve user facts separately from reusable execution patterns",
+                "action": "Implemented an episodic lane with a success heuristic",
+                "result": "Focused tests passed",
+            }
+        )
+    ]
+
+    provider.sync_turn(
+        "Proceed with the next LangMem task and keep going",
+        "Implemented the episodic lane and verified the focused tests pass.",
+    )
+    if provider._sync_thread:
+        provider._sync_thread.join(timeout=5.0)
+
+    rows = provider._store.list_memories("nick")
+    episodes = [row for row in rows if row["kind"] == "episode"]
+    assert len(episodes) == 1
+    assert episodes[0]["source"] == "langmem-episode"
+    payload = json.loads(episodes[0]["content"])
+    assert payload["action"] == "Implemented an episodic lane with a success heuristic"
+    meta = json.loads(episodes[0]["metadata_json"])
+    assert meta["lane"] == "episodes"
+    assert meta["source_type"] == "episode_sync"
+
+
+def test_episode_lane_skips_error_turns(tmp_path):
+    provider = _make_provider(tmp_path)
+    provider._episode_manager = MagicMock()
+    provider._episode_manager.invoke.return_value = [
+        _fake_episode(
+            {
+                "observation": "User asked for a task",
+                "thoughts": "This should not be stored when the assistant errors",
+                "action": "Tried a failing step",
+                "result": "Command failed",
+            }
+        )
+    ]
+
+    provider.sync_turn(
+        "Proceed",
+        "Error: failed to complete the task due to a missing dependency.",
+    )
+    if provider._sync_thread:
+        provider._sync_thread.join(timeout=5.0)
+
+    rows = provider._store.list_memories("nick")
+    assert [row for row in rows if row["kind"] == "episode"] == []
+    assert provider._episode_manager.invoke.call_count == 0

--- a/tests/agent/test_langmem_profile_lane.py
+++ b/tests/agent/test_langmem_profile_lane.py
@@ -1,0 +1,42 @@
+"""Tests for the typed LangMem profile lane."""
+
+import json
+
+
+def test_langmem_profile_returns_structured_profile(tmp_path):
+    from plugins.memory.langmem import LangMemMemoryProvider
+    from plugins.memory.langmem.store import LangMemStore
+
+    provider = LangMemMemoryProvider()
+    provider._store = LangMemStore(tmp_path / "langmem.sqlite3")
+    provider._user_id = "nick"
+    provider._session_id = "sess-test"
+    provider._store.upsert_profile(
+        "nick",
+        {"preferred_name": "Nick", "timezone": "America/Detroit"},
+        session_id="sess-test",
+    )
+
+    result = json.loads(provider.handle_tool_call("langmem_profile", {}))
+    assert result["kind"] == "profile"
+    assert result["result"]["preferred_name"] == "Nick"
+    assert result["result"]["timezone"] == "America/Detroit"
+
+
+def test_langmem_profile_falls_back_when_profile_missing(tmp_path):
+    from plugins.memory.langmem import LangMemMemoryProvider
+    from plugins.memory.langmem.store import LangMemStore
+
+    provider = LangMemMemoryProvider()
+    provider._store = LangMemStore(tmp_path / "langmem.sqlite3")
+    provider._user_id = "nick"
+    provider._session_id = "sess-test"
+    provider._store.upsert_many(
+        "nick",
+        [{"id": "m1", "content": "Nick prefers concise responses"}],
+        session_id="sess-test",
+    )
+
+    result = json.loads(provider.handle_tool_call("langmem_profile", {}))
+    assert result.get("kind") != "profile"
+    assert "Nick prefers concise responses" in result["result"]

--- a/tests/agent/test_langmem_provider.py
+++ b/tests/agent/test_langmem_provider.py
@@ -1,0 +1,317 @@
+"""Tests for the LangMem MemoryProvider implementation."""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_provider(tmp_path, user_id="nick"):
+    """Build an initialized LangMemMemoryProvider backed by a tmp store."""
+    from plugins.memory.langmem import LangMemMemoryProvider
+    from plugins.memory.langmem.store import LangMemStore
+
+    provider = LangMemMemoryProvider()
+    provider._store = LangMemStore(tmp_path / "langmem.sqlite3")
+    provider._store_path = tmp_path / "langmem.sqlite3"
+    provider._user_id = user_id
+    provider._session_id = "sess-test"
+    provider._model = "anthropic:claude-3-5-haiku-latest"
+    provider._enable_deletes = True
+    provider._max_existing = 50
+    provider._debounce_seconds = 0.0
+    provider._profile_manager = MagicMock()
+    provider._profile_manager.invoke.return_value = []
+    return provider
+
+
+def _fake_memory(mem_id, content, action="insert"):
+    """Create a fake LangMem memory object."""
+    inner = type("Content", (), {"content": content})()
+    return type("FakeMem", (), {"id": mem_id, "content": inner, "action": action})()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_memory
+# ---------------------------------------------------------------------------
+
+class TestNormalizeMemory:
+    def test_nested_content_object(self):
+        from plugins.memory.langmem import _normalize_memory
+
+        mem = _fake_memory("m1", "Nick prefers concise responses")
+        result = _normalize_memory(mem)
+        assert result["content"] == "Nick prefers concise responses"
+        assert result["id"] == "m1"
+        assert result["action"] == "insert"
+
+    def test_string_content(self):
+        from plugins.memory.langmem import _normalize_memory
+
+        mem = type("M", (), {"id": "m2", "content": "plain string", "action": "update"})()
+        result = _normalize_memory(mem)
+        assert result["content"] == "plain string"
+
+    def test_missing_id_returns_none(self):
+        from plugins.memory.langmem import _normalize_memory
+
+        mem = type("M", (), {"content": "something", "action": "insert"})()
+        result = _normalize_memory(mem)
+        assert result["id"] is None
+
+    def test_delete_action(self):
+        from plugins.memory.langmem import _normalize_memory
+
+        mem = _fake_memory("m3", "stale fact", action="delete")
+        result = _normalize_memory(mem)
+        assert result["action"] == "delete"
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+class TestToolSchemas:
+    def test_returns_three_tools(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        schemas = provider.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        assert names == {"langmem_profile", "langmem_search", "langmem_conclude"}
+
+    def test_search_requires_query(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        schemas = {s["name"]: s for s in provider.get_tool_schemas()}
+        assert "query" in schemas["langmem_search"]["parameters"]["required"]
+
+    def test_conclude_requires_conclusion(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        schemas = {s["name"]: s for s in provider.get_tool_schemas()}
+        assert "conclusion" in schemas["langmem_conclude"]["parameters"]["required"]
+
+
+# ---------------------------------------------------------------------------
+# handle_tool_call
+# ---------------------------------------------------------------------------
+
+class TestHandleToolCall:
+    def test_profile_empty(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        result = json.loads(provider.handle_tool_call("langmem_profile", {}))
+        assert "No memories" in result["result"]
+
+    def test_conclude_stores_fact(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        result = json.loads(provider.handle_tool_call(
+            "langmem_conclude", {"conclusion": "Nick hates verbose explanations"}
+        ))
+        assert result["result"] == "Fact stored."
+
+        profile = json.loads(provider.handle_tool_call("langmem_profile", {}))
+        assert "Nick hates verbose explanations" in profile["result"]
+
+        row = provider._store.get_memory("nick", result["id"])
+        meta = json.loads(row["metadata_json"])
+        assert meta["lane"] == "preferences"
+        assert meta["source_type"] == "conclude"
+        assert "explicit" in meta["tags"]
+
+    def test_search_finds_stored_fact(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.handle_tool_call("langmem_conclude", {"conclusion": "Nick prefers dark mode UI"})
+
+        result = json.loads(provider.handle_tool_call("langmem_search", {"query": "dark mode"}))
+        assert result["count"] > 0
+        assert any("dark mode" in item["memory"] for item in result["results"])
+
+    def test_search_empty_query_returns_error(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        result = json.loads(provider.handle_tool_call("langmem_search", {}))
+        assert "error" in result
+
+    def test_conclude_empty_returns_error(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        result = json.loads(provider.handle_tool_call("langmem_conclude", {}))
+        assert "error" in result
+
+    def test_unknown_tool_returns_error(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        result = json.loads(provider.handle_tool_call("langmem_nonexistent", {}))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# sync_turn — mocked LangMem manager
+# ---------------------------------------------------------------------------
+
+class TestSyncTurn:
+    def test_sync_turn_persists_memories(self, tmp_path):
+        provider = _make_provider(tmp_path)
+
+        fake_mem = _fake_memory("m1", "Nick prefers concise responses", action="insert")
+        provider._manager = MagicMock()
+        provider._manager.invoke.return_value = [fake_mem]
+
+        provider.sync_turn("remember I like short answers", "got it")
+        # Wait for background thread
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        rows = provider._store.list_memories("nick")
+        assert len(rows) == 1
+        assert rows[0]["content"] == "Nick prefers concise responses"
+
+    def test_sync_turn_delete_action_soft_deletes(self, tmp_path):
+        provider = _make_provider(tmp_path)
+
+        # Seed an existing memory
+        provider._store.upsert_many("nick", [{"id": "old-id", "content": "old preference"}])
+
+        fake_del = _fake_memory("old-id", "old preference", action="delete")
+        provider._manager = MagicMock()
+        provider._manager.invoke.return_value = [fake_del]
+
+        provider.sync_turn("I changed my mind", "noted")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        rows = provider._store.list_memories("nick", include_deleted=True)
+        deleted = [r for r in rows if r["id"] == "old-id"]
+        assert deleted[0]["deleted_at"] is not None
+
+    def test_sync_turn_omission_does_not_delete(self, tmp_path):
+        """LangMem returning no update for an existing memory must not delete it."""
+        provider = _make_provider(tmp_path)
+
+        provider._store.upsert_many("nick", [
+            {"id": "keep", "content": "Nick wants concise responses"},
+            {"id": "also-keep", "content": "Nick uses dark mode"},
+        ])
+
+        # LangMem returns only one memory (omitting 'also-keep')
+        fake = _fake_memory("keep", "Nick wants concise responses", action="update")
+        provider._manager = MagicMock()
+        provider._manager.invoke.return_value = [fake]
+
+        provider.sync_turn("short answer please", "sure")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        rows = {r["id"]: r for r in provider._store.list_memories("nick")}
+        assert "also-keep" in rows, "Omitted memory must not be deleted"
+        assert rows["also-keep"]["deleted_at"] is None
+
+    def test_sync_turn_no_crash_on_empty_result(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._manager = MagicMock()
+        provider._manager.invoke.return_value = []
+
+        provider.sync_turn("hello", "hi")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        # No crash, no rows
+        rows = provider._store.list_memories("nick")
+        assert rows == []
+
+    def test_sync_turn_debounces_multiple_quick_calls(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider._debounce_seconds = 0.05
+        provider._manager = MagicMock()
+        provider._manager.invoke.return_value = [
+            _fake_memory("m1", "latest fact", action="insert")
+        ]
+
+        provider.sync_turn("first", "one")
+        provider.sync_turn("second", "two")
+        provider.sync_turn("third", "three")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        assert provider._manager.invoke.call_count == 1
+        payload = provider._manager.invoke.call_args[0][0]
+        assert payload["messages"][0]["content"] == "third"
+        assert payload["messages"][1]["content"] == "three"
+
+        rows = provider._store.list_memories("nick")
+        assert len(rows) == 1
+        assert rows[0]["content"] == "latest fact"
+
+
+# ---------------------------------------------------------------------------
+# User ID scoping
+# ---------------------------------------------------------------------------
+
+class TestUserIdScoping:
+    def test_initialize_sets_user_id(self, tmp_path, monkeypatch):
+        from plugins.memory.langmem import LangMemMemoryProvider
+        from plugins.memory.langmem.store import LangMemStore
+
+        provider = LangMemMemoryProvider()
+        # Patch store initialization to use tmp_path
+        orig_init = LangMemStore.__init__
+        def fake_store_init(self, path):
+            orig_init(self, tmp_path / "langmem.sqlite3")
+        monkeypatch.setattr(LangMemStore, "__init__", fake_store_init)
+        monkeypatch.setattr(
+            "plugins.memory.langmem._load_config",
+            lambda: {"model": "anthropic:claude-3-5-haiku-latest", "enable_deletes": True, "max_existing": 50, "debounce_seconds": 0.0}
+        )
+        from hermes_constants import get_hermes_home
+        monkeypatch.setattr(
+            "plugins.memory.langmem.LangMemMemoryProvider.initialize",
+            lambda self, session_id, **kw: (
+                setattr(self, "_user_id", kw.get("user_id") or "hermes-user"),
+                setattr(self, "_session_id", session_id),
+                setattr(self, "_model", "anthropic:claude-3-5-haiku-latest"),
+                setattr(self, "_enable_deletes", True),
+                setattr(self, "_max_existing", 50),
+                setattr(self, "_store", LangMemStore(tmp_path / "langmem.sqlite3")),
+            )
+        )
+
+        provider.initialize("sess-abc", user_id="alice")
+        assert provider._user_id == "alice"
+
+    def test_conclude_is_user_scoped(self, tmp_path):
+        alice = _make_provider(tmp_path, user_id="alice")
+        bob = _make_provider(tmp_path, user_id="bob")
+        # Both share the same store path
+        bob._store = alice._store
+
+        alice.handle_tool_call("langmem_conclude", {"conclusion": "Alice likes Python"})
+        bob.handle_tool_call("langmem_conclude", {"conclusion": "Bob likes Go"})
+
+        alice_profile = json.loads(alice.handle_tool_call("langmem_profile", {}))
+        assert "Alice" in alice_profile["result"]
+        assert "Bob" not in alice_profile["result"]
+
+        bob_profile = json.loads(bob.handle_tool_call("langmem_profile", {}))
+        assert "Bob" in bob_profile["result"]
+        assert "Alice" not in bob_profile["result"]
+
+
+# ---------------------------------------------------------------------------
+# Provider discovery
+# ---------------------------------------------------------------------------
+
+class TestDiscovery:
+    def test_langmem_is_discoverable(self):
+        from plugins.memory import find_provider_dir
+        path = find_provider_dir("langmem")
+        assert path is not None
+        assert path.name == "langmem"
+
+    def test_langmem_loads_via_plugin_system(self):
+        from plugins.memory import load_memory_provider
+        p = load_memory_provider("langmem")
+        assert p is not None
+        assert p.name == "langmem"
+
+    def test_langmem_in_discover_list(self):
+        from plugins.memory import discover_memory_providers
+        providers = discover_memory_providers()
+        names = [n for n, _, _ in providers]
+        assert "langmem" in names

--- a/tests/agent/test_langmem_store.py
+++ b/tests/agent/test_langmem_store.py
@@ -1,0 +1,260 @@
+"""Tests for the LangMem local SQLite store."""
+
+import pytest
+
+
+def test_store_round_trip(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many(
+        "u1",
+        [{
+            "id": "a",
+            "content": "Nick prefers concise answers",
+            "metadata": {
+                "lane": "preferences",
+                "source_type": "test",
+                "first_seen_session_id": "sess-1",
+                "last_seen_session_id": "sess-1",
+                "confirmation_count": 1,
+                "tags": ["preference"],
+            },
+        }],
+        session_id="sess-1",
+    )
+    rows = store.list_memories("u1")
+    assert len(rows) == 1
+    assert rows[0]["content"] == "Nick prefers concise answers"
+    assert rows[0]["id"] == "a"
+    assert rows[0]["deleted_at"] is None
+
+    import json
+    meta = json.loads(rows[0]["metadata_json"])
+    assert meta["lane"] == "preferences"
+    assert meta["source_type"] == "test"
+
+
+def test_store_search_is_user_scoped(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("alice", [{"id": "a", "content": "likes dark mode"}])
+    store.upsert_many("bob", [{"id": "b", "content": "likes light mode"}])
+
+    hits = store.search_memories("alice", "dark mode")
+    assert len(hits) == 1
+    assert hits[0]["id"] == "a"
+
+    hits = store.search_memories("bob", "dark mode")
+    assert len(hits) == 0
+
+
+def test_reconcile_many_only_soft_deletes_explicit_delete_ids(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [
+        {"id": "keep", "content": "Nick wants browser-verified fixes"},
+        {"id": "old", "content": "Nick prefers long essays"},
+    ])
+
+    # Reconcile with upsert of 'keep' only, and empty delete_ids.
+    # 'old' must NOT be soft-deleted — omission ≠ deletion.
+    store.reconcile_many(
+        "u1",
+        upserts=[{"id": "keep", "content": "Nick wants browser-verified fixes"}],
+        delete_ids=[],
+    )
+
+    rows = {row["id"]: row for row in store.list_memories("u1")}
+    assert "old" in rows, "'old' should still exist (omission != deletion)"
+    assert rows["old"]["deleted_at"] is None, "'old' must not be soft-deleted"
+    assert "keep" in rows
+
+
+def test_reconcile_many_explicit_delete_soft_deletes(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [
+        {"id": "x", "content": "stale fact"},
+        {"id": "y", "content": "good fact"},
+    ])
+
+    store.reconcile_many("u1", upserts=[], delete_ids=["x"])
+
+    rows = {row["id"]: row for row in store.list_memories("u1", include_deleted=True)}
+    assert rows["x"]["deleted_at"] is not None, "'x' should be soft-deleted"
+    assert rows["y"]["deleted_at"] is None, "'y' should be unaffected"
+
+    # list_memories excludes deleted by default
+    live = [r["id"] for r in store.list_memories("u1")]
+    assert "x" not in live
+    assert "y" in live
+
+
+def test_upsert_updates_content(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [{"id": "m1", "content": "old content"}])
+    store.upsert_many("u1", [{"id": "m1", "content": "new content"}])
+
+    rows = store.list_memories("u1")
+    assert len(rows) == 1
+    assert rows[0]["content"] == "new content"
+
+
+def test_upsert_revives_soft_deleted(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [{"id": "m1", "content": "fact"}])
+    store.delete_memory("u1", "m1")
+
+    # Upserting again should clear deleted_at
+    store.upsert_many("u1", [{"id": "m1", "content": "fact updated"}])
+    rows = store.list_memories("u1")
+    assert len(rows) == 1
+    assert rows[0]["deleted_at"] is None
+
+
+def test_search_returns_empty_on_no_match(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [{"id": "a", "content": "Nick likes TypeScript"}])
+    hits = store.search_memories("u1", "python")
+    assert hits == []
+
+
+def test_search_does_not_return_deleted(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [{"id": "del", "content": "old preference deleted"}])
+    store.delete_memory("u1", "del")
+
+    hits = store.search_memories("u1", "old preference")
+    assert all(h["id"] != "del" for h in hits)
+
+
+def test_auto_generated_id(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [{"content": "no explicit id"}])
+    rows = store.list_memories("u1")
+    assert len(rows) == 1
+    assert rows[0]["id"]  # should be auto-generated UUID
+
+
+def test_upsert_tracks_first_and_last_seen_sessions(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+    import json
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many(
+        "u1",
+        [{"id": "m1", "content": "Nick prefers concise answers", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-1",
+    )
+    store.upsert_many(
+        "u1",
+        [{"id": "m1", "content": "Nick prefers concise answers", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-2",
+    )
+
+    row = store.get_memory("u1", "m1")
+    meta = json.loads(row["metadata_json"])
+    assert meta["first_seen_session_id"] == "sess-1"
+    assert meta["last_seen_session_id"] == "sess-2"
+
+
+def test_upsert_increments_confirmation_count(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+    import json
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many("u1", [{"id": "m1", "content": "Nick likes dark mode"}], session_id="sess-1")
+    store.upsert_many("u1", [{"id": "m1", "content": "Nick likes dark mode"}], session_id="sess-2")
+
+    row = store.get_memory("u1", "m1")
+    meta = json.loads(row["metadata_json"])
+    assert meta["confirmation_count"] == 2
+
+
+def test_profile_upsert_writes_profile_metadata(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+    import json
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_profile("u1", {"preferred_name": "Nick"}, session_id="sess-profile")
+
+    row = store.get_memory("u1", "profile:u1")
+    meta = json.loads(row["metadata_json"])
+    assert meta["lane"] == "profile"
+    assert meta["source_type"] == "profile_sync"
+    assert meta["last_seen_session_id"] == "sess-profile"
+
+
+def test_search_prefers_confirmed_memory(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many(
+        "u1",
+        [{"id": "low", "content": "Nick prefers dark mode UI", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-1",
+    )
+    store.upsert_many(
+        "u1",
+        [{"id": "high", "content": "Nick prefers dark mode UI", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-1",
+    )
+    store.upsert_many(
+        "u1",
+        [{"id": "high", "content": "Nick prefers dark mode UI", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-2",
+    )
+    store.upsert_many(
+        "u1",
+        [{"id": "high", "content": "Nick prefers dark mode UI", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-3",
+    )
+
+    hits = store.search_memories("u1", "dark mode", limit=5)
+    assert [row["id"] for row in hits[:2]] == ["high", "low"]
+
+
+def test_search_prefers_recent_memory_when_text_matches(tmp_path):
+    from plugins.memory.langmem.store import LangMemStore
+
+    store = LangMemStore(tmp_path / "langmem.sqlite3")
+    store.upsert_many(
+        "u1",
+        [{"id": "older", "content": "Nick wants browser verified fixes", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-old",
+    )
+    store._conn.execute(
+        "UPDATE memories SET created_at = ?, updated_at = ? WHERE id = ?",
+        (1.0, 1.0, "older"),
+    )
+    store._conn.commit()
+    store.upsert_many(
+        "u1",
+        [{"id": "newer", "content": "Nick wants browser verified fixes", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-new",
+    )
+
+    hits = store.search_memories("u1", "browser verified fixes", limit=5)
+    assert [row["id"] for row in hits[:2]] == ["newer", "older"]
+
+
+def test_langmem_plugin_dir_is_discoverable():
+    from plugins.memory import find_provider_dir
+
+    path = find_provider_dir("langmem")
+    assert path is not None
+    assert path.name == "langmem"

--- a/tests/integration/test_langmem_eval.py
+++ b/tests/integration/test_langmem_eval.py
@@ -1,0 +1,234 @@
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+ARTIFACT_PATH = Path("tmp/langmem-eval/latest.json")
+
+
+def _make_provider(tmp_path, user_id="nick", session_id="sess-eval"):
+    from plugins.memory.langmem import LangMemMemoryProvider
+    from plugins.memory.langmem.store import LangMemStore
+
+    provider = LangMemMemoryProvider()
+    provider._store = LangMemStore(tmp_path / "langmem.sqlite3")
+    provider._store_path = tmp_path / "langmem.sqlite3"
+    provider._user_id = user_id
+    provider._session_id = session_id
+    provider._model = "anthropic:claude-3-5-haiku-latest"
+    provider._enable_deletes = True
+    provider._max_existing = 50
+    provider._debounce_seconds = 0.0
+    return provider
+
+
+def _score(ok: bool) -> float:
+    return 1.0 if ok else 0.0
+
+
+def _write_results(results: dict) -> None:
+    ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ARTIFACT_PATH.write_text(json.dumps(results, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _explicit_preference_write_scenario(tmp_path) -> dict:
+    provider = _make_provider(tmp_path, session_id="sess-explicit")
+    response = json.loads(
+        provider.handle_tool_call(
+            "langmem_conclude",
+            {"conclusion": "Nick prefers concise responses"},
+        )
+    )
+    row = provider._store.get_memory("nick", response["id"])
+    meta = json.loads(row["metadata_json"])
+    search = json.loads(provider.handle_tool_call("langmem_search", {"query": "concise responses", "top_k": 5}))
+    profile = json.loads(provider.handle_tool_call("langmem_profile", {}))
+
+    extraction_ok = row["content"] == "Nick prefers concise responses"
+    reconciliation_ok = meta["lane"] == "preferences" and meta["source_type"] == "conclude"
+    retrieval_ok = any(item["id"] == response["id"] for item in search.get("results", []))
+    injection_ok = "Nick prefers concise responses" in profile.get("result", "")
+
+    return {
+        "scenario": "explicit_preference_write",
+        "extraction_score": _score(extraction_ok),
+        "reconciliation_score": _score(reconciliation_ok),
+        "retrieval_score": _score(retrieval_ok),
+        "injection_usefulness_score": _score(injection_ok),
+        "notes": {
+            "stored_id": response["id"],
+            "profile_kind": profile.get("kind", "fallback"),
+        },
+    }
+
+
+def _preference_correction_scenario(tmp_path) -> dict:
+    provider = _make_provider(tmp_path, session_id="sess-correct-1")
+    old_response = json.loads(
+        provider.handle_tool_call(
+            "langmem_conclude",
+            {"conclusion": "Nick prefers long essays"},
+        )
+    )
+    provider._store.delete_memory("nick", old_response["id"])
+    provider._session_id = "sess-correct-2"
+    new_response = json.loads(
+        provider.handle_tool_call(
+            "langmem_conclude",
+            {"conclusion": "Nick prefers concise responses"},
+        )
+    )
+
+    old_live = provider._store.get_memory("nick", old_response["id"])
+    all_rows = {row["id"]: row for row in provider._store.list_memories("nick", include_deleted=True)}
+    new_row = provider._store.get_memory("nick", new_response["id"])
+    search_new = json.loads(provider.handle_tool_call("langmem_search", {"query": "concise responses", "top_k": 5}))
+    search_old = json.loads(provider.handle_tool_call("langmem_search", {"query": "long essays", "top_k": 5}))
+    profile = json.loads(provider.handle_tool_call("langmem_profile", {}))
+    profile_text = profile.get("result", "")
+
+    extraction_ok = new_row is not None and new_row["content"] == "Nick prefers concise responses"
+    reconciliation_ok = old_live is None and all_rows[old_response["id"]]["deleted_at"] is not None
+    retrieval_ok = any(item["id"] == new_response["id"] for item in search_new.get("results", [])) and search_old.get("count", 0) == 0
+    injection_ok = "Nick prefers concise responses" in profile_text and "Nick prefers long essays" not in profile_text
+
+    return {
+        "scenario": "preference_correction_supersession",
+        "extraction_score": _score(extraction_ok),
+        "reconciliation_score": _score(reconciliation_ok),
+        "retrieval_score": _score(retrieval_ok),
+        "injection_usefulness_score": _score(injection_ok),
+        "notes": {
+            "old_id": old_response["id"],
+            "new_id": new_response["id"],
+        },
+    }
+
+
+def _cross_session_recall_scenario(tmp_path) -> dict:
+    provider_a = _make_provider(tmp_path, session_id="sess-a")
+    response = json.loads(
+        provider_a.handle_tool_call(
+            "langmem_conclude",
+            {"conclusion": "Nick wants browser-verified fixes"},
+        )
+    )
+
+    provider_b = _make_provider(tmp_path, session_id="sess-b")
+    provider_b._store = provider_a._store
+    provider_b._store_path = provider_a._store_path
+    search = json.loads(provider_b.handle_tool_call("langmem_search", {"query": "browser verified fixes", "top_k": 5}))
+    profile = json.loads(provider_b.handle_tool_call("langmem_profile", {}))
+    row = provider_b._store.get_memory("nick", response["id"])
+
+    extraction_ok = row is not None
+    reconciliation_ok = row is not None and row["deleted_at"] is None
+    retrieval_ok = any(item["id"] == response["id"] for item in search.get("results", []))
+    injection_ok = "Nick wants browser-verified fixes" in profile.get("result", "")
+
+    return {
+        "scenario": "cross_session_recall",
+        "extraction_score": _score(extraction_ok),
+        "reconciliation_score": _score(reconciliation_ok),
+        "retrieval_score": _score(retrieval_ok),
+        "injection_usefulness_score": _score(injection_ok),
+        "notes": {
+            "stored_id": response["id"],
+        },
+    }
+
+
+def _lexical_ambiguity_scenario(tmp_path) -> dict:
+    provider = _make_provider(tmp_path, session_id="sess-lexical")
+    provider._store.upsert_many(
+        "nick",
+        [{"id": "pref", "content": "Nick prefers concise responses", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-lexical-1",
+    )
+    provider._store.upsert_many(
+        "nick",
+        [{"id": "pref", "content": "Nick prefers concise responses", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-lexical-2",
+    )
+    provider._store.upsert_many(
+        "nick",
+        [{"id": "music", "content": "Nick likes concise techno mixes", "metadata": {"lane": "preferences", "source_type": "sync_turn"}}],
+        session_id="sess-lexical-1",
+    )
+
+    row_pref = provider._store.get_memory("nick", "pref")
+    row_music = provider._store.get_memory("nick", "music")
+    meta_pref = json.loads(row_pref["metadata_json"])
+    meta_music = json.loads(row_music["metadata_json"])
+    search = json.loads(provider.handle_tool_call("langmem_search", {"query": "concise", "top_k": 5}))
+    top_memory = search.get("results", [{}])[0].get("memory", "") if search.get("results") else ""
+
+    extraction_ok = row_pref is not None and row_music is not None
+    reconciliation_ok = meta_pref["confirmation_count"] > meta_music["confirmation_count"]
+    retrieval_ok = search.get("results", [{}])[0].get("id") == "pref"
+    injection_ok = "concise responses" in top_memory
+
+    return {
+        "scenario": "retrieval_under_lexical_ambiguity",
+        "extraction_score": _score(extraction_ok),
+        "reconciliation_score": _score(reconciliation_ok),
+        "retrieval_score": _score(retrieval_ok),
+        "injection_usefulness_score": _score(injection_ok),
+        "notes": {
+            "top_result": top_memory,
+        },
+    }
+
+
+def run_langmem_eval_harness(tmp_path) -> dict:
+    scenario_results = [
+        _explicit_preference_write_scenario(tmp_path / "explicit"),
+        _preference_correction_scenario(tmp_path / "correction"),
+        _cross_session_recall_scenario(tmp_path / "cross-session"),
+        _lexical_ambiguity_scenario(tmp_path / "lexical"),
+    ]
+    summary = {
+        "scenario_count": len(scenario_results),
+        "average_extraction_score": sum(item["extraction_score"] for item in scenario_results) / len(scenario_results),
+        "average_reconciliation_score": sum(item["reconciliation_score"] for item in scenario_results) / len(scenario_results),
+        "average_retrieval_score": sum(item["retrieval_score"] for item in scenario_results) / len(scenario_results),
+        "average_injection_usefulness_score": sum(item["injection_usefulness_score"] for item in scenario_results) / len(scenario_results),
+    }
+    results = {
+        "scenarios": scenario_results,
+        "summary": summary,
+    }
+    _write_results(results)
+    return results
+
+
+def test_langmem_eval_harness_writes_latest_results(tmp_path):
+    results = run_langmem_eval_harness(tmp_path)
+
+    assert results["summary"]["scenario_count"] == 4
+    scenario_names = {scenario["scenario"] for scenario in results["scenarios"]}
+    assert scenario_names == {
+        "explicit_preference_write",
+        "preference_correction_supersession",
+        "cross_session_recall",
+        "retrieval_under_lexical_ambiguity",
+    }
+    for scenario in results["scenarios"]:
+        assert set(scenario) >= {
+            "scenario",
+            "extraction_score",
+            "reconciliation_score",
+            "retrieval_score",
+            "injection_usefulness_score",
+        }
+        assert scenario["extraction_score"] == 1.0
+        assert scenario["reconciliation_score"] == 1.0
+        assert scenario["retrieval_score"] == 1.0
+        assert scenario["injection_usefulness_score"] == 1.0
+
+    assert ARTIFACT_PATH.exists()
+    artifact = json.loads(ARTIFACT_PATH.read_text(encoding="utf-8"))
+    assert artifact["summary"]["scenario_count"] == 4


### PR DESCRIPTION
## Summary
- add a structured `langmem` memory provider with explicit profile and episodic lanes
- store provenance metadata plus lightweight retrieval reranking and conservative reconciliation
- debounce background sync, add deterministic eval coverage, and scaffold a reviewed prompt-learning loop

## Testing
- `pytest tests/agent/test_langmem_store.py tests/agent/test_langmem_provider.py tests/agent/test_langmem_profile_lane.py tests/agent/test_langmem_episodic_lane.py -q`
- `pytest -q -m integration tests/integration/test_langmem_eval.py`
- `python scripts/langmem_prompt_review.py --help`
