### PR TITLE
fix(wecom): split long markdown into multiple messages instead of silently truncating

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1211,7 +1211,7 @@ class WeComAdapter(BasePlatformAdapter):
             reply_req_id,
             {
                 "msgtype": "markdown",
-                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                "markdown": {"content": content},
             },
         )
         self._raise_for_wecom_error(response, "send reply markdown")
@@ -1348,26 +1348,32 @@ class WeComAdapter(BasePlatformAdapter):
             if not reply_req_id and chat_id in self._last_chat_req_ids:
                 reply_req_id = self._last_chat_req_ids[chat_id]
 
-            if reply_req_id:
-                response = await self._send_reply_markdown(reply_req_id, content)
-            else:
-                response = await self._send_request(
-                    APP_CMD_SEND,
-                    {
-                        "chatid": chat_id,
-                        "msgtype": "markdown",
-                        "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-                    },
-                )
+            chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+
+            response: Dict[str, Any] = {}
+            for index, chunk in enumerate(chunks):
+                # WeCom reply_req_id is single-use: only the first chunk can ride
+                # the inbound reply context. Subsequent chunks fall back to the
+                # proactive APP_CMD_SEND path, which is stateless.
+                if index == 0 and reply_req_id:
+                    response = await self._send_reply_markdown(reply_req_id, chunk)
+                else:
+                    response = await self._send_request(
+                        APP_CMD_SEND,
+                        {
+                            "chatid": chat_id,
+                            "msgtype": "markdown",
+                            "markdown": {"content": chunk},
+                        },
+                    )
+                error = self._response_error(response)
+                if error:
+                    return SendResult(success=False, error=error)
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
             logger.error("[%s] Send failed: %s", self.name, exc)
             return SendResult(success=False, error=str(exc))
-
-        error = self._response_error(response)
-        if error:
-            return SendResult(success=False, error=error)
 
         return SendResult(
             success=True,

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -461,6 +461,99 @@ class TestSend:
         assert "40001" in (result.error or "")
 
     @pytest.mark.asyncio
+    async def test_send_splits_long_proactive_markdown_into_multiple_messages(self):
+        """Long markdown must be split into multiple sends, not silently truncated."""
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(return_value={"headers": {"req_id": "req-1"}, "errcode": 0})
+
+        long_content = "abc " * 1500  # 6000 chars, > MAX_MESSAGE_LENGTH (4000)
+        result = await adapter.send("chat-123", long_content)
+
+        assert result.success is True
+        # Multiple proactive sends, none silently dropped at 4000 chars.
+        assert adapter._send_request.await_count >= 2
+        full_sent = ""
+        for call in adapter._send_request.await_args_list:
+            cmd, payload = call.args
+            assert cmd == APP_CMD_SEND
+            assert payload["chatid"] == "chat-123"
+            assert payload["msgtype"] == "markdown"
+            chunk = payload["markdown"]["content"]
+            assert len(chunk) <= adapter.MAX_MESSAGE_LENGTH
+            full_sent += chunk
+
+        # The body of the original message must survive across the chunks
+        # (chunk indicators add a small suffix; we check substantive content).
+        assert long_content.strip()[:3000] in full_sent
+
+    @pytest.mark.asyncio
+    async def test_send_long_message_first_chunk_uses_reply_then_proactive(self):
+        """First chunk rides the reply context; subsequent chunks must go via APP_CMD_SEND
+        because the WeCom reply_req_id is single-use."""
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+        adapter._send_request = AsyncMock(return_value={"headers": {"req_id": "req-2"}, "errcode": 0})
+
+        long_content = "abc " * 1500  # 6000 chars
+        result = await adapter.send("chat-123", long_content, reply_to="msg-1")
+
+        assert result.success is True
+        # Exactly one passive reply (reply_req_id is single-use).
+        adapter._send_reply_request.assert_awaited_once()
+        assert adapter._send_reply_request.await_args.args[0] == "req-1"
+        # At least one follow-up via proactive APP_CMD_SEND for the remaining chunks.
+        assert adapter._send_request.await_count >= 1
+        for call in adapter._send_request.await_args_list:
+            cmd, payload = call.args
+            assert cmd == APP_CMD_SEND
+            assert len(payload["markdown"]["content"]) <= adapter.MAX_MESSAGE_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_send_short_message_is_not_chunked(self):
+        """A message under MAX_MESSAGE_LENGTH must produce exactly one send,
+        with content unchanged (no spurious indicator suffix)."""
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(return_value={"headers": {"req_id": "req-1"}, "errcode": 0})
+
+        result = await adapter.send("chat-123", "short message")
+
+        assert result.success is True
+        adapter._send_request.assert_awaited_once_with(
+            APP_CMD_SEND,
+            {
+                "chatid": "chat-123",
+                "msgtype": "markdown",
+                "markdown": {"content": "short message"},
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_long_message_aborts_on_first_chunk_error(self):
+        """If WeCom rejects an early chunk, do not keep firing follow-ups —
+        return the failure."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(return_value={"errcode": 40001, "errmsg": "bad request"})
+
+        long_content = "abc " * 1500
+        result = await adapter.send("chat-123", long_content)
+
+        assert result.success is False
+        assert "40001" in (result.error or "")
+        # First chunk failed → no further sends attempted.
+        assert adapter._send_request.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_send_image_falls_back_to_text_for_remote_url(self):
         from gateway.platforms.wecom import WeComAdapter
 


### PR DESCRIPTION
## Summary

- WeCom outbound markdown is silently truncated at 4000 characters: both the proactive `send` path and the passive `_send_reply_markdown` path slice with `content[:self.MAX_MESSAGE_LENGTH]` before sending. The WeCom API accepts the request, so Hermes reports success while everything past 4000 chars is dropped from the user's view.
- Switch `send()` to chunk via `BasePlatformAdapter.truncate_message` (already used by Discord, Telegram, Feishu, Matrix). The first chunk rides the inbound reply context when present; subsequent chunks fall back to proactive `APP_CMD_SEND` since the WeCom `reply_req_id` is single-use.

## The bug

`gateway/platforms/wecom.py:1214` and `gateway/platforms/wecom.py:1359` (pre-fix line numbers):

```python
"markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
```

A 6000-character agent response sends one 4000-char message; the remaining 2000 chars are silently discarded. `SendResult` still reports `success=True`. The user has no signal that content was lost.

Reported in #19689.

## The fix

In `WeComAdapter.send`:

```python
chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)

response: Dict[str, Any] = {}
for index, chunk in enumerate(chunks):
    # WeCom reply_req_id is single-use: only the first chunk can ride
    # the inbound reply context. Subsequent chunks fall back to the
    # proactive APP_CMD_SEND path, which is stateless.
    if index == 0 and reply_req_id:
        response = await self._send_reply_markdown(reply_req_id, chunk)
    else:
        response = await self._send_request(
            APP_CMD_SEND,
            {
                "chatid": chat_id,
                "msgtype": "markdown",
                "markdown": {"content": chunk},
            },
        )
    error = self._response_error(response)
    if error:
        return SendResult(success=False, error=error)
```

`truncate_message` already preserves code-block fences across chunk boundaries and adds `(1/N)` indicators within `MAX_MESSAGE_LENGTH`. The redundant `content[:self.MAX_MESSAGE_LENGTH]` slice in `_send_reply_markdown` is dropped as well: the only caller (`send`) pre-chunks now, and the slice read like an ongoing truncation contract that no longer applies.

If a chunk fails (e.g. WeCom errcode), `send()` aborts and returns the failure rather than continuing to fire follow-ups against an already-rejecting endpoint.

## Test plan

- [x] Focused regression: `tests/gateway/test_wecom.py::TestSend` — 4 new tests cover (a) long proactive markdown splits into multiple `APP_CMD_SEND` calls, each ≤ `MAX_MESSAGE_LENGTH`; (b) long content with reply context uses passive reply for chunk 1 and proactive `APP_CMD_SEND` for chunks 2+; (c) short messages still produce exactly one send with content unchanged; (d) early-chunk failure aborts the send loop.
- [x] Adjacent suite: `tests/gateway/test_wecom.py` (45 passed), `tests/gateway/test_wecom_callback.py` + `tests/gateway/test_text_batching.py` (31 passed).
- [x] Regression guard: with the production change reverted, `test_send_splits_long_proactive_markdown_into_multiple_messages` and `test_send_long_message_first_chunk_uses_reply_then_proactive` both fail (`await_count == 1` instead of `>= 2`) — confirming the silent-truncation behavior the fix removes.

## Related

Fixes #19689.

> Sibling code paths that may need the same fix: `gateway/platforms/dingtalk.py` (lines around the two `content[: self.MAX_MESSAGE_LENGTH]` slices, with limit 20000) and `gateway/platforms/homeassistant.py:405` (limit 4096) both still slice instead of chunking. Intentionally left out of this PR's scope to keep the diff small and focused on the reported WeCom bug — happy to widen if preferred.