### PR TITLE
Windows Native PowerShell Terminal Support

### DIFF
--- a/_plan_/windows-native-terminal.md
+++ b/_plan_/windows-native-terminal.md
@@ -1,0 +1,167 @@
+# Hermes Windows Native Terminal Refactor Plan
+
+Branch: `feature/windows-native-terminal`
+
+## 目标
+
+让 Hermes 在 Windows 上摆脱 Git Bash 中间层，直接使用 PowerShell 原生执行命令，
+借鉴 OpenClaw 的 Windows 策略：承认 Windows 不是 POSIX，用平台原生 shell。
+
+## 进度
+
+### Phase 0: Windows 基础补丁 ✅
+
+| 改动 | 文件 | 说明 |
+|------|------|------|
+| `select.select` 修复 | `base.py` | Windows 用 `stdout.buffer.read()` 替代 `select.select` |
+| `shlex.quote` 路径 | `base.py` | snapshot/cwd 文件路径加引号（Windows 用户目录有空格） |
+| `get_temp_dir()` | `local.py` | Windows 返回 `TEMP` 路径而非 `/tmp` |
+
+Commit: `50ff3f82` (合并在 Phase 1 提交中)
+
+### Phase 1: WindowsLocalEnvironment ✅
+
+| 改动 | 文件 | 说明 |
+|------|------|------|
+| 新建 WindowsLocalEnvironment | `windows_local.py` | 直接 spawn PowerShell，不经过 bash |
+| PowerShell 查找优先级 | `windows_local.py` | pwsh7 → powershell5.1 |
+| BOM 安全 CWD 写入 | `windows_local.py` | `[IO.File]::WriteAllText` + `utf-8-sig` 读取 |
+| 进程终止 | `windows_local.py` | `taskkill /T /F /PID` |
+| CLIXML 噪音抑制 | `windows_local.py` | `$ProgressPreference = 'SilentlyContinue'` |
+| 路由改造 | `terminal_tool.py` | Windows → `_WindowsLocalEnvironment` |
+| 回退开关 | `terminal_tool.py` | `HERMES_USE_GIT_BASH=1` 回退旧模式 |
+| hermes.ps1 | `hermes.ps1` | 注释掉 `HERMES_GIT_BASH_PATH` |
+| hermes.cmd | `hermes.cmd` | cmd.exe 版启动器 |
+
+Commits: `50ff3f82`, `82e1ac32`, `367417a0`
+
+关键修复：
+- BOM 污染 cwd → `NotADirectoryError`（`Out-File -Encoding utf8` 在 PS5.1 写 BOM）
+- `Get-Location`/`pwd` 在 `-NonInteractive -File` 模式不输出 → Override 为 `Write-Output`
+
+### Phase 2: PowerShell Env Snapshot ✅
+
+| 改动 | 文件 | 说明 |
+|------|------|------|
+| `init_session()` | `windows_local.py` | 首次启动捕获环境变量到 NUL 分隔的快照文件 |
+| `_wrap_command()` 恢复环境 | `windows_local.py` | 每次命令前从快照恢复 `$env:` |
+| `_wrap_command()` 重导出环境 | `windows_local.py` | 每次命令后重新导出到快照（捕获新变量） |
+| BOM-free 写入 | `windows_local.py` | `[IO.File]::WriteAllText/WriteAllLines` + `UTF8Encoding($false)` |
+
+Commit: `8446226b`
+
+测试验证：
+- `$env:MY_VAR = "hello hermes"` → 跨命令保持 ✅
+- `Write-Output $env:MY_VAR` → `hello hermes` ✅
+- `Get-Location` → `D:\Agents\hermes-agent` ✅
+- `Set-Location C:\Users` + `Get-Location` → `C:\Users` ✅
+
+### Phase 3: BaseEnvironment 去 Bash 化 (待做)
+
+目标：把 `BaseEnvironment` 从 "bash 专属" 重构为 "通用执行框架"。
+
+**3.1 重命名/抽象化**
+
+```
+_run_bash(...)      →  _spawn(self, script, ...) -> ProcessHandle
+_wrap_command(...)  →  _build_script(self, command, cwd) -> str
+init_session()      →  保持，子类负责具体实现
+```
+
+**3.2 引入 ShellBackend 策略**
+
+```python
+class ShellBackend(ABC):
+    def find_shell(self) -> str: ...
+    def capture_env(self, cwd) -> dict: ...
+    def build_script(self, command, cwd, env_snapshot) -> str: ...
+    def parse_env_output(self, output) -> dict: ...
+
+class BashBackend(ShellBackend): ...       # Unix
+class PowerShellBackend(ShellBackend): ... # Windows
+
+class LocalEnvironment(BaseEnvironment):
+    def __init__(self):
+        self._shell = PowerShellBackend() if _IS_WINDOWS else BashBackend()
+```
+
+**3.3 测试要求**
+
+- Unix 回归测试：所有 bash 路径行为不变
+- Windows 测试：所有 PowerShell 路径行为不变
+- 远程后端（Docker/SSH/Modal）不受影响
+
+### Phase 4: Windows 编码与 .cmd Shim (待做)
+
+**4.1 编码自动检测**
+
+```python
+# tools/environments/windows_encoding.py
+def resolve_windows_console_encoding() -> str | None:
+    """Detect Windows console codepage (936=GBK, 65001=UTF-8)."""
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/s", "/c", "chcp"],
+        capture_output=True, text=True, timeout=5,
+        creationflags=subprocess.CREATE_NO_WINDOW,
+    )
+    # Parse "Active code page: 936"
+    ...
+```
+
+借鉴 OpenClaw 的 `windows-encoding.ts`：
+- 运行时查 `chcp` 获取代码页
+- 用 `TextDecoder` 做流式解码
+- 处理 GBK 字符被拆分成多个 chunk 的情况
+
+**4.2 .cmd 命令解析**
+
+类似 OpenClaw 的 `resolveNpmArgvForWindows`：
+
+```python
+def resolve_windows_argv(argv: list[str]) -> list[str]:
+    """Resolve command for Windows spawn.
+    - npm/npx → [node.exe, npm-cli.js, ...]
+    - .cmd/.bat → [cmd.exe, "/c", ...]
+    - .exe → direct spawn
+    """
+```
+
+解决 Node.js CVE-2024-27980：直接 spawn `.cmd` 文件可能导致 EINVAL。
+
+### Phase 5: 清理 (待做)
+
+| 任务 | 说明 |
+|------|------|
+| 删除 `HERMES_GIT_BASH_PATH` | Windows 不再需要 Git Bash |
+| 删除 `_find_bash` Windows 分支 | 不再找 bash |
+| 文档更新 | README 中 "Windows not supported" 改为支持说明 |
+| 测试覆盖 | Windows spawn、编码、exit code、.cmd shim |
+
+## 回退方案
+
+任何时候设 `HERMES_USE_GIT_BASH=1` 即可回退到旧的 Git Bash 模式：
+
+```powershell
+$env:HERMES_USE_GIT_BASH=1
+.\hermes.ps1
+```
+
+## 参考架构
+
+```
+当前 (Phase 1-2 完成):
+  terminal_tool → WindowsLocalEnvironment → PowerShell (spawn-per-call)
+                                             ↑ env snapshot 恢复/重导出
+
+目标 (Phase 3-4):
+  terminal_tool → LocalEnvironment → ShellBackend (Bash/PowerShell)
+                                     ↑ 统一接口，平台自适应
+```
+
+## 已知问题
+
+1. `Get-Location` 输出被 marker 剥离逻辑吃掉 → 已修复（override 为 Write-Output）
+2. PowerShell 5.1 BOM 污染 cwd → 已修复（BOM-free 写入 + utf-8-sig 读取）
+3. `python` 命令可能触发 Windows Store stub → 待 Phase 4 处理
+4. GBK 编码的命令输出可能乱码 → 待 Phase 4 编码检测
+5. 每次命令 env dump 包含所有环境变量，大环境下可能较慢 → 可优化为增量 diff

--- a/_plan_/windows-native-terminal.md
+++ b/_plan_/windows-native-terminal.md
@@ -2,73 +2,74 @@
 
 Branch: `feature/windows-native-terminal`
 
-## 目标
+## Goal
 
-让 Hermes 在 Windows 上摆脱 Git Bash 中间层，直接使用 PowerShell 原生执行命令，
-借鉴 OpenClaw 的 Windows 策略：承认 Windows 不是 POSIX，用平台原生 shell。
+Make Hermes on Windows shed the Git Bash middleware and execute commands directly
+through PowerShell natively, following OpenClaw's Windows strategy: acknowledge
+that Windows is not POSIX, and use the platform's native shell.
 
-## 进度
+## Progress
 
-### Phase 0: Windows 基础补丁 ✅
+### Phase 0: Windows Foundation Patches ✅
 
-| 改动 | 文件 | 说明 |
-|------|------|------|
-| `select.select` 修复 | `base.py` | Windows 用 `stdout.buffer.read()` 替代 `select.select` |
-| `shlex.quote` 路径 | `base.py` | snapshot/cwd 文件路径加引号（Windows 用户目录有空格） |
-| `get_temp_dir()` | `local.py` | Windows 返回 `TEMP` 路径而非 `/tmp` |
+| Change | File | Description |
+|--------|------|-------------|
+| `select.select` fix | `base.py` | Use `stdout.buffer.read()` instead of `select.select` on Windows |
+| `shlex.quote` paths | `base.py` | Quote snapshot/cwd file paths (Windows user dirs contain spaces) |
+| `get_temp_dir()` | `local.py` | Return `TEMP` path on Windows instead of `/tmp` |
 
-Commit: `50ff3f82` (合并在 Phase 1 提交中)
+Commit: `50ff3f82` (merged into Phase 1 commit)
 
 ### Phase 1: WindowsLocalEnvironment ✅
 
-| 改动 | 文件 | 说明 |
-|------|------|------|
-| 新建 WindowsLocalEnvironment | `windows_local.py` | 直接 spawn PowerShell，不经过 bash |
-| PowerShell 查找优先级 | `windows_local.py` | pwsh7 → powershell5.1 |
-| BOM 安全 CWD 写入 | `windows_local.py` | `[IO.File]::WriteAllText` + `utf-8-sig` 读取 |
-| 进程终止 | `windows_local.py` | `taskkill /T /F /PID` |
-| CLIXML 噪音抑制 | `windows_local.py` | `$ProgressPreference = 'SilentlyContinue'` |
-| 路由改造 | `terminal_tool.py` | Windows → `_WindowsLocalEnvironment` |
-| 回退开关 | `terminal_tool.py` | `HERMES_USE_GIT_BASH=1` 回退旧模式 |
-| hermes.ps1 | `hermes.ps1` | 注释掉 `HERMES_GIT_BASH_PATH` |
-| hermes.cmd | `hermes.cmd` | cmd.exe 版启动器 |
+| Change | File | Description |
+|--------|------|-------------|
+| New WindowsLocalEnvironment | `windows_local.py` | Spawn PowerShell directly, bypassing bash |
+| PowerShell lookup priority | `windows_local.py` | pwsh7 → powershell5.1 |
+| BOM-safe CWD write | `windows_local.py` | `[IO.File]::WriteAllText` + `utf-8-sig` read |
+| Process termination | `windows_local.py` | `taskkill /T /F /PID` |
+| CLIXML noise suppression | `windows_local.py` | `$ProgressPreference = 'SilentlyContinue'` |
+| Routing change | `terminal_tool.py` | Windows → `_WindowsLocalEnvironment` |
+| Fallback switch | `terminal_tool.py` | `HERMES_USE_GIT_BASH=1` reverts to legacy mode |
+| hermes.ps1 | `hermes.ps1` | Comment out `HERMES_GIT_BASH_PATH` |
+| hermes.cmd | `hermes.cmd` | cmd.exe launcher |
 
 Commits: `50ff3f82`, `82e1ac32`, `367417a0`
 
-关键修复：
-- BOM 污染 cwd → `NotADirectoryError`（`Out-File -Encoding utf8` 在 PS5.1 写 BOM）
-- `Get-Location`/`pwd` 在 `-NonInteractive -File` 模式不输出 → Override 为 `Write-Output`
+Key fixes:
+- BOM contaminating cwd → `NotADirectoryError` (`Out-File -Encoding utf8` writes BOM on PS5.1)
+- `Get-Location`/`pwd` produces no output in `-NonInteractive -File` mode → Override with `Write-Output`
 
 ### Phase 2: PowerShell Env Snapshot ✅
 
