### PR TITLE
fix: prevent stale-code restart message from leaking to unauthorized senders

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -318,6 +318,22 @@ class EmailAdapter(BasePlatformAdapter):
             self._poll_task = None
         logger.info("[Email] Disconnected.")
 
+    def _mark_as_seen(self, uid: str) -> None:
+        """Mark a message as SEEN on the IMAP server. Runs in executor thread."""
+        try:
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=15)
+            try:
+                imap.login(self._address, self._password)
+                imap.select("INBOX")
+                imap.uid("store", uid, "+FLAGS", "\\Seen")
+            finally:
+                try:
+                    imap.logout()
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.debug("[Email] IMAP mark_seen error for uid %s: %s", uid, e)
+
     async def _poll_loop(self) -> None:
         """Poll IMAP for new messages at regular intervals."""
         while self._running:
@@ -462,6 +478,17 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
+
+        # Mark as SEEN on the IMAP server so the message isn't re-fetched
+        # after a gateway restart (which would re-trigger processing
+        # including any pre-auth early returns like the stale-code check).
+        uid = msg_data.get("uid")
+        if uid:
+            try:
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, self._mark_as_seen, uid)
+            except Exception as _se:
+                logger.debug("[Email] Failed to mark uid %s as seen: %s", uid, _se)
 
     async def send(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4612,14 +4612,16 @@ class GatewayRunner:
         try:
             if self._detect_stale_code():
                 self._trigger_stale_code_restart()
-                # Acknowledge to the user so they don't see a silent
-                # drop; the gateway will be back up in a moment via the
-                # service manager / profile-watcher respawn.
-                return (
-                    "⟳ Gateway code was updated in the background — "
-                    "restarting this gateway so your next message runs "
-                    "on the new code. Please retry in a moment."
-                )
+                # Only acknowledge to authorized users so the restart
+                # message doesn't leak to unauthorized senders (e.g.
+                # email replies to strangers — Issue #17648 follow-up).
+                if self._is_user_authorized(source):
+                    return (
+                        "⟳ Gateway code was updated in the background — "
+                        "restarting this gateway so your next message runs "
+                        "on the new code. Please retry in a moment."
+                    )
+                return None
         except Exception as _stale_exc:
             logger.debug("Stale-code self-check failed: %s", _stale_exc)
 


### PR DESCRIPTION
## Summary

The stale-code self-check in _handle_message() returned the restart acknowledgement before reaching _is_user_authorized(). Unauthorized senders (e.g. IMAP re-fetched emails after restart) received the gateway restart boilerplate as a reply.

## Changes

**1. gateway/run.py** — Gate stale-code restart message behind auth check. Only authorized users see it; unauthorized get None.

**2. gateway/platforms/email.py** — Mark fetched emails as \Seen on IMAP after dispatch, preventing re-fetch on restart.