### PR TITLE
fix(installer): install xz-utils before Node.js tar.xz extraction

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -568,9 +568,26 @@ install_node() {
 
     log_info "Extracting to ~/.hermes/node/..."
     if [[ "$tarball_name" == *.tar.xz ]]; then
-        tar xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+        if ! command -v xz &> /dev/null; then
+            log_warn "xz is required to extract $tarball_name"
+            show_manual_install_hint "xz-utils"
+            rm -rf "$tmp_dir"
+            HAS_NODE=false
+            return 0
+        fi
+        if ! tar xf "$tmp_dir/$tarball_name" -C "$tmp_dir"; then
+            log_warn "Extraction failed"
+            rm -rf "$tmp_dir"
+            HAS_NODE=false
+            return 0
+        fi
     else
-        tar xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+        if ! tar xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"; then
+            log_warn "Extraction failed"
+            rm -rf "$tmp_dir"
+            HAS_NODE=false
+            return 0
+        fi
     fi
 
     local extracted_dir
@@ -606,8 +623,10 @@ install_system_packages() {
     # Detect what's missing
     HAS_RIPGREP=false
     HAS_FFMPEG=false
+    HAS_XZ=false
     local need_ripgrep=false
     local need_ffmpeg=false
+    local need_xz=false
 
     log_info "Checking ripgrep (fast file search)..."
     if command -v rg &> /dev/null; then
@@ -624,6 +643,17 @@ install_system_packages() {
         HAS_FFMPEG=true
     else
         need_ffmpeg=true
+    fi
+
+    if [ "$DISTRO" = "ubuntu" ] || [ "$DISTRO" = "debian" ]; then
+        log_info "Checking xz (Node.js archive extraction)..."
+        if command -v xz &> /dev/null; then
+            HAS_XZ=true
+        else
+            need_xz=true
+        fi
+    else
+        HAS_XZ=true
     fi
 
     # Termux always needs the Android build toolchain for the tested pip path,
@@ -651,7 +681,7 @@ install_system_packages() {
     fi
 
     # Nothing to install — done
-    if [ "$need_ripgrep" = false ] && [ "$need_ffmpeg" = false ]; then
+    if [ "$need_ripgrep" = false ] && [ "$need_ffmpeg" = false ] && [ "$need_xz" = false ]; then
         return 0
     fi
 
@@ -665,6 +695,10 @@ install_system_packages() {
     if [ "$need_ffmpeg" = true ]; then
         desc_parts+=("ffmpeg for TTS voice messages")
         pkgs+=("ffmpeg")
+    fi
+    if [ "$need_xz" = true ]; then
+        desc_parts+=("xz-utils for Node.js archive extraction")
+        pkgs+=("xz-utils")
     fi
     local description
     description=$(IFS=" and "; echo "${desc_parts[*]}")
@@ -706,6 +740,7 @@ install_system_packages() {
             if $install_cmd; then
                 [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
                 [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                [ "$need_xz" = true ]      && HAS_XZ=true      && log_success "xz-utils installed"
                 return 0
             fi
         # Passwordless sudo — just install
@@ -714,6 +749,7 @@ install_system_packages() {
             if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd; then
                 [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
                 [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                [ "$need_xz" = true ]      && HAS_XZ=true      && log_success "xz-utils installed"
                 return 0
             fi
         # sudo needs password — ask once for everything
@@ -726,6 +762,7 @@ install_system_packages() {
                     if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd; then
                         [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
                         [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                        [ "$need_xz" = true ]      && HAS_XZ=true      && log_success "xz-utils installed"
                         return 0
                     fi
                 fi
@@ -742,6 +779,7 @@ install_system_packages() {
                     if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd < /dev/tty; then
                         [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
                         [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
+                        [ "$need_xz" = true ]      && HAS_XZ=true      && log_success "xz-utils installed"
                         return 0
                     fi
                 fi
@@ -772,6 +810,10 @@ install_system_packages() {
         log_warn "ffmpeg not installed (TTS voice messages will be limited)"
         show_manual_install_hint "ffmpeg"
     fi
+    if [ "$HAS_XZ" = false ] && [ "$need_xz" = true ]; then
+        log_warn "xz-utils not installed (Node.js auto-install may be unavailable)"
+        show_manual_install_hint "xz-utils"
+    fi
 }
 
 show_manual_install_hint() {
@@ -781,15 +823,33 @@ show_manual_install_hint() {
         linux)
             case "$DISTRO" in
                 ubuntu|debian) log_info "  sudo apt install $pkg" ;;
-                fedora)        log_info "  sudo dnf install $pkg" ;;
-                arch)          log_info "  sudo pacman -S $pkg"   ;;
+                fedora)
+                    if [ "$pkg" = "xz-utils" ]; then
+                        log_info "  sudo dnf install xz"
+                    else
+                        log_info "  sudo dnf install $pkg"
+                    fi
+                    ;;
+                arch)
+                    if [ "$pkg" = "xz-utils" ]; then
+                        log_info "  sudo pacman -S xz"
+                    else
+                        log_info "  sudo pacman -S $pkg"
+                    fi
+                    ;;
                 *)             log_info "  Use your package manager or visit the project homepage" ;;
             esac
             ;;
         android)
             log_info "  pkg install $pkg"
             ;;
-        macos) log_info "  brew install $pkg" ;;
+        macos)
+            if [ "$pkg" = "xz-utils" ]; then
+                log_info "  brew install xz"
+            else
+                log_info "  brew install $pkg"
+            fi
+            ;;
     esac
 }
 

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -169,6 +169,12 @@ _nb_install_bundled_node() {
 
     _nb_log "Extracting to $HERMES_HOME/node/..."
     if [[ "$tarball" == *.tar.xz ]]; then
+        if ! command -v xz >/dev/null 2>&1; then
+            _nb_warn "xz is required to extract $tarball"
+            _nb_warn "Install it with your package manager, for example: sudo apt install xz-utils"
+            rm -rf "$tmp"
+            return 1
+        fi
         tar xf  "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }
     else
         tar xzf "$tmp/$tarball" -C "$tmp" || { rm -rf "$tmp"; return 1; }

--- a/tests/test_install_sh_node_xz_dependency.py
+++ b/tests/test_install_sh_node_xz_dependency.py
@@ -1,0 +1,46 @@
+"""Regression coverage for Node.js tar.xz extraction on minimal Debian.
+
+Node's Linux binaries are distributed as ``.tar.xz`` archives. Minimal
+Debian/Ubuntu images can have ``tar`` and ``curl`` without the external ``xz``
+helper that GNU tar uses to decompress those archives.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _function_body(name: str) -> str:
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        rf"^{re.escape(name)}\(\)\s*\{{\s*\n(?P<body>.*?)^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name}() not found in scripts/install.sh"
+    return match["body"]
+
+
+def test_debian_installs_xz_utils_for_node_tar_xz_extraction() -> None:
+    body = _function_body("install_system_packages")
+
+    assert "command -v xz" in body
+    assert "xz-utils" in body
+    assert "Node.js archive extraction" in body
+
+
+def test_node_tar_xz_extraction_checks_for_xz_before_tar() -> None:
+    body = _function_body("install_node")
+    tar_xz_branch = re.search(
+        r'if \[\[ "\$tarball_name" == \*\.tar\.xz \]\]; then(?P<body>.*?)else',
+        body,
+        re.DOTALL,
+    )
+
+    assert tar_xz_branch is not None
+    assert "command -v xz" in tar_xz_branch["body"]
+    assert 'tar xf "$tmp_dir/$tarball_name"' in tar_xz_branch["body"]


### PR DESCRIPTION
## Summary

Minimal Debian/Ubuntu images can include `tar` without the `xz` helper that GNU tar needs for `.tar.xz` archives. The installer downloads Node.js as a `.tar.xz` archive, then fails during extraction with:

`tar (child): xz: Cannot exec: No such file or directory`

Install `xz-utils` on Debian/Ubuntu when missing, and guard Node extraction with a clear warning if `xz` is still unavailable.

## Changes

- Add `xz-utils` to the Debian/Ubuntu installer package checks.
- Check for `xz` before extracting Node.js `.tar.xz` archives.
- Add regression coverage for the installer dependency.

## Validation

- `bash -n scripts/install.sh`
- `bash -n scripts/lib/node-bootstrap.sh`
- `uv run --extra dev pytest tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_node_xz_dependency.py -q`