-| 改动 | 文件 | 说明 |
-|------|------|------|
-| `init_session()` | `windows_local.py` | 首次启动捕获环境变量到 NUL 分隔的快照文件 |
-| `_wrap_command()` 恢复环境 | `windows_local.py` | 每次命令前从快照恢复 `$env:` |
-| `_wrap_command()` 重导出环境 | `windows_local.py` | 每次命令后重新导出到快照（捕获新变量） |
-| BOM-free 写入 | `windows_local.py` | `[IO.File]::WriteAllText/WriteAllLines` + `UTF8Encoding($false)` |
+| Change | File | Description |
+|--------|------|-------------|
+| `init_session()` | `windows_local.py` | Capture environment variables to NUL-delimited snapshot file on first launch |
+| `_wrap_command()` restore env | `windows_local.py` | Restore `$env:` from snapshot before each command |
+| `_wrap_command()` re-export env | `windows_local.py` | Re-export to snapshot after each command (captures new variables) |
+| BOM-free write | `windows_local.py` | `[IO.File]::WriteAllText/WriteAllLines` + `UTF8Encoding($false)` |
 
 Commit: `8446226b`
 
-测试验证：
-- `$env:MY_VAR = "hello hermes"` → 跨命令保持 ✅
+Test verification:
+- `$env:MY_VAR = "hello hermes"` → persists across commands ✅
 - `Write-Output $env:MY_VAR` → `hello hermes` ✅
 - `Get-Location` → `D:\Agents\hermes-agent` ✅
 - `Set-Location C:\Users` + `Get-Location` → `C:\Users` ✅
 
-### Phase 3: BaseEnvironment 去 Bash 化 (待做)
+### Phase 3: De-bash BaseEnvironment (TODO)
 
-目标：把 `BaseEnvironment` 从 "bash 专属" 重构为 "通用执行框架"。
+Goal: Refactor `BaseEnvironment` from "bash-specific" to "generic execution framework".
 
-**3.1 重命名/抽象化**
+**3.1 Rename / Abstract**
 
 ```
 _run_bash(...)      →  _spawn(self, script, ...) -> ProcessHandle
 _wrap_command(...)  →  _build_script(self, command, cwd) -> str
-init_session()      →  保持，子类负责具体实现
+init_session()      →  Keep as-is; subclasses handle concrete implementation
 ```
 
-**3.2 引入 ShellBackend 策略**
+**3.2 Introduce ShellBackend Strategy**
 
 ```python
 class ShellBackend(ABC):
@@ -85,15 +86,15 @@ class LocalEnvironment(BaseEnvironment):
         self._shell = PowerShellBackend() if _IS_WINDOWS else BashBackend()
 ```
 
-**3.3 测试要求**
+**3.3 Test Requirements**
 
-- Unix 回归测试：所有 bash 路径行为不变
-- Windows 测试：所有 PowerShell 路径行为不变
-- 远程后端（Docker/SSH/Modal）不受影响
+- Unix regression: all bash-path behavior unchanged
+- Windows: all PowerShell-path behavior unchanged
+- Remote backends (Docker/SSH/Modal) unaffected
 
-### Phase 4: Windows 编码与 .cmd Shim (待做)
+### Phase 4: Windows Encoding & .cmd Shim (TODO)
 
-**4.1 编码自动检测**
+**4.1 Encoding Auto-Detection**
 
 ```python
 # tools/environments/windows_encoding.py
@@ -108,14 +109,14 @@ def resolve_windows_console_encoding() -> str | None:
     ...
 ```
 
-借鉴 OpenClaw 的 `windows-encoding.ts`：
-- 运行时查 `chcp` 获取代码页
-- 用 `TextDecoder` 做流式解码
-- 处理 GBK 字符被拆分成多个 chunk 的情况
+Inspired by OpenClaw's `windows-encoding.ts`:
+- Query `chcp` at runtime for the codepage
+- Use `TextDecoder` for streaming decode
+- Handle GBK characters split across multiple chunks
 
-**4.2 .cmd 命令解析**
+**4.2 .cmd Command Resolution**
 
-类似 OpenClaw 的 `resolveNpmArgvForWindows`：
+Similar to OpenClaw's `resolveNpmArgvForWindows`:
 
 ```python
 def resolve_windows_argv(argv: list[str]) -> list[str]:
@@ -126,42 +127,42 @@ def resolve_windows_argv(argv: list[str]) -> list[str]:
     """
 ```
 
-解决 Node.js CVE-2024-27980：直接 spawn `.cmd` 文件可能导致 EINVAL。
+Addresses Node.js CVE-2024-27980: directly spawning `.cmd` files can cause EINVAL.
 
-### Phase 5: 清理 (待做)
+### Phase 5: Cleanup (TODO)
 
-| 任务 | 说明 |
-|------|------|
-| 删除 `HERMES_GIT_BASH_PATH` | Windows 不再需要 Git Bash |
-| 删除 `_find_bash` Windows 分支 | 不再找 bash |
-| 文档更新 | README 中 "Windows not supported" 改为支持说明 |
-| 测试覆盖 | Windows spawn、编码、exit code、.cmd shim |
+| Task | Description |
+|------|-------------|
+| Remove `HERMES_GIT_BASH_PATH` | No longer needed on Windows |
+| Remove `_find_bash` Windows branch | No longer searching for bash |
+| Documentation update | Change "Windows not supported" in README to supported |
+| Test coverage | Windows spawn, encoding, exit code, .cmd shim |
 
-## 回退方案
+## Fallback Plan
 
-任何时候设 `HERMES_USE_GIT_BASH=1` 即可回退到旧的 Git Bash 模式：
+Set `HERMES_USE_GIT_BASH=1` at any time to revert to the legacy Git Bash mode:
 
 ```powershell
 $env:HERMES_USE_GIT_BASH=1
 .\hermes.ps1
 ```
 
-## 参考架构
+## Architecture Reference
 
 ```
-当前 (Phase 1-2 完成):
+Current (Phase 1-2 complete):
   terminal_tool → WindowsLocalEnvironment → PowerShell (spawn-per-call)
-                                             ↑ env snapshot 恢复/重导出
+                                             ↑ env snapshot restore/re-export
 
-目标 (Phase 3-4):
+Target (Phase 3-4):
   terminal_tool → LocalEnvironment → ShellBackend (Bash/PowerShell)
-                                     ↑ 统一接口，平台自适应
+                                     ↑ unified interface, platform-adaptive
 ```
 
-## 已知问题
+## Known Issues
 
-1. `Get-Location` 输出被 marker 剥离逻辑吃掉 → 已修复（override 为 Write-Output）
-2. PowerShell 5.1 BOM 污染 cwd → 已修复（BOM-free 写入 + utf-8-sig 读取）
-3. `python` 命令可能触发 Windows Store stub → 待 Phase 4 处理
-4. GBK 编码的命令输出可能乱码 → 待 Phase 4 编码检测
-5. 每次命令 env dump 包含所有环境变量，大环境下可能较慢 → 可优化为增量 diff
+1. `Get-Location` output consumed by marker-stripping logic → Fixed (override with Write-Output)
+2. PowerShell 5.1 BOM contaminating cwd → Fixed (BOM-free write + utf-8-sig read)
+3. `python` command may trigger Windows Store stub → Deferred to Phase 4
+4. GBK-encoded command output may garble → Deferred to Phase 4 encoding detection
+5. Per-command env dump includes all variables; may be slow with large environments → Can optimize with incremental diff

--- a/hermes.cmd
+++ b/hermes.cmd
@@ -1,0 +1,50 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+:: Hermes Agent Windows native launcher (cmd.exe version)
+:: Automatically sets UTF-8 encoding and routes to the project venv.
+::
+:: Usage:
+::   hermes.cmd                Interactive chat
+::   hermes.cmd doctor         Run diagnostics
+::   hermes.cmd setup          Setup wizard
+::   hermes.cmd -q "hello"     Single query
+::   hermes.cmd --list-tools   List tools
+
+:: UTF-8 enforcement for Rich / prompt_toolkit output
+set "PYTHONIOENCODING=utf-8"
+chcp 65001 >nul 2>&1
+
+:: Legacy: force Git Bash (not WSL bash) on Windows.
+:: As of Phase 1 Windows-native refactor, Hermes now uses PowerShell
+:: directly via WindowsLocalEnvironment.  The Git Bash fallback is
+:: still available via HERMES_USE_GIT_BASH=1 if needed.
+:: set "HERMES_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe"
+
+set "SCRIPT_DIR=%~dp0"
+set "VENV_PATH=%SCRIPT_DIR%.venv"
+set "PYTHON_EXE=%VENV_PATH%\Scripts\python.exe"
+
+if not exist "%PYTHON_EXE%" (
+    echo [ERROR] Virtual environment not found: %VENV_PATH%
+    echo         Run the following to create it:
+    echo         uv venv .venv --python 3.13
+    echo         uv pip install --python .venv\Scripts\python.exe -e ".[all]"
+    exit /b 1
+)
+
+:: Determine entry point based on first argument
+set "FIRST_ARG=%~1"
+set "MODULE=hermes_cli.main"
+
+if "%FIRST_ARG%"=="" set "MODULE=hermes_cli.main" & goto :launch
+if "%FIRST_ARG:~0,1%"=="-" set "MODULE=cli" & goto :launch
+if "%FIRST_ARG%"=="--tui" set "MODULE=tui_gateway.entry" & goto :launch
+
+:: Known hermes_cli.main subcommands
+set "SUBCOMMANDS=chat gateway cron setup status doctor model tools config skills sessions logs auth honcho claw version update uninstall acp backup dump plugins"
+echo %SUBCOMMANDS% | findstr /I /C:" %FIRST_ARG% " >nul || set "MODULE=cli"
+
+:launch
+"%PYTHON_EXE%" -m %MODULE% %*
+exit /b %ERRORLEVEL%

