### PR TITLE
fix(dashboard): gate dashboard plugin discovery by config

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3555,6 +3555,74 @@ async def set_dashboard_theme(body: ThemeSetBody):
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
 
+def _dashboard_plugin_config_sets() -> Tuple[Optional[set[str]], set[str]]:
+    """Return dashboard plugin allow/deny lists from config.yaml."""
+    try:
+        config = load_config()
+    except Exception:
+        return None, set()
+
+    plugins_cfg = config.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        return None, set()
+
+    raw_enabled = plugins_cfg.get("enabled")
+    enabled = (
+        {str(item) for item in raw_enabled if isinstance(item, str)}
+        if isinstance(raw_enabled, list)
+        else None
+    )
+
+    raw_disabled = plugins_cfg.get("disabled")
+    disabled = (
+        {str(item) for item in raw_disabled if isinstance(item, str)}
+        if isinstance(raw_disabled, list)
+        else set()
+    )
+    return enabled, disabled
+
+
+def _dashboard_plugin_yaml_names(plugin_dir: Path) -> set[str]:
+    """Read names from plugin.yaml/yml without importing plugin code."""
+    names = set()
+    for manifest_name in ("plugin.yaml", "plugin.yml"):
+        manifest_file = plugin_dir / manifest_name
+        if not manifest_file.exists():
+            continue
+        try:
+            data = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+        except Exception as exc:
+            _log.warning("Bad plugin manifest %s: %s", manifest_file, exc)
+            return names
+        if isinstance(data, dict):
+            raw_name = data.get("name")
+            if isinstance(raw_name, str) and raw_name.strip():
+                names.add(raw_name.strip())
+        return names
+    return names
+
+
+def _dashboard_plugin_lookup_keys(plugin_dir: Path, manifest_data: dict) -> set[str]:
+    """Names accepted by plugins.enabled/plugins.disabled for dashboard plugins."""
+    keys = {plugin_dir.name}
+    raw_name = manifest_data.get("name")
+    if isinstance(raw_name, str) and raw_name.strip():
+        keys.add(raw_name.strip())
+    keys.update(_dashboard_plugin_yaml_names(plugin_dir))
+    return keys
+
+
+def _dashboard_plugin_is_enabled(
+    source: str,
+    lookup_keys: set[str],
+    enabled: Optional[set[str]],
+) -> bool:
+    """Dashboard discovery policy matching hermes_cli.plugins trust boundaries."""
+    if source == "bundled":
+        return True
+    return enabled is not None and bool(lookup_keys & enabled)
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -3565,6 +3633,7 @@ def _discover_dashboard_plugins() -> list:
     """
     plugins = []
     seen_names: set = set()
+    enabled_plugins, disabled_plugins = _dashboard_plugin_config_sets()
 
     from hermes_cli.plugins import get_bundled_plugins_dir
     bundled_root = get_bundled_plugins_dir()
@@ -3587,7 +3656,26 @@ def _discover_dashboard_plugins() -> list:
                 continue
             try:
                 data = json.loads(manifest_file.read_text(encoding="utf-8"))
-                name = data.get("name", child.name)
+                lookup_keys = _dashboard_plugin_lookup_keys(child, data)
+                if lookup_keys & disabled_plugins:
+                    _log.debug(
+                        "Skipping disabled dashboard plugin '%s'",
+                        child.name,
+                    )
+                    continue
+                if not _dashboard_plugin_is_enabled(source, lookup_keys, enabled_plugins):
+                    _log.debug(
+                        "Skipping dashboard plugin '%s' (not in plugins.enabled)",
+                        child.name,
+                    )
+                    continue
+
+                raw_name = data.get("name", child.name)
+                name = (
+                    raw_name.strip()
+                    if isinstance(raw_name, str) and raw_name.strip()
+                    else child.name
+                )
                 if name in seen_names:
                     continue
                 seen_names.add(name)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1830,11 +1830,28 @@ class TestDashboardPluginManifestExtensions:
     """Tests for the extended plugin manifest fields (tab.override,
     tab.hidden, slots) read by _discover_dashboard_plugins()."""
 
-    def _write_plugin(self, tmp_path, name, manifest):
+    def _write_plugin_config(self, tmp_path, *, enabled=None, disabled=None):
+        import yaml
+
+        cfg = {"plugins": {}}
+        if enabled is not None:
+            cfg["plugins"]["enabled"] = list(enabled)
+        if disabled is not None:
+            cfg["plugins"]["disabled"] = list(disabled)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    def _write_plugin(self, tmp_path, name, manifest, *, enabled=True, disabled=False):
         import json
         plug_dir = tmp_path / "plugins" / name / "dashboard"
         plug_dir.mkdir(parents=True)
         (plug_dir / "manifest.json").write_text(json.dumps(manifest))
+        enabled_names = [name] if enabled else []
+        disabled_names = [name] if disabled else []
+        self._write_plugin_config(
+            tmp_path,
+            enabled=enabled_names,
+            disabled=disabled_names,
+        )
         return plug_dir
 
     def test_override_and_hidden_carried_through(self, tmp_path, monkeypatch):
@@ -1938,6 +1955,48 @@ class TestDashboardPluginManifestExtensions:
             "cron:bottom",
             "chat:top",
         ]
+
+    def test_user_dashboard_plugin_requires_plugins_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "inactive-dashboard", {
+            "name": "inactive-dashboard",
+            "label": "Inactive",
+            "tab": {"path": "/inactive"},
+            "entry": "dist/index.js",
+        }, enabled=False)
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+
+        assert "inactive-dashboard" not in {p["name"] for p in plugins}
+
+    def test_disabled_dashboard_plugin_api_is_not_imported(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        marker = tmp_path / "api-imported.txt"
+        plug_dir = self._write_plugin(tmp_path, "disabled-dashboard-api", {
+            "name": "disabled-dashboard-api",
+            "label": "Disabled API",
+            "tab": {"path": "/disabled-api"},
+            "entry": "dist/index.js",
+            "api": "plugin_api.py",
+        }, enabled=True, disabled=True)
+        (plug_dir / "plugin_api.py").write_text(
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('executed')\n"
+            "from fastapi import APIRouter\n"
+            "router = APIRouter()\n",
+            encoding="utf-8",
+        )
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert "disabled-dashboard-api" not in {p["name"] for p in plugins}
+
+        web_server._mount_plugin_api_routes()
+
+        assert not marker.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -256,9 +256,9 @@ Adds a **Steam-style achievements tab to the dashboard** — 60+ collectible, ti
 - Warm rescan reuses per-session stats for every session whose `started_at` + `last_active` fingerprint matches the checkpoint — completes in seconds even on large histories.
 - The in-memory snapshot TTL is 120s; stale requests serve the old snapshot immediately and kick a background refresh. You never wait on a spinner just because TTL expired.
 
-**Enabling:** Nothing to enable — `hermes-achievements` is a dashboard-only plugin (no lifecycle hooks, no model-visible tools). It auto-registers as a tab in `hermes dashboard` on first launch. The `plugins.enabled` config only gates lifecycle/tool plugins; dashboard plugins are discovered purely via their `dashboard/manifest.json`.
+**Enabling:** Nothing to enable — `hermes-achievements` is a bundled dashboard-only plugin (no lifecycle hooks, no model-visible tools). Bundled dashboard plugins auto-register as tabs in `hermes dashboard` unless their name appears in `plugins.disabled`.
 
-**Opting out:** Delete or rename `plugins/hermes-achievements/dashboard/manifest.json`, or override it with a user plugin of the same name in `~/.hermes/plugins/hermes-achievements/` that ships no dashboard. The plugin's state files under `$HERMES_HOME/plugins/hermes-achievements/` survive — reinstalling preserves your unlock history.
+**Opting out:** Add `hermes-achievements` to `plugins.disabled`, delete or rename `plugins/hermes-achievements/dashboard/manifest.json`, or override it with a user plugin of the same name in `~/.hermes/plugins/hermes-achievements/` that ships no dashboard. The plugin's state files under `$HERMES_HOME/plugins/hermes-achievements/` survive — reinstalling preserves your unlock history.
 
 ## Adding a bundled plugin
 

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -340,7 +340,7 @@ Refresh the dashboard after creating the file. Switch themes live from the heade
 
 ## Plugins
 
-A dashboard plugin is a directory with a `manifest.json`, a pre-built JS bundle, and optionally a CSS file and a Python file with FastAPI routes. Plugins live next to other Hermes plugins in `~/.hermes/plugins/<name>/` — the dashboard extension is a `dashboard/` subfolder inside that plugin directory, so one plugin can extend both the CLI/gateway and the dashboard from a single install.
+A dashboard plugin is a directory with a `manifest.json`, a pre-built JS bundle, and optionally a CSS file and a Python file with FastAPI routes. Plugins live next to other Hermes plugins in `~/.hermes/plugins/<name>/` — the dashboard extension is a `dashboard/` subfolder inside that plugin directory, so one plugin can extend both the CLI/gateway and the dashboard from a single install. User and project dashboard plugins are opt-in: the plugin name must be listed in `plugins.enabled`, and `plugins.disabled` always wins.
 
 Plugins don't bundle React or UI components. They use the **Plugin SDK** exposed on `window.__HERMES_PLUGIN_SDK__`. This keeps plugin bundles tiny (typically a few KB) and avoids version conflicts.
 
@@ -397,7 +397,13 @@ Write the JS bundle (a plain IIFE — no build step needed):
 })();
 ```
 
-Refresh the dashboard — your tab appears in the nav bar, after **Skills**.
+Enable it, then refresh the dashboard:
+
+```bash
+hermes plugins enable my-plugin
+```
+
+Your tab appears in the nav bar, after **Skills**.
 
 :::tip Skip React.createElement
 If you prefer JSX, use any bundler (esbuild, Vite, rollup) with React as an external and IIFE output. The only hard requirement is that the final file is a single JS file loadable via `<script>`. React is never bundled; it comes from `SDK.React`.
@@ -793,6 +799,8 @@ The dashboard scans three directories for `dashboard/manifest.json`:
 | 3 | `./.hermes/plugins/<name>/dashboard/` | `project` — only when `HERMES_ENABLE_PROJECT_PLUGINS` is set |
 
 Discovery results are cached per dashboard process. After adding a new plugin, either:
+
+User and project plugins are only discovered after their directory name, `dashboard/manifest.json:name`, or `plugin.yaml:name` appears in `plugins.enabled`. Add the same name to `plugins.disabled` to prevent both the JavaScript bundle and any `dashboard/plugin_api.py` routes from loading.
 
 ```bash
 # Force a rescan without restart


### PR DESCRIPTION
## Summary

Gate dashboard plugin discovery and backend API mounting through the same config policy used by the general plugin loader.

- User and project dashboard plugins now require an explicit `plugins.enabled` entry.
- `plugins.disabled` wins before the dashboard exposes the manifest or imports `dashboard/plugin_api.py`.
- Bundled dashboard plugins remain enabled by default, but can be opted out with `plugins.disabled`.
- Dashboard plugin docs now describe the opt-in behavior for user/project plugins.

## Problem

The dashboard plugin path bypassed the general plugin manager. `hermes_cli.web_server` scanned `~/.hermes/plugins/<name>/dashboard/manifest.json` directly and mounted any declared backend API file during dashboard startup.

That meant an installed plugin could still affect the dashboard even when the user had not enabled it, or had explicitly disabled it:

- JavaScript bundles could still be surfaced through `/api/dashboard/plugins`.
- Python `plugin_api.py` files could still be imported, executing top-level plugin code in the dashboard process.

## Fix

Add a dashboard-specific config gate at discovery time:

- Read `plugins.enabled` and `plugins.disabled` once per discovery scan.
- Match dashboard plugins by directory name, `dashboard/manifest.json:name`, and optional `plugin.yaml` / `plugin.yml` name.
- Skip disabled plugins before adding them to the discovery result.
- Require `plugins.enabled` for user/project dashboard plugins.
- Keep bundled dashboard plugins available by default to preserve existing built-in dashboard tabs.

Because `_mount_plugin_api_routes()` only imports APIs from discovered dashboard plugins, this also prevents disabled plugin Python code from being imported.

## Compatibility

This changes behavior for user-installed and project dashboard plugins: dropping a `dashboard/manifest.json` into `~/.hermes/plugins/<name>/` is no longer enough. Users must also run:

```bash
hermes plugins enable <name>
```

Bundled dashboard plugins keep the previous default-on behavior unless listed in `plugins.disabled`.

## Validation

- `PYTHONPATH=. uv run --no-project --with pytest --with pyyaml --with fastapi --with 'uvicorn[standard]' --with httpx --with ptyprocess python -m pytest -o addopts= tests/hermes_cli/test_web_server.py -q` -> 139 passed
- `python3 -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check upstream/main HEAD`

## Platforms Tested

- macOS / darwin-arm64, local pytest run

## Related

No issue number; this came from a security review finding around disabled dashboard plugin execution.

Opened as draft because this is a security-relevant behavior change and should get maintainer review before merge.