### PR TITLE
fix(gateway): preserve full MessageEvent in active interrupt path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1066,7 +1066,10 @@ class GatewayRunner:
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
-        self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        # Legacy text-only fallback for interrupt follow-ups when no platform
+        # adapter queue is available. Prefer adapter._pending_messages so
+        # media metadata survives the next-turn handoff intact.
+        self._pending_messages: Dict[str, str] = {}
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
         # "next-turn" follow-ups where repeated sends collapse into one
@@ -5175,11 +5178,20 @@ class GatewayRunner:
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                merge_pending_message_event(
+                    adapter._pending_messages,
+                    _quick_key,
+                    event,
+                    merge_text=(event.message_type == MessageType.TEXT),
+                )
             running_agent.interrupt(event.text)
-            if _quick_key in self._pending_messages:
-                self._pending_messages[_quick_key] += "\n" + event.text
-            else:
-                self._pending_messages[_quick_key] = event.text
+            if not adapter:
+                if _quick_key in self._pending_messages:
+                    self._pending_messages[_quick_key] += "\n" + event.text
+                else:
+                    self._pending_messages[_quick_key] = event.text
             return None
 
         # Check for commands

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -159,6 +159,52 @@ class TestBusySessionAck:
         agent.interrupt.assert_called_once_with("Are you working?")
 
     @pytest.mark.asyncio
+    async def test_handle_message_interrupt_mode_preserves_voice_followup_event(self):
+        """Media-only interrupt follow-ups must keep their full MessageEvent."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        source = SessionSource(
+            platform=MagicMock(value="telegram"),
+            chat_id="123",
+            chat_type="private",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=source,
+            message_id="voice1",
+            media_urls=["/tmp/followup.ogg"],
+            media_types=["audio/ogg"],
+        )
+        sk = build_session_key(source)
+
+        running_agent = MagicMock()
+        running_agent.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 60,
+            "current_tool": "voice",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "voice",
+            "seconds_since_activity": 0.0,
+        }
+        runner._running_agents[sk] = running_agent
+        runner._running_agents_ts[sk] = time.time() - 5
+        runner.adapters[source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert adapter._pending_messages[sk] is event
+        assert adapter._pending_messages[sk].media_urls == ["/tmp/followup.ogg"]
+        assert sk not in runner._pending_messages
+        running_agent.interrupt.assert_called_once_with("")
+
+    @pytest.mark.asyncio
     async def test_queue_mode_suppresses_interrupt_and_updates_ack(self):
         """When busy_input_mode is 'queue', message is queued WITHOUT interrupt."""
         runner, sentinel = _make_runner()


### PR DESCRIPTION
## Summary

This fixes a gateway reliability bug in the active-session interrupt path.

When a user sent a follow-up message during an active run, the priority interrupt branch in `GatewayRunner._handle_message()` stored only `event.text` in the runner-local pending queue. That worked for plain text, but it dropped the full `MessageEvent` for media follow-ups such as voice, audio, or documents.

As a result, caption-less or media-only follow-ups could lose their attachment metadata before the next-turn drain, so the queued follow-up no longer re-entered the normal media/STT/document preprocessing path.

## What changed

- Queue the full follow-up `MessageEvent` into `adapter._pending_messages` in the priority interrupt path.
- Preserve existing text-merge behavior for text follow-ups.
- Keep the old runner-local text-only queue only as a fallback when no adapter is available.

## Why this is correct

The gateway already treats adapter-level pending queues as the canonical next-turn handoff for rich follow-ups. Other paths already preserve full events there; this patch aligns the priority interrupt branch with the same behavior instead of collapsing the follow-up into plain text.

That means media follow-ups now survive the interrupt boundary with their original metadata intact.

## Tests

Added a regression test covering an active-session interrupt with a media-only voice follow-up:

- `test_handle_message_interrupt_mode_preserves_voice_followup_event`

Verified with:

- `pytest tests/gateway/test_busy_session_ack.py -q`
- `pytest tests/gateway/test_queue_consumption.py -q`

## Risk

Low. This is a narrow change in one gateway branch and keeps the legacy text-only path only for the no-adapter fallback case.