--- a/hermes.ps1
+++ b/hermes.ps1
@@ -1,0 +1,96 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Hermes Agent Windows native launcher.
+.DESCRIPTION
+    Launches hermes-agent on Windows without WSL/Docker.
+    Automatically sets UTF-8 encoding and routes to the project venv.
+.EXAMPLE
+    .\hermes.ps1                    # Interactive chat
+    .\hermes.ps1 doctor             # Run diagnostics
+    .\hermes.ps1 setup              # Setup wizard
+    .\hermes.ps1 -q "hello"         # Single query
+    .\hermes.ps1 --list-tools       # List tools
+    .\hermes.ps1 --tui              # Try TUI mode
+#>
+
+$ErrorActionPreference = "Stop"
+
+# --- UTF-8 enforcement for Windows console ----------------------------------
+# Rich / prompt_toolkit output contains Braille patterns and box-drawing chars
+# that fail under the default GBK (936) code page.
+$env:PYTHONIOENCODING = "utf-8"
+
+# Legacy: force Git Bash (not WSL bash) on Windows.
+# As of Phase 1 Windows-native refactor, Hermes now uses PowerShell
+# directly via WindowsLocalEnvironment.  The Git Bash fallback is
+# still available via HERMES_USE_GIT_BASH=1 if needed.
+# $env:HERMES_GIT_BASH_PATH = "C:\Program Files\Git\bin\bash.exe"
+
+# Also switch the active console code page to UTF-8 (65001) if possible.
+# This makes PowerShell-native output safe as well.
+$_originalCp = [Console]::OutputEncoding.CodePage
+try {
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    [Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+} catch {
+    # Non-interactive hosts (e.g. some CI) may not allow this; ignore.
+}
+
+# --- Locate project root and venv ------------------------------------------
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$venvPath  = Join-Path $scriptDir ".venv"
+$pythonExe = Join-Path $venvPath "Scripts\python.exe"
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Host "[ERROR] Virtual environment not found: $venvPath" -ForegroundColor Red
+    Write-Host "        Run the following to create it:" -ForegroundColor Yellow
+    Write-Host "        uv venv .venv --python 3.13" -ForegroundColor Cyan
+    Write-Host "        uv pip install --python .venv\Scripts\python.exe -e `".[all]`"" -ForegroundColor Cyan
+    exit 1
+}
+
+# --- Route subcommands ------------------------------------------------------
+# If no arguments are given, default to interactive chat (same as `hermes`).
+$passArgs = $args
+if ($passArgs.Count -eq 0) {
+    $passArgs = @("chat")
+}
+
+# Detect whether the first argument is a known hermes subcommand or a CLI flag.
+# Known subcommands are handled by `hermes_cli.main`; everything else (like `-q`)
+# is forwarded to `cli.py` which uses Python Fire.
+$mainSubcommands = @(
+    "chat", "gateway", "cron", "setup", "status", "doctor", "model", "tools",
+    "config", "skills", "sessions", "logs", "auth", "honcho", "claw",
+    "version", "update", "uninstall", "acp", "backup", "dump", "plugins"
+)
+
+$first = $passArgs[0]
+if ($first -in $mainSubcommands) {
+    $module = "hermes_cli.main"
+} else {
+    # Fallback to cli.py for Fire-style invocations (`-q`, `--list-tools`, etc.)
+    $module = "cli"
+}
+
+# --- Launch -----------------------------------------------------------------
+$pythonArgs = @("-m", $module) + $passArgs
+
+# For TUI mode, route through the dedicated TUI entry if requested.
+if ($first -eq "--tui") {
+    $pythonArgs = @("-m", "tui_gateway.entry")
+}
+
+Write-Host "[Hermes] launching: $pythonExe $([string]::Join(' ', $pythonArgs))" -ForegroundColor DarkGray
+& $pythonExe @pythonArgs
+
+$exitCode = $LASTEXITCODE
+
+# --- Restore console code page ----------------------------------------------
+try {
+    [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding($_originalCp)
+} catch { }
+
+exit $exitCode

--- a/tests/tools/test_windows_local_environment.py
+++ b/tests/tools/test_windows_local_environment.py
@@ -1,0 +1,772 @@
+"""Tests for WindowsLocalEnvironment — PowerShell backend.
+
+Covers pure-logic methods that can run on any platform (no Windows required)
+plus a small integration suite gated on platform.system() == "Windows".
+"""
+
+import os
+import platform
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments.windows_local import (
+    _ENV_SEP,
+    _find_powershell,
+    _quote_ps_literal,
+    WindowsLocalEnvironment,
+)
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+
+# ---------------------------------------------------------------------------
+# Testable subclass — skips init_session() to avoid spawning PowerShell
+# ---------------------------------------------------------------------------
+
+
+class _TestableWinEnv(WindowsLocalEnvironment):
+    """Concrete subclass that skips init_session() and provides a mock _run_bash."""
+
+    def __init__(self, cwd="C:/tmp", timeout=60, env=None):
+        # Bypass WindowsLocalEnvironment.__init__ which calls init_session().
+        # Instead, call BaseEnvironment.__init__ directly to set up fields.
+        from tools.environments.base import BaseEnvironment
+
+        if cwd:
+            cwd = os.path.expanduser(cwd)
+        BaseEnvironment.__init__(self, cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        # _snapshot_ready is already False from BaseEnvironment.__init__
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        raise NotImplementedError("Use mock in tests")
+
+
+# ===================================================================
+# _quote_ps_literal
+# ===================================================================
+
+
+class TestQuotePsLiteral:
+    def test_plain_path(self):
+        assert _quote_ps_literal(r"C:\Users\test") == r"'C:\Users\test'"
+
+    def test_single_quote_doubled(self):
+        assert _quote_ps_literal(r"C:\Users\O'Brien") == r"'C:\Users\O''Brien'"
+
+    def test_space_preserved(self):
+        assert _quote_ps_literal(r"C:\Program Files\foo") == r"'C:\Program Files\foo'"
+
+    def test_empty_string(self):
+        assert _quote_ps_literal("") == "''"
+
+    def test_backslash_and_quote(self):
+        assert _quote_ps_literal(r"D:\it's\path") == r"'D:\it''s\path'"
+
+    def test_multiple_quotes(self):
+        assert _quote_ps_literal("a'b'c") == "'a''b''c'"
+
+
+# ===================================================================
+# _find_powershell
+# ===================================================================
+
+
+class TestFindPowershell:
+    def test_pwsh_in_path(self):
+        with patch("shutil.which", side_effect=lambda x: "/usr/bin/pwsh" if x == "pwsh" else None):
+            result = _find_powershell()
+            assert result == "/usr/bin/pwsh"
+
+    def test_pwsh_in_program_files(self):
+        with (
+            patch("shutil.which", return_value=None),
+            patch("os.path.isfile", side_effect=lambda p: "pwsh.exe" in p),
+            patch.dict(os.environ, {"ProgramFiles": r"C:\Program Files"}, clear=False),
+        ):
+            result = _find_powershell()
+            assert "pwsh.exe" in result
+
+    def test_fallback_to_ps51_system32(self):
+        def _isfile(path):
+            return "System32" in path and "powershell.exe" in path
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("os.path.isfile", side_effect=_isfile),
+            patch.dict(os.environ, {"SystemRoot": r"C:\Windows", "ProgramFiles": r"C:\Program Files"}, clear=False),
+        ):
+            result = _find_powershell()
+            assert "powershell.exe" in result
+            assert "System32" in result
+
+    def test_powershell_on_path_as_last_resort(self):
+        with (
+            patch("shutil.which", side_effect=lambda x: "/usr/bin/powershell" if x == "powershell" else None),
+            patch("os.path.isfile", return_value=False),
+        ):
+            result = _find_powershell()
+            assert result == "/usr/bin/powershell"
+
+    def test_raises_when_not_found(self):
+        with (
+            patch("shutil.which", return_value=None),
+            patch("os.path.isfile", return_value=False),
+        ):
+            with pytest.raises(RuntimeError, match="PowerShell not found"):
+                _find_powershell()
+
+    def test_programw6432_checked(self):
+        """ProgramW6432 is also checked for pwsh.exe on WoW64."""
+        seen_paths = []
+
+        def _isfile(path):
+            seen_paths.append(path)
+            return False
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("os.path.isfile", side_effect=_isfile),
+            patch.dict(
+                os.environ,
+                {"ProgramFiles": r"C:\Program Files", "ProgramW6432": r"C:\Program Files", "SystemRoot": r"C:\Windows"},
+                clear=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                _find_powershell()
+            # Verify ProgramW6432 was checked
+            assert any("ProgramW6432" in p or "Program Files" in p for p in seen_paths)
+
+
+# ===================================================================
+# _wrap_command
+# ===================================================================
+
+
+class TestWrapCommand:
+    def _make_env(self, **kwargs):
+        env = _TestableWinEnv(**kwargs)
+        env._snapshot_ready = True
+        return env
+
+    def test_basic_structure_snapshot_ready(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("Write-Output hello", "C:/Users/test")
+
+        assert "$ProgressPreference = 'SilentlyContinue'" in wrapped
+        assert "Set-Location -LiteralPath" in wrapped
+        assert "Invoke-Expression $__cmd" in wrapped
+        assert "$__hermes_ec" in wrapped
+        assert "[IO.File]::WriteAllText" in wrapped
+        assert "exit $__hermes_ec" in wrapped
+
+    def test_no_snapshot_skips_restore_and_dump(self):
+        env = self._make_env()
+        env._snapshot_ready = False
+        wrapped = env._wrap_command("Write-Output hello", "C:/Users/test")
+
+        assert "Test-Path" not in wrapped  # no restore block
+        assert "ReadAllText" not in wrapped  # no restore block
+        assert "Get-ChildItem Env:" not in wrapped  # no dump block
+        assert "WriteAllLines" not in wrapped  # no dump block
+
+    def test_cwd_with_spaces_quoted(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", r"C:\Program Files")
+        # _quote_ps_literal wraps in single quotes
+        assert "'C:\\Program Files'" in wrapped
+
+    def test_cwd_with_single_quote_escaped(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", r"C:\Users\O'Brien")
+        assert "O''Brien" in wrapped
+
+    def test_command_in_here_string(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("Get-Process", "C:/tmp")
+        assert "$__cmd = @'" in wrapped
+        assert "'@" in wrapped
+        assert "Get-Process" in wrapped
+
+    def test_marker_contains_session_id(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        assert env._cwd_marker in wrapped
+        assert env._session_id in env._cwd_marker
+
+    def test_cwd_file_path_in_writealltext(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        # _cwd_file is referenced in [IO.File]::WriteAllText
+        assert env._cwd_file in wrapped
+
+    def test_snapshot_path_in_readalltext(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        assert env._snapshot_path in wrapped
+
+    def test_exit_code_preserved(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        assert "$__hermes_ec = $LASTEXITCODE" in wrapped
+        assert "exit $__hermes_ec" in wrapped
+
+    def test_pwd_and_get_location_overridden(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        assert "function pwd" in wrapped
+        assert "function Get-Location" in wrapped
+        assert "Remove-Item Alias:pwd" in wrapped
+
+    def test_progress_preference_silenced(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        assert "$ProgressPreference = 'SilentlyContinue'" in wrapped
+
+    def test_null_exit_code_guard(self):
+        env = self._make_env()
+        wrapped = env._wrap_command("ls", "C:/tmp")
+        # PowerShell: $LASTEXITCODE can be $null if no external command was run
+        assert "if ($__hermes_ec -eq $null)" in wrapped
+
+
+# ===================================================================
+# _load_snapshot
+# ===================================================================
+
+
+class TestLoadSnapshot:
+    def _make_env_with_temp(self, tmp_path):
+        env = _TestableWinEnv()
+        env._snapshot_path = str(tmp_path / "snap.txt")
+        return env
+
+    def test_normal_nul_separated(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        content = f"PATH{_ENV_SEP}C:\\Windows\nFOO{_ENV_SEP}bar\n"
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        result = env._load_snapshot()
+        assert result == {"PATH": r"C:\Windows", "FOO": "bar"}
+
+    def test_value_with_equals_sign(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        content = f"FOO{_ENV_SEP}a=b=c\n"
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        result = env._load_snapshot()
+        assert result == {"FOO": "a=b=c"}
+
+    def test_bom_file(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        # Write with utf-8 to get raw BOM bytes, then read with utf-8-sig
+        raw_content = f"\ufeffKEY{_ENV_SEP}value\n"
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write(raw_content)
+
+        result = env._load_snapshot()
+        assert result == {"KEY": "value"}
+
+    def test_empty_file(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write("")
+
+        result = env._load_snapshot()
+        assert result == {}
+
+    def test_missing_file(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        env._snapshot_path = str(tmp_path / "nonexistent.txt")
+
+        result = env._load_snapshot()
+        assert result == {}
+
+    def test_line_without_separator_skipped(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        content = f"VALID{_ENV_SEP}yes\nNOISE_LINE\n"
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        result = env._load_snapshot()
+        assert result == {"VALID": "yes"}
+
+    def test_empty_value(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        content = f"EMPTY{_ENV_SEP}\n"
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        result = env._load_snapshot()
+        assert result == {"EMPTY": ""}
+
+
+# ===================================================================
+# _save_snapshot
+# ===================================================================
+
+
+class TestSaveSnapshot:
+    def _make_env_with_temp(self, tmp_path):
+        env = _TestableWinEnv()
+        env._snapshot_path = str(tmp_path / "snap.txt")
+        return env
+
+    def test_normal_write(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        env._save_snapshot({"PATH": r"C:\Windows", "FOO": "bar"})
+
+        with open(env._snapshot_path, encoding="utf-8") as f:
+            content = f.read()
+        assert f"PATH{_ENV_SEP}C:\\Windows\n" in content
+        assert f"FOO{_ENV_SEP}bar\n" in content
+
+    def test_empty_dict(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        env._save_snapshot({})
+
+        with open(env._snapshot_path, encoding="utf-8") as f:
+            content = f.read()
+        assert content == ""
+
+    def test_no_bom_in_output(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        env._save_snapshot({"KEY": "value"})
+
+        with open(env._snapshot_path, "rb") as f:
+            raw = f.read()
+        # UTF-8 BOM is 0xEF 0xBB 0xBF — must NOT be present
+        assert not raw.startswith(b"\xef\xbb\xbf")
+
+    def test_value_with_special_chars(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        env._save_snapshot({"A": "line1\nline2", "B": "x=y"})
+
+        with open(env._snapshot_path, encoding="utf-8") as f:
+            content = f.read()
+        assert f"A{_ENV_SEP}line1\nline2\n" in content
+        assert f"B{_ENV_SEP}x=y\n" in content
+
+
+# ===================================================================
+# _strip_cwd_marker
+# ===================================================================
+
+
+class TestStripCwdMarker:
+    def _make_env(self):
+        env = _TestableWinEnv()
+        return env
+
+    def test_normal_removal(self):
+        env = self._make_env()
+        marker = env._cwd_marker
+        result = {"output": f"hello\n{marker}C:\\Users{marker}\n"}
+        env._strip_cwd_marker(result)
+
+        assert result["output"] == "hello"
+
+    def test_no_marker(self):
+        env = self._make_env()
+        result = {"output": "hello world\n"}
+        env._strip_cwd_marker(result)
+
+        assert result["output"] == "hello world\n"
+
+    def test_marker_after_get_location_output(self):
+        """Get-Location output should be preserved; only the marker line removed."""
+        env = self._make_env()
+        marker = env._cwd_marker
+        # Simulates: command output includes "C:\Users", then marker line
+        result = {"output": f"C:\\Users\n{marker}C:\\Users{marker}\n"}
+        env._strip_cwd_marker(result)
+
+        assert "C:\\Users" in result["output"]
+        assert marker not in result["output"]
+
+    def test_only_marker_line(self):
+        env = self._make_env()
+        marker = env._cwd_marker
+        result = {"output": f"{marker}C:\\Users{marker}\n"}
+        env._strip_cwd_marker(result)
+
+        assert marker not in result["output"]
+
+    def test_multiline_command_plus_marker(self):
+        env = self._make_env()
+        marker = env._cwd_marker
+        result = {"output": f"line1\nline2\nline3\n{marker}C:\\tmp{marker}\n"}
+        env._strip_cwd_marker(result)
+
+        assert "line1" in result["output"]
+        assert "line2" in result["output"]
+        assert "line3" in result["output"]
+        assert marker not in result["output"]
+
+    def test_marker_not_at_end_ignored(self):
+        """If marker appears in the middle (not at end), it shouldn't be stripped."""
+        env = self._make_env()
+        marker = env._cwd_marker
+        # Malformed: marker not at the end of output
+        result = {"output": f"{marker}C:\\tmp{marker}\nextra stuff\n"}
+        env._strip_cwd_marker(result)
+
+        # The marker line is removed, but "extra stuff" remains
+        assert "extra stuff" in result["output"]
+
+
+# ===================================================================
+# get_temp_dir
+# ===================================================================
+
+
+class TestGetTempDir:
+    def test_temp_env_var(self):
+        env = _TestableWinEnv(env={"TEMP": r"C:\Temp"})
+        result = env.get_temp_dir()
+        assert result == "C:/Temp"
+
+    def test_tmp_fallback(self):
+        env = _TestableWinEnv(env={"TMP": r"C:\Tmp"})
+        result = env.get_temp_dir()
+        assert result == "C:/Tmp"
+
+    def test_backslash_to_forward_slash(self):
+        env = _TestableWinEnv(env={"TEMP": r"C:\Users\TEMP"})
+        result = env.get_temp_dir()
+        assert "\\" not in result
+        assert result == "C:/Users/TEMP"
+
+    def test_trailing_slash_stripped(self):
+        env = _TestableWinEnv(env={"TEMP": "C:\\Temp\\"})
+        result = env.get_temp_dir()
+        assert not result.endswith("/")
+
+    def test_os_environ_fallback(self):
+        env = _TestableWinEnv(env={})
+        # The fallback chain hits os.environ and then tempfile.gettempdir()
+        result = env.get_temp_dir()
+        assert result  # non-empty
+
+
+# ===================================================================
+# init_session
+# ===================================================================
+
+
+class TestInitSession:
+    def test_success_sets_snapshot_ready(self):
+        env = _TestableWinEnv()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+        # Mock stdout with a proper buffer for the drain thread
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.buffer = MagicMock()
+        mock_proc.stdout.buffer.read = MagicMock(return_value=b"")
+        mock_proc.stdout.fileno = MagicMock(return_value=1)
+
+        env._run_bash = MagicMock(return_value=mock_proc)
+        env._load_snapshot = MagicMock(return_value={})
+
+        env.init_session()
+        assert env._snapshot_ready is True
+
+    def test_failure_does_not_crash(self):
+        env = _TestableWinEnv()
+        env._run_bash = MagicMock(side_effect=RuntimeError("no PowerShell"))
+
+        env.init_session()
+        assert env._snapshot_ready is False
+
+    def test_load_snapshot_called_on_success(self):
+        env = _TestableWinEnv()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.buffer = MagicMock()
+        mock_proc.stdout.buffer.read = MagicMock(return_value=b"")
+        mock_proc.stdout.fileno = MagicMock(return_value=1)
+
+        env._run_bash = MagicMock(return_value=mock_proc)
+        env._load_snapshot = MagicMock(return_value={})
+
+        env.init_session()
+        env._load_snapshot.assert_called_once()
+
+
+# ===================================================================
+# _kill_process
+# ===================================================================
+
+
+class TestKillProcess:
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="taskkill is Windows-only")
+    def test_calls_taskkill(self):
+        env = _TestableWinEnv()
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+
+        with patch("subprocess.run") as mock_run:
+            env._kill_process(mock_proc)
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args[0] == "taskkill"
+            assert "/T" in args
+            assert "/F" in args
+            assert "/PID" in args
+            assert "12345" in args
+
+    def test_terminate_called(self):
+        env = _TestableWinEnv()
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with patch("subprocess.run", side_effect=Exception("no taskkill")):
+            env._kill_process(mock_proc)
+            mock_proc.terminate.assert_called_once()
+
+    def test_no_exception_on_failure(self):
+        env = _TestableWinEnv()
+        mock_proc = MagicMock()
+        mock_proc.terminate.side_effect = PermissionError("denied")
+        mock_proc.pid = 99999
+
+        # Should not raise
+        with patch("subprocess.run", side_effect=Exception("no taskkill")):
+            env._kill_process(mock_proc)
+
+
+# ===================================================================
+# _update_cwd
+# ===================================================================
+
+
+class TestUpdateCwd:
+    def _make_env_with_temp(self, tmp_path):
+        env = _TestableWinEnv()
+        env._cwd_file = str(tmp_path / "cwd.txt")
+        return env
+
+    def test_reads_cwd_from_file(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        with open(env._cwd_file, "w", encoding="utf-8") as f:
+            f.write(r"C:\Projects")
+
+        result = {"output": "ok"}
+        env._update_cwd(result)
+        assert env.cwd == r"C:\Projects"
+
+    def test_bom_file_handled(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        with open(env._cwd_file, "w", encoding="utf-8-sig") as f:
+            f.write(r"C:\BOM\Path")
+
+        result = {"output": "ok"}
+        env._update_cwd(result)
+        # BOM should be stripped transparently
+        assert "\ufeff" not in env.cwd
+
+    def test_missing_file_cwd_unchanged(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        original_cwd = env.cwd
+        env._cwd_file = str(tmp_path / "nonexistent.txt")
+
+        result = {"output": "ok"}
+        env._update_cwd(result)
+        assert env.cwd == original_cwd
+
+    def test_empty_file_cwd_unchanged(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        original_cwd = env.cwd
+        with open(env._cwd_file, "w", encoding="utf-8") as f:
+            f.write("")
+
+        result = {"output": "ok"}
+        env._update_cwd(result)
+        assert env.cwd == original_cwd
+
+    def test_marker_stripped_from_output(self, tmp_path):
+        env = self._make_env_with_temp(tmp_path)
+        marker = env._cwd_marker
+        with open(env._cwd_file, "w", encoding="utf-8") as f:
+            f.write(r"C:\test")
+
+        result = {"output": f"hello\n{marker}C:\\test{marker}\n"}
+        env._update_cwd(result)
+        assert marker not in result["output"]
+
+
+# ===================================================================
+# cleanup
+# ===================================================================
+
+
+class TestCleanup:
+    def test_deletes_snapshot_and_cwd_files(self, tmp_path):
+        env = _TestableWinEnv()
+        env._snapshot_path = str(tmp_path / "snap.txt")
+        env._cwd_file = str(tmp_path / "cwd.txt")
+
+        # Create the files
+        for p in (env._snapshot_path, env._cwd_file):
+            with open(p, "w") as f:
+                f.write("test")
+
+        env.cleanup()
+        assert not os.path.exists(env._snapshot_path)
+        assert not os.path.exists(env._cwd_file)
+
+    def test_missing_files_no_crash(self, tmp_path):
+        env = _TestableWinEnv()
+        env._snapshot_path = str(tmp_path / "nonexistent_snap.txt")
+        env._cwd_file = str(tmp_path / "nonexistent_cwd.txt")
+        # Should not raise
+        env.cleanup()
+
+    def test_ps1_file_cleaned(self, tmp_path):
+        env = _TestableWinEnv()
+        env._snapshot_path = str(tmp_path / "snap.txt")
+        env._cwd_file = str(tmp_path / "cwd.txt")
+
+        # Create the .ps1 temp file
+        ps1_path = os.path.join(env.get_temp_dir(), f"hermes-ps-{env._session_id}.ps1")
+        os.makedirs(os.path.dirname(ps1_path), exist_ok=True)
+        with open(ps1_path, "w") as f:
+            f.write("$ProgressPreference = 'SilentlyContinue'")
+
+        env.cleanup()
+        assert not os.path.exists(ps1_path)
+
+
+# ===================================================================
+# Integration tests (Windows only)
+# ===================================================================
+
+
+@pytest.mark.skipif(not _IS_WINDOWS, reason="Requires Windows PowerShell")
+class TestWindowsLocalIntegration:
+    """End-to-end tests that spawn real PowerShell processes.
+
+    These require a full project environment (yaml, etc.) and a Windows
+    system with PowerShell.  They are skipped automatically outside Windows.
+    """
+
+    @classmethod
+    def _check_deps(cls):
+        """Verify yaml is importable (required by tools.terminal_tool chain)."""
+        try:
+            import yaml  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def test_echo_hello(self):
+        if not self._check_deps():
+            pytest.skip("yaml module not installed")
+        env = WindowsLocalEnvironment()
+        try:
+            result = env.execute('Write-Output "hello"')
+            assert "hello" in result["output"]
+            assert result["returncode"] == 0
+        finally:
+            env.cleanup()
+
+    def test_env_var_persistence(self):
+        if not self._check_deps():
+            pytest.skip("yaml module not installed")
+        env = WindowsLocalEnvironment()
+        try:
+            env.execute('$env:HERMES_TEST_VAR = "test_value_12345"')
+            result = env.execute("Write-Output $env:HERMES_TEST_VAR")
+            assert "test_value_12345" in result["output"]
+        finally:
+            env.cleanup()
+
+    def test_cwd_persistence(self):
+        if not self._check_deps():
+            pytest.skip("yaml module not installed")
+        env = WindowsLocalEnvironment()
+        try:
+            env.execute("Set-Location C:\\Windows")
+            result = env.execute("(Get-Location).Path")
+            # CWD file is read back, so env.cwd should update
+            assert "Windows" in env.cwd
+        finally:
+            env.cleanup()
+
+    def test_exit_code_propagation(self):
+        if not self._check_deps():
+            pytest.skip("yaml module not installed")
+        env = WindowsLocalEnvironment()
+        try:
+            result = env.execute("exit 42")
+            assert result["returncode"] == 42
+        finally:
+            env.cleanup()
+
+    def test_unicode_output(self):
+        if not self._check_deps():
+            pytest.skip("yaml module not installed")
+        env = WindowsLocalEnvironment()
+        try:
+            result = env.execute('Write-Output "你好世界"')
+            assert "你好" in result["output"]
+        finally:
+            env.cleanup()
+
+    def test_multiline_output(self):
+        if not self._check_deps():
+            pytest.skip("yaml module not installed")
+        env = WindowsLocalEnvironment()
+        try:
+            result = env.execute('Write-Output "line1"; Write-Output "line2"; Write-Output "line3"')
+            assert "line1" in result["output"]
+            assert "line2" in result["output"]
+            assert "line3" in result["output"]
+        finally:
+            env.cleanup()
+
+    def test_snapshot_path_uses_forward_slashes(self):
+        """Verify temp paths use forward slashes (consistency with BaseEnvironment)."""
+        env = _TestableWinEnv()
+        assert "/" in env._snapshot_path or "\\" not in env._snapshot_path
+
+    def test_crlf_snapshot_values_stripped(self, tmp_path):
+        """CRLF line endings in snapshot must not leave trailing \\r in values.
+
+        [IO.File]::WriteAllLines on Windows produces CRLF.  PowerShell's
+        -split \"`n\" splits on LF only, leaving \\r at the end of each
+        value.  The restore script uses .TrimEnd([char]13) to strip it.
+        If \\r leaks into PATH or other critical env vars, DNS resolution
+        and other system calls can break silently.
+        """
+        env = _TestableWinEnv()
+        env._snapshot_path = str(tmp_path / "snap-crlf.txt")
+
+        # Simulate what [IO.File]::WriteAllLines produces on Windows:
+        # each line ends with \\r\\n, and the separator is \\x02\\x03
+        content = f"PATH{_ENV_SEP}C:\\Windows;C:\\Users\\test\\r\\nFOO{_ENV_SEP}bar\\r\\n"
+        with open(env._snapshot_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        # _load_snapshot uses rstrip("\\n\\r") which strips the \\r
+        result = env._load_snapshot()
+        assert result["PATH"] == r"C:\Windows;C:\Users\test"
+        assert result["FOO"] == "bar"
+        assert not result["PATH"].endswith("\r")
+        assert not result["FOO"].endswith("\r")
+
+    def test_wrap_command_includes_trimend(self):
+        """Verify the restore script strips trailing CR from values."""
+        env = _TestableWinEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo hi", "C:/tmp")
+        # The restore block must include .TrimEnd([char]13) to handle CRLF
+        assert "TrimEnd([char]13)" in wrapped

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -13,6 +13,7 @@ import os
 import select
 import shlex
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -339,15 +340,17 @@ class BaseEnvironment(ABC):
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
         _quoted_cwd = shlex.quote(self.cwd)
+        _snap = shlex.quote(self._snapshot_path)
+        _cwd_f = shlex.quote(self._cwd_file)
         bootstrap = (
-            f"export -p > {self._snapshot_path}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
-            f"alias -p >> {self._snapshot_path}\n"
-            f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
-            f"echo 'set +e' >> {self._snapshot_path}\n"
-            f"echo 'set +u' >> {self._snapshot_path}\n"
+            f"export -p > {_snap}\n"
+            f"declare -f | grep -vE '^_[^_]' >> {_snap}\n"
+            f"alias -p >> {_snap}\n"
+            f"echo 'shopt -s expand_aliases' >> {_snap}\n"
+            f"echo 'set +e' >> {_snap}\n"
+            f"echo 'set +u' >> {_snap}\n"
             f"builtin cd {_quoted_cwd} 2>/dev/null || true\n"
-            f"pwd -P > {self._cwd_file} 2>/dev/null || true\n"
+            f"pwd -P > {_cwd_f} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )
         try:
@@ -397,9 +400,12 @@ class BaseEnvironment(ABC):
         # can emit the declarations to stdout, leaking ~60 lines of env
         # vars into every tool response (issue #15459).  Linux bash is
         # silent here, but the redirect is harmless.
+        _snap = shlex.quote(self._snapshot_path)
+        _cwd_f = shlex.quote(self._cwd_file)
+
         if self._snapshot_ready:
             parts.append(
-                f"source {self._snapshot_path} >/dev/null 2>&1 || true"
+                f"source {_snap} >/dev/null 2>&1 || true"
             )
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
@@ -414,10 +420,10 @@ class BaseEnvironment(ABC):
 
         # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
         if self._snapshot_ready:
-            parts.append(f"export -p > {self._snapshot_path} 2>/dev/null || true")
+            parts.append(f"export -p > {_snap} 2>/dev/null || true")
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)
-        parts.append(f"pwd -P > {self._cwd_file} 2>/dev/null || true")
+        parts.append(f"pwd -P > {_cwd_f} 2>/dev/null || true")
         # Use a distinct line for the marker. The leading \n ensures
         # the marker starts on its own line even if the command doesn't
         # end with a newline (e.g. printf 'exact'). We'll strip this
@@ -492,6 +498,22 @@ class BaseEnvironment(ABC):
             idle_after_exit = 0
             try:
                 while True:
+                    # Windows: select.select() does not support pipe fds.
+                    # Use the TextIOWrapper's underlying buffer for blocking
+                    # reads in this daemon thread.  On Windows there is no
+                    # fork(), so grandchild pipe-inheritance hangs are far
+                    # less common; a blocking read terminates naturally when
+                    # the subprocess exits and the pipe closes.
+                    if sys.platform == "win32":
+                        try:
+                            chunk = proc.stdout.buffer.read(4096)
+                        except (ValueError, OSError):
+                            break
+                        if not chunk:
+                            break
+                        output_chunks.append(decoder.decode(chunk))
+                        continue
+
                     try:
                         ready, _, _ = select.select([fd], [], [], 0.1)
                     except (ValueError, OSError):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -207,8 +207,17 @@ def _find_bash() -> str:
     )
 
 
-# Backward compat — process_registry.py imports this name
+    # Backward compat — process_registry.py imports this name
 _find_shell = _find_bash
+
+
+def _quote_path_for_shell(path: str) -> str:
+    """Quote a path for shell redirection so spaces survive.
+
+    Used for snapshot_path and cwd_file which may live under
+    C:/Users/<user name>/AppData/Local/Temp on Windows.
+    """
+    return shlex.quote(path.replace("\\", "/"))
 
 
 # Standard PATH entries for environments with minimal PATH.
@@ -353,10 +362,16 @@ class LocalEnvironment(BaseEnvironment):
         Unix systems, and only fall back to tempfile.gettempdir() when it also
         resolves to a POSIX path.
 
-        Check the environment configured for this backend first so callers can
-        override the temp root explicitly (for example via terminal.env or a
-        custom TMPDIR), then fall back to the host process environment.
+        On Windows we return a forward-slashed path so bash and Python agree
+        on the same file (Git Bash maps e.g. C:/Users/…/Temp to /tmp, but
+        we want an explicit absolute path both sides can read/write).
         """
+        if _IS_WINDOWS:
+            candidate = self.env.get("TEMP") or self.env.get("TMP") or os.environ.get("TEMP") or os.environ.get("TMP") or tempfile.gettempdir()
+            # Git Bash understands C:/foo; forward slashes keep bash scripts
+            # from treating backslashes as escape sequences.
+            return candidate.replace("\\", "/").rstrip("/") or "/"
+
         for env_var in ("TMPDIR", "TMP", "TEMP"):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
             if candidate and candidate.startswith("/"):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -207,7 +207,7 @@ def _find_bash() -> str:
     )
 
 
