### PR TITLE
perf(plugins): seed plugin routes from sessionStorage cache for instant render

### DIFF
--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getCachedManifests,
+  cacheManifests,
+  MANIFEST_CACHE_KEY,
+} from "./usePlugins";
+import type { PluginManifest } from "./types";
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+    get length() {
+      return store.size;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+  } as Storage;
+}
+
+const exampleManifest: PluginManifest = {
+  name: "test",
+  label: "Test",
+  description: "A test plugin",
+  icon: "Puzzle",
+  version: "1.0.0",
+  tab: { path: "/test" },
+  entry: "index.js",
+  has_api: false,
+  source: "local",
+};
+
+describe("plugin manifest cache helpers", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    vi.stubGlobal("sessionStorage", storage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getCachedManifests returns null when nothing is cached", () => {
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns null for invalid JSON", () => {
+    storage.setItem(MANIFEST_CACHE_KEY, "not-json");
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns null for non-array JSON", () => {
+    storage.setItem(MANIFEST_CACHE_KEY, JSON.stringify({ foo: "bar" }));
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns null for scalar JSON", () => {
+    storage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(42));
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns a valid manifest array", () => {
+    const list: PluginManifest[] = [exampleManifest];
+    cacheManifests(list);
+    expect(getCachedManifests()).toEqual(list);
+  });
+
+  it("cacheManifests overwrites a previous cache on refresh", () => {
+    const first: PluginManifest[] = [exampleManifest];
+    cacheManifests(first);
+    expect(getCachedManifests()).toEqual(first);
+
+    const second: PluginManifest[] = [
+      { ...exampleManifest, name: "updated", label: "Updated" },
+    ];
+    cacheManifests(second);
+    expect(getCachedManifests()).toEqual(second);
+  });
+
+  it("cacheManifests swallows storage errors", () => {
+    const badStorage = makeStorage();
+    badStorage.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    vi.stubGlobal("sessionStorage", badStorage);
+    expect(() => cacheManifests([exampleManifest])).not.toThrow();
+  });
+});

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -17,17 +17,51 @@ import {
   setPluginLoadError,
 } from "./registry";
 
+const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
+
+function getCachedManifests(): PluginManifest[] | null {
+  try {
+    const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
+    return raw ? (JSON.parse(raw) as PluginManifest[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function cacheManifests(manifests: PluginManifest[]): void {
+  try {
+    sessionStorage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(manifests));
+  } catch {
+    // sessionStorage unavailable (private browsing, storage full, etc.)
+  }
+}
+
 export function usePlugins() {
-  const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  // Lazy initialisers run once at mount — safe to read sessionStorage here.
+  // This avoids the "cannot access ref during render" lint error that would
+  // occur if we stored the cached value in a useRef and read .current in the
+  // useState initial value expression.
+  const [manifests, setManifests] = useState<PluginManifest[]>(
+    () => getCachedManifests() ?? [],
+  );
   const [plugins, setPlugins] = useState<RegisteredPlugin[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Start loading=false when the cache has manifests so plugin routes are
+  // registered synchronously on the first render after a refresh.
+  // The catch-all in App.tsx is only a safety net for the very first visit
+  // (no cache yet). On subsequent visits this flag starts false immediately.
+  const [loading, setLoading] = useState<boolean>(
+    () => getCachedManifests() === null,
+  );
   const loadedScripts = useRef<Set<string>>(new Set());
 
-  // Fetch manifests on mount.
+  // Always re-fetch in the background to keep the cache fresh.
+  // This handles: new plugins added, plugins removed, manifest changes.
+  // setManifests(list) will update routes if the server list differs from cache.
   useEffect(() => {
     api
       .getPlugins()
       .then((list) => {
+        cacheManifests(list);
         setManifests(list);
         if (list.length === 0) setLoading(false);
       })

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -22,7 +22,9 @@ const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
 function getCachedManifests(): PluginManifest[] | null {
   try {
     const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
-    return raw ? (JSON.parse(raw) as PluginManifest[]) : null;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PluginManifest[]) : null;
   } catch {
     return null;
   }

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -17,9 +17,9 @@ import {
   setPluginLoadError,
 } from "./registry";
 
-const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
+export const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
 
-function getCachedManifests(): PluginManifest[] | null {
+export function getCachedManifests(): PluginManifest[] | null {
   try {
     const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
     if (!raw) return null;
@@ -30,7 +30,7 @@ function getCachedManifests(): PluginManifest[] | null {
   }
 }
 
-function cacheManifests(manifests: PluginManifest[]): void {
+export function cacheManifests(manifests: PluginManifest[]): void {
   try {
     sessionStorage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(manifests));
   } catch {


### PR DESCRIPTION
## What does this PR do?

Caches plugin manifests in `sessionStorage` so that on repeat visits, plugin routes are available synchronously on the first render, reducing the brief loading flash before the plugin board appears.

## Related Issue

Complements #18660 (fixed by #18661). This is a follow-up performance improvement, not a correctness fix — the race condition is already resolved by #18661's `pluginsLoading` guard.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ Performance improvement

## Changes Made
- `web/src/plugins/usePlugins.ts`: initialize `manifests` from
  `sessionStorage` cache, then re-fetch in the background to refresh
  the cache and update routes if manifests changed.

## How to Test
1. Visit a plugin page for the first time.
2. Refresh the page after manifests have been cached.
3. Confirm plugin routes are available immediately on repeat visits.
4. Confirm manifest updates still propagate after the background fetch.