### PR TITLE
fix: restart all launchd profile gateways on hermes update (macOS)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -108,22 +108,30 @@ def _get_service_pids() -> set:
     # --- launchd (macOS) ---
     if is_macos():
         try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+            _launchd_dir = Path.home() / "Library" / "LaunchAgents"
+            _labels = set()
+            _labels.add(get_launchd_label())
+            # Discover profile labels from plist files on disk
+            if _launchd_dir.exists():
+                for _pf in _launchd_dir.glob("ai.hermes.gateway.*.plist"):
+                    _labels.add(_pf.stem)
+                for _pf in _launchd_dir.glob("ai.hermes.gateway-*.plist"):
+                    _labels.add(_pf.stem)
+            for _lbl in _labels:
+                result = subprocess.run(
+                    ["launchctl", "list", _lbl],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.returncode == 0:
+                    for line in result.stdout.strip().splitlines():
+                        parts = line.split()
+                        if len(parts) >= 3 and parts[2] == _lbl:
+                            try:
+                                pid = int(parts[0])
+                                if pid > 0:
+                                    pids.add(pid)
+                            except ValueError:
+                                pass
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7491,23 +7491,75 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         launchd_restart,
                         get_launchd_label,
                         get_launchd_plist_path,
+                        _launchd_domain,
                     )
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
+                    _launchd_dir = Path.home() / "Library" / "LaunchAgents"
+                    _domain = _launchd_domain()
+
+                    # Collect all hermes gateway plist labels (main + profiles).
+                    # Supports both dot naming (ai.hermes.gateway.dave) and
+                    # dash naming (ai.hermes.gateway-dave) for compatibility.
+                    _launchd_labels = []
+
+                    # Main gateway
+                    _main_plist = get_launchd_plist_path()
+                    if _main_plist.exists():
+                        _launchd_labels.append(get_launchd_label())
+
+                    # Profile gateways — discover from plist files on disk
+                    if _launchd_dir.exists():
+                        for _plist_file in _launchd_dir.glob("ai.hermes.gateway.*.plist"):
+                            _label = _plist_file.stem
+                            if _label != get_launchd_label():
+                                _launchd_labels.append(_label)
+                        for _plist_file in _launchd_dir.glob("ai.hermes.gateway-*.plist"):
+                            _label = _plist_file.stem
+                            if _label != get_launchd_label():
+                                _launchd_labels.append(_label)
+
+                    for _label in sorted(set(_launchd_labels)):
+                        _check = subprocess.run(
+                            ["launchctl", "list", _label],
                             capture_output=True,
                             text=True,
                             timeout=5,
                         )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
+                        if _check.returncode != 0:
+                            continue
+
+                        _target = f"{_domain}/{_label}"
+                        try:
+                            # Attempt graceful restart via launchctl kickstart -k
+                            subprocess.run(
+                                ["launchctl", "kickstart", "-k", _target],
+                                check=True,
+                                timeout=90,
+                            )
+                            restarted_services.append(_label)
+                            print(f"  ✓ Restarted {_label}")
+                        except subprocess.CalledProcessError as _e:
+                            _stderr = (getattr(_e, "stderr", "") or "").strip()
+                            # Code 3 or 113 = job not loaded; try bootstrap + kickstart
+                            if _e.returncode in (3, 113):
+                                try:
+                                    _plist = _launchd_dir / f"{_label}.plist"
+                                    subprocess.run(
+                                        ["launchctl", "bootstrap", _domain, str(_plist)],
+                                        check=True,
+                                        timeout=30,
+                                    )
+                                    subprocess.run(
+                                        ["launchctl", "kickstart", _target],
+                                        check=True,
+                                        timeout=30,
+                                    )
+                                    restarted_services.append(_label)
+                                    print(f"  ✓ Reloaded and restarted {_label}")
+                                except subprocess.CalledProcessError as _e2:
+                                    print(f"  ⚠ {_label} reload failed: {_e2}")
+                            else:
+                                print(f"  ⚠ {_label} restart failed: {_stderr}")
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 


### PR DESCRIPTION
## Problem

On macOS, `hermes update` only restarted the current profile's launchd service, leaving other profile gateways running stale code. The systemd path (Linux) already correctly discovers and restarts all `hermes-gateway*` units, but the macOS launchd path was missing equivalent logic.

Additionally, `_get_service_pids()` in `gateway.py` only returned the main gateway PID for launchd, which meant the stale-process sweep after `hermes update` could accidentally SIGTERM a freshly-restarted profile gateway.

## Changes

### `hermes_cli/main.py` (~line 7487)
- Discovers all `ai.hermes.gateway*.plist` files in `~/Library/LaunchAgents/`
- Restarts each loaded service via `launchctl kickstart -k`
- Falls back to `bootstrap` + `kickstart` for unloaded jobs (exit codes 3/113)
- Supports both dot (`ai.hermes.gateway.dave`) and dash (`ai.hermes.gateway-dave`) naming conventions for backward compatibility

### `hermes_cli/gateway.py` (~line 108)
- `_get_service_pids()` now collects PIDs from all profile launchd services, not just the current one
- Uses the same plist-discovery logic to prevent the stale-process sweep from killing freshly-restarted profile gateways

## Testing

Tested on macOS with a 5-profile fleet (relay, dave, archer, iris, cora):
- Ran `hermes update` and verified all 5 gateways restarted
- Verified `launchctl list` showed new PIDs for all profiles
- Confirmed Telegram bots responded with correct personas post-restart

## Related

Fixes incomplete multi-profile fleet updates on macOS.