-    # Backward compat — process_registry.py imports this name
+# Backward compat — process_registry.py imports this name
 _find_shell = _find_bash
 
 

--- a/tools/environments/windows_local.py
+++ b/tools/environments/windows_local.py
@@ -70,8 +70,17 @@ def _quote_ps_literal(value: str) -> str:
 
 
 # Separator used in the env snapshot file.
-# Chosen to be extremely unlikely in env var names or values.
-_ENV_SEP = "\x00"
+#
+# We need a character that:
+#   1. Cannot appear in Windows env var names or values (rules out =, ;, etc.)
+#   2. Is safe inside a .ps1 file (rules out \x00 NUL — PS parser truncates;
+#      \x01 SOH also causes intermittent issues on PS 5.1)
+#   3. Survives round-trip through [IO.File]::WriteAllText / ReadAllText
+#
+# The sequence \x02\x03 (STX + ETX) satisfies all three: control chars are
+# illegal in Windows env var names/values, and the two-byte sequence is
+# astronomically unlikely to appear in any value by accident.
+_ENV_SEP = "\x02\x03"
 
 
 class WindowsLocalEnvironment(BaseEnvironment):
@@ -116,10 +125,15 @@ class WindowsLocalEnvironment(BaseEnvironment):
         quoted_snap = _quote_ps_literal(self._snapshot_path)
         bootstrap = (
             "$ProgressPreference = 'SilentlyContinue'\n"
-            # Dump all env vars as KEY\x00VALUE lines
-            "Get-ChildItem Env: | ForEach-Object {\n"
+            # Dump all env vars as KEY\x00VALUE lines using BOM-free UTF-8 write.
+            # Out-File -Encoding utf8 on PS5.1 adds a BOM and strips NUL chars,
+            # which destroys the NUL separator — the exact bug that caused env
+            # snapshot restore to corrupt the subprocess environment.
+            "$__envLines = Get-ChildItem Env: | ForEach-Object {\n"
             f"  \"$($_.Name){_ENV_SEP}$($_.Value)\"\n"
-            "} | Out-File -FilePath " + quoted_snap + " -Encoding utf8\n"
+            "}\n"
+            f"[IO.File]::WriteAllLines({quoted_snap}, $__envLines, "
+            "[System.Text.UTF8Encoding]::new($false))\n"
         )
         try:
             proc = self._run_bash(bootstrap, login=True, timeout=self._snapshot_timeout)
