### PR TITLE
fix: guard dict model.provider + NVIDIA NIM free fallback setup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1672,9 +1672,10 @@ class HermesCLI:
         self._explicit_base_url = base_url
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
+        _cfg_provider = CLI_CONFIG["model"].get("provider")
         self.requested_provider = (
             provider
-            or CLI_CONFIG["model"].get("provider")
+            or (_cfg_provider if isinstance(_cfg_provider, str) else None)
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
         )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -805,7 +805,8 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         cfg = load_config()
         model_cfg = cfg.get("model")
         if isinstance(model_cfg, dict):
-            cfg_provider = (model_cfg.get("provider") or "").strip().lower()
+            _raw_provider = model_cfg.get("provider")
+            cfg_provider = (str(_raw_provider) if isinstance(_raw_provider, str) else "").strip().lower()
             if cfg_provider == normalized:
                 return True
     except Exception:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -378,7 +378,7 @@ def _resolve_openrouter_runtime(
         if isinstance(v, str) and v.strip():
             cfg_api_key = v.strip()
             break
-    requested_norm = (requested_provider or "").strip().lower()
+    requested_norm = (str(requested_provider) if isinstance(requested_provider, str) else "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
 
     env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()

--- a/setup/.env.template
+++ b/setup/.env.template
@@ -1,0 +1,21 @@
+# Copy this file to ~/.hermes/.env and fill in your actual keys
+
+# OpenRouter — free models require `:free` suffix in model IDs
+# Get key at: https://openrouter.ai/keys
+OPENROUTER_API_KEY=sk-or-v1-YOUR_KEY_HERE
+
+# DeepSeek — requires paid credits (avoid as primary, use as fallback only)
+# Get key at: https://platform.deepseek.com/api_keys
+DEEPSEEK_API_KEY=sk-YOUR_DEEPSEEK_KEY_HERE
+
+# NVIDIA NIM — truly free inference API (no credits needed for most models)
+# Get key at: https://build.nvidia.com (sign up, generate API key)
+# Free models that support OpenAI tool-use format:
+#   meta/llama-3.3-70b-instruct
+#   nvidia/llama-3.3-nemotron-super-49b-v1
+NVIDIA_API_KEY=nvapi-YOUR_NVIDIA_KEY_HERE
+NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
+
+# Cloudflare Workers AI — free tier available
+# Account ID and API token from: https://dash.cloudflare.com/
+CLOUDFLARE_API_TOKEN=cfat_YOUR_CLOUDFLARE_TOKEN_HERE

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,0 +1,62 @@
+# Hermes Agent — Setup Guide
+
+This directory contains the config template and setup instructions for reproducing this hermes-agent setup on a new machine.
+
+## What's in this branch
+
+- **3 bug fixes** in the hermes-agent Python code (see PR description):
+  - `cli.py`: `model.provider` dict no longer crashes provider selection
+  - `hermes_cli/auth.py`: same dict-vs-string guard
+  - `hermes_cli/runtime_provider.py`: same guard in runtime resolver
+- **`setup/config-template.yaml`**: hermes config with NVIDIA NIM free API as fallback
+- **`setup/.env.template`**: environment variable template
+
+## Setup on a new laptop
+
+### 1. Clone this fork
+```bash
+git clone https://github.com/namangoyal3/hermes-agent.git ~/.hermes-agent
+cd ~/.hermes-agent
+pip install -e .
+```
+
+### 2. Create hermes config directory
+```bash
+mkdir -p ~/.hermes
+cp ~/.hermes-agent/setup/config-template.yaml ~/.hermes/config.yaml
+cp ~/.hermes-agent/setup/.env.template ~/.hermes/.env
+```
+
+### 3. Fill in your API keys
+Edit `~/.hermes/.env` with your real keys:
+- **NVIDIA NIM** (free): https://build.nvidia.com — sign up, generate API key
+- **Cloudflare Workers AI** (free tier): https://dash.cloudflare.com/
+- **OpenRouter** (free models): https://openrouter.ai/keys
+
+Also update `~/.hermes/config.yaml`:
+- Replace `YOUR_CF_ACCOUNT_ID` with your Cloudflare account ID
+- Replace `YOUR_CLOUDFLARE_API_TOKEN` and `YOUR_NVIDIA_API_KEY` in `custom_providers`
+
+### 4. Start the hermes gateway
+```bash
+hermes gateway start
+```
+
+## Free model stack
+
+| Priority | Provider | Model | Context |
+|----------|----------|-------|---------|
+| Primary | Cloudflare Workers AI | `kimi-k2.6` | 128K |
+| Fallback 1 | NVIDIA NIM (free) | `meta/llama-3.3-70b-instruct` | 128K |
+| Fallback 2 | NVIDIA NIM (free) | `nvidia/llama-3.3-nemotron-super-49b-v1` | 128K |
+| Fallback 3 | OpenRouter (free) | `minimax/minimax-m2.5:free` | 1M |
+
+## Why these models?
+
+NVIDIA NIM's `meta/llama-3.3-70b-instruct` and `nvidia/llama-3.3-nemotron-super-49b-v1` return proper OpenAI-format JSON tool calls. Other NVIDIA models (MiniMax M2.7, Nemotron 120B) use a custom XML format that breaks hermes tool use.
+
+## Troubleshooting
+
+- **HTTP 402**: API account has no credits — hermes will automatically fall through to next fallback
+- **HTTP 429**: Rate limited — hermes will automatically fall through to next fallback  
+- **`'dict' object has no attribute 'strip'`**: Fixed in this branch — `model.provider` is a dict in config but code assumed string

--- a/setup/config-template.yaml
+++ b/setup/config-template.yaml
@@ -1,0 +1,88 @@
+model:
+  default: cloudflare:kimi-k2.6
+  fallback:
+  - nvidia:meta/llama-3.3-70b-instruct
+  provider:
+    cloudflare: true
+    nvidia: true
+    openrouter: true
+    deepseek: true
+    custom:
+      cloudflare:
+        base_url: https://api.cloudflare.com/client/v4/accounts/YOUR_CF_ACCOUNT_ID/ai
+        api_key_env: CLOUDFLARE_API_TOKEN
+        models:
+        - id: kimi-k2.6
+          name: Kimi K2.6 (Free)
+          context_window: 131072
+      nvidia:
+        base_url: https://integrate.api.nvidia.com/v1
+        api_key_env: NVIDIA_API_KEY
+        models:
+        - id: minimaxai/minimax-m2.7
+          name: NVIDIA MiniMax M2.7
+          context_window: 200000
+        - id: nemotron-120b-a12b
+          name: NVIDIA Nemotron 120B a12b
+          context_window: 200000
+        - id: meta/llama-3.3-70b-instruct
+          name: Llama 3.3 70B
+          context_window: 128000
+
+providers: {}
+
+custom_providers:
+- name: cloudflare
+  base_url: https://api.cloudflare.com/client/v4/accounts/YOUR_CF_ACCOUNT_ID/ai
+  api_key: YOUR_CLOUDFLARE_API_TOKEN
+- name: nvidia
+  base_url: https://integrate.api.nvidia.com/v1
+  api_key: YOUR_NVIDIA_API_KEY
+
+# Fallback chain: tries these providers in order when primary fails (429, 402, 503)
+fallback_providers:
+- provider: nvidia
+  model: meta/llama-3.3-70b-instruct
+- provider: nvidia
+  model: nvidia/llama-3.3-nemotron-super-49b-v1
+- provider: openrouter
+  model: minimax/minimax-m2.5:free
+toolsets:
+- hermes-cli
+agent:
+  max_turns: 90
+  gateway_timeout: 1800
+  restart_drain_timeout: 60
+  service_tier: ''
+  tool_use_enforcement: auto
+  gateway_timeout_warning: 900
+  gateway_notify_interval: 600
+terminal:
+  backend: local
+  modal_mode: auto
+  cwd: .
+  timeout: 180
+  env_passthrough: []
+  docker_image: nikolaik/python-nodejs:python3.11-nodejs20
+  persistent_shell: true
+browser:
+  inactivity_timeout: 120
+  command_timeout: 30
+  record_sessions: false
+  allow_private_urls: false
+checkpoints:
+  enabled: true
+  max_snapshots: 50
+display:
+  compact: false
+  personality: kawaii
+  streaming: false
+  inline_diffs: true
+  show_cost: false
+approvals:
+  mode: manual
+  timeout: 60
+security:
+  redact_secrets: true
+  tirith_enabled: true
+_config_version: 16


### PR DESCRIPTION
## Summary

- **Bug fix**: `model.provider` in hermes config is a complex dict (for multi-provider gateway routing), but 3 code paths assumed it was always a string, causing `'dict' object has no attribute 'strip'` crashes at startup
- **Fallback config**: Added `setup/` directory with config template wired to NVIDIA NIM free API as the primary fallback chain (no credits required)

## Bug fixes

### `cli.py` — provider selection
```python
# Before (crash when model.provider is a dict)
self.requested_provider = provider or CLI_CONFIG["model"].get("provider") or ...

# After
_cfg_provider = CLI_CONFIG["model"].get("provider")
self.requested_provider = provider or (_cfg_provider if isinstance(_cfg_provider, str) else None) or ...
```

### `hermes_cli/auth.py` — provider check
```python
# Before
cfg_provider = (model_cfg.get("provider") or "").strip().lower()

# After
_raw_provider = model_cfg.get("provider")
cfg_provider = (str(_raw_provider) if isinstance(_raw_provider, str) else "").strip().lower()
```

### `hermes_cli/runtime_provider.py` — runtime resolver
```python
# Before
requested_norm = (requested_provider or "").strip().lower()

# After
requested_norm = (str(requested_provider) if isinstance(requested_provider, str) else "").strip().lower()
```

## Setup files (`setup/`)

| File | Purpose |
|------|---------|
| `config-template.yaml` | Drop-in hermes config with Cloudflare primary + NVIDIA NIM fallback chain |
| `.env.template` | API key template with links to where to get each key |
| `README.md` | Step-by-step setup instructions for a new machine |

## Free model fallback chain

```
Primary:    cloudflare:kimi-k2.6
Fallback 1: nvidia:meta/llama-3.3-70b-instruct   (free, proper JSON tool calls)
Fallback 2: nvidia:llama-3.3-nemotron-super-49b  (free, proper JSON tool calls)
Fallback 3: openrouter:minimax/minimax-m2.5:free
```

> **Note**: NVIDIA MiniMax M2.7 and Nemotron 120B use a custom XML tool-call format that breaks hermes tool use — use `meta/llama-3.3-70b-instruct` or `nemotron-super-49b` instead.

## Test plan

- [ ] Start hermes with `model.provider` set to a dict in config — should not crash
- [ ] Kill primary model credits — fallback should kick in via `fallback_providers`
- [ ] Tool use (function calls) should work on NVIDIA Llama 3.3 70B fallback