### PR TITLE
fix(agent): use runtime model for vision auto-detection (#14744)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2625,6 +2625,7 @@ def resolve_vision_provider_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     async_mode: bool = False,
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
 
@@ -2675,8 +2676,9 @@ def resolve_vision_provider_client(
         #   2. OpenRouter  (vision-capable aggregator fallback)
         #   3. Nous Portal (vision-capable aggregator fallback)
         #   4. Stop
-        main_provider = _read_main_provider()
-        main_model = _read_main_model()
+        runtime = _normalize_main_runtime(main_runtime)
+        main_provider = runtime.get("provider", "") or _read_main_provider()
+        main_model = runtime.get("model", "") or _read_main_model()
         if main_provider and main_provider not in ("auto", ""):
             vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
             if main_provider == "nous":
@@ -3408,6 +3410,7 @@ def call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=False,
+            main_runtime=main_runtime,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -3418,6 +3421,7 @@ def call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=False,
+                main_runtime=main_runtime,
             )
         if client is None:
             raise RuntimeError(
@@ -3571,6 +3575,7 @@ def call_llm(
                         provider=resolved_provider,
                         model=final_model,
                         async_mode=False,
+                        main_runtime=main_runtime,
                     )[1:]
                     if task == "vision"
                     else _get_cached_client(
@@ -3698,6 +3703,7 @@ async def async_call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
     max_tokens: int = None,
@@ -3721,6 +3727,7 @@ async def async_call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=True,
+            main_runtime=main_runtime,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -3731,6 +3738,7 @@ async def async_call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=True,
+                main_runtime=main_runtime,
             )
         if client is None:
             raise RuntimeError(
@@ -3862,6 +3870,7 @@ async def async_call_llm(
                         provider=resolved_provider,
                         model=final_model,
                         async_mode=True,
+                        main_runtime=main_runtime,
                     )
                 else:
                     retry_client, retry_model = _get_cached_client(

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -62,3 +62,67 @@ def test_vision_base_url_override_keeps_explicit_provider():
     assert model == "glm-4v"
     assert mock_resolve.call_args.args[0] == "zai"
     assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://open.bigmodel.cn/api/paas/v4"
+
+
+def test_vision_call_passes_main_runtime():
+    """main_runtime must be forwarded to resolve_vision_provider_client."""
+    from agent.auxiliary_client import call_llm
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="description"))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+    runtime = {"model": "mimo-v2.6", "provider": "opencode-go"}
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("opencode-go", fake_client, "mimo-v2.6"),
+        ) as mock_vision,
+    ):
+        call_llm(
+            "vision",
+            main_runtime=runtime,
+            messages=[{"role": "user", "content": "describe this"}],
+        )
+
+    call_args = mock_vision.call_args
+    assert call_args.kwargs["main_runtime"] is runtime
+
+
+def test_vision_auto_detect_uses_runtime_model():
+    """Auto-detection must prefer runtime model over config default."""
+    from agent.auxiliary_client import resolve_vision_provider_client
+
+    mock_client = MagicMock()
+
+    with (
+        patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="opencode-go",
+        ),
+        patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="deepseek-v4-flash",
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "mimo-v2.6"),
+        ) as mock_resolve,
+    ):
+        provider, client, model = resolve_vision_provider_client(
+            provider="auto",
+            main_runtime={"model": "mimo-v2.6", "provider": "opencode-go"},
+        )
+
+    assert provider == "opencode-go"
+    assert client is mock_client
+    assert model == "mimo-v2.6"
+    # Must have been called with runtime model, not config default
+    call_args = mock_resolve.call_args
+    assert call_args.args[1] == "mimo-v2.6"


### PR DESCRIPTION
## Summary

Fixes #14744.

Vision auto-detection in `resolve_vision_provider_client()` read only from `config.yaml` via `_read_main_model()`, ignoring the runtime model set via `/model`. When a user switched to a vision-capable model (e.g. `mimo-v2.6`) at runtime, the vision pipeline still used the config default (e.g. `deepseek-v4-flash`), which may not support vision.

## Root Cause

`_read_main_model()` reads `config.yaml` `model.default` — it has no awareness of session-level model switches. The `/model` command stores the active model in:
- CLI: `self.model` instance attribute
- Gateway: `_session_model_overrides` dict
- Agent: `AgentRunner.model` attribute

But `resolve_vision_provider_client()` never receives this runtime state.

## Changes

- `agent/auxiliary_client.py`:
  - Add `main_runtime` parameter to `resolve_vision_provider_client()`
  - In auto-detection branch, prefer runtime model/provider over config (same pattern as `_resolve_auto()` at line 1882-1883)
  - Add `main_runtime` to `async_call_llm()` signature
  - Forward `main_runtime` from `call_llm`/`async_call_llm` to all `resolve_vision_provider_client()` call sites

- `tests/agent/test_vision_resolved_args.py`:
  - `test_vision_call_passes_main_runtime`: verify `main_runtime` is forwarded
  - `test_vision_auto_detect_uses_runtime_model`: verify runtime model takes priority over config default

## How It Works

```
Before:
  /model mimo-v2.6  →  vision uses config default (deepseek-v4-flash)

After:
  /model mimo-v2.6  →  vision uses runtime model (mimo-v2.6)
```

The fix follows the existing pattern from `_resolve_auto()`:
```python
main_model = runtime.get("model", "") or _read_main_model()
```

## Validation

```
138 tests passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.ai/code)