@@ -179,15 +193,20 @@ class WindowsLocalEnvironment(BaseEnvironment):
         # --- Restore env from snapshot ---
         restore_env = ""
         if self._snapshot_ready:
-            # Read the snapshot file line by line, split on NUL, set $env:
+            # Read the snapshot file line by line, split on separator, set $env:
             # Using -Raw + split is faster than Get-Content for large files.
+            # We embed the separator bytes into the script via PowerShell
+            # string interpolation so the .ps1 file itself never contains
+            # raw control characters.
             restore_env = (
                 f"if (Test-Path {quoted_snap}) {{\n"
                 f"  $__snap = [IO.File]::ReadAllText({quoted_snap}, [System.Text.UTF8Encoding]::new($false))\n"
+                f"  $__sep = [string]::new([char[]]@({', '.join(str(ord(c)) for c in _ENV_SEP)}))\n"
                 f"  $__snap -split \"`n\" | ForEach-Object {{\n"
-                f"    $__parts = $_ -split [char]0, 2\n"
+                f"    $__parts = $_ -split [regex]::Escape($__sep), 2\n"
                 f"    if ($__parts.Length -eq 2 -and $__parts[0]) {{\n"
-                f"      Set-Item -Path \"Env:$($__parts[0])\" -Value $__parts[1] -ErrorAction SilentlyContinue\n"
+                f"      $__val = $__parts[1].TrimEnd([char]13)\n"
+                f"      Set-Item -Path \"Env:$($__parts[0])\" -Value $__val -ErrorAction SilentlyContinue\n"
                 f"    }}\n"
                 f"  }}\n"
                 f"}}\n"
@@ -198,9 +217,13 @@ class WindowsLocalEnvironment(BaseEnvironment):
         if self._snapshot_ready:
             # Collect env lines into a variable, then write all at once.
             # Can't pipe directly into [IO.File]::WriteAllLines (PS parser error).
+            # Build separator in-script via char codes so the .ps1 file never
+            # contains raw control characters that might trip up PS 5.1.
+            sep_char_codes = ", ".join(str(ord(c)) for c in _ENV_SEP)
             dump_env = (
+                f"$__sep = [string]::new([char[]]@({sep_char_codes}))\n"
                 "$__envLines = Get-ChildItem Env: | ForEach-Object {\n"
-                f"  \"$($_.Name){_ENV_SEP}$($_.Value)\"\n"
+                f"  \"$($_.Name)$__sep$($_.Value)\"\n"
                 "}\n"
                 f"[IO.File]::WriteAllLines({quoted_snap}, $__envLines, [System.Text.UTF8Encoding]::new($false))\n"
             )

--- a/tools/environments/windows_local.py
+++ b/tools/environments/windows_local.py
@@ -110,6 +110,15 @@ class WindowsLocalEnvironment(BaseEnvironment):
         quoted_cwd_file_bare = self._cwd_file.replace("\\", "/")
         ps_script = (
             f"$ProgressPreference = 'SilentlyContinue'\n"
+            # Override Get-Location / pwd to emit the path string to stdout.
+            # In -NonInteractive -File mode, Get-Location returns a PathInfo
+            # object that does NOT flow to stdout (unlike interactive mode).
+            # Replacing it with a function that explicitly Write-Output's the
+            # path string makes ``Get-Location`` and ``pwd`` behave as users
+            # expect when called through hermes.
+            f"Remove-Item Alias:pwd -ErrorAction SilentlyContinue\n"
+            f"function pwd {{ Write-Output (Microsoft.PowerShell.Management\\Get-Location).Path }}\n"
+            f"function Get-Location {{ Write-Output (Microsoft.PowerShell.Management\\Get-Location).Path }}\n"
             f"Set-Location -LiteralPath {quoted_cwd}\n"
             f"$__cmd = @'\n"
             f"{command}\n"
@@ -117,8 +126,8 @@ class WindowsLocalEnvironment(BaseEnvironment):
             f"Invoke-Expression $__cmd\n"
             f"$__hermes_ec = $LASTEXITCODE\n"
             f"if ($__hermes_ec -eq $null) {{ $__hermes_ec = 0 }}\n"
-            f"[IO.File]::WriteAllText({quoted_cwd_file}, (Get-Location).Path, [System.Text.UTF8Encoding]::new($false))\n"
-            f'Write-Output "`n{marker}$((Get-Location).Path){marker}"\n'
+            f"[IO.File]::WriteAllText({quoted_cwd_file}, (Microsoft.PowerShell.Management\\Get-Location).Path, [System.Text.UTF8Encoding]::new($false))\n"
+            f'Write-Output "`n{marker}$((Microsoft.PowerShell.Management\\Get-Location).Path){marker}"\n'
             f"exit $__hermes_ec\n"
         )
         return ps_script
@@ -202,8 +211,51 @@ class WindowsLocalEnvironment(BaseEnvironment):
         except (OSError, FileNotFoundError):
             pass
 
-        # Still strip the marker from output so it's not visible to the user.
-        self._extract_cwd_from_output(result)
+        # Strip the CWD marker from output using a precise line-based approach
+        # that preserves normal command output (e.g. Get-Location output).
+        self._strip_cwd_marker(result)
+
+    def _strip_cwd_marker(self, result: dict):
+        """Remove the CWD marker line from output without touching command output.
+
+        The marker line is always the LAST line of output and has the format:
+            __HERMES_CWD_{id}__{path}__HERMES_CWD_{id}__
+
+        We only remove that exact line, preserving everything above it — even
+        if the command output (like Get-Location) prints the same path on the
+        preceding line.
+        """
+        output = result.get("output", "")
+        marker = self._cwd_marker
+        last = output.rfind(marker)
+        if last == -1:
+            return
+
+        # Find the closing marker
+        first = output.rfind(marker, max(0, last - 4096), last)
+        if first == -1 or first == last:
+            return
+
+        # Find the start of the marker line (the \n we injected before it)
+        line_start = output.rfind("\n", 0, first)
+        # Find the end of the marker line
+        line_end = output.find("\n", last + len(marker))
+        if line_end != -1:
+            line_end += 1  # include the trailing newline
+        else:
+            line_end = len(output)
+
+        # Only strip if the line contains NOTHING but the marker.
+        # The injected line is: \n__MARKER__path__MARKER__\n
+        # If line_start == -1, the marker is at the very beginning of output.
+        marker_line = output[line_start + 1 : line_end].strip() if line_start != -1 else output[:line_end].strip()
+
+        # Verify this line is a pure marker (starts and ends with the marker tag)
+        if marker_line.startswith(marker) and marker_line.endswith(marker):
+            if line_start != -1:
+                result["output"] = output[:line_start] + output[line_end:]
+            else:
+                result["output"] = output[line_end:]
 
     def cleanup(self):
         """Clean up temp files."""

--- a/tools/environments/windows_local.py
+++ b/tools/environments/windows_local.py
@@ -1,0 +1,223 @@
+"""Windows-native execution environment using PowerShell.
+
+Phase 1 MVP: direct PowerShell spawn without bash intermediate.
+No session snapshot (env vars do not persist across commands yet).
+"""
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+from typing import Optional
+
+from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.local import _sanitize_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+
+def _find_powershell() -> str:
+    """Find the best PowerShell executable on Windows.
+
+    Priority:
+    1. PowerShell 7 (pwsh.exe) — modern, faster, better pipeline support
+    2. PowerShell 5.1 (powershell.exe) — built-in on all Windows versions
+    """
+    # 1. Check PATH for pwsh (PowerShell 7)
+    pwsh = shutil.which("pwsh")
+    if pwsh:
+        return pwsh
+
+    # 2. Known PowerShell 7 locations
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    for base in (program_files, os.environ.get("ProgramW6432", "")):
+        if not base:
+            continue
+        candidate = os.path.join(base, "PowerShell", "7", "pwsh.exe")
+        if os.path.isfile(candidate):
+            return candidate
+
+    # 3. Fallback to Windows PowerShell 5.1
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    candidate = os.path.join(
+        system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
+    )
+    if os.path.isfile(candidate):
+        return candidate
+
+    # 4. Last resort — hope it's on PATH
+    ps = shutil.which("powershell")
+    if ps:
+        return ps
+
+    raise RuntimeError(
+        "PowerShell not found on Windows. "
+        "Please ensure PowerShell is installed and available in PATH."
+    )
+
+
+def _quote_ps_literal(value: str) -> str:
+    """Quote a string for PowerShell single-quoted literals.
+
+    In PowerShell single-quoted strings, the only escape is doubling the
+    single quote: ' → ''.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
+class WindowsLocalEnvironment(BaseEnvironment):
+    """Run commands directly on Windows using PowerShell (no bash)."""
+
+    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
+        if cwd:
+            cwd = os.path.expanduser(cwd)
+        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        # Phase 1: skip init_session — env snapshot not yet implemented for PowerShell.
+        # Commands will run with the current process environment only.
+        self._snapshot_ready = False
+
+    def get_temp_dir(self) -> str:
+        """Return a writable temp dir for local execution on Windows."""
+        candidate = (
+            self.env.get("TEMP")
+            or self.env.get("TMP")
+            or os.environ.get("TEMP")
+            or os.environ.get("TMP")
+            or tempfile.gettempdir()
+        )
+        # Keep forward slashes for consistency with BaseEnvironment path handling.
+        return candidate.replace("\\", "/").rstrip("/") or "/"
+
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        """Build a PowerShell script that cd's, runs the command, and emits CWD."""
+        quoted_cwd = _quote_ps_literal(cwd)
+        quoted_cwd_file = _quote_ps_literal(self._cwd_file)
+        marker = self._cwd_marker
+
+        # Use a here-string so the user's command needs almost no escaping.
+        # The only thing that breaks a here-string is '@' at the start of a
+        # line immediately followed by a single quote. That's vanishingly rare.
+        #
+        # $ProgressPreference suppresses CLIXML noise from PowerShell 5.1's
+        # first-run module-initialization progress bars.
+        # Write CWD via [IO.File]::WriteAllText() — avoids the UTF-8 BOM that
+        # PowerShell 5.1's Out-File -Encoding utf8 injects.  The BOM (\ufeff)
+        # poisons self.cwd and breaks Set-Location on the next call.
+        quoted_cwd_file_bare = self._cwd_file.replace("\\", "/")
+        ps_script = (
+            f"$ProgressPreference = 'SilentlyContinue'\n"
+            f"Set-Location -LiteralPath {quoted_cwd}\n"
+            f"$__cmd = @'\n"
+            f"{command}\n"
+            f"'@\n"
+            f"Invoke-Expression $__cmd\n"
+            f"$__hermes_ec = $LASTEXITCODE\n"
+            f"if ($__hermes_ec -eq $null) {{ $__hermes_ec = 0 }}\n"
+            f"[IO.File]::WriteAllText({quoted_cwd_file}, (Get-Location).Path, [System.Text.UTF8Encoding]::new($false))\n"
+            f'Write-Output "`n{marker}$((Get-Location).Path){marker}"\n'
+            f"exit $__hermes_ec\n"
+        )
+        return ps_script
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: Optional[str] = None,
+    ) -> subprocess.Popen:
+        """Spawn PowerShell to run *cmd_string* (a PowerShell script).
+
+        Writes the script to a temporary .ps1 file so we don't have to fight
+        PowerShell's command-line quoting rules, then invokes it with
+        ``-NoProfile -NonInteractive -ExecutionPolicy Bypass -File <path>``.
+        """
+        pwsh = _find_powershell()
+        run_env = _sanitize_subprocess_env(os.environ, self.env)
+
+        temp_dir = self.get_temp_dir()
+        ps1_path = os.path.join(temp_dir, f"hermes-ps-{self._session_id}.ps1")
+        with open(ps1_path, "w", encoding="utf-8") as f:
+            f.write(cmd_string)
+
+        args = [
+            pwsh,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            ps1_path,
+        ]
+
+        proc = subprocess.Popen(
+            args,
+            text=True,
+            env=run_env,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            cwd=self.cwd.strip("\ufeff"),  # Guard against BOM leaking into cwd
+        )
+
+        if stdin_data is not None:
+            _pipe_stdin(proc, stdin_data)
+
+        return proc
+
+    def _kill_process(self, proc):
+        """Kill the process and its children on Windows."""
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        try:
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                capture_output=True,
+                timeout=5,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+        except Exception:
+            pass
+
+    def _update_cwd(self, result: dict):
+        """Read CWD from temp file (local-only, no round-trip needed).
+
+        Uses ``utf-8-sig`` to transparently strip any BOM that PowerShell 5.1's
+        ``Out-File -Encoding utf8`` may have left in the file.
+        """
+        try:
+            with open(self._cwd_file, encoding="utf-8-sig") as f:
+                cwd_path = f.read().strip()
+            if cwd_path:
+                self.cwd = cwd_path
+        except (OSError, FileNotFoundError):
+            pass
+
+        # Still strip the marker from output so it's not visible to the user.
+        self._extract_cwd_from_output(result)
+
+    def cleanup(self):
+        """Clean up temp files."""
+        for f in (self._snapshot_path, self._cwd_file):
+            try:
+                if f and os.path.exists(f):
+                    os.unlink(f)
+            except OSError:
+                pass
+        # Also clean up the temporary .ps1 script.
+        temp_dir = self.get_temp_dir()
+        ps1_path = os.path.join(temp_dir, f"hermes-ps-{self._session_id}.ps1")
+        try:
+            if os.path.exists(ps1_path):
+                os.unlink(ps1_path)
+        except OSError:
+            pass

