### PR TITLE
fix(tui): add missing emnapi lockfile entries

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -503,6 +503,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",


### PR DESCRIPTION
## Summary
- Add missing `@emnapi/core` and `@emnapi/runtime` entries to `ui-tui/package-lock.json`.
- Keep the lockfile change minimal: only the two missing package entries were added, preserving the existing peer metadata.
- This lets the TUI dependency install stay on `npm ci` instead of falling back to `npm install` and dirtying the checkout.

## Why
With the current lockfile, `npm ci --prefix ui-tui` can fail because the lockfile is missing optional peer entries required by the resolved dependency graph:

- `@emnapi/core@1.10.0`
- `@emnapi/runtime@1.10.0`

When that happens during `hermes update`, the deterministic install path may fall back to `npm install`, which can rewrite lockfile metadata and leave the working tree dirty.

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund --prefix ui-tui`
- `npm run type-check --prefix ui-tui`
- `git diff --check -- ui-tui/package-lock.json`
