### PR TITLE
fix(cron): propagate HERMES_HOME to script subprocesses

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -614,6 +614,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     script_timeout = _get_script_timeout()
 
+    # Propagate HERMES_HOME into the child environment. The cron daemon may
+    # have resolved HERMES_HOME via config file, command-line flag, or active
+    # profile sticky-file even when the shell environment doesn't have it set
+    # — but subprocess.run() without env= inherits only the shell env, not
+    # the resolved value. Without this, cron-spawned scripts silently read
+    # ~/.hermes (default profile) instead of the active profile, causing
+    # cross-profile data corruption (see #18594).
+    child_env = dict(os.environ)
+    child_env.setdefault("HERMES_HOME", str(_hermes_home))
+
     try:
         result = subprocess.run(
             [sys.executable, str(path)],
@@ -621,6 +631,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             text=True,
             timeout=script_timeout,
             cwd=str(path.parent),
+            env=child_env,
         )
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -174,6 +174,104 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_script_sees_hermes_home_when_shell_env_dropped(self, cron_env, monkeypatch):
+        """Regression test for #18594: if the cron daemon resolved HERMES_HOME
+        at startup but the shell env later drops it (e.g. systemd unit without
+        Environment=HERMES_HOME=, launchd, docker exec into a container),
+        scripts must still see the resolved value, not silently fall back to
+        ~/.hermes (the default profile) via get_hermes_home()'s fallback.
+
+        Simulates this by patching the scheduler's resolved _hermes_home AND
+        patching get_hermes_home() at its module location so the sandbox
+        check still finds the scripts dir. The subprocess must then receive
+        HERMES_HOME in its env even though the parent shell doesn't have it.
+        """
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        # Scheduler-resolved profile-mode hermes_home
+        monkeypatch.setattr(sched_mod, "_hermes_home", cron_env)
+
+        # hermes_constants.get_hermes_home() at its module location keeps
+        # resolving to cron_env for the sandbox check (the scheduler reads
+        # HERMES_HOME from env at each call). This represents a world where
+        # the scheduler has a stable view even when shell env shifts mid-run.
+        import hermes_constants
+        monkeypatch.setattr(
+            hermes_constants, "get_hermes_home", lambda: cron_env
+        )
+
+        # Shell env drops HERMES_HOME. Without env= in subprocess.run, the
+        # child sees nothing for this var.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        script = cron_env / "scripts" / "echo_env.py"
+        script.write_text(textwrap.dedent("""\
+            import os
+            print(os.environ.get("HERMES_HOME", "<UNSET>"))
+        """))
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == str(cron_env), (
+            f"Expected child to see HERMES_HOME={cron_env}, got {output!r}. "
+            "If this is '<UNSET>', the scheduler regressed and scripts will "
+            "silently run against the default profile (#18594)."
+        )
+
+    def test_script_env_does_not_overwrite_explicit_shell_value(self, cron_env, monkeypatch):
+        """If the shell env DOES have HERMES_HOME set (e.g. user launched
+        hermes with HERMES_HOME=/custom/path), that value must win over
+        the scheduler's resolved _hermes_home.  Use setdefault semantics."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        # Scheduler thinks hermes_home is cron_env, but shell env overrides
+        # it to a different value.
+        monkeypatch.setattr(sched_mod, "_hermes_home", cron_env)
+        override_path = str(cron_env.parent / "override-hermes-home")
+        monkeypatch.setenv("HERMES_HOME", override_path)
+
+        # Make the sandbox check still pass (use the override path for
+        # scripts dir lookup too, or keep cron_env — script lives in cron_env).
+        import hermes_constants
+        monkeypatch.setattr(
+            hermes_constants, "get_hermes_home", lambda: cron_env
+        )
+
+        script = cron_env / "scripts" / "echo_env.py"
+        script.write_text(textwrap.dedent("""\
+            import os
+            print(os.environ.get("HERMES_HOME", "<UNSET>"))
+        """))
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == override_path, (
+            "Shell env HERMES_HOME must override the scheduler's resolved value"
+        )
+
+    def test_script_inherits_other_env_vars(self, cron_env, monkeypatch):
+        """Regression guard: the env propagation must use `dict(os.environ)`
+        as the base so other env vars (PATH, HOME, HERMES_PROFILE, etc.)
+        still flow through.  Using a clean env{HERMES_HOME: ...} would break
+        anything the user script depends on."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        monkeypatch.setattr(sched_mod, "_hermes_home", cron_env)
+        monkeypatch.setenv("HERMES_CUSTOM_MARKER", "visible-in-child")
+
+        script = cron_env / "scripts" / "echo_marker.py"
+        script.write_text(textwrap.dedent("""\
+            import os
+            print(os.environ.get("HERMES_CUSTOM_MARKER", "<UNSET>"))
+        """))
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "visible-in-child"
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""