--- a/tools/environments/windows_local.py
+++ b/tools/environments/windows_local.py
@@ -1,7 +1,7 @@
 """Windows-native execution environment using PowerShell.
 
-Phase 1 MVP: direct PowerShell spawn without bash intermediate.
-No session snapshot (env vars do not persist across commands yet).
+Phase 2: direct PowerShell spawn with session snapshot (env var persistence).
+Env vars set via `$env:FOO = "bar"` or `set FOO=bar` persist across commands.
 """
 
 import logging
@@ -69,16 +69,23 @@ def _quote_ps_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
+# Separator used in the env snapshot file.
+# Chosen to be extremely unlikely in env var names or values.
+_ENV_SEP = "\x00"
+
+
 class WindowsLocalEnvironment(BaseEnvironment):
-    """Run commands directly on Windows using PowerShell (no bash)."""
+    """Run commands directly on Windows using PowerShell (no bash).
+
+    Session snapshot preserves environment variables across commands.
+    CWD persists via file-based read after each command.
+    """
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
-        # Phase 1: skip init_session — env snapshot not yet implemented for PowerShell.
-        # Commands will run with the current process environment only.
-        self._snapshot_ready = False
+        self.init_session()
 
     def get_temp_dir(self) -> str:
         """Return a writable temp dir for local execution on Windows."""
@@ -92,45 +99,142 @@ class WindowsLocalEnvironment(BaseEnvironment):
         # Keep forward slashes for consistency with BaseEnvironment path handling.
         return candidate.replace("\\", "/").rstrip("/") or "/"
 
