### PR TITLE
fix: render Rich markup in goodbye message using Console.print()

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6911,7 +6911,7 @@ class HermesCLI:
                 goodbye = get_active_goodbye("Goodbye! ⚕")
             except Exception:
                 goodbye = "Goodbye! ⚕"
-            print(goodbye)
+            Console().print(goodbye)
 
     def _get_tui_prompt_symbols(self) -> tuple[str, str]:
         """Return ``(normal_prompt, state_suffix)`` for the active skin.


### PR DESCRIPTION
## Summary

Skins with Rich markup in their `goodbye` branding string (e.g. the `sakura` skin) were printing raw markup tags like `[bold #CC3366]The[/]` instead of colored text.

**Root cause:** `cli.py` used Python's built-in `print(goodbye)` which outputs strings verbatim. Rich markup tags are only interpreted by `Console.print()`.

**Fix:** Replace `print(goodbye)` with `Console().print(goodbye)` — `Console` is already imported at the top of the file.

## Example

Before (with sakura skin active):
```
[bold #CC3366]T[/][bold #CC3366]h[/][bold #CC3467]e[/] [bold #CD3769]b[/]...
```

After:
```
The blossoms scatter. Until next spring.
```

*(with per-character gradient coloring as intended)*