### PR TITLE
feat(stt): support OpenAI timeout env var

### DIFF
--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -5,6 +5,7 @@ dispatch.  All external dependencies (faster_whisper, openai) are mocked.
 """
 
 import json
+import importlib
 import os
 import tempfile
 from pathlib import Path
@@ -21,6 +22,7 @@ import pytest
 @pytest.fixture(autouse=True)
 def _clear_openai_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("STT_OPENAI_TIMEOUT", raising=False)
 
 
 class TestGetProvider:
@@ -168,6 +170,21 @@ class TestTranscribeOpenAI:
         assert result["success"] is False
         assert "VOICE_TOOLS_OPENAI_KEY" in result["error"]
 
+    def test_resolve_client_config_includes_timeout(self, monkeypatch):
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.setenv("STT_OPENAI_TIMEOUT", "95.5")
+
+        from tools import transcription_tools
+        transcription_tools = importlib.reload(transcription_tools)
+        try:
+            api_key, base_url, timeout = transcription_tools._resolve_openai_audio_client_config()
+            assert api_key == "sk-test"
+            assert base_url == "https://api.openai.com/v1"
+            assert timeout == 95.5
+        finally:
+            monkeypatch.delenv("STT_OPENAI_TIMEOUT", raising=False)
+            importlib.reload(transcription_tools)
+
     def test_successful_transcription(self, monkeypatch, tmp_path):
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
         audio_file = tmp_path / "test.ogg"
@@ -177,12 +194,35 @@ class TestTranscribeOpenAI:
         mock_client.audio.transcriptions.create.return_value = "Hello from OpenAI"
 
         with patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("openai.OpenAI", return_value=mock_client):
+             patch("openai.OpenAI", return_value=mock_client) as mock_openai:
             from tools.transcription_tools import _transcribe_openai
             result = _transcribe_openai(str(audio_file), "whisper-1")
 
         assert result["success"] is True
         assert result["transcript"] == "Hello from OpenAI"
+        assert mock_openai.call_args.kwargs["timeout"] == 30.0
+
+    def test_openai_timeout_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.setenv("STT_OPENAI_TIMEOUT", "95.5")
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "Hello from OpenAI"
+
+        from tools import transcription_tools
+        transcription_tools = importlib.reload(transcription_tools)
+        try:
+            with patch.object(transcription_tools, "_HAS_OPENAI", True), \
+                 patch("openai.OpenAI", return_value=mock_client) as mock_openai:
+                result = transcription_tools._transcribe_openai(str(audio_file), "whisper-1")
+
+            assert result["success"] is True
+            assert mock_openai.call_args.kwargs["timeout"] == 95.5
+        finally:
+            monkeypatch.delenv("STT_OPENAI_TIMEOUT", raising=False)
+            importlib.reload(transcription_tools)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -90,6 +90,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENAI_TIMEOUT = float(os.getenv("STT_OPENAI_TIMEOUT", "30"))
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
@@ -594,7 +595,7 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using OpenAI Whisper API (paid)."""
     try:
-        api_key, base_url = _resolve_openai_audio_client_config()
+        api_key, base_url, timeout = _resolve_openai_audio_client_config()
     except ValueError as exc:
         return {
             "success": False,
@@ -612,7 +613,12 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
-        client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=0,
+        )
         try:
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(
@@ -868,18 +874,18 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     }
 
 
-def _resolve_openai_audio_client_config() -> tuple[str, str]:
+def _resolve_openai_audio_client_config() -> tuple[str, str, float]:
     """Return direct OpenAI audio config or a managed gateway fallback."""
     stt_config = _load_stt_config()
     openai_cfg = stt_config.get("openai", {})
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
     if cfg_api_key:
-        return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
+        return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL), OPENAI_TIMEOUT
 
     direct_api_key = resolve_openai_audio_api_key()
     if direct_api_key:
-        return direct_api_key, OPENAI_BASE_URL
+        return direct_api_key, OPENAI_BASE_URL, OPENAI_TIMEOUT
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
@@ -888,8 +894,10 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
             message += ", and the managed OpenAI audio gateway is unavailable"
         raise ValueError(message)
 
-    return managed_gateway.nous_user_token, urljoin(
-        f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"
+    return (
+        managed_gateway.nous_user_token,
+        urljoin(f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"),
+        OPENAI_TIMEOUT,
     )
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -132,6 +132,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |
 | `STT_OPENAI_BASE_URL` | Override the OpenAI-compatible STT endpoint |
+| `STT_OPENAI_TIMEOUT` | Override the OpenAI STT request timeout in seconds (default: `30`) |
 | `GITHUB_TOKEN` | GitHub token for Skills Hub (higher API rate limits, skill publish) |
 | `HONCHO_API_KEY` | Cross-session user modeling ([honcho.dev](https://honcho.dev/)) |
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1261,6 +1261,7 @@ STT_GROQ_MODEL=whisper-large-v3-turbo
 STT_OPENAI_MODEL=whisper-1
 GROQ_BASE_URL=https://api.groq.com/openai/v1
 STT_OPENAI_BASE_URL=https://api.openai.com/v1
+STT_OPENAI_TIMEOUT=30
 ```
 
 ## Voice Mode (CLI)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -428,6 +428,7 @@ STT_GROQ_MODEL=whisper-large-v3-turbo    # Override default Groq STT model
 STT_OPENAI_MODEL=whisper-1               # Override default OpenAI STT model
 GROQ_BASE_URL=https://api.groq.com/openai/v1     # Custom Groq endpoint
 STT_OPENAI_BASE_URL=https://api.openai.com/v1    # Custom OpenAI STT endpoint
+STT_OPENAI_TIMEOUT=30                         # OpenAI STT request timeout in seconds
 
 # Text-to-Speech providers (Edge TTS and NeuTTS need no key)
 ELEVENLABS_API_KEY=***             # ElevenLabs (premium quality)


### PR DESCRIPTION
## What does this PR do?

Adds `STT_OPENAI_TIMEOUT` so users can override the OpenAI STT client timeout. This matches the existing `STT_OPENAI_BASE_URL` pattern by resolving the value from the environment at import time and passing it through the OpenAI audio client config.

## Why?

I'm running my own OpenAI API compatible STT server and the default 30s isn't long enough for me sometimes (long voice message, server resources used by something else, etc.).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/transcription_tools.py`: add `STT_OPENAI_TIMEOUT` env support and pass the timeout into the OpenAI STT client
- `tests/tools/test_transcription.py`: add coverage for default and overridden OpenAI STT timeout behavior

## How to Test

1. Set `STT_OPENAI_TIMEOUT=95.5`.
2. Run OpenAI STT transcription with `stt.provider: openai`.
3. Confirm the OpenAI client receives `timeout=95.5`.

Local checks run:

- `python3 -m py_compile hermes_cli/config.py tools/transcription_tools.py tests/tools/test_transcription.py tests/hermes_cli/test_config.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
