### PR TITLE
fix(gateway): raise default Discord connect timeout to 90s

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -62,6 +62,14 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+# Discord registers slash commands during connect.  With many skills
+# enabled, local registration + login + WS handshake + on_ready can
+# legitimately exceed 30s on a cold start (#19776), tripping the outer
+# connect timeout even though Discord is making progress.  Give Discord
+# a higher default; HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT still wins.
+_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULTS: Dict[str, float] = {
+    "discord": 90.0,
+}
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 
@@ -1529,8 +1537,14 @@ class GatewayRunner:
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
-    def _platform_connect_timeout_secs(self) -> float:
-        """Return the per-platform connect timeout used during startup/retry."""
+    def _platform_connect_timeout_secs(self, platform=None) -> float:
+        """Return the per-platform connect timeout used during startup/retry.
+
+        Platforms whose connect path includes substantial pre-ready work
+        (notably Discord, which registers many slash commands) get a
+        longer default than the global one; the env var still overrides
+        both.
+        """
         raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
         if raw:
             try:
@@ -1542,11 +1556,16 @@ class GatewayRunner:
                 )
             else:
                 return max(0.0, timeout)
+        platform_value = getattr(platform, "value", platform)
+        if isinstance(platform_value, str):
+            override = _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULTS.get(platform_value)
+            if override is not None:
+                return override
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
     async def _connect_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect an adapter without allowing one platform to block others."""
-        timeout = self._platform_connect_timeout_secs()
+        timeout = self._platform_connect_timeout_secs(platform)
         if timeout <= 0:
             return await adapter.connect()
         try:

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -150,6 +150,24 @@ class TestStartupPlatformIsolation:
         with pytest.raises(TimeoutError, match="telegram connect timed out"):
             await runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM)
 
+    def test_discord_default_connect_timeout_higher_than_global(self, monkeypatch):
+        """Discord's connect path includes slash command registration, so its
+        default connect timeout must be longer than the global default
+        (#19776). The env var still overrides both when set."""
+        runner = _make_runner()
+        monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+
+        global_default = runner._platform_connect_timeout_secs(Platform.TELEGRAM)
+        discord_default = runner._platform_connect_timeout_secs(Platform.DISCORD)
+
+        assert global_default == 30.0
+        assert discord_default >= 60.0
+        assert discord_default > global_default
+
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "15")
+        assert runner._platform_connect_timeout_secs(Platform.DISCORD) == 15.0
+        assert runner._platform_connect_timeout_secs(Platform.TELEGRAM) == 15.0
+
 
 class TestStartupFailureQueuing:
     """Verify that failed platforms are queued during startup."""

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -467,7 +467,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS` / `_SPLIT_DELAY_SECONDS` | WeCom batcher tuning. |
 | `HERMES_VISION_DOWNLOAD_TIMEOUT` | Timeout in seconds for downloading an image before handing it to vision models (default: `30`). |
 | `HERMES_RESTART_DRAIN_TIMEOUT` | Gateway: seconds to wait for active runs to drain on `/restart` before forcing the restart (default: `900`). |
-| `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` | Per-platform connect timeout during gateway startup (seconds). |
+| `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` | Per-platform connect timeout during gateway startup (seconds). Default is `30` for most platforms; Discord uses `90` to accommodate slash command registration on cold start with many skills. Setting this env var overrides both. |
 | `HERMES_GATEWAY_BUSY_INPUT_MODE` | Default gateway busy-input behavior: `queue`, `steer`, or `interrupt`. Can be overridden per chat with `/busy`. |
 | `HERMES_GATEWAY_BUSY_ACK_ENABLED` | Whether the gateway sends an acknowledgment message (⚡/⏳/⏩) when a user sends input while the agent is busy (default: `true`). Set to `false` to suppress these messages entirely — the input is still queued/steered/interrupts as normal, only the chat reply is silenced. Bridged from `display.busy_ack_enabled` in `config.yaml`. |
 | `HERMES_CRON_TIMEOUT` | Inactivity timeout for cron job agent runs in seconds (default: `600`). The agent can run indefinitely while actively calling tools or receiving stream tokens — this only triggers when idle. Set to `0` for unlimited. |


### PR DESCRIPTION
Raise the default platform connect timeout for Discord from 30s to 90s so launchd-managed Discord gateways with many slash commands no longer fail at startup.

## What changed and why
- `_platform_connect_timeout_secs()` in `gateway/run.py` now takes the target platform and returns a per-platform default. Discord defaults to 90s, every other platform keeps the existing 30s default.
- `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` still overrides every platform when set, so the documented escape hatch is unchanged.
- Updated `website/docs/reference/environment-variables.md` to mention the Discord-specific default.
- Reason: Discord registers slash commands during `connect()`. With many skills the local registration + login + WS handshake + `on_ready` can legitimately exceed the old 30s outer timeout, killing the connect even though Discord is making progress and would have come up shortly after. Reporters confirmed `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT=90` resolves the failure.

## How to test
- `pytest tests/gateway/test_platform_reconnect.py -q` — includes a new regression test that asserts Discord's default is higher than the global default and that the env var still overrides both.
- Manual: on a Discord-only gateway with many skills, restart the gateway without `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` set and confirm it connects (no "discord connect timed out after 30s" error).

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #19776

<!-- autocontrib:worker-id=issue-new-8d7c75a7 kind=pr-open -->