### PR TITLE
[codex] Fix Kanban retry runtime clock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1729,7 +1729,7 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+                   started_at    = ?
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -747,6 +747,79 @@ def test_enforce_max_runtime_integrates_with_dispatch(kanban_home, monkeypatch):
         conn.close()
 
 
+def test_claim_resets_task_started_at_after_unblock(kanban_home):
+    """A blocked task gets a fresh task-level runtime clock when retried."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="blocked then retried",
+            assignee="worker",
+            max_runtime_seconds=60,
+        )
+        kb.claim_task(conn, tid)
+        kb.block_task(conn, tid, reason="waiting for input")
+        assert kb.unblock_task(conn, tid) is True
+
+        stale_started_at = int(time.time()) - 3600
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET started_at = ? WHERE id = ?",
+                (stale_started_at, tid),
+            )
+
+        before_claim = int(time.time())
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.started_at is not None
+        assert claimed.started_at >= before_claim
+        assert claimed.started_at != stale_started_at
+    finally:
+        conn.close()
+
+
+def test_timeout_retry_uses_fresh_task_started_at(kanban_home):
+    """A timed-out task should not immediately time out again on retry."""
+    signals = []
+
+    def _signal_fn(pid, sig):
+        signals.append((pid, sig))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="timeout then retry",
+            assignee="worker",
+            max_runtime_seconds=60,
+        )
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 999_999)
+        stale_started_at = int(time.time()) - 3600
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET started_at = ? WHERE id = ?",
+                (stale_started_at, tid),
+            )
+
+        timed_out = kb.enforce_max_runtime(conn, signal_fn=_signal_fn)
+        assert timed_out == [tid]
+        assert kb.get_task(conn, tid).status == "ready"
+
+        before_retry = int(time.time())
+        retried = kb.claim_task(conn, tid)
+        assert retried is not None
+        assert retried.started_at is not None
+        assert retried.started_at >= before_retry
+        assert retried.started_at != stale_started_at
+        kb._set_worker_pid(conn, tid, 999_999)
+
+        assert kb.enforce_max_runtime(conn, signal_fn=_signal_fn) == []
+        assert kb.get_task(conn, tid).status == "running"
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Heartbeat (item 2 from the Multica audit)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Reset the task-level `started_at` timestamp on every Kanban claim.
- Add regressions for retry-after-unblock and retry-after-timeout behavior.

## Root Cause

`claim_task` preserved `tasks.started_at` with `COALESCE(started_at, ?)`, while max-runtime enforcement reads the task-level `started_at` value. When a blocked or timed-out task was retried, the retry could inherit an old runtime clock and immediately time out again.

## Impact

Retries now receive a fresh task runtime window when they are claimed again. Attempt history is still preserved in `task_runs`, but the active task record reflects the current attempt's runtime clock.

## Validation

- `/home/clockwork/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k 'claim_resets_task_started_at_after_unblock or timeout_retry_uses_fresh_task_started_at or enforce_max_runtime_integrates_with_dispatch'`
- `/home/clockwork/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py`

