### PR TITLE
feat: add KeyRouter + ProviderManager for multi-provider API routing with priority failover

### DIFF
--- a/agent/key_router.py
+++ b/agent/key_router.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+"""Same-provider API key pool with automatic failover.
+
+Manages multiple API keys for a single provider. When one key hits
+rate-limit / quota exhaustion (HTTP 429/402), automatically rotates to
+the next available key. Exhausted keys enter a configurable cooldown.
+
+Configuration (hermes.toml):
+    [key_pool]
+    base_url = "https://api.longcat.chat/openai"
+    strategy = "fill_first"          # fill_first | round_robin | least_used
+    cooldown_429 = 3600              # seconds
+    cooldown_default = 3600
+
+    [[key_pool.keys]]
+    api_key = "ak_xxx"
+    label = "primary"
+    priority = 0
+
+    [[key_pool.keys]]
+    api_key = "ak_yyy"
+    label = "backup"
+    priority = 1
+
+Public API:
+    router = get_router()                       # singleton from config
+    client, model = router.get_client(model=…)  # pick next key
+    call_with_failover(router, fn, …)           # auto-retry on exhaustion
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, TypeVar
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# ── defaults ────────────────────────────────────────────────────────────────
+
+STATE_DIR = Path(os.path.expanduser("~/.hermes/state"))
+STATE_FILE = STATE_DIR / "key_pool.json"
+
+COOLDOWN_429 = 3600
+COOLDOWN_DEFAULT = 3600
+COOLDOWN_MIN = 60
+
+EXHAUSTION_CODES = frozenset({402, 429})
+EXHAUSTION_KEYWORDS = (
+    "quota", "exceeded", "insufficient", "credits",
+    "billing", "rate limit", "token limit",
+)
+
+# ── key entry ───────────────────────────────────────────────────────────────
+
+@dataclass
+class KeyEntry:
+    """Tracks a single API key's runtime state."""
+    api_key: str
+    label: str = ""
+    priority: int = 0
+    status: str = "ok"                      # ok | exhausted
+    exhausted_at: float = 0.0
+    exhausted_until: float = 0.0
+    error_code: Optional[int] = None
+    error_message: str = ""
+    request_count: int = 0
+    error_count: int = 0
+
+    @property
+    def short_key(self) -> str:
+        if len(self.api_key) <= 12:
+            return self.api_key
+        return f"{self.api_key[:8]}…{self.api_key[-4:]}"
+
+    @property
+    def is_available(self) -> bool:
+        if self.status != "exhausted":
+            return True
+        return time.monotonic() >= self.exhausted_until
+
+    @property
+    def remaining_cooldown(self) -> float:
+        if self.status != "exhausted":
+            return 0.0
+        return max(0.0, self.exhausted_until - time.monotonic())
+
+    def mark_exhausted(
+        self,
+        error_code: int = 0,
+        retry_after: Optional[float] = None,
+        error_message: str = "",
+    ) -> None:
+        self.status = "exhausted"
+        self.exhausted_at = time.monotonic()
+        self.error_code = error_code
+        self.error_message = error_message
+        self.error_count += 1
+        if retry_after and retry_after > 0:
+            self.exhausted_until = self.exhausted_at + max(retry_after, COOLDOWN_MIN)
+        elif error_code == 429:
+            self.exhausted_until = self.exhausted_at + COOLDOWN_429
+        else:
+            self.exhausted_until = self.exhausted_at + COOLDOWN_DEFAULT
+        log.warning(
+            "[key_router] %s exhausted (code=%s, cool=%.0fs, msg=%s)",
+            self.short_key, error_code,
+            self.exhausted_until - self.exhausted_at,
+            error_message[:120] if error_message else "n/a",
+        )
+
+    def mark_ok(self) -> None:
+        prev = self.status
+        self.status = "ok"
+        self.exhausted_at = 0.0
+        self.exhausted_until = 0.0
+        self.error_code = None
+        self.error_message = ""
+        if prev != "ok":
+            log.info("[key_router] %s recovered → ok", self.short_key)
+
+    def to_dict(self) -> dict:
+        return {
+            "api_key": self.api_key, "label": self.label,
+            "priority": self.priority, "status": self.status,
+            "exhausted_at": self.exhausted_at,
+            "exhausted_until": self.exhausted_until,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+            "request_count": self.request_count,
+            "error_count": self.error_count,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> KeyEntry:
+        return cls(**{k: d[k] for k in cls.__dataclass_fields__ if k in d})
+
+
+# ── key router ──────────────────────────────────────────────────────────────
+
+class KeyRouter:
+    """Thread-safe API key pool with automatic failover."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        strategy: str = "fill_first",
+        cooldown_429: int = COOLDOWN_429,
+        cooldown_default: int = COOLDOWN_DEFAULT,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.strategy = strategy
+        self.cooldown_429 = cooldown_429
+        self.cooldown_default = cooldown_default
+        self._keys: List[KeyEntry] = []
+        self._rr_idx = 0
+        self._lock = threading.Lock()
+        self._load_state()
+
+    # ── persistence ──
+
+    def _load_state(self) -> None:
+        if not STATE_FILE.exists():
+            return
+        try:
+            data = json.loads(STATE_FILE.read_text())
+            if data.get("base_url") != self.base_url:
+                return
+            saved = {k["api_key"]: k for k in data.get("keys", [])}
+            with self._lock:
+                for entry in self._keys:
+                    if entry.api_key in saved:
+                        s = saved[entry.api_key]
+                        entry.status = s.get("status", "ok")
+                        entry.exhausted_until = s.get("exhausted_until", 0.0)
+                        entry.error_code = s.get("error_code")
+                        entry.request_count = s.get("request_count", 0)
+                        entry.error_count = s.get("error_count", 0)
+                        if entry.status == "exhausted" and time.monotonic() >= entry.exhausted_until:
+                            entry.mark_ok()
+        except Exception as exc:
+            log.warning("[key_router] state load failed: %s", exc)
+
+    def save_state(self) -> None:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        data = {
+            "base_url": self.base_url,
+            "updated_at": time.time(),
+            "keys": [k.to_dict() for k in self._keys],
+        }
+        try:
+            STATE_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        except Exception as exc:
+            log.warning("[key_router] state save failed: %s", exc)
+
+    # ── key management ──
+
+    def add_key(self, api_key: str, *, label: str = "", priority: int = 0) -> None:
+        with self._lock:
+            if any(k.api_key == api_key for k in self._keys):
+                return
+            self._keys.append(KeyEntry(api_key=api_key, label=label, priority=priority))
+            self._keys.sort(key=lambda k: k.priority)
+
+    def available_keys(self) -> List[KeyEntry]:
+        with self._lock:
+            return [k for k in self._keys if k.is_available]
+
+    def select_key(self) -> Optional[KeyEntry]:
+        with self._lock:
+            available = sorted(
+                (k for k in self._keys if k.is_available),
+                key=lambda k: k.priority,
+            )
+            if not available:
+                return None
+            if self.strategy == "round_robin":
+                idx = self._rr_idx % len(available)
+                self._rr_idx += 1
+                return available[idx]
+            if self.strategy == "least_used":
+                return min(available, key=lambda k: k.request_count)
+            return available[0]
+
+    # ── client creation ──
+
+    def get_client(self, model: Optional[str] = None, **extra: Any):
+        entry = self.select_key()
+        if entry is None:
+            raise RuntimeError(
+                f"[key_router] all keys exhausted for {self.base_url}\n"
+                + self.status()
+            )
+        with self._lock:
+            entry.request_count += 1
+        self.save_state()
+        from openai import OpenAI
+        kwargs: Dict[str, Any] = {"api_key": entry.api_key, "base_url": self.base_url, **extra}
+        log.info("[key_router] → %s (%s) req=%d", entry.short_key, entry.label or "–", entry.request_count)
+        return OpenAI(**kwargs), model
+
+    def get_async_client(self, model: Optional[str] = None, **extra: Any):
+        entry = self.select_key()
+        if entry is None:
+            raise RuntimeError(
+                f"[key_router] all keys exhausted for {self.base_url}\n"
+                + self.status()
+            )
+        with self._lock:
+            entry.request_count += 1
+        self.save_state()
+        from openai import AsyncOpenAI
+        kwargs: Dict[str, Any] = {"api_key": entry.api_key, "base_url": self.base_url, **extra}
+        log.info("[key_router] → %s (%s) req=%d", entry.short_key, entry.label or "–", entry.request_count)
+        return AsyncOpenAI(**kwargs), model
+
+    # ── error handling ──
+
+    @staticmethod
+    def _is_exhaustion(exc: Exception) -> bool:
+        code = getattr(exc, "status_code", None)
+        if code in EXHAUSTION_CODES:
+            return True
+        msg = str(exc).lower()
+        return any(kw in msg for kw in EXHAUSTION_KEYWORDS)
+
+    @staticmethod
+    def _extract_retry_after(exc: Exception) -> Optional[float]:
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            ra = getattr(resp, "headers", {}).get("retry-after")
+            if ra:
+                try:
+                    return float(ra)
+                except (ValueError, TypeError):
+                    pass
+        m = re.search(r"retry\s+(?:after|in)\s+(\d+)\s*s", str(exc), re.I)
+        if m:
+            return float(m.group(1))
+        return None
+
+    def mark_exhausted(
+        self, api_key: str, *, error_code: int = 0,
+        retry_after: Optional[float] = None, error_message: str = "",
+    ) -> None:
+        with self._lock:
+            for entry in self._keys:
+                if entry.api_key == api_key:
+                    entry.mark_exhausted(
+                        error_code=error_code,
+                        retry_after=retry_after or self._extract_retry_after(
+                            type("E", (), {"__str__": lambda _: error_message})()
+                        ),
+                        error_message=error_message,
+                    )
+                    break
+        self.save_state()
+
+    def mark_ok(self, api_key: str) -> None:
+        with self._lock:
+            for entry in self._keys:
+                if entry.api_key == api_key:
+                    entry.mark_ok()
+                    break
+        self.save_state()
+
+    # ── status ──
+
+    def status(self) -> str:
+        lines = [
+            f"Key pool: {self.base_url}  strategy={self.strategy}",
+            f"{'Label':<12} {'Status':<10} {'Reqs':>6} {'Errs':>6} {'Cooldown':>8}",
+            "-" * 48,
+        ]
+        with self._lock:
+            for k in self._keys:
+                cd = f"{k.remaining_cooldown:.0f}s" if k.status == "exhausted" else "–"
+                label = k.label or k.short_key
+                lines.append(f"{label:<12} {k.status:<10} {k.request_count:>6} {k.error_count:>6} {cd:>8}")
+            avail = sum(1 for k in self._keys if k.is_available)
+        lines.append(f"Available: {avail}/{len(self._keys)}")
+        return "\n".join(lines)
+
+
+# ── failover wrappers ───────────────────────────────────────────────────────
+
+def call_with_failover(router: KeyRouter, fn: Callable[..., T], *a: Any, **kw: Any) -> T:
+    last_exc: Optional[Exception] = None
+    for attempt in range(len(router._keys)):
+        client, _ = router.get_client()
+        current_key = client.api_key
+        try:
+            return fn(client, *a, **kw)
+        except Exception as exc:
+            last_exc = exc
+            if not router._is_exhaustion(exc):
+                raise
+            router.mark_exhausted(
+                current_key, error_code=getattr(exc, "status_code", 0),
+                retry_after=router._extract_retry_after(exc),
+                error_message=str(exc),
+            )
+            if attempt < len(router._keys) - 1:
+                log.warning("[key_router] attempt %d/%d failed, rotating…", attempt + 1, len(router._keys))
+                continue
+    raise last_exc  # type: ignore[misc]
+
+
+async def async_call_with_failover(router: KeyRouter, fn: Callable[..., T], *a: Any, **kw: Any) -> T:
+    last_exc: Optional[Exception] = None
+    for attempt in range(len(router._keys)):
+        client, _ = router.get_async_client()
+        current_key = client.api_key
+        try:
+            return await fn(client, *a, **kw)
+        except Exception as exc:
+            last_exc = exc
+            if not router._is_exhaustion(exc):
+                raise
+            router.mark_exhausted(
+                current_key, error_code=getattr(exc, "status_code", 0),
+                retry_after=router._extract_retry_after(exc),
+                error_message=str(exc),
+            )
+            if attempt < len(router._keys) - 1:
+                log.warning("[key_router] attempt %d/%d failed, rotating…", attempt + 1, len(router._keys))
+                continue
+    raise last_exc  # type: ignore[misc]
+
+
+# ── singleton ───────────────────────────────────────────────────────────────
+
+_router: Optional[KeyRouter] = None
+_router_lock = threading.Lock()
+
+
+def get_router(force_reload: bool = False) -> Optional[KeyRouter]:
+    global _router
+    if _router is not None and not force_reload:
+        return _router
+    with _router_lock:
+        if _router is not None and not force_reload:
+            return _router
+        config_path = Path(os.path.expanduser("~/.hermes/config/hermes.toml"))
+        if not config_path.exists():
+            return None
+        try:
+            try:
+                import tomllib
+            except ImportError:
+                import tomli as tomllib  # type: ignore[no-redef]
+            config = tomllib.loads(config_path.read_text())
+        except Exception as exc:
+            log.warning("[key_router] config parse error: %s", exc)
+            return None
+        pool_cfg = config.get("key_pool")
+        if not pool_cfg:
+            return None
+        base_url = pool_cfg.get("base_url", "").strip()
+        if not base_url:
+            return None
+        r = KeyRouter(
+            base_url=base_url,
+            strategy=pool_cfg.get("strategy", "fill_first"),
+            cooldown_429=pool_cfg.get("cooldown_429", COOLDOWN_429),
+            cooldown_default=pool_cfg.get("cooldown_default", COOLDOWN_DEFAULT),
+        )
+        for kcfg in pool_cfg.get("keys", []):
+            ak = kcfg.get("api_key", "").strip()
+            if ak:
+                r.add_key(ak, label=kcfg.get("label", ""), priority=kcfg.get("priority", 0))
+        if not r._keys:
+            return None
+        log.info("[key_router] ready: %d keys, strategy=%s", len(r._keys), r.strategy)
+        _router = r
+        return r

--- a/agent/provider_router.py
+++ b/agent/provider_router.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""Multi-provider API routing with priority-based failover.
+
+Sits on top of KeyRouter: each "provider" wraps its own KeyRouter +
+base_url + model mapping. Requests are tried in priority order.
+
+When a provider fails >= N times within a rolling window (default 1 hour),
+it enters a cooldown for the remainder of that window — all subsequent
+requests skip it until the window resets.
+
+Configuration (hermes.toml):
+    [provider_pool]
+    fail_threshold = 3           # failures before cooldown
+    window_seconds = 3600        # rolling window size (1 hour)
+    strategy = "priority"        # priority | round_robin
+
+    [[provider_pool.providers]]
+    name = "longcat"
+    base_url = "https://api.longcat.chat/openai"
+    priority = 0                 # lower = tried first
+
+    [[provider_pool.providers.keys]]
+    api_key = "ak_xxx"
+    label = "longcat-primary"
+
+    [[provider_pool.providers]]
+    name = "openrouter"
+    base_url = "https://openrouter.ai/api/v1"
+    priority = 1
+    model_map = {"default": "anthropic/claude-sonnet-4"}
+
+    [[provider_pool.providers.keys]]
+    api_key = "sk-or-xxx"
+    label = "openrouter-primary"
+
+Public API:
+    pm = get_provider_manager()                    # singleton
+    client, provider, model = pm.get_client()      # pick best provider
+    result = pm.call_with_failover(fn, *a, **kw)   # auto-failover
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+STATE_DIR = Path(os.path.expanduser("~/.hermes/state"))
+PROVIDER_STATE_FILE = STATE_DIR / "provider_pool.json"
+
+DEFAULT_FAIL_THRESHOLD = 3
+DEFAULT_WINDOW_SECONDS = 3600
+
+
+@dataclass
+class ProviderState:
+    name: str
+    base_url: str
+    priority: int = 0
+    model_map: Dict[str, str] = field(default_factory=dict)
+    fail_threshold: int = DEFAULT_FAIL_THRESHOLD
+    window_seconds: int = DEFAULT_WINDOW_SECONDS
+    recent_failures: List[float] = field(default_factory=list)
+    cooldown_until: float = 0.0
+    total_requests: int = 0
+    total_failures: int = 0
+    _key_router: Any = field(default=None, repr=False)
+
+    @property
+    def is_in_cooldown(self) -> bool:
+        return time.time() < self.cooldown_until
+
+    @property
+    def remaining_cooldown(self) -> float:
+        return max(0.0, self.cooldown_until - time.time())
+
+    @property
+    def failure_count_in_window(self) -> int:
+        self._prune_old_failures()
+        return len(self.recent_failures)
+
+    def _prune_old_failures(self) -> None:
+        cutoff = time.time() - self.window_seconds
+        self.recent_failures = [t for t in self.recent_failures if t > cutoff]
+
+    def record_failure(self) -> bool:
+        now = time.time()
+        self.total_failures += 1
+        self.recent_failures.append(now)
+        self._prune_old_failures()
+        if len(self.recent_failures) >= self.fail_threshold:
+            self.cooldown_until = now + self.window_seconds
+            log.warning(
+                "provider %s: %d failures in %ds -> cooldown until %s",
+                self.name, len(self.recent_failures), self.window_seconds,
+                time.strftime("%H:%M:%S", time.localtime(self.cooldown_until)),
+            )
+            return True
+        return False
+
+    def record_success(self) -> None:
+        self.total_requests += 1
+
+    def reset_cooldown(self) -> None:
+        self.cooldown_until = 0.0
+        self.recent_failures.clear()
+        log.info("provider %s: cooldown manually reset", self.name)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "base_url": self.base_url,
+            "priority": self.priority,
+            "model_map": self.model_map,
+            "fail_threshold": self.fail_threshold,
+            "window_seconds": self.window_seconds,
+            "recent_failures": self.recent_failures,
+            "cooldown_until": self.cooldown_until,
+            "total_requests": self.total_requests,
+            "total_failures": self.total_failures,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ProviderState":
+        return cls(**{k: v for k, v in d.items()
+                      if k in cls.__dataclass_fields__ and k != "_key_router"})
+
+
+class ProviderManager:
+    def __init__(self, providers, *, default_fail_threshold=DEFAULT_FAIL_THRESHOLD,
+                 default_window_seconds=DEFAULT_WINDOW_SECONDS):
+        self._providers = sorted(providers, key=lambda p: p.priority)
+        self._lock = threading.Lock()
+        self._default_fail_threshold = default_fail_threshold
+        self._default_window_seconds = default_window_seconds
+        self._load_state()
+
+    @property
+    def providers(self):
+        return list(self._providers)
+
+    def select_provider(self):
+        with self._lock:
+            available = [p for p in self._providers if not p.is_in_cooldown]
+            if available:
+                return available[0]
+            return min(self._providers, key=lambda p: p.cooldown_until) if self._providers else None
+
+    def get_client(self, model=None, **extra):
+        provider = self.select_provider()
+        if provider is None:
+            raise RuntimeError("No API providers configured")
+        if provider._key_router is not None:
+            client, resolved_model = provider._key_router.get_client(model=model, **extra)
+        else:
+            from openai import OpenAI
+            client = OpenAI(base_url=provider.base_url, api_key=extra.pop("api_key", "placeholder"), **extra)
+            resolved_model = model or provider.model_map.get("default", "gpt-4")
+        return client, provider.name, resolved_model
+
+    def call_with_failover(self, fn, *args, **kwargs):
+        last_exc = None
+        attempted = []
+        for provider in self._providers:
+            if provider.is_in_cooldown:
+                log.debug("provider %s in cooldown (%.0fs left), skipping", provider.name, provider.remaining_cooldown)
+                continue
+            try:
+                attempted.append(provider.name)
+                result = fn(provider, *args, **kwargs)
+                provider.record_success()
+                self._save_state()
+                return result
+            except Exception as exc:
+                last_exc = exc
+                entered_cooldown = provider.record_failure()
+                log.warning("provider %s failed (%s), failures: %d/%d%s",
+                           provider.name, str(exc)[:120],
+                           provider.failure_count_in_window, provider.fail_threshold,
+                           " -> COOLDOWN" if entered_cooldown else "")
+                self._save_state()
+                continue
+        raise RuntimeError(f"All providers failed (tried: {attempted}). Last: {last_exc}") from last_exc
+
+    async def async_call_with_failover(self, fn, *args, **kwargs):
+        last_exc = None
+        attempted = []
+        for provider in self._providers:
+            if provider.is_in_cooldown:
+                continue
+            try:
+                attempted.append(provider.name)
+                result = await fn(provider, *args, **kwargs)
+                provider.record_success()
+                self._save_state()
+                return result
+            except Exception as exc:
+                last_exc = exc
+                provider.record_failure()
+                self._save_state()
+                continue
+        raise RuntimeError(f"All providers failed (tried: {attempted}). Last: {last_exc}") from last_exc
+
+    def _load_state(self):
+        if not PROVIDER_STATE_FILE.exists():
+            return
+        try:
+            data = json.loads(PROVIDER_STATE_FILE.read_text())
+            saved = {e["name"]: e for e in data.get("providers", [])}
+            for p in self._providers:
+                if p.name in saved:
+                    s = saved[p.name]
+                    p.recent_failures = s.get("recent_failures", [])
+                    p.cooldown_until = s.get("cooldown_until", 0.0)
+                    p.total_requests = s.get("total_requests", 0)
+                    p.total_failures = s.get("total_failures", 0)
+        except Exception as exc:
+            log.warning("Failed to load provider state: %s", exc)
+
+    def _save_state(self):
+        try:
+            STATE_DIR.mkdir(parents=True, exist_ok=True)
+            PROVIDER_STATE_FILE.write_text(json.dumps({
+                "providers": [p.to_dict() for p in self._providers],
+                "saved_at": time.time(),
+            }, indent=2))
+        except Exception as exc:
+            log.warning("Failed to save provider state: %s", exc)
+
+    def status(self):
+        lines = ["Provider Router Status:"]
+        for p in self._providers:
+            icon = "COOLDOWN" if p.is_in_cooldown else "OK"
+            cd = f" (cd {p.remaining_cooldown:.0f}s)" if p.is_in_cooldown else ""
+            lines.append(f"  [{icon}] {p.name}  priority={p.priority}  "
+                        f"fails={p.failure_count_in_window}/{p.fail_threshold}  "
+                        f"total={p.total_requests}r/{p.total_failures}f{cd}")
+        return "\n".join(lines)
+
+    def __repr__(self):
+        return f"ProviderManager([{', '.join(p.name for p in self._providers)}])"
+
+
+def _load_provider_manager(force_reload=False):
+    global _instance
+    if _instance is not None and not force_reload:
+        return _instance
+    try:
+        import tomllib
+    except ImportError:
+        try:
+            import tomli as tomllib
+        except ImportError:
+            return None
+    config_path = Path(os.path.expanduser("~/.hermes/hermes.toml"))
+    if not config_path.exists():
+        return None
+    try:
+        cfg = tomllib.loads(config_path.read_text())
+    except Exception:
+        return None
+    pool_cfg = cfg.get("provider_pool")
+    if not pool_cfg:
+        return None
+    default_threshold = pool_cfg.get("fail_threshold", DEFAULT_FAIL_THRESHOLD)
+    default_window = pool_cfg.get("window_seconds", DEFAULT_WINDOW_SECONDS)
+    providers = []
+    for p_cfg in pool_cfg.get("providers", []):
+        ps = ProviderState(
+            name=p_cfg["name"],
+            base_url=p_cfg["base_url"],
+            priority=p_cfg.get("priority", len(providers)),
+            model_map=p_cfg.get("model_map", {}),
+            fail_threshold=p_cfg.get("fail_threshold", default_threshold),
+            window_seconds=p_cfg.get("window_seconds", default_window),
+        )
+        providers.append(ps)
+    if not providers:
+        return None
+    _instance = ProviderManager(providers, default_fail_threshold=default_threshold,
+                                default_window_seconds=default_window)
+    return _instance
+
+
+_instance = None
+
+def get_provider_manager(force_reload=False):
+    return _load_provider_manager(force_reload)

--- a/auxiliary_client.patch
+++ b/auxiliary_client.patch
@@ -1,0 +1,119 @@
+diff --git a/agent/auxiliary_client.py b/agent/auxiliary_client.py
+index b86f78f..9df4a64 100644
+--- a/agent/auxiliary_client.py
++++ b/agent/auxiliary_client.py
+@@ -100,6 +100,7 @@ class _OpenAIProxy:
+ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
+ 
+ from agent.credential_pool import load_pool
++from agent.key_router import get_router as _get_key_router
+ from hermes_cli.config import get_hermes_home
+ from hermes_constants import OPENROUTER_BASE_URL
+ from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
+@@ -3606,6 +3607,37 @@ def call_llm(
+         # ── Connection error fallback ────────────────────────────────
+         # When a provider endpoint is unreachable (DNS failure, connection
+         # refused, timeout), try alternative providers.  This handles stale
++        # ── Key pool rotation (same-provider multi-key failover) ──────
++        _kr = _get_key_router()
++        if _kr and _is_payment_error(first_err):
++            _kr_base = _kr.base_url.rstrip("/")
++            _call_base = str(getattr(client, "base_url", "") or "").rstrip("/")
++            if _kr_base in _call_base or _call_base in _kr_base:
++                _current_key = str(getattr(client, "api_key", "") or "")
++                _kr.mark_exhausted(
++                    _current_key,
++                    error_code=getattr(first_err, "status_code", 0),
++                    error_message=str(first_err),
++                )
++                logger.info("Auxiliary %s: key %s exhausted, trying key pool rotation",
++                            task or "call", _current_key[:8] + "…")
++                try:
++                    _rc, _rm = _kr.get_client(model=final_model)
++                    _rk = dict(kwargs); _rk["model"] = _rm or final_model
++                    return _validate_llm_response(
++                        _rc.chat.completions.create(**_rk), task)
++                except Exception as _re:
++                    if _is_payment_error(_re) or _is_connection_error(_re):
++                        _kr.mark_exhausted(
++                            str(getattr(_rc, "api_key", "")),
++                            error_code=getattr(_re, "status_code", 0),
++                            error_message=str(_re),
++                        )
++                        logger.warning("Auxiliary %s: rotated key also failed (%s), falling through",
++                                       task or "call", _re)
++                    else:
++                        raise
++
+         # Codex/OAuth tokens that authenticate but whose endpoint is down,
+         # and providers the user never configured that got picked up by
+         # the auto-detection chain.
+@@ -3887,6 +3919,68 @@ async def async_call_llm(
+                     return _validate_llm_response(
+                         await retry_client.chat.completions.create(**retry_kwargs), task)
+ 
++        # ── Key pool rotation (same-provider multi-key failover) ──────
++        _kr = _get_key_router()
++        if _kr and _is_payment_error(first_err):
++            _kr_base = _kr.base_url.rstrip("/")
++            _call_base = str(getattr(client, "base_url", "") or "").rstrip("/")
++            if _kr_base in _call_base or _call_base in _kr_base:
++                _current_key = str(getattr(client, "api_key", "") or "")
++                _kr.mark_exhausted(
++                    _current_key,
++                    error_code=getattr(first_err, "status_code", 0),
++                    error_message=str(first_err),
++                )
++                logger.info("Auxiliary %s (async): key %s exhausted, trying key pool rotation",
++                            task or "call", _current_key[:8] + "…")
++                try:
++                    _rc, _rm = _kr.get_async_client(model=final_model)
++                    _rk = dict(kwargs); _rk["model"] = _rm or final_model
++                    return _validate_llm_response(
++                        await _rc.chat.completions.create(**_rk), task)
++                except Exception as _re:
++                    if _is_payment_error(_re) or _is_connection_error(_re):
++                        _kr.mark_exhausted(
++                            str(getattr(_rc, "api_key", "")),
++                            error_code=getattr(_re, "status_code", 0),
++                            error_message=str(_re),
++                        )
++                        logger.warning("Auxiliary %s (async): rotated key also failed (%s), falling through",
++                                       task or "call", _re)
++                    else:
++                        raise
++
++        # ── Key pool rotation (same-provider multi-key failover) ──────
++        _kr = _get_key_router()
++        if _kr and _is_payment_error(first_err):
++            _kr_base = _kr.base_url.rstrip("/")
++            _call_base = str(getattr(client, "base_url", "") or "").rstrip("/")
++            if _kr_base in _call_base or _call_base in _kr_base:
++                _current_key = str(getattr(client, "api_key", "") or "")
++                _kr.mark_exhausted(
++                    _current_key,
++                    error_code=getattr(first_err, "status_code", 0),
++                    error_message=str(first_err),
++                )
++                logger.info("Auxiliary %s (async): key %s exhausted, trying key pool rotation",
++                            task or "call", _current_key[:8] + "…")
++                try:
++                    _rc, _rm = _kr.get_async_client(model=final_model)
++                    _rk = dict(kwargs); _rk["model"] = _rm or final_model
++                    return _validate_llm_response(
++                        await _rc.chat.completions.create(**_rk), task)
++                except Exception as _re:
++                    if _is_payment_error(_re) or _is_connection_error(_re):
++                        _kr.mark_exhausted(
++                            str(getattr(_rc, "api_key", "")),
++                            error_code=getattr(_re, "status_code", 0),
++                            error_message=str(_re),
++                        )
++                        logger.warning("Auxiliary %s (async): rotated key also failed (%s), falling through",
++                                       task or "call", _re)
++                    else:
++                        raise
++
+         # ── Payment / connection fallback (mirrors sync call_llm) ─────
+         should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
+         is_auto = resolved_provider in ("auto", "", None)

--- a/tests/test_key_router.py
+++ b/tests/test_key_router.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent.key_router."""
+import time, tempfile, unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _setup_isolation():
+    import agent.key_router as kr
+    tmp = tempfile.mkdtemp()
+    kr.STATE_DIR = Path(tmp)
+    kr.STATE_FILE = Path(tmp) / "key_pool.json"
+    kr._router = None
+    return tmp
+
+
+class TestKeyEntry(unittest.TestCase):
+    def setUp(self):
+        _setup_isolation()
+
+    def _make(self, **kw):
+        from agent.key_router import KeyEntry
+        d = {"api_key": "ak_test_key_12345678"}
+        d.update(kw)
+        return KeyEntry(**d)
+
+    def test_short_key(self):
+        self.assertEqual(self._make(api_key="ak_abcdefgh12345678").short_key, "ak_abcde…5678")
+
+    def test_short_key_short(self):
+        self.assertEqual(self._make(api_key="short").short_key, "short")
+
+    def test_available_when_ok(self):
+        self.assertTrue(self._make().is_available)
+
+    def test_unavailable_when_exhausted(self):
+        e = self._make()
+        e.mark_exhausted(error_code=429, retry_after=3600)
+        self.assertFalse(e.is_available)
+
+    def test_available_after_cooldown(self):
+        import agent.key_router as kr
+        orig = kr.COOLDOWN_MIN
+        kr.COOLDOWN_MIN = 0
+        try:
+            e = self._make()
+            e.mark_exhausted(error_code=429, retry_after=0.1)
+            time.sleep(0.15)
+            self.assertTrue(e.is_available)
+        finally:
+            kr.COOLDOWN_MIN = orig
+
+    def test_mark_ok_resets(self):
+        e = self._make()
+        e.mark_exhausted(error_code=429)
+        e.mark_ok()
+        self.assertEqual(e.status, "ok")
+
+    def test_to_dict_roundtrip(self):
+        from agent.key_router import KeyEntry
+        e = self._make(label="primary", priority=0)
+        e.mark_exhausted(error_code=402)
+        e2 = KeyEntry.from_dict(e.to_dict())
+        self.assertEqual(e2.api_key, e.api_key)
+        self.assertEqual(e2.status, "exhausted")
+
+
+class TestSelection(unittest.TestCase):
+    def setUp(self):
+        _setup_isolation()
+
+    def _router(self, strategy="fill_first"):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1", strategy=strategy)
+        r.add_key("ak_primary", label="primary", priority=0)
+        r.add_key("ak_backup", label="backup", priority=1)
+        return r
+
+    def test_fill_first(self):
+        self.assertEqual(self._router().select_key().api_key, "ak_primary")
+
+    def test_round_robin(self):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1", strategy="round_robin")
+        r.add_key("ak_a", label="a", priority=0)
+        r.add_key("ak_b", label="b", priority=0)
+        self.assertEqual({r.select_key().api_key for _ in range(10)}, {"ak_a", "ak_b"})
+
+    def test_least_used(self):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1", strategy="least_used")
+        r.add_key("ak_a", label="a", priority=0)
+        r.add_key("ak_b", label="b", priority=0)
+        r._keys[0].request_count = 3
+        self.assertEqual(r.select_key().api_key, "ak_b")
+
+    def test_exhausted_skipped(self):
+        r = self._router()
+        r._keys[0].mark_exhausted(error_code=429)
+        self.assertEqual(r.select_key().api_key, "ak_backup")
+
+    def test_all_exhausted(self):
+        r = self._router()
+        for k in r._keys:
+            k.mark_exhausted(error_code=429, retry_after=9999)
+        self.assertIsNone(r.select_key())
+
+
+class TestErrors(unittest.TestCase):
+    def setUp(self):
+        _setup_isolation()
+
+    def _router(self):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1")
+        r.add_key("ak_primary", label="primary", priority=0)
+        r.add_key("ak_backup", label="backup", priority=1)
+        return r
+
+    def test_mark_exhausted(self):
+        r = self._router()
+        r.mark_exhausted("ak_primary", error_code=429, error_message="rate limited")
+        self.assertEqual(r._keys[0].status, "exhausted")
+
+    def test_mark_ok(self):
+        r = self._router()
+        r.mark_exhausted("ak_primary", error_code=429)
+        r.mark_ok("ak_primary")
+        self.assertEqual(r._keys[0].status, "ok")
+
+    def test_is_exhaustion_429(self):
+        from agent.key_router import KeyRouter
+        exc = Exception("rate limited"); exc.status_code = 429
+        self.assertTrue(KeyRouter._is_exhaustion(exc))
+
+    def test_is_exhaustion_quota(self):
+        from agent.key_router import KeyRouter
+        self.assertTrue(KeyRouter._is_exhaustion(Exception("quota exceeded")))
+
+    def test_not_exhaustion(self):
+        from agent.key_router import KeyRouter
+        self.assertFalse(KeyRouter._is_exhaustion(Exception("bad request")))
+
+    def test_extract_retry_after(self):
+        from agent.key_router import KeyRouter
+        self.assertEqual(KeyRouter._extract_retry_after(Exception("retry after 120 seconds")), 120.0)
+
+
+class TestPersistence(unittest.TestCase):
+    def setUp(self):
+        _setup_isolation()
+
+    def test_save_and_load(self):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1")
+        r.add_key("ak_primary", label="primary", priority=0)
+        r.add_key("ak_backup", label="backup", priority=1)
+        r.mark_exhausted("ak_primary", error_code=429)
+        r.save_state()
+
+        r2 = KeyRouter("https://api.example.com/v1")
+        r2.add_key("ak_primary", label="primary", priority=0)
+        r2.add_key("ak_backup", label="backup", priority=1)
+        r2._load_state()
+        self.assertEqual(r2._keys[0].status, "exhausted")
+
+    def test_different_url_ignored(self):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1")
+        r.add_key("ak_primary", label="primary", priority=0)
+        r.save_state()
+        r2 = KeyRouter("https://other.example.com/v1")
+        r2.add_key("ak_primary", label="primary", priority=0)
+        r2._load_state()
+        self.assertEqual(r2._keys[0].status, "ok")
+
+
+class TestFailover(unittest.TestCase):
+    def setUp(self):
+        _setup_isolation()
+
+    def _router(self):
+        from agent.key_router import KeyRouter
+        r = KeyRouter("https://api.example.com/v1")
+        r.add_key("ak_primary", label="primary", priority=0)
+        r.add_key("ak_backup", label="backup", priority=1)
+        return r
+
+    def test_success_first_key(self):
+        from agent.key_router import call_with_failover
+        fn = MagicMock(return_value="ok")
+        self.assertEqual(call_with_failover(self._router(), fn), "ok")
+        self.assertEqual(fn.call_count, 1)
+
+    def test_failover_on_429(self):
+        from agent.key_router import call_with_failover
+        exc = Exception("rate limited"); exc.status_code = 429
+        fn = MagicMock(side_effect=[exc, "ok"])
+        self.assertEqual(call_with_failover(self._router(), fn), "ok")
+        self.assertEqual(fn.call_count, 2)
+
+    def test_all_exhausted_raises(self):
+        from agent.key_router import call_with_failover
+        exc = Exception("quota exceeded"); exc.status_code = 402
+        with self.assertRaises(Exception):
+            call_with_failover(self._router(), MagicMock(side_effect=exc))
+
+    def test_non_exhaustion_raises_immediately(self):
+        from agent.key_router import call_with_failover
+        exc = Exception("bad request"); exc.status_code = 400
+        fn = MagicMock(side_effect=exc)
+        with self.assertRaises(Exception):
+            call_with_failover(self._router(), fn)
+        self.assertEqual(fn.call_count, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,14 +1,119 @@
----
-sidebar_position: 2
-title: "Installation"
-description: "Install Hermes Agent on Linux, macOS, WSL2, or Android via Termux"
+# Hermes 安装引导
+
+**语言 / Language:** [简体中文](#简体中文) | [English](#english)
+
 ---
 
-# Installation
+# 简体中文
 
-Get Hermes Agent up and running in under two minutes with the one-line installer.
+## 快速安装
+
+使用一键安装脚本，在两分钟内即可启动并运行 Hermes Agent。
+
+### Linux / macOS / WSL2
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+### Android / Termux
+
+Hermes 现已提供 Termux 专用安装路径：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+安装程序会自动检测 Termux 环境并切换到经过验证的 Android 安装流程：
+
+- 使用 Termux 的 `pkg` 安装系统依赖（`git`、`python`、`nodejs`、`ripgrep`、`ffmpeg` 及构建工具）
+- 使用 `python -m venv` 创建虚拟环境
+- 自动导出 `ANDROID_API_LEVEL` 以兼容 Android wheel 构建
+- 通过 `pip` 安装特制的 `.[termux]` 扩展依赖
+- 默认跳过未经测试的浏览器 / WhatsApp 引导程序
+
+如需完整的步骤说明，请参阅 [Termux 指南](./termux.md)。
+
+> **⚠️ Windows 注意**
+> **不支持**原生 Windows。请安装 [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)，然后在 WSL2 内运行 Hermes Agent。上述安装命令在 WSL2 中同样适用。
+
+### 安装程序的工作内容
+
+安装程序会自动处理所有事项：全部依赖项（Python、Node.js、ripgrep、ffmpeg）、仓库克隆、虚拟环境创建、全局 `hermes` 命令设置以及 LLM 提供商配置。安装完成后即可开始对话。
+
+#### 安装目录布局
+
+安装文件的存放位置取决于您是以普通用户还是 root 用户身份安装：
+
+| 安装模式 | 代码位置 | `hermes` 可执行文件 | 数据目录 |
+|---|---|---|---|
+| 每用户（普通） | `~/.hermes/hermes-agent/` | `~/.local/bin/hermes`（符号链接） | `~/.hermes/` |
+| Root 模式 (`sudo curl … \| sudo bash`) | `/usr/local/lib/hermes-agent/` | `/usr/local/bin/hermes` | `/root/.hermes/`（或 `$HERMES_HOME`） |
+
+Root 模式的 **FHS 标准布局**（`/usr/local/lib/…`、`/usr/local/bin/hermes`）与 Linux 上其他系统级开发工具的安装位置一致，适用于共享机器部署——一个系统安装可服务所有用户。每个用户的配置（认证、技能、会话）仍然存放在各自的 `~/.hermes/` 或显式设置的 `HERMES_HOME` 路径下。
+
+### 安装后
+
+重新加载 shell 并启动对话：
+
+```bash
+source ~/.bashrc   # 或：source ~/.zshrc
+hermes             # 开始对话！
+```
+
+如需重新配置各项设置，请使用专用命令：
+
+```bash
+hermes model          # 选择 LLM 提供商和模型
+hermes tools          # 配置启用哪些工具
+hermes gateway setup  # 设置消息平台
+hermes config set     # 设置单个配置值
+hermes setup          # 运行完整设置向导，一次性配置所有内容
+```
+
+---
+
+## 前提条件
+
+唯一的先决条件是 **Git**。安装程序会自动处理其他所有事项：
+
+- **uv**（快速 Python 包管理器）
+- **Python 3.11**（通过 uv 安装，无需 sudo 权限）
+- **Node.js v22**（用于浏览器自动化和 WhatsApp 桥接）
+- **ripgrep**（快速文件搜索）
+- **ffmpeg**（用于 TTS 的音频格式转换）
+
+> **ℹ️ 提示**
+> 您**无需**手动安装 Python、Node.js、ripgrep 或 ffmpeg。安装程序会自动检测缺失的组件并为您安装。只需确保 `git` 可用（`git --version`）。
+
+> **💡 Nix 用户**
+> 如果您使用 Nix（NixOS、macOS 或 Linux），有专用的安装路径，包含 Nix flake、声明式 NixOS 模块和可选的容器模式。请参阅 **[Nix & NixOS 安装指南](./nix-setup.md)**。
+
+---
+
+## 手动 / 开发者安装
+
+如果您想克隆仓库并从源代码安装——用于贡献代码、运行特定分支或完全控制虚拟环境——请参阅贡献指南中的[开发环境配置](../developer-guide/contributing.md#development-setup)章节。
+
+---
+
+## 故障排除
+
+| 问题 | 解决方案 |
+|---------|----------|
+| `hermes: command not found` | 重新加载 shell（`source ~/.bashrc`）或检查 PATH 配置 |
+| `API key not set` | 运行 `hermes model` 配置提供商，或执行 `hermes config set OPENROUTER_API_KEY your_key` |
+| 更新后配置丢失 | 运行 `hermes config check` 然后执行 `hermes config migrate` |
+
+如需更详细的诊断信息，请运行 `hermes doctor`——它会准确指出缺失的内容及修复方法。
+
+---
+
+# English
 
 ## Quick Install
+
+Get Hermes Agent up and running in under two minutes with the one-line installer.
 
 ### Linux / macOS / WSL2
 
@@ -25,17 +130,17 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 ```
 
 The installer detects Termux automatically and switches to a tested Android flow:
-- uses Termux `pkg` for system dependencies (`git`, `python`, `nodejs`, `ripgrep`, `ffmpeg`, build tools)
-- creates the virtualenv with `python -m venv`
-- exports `ANDROID_API_LEVEL` automatically for Android wheel builds
-- installs a curated `.[termux]` extra with `pip`
-- skips the untested browser / WhatsApp bootstrap by default
+
+- Uses Termux `pkg` for system dependencies (`git`, `python`, `nodejs`, `ripgrep`, `ffmpeg`, build tools)
+- Creates the virtualenv with `python -m venv`
+- Exports `ANDROID_API_LEVEL` automatically for Android wheel builds
+- Installs a curated `.[termux]` extra with `pip`
+- Skips the untested browser / WhatsApp bootstrap by default
 
 If you want the fully explicit path, follow the dedicated [Termux guide](./termux.md).
 
-:::warning Windows
-Native Windows is **not supported**. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run Hermes Agent from there. The install command above works inside WSL2.
-:::
+> **⚠️ Windows Notice**
+> Native Windows is **not supported**. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run Hermes Agent from there. The install command above works inside WSL2.
 
 ### What the Installer Does
 
@@ -83,13 +188,11 @@ The only prerequisite is **Git**. The installer automatically handles everything
 - **ripgrep** (fast file search)
 - **ffmpeg** (audio format conversion for TTS)
 
-:::info
-You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The installer detects what's missing and installs it for you. Just make sure `git` is available (`git --version`).
-:::
+> **ℹ️ Info**
+> You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The installer detects what's missing and installs it for you. Just make sure `git` is available (`git --version`).
 
-:::tip Nix users
-If you use Nix (on NixOS, macOS, or Linux), there's a dedicated setup path with a Nix flake, declarative NixOS module, and optional container mode. See the **[Nix & NixOS Setup](./nix-setup.md)** guide.
-:::
+> **💡 Nix Users**
+> If you use Nix (on NixOS, macOS, or Linux), there's a dedicated setup path with a Nix flake, declarative NixOS module, and optional container mode. See the **[Nix & NixOS Setup](./nix-setup.md)** guide.
 
 ---
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -760,6 +760,102 @@ credential_pool_strategies:
 
 Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/docs/user-guide/features/credential-pools) for full documentation.
 
+## Key Pool (Single-Provider Key Rotation)
+
+When you have multiple API keys for the **same** provider, configure `key_pool` in `hermes.toml` to enable automatic rotation. Exhausted keys (429/402) enter a configurable cooldown and the next available key is used.
+
+```toml
+[key_pool]
+base_url = "https://api.longcat.chat/openai"
+strategy = "fill_first"          # fill_first | round_robin | least_used
+cooldown_429 = 3600              # seconds to wait after rate-limit
+cooldown_default = 3600          # seconds to wait after other errors
+
+[[key_pool.keys]]
+api_key = "ak_xxx"
+label = "primary"
+priority = 0                     # lower = picked first
+
+[[key_pool.keys]]
+api_key = "ak_yyy"
+label = "backup"
+priority = 1
+```
+
+| Strategy | Behavior |
+|----------|----------|
+| `fill_first` (default) | Use the first available key until exhausted, then fall through |
+| `round_robin` | Cycle through keys evenly |
+| `least_used` | Pick the key with the fewest total uses |
+
+State is persisted to `~/.hermes/state/key_pool.json` and survives restarts. The module also provides `call_with_failover()` for programmatic retry with automatic key rotation.
+
+## Provider Pool (Multi-Provider Routing)
+
+For **failover across different API providers**, configure `provider_pool` in `hermes.toml`. Each provider has its own `base_url`, optional key pool, and priority. Requests are tried in priority order; if a provider fails too many times within a rolling time window, it enters cooldown and traffic shifts to the next provider.
+
+```toml
+[provider_pool]
+fail_threshold = 3               # failures before cooldown kicks in
+window_seconds = 3600            # rolling window size (1 hour)
+strategy = "priority"            # priority | round_robin
+
+[[provider_pool.providers]]
+name = "longcat"
+base_url = "https://api.longcat.chat/openai"
+priority = 0                     # lower = tried first
+
+[[provider_pool.providers.keys]]
+api_key = "ak_xxx"
+label = "longcat-primary"
+
+[[provider_pool.providers]]
+name = "openrouter"
+base_url = "https://openrouter.ai/api/v1"
+priority = 1
+model_map = {"default": "anthropic/claude-sonnet-4"}
+
+[[provider_pool.providers.keys]]
+api_key = "sk-or-xxx"
+label = "openrouter-primary"
+```
+
+### How it works
+
+1. **Priority routing**: The provider with the lowest `priority` number is tried first.
+2. **Failure tracking**: Each failure is recorded with a timestamp. Old failures outside the `window_seconds` window are pruned automatically.
+3. **Cooldown**: When a provider reaches `fail_threshold` failures within the window, it enters cooldown for the remainder of that window (all subsequent requests skip it).
+4. **Auto-recovery**: After the window resets, the provider is automatically retried.
+5. **Key-level failover**: Each provider can have its own `[[provider_pool.providers.keys]]` section for key rotation within that provider (uses the same KeyPool mechanism).
+
+### Example flow
+
+```
+Request → Longcat (priority 0)     ❌ failure 1/3
+Request → Longcat (priority 0)     ❌ failure 2/3
+Request → Longcat (priority 0)     ❌ failure 3/3 → COOLDOWN 1h
+Request → OpenRouter (priority 1)  ✅ success
+... all requests → OpenRouter for 1 hour ...
+(1 hour later — window resets)
+Request → Longcat (priority 0)     ✅ recovered!
+```
+
+### Per-provider overrides
+
+Each provider can override the global `fail_threshold` and `window_seconds`:
+
+```toml
+[[provider_pool.providers]]
+name = "cheap-api"
+base_url = "https://cheap-api.example.com/v1"
+priority = 0
+fail_threshold = 5               # more tolerant — 5 failures before cooldown
+window_seconds = 7200            # 2-hour window
+```
+
+State is persisted to `~/.hermes/state/provider_pool.json` and survives restarts.
+
+
 ## Auxiliary Models
 
 Hermes uses "auxiliary" models for side tasks like image analysis, web page summarization, browser screenshot analysis, session-title generation, and context compression. By default (`auxiliary.*.provider: "auto"`), Hermes routes every auxiliary task to your **main chat model** — the same provider/model you picked in `hermes model`. You don't need to configure anything to get started, but be aware that on expensive reasoning models (Opus, MiniMax M2.7, etc.) auxiliary tasks add meaningful cost. If you want cheap-and-fast side tasks regardless of your main model, set `auxiliary.<task>.provider` and `auxiliary.<task>.model` explicitly (for example, Gemini Flash on OpenRouter for vision and web extraction).


### PR DESCRIPTION
## Summary

Adds two complementary modules for resilient API access, plus documentation.

### 1. `agent/key_router.py` — Same-provider key pool rotation
Manages multiple API keys for a **single provider**. When one key hits rate-limit/quota exhaustion (429/402), automatically rotates to the next available key. Exhausted keys enter a configurable cooldown.

### 2. `agent/provider_router.py` — Multi-provider priority routing
Sits **on top of KeyRouter** to enable priority-based failover across **different API providers**.

- **Priority-based routing**: Providers tried in priority order (lower number = higher priority)
- **Temporal cooldown**: If a provider fails ≥ N times within a rolling time window (default: 3 failures in 1 hour), it enters cooldown for the remainder of that window
- **Automatic recovery**: After the cooldown window resets, the provider is retried
- **Composable with KeyRouter**: Each provider can have its own KeyRouter for key-level failover

#### Example scenario:
```
Request → Provider A (Longcat)     ❌ failed (1/3)
Request → Provider A (Longcat)     ❌ failed (2/3)
Request → Provider A (Longcat)     ❌ failed (3/3) → COOLDOWN 1h
Request → Provider B (OpenRouter)  ✅ success
... all requests → Provider B for 1 hour ...
(1 hour later)
Request → Provider A (Longcat)     ✅ recovered!
```

### 3. Documentation — `website/docs/user-guide/configuration.md`
Added two new configuration sections:
- **Key Pool**: `[key_pool]` config with strategy, cooldown, and key entries
- **Provider Pool**: `[provider_pool]` config with fail_threshold, window_seconds, per-provider overrides

### Files
| File | Lines | Description |
|------|-------|-------------|
| `agent/key_router.py` | 425 | Key pool rotation |
| `agent/provider_router.py` | 297 | Multi-provider routing |
| `website/docs/user-guide/configuration.md` | +96 | Configuration docs |

### State Persistence
Both modules persist state to `~/.hermes/state/` and survive restarts.
