### PR TITLE
fix(teams): import prompt/print helpers from cli_output, not config

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -592,6 +592,8 @@ def interactive_setup() -> None:
     from hermes_cli.config import (
         get_env_value,
         save_env_value,
+    )
+    from hermes_cli.cli_output import (
         prompt,
         prompt_yes_no,
         print_info,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -344,6 +344,7 @@ AUTHOR_MAP = {
     "greer.guthrie@gmail.com": "g-guthrie",
     "kennyx102@gmail.com": "bobashopcashier",
     "77253505+bobashopcashier@users.noreply.github.com": "bobashopcashier",
+    "25355950+megastary@users.noreply.github.com": "megastary",  # PR #18325
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -313,8 +313,32 @@ class TestTeamsPluginRegistration:
 
 
 # ---------------------------------------------------------------------------
-# Tests: Connect / Disconnect
+# Tests: Interactive setup (import fix regression — #18325 / #19173)
 # ---------------------------------------------------------------------------
+
+class TestTeamsInteractiveSetup:
+    def test_interactive_setup_persists_credentials(self, tmp_path, monkeypatch):
+        """Regression for #19173: interactive_setup must import prompt helpers
+        from hermes_cli.cli_output (not hermes_cli.config) and persist
+        credentials to .env without crashing.
+        """
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.cli_output as cli_output_mod
+
+        answers = iter(["client-id", "client-secret", "tenant-id", "aad-1, aad-2"])
+        monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(answers))
+        monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: True)
+        monkeypatch.setattr(cli_output_mod, "print_info", lambda *_a, **_kw: None)
+        monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+        monkeypatch.setattr(cli_output_mod, "print_warning", lambda *_a, **_kw: None)
+
+        _teams_mod.interactive_setup()
+
+        env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+        assert "TEAMS_CLIENT_ID=client-id" in env_text
+        assert "TEAMS_TENANT_ID=tenant-id" in env_text
 
 class TestTeamsConnect:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Salvage of PR #18325 by @megastary — fixes `hermes setup` crashing with `ImportError` when the user picks Teams in the messaging-platforms wizard.

Fixes #19173.

### Bug

`interactive_setup()` in `plugins/platforms/teams/adapter.py` imports `prompt`, `prompt_yes_no`, `print_info`, `print_success`, and `print_warning` from `hermes_cli.config`, but those helpers live in `hermes_cli.cli_output`. Only `get_env_value`/`save_env_value` live in `hermes_cli.config`.

```
ImportError: cannot import name 'prompt' from 'hermes_cli.config'
```

### Fix

Split the import: credential helpers from `hermes_cli.config`, UI helpers from `hermes_cli.cli_output`.

### Changes

**From contributor (cherry-picked):**
- `plugins/platforms/teams/adapter.py` — split import statement (+2/-0)

**Follow-up:**
- `tests/gateway/test_teams.py` — regression test adapted from PR #19188 by @LeonSGP43. Mocks cli_output helpers and verifies `interactive_setup()` persists credentials to `.env` without crashing.
- `scripts/release.py` — add megastary to AUTHOR_MAP

### Duplicate PRs

- PR #19188 by @LeonSGP43 — same fix using `hermes_cli.setup` as import source (works but less canonical). Test adapted from this PR with credit.
- PR #18325 by @megastary — submitted first (May 1 vs May 3), uses canonical import sources.

### Test results

- 1/1 regression test passed (TestTeamsInteractiveSetup)
