### PR TITLE
fix(gateway): propagate max_output_tokens from named provider config to AIAgent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -617,7 +617,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    return {
+    result = {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -626,6 +626,10 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+    mot = runtime.get("max_output_tokens")
+    if isinstance(mot, int) and mot > 0:
+        result["max_tokens"] = mot
+    return result
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -1547,6 +1551,10 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
+        # Propagate max_tokens if the provider config specified max_output_tokens
+        mot = runtime_kwargs.get("max_tokens")
+        if isinstance(mot, int) and mot > 0:
+            runtime["max_tokens"] = mot
         route = {
             "model": model,
             "runtime": runtime,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -410,6 +410,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    # Propagate max_output_tokens if set in the provider block
+                    mot = entry.get("max_output_tokens")
+                    if isinstance(mot, int) and mot > 0:
+                        result["max_output_tokens"] = mot
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -428,6 +432,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        # Propagate max_output_tokens if set in the provider block
+                        mot = entry.get("max_output_tokens")
+                        if isinstance(mot, int) and mot > 0:
+                            result["max_output_tokens"] = mot
                         return result
 
     # Fall back to custom_providers: list (legacy format)


### PR DESCRIPTION
## Bug

Setting `max_output_tokens` under a named provider block in `~/.hermes/config.yaml`
(e.g. `providers: apigw2: max_output_tokens: 64000`) was silently ignored at runtime.
Gateway-spawned agents always had `self.max_tokens = None`, so the API fell back to
its server-side default (~4k–8k tokens), causing truncated responses on long tasks.

## Root Cause

`_get_named_custom_provider()` in `hermes_cli/runtime_provider.py` read all other
fields from the provider entry dict (api_key, base_url, api_mode, …) but never read
`max_output_tokens`, so it was dropped before reaching the gateway layer.  Even if it
had been present in the runtime dict, `_resolve_runtime_agent_kwargs()` in
`gateway/run.py` did not map it to a `max_tokens` kwarg, and `_resolve_turn_agent_config`
did not forward it into the `runtime` dict handed to `AIAgent`.

## Fix (three points)

1. **`hermes_cli/runtime_provider.py` — `_get_named_custom_provider()`**
   Read `max_output_tokens` from the provider entry dict and include it in the
   returned result dict (both the key-match and name-match code paths).

2. **`gateway/run.py` — `_resolve_runtime_agent_kwargs()`**
   After building the result dict, check for `max_output_tokens` in the resolved
   runtime dict and expose it as `max_tokens` in the returned kwargs.

3. **`gateway/run.py` — `GatewayRunner._resolve_turn_agent_config()`**
   Propagate `max_tokens` from `runtime_kwargs` into the `runtime` dict that is
   passed to `AIAgent`, so the agent is constructed with the correct token limit.

Without this fix, `max_output_tokens` in any `providers:` block is silently ignored
and all gateway agents use the API server default token cap.