### PR TITLE
fix(docker): replace recursive chown with targeted per-directory chown

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,8 +37,18 @@ if [ "$(id -u)" = "0" ]; then
         # In rootless Podman the container's "root" is mapped to an unprivileged
         # host UID — chown will fail.  That's fine: the volume is already owned
         # by the mapped user on the host side.
-        chown -R hermes:hermes "$HERMES_HOME" 2>/dev/null || \
-            echo "Warning: chown failed (rootless container?) — continuing anyway"
+        #
+        # WARNING: Do NOT use `chown -R` on the entire HERMES_HOME volume.
+        # That would recursively change every file in the mounted host directory,
+        # potentially destroying host-side file ownership (see issue #19788).
+        # Instead, fix only the top-level directory and the specific subdirectories
+        # that hermes actually writes to at runtime.
+        chown hermes:hermes "$HERMES_HOME" 2>/dev/null || true
+        for subdir in cron sessions logs hooks memories skills skins plans workspace home; do
+            mkdir -p "$HERMES_HOME/$subdir"
+            chown hermes:hermes "$HERMES_HOME/$subdir" 2>/dev/null || true
+        done
+        echo "Ownership fix complete (non-recursive)"
     fi
 
     # Ensure config.yaml is readable by the hermes runtime user even if it was


### PR DESCRIPTION
## Fix #19788 — Avoid destructive recursive chown in Docker entrypoint

### Problem

The `docker/entrypoint.sh` ran `chown -R hermes:hermes "$HERMES_HOME"` when ownership needed fixing. Since `HERMES_HOME` is typically a bind mount (`-v /host/path:/opt/data`), this recursively changed **every file's owner** on the host filesystem — including system files if the user naively mounted `/`.

### Solution

Replace the recursive `chown -R` with targeted, non-recursive `chown` of only the specific subdirectories hermes actually writes to at runtime:

```bash
chown hermes:hermes "$HERMES_HOME"
for subdir in cron sessions logs hooks memories skills skins plans workspace home; do
    mkdir -p "$HERMES_HOME/$subdir"
    chown hermes:hermes "$HERMES_HOME/$subdir"
done
```

This preserves host-side file ownership while still ensuring hermes has write access to its working directories.

### Testing

- [x] `docker build` completes successfully
- [x] Entrypoint correctly creates subdirectories
- [x] Ownership is set correctly when `HERMES_UID` differs from default

### Related

- Fixes #19788