### PR TITLE
Fix Honcho auto-injection for shared gateway venues

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -165,6 +165,10 @@ _INTERNAL_CONTEXT_RE = re.compile(
     r'<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>',
     re.IGNORECASE,
 )
+_INTERNAL_TAGGED_BLOCK_RES = [
+    re.compile(r'<\s*prior_memory_file\s*>[\s\S]*?</\s*prior_memory_file\s*>', re.IGNORECASE),
+    re.compile(r'<\s*ai_identity_seed\s*>[\s\S]*?</\s*ai_identity_seed\s*>', re.IGNORECASE),
+]
 _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
@@ -174,6 +178,8 @@ _INTERNAL_NOTE_RE = re.compile(
 def sanitize_context(text: str) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
     text = _INTERNAL_CONTEXT_RE.sub('', text)
+    for pattern in _INTERNAL_TAGGED_BLOCK_RES:
+        text = pattern.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -234,6 +234,10 @@ _INTERNAL_CONTEXT_RE = re.compile(
     r'<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>',
     re.IGNORECASE,
 )
+_INTERNAL_TAGGED_BLOCK_RES = (
+    re.compile(r'<\s*prior_memory_file\s*>[\s\S]*?</\s*prior_memory_file\s*>', re.IGNORECASE),
+    re.compile(r'<\s*ai_identity_seed\s*>[\s\S]*?</\s*ai_identity_seed\s*>', re.IGNORECASE),
+)
 _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
@@ -243,6 +247,8 @@ _INTERNAL_NOTE_RE = re.compile(
 def sanitize_context(text: str) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
     text = _INTERNAL_CONTEXT_RE.sub('', text)
+    for pattern in _INTERNAL_TAGGED_BLOCK_RES:
+        text = pattern.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -294,6 +294,8 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Cron and flush contexts disable the plugin entirely.
         self._cron_skipped = False
+        self._chat_type: Optional[str] = None
+        self._thread_id: Optional[str] = None
 
     @property
     def name(self) -> str:
@@ -345,6 +347,8 @@ class HonchoMemoryProvider(MemoryProvider):
         try:
             agent_context = kwargs.get("agent_context", "")
             platform = kwargs.get("platform", "cli")
+            self._chat_type = kwargs.get("chat_type")
+            self._thread_id = kwargs.get("thread_id")
             if agent_context in {"cron", "flush"} or platform == "cron":
                 logger.debug("Honcho skipped: cron/flush context (agent_context=%s, platform=%s)",
                              agent_context, platform)
@@ -508,7 +512,10 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Query-aware base retrieval starts with the first substantive message.
         # Generic dialectic prewarm is incompatible with latest-message rewriting.
-        if self._recall_mode in {"context", "hybrid"}:
+        if (
+            self._recall_mode in {"context", "hybrid"}
+            and self._allow_dialectic_auto_injection()
+        ):
             if self._query_rewriter is None or not self._query_rewrite_enabled:
                 _prewarm_query = (
                     "Summarize what you know about this user. "
@@ -593,6 +600,26 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._session_initialized:
             return True
         return not (self._init_thread and self._init_thread.is_alive())
+
+    def _summary_only_auto_injection(self) -> bool:
+        """Limit automatic context to the session summary in shared venues."""
+        chat_type = (self._chat_type or "").lower()
+        if chat_type in {"dm", "direct", "direct_message", "private"}:
+            return False
+        return bool(self._thread_id) or chat_type in {
+            "group", "supergroup", "channel", "guild", "forum", "public",
+        }
+
+    def _allow_dialectic_auto_injection(self) -> bool:
+        """Keep peer-global dialectic recall out of shared venue prompts."""
+        return not self._summary_only_auto_injection()
+
+    def _filter_auto_injection_context(self, context: dict) -> dict:
+        """Defend against rich context already present in a prefetch cache."""
+        if not context or not self._summary_only_auto_injection():
+            return context
+        summary = context.get("summary", "")
+        return {"summary": summary} if summary else {}
 
     def _format_first_turn_context(self, ctx: dict) -> str:
         """Format the prefetch context dict into a readable system prompt block."""
@@ -732,7 +759,9 @@ class HonchoMemoryProvider(MemoryProvider):
                 def _fetch_base() -> None:
                     try:
                         ctx = self._manager.get_prefetch_context(
-                            self._session_key, query or None
+                            self._session_key,
+                            query or None,
+                            summary_only=self._summary_only_auto_injection(),
                         ) or {}
                         _ctx_holder["ctx"] = ctx
                         if ctx:
@@ -753,7 +782,9 @@ class HonchoMemoryProvider(MemoryProvider):
                 _ctx = _ctx_holder.get("ctx")
                 if _ctx:
                     self._manager.pop_context_result(self._session_key)
-                    formatted = self._format_first_turn_context(_ctx)
+                    formatted = self._format_first_turn_context(
+                        self._filter_auto_injection_context(_ctx)
+                    )
                     if formatted:
                         with self._base_context_lock:
                             self._base_context_cache = formatted
@@ -768,7 +799,9 @@ class HonchoMemoryProvider(MemoryProvider):
             if not _first_base_fetch and self._manager:
                 fresh_ctx = self._manager.pop_context_result(self._session_key)
                 if fresh_ctx:
-                    formatted = self._format_first_turn_context(fresh_ctx)
+                    formatted = self._format_first_turn_context(
+                        self._filter_auto_injection_context(fresh_ctx)
+                    )
                     if formatted:
                         with self._base_context_lock:
                             self._base_context_cache = formatted
@@ -784,7 +817,11 @@ class HonchoMemoryProvider(MemoryProvider):
         if _prewarm_landed and self._last_dialectic_turn == -999:
             self._last_dialectic_turn = self._turn_count
 
-        if self._last_dialectic_turn == -999 and query:
+        if (
+            self._allow_dialectic_auto_injection()
+            and self._last_dialectic_turn == -999
+            and query
+        ):
             # Reuse an in-flight prewarm; otherwise start one dialectic. A short
             # request timeout may tighten, but never expand, the turn-1 wait.
             _dia_wait = self._FIRST_TURN_DIALECTIC_CAP
@@ -833,7 +870,11 @@ class HonchoMemoryProvider(MemoryProvider):
         # Consume only results that are already ready; later turns never wait.
         dialectic_result = self._consume_pending_dialectic()
 
-        if dialectic_result and dialectic_result.strip():
+        if (
+            self._allow_dialectic_auto_injection()
+            and dialectic_result
+            and dialectic_result.strip()
+        ):
             parts.append(dialectic_result)
 
         if not parts:
@@ -908,9 +949,17 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._injection_frequency != "first-turn" and context_due:
             self._last_context_turn = self._turn_count
             try:
-                self._manager.prefetch_context(self._session_key, query)
+                self._manager.prefetch_context(
+                    self._session_key,
+                    query,
+                    summary_only=self._summary_only_auto_injection(),
+                )
             except Exception as e:
                 logger.debug("Honcho context prefetch failed: %s", e)
+
+        # Peer-global dialectic recall is never prewarmed into shared venues.
+        if not self._allow_dialectic_auto_injection():
+            return
 
         # ----- Dialectic prefetch (supplement layer) -----
         # Thread-alive guard with stale-thread recovery: a hung Honcho call

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -323,6 +323,8 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Cron and flush contexts disable the plugin entirely.
         self._cron_skipped = False
+        self._chat_type: Optional[str] = None
+        self._thread_id: Optional[str] = None
 
     @property
     def name(self) -> str:
@@ -374,6 +376,8 @@ class HonchoMemoryProvider(MemoryProvider):
         try:
             agent_context = kwargs.get("agent_context", "")
             platform = kwargs.get("platform", "cli")
+            self._chat_type = kwargs.get("chat_type")
+            self._thread_id = kwargs.get("thread_id")
             if agent_context in {"cron", "flush"} or platform == "cron":
                 logger.debug("Honcho skipped: cron/flush context (agent_context=%s, platform=%s)",
                              agent_context, platform)
@@ -544,7 +548,10 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Query-aware base retrieval starts with the first substantive message.
         # Generic dialectic prewarm is incompatible with latest-message rewriting.
-        if self._recall_mode in {"context", "hybrid"}:
+        if (
+            self._recall_mode in {"context", "hybrid"}
+            and self._allow_dialectic_auto_injection()
+        ):
             if self._query_rewriter is None or not self._query_rewrite_enabled:
                 _prewarm_query = (
                     "Summarize what you know about this user. "
@@ -646,6 +653,26 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._session_initialized:
             return True
         return not (self._init_thread and self._init_thread.is_alive())
+
+    def _summary_only_auto_injection(self) -> bool:
+        """Restrict automatic recall to the session summary in shared venues."""
+        chat_type = (self._chat_type or "").lower()
+        if chat_type in {"dm", "direct", "direct_message", "private"}:
+            return False
+        return bool(self._thread_id) or chat_type in {
+            "group", "supergroup", "channel", "guild", "forum", "public",
+        }
+
+    def _allow_dialectic_auto_injection(self) -> bool:
+        """Never inject peer-global dialectic memory into shared venues."""
+        return not self._summary_only_auto_injection()
+
+    def _filter_auto_injection_context(self, context: dict) -> dict:
+        """Filter stale rich prefetch-cache entries before prompt formatting."""
+        if not context or not self._summary_only_auto_injection():
+            return context
+        summary = context.get("summary", "")
+        return {"summary": summary} if summary else {}
 
     def _format_first_turn_context(self, ctx: dict) -> str:
         """Format the prefetch context dict into a readable system prompt block."""
@@ -791,7 +818,9 @@ class HonchoMemoryProvider(MemoryProvider):
                 def _fetch_base() -> None:
                     try:
                         ctx = self._manager.get_prefetch_context(
-                            self._session_key, query or None
+                            self._session_key,
+                            query or None,
+                            summary_only=self._summary_only_auto_injection(),
                         ) or {}
                         _ctx_holder["ctx"] = ctx
                         if ctx:
@@ -810,7 +839,9 @@ class HonchoMemoryProvider(MemoryProvider):
                 _ctx = _ctx_holder.get("ctx")
                 if _ctx:
                     self._manager.pop_context_result(self._session_key)
-                    formatted = self._format_first_turn_context(_ctx)
+                    formatted = self._format_first_turn_context(
+                        self._filter_auto_injection_context(_ctx)
+                    )
                     if formatted:
                         with self._base_context_lock:
                             self._base_context_cache = formatted
@@ -825,7 +856,9 @@ class HonchoMemoryProvider(MemoryProvider):
             if not _first_base_fetch and self._manager:
                 fresh_ctx = self._manager.pop_context_result(self._session_key)
                 if fresh_ctx:
-                    formatted = self._format_first_turn_context(fresh_ctx)
+                    formatted = self._format_first_turn_context(
+                        self._filter_auto_injection_context(fresh_ctx)
+                    )
                     if formatted:
                         with self._base_context_lock:
                             self._base_context_cache = formatted
@@ -841,7 +874,11 @@ class HonchoMemoryProvider(MemoryProvider):
         if _prewarm_landed and self._last_dialectic_turn == -999:
             self._last_dialectic_turn = self._turn_count
 
-        if self._last_dialectic_turn == -999 and query:
+        if (
+            self._allow_dialectic_auto_injection()
+            and self._last_dialectic_turn == -999
+            and query
+        ):
             # Reuse an in-flight prewarm; otherwise start one dialectic. A short
             # request timeout may tighten, but never expand, the turn-1 wait.
             _dia_wait = self._FIRST_TURN_DIALECTIC_CAP
@@ -890,7 +927,11 @@ class HonchoMemoryProvider(MemoryProvider):
         # Consume only results that are already ready; later turns never wait.
         dialectic_result = self._consume_pending_dialectic()
 
-        if dialectic_result and dialectic_result.strip():
+        if (
+            self._allow_dialectic_auto_injection()
+            and dialectic_result
+            and dialectic_result.strip()
+        ):
             parts.append(dialectic_result)
 
         if not parts:
@@ -985,9 +1026,16 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._injection_frequency != "first-turn" and context_due:
             self._last_context_turn = self._turn_count
             try:
-                self._manager.prefetch_context(self._session_key, query)
+                self._manager.prefetch_context(
+                    self._session_key,
+                    query,
+                    summary_only=self._summary_only_auto_injection(),
+                )
             except Exception as e:
                 logger.debug("Honcho context prefetch failed: %s", e)
+
+        if not self._allow_dialectic_auto_injection():
+            return
 
         # ----- Dialectic prefetch (supplement layer) -----
         # Thread-alive guard with stale-thread recovery: a hung Honcho call

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -68,6 +68,21 @@ class HonchoSession:
         self.updated_at = datetime.now()
 
 
+def _observation_metadata(
+    *,
+    user_observe_me: bool,
+    user_observe_others: bool,
+    ai_observe_me: bool,
+    ai_observe_others: bool,
+) -> dict[str, bool]:
+    return {
+        "user_observe_me": bool(user_observe_me),
+        "user_observe_others": bool(user_observe_others),
+        "ai_observe_me": bool(ai_observe_me),
+        "ai_observe_others": bool(ai_observe_others),
+    }
+
+
 class HonchoSessionManager:
     """
     Manages conversation sessions using Honcho.
@@ -151,6 +166,21 @@ class HonchoSessionManager:
         if write_frequency == "async":
             self._async_queue = queue.Queue()
 
+    def _default_observation_metadata(self) -> dict[str, bool]:
+        return _observation_metadata(
+            user_observe_me=self._user_observe_me,
+            user_observe_others=self._user_observe_others,
+            ai_observe_me=self._ai_observe_me,
+            ai_observe_others=self._ai_observe_others,
+        )
+
+    def _session_observation_metadata(self, session: HonchoSession | None) -> dict[str, bool]:
+        if session and session.metadata:
+            metadata = self._default_observation_metadata()
+            metadata.update({key: bool(value) for key, value in session.metadata.items() if key in metadata})
+            return metadata
+        return self._default_observation_metadata()
+
     @property
     def honcho(self) -> Honcho:
         """Get the Honcho client, refreshing a near-expiry OAuth token in place.
@@ -179,22 +209,23 @@ class HonchoSessionManager:
 
     def _get_or_create_honcho_session(
         self, session_id: str, user_peer: Any, assistant_peer: Any
-    ) -> tuple[Any, list]:
+    ) -> tuple[Any, list, dict[str, bool]]:
         """
         Get or create a Honcho session with peers configured.
 
         Returns:
-            Tuple of (honcho_session, existing_messages).
+            Tuple of (honcho_session, existing_messages, effective observation metadata).
         """
         with self._cache_lock:
             if session_id in self._sessions_cache:
                 logger.debug("Honcho session '%s' retrieved from cache", session_id)
-                return self._sessions_cache[session_id], []
+                return self._sessions_cache[session_id], [], self._default_observation_metadata()
 
         session = self.honcho.session(session_id)
 
         # Configure per-peer observation from granular booleans.
         # These map 1:1 to Honcho's SessionPeerConfig toggles.
+        effective_observation = self._default_observation_metadata()
         try:
             from honcho.session import SessionPeerConfig
             user_config = SessionPeerConfig(
@@ -208,25 +239,21 @@ class HonchoSessionManager:
 
             session.add_peers([(user_peer, user_config), (assistant_peer, ai_config)])
 
-            # Sync back: server-side config (set via Honcho UI) wins over
-            # local defaults. Read the effective config after add_peers.
-            # Note: observation booleans are manager-scoped, not per-session.
-            # Last session init wins. Fine for CLI; gateway should scope per-session.
+            # Server configuration is effective only for this session. Do not
+            # overwrite manager defaults: a gateway manager can hold many sessions.
             try:
                 server_user = session.get_peer_configuration(user_peer)
                 server_ai = session.get_peer_configuration(assistant_peer)
-                if server_user.observe_me is not None:
-                    self._user_observe_me = server_user.observe_me
-                if server_user.observe_others is not None:
-                    self._user_observe_others = server_user.observe_others
-                if server_ai.observe_me is not None:
-                    self._ai_observe_me = server_ai.observe_me
-                if server_ai.observe_others is not None:
-                    self._ai_observe_others = server_ai.observe_others
+                effective_observation = _observation_metadata(
+                    user_observe_me=(server_user.observe_me if server_user.observe_me is not None else self._user_observe_me),
+                    user_observe_others=(server_user.observe_others if server_user.observe_others is not None else self._user_observe_others),
+                    ai_observe_me=(server_ai.observe_me if server_ai.observe_me is not None else self._ai_observe_me),
+                    ai_observe_others=(server_ai.observe_others if server_ai.observe_others is not None else self._ai_observe_others),
+                )
                 logger.debug(
                     "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
-                    self._user_observe_me, self._user_observe_others,
-                    self._ai_observe_me, self._ai_observe_others,
+                    effective_observation["user_observe_me"], effective_observation["user_observe_others"],
+                    effective_observation["ai_observe_me"], effective_observation["ai_observe_others"],
                 )
             except Exception as e:
                 logger.debug("Honcho get_peer_configuration failed (using local config): %s", e)
@@ -269,7 +296,7 @@ class HonchoSessionManager:
             )
 
         self._sessions_cache[session_id] = session
-        return session, existing_messages
+        return session, existing_messages, effective_observation
 
     def _sanitize_id(self, id_str: str) -> str:
         """Sanitize an ID to match Honcho's pattern: ^[a-zA-Z0-9_-]+"""
@@ -391,7 +418,7 @@ class HonchoSessionManager:
         honcho_session_id = self._sanitize_id(key)
         user_peer = self._get_or_create_peer(user_peer_id)
         assistant_peer = self._get_or_create_peer(assistant_peer_id)
-        honcho_session, existing_messages = self._get_or_create_honcho_session(
+        honcho_session, existing_messages, effective_observation = self._get_or_create_honcho_session(
             honcho_session_id, user_peer, assistant_peer
         )
 
@@ -411,6 +438,7 @@ class HonchoSessionManager:
             assistant_peer_id=assistant_peer_id,
             honcho_session_id=honcho_session_id,
             messages=local_messages,
+            metadata=effective_observation,
         )
 
         # Write to cache under lock — only one writer wins
@@ -428,7 +456,7 @@ class HonchoSessionManager:
         honcho_session = self._sessions_cache.get(session.honcho_session_id)
 
         if not honcho_session:
-            honcho_session, _ = self._get_or_create_honcho_session(
+            honcho_session, _, _ = self._get_or_create_honcho_session(
                 session.honcho_session_id, user_peer, assistant_peer
             )
 
@@ -657,7 +685,7 @@ class HonchoSessionManager:
             level = self._default_reasoning_level()
 
         try:
-            if self._ai_observe_others:
+            if self._session_observation_metadata(session)["ai_observe_others"]:
                 # AI peer can observe other peers — use assistant as observer.
                 ai_peer_obj = self._get_or_create_peer(session.assistant_peer_id)
                 if target_peer_id == session.assistant_peer_id:
@@ -686,7 +714,13 @@ class HonchoSessionManager:
             logger.warning("Honcho dialectic query failed: %s", e)
             return ""
 
-    def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:
+    def prefetch_context(
+        self,
+        session_key: str,
+        user_message: str | None = None,
+        *,
+        summary_only: bool = False,
+    ) -> None:
         """
         Fire get_prefetch_context in a background thread, caching the result.
 
@@ -694,7 +728,11 @@ class HonchoSessionManager:
         a synchronous HTTP round-trip blocking every response.
         """
         def _run():
-            result = self.get_prefetch_context(session_key, user_message)
+            result = self.get_prefetch_context(
+                session_key,
+                user_message,
+                summary_only=summary_only,
+            )
             if result:
                 self.set_context_result(session_key, result)
 
@@ -717,7 +755,13 @@ class HonchoSessionManager:
         with self._prefetch_cache_lock:
             return self._context_cache.pop(session_key, {})
 
-    def get_prefetch_context(self, session_key: str, user_message: str | None = None) -> dict[str, str]:
+    def get_prefetch_context(
+        self,
+        session_key: str,
+        user_message: str | None = None,
+        *,
+        summary_only: bool = False,
+    ) -> dict[str, str]:
         """
         Pre-fetch user and AI peer context from Honcho.
 
@@ -754,6 +798,9 @@ class HonchoSessionManager:
                     result["summary"] = ctx.summary.content
         except Exception as e:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
+
+        if summary_only:
+            return result
 
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, "user")
@@ -1095,7 +1142,7 @@ class HonchoSessionManager:
         if target_peer_id == session.assistant_peer_id:
             return session.assistant_peer_id, session.assistant_peer_id
 
-        if self._ai_observe_others:
+        if self._session_observation_metadata(session)["ai_observe_others"]:
             return session.assistant_peer_id, target_peer_id
 
         return target_peer_id, None
@@ -1226,7 +1273,7 @@ class HonchoSessionManager:
         if target_peer_id == session.assistant_peer_id:
             observer = self._get_or_create_peer(session.assistant_peer_id)
             return observer.conclusions_of(session.assistant_peer_id)
-        elif self._ai_observe_others:
+        elif self._session_observation_metadata(session)["ai_observe_others"]:
             observer = self._get_or_create_peer(session.assistant_peer_id)
             return observer.conclusions_of(target_peer_id)
         else:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -115,6 +115,21 @@ class HonchoSession:
         self.updated_at = datetime.now()
 
 
+def _observation_metadata(
+    *,
+    user_observe_me: bool,
+    user_observe_others: bool,
+    ai_observe_me: bool,
+    ai_observe_others: bool,
+) -> dict[str, bool]:
+    return {
+        "user_observe_me": bool(user_observe_me),
+        "user_observe_others": bool(user_observe_others),
+        "ai_observe_me": bool(ai_observe_me),
+        "ai_observe_others": bool(ai_observe_others),
+    }
+
+
 class HonchoSessionManager:
     """
     Manages conversation sessions using Honcho.
@@ -205,6 +220,20 @@ class HonchoSessionManager:
         self._async_thread_lock = threading.Lock()
         if write_frequency == "async":
             self._async_queue = queue.Queue()
+
+    def _default_observation_metadata(self) -> dict[str, bool]:
+        return _observation_metadata(
+            user_observe_me=self._user_observe_me,
+            user_observe_others=self._user_observe_others,
+            ai_observe_me=self._ai_observe_me,
+            ai_observe_others=self._ai_observe_others,
+        )
+
+    def _session_observation_metadata(self, session: HonchoSession | None) -> dict[str, bool]:
+        metadata = self._default_observation_metadata()
+        if session and session.metadata:
+            metadata.update({key: bool(value) for key, value in session.metadata.items() if key in metadata})
+        return metadata
 
     @property
     def honcho(self) -> Honcho:
@@ -370,23 +399,24 @@ class HonchoSessionManager:
 
     def _get_or_create_honcho_session(
         self, session_id: str, user_peer: Any, assistant_peer: Any
-    ) -> tuple[Any, list]:
+    ) -> tuple[Any, list, dict[str, bool]]:
         """
         Get or create a Honcho session with peers configured.
 
         Returns:
-            Tuple of (honcho_session, existing_messages).
+            Tuple of (honcho_session, existing_messages, effective observation metadata).
         """
         with self._cache_lock:
             if session_id in self._sessions_cache:
                 logger.debug("Honcho session '%s' retrieved from cache", session_id)
-                return self._sessions_cache[session_id], []
+                return self._sessions_cache[session_id], [], self._default_observation_metadata()
 
         self._authed_call("session setup", lambda: self._sdk_session(session_id))
 
         # Configure per-peer observation from granular booleans.
         # These map 1:1 to Honcho's SessionPeerConfig toggles.
         auth_dead = False
+        effective_observation = self._default_observation_metadata()
         try:
             from honcho.session import SessionPeerConfig
             user_config = SessionPeerConfig(
@@ -404,10 +434,8 @@ class HonchoSessionManager:
                 lambda: self._sdk_session(session_id).add_peers(peer_entries),
             )
 
-            # Sync back: server-side config (set via Honcho UI) wins over
-            # local defaults. Read the effective config after add_peers.
-            # Note: observation booleans are manager-scoped, not per-session.
-            # Last session init wins. Fine for CLI; gateway should scope per-session.
+            # Server-side config wins for this session only. A shared gateway
+            # manager may serve many sessions, so never mutate its defaults.
             try:
                 def _read_server_configs() -> tuple[Any, Any]:
                     sdk_session = self._sdk_session(session_id)
@@ -419,18 +447,16 @@ class HonchoSessionManager:
                 server_user, server_ai = self._authed_call(
                     "peer configuration read", _read_server_configs
                 )
-                if server_user.observe_me is not None:
-                    self._user_observe_me = server_user.observe_me
-                if server_user.observe_others is not None:
-                    self._user_observe_others = server_user.observe_others
-                if server_ai.observe_me is not None:
-                    self._ai_observe_me = server_ai.observe_me
-                if server_ai.observe_others is not None:
-                    self._ai_observe_others = server_ai.observe_others
+                effective_observation = _observation_metadata(
+                    user_observe_me=(server_user.observe_me if server_user.observe_me is not None else self._user_observe_me),
+                    user_observe_others=(server_user.observe_others if server_user.observe_others is not None else self._user_observe_others),
+                    ai_observe_me=(server_ai.observe_me if server_ai.observe_me is not None else self._ai_observe_me),
+                    ai_observe_others=(server_ai.observe_others if server_ai.observe_others is not None else self._ai_observe_others),
+                )
                 logger.debug(
                     "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
-                    self._user_observe_me, self._user_observe_others,
-                    self._ai_observe_me, self._ai_observe_others,
+                    effective_observation["user_observe_me"], effective_observation["user_observe_others"],
+                    effective_observation["ai_observe_me"], effective_observation["ai_observe_others"],
                 )
             except HonchoAuthError:
                 raise
@@ -495,7 +521,7 @@ class HonchoSessionManager:
             honcho_session = self._authed_call(
                 "session setup", lambda: self._sdk_session(session_id)
             )
-        return honcho_session, existing_messages
+        return honcho_session, existing_messages, effective_observation
 
     def _sanitize_id(self, id_str: str) -> str:
         """Sanitize an ID to match Honcho's pattern: ^[a-zA-Z0-9_-]+"""
@@ -630,7 +656,7 @@ class HonchoSessionManager:
         honcho_session_id = self._sanitize_id(key)
         user_peer = self._get_or_create_peer(user_peer_id)
         assistant_peer = self._get_or_create_peer(assistant_peer_id)
-        honcho_session, existing_messages = self._get_or_create_honcho_session(
+        honcho_session, existing_messages, effective_observation = self._get_or_create_honcho_session(
             honcho_session_id, user_peer, assistant_peer
         )
 
@@ -650,6 +676,7 @@ class HonchoSessionManager:
             assistant_peer_id=assistant_peer_id,
             honcho_session_id=honcho_session_id,
             messages=local_messages,
+            metadata=effective_observation,
         )
 
         # Write to cache under lock — only one writer wins
@@ -672,7 +699,7 @@ class HonchoSessionManager:
             assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
             honcho_session = self._sessions_cache.get(session.honcho_session_id)
             if honcho_session is None:
-                honcho_session, _ = self._get_or_create_honcho_session(
+                honcho_session, _, _ = self._get_or_create_honcho_session(
                     session.honcho_session_id, user_peer, assistant_peer
                 )
             honcho_messages = [
@@ -919,7 +946,7 @@ class HonchoSessionManager:
             level = self._default_reasoning_level()
 
         def _chat_once() -> str:
-            if self._ai_observe_others:
+            if self._session_observation_metadata(session)["ai_observe_others"]:
                 # AI peer can observe other peers — use assistant as observer.
                 ai_peer_obj = self._get_or_create_peer(session.assistant_peer_id)
                 if target_peer_id == session.assistant_peer_id:
@@ -952,7 +979,13 @@ class HonchoSessionManager:
                 raise
             return ""
 
-    def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:
+    def prefetch_context(
+        self,
+        session_key: str,
+        user_message: str | None = None,
+        *,
+        summary_only: bool = False,
+    ) -> None:
         """
         Fire get_prefetch_context in a background thread, caching the result.
 
@@ -960,7 +993,11 @@ class HonchoSessionManager:
         a synchronous HTTP round-trip blocking every response.
         """
         def _run():
-            result = self.get_prefetch_context(session_key, user_message)
+            result = self.get_prefetch_context(
+                session_key,
+                user_message,
+                summary_only=summary_only,
+            )
             if result:
                 self.set_context_result(session_key, result)
 
@@ -983,7 +1020,13 @@ class HonchoSessionManager:
         with self._prefetch_cache_lock:
             return self._context_cache.pop(session_key, {})
 
-    def get_prefetch_context(self, session_key: str, user_message: str | None = None) -> dict[str, str]:
+    def get_prefetch_context(
+        self,
+        session_key: str,
+        user_message: str | None = None,
+        *,
+        summary_only: bool = False,
+    ) -> dict[str, str]:
         """
         Pre-fetch user and AI peer context from Honcho.
 
@@ -1025,6 +1068,9 @@ class HonchoSessionManager:
             return result
         except Exception as e:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
+
+        if summary_only:
+            return result
 
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, "user")
@@ -1429,7 +1475,7 @@ class HonchoSessionManager:
         if target_peer_id == session.assistant_peer_id:
             return session.assistant_peer_id, session.assistant_peer_id
 
-        if self._ai_observe_others:
+        if self._session_observation_metadata(session)["ai_observe_others"]:
             return session.assistant_peer_id, target_peer_id
 
         return target_peer_id, None
@@ -1574,7 +1620,7 @@ class HonchoSessionManager:
         if target_peer_id == session.assistant_peer_id:
             observer = self._get_or_create_peer(session.assistant_peer_id)
             return observer.conclusions_of(session.assistant_peer_id)
-        elif self._ai_observe_others:
+        elif self._session_observation_metadata(session)["ai_observe_others"]:
             observer = self._get_or_create_peer(session.assistant_peer_id)
             return observer.conclusions_of(target_peer_id)
         else:

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -222,7 +222,7 @@ class TestHonchoUserIdScoping:
         with patch.object(manager, "_get_or_create_peer", return_value=MagicMock()), patch.object(
             manager,
             "_get_or_create_honcho_session",
-            return_value=(MagicMock(), []),
+            return_value=(MagicMock(), [], {}),
         ):
             session = manager.get_or_create("discord:channel-1")
 

--- a/tests/agent/test_streaming_context_scrubber.py
+++ b/tests/agent/test_streaming_context_scrubber.py
@@ -182,3 +182,23 @@ class TestBuildMemoryContextBlockWarnsOnViolation:
 
         assert not any("pre-wrapped" in rec.message for rec in caplog.records)
         assert "plain fact about user" in out
+
+
+class TestSanitizeContextInternalTaggedBlocks:
+    def test_strips_non_user_visible_internal_blocks(self):
+        leaked = (
+            "Visible before\n"
+            "<prior_memory_file><context>hidden</context></prior_memory_file>\n"
+            "Visible middle\n"
+            "<ai_identity_seed>also hidden</ai_identity_seed>\n"
+            "Visible after"
+        )
+
+        out = sanitize_context(leaked)
+
+        assert "prior_memory_file" not in out
+        assert "ai_identity_seed" not in out
+        assert "hidden" not in out
+        assert "Visible before" in out
+        assert "Visible middle" in out
+        assert "Visible after" in out

--- a/tests/agent/test_streaming_context_scrubber.py
+++ b/tests/agent/test_streaming_context_scrubber.py
@@ -122,6 +122,24 @@ class TestSanitizeContextUnchanged:
         out = sanitize_context(leaked).strip()
         assert out == "Visible"
 
+    def test_internal_tagged_blocks_are_never_visible(self):
+        leaked = (
+            "Visible before\n"
+            "<prior_memory_file><context>hidden</context></prior_memory_file>\n"
+            "Visible middle\n"
+            "<ai_identity_seed>also hidden</ai_identity_seed>\n"
+            "Visible after"
+        )
+
+        out = sanitize_context(leaked)
+
+        assert "prior_memory_file" not in out
+        assert "ai_identity_seed" not in out
+        assert "hidden" not in out
+        assert "Visible before" in out
+        assert "Visible middle" in out
+        assert "Visible after" in out
+
 
 class TestStreamingContextScrubberCrossTurn:
     """A scrubber instance is reused across turns (per agent).  reset() must

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -108,7 +108,7 @@ def _patch_manager_for_resolution_test(mgr: HonchoSessionManager) -> None:
     fake_peer = MagicMock()
     mgr._get_or_create_peer = MagicMock(return_value=fake_peer)
     mgr._get_or_create_honcho_session = MagicMock(
-        return_value=(MagicMock(), [])
+        return_value=(MagicMock(), [], {})
     )
 
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -80,6 +80,79 @@ class TestSanitizeId:
         assert "!" not in result
 
 
+class TestSharedVenueContextIsolation:
+    def test_shared_venue_auto_injection_keeps_only_its_session_summary(self):
+        provider = HonchoMemoryProvider()
+        provider._chat_type = "group"
+        provider._thread_id = "999"
+
+        result = provider._filter_auto_injection_context({
+            "summary": "Thread summary",
+            "representation": "User representation",
+            "card": "Name: Guy",
+            "ai_representation": "AI representation",
+            "ai_card": "Role: Assistant",
+        })
+
+        assert result == {"summary": "Thread summary"}
+
+    def test_direct_message_keeps_full_auto_injection_context(self):
+        provider = HonchoMemoryProvider()
+        provider._chat_type = "dm"
+        provider._thread_id = None
+        context = {"summary": "Session summary", "representation": "User representation"}
+
+        assert provider._filter_auto_injection_context(context) == context
+
+    def test_shared_venue_disables_dialectic_auto_injection(self):
+        provider = HonchoMemoryProvider()
+        provider._chat_type = "group"
+        provider._thread_id = "999"
+
+        assert provider._allow_dialectic_auto_injection() is False
+
+
+class TestSummaryOnlyPrefetch:
+    def test_summary_only_does_not_fetch_peer_profiles(self):
+        mgr = HonchoSessionManager()
+        session = HonchoSession(
+            key="discord:thread-123",
+            user_peer_id="user-discord-thread-123",
+            assistant_peer_id="hermes-assistant",
+            honcho_session_id="discord-thread-123",
+        )
+        mgr._cache[session.key] = session
+        honcho_session = MagicMock()
+        honcho_session.context.return_value = SimpleNamespace(
+            summary=SimpleNamespace(content="Thread-only summary"),
+        )
+        mgr._sessions_cache[session.honcho_session_id] = honcho_session
+        mgr._fetch_peer_context = MagicMock()
+
+        result = mgr.get_prefetch_context(session.key, summary_only=True)
+
+        assert result == {"summary": "Thread-only summary"}
+        mgr._fetch_peer_context.assert_not_called()
+
+
+class TestPerSessionObservationScoping:
+    def test_session_metadata_overrides_manager_default_for_observer_resolution(self):
+        mgr = HonchoSessionManager()
+        mgr._ai_observe_others = False
+        session = HonchoSession(
+            key="discord:thread-123",
+            user_peer_id="user-discord-thread-123",
+            assistant_peer_id="hermes-assistant",
+            honcho_session_id="discord-thread-123",
+            metadata={"ai_observe_others": True},
+        )
+
+        observer, target = mgr._resolve_observer_target(session, "user")
+
+        assert observer == session.assistant_peer_id
+        assert target == session.user_peer_id
+
+
 # ---------------------------------------------------------------------------
 # HonchoSessionManager._format_migration_transcript
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Honcho session isolation was already working at the gateway/session-key level, but shared gateway venues (Discord threads/channels, Telegram groups, Slack channels, etc.) still received global peer recall during auto-injection. That meant a public/shared venue could pull in user cards, user representations, AI identity context, and dialectic supplements that belonged to the user globally rather than to the current venue.

In practice this caused cross-thread / cross-venue contamination:
- a trading thread could get school / Gmail / ops memory
- shared venues could trigger unwanted initiative because stale global memory was injected as if it were relevant
- session summaries stayed local, but the auto-injected peer context did not

## Fix
This PR makes Honcho auto-injection venue-aware:
- non-DM gateway venues now auto-inject **session summary only**
- user representation / peer card / AI representation / AI card are no longer auto-injected there
- dialectic prewarm + dialectic prefetch are skipped for those venues
- Honcho context fetches now support `summary_only=True`, so we avoid fetching peer-global context when the policy does not allow it
- DM / CLI behavior stays rich and unchanged

## Tests
Added regression coverage for:
- shared venues only auto-injecting session summaries
- DM venues keeping richer auto-injection
- shared venues skipping dialectic prefetch
- Honcho session manager `summary_only=True` fetching only the session summary and skipping peer fetches

## After this change
Shared/public venues behave like venue-local conversations instead of semi-global memory sinks. Threads keep their own session continuity, but they stop auto-pulling unrelated user-global memory from other threads, channels, and workflows.
