### PR TITLE
fix(gateway): fail fast on undeliverable approval notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15605,6 +15605,12 @@ class GatewayRunner:
                     f"Reply `/approve` to execute, `/approve session` to approve this pattern "
                     f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
                 )
+                # Propagate delivery failure to the approval system so it fails
+                # fast with BLOCKED instead of waiting out the gateway_timeout
+                # (default 5 min). Adapters that don't support push delivery
+                # (e.g. APIServerAdapter.send returns SendResult(success=False))
+                # would otherwise leave the agent thread blocked on
+                # entry.event.wait() with no path to ever resolve. See #19731.
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(
                         _status_adapter.send(
@@ -15616,10 +15622,23 @@ class GatewayRunner:
                         logger=logger,
                         log_message="Approval text-send scheduling error",
                     )
-                    if _approval_send_fut is not None:
-                        _approval_send_fut.result(timeout=15)
+                    if _approval_send_fut is None:
+                        raise RuntimeError(
+                            "Approval text-send scheduling failed: loop unavailable"
+                        )
+                    _send_result = _approval_send_fut.result(timeout=15)
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
+                    raise
+                if not getattr(_send_result, "success", False):
+                    _err = getattr(_send_result, "error", None) or "send returned success=False"
+                    logger.error(
+                        "Approval delivery rejected by %s adapter (%s); denying instead of hanging.",
+                        type(_status_adapter).__name__, _err,
+                    )
+                    raise RuntimeError(
+                        f"approval delivery failed via {type(_status_adapter).__name__}: {_err}"
+                    )
 
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})

--- a/tests/tools/test_approval_plugin_hooks.py
+++ b/tests/tools/test_approval_plugin_hooks.py
@@ -142,4 +142,54 @@ class TestGatewayPathFiresHooks:
     approval event until resolve_gateway_approval() is called from another
     thread."""
 
+    def test_notify_cb_failure_blocks_fast_without_waiting_for_timeout(
+        self, isolated_session, monkeypatch
+    ):
+        """Regression for #19731: when the gateway can't deliver the approval
+        request (e.g. APIServerAdapter.send returns SendResult(success=False)
+        because it has no push channel), the gateway-side notify_cb raises and
+        the approval flow must return BLOCKED immediately rather than blocking
+        the agent thread on event.wait() for the full gateway_timeout (5 min).
+        """
+        import threading
 
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+        # Use a deliberately long gateway_timeout: the test should finish in
+        # well under a second because notify_cb raises, not because the
+        # timeout fires. If the test takes anywhere near gateway_timeout,
+        # the fail-fast path is broken.
+        monkeypatch.setattr(
+            approval_module, "_get_approval_config", lambda: {"gateway_timeout": 60}
+        )
+
+        def failing_notify_cb(approval_data):
+            raise RuntimeError(
+                "approval delivery failed via APIServerAdapter: "
+                "API server uses HTTP request/response, not send()"
+            )
+
+        register_gateway_notify(isolated_session, failing_notify_cb)
+        result_holder = {}
+
+        def run_guard():
+            with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+                result_holder["result"] = check_all_command_guards(
+                    "rm -rf /tmp/test-notify-fail", "local",
+                )
+
+        t = threading.Thread(target=run_guard, daemon=True)
+        t.start()
+        # Generous join cap; the actual return path is synchronous after
+        # notify_cb raises, so this should complete in milliseconds.
+        t.join(timeout=5)
+        assert not t.is_alive(), "Agent thread hung after notify_cb raised"
+        unregister_gateway_notify(isolated_session)
+
+        result = result_holder["result"]
+        assert result["approved"] is False
+        assert "BLOCKED" in result["message"]
+        # Queue should be drained — no orphaned approval entries left behind.
+        assert isolated_session not in approval_module._gateway_queues


### PR DESCRIPTION
## What does this PR do?

Stops the 5-minute hang when a dangerous command needs approval but the platform adapter can't deliver the prompt to the user.

`_approval_notify_sync` (in `gateway/run.py`) used to swallow `SendResult(success=False)` and exceptions raised by `adapter.send()`. The notify_cb returned normally, the approval entry stayed queued, and the agent thread blocked on `entry.event.wait(timeout=gateway_timeout)` for the full 5 minutes — the user never saw the prompt, and there was no path to resolve it via `/approve` or `/deny`.

The fallback `send()` result is now checked: if scheduling yields no future, `send()` raises, or `SendResult.success` is False, we log and re-raise. The existing safety net in `tools.approval.check_all_command_guards` already catches exceptions from `notify_cb`, drains the entry from `_gateway_queues`, and returns a `BLOCKED: Failed to send approval request to user` result — we just have to reach it. Concretely fixes the `/background` flow on the API Server adapter (`APIServerAdapter.send` always returns `SendResult(success=False, ...)`), but applies to any adapter where push delivery is unavailable.

## Related Issue

Fixes #19731

Related: #6059 — implements the dashboard SSE approval stream for the API Server (the long-term push path). This PR is complementary: even once #6059 lands, `_approval_notify_sync` should fail fast on `SendResult(success=False)` rather than block on `entry.event.wait()`, so any future adapter without a push channel surfaces a clear `BLOCKED` instead of a hang.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: in the approval text-send fallback, raise when `safe_schedule_threadsafe` returns no future, when `send()` raises, or when the returned `SendResult.success` is false — so the approval guard fails fast with `BLOCKED` instead of waiting out `gateway_timeout`.
- `tests/tools/test_approval_plugin_hooks.py`: adds `test_notify_cb_failure_blocks_fast_without_waiting_for_timeout`, which registers a notify_cb mimicking the API Server failure and asserts the guard returns `BLOCKED` well under the configured `gateway_timeout`.

## How to Test

1. `pytest tests/tools/test_approval_plugin_hooks.py -q` (the new regression test plus the existing suite).
2. `pytest tests/tools/test_approval_plugin_hooks.py tests/gateway/test_approve_deny_commands.py tests/gateway/test_background_command.py tests/gateway/test_session_boundary_security_state.py -q` (related approval and background-command suites).
3. Manual repro of the original hang requires an API Server gateway session and isn't reproducible in local pytest, so the regression test simulates the failure pattern at the notify_cb seam.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Addressing maintainer feedback

- @austinpickett — reformatted this PR description to follow `PULL_REQUEST_TEMPLATE.md` as requested.
- #6059 (raised by @alt-glitch) is OPEN and implements the SSE approval stream for the API Server. This PR is intentionally complementary defense-in-depth, not a duplicate — see the **Related Issue** section above.
- Note on the `pytest tests/ -q` checkbox: the PR's own suite (`tests/tools/test_approval_plugin_hooks.py`) passes locally (4 passed). The branch was rebased onto current `main`; the earlier CI `test` failures were on files this PR does not touch (e.g. `test_registry_manifest`, `test_google_chat`, `test_teams`, model-list tests) caused by a stale base, which the rebase resolves.

<!-- autocontrib:worker-id=issue-new-c5f6c3fb kind=pr-open -->
