### PR TITLE
Add credential pool introspection selection

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -817,6 +817,89 @@ class CredentialPool:
             return False
         return False
 
+    def select_for_introspection(self) -> Optional[PooledCredential]:
+        """Return a credential for account-level introspection endpoints.
+
+        ``select()`` intentionally filters out entries that are currently
+        exhausted for inference so the runtime does not keep retrying known
+        quota/rate-limit failures. Account/usage endpoints are different: a
+        caller may need the same OAuth token specifically to inspect the quota
+        state that made the credential exhausted in the first place.
+
+        This method therefore includes exhausted entries, while avoiding all
+        runtime-selection side effects: it does not rotate entries, acquire
+        leases, update ``_current_id``, increment usage counters, or clear an
+        exhausted status just because a reset window is still active. It may
+        still sync token state from provider auth stores and refresh expiring
+        OAuth access tokens so callers do not need to duplicate provider-specific
+        credential handling.
+        """
+        with self._lock:
+            current = self.current()
+            candidates: List[PooledCredential] = []
+            if current is not None:
+                candidates.append(current)
+            candidates.extend(
+                entry for entry in self._entries
+                if current is None or entry.id != current.id
+            )
+
+            for entry in candidates:
+                # Pick up tokens refreshed by another process before deciding
+                # whether this entry can be used for introspection. Unlike
+                # _available_entries(), do this regardless of exhaustion status:
+                # introspection callers frequently run when every inference
+                # credential is exhausted.
+                if self.provider == "anthropic" and entry.source == "claude_code":
+                    synced = self._sync_anthropic_entry_from_credentials_file(entry)
+                    if synced is not entry:
+                        entry = synced
+                elif self.provider == "nous" and entry.source == "device_code":
+                    synced = self._sync_nous_entry_from_auth_store(entry)
+                    if synced is not entry:
+                        entry = synced
+                elif self.provider == "openai-codex" and entry.source == "device_code":
+                    synced = self._sync_codex_entry_from_auth_store(entry)
+                    if synced is not entry:
+                        entry = synced
+
+                if not entry.access_token:
+                    continue
+
+                if self._entry_needs_refresh(entry):
+                    preserved_status = {
+                        "last_status": entry.last_status,
+                        "last_status_at": entry.last_status_at,
+                        "last_error_code": entry.last_error_code,
+                        "last_error_reason": entry.last_error_reason,
+                        "last_error_message": entry.last_error_message,
+                        "last_error_reset_at": entry.last_error_reset_at,
+                    }
+                    refreshed = self._refresh_entry(entry, force=False)
+                    if refreshed is None:
+                        if preserved_status["last_status"] == STATUS_EXHAUSTED:
+                            current_entry = next(
+                                (
+                                    candidate for candidate in self._entries
+                                    if candidate.id == entry.id
+                                ),
+                                entry,
+                            )
+                            restored = replace(current_entry, **preserved_status)
+                            self._replace_entry(current_entry, restored)
+                            self._persist()
+                        continue
+                    if preserved_status["last_status"] == STATUS_EXHAUSTED:
+                        restored = replace(refreshed, **preserved_status)
+                        self._replace_entry(refreshed, restored)
+                        self._persist()
+                        refreshed = restored
+                    entry = refreshed
+
+                return entry
+
+            return None
+
     def select(self) -> Optional[PooledCredential]:
         with self._lock:
             return self._select_unlocked()

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1568,3 +1568,108 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     # still skips it.
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
+
+
+def test_select_for_introspection_returns_exhausted_codex_entry(tmp_path, monkeypatch):
+    """Usage/quota probes must be able to read an exhausted Codex OAuth token.
+
+    ``select()`` should keep refusing the entry for inference, but account-level
+    introspection still needs the token to ask the provider when the limit resets.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+    from dataclasses import replace as dc_replace
+
+    _write_auth_store(tmp_path, _codex_auth_store("access-same", "refresh-same"))
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+
+    now = time.time()
+    exhausted = dc_replace(
+        entry,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=now,
+        last_error_code=429,
+        last_error_reason="rate_limit_exceeded",
+        last_error_message="quota reset later",
+        last_error_reset_at=now + 3600,
+    )
+    pool._replace_entry(entry, exhausted)
+    pool._persist()
+    pool._current_id = None
+
+    assert pool.select() is None
+    assert pool.current() is None
+
+    introspection_entry = pool.select_for_introspection()
+
+    assert introspection_entry is not None
+    assert introspection_entry.access_token == "access-same"
+    assert introspection_entry.last_status == STATUS_EXHAUSTED
+    assert introspection_entry.last_error_code == 429
+    assert pool.current() is None
+    assert pool.select() is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["last_status"] == STATUS_EXHAUSTED
+    assert persisted["last_error_code"] == 429
+
+
+def test_select_for_introspection_refreshes_expired_codex_token_without_clearing_exhaustion(
+    tmp_path,
+    monkeypatch,
+):
+    """Refreshing an expired access token must not imply quota recovery."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+    from dataclasses import replace as dc_replace
+
+    expired_access_token = "header.eyJleHAiOjB9.sig"
+    _write_auth_store(tmp_path, _codex_auth_store(expired_access_token, "refresh-OLD"))
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        lambda access_token, refresh_token: {
+            "access_token": "access-FRESH",
+            "refresh_token": "refresh-FRESH",
+            "last_refresh": "2026-05-04T00:00:00Z",
+        },
+    )
+
+    pool = load_pool("openai-codex")
+    entry = pool.entries()[0]
+    now = time.time()
+    exhausted = dc_replace(
+        entry,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=now,
+        last_error_code=429,
+        last_error_reason="rate_limit_exceeded",
+        last_error_message="quota reset later",
+        last_error_reset_at=now + 3600,
+    )
+    pool._replace_entry(entry, exhausted)
+    pool._persist()
+
+    introspection_entry = pool.select_for_introspection()
+
+    assert introspection_entry is not None
+    assert introspection_entry.access_token == "access-FRESH"
+    assert introspection_entry.refresh_token == "refresh-FRESH"
+    assert introspection_entry.last_status == STATUS_EXHAUSTED
+    assert introspection_entry.last_error_code == 429
+    assert pool.select() is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    provider_tokens = auth_payload["providers"]["openai-codex"]["tokens"]
+    assert provider_tokens["access_token"] == "access-FRESH"
+    assert provider_tokens["refresh_token"] == "refresh-FRESH"
+
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["access_token"] == "access-FRESH"
+    assert persisted["refresh_token"] == "refresh-FRESH"
+    assert persisted["last_status"] == STATUS_EXHAUSTED
+    assert persisted["last_error_code"] == 429


### PR DESCRIPTION
## Summary
- add `CredentialPool.select_for_introspection()` for account/usage endpoints that need a token even when inference credentials are exhausted
- keep inference selection semantics unchanged: exhausted entries remain unavailable to `select()` and are not rotated, leased, or marked recovered by introspection
- sync provider auth-store tokens and refresh expiring OAuth access tokens while preserving exhausted quota state

## Test plan
- `python -m pytest tests/agent/test_credential_pool.py -q`
- `python -m py_compile agent/credential_pool.py tests/agent/test_credential_pool.py`