+    # ------------------------------------------------------------------
+    # Session snapshot
+    # ------------------------------------------------------------------
+
+    def init_session(self):
+        """Capture initial environment into a snapshot file.
+
+        The snapshot is a UTF-8 text file with NUL-separated key-value pairs,
+        one per line:  NAME\x00VALUE
+        This format handles env values containing newlines, equals signs, etc.
+        """
+        # Build a PowerShell script that dumps all env vars to the snapshot.
+        # We use NUL as separator because it cannot appear in env var names
+        # or values on Windows.
+        quoted_snap = _quote_ps_literal(self._snapshot_path)
+        bootstrap = (
+            "$ProgressPreference = 'SilentlyContinue'\n"
+            # Dump all env vars as KEY\x00VALUE lines
+            "Get-ChildItem Env: | ForEach-Object {\n"
+            f"  \"$($_.Name){_ENV_SEP}$($_.Value)\"\n"
+            "} | Out-File -FilePath " + quoted_snap + " -Encoding utf8\n"
+        )
+        try:
+            proc = self._run_bash(bootstrap, login=True, timeout=self._snapshot_timeout)
+            self._wait_for_process(proc, timeout=self._snapshot_timeout)
+            # Verify the snapshot file is readable
+            self._load_snapshot()
+            self._snapshot_ready = True
+            logger.info(
+                "PowerShell session snapshot created (session=%s, cwd=%s)",
+                self._session_id, self.cwd,
+            )
+        except Exception as exc:
+            logger.warning(
+                "init_session failed (session=%s): %s — "
+                "env vars will not persist across commands",
+                self._session_id, exc,
+            )
+            self._snapshot_ready = False
+
+    def _load_snapshot(self) -> dict:
+        """Load the env snapshot file into a dict."""
+        env = {}
+        try:
+            with open(self._snapshot_path, encoding="utf-8-sig") as f:
+                for line in f:
+                    line = line.rstrip("\n\r")
+                    if not line:
+                        continue
+                    parts = line.split(_ENV_SEP, 1)
+                    if len(parts) == 2:
+                        env[parts[0]] = parts[1]
+        except (OSError, FileNotFoundError):
+            pass
+        return env
+
+    def _save_snapshot(self, env: dict) -> None:
+        """Write env dict back to the snapshot file (BOM-free UTF-8)."""
+        try:
+            with open(self._snapshot_path, "w", encoding="utf-8") as f:
+                for key, value in env.items():
+                    f.write(f"{key}{_ENV_SEP}{value}\n")
+        except OSError as exc:
+            logger.debug("Failed to save env snapshot: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Command wrapping
+    # ------------------------------------------------------------------
+
     def _wrap_command(self, command: str, cwd: str) -> str:
-        """Build a PowerShell script that cd's, runs the command, and emits CWD."""
+        """Build a PowerShell script that restores env, cd's, runs command,
+        re-dumps env vars, saves CWD, and emits CWD marker."""
         quoted_cwd = _quote_ps_literal(cwd)
         quoted_cwd_file = _quote_ps_literal(self._cwd_file)
+        quoted_snap = _quote_ps_literal(self._snapshot_path)
         marker = self._cwd_marker
 
-        # Use a here-string so the user's command needs almost no escaping.
-        # The only thing that breaks a here-string is '@' at the start of a
-        # line immediately followed by a single quote. That's vanishingly rare.
-        #
-        # $ProgressPreference suppresses CLIXML noise from PowerShell 5.1's
-        # first-run module-initialization progress bars.
-        # Write CWD via [IO.File]::WriteAllText() — avoids the UTF-8 BOM that
-        # PowerShell 5.1's Out-File -Encoding utf8 injects.  The BOM (\ufeff)
-        # poisons self.cwd and breaks Set-Location on the next call.
-        quoted_cwd_file_bare = self._cwd_file.replace("\\", "/")
+        # --- Restore env from snapshot ---
+        restore_env = ""
+        if self._snapshot_ready:
+            # Read the snapshot file line by line, split on NUL, set $env:
+            # Using -Raw + split is faster than Get-Content for large files.
+            restore_env = (
+                f"if (Test-Path {quoted_snap}) {{\n"
+                f"  $__snap = [IO.File]::ReadAllText({quoted_snap}, [System.Text.UTF8Encoding]::new($false))\n"
+                f"  $__snap -split \"`n\" | ForEach-Object {{\n"
+                f"    $__parts = $_ -split [char]0, 2\n"
+                f"    if ($__parts.Length -eq 2 -and $__parts[0]) {{\n"
+                f"      Set-Item -Path \"Env:$($__parts[0])\" -Value $__parts[1] -ErrorAction SilentlyContinue\n"
+                f"    }}\n"
+                f"  }}\n"
+                f"}}\n"
+            )
+
+        # --- Dump env back to snapshot after command ---
+        dump_env = ""
+        if self._snapshot_ready:
+            # Collect env lines into a variable, then write all at once.
+            # Can't pipe directly into [IO.File]::WriteAllLines (PS parser error).
+            dump_env = (
+                "$__envLines = Get-ChildItem Env: | ForEach-Object {\n"
+                f"  \"$($_.Name){_ENV_SEP}$($_.Value)\"\n"
+                "}\n"
+                f"[IO.File]::WriteAllLines({quoted_snap}, $__envLines, [System.Text.UTF8Encoding]::new($false))\n"
+            )
+
         ps_script = (
             f"$ProgressPreference = 'SilentlyContinue'\n"
-            # Override Get-Location / pwd to emit the path string to stdout.
-            # In -NonInteractive -File mode, Get-Location returns a PathInfo
-            # object that does NOT flow to stdout (unlike interactive mode).
-            # Replacing it with a function that explicitly Write-Output's the
-            # path string makes ``Get-Location`` and ``pwd`` behave as users
-            # expect when called through hermes.
+            # Override Get-Location / pwd to emit path string to stdout
             f"Remove-Item Alias:pwd -ErrorAction SilentlyContinue\n"
             f"function pwd {{ Write-Output (Microsoft.PowerShell.Management\\Get-Location).Path }}\n"
             f"function Get-Location {{ Write-Output (Microsoft.PowerShell.Management\\Get-Location).Path }}\n"
+            # Restore env vars from snapshot
+            f"{restore_env}"
+            # cd to working directory
             f"Set-Location -LiteralPath {quoted_cwd}\n"
+            # Run user command via here-string
             f"$__cmd = @'\n"
             f"{command}\n"
             f"'@\n"
             f"Invoke-Expression $__cmd\n"
             f"$__hermes_ec = $LASTEXITCODE\n"
             f"if ($__hermes_ec -eq $null) {{ $__hermes_ec = 0 }}\n"
+            # Save CWD
             f"[IO.File]::WriteAllText({quoted_cwd_file}, (Microsoft.PowerShell.Management\\Get-Location).Path, [System.Text.UTF8Encoding]::new($false))\n"
+            # Re-dump env vars to snapshot
+            f"{dump_env}"
+            # CWD marker
             f'Write-Output "`n{marker}$((Microsoft.PowerShell.Management\\Get-Location).Path){marker}"\n'
             f"exit $__hermes_ec\n"
         )
         return ps_script
+
+    # ------------------------------------------------------------------
+    # Process spawning
+    # ------------------------------------------------------------------
 
     def _run_bash(
         self,
@@ -181,6 +285,10 @@ class WindowsLocalEnvironment(BaseEnvironment):
 
         return proc
 
+    # ------------------------------------------------------------------
+    # Process lifecycle
+    # ------------------------------------------------------------------
+
     def _kill_process(self, proc):
         """Kill the process and its children on Windows."""
         try:
@@ -196,6 +304,10 @@ class WindowsLocalEnvironment(BaseEnvironment):
             )
         except Exception:
             pass
+
+    # ------------------------------------------------------------------
+    # CWD tracking
+    # ------------------------------------------------------------------
 
     def _update_cwd(self, result: dict):
         """Read CWD from temp file (local-only, no round-trip needed).
@@ -246,8 +358,6 @@ class WindowsLocalEnvironment(BaseEnvironment):
             line_end = len(output)
 
         # Only strip if the line contains NOTHING but the marker.
-        # The injected line is: \n__MARKER__path__MARKER__\n
-        # If line_start == -1, the marker is at the very beginning of output.
         marker_line = output[line_start + 1 : line_end].strip() if line_start != -1 else output[:line_end].strip()
 
         # Verify this line is a pure marker (starts and ends with the marker tag)
@@ -256,6 +366,10 @@ class WindowsLocalEnvironment(BaseEnvironment):
                 result["output"] = output[:line_start] + output[line_end:]
             else:
                 result["output"] = output[line_end:]
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
 
     def cleanup(self):
         """Clean up temp files."""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import os
 import re
+import shutil
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -1559,3 +1560,475 @@ class ShellFileOperations(FileOperations):
                 total_count=total,
                 truncated=total > offset + limit
             )
+
+
+# =============================================================================
+# Windows Native Implementation
+# =============================================================================
+
+class PowerShellFileOperations(ShellFileOperations):
+    """File operations using Python native APIs instead of Unix shell commands.
+
+    On Windows, ``sed``, ``cat``, ``wc``, ``head``, ``ls``, ``rm``, ``mv``,
+    ``mkdir``, ``test``, and ``command`` are not available in the native
+    PowerShell environment.  This subclass overrides every method that relies
+    on those commands, using ``os`` / ``shutil`` / built-in file I/O instead.
+
+    Methods that *already* work cross-platform (e.g. ripgrep search when
+    ``rg`` is on PATH) are inherited unchanged.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve(path: str) -> str:
+        """Resolve a path to absolute, expanding ~ via os.path.expanduser."""
+        return os.path.abspath(os.path.expanduser(path))
+
+    def _has_command(self, cmd: str) -> bool:
+        """Check if a command exists (uses shutil.which, not ``command -v``)."""
+        if cmd not in self._command_cache:
+            self._command_cache[cmd] = shutil.which(cmd) is not None
+        return self._command_cache[cmd]
+
+    def _expand_path(self, path: str) -> str:
+        """Expand ~ and shell-style paths using Python, not ``echo $HOME``."""
+        if not path:
+            return path
+        return os.path.expanduser(path)
+
+    # ------------------------------------------------------------------
+    # READ
+    # ------------------------------------------------------------------
+
+    def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
+        path = self._resolve(self._expand_path(path))
+        offset, limit = normalize_read_pagination(offset, limit)
+
+        if not os.path.isfile(path):
+            return self._suggest_similar_files(path)
+
+        file_size = os.path.getsize(path)
+
+        if self._is_image(path):
+            return ReadResult(
+                is_image=True, is_binary=True, file_size=file_size,
+                hint="Image file detected. Automatically redirected to vision_analyze tool. "
+                     "Use vision_analyze with this file path to inspect the image contents.",
+            )
+
+        # Binary detection: read first 1000 bytes
+        try:
+            with open(path, "rb") as f:
+                sample = f.read(1000)
+        except OSError as e:
+            return ReadResult(error=f"Failed to read file: {e}")
+
+        if self._is_likely_binary(path, sample.decode("utf-8", errors="replace")[:1000]):
+            return ReadResult(
+                is_binary=True, file_size=file_size,
+                error="Binary file - cannot display as text. Use appropriate tools to handle this file type.",
+            )
+
+        # Read lines with pagination
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                all_lines = f.readlines()
+        except OSError as e:
+            return ReadResult(error=f"Failed to read file: {e}")
+
+        total_lines = len(all_lines)
+        end_line = offset + limit - 1
+        selected = all_lines[offset - 1 : end_line]
+        content = "".join(selected)
+
+        truncated = total_lines > end_line
+        hint = None
+        if truncated:
+            hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
+
+        return ReadResult(
+            content=self._add_line_numbers(content, offset),
+            total_lines=total_lines,
+            file_size=file_size,
+            truncated=truncated,
+            hint=hint,
+        )
+
+    def read_file_raw(self, path: str) -> ReadResult:
+        path = self._resolve(self._expand_path(path))
+        if not os.path.isfile(path):
+            return self._suggest_similar_files(path)
+        file_size = os.path.getsize(path)
+        if self._is_image(path):
+            return ReadResult(is_image=True, is_binary=True, file_size=file_size)
+        try:
+            with open(path, "rb") as f:
+                sample = f.read(1000)
+        except OSError as e:
+            return ReadResult(error=f"Failed to read file: {e}")
+        if self._is_likely_binary(path, sample.decode("utf-8", errors="replace")[:1000]):
+            return ReadResult(is_binary=True, file_size=file_size,
+                              error="Binary file — cannot display as text.")
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                content = f.read()
+        except OSError as e:
+            return ReadResult(error=f"Failed to read file: {e}")
+        return ReadResult(content=content, file_size=file_size)
+
+    # ------------------------------------------------------------------
+    # WRITE / DELETE / MOVE
+    # ------------------------------------------------------------------
+
+    def write_file(self, path: str, content: str) -> WriteResult:
+        path = self._resolve(self._expand_path(path))
+        if _is_write_denied(path):
+            return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+
+        parent = os.path.dirname(path)
+        dirs_created = False
+        if parent and not os.path.isdir(parent):
+            try:
+                os.makedirs(parent, exist_ok=True)
+                dirs_created = True
+            except OSError as e:
+                return WriteResult(error=f"Failed to create directory {parent}: {e}")
+
+        try:
+            with open(path, "w", encoding="utf-8", newline="") as f:
+                f.write(content)
+        except OSError as e:
+            return WriteResult(error=f"Failed to write file: {e}")
+
+        bytes_written = os.path.getsize(path)
+        return WriteResult(bytes_written=bytes_written, dirs_created=dirs_created)
+
+    def delete_file(self, path: str) -> WriteResult:
+        path = self._resolve(self._expand_path(path))
+        if _is_write_denied(path):
+            return WriteResult(error=f"Delete denied: {path} is a protected path")
+        try:
+            os.remove(path)
+        except OSError as e:
+            return WriteResult(error=f"Failed to delete {path}: {e}")
+        return WriteResult()
+
+    def move_file(self, src: str, dst: str) -> WriteResult:
+        src = self._resolve(self._expand_path(src))
+        dst = self._resolve(self._expand_path(dst))
+        for p in (src, dst):
+            if _is_write_denied(p):
+                return WriteResult(error=f"Move denied: {p} is a protected path")
+        try:
+            shutil.move(src, dst)
+        except OSError as e:
+            return WriteResult(error=f"Failed to move {src} -> {dst}: {e}")
+        return WriteResult()
+
+    # ------------------------------------------------------------------
+    # PATCH — uses Python read/write instead of ``cat``
+    # ------------------------------------------------------------------
+
+    def patch_replace(self, path: str, old_string: str, new_string: str,
+                      replace_all: bool = False) -> PatchResult:
+        path = self._resolve(self._expand_path(path))
+        if _is_write_denied(path):
+            return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
+
+        # Read current content via Python
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                content = f.read()
+        except OSError:
+            return PatchResult(error=f"Failed to read file: {path}")
+
+        from tools.fuzzy_match import fuzzy_find_and_replace
+        new_content, match_count, _strategy, error = fuzzy_find_and_replace(
+            content, old_string, new_string, replace_all
+        )
+
+        if error or match_count == 0:
+            err_msg = error or f"Could not find match for old_string in {path}"
+            try:
+                from tools.fuzzy_match import format_no_match_hint
+                err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+            except Exception:
+                pass
+            return PatchResult(error=err_msg)
+
+        # Write back
+        write_result = self.write_file(path, new_content)
+        if write_result.error:
+            return PatchResult(error=f"Failed to write changes: {write_result.error}")
+
+        # Post-write verification
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                verify = f.read()
+        except OSError:
+            return PatchResult(error=f"Post-write verification failed: could not re-read {path}")
+        if verify != new_content:
+            return PatchResult(error=(
+                f"Post-write verification failed for {path}: on-disk content "
+                f"differs from intended write "
+                f"(wrote {len(new_content)} chars, read back {len(verify)}). "
+                "The patch did not persist. Re-read the file and try again."
+            ))
+
+        diff = self._unified_diff(content, new_content, path)
+        lint_result = self._check_lint(path)
+        return PatchResult(
+            success=True, diff=diff, files_modified=[path],
+            lint=lint_result.to_dict() if lint_result else None,
+        )
+
+    # ------------------------------------------------------------------
+    # SEARCH — path-existence checks use os.path instead of ``test -e``
+    # ------------------------------------------------------------------
+
+    def search(self, pattern: str, path: str = ".", target: str = "content",
+               file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
+               output_mode: str = "content", context: int = 0) -> SearchResult:
+        offset, limit = normalize_search_pagination(offset, limit)
+        path = self._resolve(self._expand_path(path))
+
+        if not os.path.exists(path):
+            parent = os.path.dirname(path) or "."
+            basename_query = os.path.basename(path)
+            hint_parts = [f"Path not found: {path}"]
+            if os.path.isdir(parent) and basename_query:
+                try:
+                    entries = os.listdir(parent)
+                except OSError:
+                    entries = []
+                lower_q = basename_query.lower()
+                candidates = []
+                for entry in entries:
+                    le = entry.lower()
+                    if lower_q in le or le in lower_q or le.startswith(lower_q[:3]):
+                        candidates.append(os.path.join(parent, entry))
+                if candidates:
+                    hint_parts.append("Similar paths: " + ", ".join(candidates[:5]))
+            return SearchResult(error=". ".join(hint_parts), total_count=0)
+
+        if target == "files":
+            return self._search_files(pattern, path, limit, offset)
+        else:
+            return self._search_content(pattern, path, file_glob, limit, offset,
+                                        output_mode, context)
+
+    def _suggest_similar_files(self, path: str) -> ReadResult:
+        """Suggest similar files using os.listdir instead of ``ls``."""
+        dir_path = os.path.dirname(path) or "."
+        filename = os.path.basename(path)
+        basename_no_ext = os.path.splitext(filename)[0]
+        ext = os.path.splitext(filename)[1].lower()
+        lower_name = filename.lower()
+
+        try:
+            entries = os.listdir(dir_path)
+        except OSError:
+            entries = []
+
+        scored: list = []
+        for f in entries[:200]:  # cap to avoid slow scoring on huge dirs
+            lf = f.lower()
+            score = 0
+            if lf == lower_name:
+                score = 100
+            elif os.path.splitext(f)[0].lower() == basename_no_ext.lower():
+                score = 90
+            elif lf.startswith(lower_name) or lower_name.startswith(lf):
+                score = 70
+            elif lower_name in lf:
+                score = 60
+            elif lf in lower_name and len(lf) > 2:
+                score = 40
+            elif ext and os.path.splitext(f)[1].lower() == ext:
+                common = set(lower_name) & set(lf)
+                if len(common) >= max(len(lower_name), len(lf)) * 0.4:
+                    score = 30
+            if score > 0:
+                scored.append((score, os.path.join(dir_path, f)))
+
+        scored.sort(key=lambda x: -x[0])
+        similar = [fp for _, fp in scored[:5]]
+
+        return ReadResult(error=f"File not found: {path}", similar_files=similar)
+
+    def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+        """Search for files by name using rg or Python os.walk."""
+        # Prefer rg when available
+        if self._has_command("rg"):
+            search_pattern = pattern.split("/")[-1] if "/" in pattern else pattern
+            if not search_pattern.startswith("*"):
+                glob_pattern = f"*{search_pattern}"
+            else:
+                glob_pattern = search_pattern
+            fetch_limit = limit + offset
+            # Use PowerShell-compatible piping
+            cmd = (
+                f'rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} '
+                f'{self._escape_shell_arg(path)} 2>$null | Select-Object -First {fetch_limit}'
+            )
+            result = self._exec(cmd, timeout=60)
+            all_files = [f for f in result.stdout.strip().split("\n") if f]
+            if not all_files:
+                cmd_plain = (
+                    f'rg --files -g {self._escape_shell_arg(glob_pattern)} '
+                    f'{self._escape_shell_arg(path)} 2>$null | Select-Object -First {fetch_limit}'
+                )
+                result = self._exec(cmd_plain, timeout=60)
+                all_files = [f for f in result.stdout.strip().split("\n") if f]
+            page = all_files[offset : offset + limit]
+            return SearchResult(files=page, total_count=len(all_files),
+                                truncated=len(all_files) >= fetch_limit)
+
+        # Fallback: Python os.walk
+        import fnmatch
+        all_files: list = []
+        search_name = pattern.split("/")[-1] if "/" in pattern else pattern
+        try:
+            for root, dirs, files in os.walk(path):
+                dirs[:] = [d for d in dirs if not d.startswith(".")]
+                for fname in files:
+                    if fnmatch.fnmatch(fname, search_name):
+                        all_files.append(os.path.join(root, fname))
+        except OSError:
+            pass
+
+        def _mtime(f: str) -> float:
+            try:
+                return os.path.getmtime(f)
+            except OSError:
+                return 0.0
+
+        all_files.sort(key=_mtime, reverse=True)
+        page = all_files[offset : offset + limit]
+        return SearchResult(files=page, total_count=len(all_files),
+                            truncated=len(all_files) > offset + limit)
+
+    def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
+                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+        """Override rg search to use PowerShell-compatible piping."""
+        cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
+
+        if context > 0:
+            cmd_parts.extend(["-C", str(context)])
+        if file_glob:
+            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+        if output_mode == "files_only":
+            cmd_parts.append("-l")
+        elif output_mode == "count":
+            cmd_parts.append("-c")
+
+        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_arg(path))
+
+        fetch_limit = limit + offset + 200 if context > 0 else limit + offset
+        # Use PowerShell's Select-Object instead of Unix head
+        cmd = " ".join(cmd_parts) + f" 2>$null | Select-Object -First {fetch_limit}"
+
+        result = self._exec(cmd, timeout=60)
+
+        if result.exit_code == 2 and not result.stdout.strip():
+            return SearchResult(error="Search failed", total_count=0)
+
+        if output_mode == "files_only":
+            all_files = [f for f in result.stdout.strip().split("\n") if f]
+            total = len(all_files)
+            page = all_files[offset : offset + limit]
+            return SearchResult(files=page, total_count=total)
+
+        elif output_mode == "count":
+            counts = {}
+            for line in result.stdout.strip().split("\n"):
+                if ":" in line:
+                    parts = line.rsplit(":", 1)
+                    if len(parts) == 2:
+                        try:
+                            counts[parts[0]] = int(parts[1].strip())
+                        except ValueError:
+                            pass
+            return SearchResult(counts=counts, total_count=sum(counts.values()))
+
+        else:
+            matches = []
+            for line in result.stdout.strip().split("\n"):
+                if not line or line == "--":
+                    continue
+                m = re.match(r"^(\x1b\[[0-9;]*m)*(.+?)(\x1b\[[0-9;]*m)*:(\d+):(.*)", line)
+                if m:
+                    matches.append(SearchMatch(
+                        path=(m.group(1) or "") + m.group(2),
+                        line_number=int(m.group(4)),
+                        content=m.group(5)[:500],
+                    ))
+            total = len(matches)
+            page = matches[offset : offset + limit]
+            return SearchResult(matches=page, total_count=total,
+                                truncated=total > offset + limit)
+
+    def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
+                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+        """Content search: prefer rg, fallback to Python re."""
+        if self._has_command("rg"):
+            return self._search_with_rg(pattern, path, file_glob, limit, offset,
+                                        output_mode, context)
+        # No rg available — use Python-based grep fallback
+        return self._search_with_python(pattern, path, file_glob, limit, offset,
+                                        output_mode, context)
+
+    def _search_with_python(self, pattern: str, path: str, file_glob: Optional[str],
+                            limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+        """Pure-Python content search fallback for Windows without rg/grep."""
+        import fnmatch as _fnmatch
+
+        try:
+            regex = re.compile(pattern)
+        except re.error as e:
+            return SearchResult(error=f"Invalid regex pattern: {e}", total_count=0)
+
+        matches: list = []
+        file_counts: dict = {}
+        file_list: list = []
+        walk_root = path if os.path.isdir(path) else os.path.dirname(path) or "."
+
+        for root, dirs, files in os.walk(walk_root):
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+            for fname in files:
+                fpath = os.path.join(root, fname)
+                if file_glob and not _fnmatch.fnmatch(fname, file_glob):
+                    continue
+                try:
+                    with open(fpath, "r", encoding="utf-8", errors="replace") as f:
+                        for lineno, line in enumerate(f, 1):
+                            if regex.search(line):
+                                if output_mode == "files_only":
+                                    file_list.append(fpath)
+                                    break
+                                elif output_mode == "count":
+                                    file_counts[fpath] = file_counts.get(fpath, 0) + 1
+                                else:
+                                    matches.append(SearchMatch(
+                                        path=fpath,
+                                        line_number=lineno,
+                                        content=line.rstrip("\r\n")[:500],
+                                    ))
+                except (OSError, UnicodeDecodeError):
+                    continue
+
+        if output_mode == "files_only":
+            total = len(file_list)
+            page = file_list[offset : offset + limit]
+            return SearchResult(files=page, total_count=total)
+        elif output_mode == "count":
+            return SearchResult(counts=file_counts, total_count=sum(file_counts.values()))
+        else:
+            total = len(matches)
+            page = matches[offset : offset + limit]
+            return SearchResult(matches=page, total_count=total,
+                                truncated=total > offset + limit)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -12,6 +12,7 @@ from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
+    PowerShellFileOperations,
     normalize_read_pagination,
     normalize_search_pagination,
 )