### PR DESCRIPTION
Partial fix for the process-spawn dimension of #18594.

## What this fixes

`#18746` (@liuhao1024) already added a one-shot stderr warning when `get_hermes_home()` falls back under an active profile. That was defense-in-depth — the observability layer. This PR addresses one of the concrete spawn sites that **triggers** the warning: the cron script runner.

## Root cause in scope

`cron/scheduler.py::_run_job_script()` calls `subprocess.run(...)` **without `env=`**, so the child inherits only the shell environment. On systemd / launchd / docker-exec deployments where the cron daemon's unit file doesn't ship an explicit `Environment=HERMES_HOME=...`, the child starts with `HERMES_HOME` unset and `get_hermes_home()` falls back to `~/.hermes` (default profile) — silently corrupting cross-profile data as described in the incident report in #18594.

## Fix shape

Inject the scheduler's resolved `_hermes_home` into the child env via `setdefault` semantics:

```python
child_env = dict(os.environ)
child_env.setdefault("HERMES_HOME", str(_hermes_home))
```

- **`setdefault` semantics**: if the shell env already has `HERMES_HOME` (user explicitly ran hermes with an override), that wins.
- **`dict(os.environ)` base**: all other env vars (PATH, HOME, HERMES_PROFILE, user custom markers) still flow through — no clean-env regression.

## Why only `cron/scheduler.py`

I audited all subprocess spawns under `cron/`, `hermes_cli/`, and `tools/`:

| Spawn site | Passes env= ? | HERMES_HOME propagated? |
|---|---|---|
| `cron/scheduler.py:595` `_run_job_script` | ❌ no env | **This PR** |
| `hermes_cli/kanban_db.py:2117` kanban dispatcher | ✅ `env = dict(os.environ)` | ✅ inherits naturally |
| `tools/skills_hub.py:193` `gh` auth lookup | (not scope — reads GitHub token, doesn't need HERMES_HOME) | n/a |
| `tools/environments/docker.py` | ✅ explicit env mapping | ✅ |
| `tools/terminal_tool.py` | ✅ passes configured env | ✅ |

So this is the single narrow fix that was needed at the cron layer. Other layers aren't regressed.

## Not in scope

- Changes to `get_hermes_home()` itself — @liuhao1024's call was that classic-mode users rely on the `~/.hermes` fallback, so strict raising isn't viable. Agreed. Spawn-layer propagation is the right fix.
- Changes to the systemd gateway unit template — that's a separate file and already has `Environment=HERMES_HOME=...` where needed.
- Audit of MCP stdio subprocesses — different failure mode, different fix.

## Tests

3 new in `TestRunJobScript`, 7 existing → 10/10 pass:

- `test_script_sees_hermes_home_when_shell_env_dropped` — the core regression: scheduler has `_hermes_home` resolved, shell env drops `HERMES_HOME`, child must still see it
- `test_script_env_does_not_overwrite_explicit_shell_value` — `setdefault` semantics guard
- `test_script_inherits_other_env_vars` — `dict(os.environ)` base semantics guard

Full file: **40/40 pass**.

## Files

- `cron/scheduler.py`: +11 / -1
- `tests/cron/test_cron_script.py`: +96