### PR TITLE
fix(tui): pass fallback provider chain to agent

### DIFF
--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -25,6 +25,10 @@ def test_make_agent_passes_resolved_provider():
     fake_cfg = {
         "model": {"default": "claude-opus-4-6", "provider": "anthropic"},
         "agent": {"system_prompt": "test"},
+        "fallback_providers": [
+            {"provider": "copilot", "model": "gpt-5.5"},
+            {"provider": "minimax", "model": "MiniMax-M2.7"},
+        ],
     }
 
     with (
@@ -57,6 +61,7 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+        assert call_kwargs.kwargs["fallback_model"] == fake_cfg["fallback_providers"]
 
 
 def test_make_agent_ignores_display_personality_without_system_prompt():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1776,6 +1776,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         requested=requested_provider,
         target_model=model or None,
     )
+    fallback_model = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -1794,6 +1795,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         platform="tui",
         session_id=session_id or key,
         session_db=_get_db(),
+        fallback_model=fallback_model,
         ephemeral_system_prompt=system_prompt or None,
         **_agent_cbs(sid),
     )


### PR DESCRIPTION
## Summary

Fixes the TUI backend so Hermes TUI sessions receive the same configured fallback provider chain as CLI and gateway sessions.

## Background / issue

While testing fallback behavior, the Telegram/gateway path correctly fell back from the primary provider to the configured `fallback_providers` chain, but the Hermes TUI did not appear to attempt fallback.

The local config already had fallback configured, for example:

```yaml
fallback_providers:
  - provider: copilot
    model: gpt-5.5
  - provider: minimax
    model: MiniMax-M2.7
```

Investigation showed this was not a config/setup problem. CLI and gateway both load `fallback_providers` / legacy `fallback_model` and pass that value into `AIAgent(..., fallback_model=...)`. The TUI backend's `_make_agent()` resolved the primary runtime provider, but never passed any fallback configuration to `AIAgent`, so TUI-created agents had no fallback chain to try when the primary failed.

## What changed

- In `tui_gateway/server.py::_make_agent()`:
  - load `fallback_providers` or legacy `fallback_model` from config
  - pass it to `AIAgent` as `fallback_model=fallback_model`
- In `tests/tui_gateway/test_make_agent_provider.py`:
  - extend the existing `_make_agent` provider regression test to verify the fallback provider list is forwarded into `AIAgent`

## Test plan

```bash
python -m pytest tests/tui_gateway/test_make_agent_provider.py -q -o 'addopts='
```

Result:

```text
6 passed in 1.30s
```