@@ -428,8 +429,15 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             _start_cleanup_thread()
             logger.info("%s environment ready for task %s", env_type, task_id[:8])
 
-    # Build file_ops from the (guaranteed live) environment and cache it
-    file_ops = ShellFileOperations(terminal_env)
+    # Build file_ops from the (guaranteed live) environment and cache it.
+    # On Windows with native PowerShell backend, use PowerShellFileOperations
+    # which replaces Unix shell commands (sed, cat, wc, etc.) with Python APIs.
+    import sys as _sys
+    from tools.environments.windows_local import WindowsLocalEnvironment as _WinEnv
+    if _sys.platform == "win32" and isinstance(terminal_env, _WinEnv):
+        file_ops = PowerShellFileOperations(terminal_env)
+    else:
+        file_ops = ShellFileOperations(terminal_env)
     with _file_ops_lock:
         _file_ops_cache[task_id] = file_ops
     return file_ops

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -882,6 +882,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
 # Environment classes now live in tools/environments/
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
+from tools.environments.windows_local import WindowsLocalEnvironment as _WindowsLocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
 from tools.environments.docker import DockerEnvironment as _DockerEnvironment
@@ -1130,6 +1131,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_env = cc.get("docker_env", {})
 
     if env_type == "local":
+        if platform.system() == "Windows" and not os.getenv("HERMES_USE_GIT_BASH"):
+            return _WindowsLocalEnvironment(cwd=cwd, timeout=timeout)
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
     
     elif env_type == "docker":

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-04-22T20:28:06.1942621Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1954,7 +1954,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.12.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
### Description
  This PR implements a native Windows execution environment for Hermes, as tracked in #2512. It aims to resolve the environment isolation and path-handling issues reported in #21074 and #20436.
  Unlike previous proposals, this implementation focuses on being zero-dependency and minimally invasive, ensuring it works out-of-the-box on stock Windows 10/11 installations.

### What
  Adds a `WindowsLocalEnvironment` that uses PowerShell 5.1 as the shell backend on Windows, replacing the previous Git Bash dependency.

### Why
PowerShell 5.1 ships with every Windows installation. Users should not need to install Git Bash just to run Hermes on Windows.

### Key Changes
- **`WindowsLocalEnvironment`** (`tools/environments/windows_local.py`): Full PowerShell-based environment with session persistence, env snapshot restore, and CWD tracking
- **Env snapshot mechanism**: Uses `[IO.File]::WriteAllLines` with `\x02\x03` (STX+ETX) separator and `.TrimEnd([char]13)` to handle CRLF corruption — a subtle bug where trailing `\r` in `PATH` silently broke Winsock DNS resolution
- **`select.select()` Windows replacement** (`tools/environments/base.py`): Uses blocking `buffer.read()` on Windows since `select` doesn't support pipe fds
- **Windows temp path handling** (`tools/environments/local.py`): Forward-slashed `TEMP`/`TMP` paths for compatibility
- **Launchers**: `hermes.ps1` and `hermes.cmd` for convenient startup
- **Tests**: `tests/tools/test_windows_local_environment.py` with unit + integration coverage

### Breaking Changes
None. Windows users are automatically routed to `WindowsLocalEnvironment`. Set `HERMES_USE_GIT_BASH=1` to fall back to the previous Git Bash behavior.

### Stability & Compatibility
- Daily Tested: This implementation is currently being used in my daily production workflows on Windows 11.
- Non-Breaking: Legacy behavior is preserved. Users can opt-back into Git Bash via HERMES_USE_GIT_BASH=1.
- Testing: Includes a new test suite: tests/tools/test_windows_local_environment.py

### 🛠 Ongoing Refinements & Roadmaps
- [x] Native PowerShell 5.1 backend (No Git Bash required)
- [x] Environment snapshot & DNS corruption fix (CRLF handling)
- [x] Unit/Integration tests for WindowsLocalEnvironment
- [ ] Refining TUI rendering for legacy Windows consoles (CMD)
- [ ] Polishing error messages for permission-related IO failures