### PR TITLE
fix(gateway): OpenViking fallback commit on idle expiry when agent is evicted

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2705,6 +2705,42 @@ class GatewayRunner:
         except Exception:
             pass
 
+
+    def _openviking_fallback_commit(self, session_id: str) -> None:
+        """Directly commit an OpenViking session when no cached agent exists.
+
+        When the idle-expiry watcher fires but the AIAgent has already been
+        evicted from the cache, the normal cleanup path
+        (shutdown_memory_provider -> on_session_end) cannot run.  If
+        OpenViking is configured and turns were synced during the session,
+        this fallback ensures the session is committed so memory extraction
+        still happens.  See #19831.
+        """
+        import os as _os
+        endpoint = _os.environ.get('OPENVIKING_ENDPOINT', '')
+        if not endpoint:
+            return
+        try:
+            from plugins.memory.openviking import _VikingClient
+            api_key = _os.environ.get('OPENVIKING_API_KEY', '')
+            account = _os.environ.get('OPENVIKING_ACCOUNT', 'default')
+            user = _os.environ.get('OPENVIKING_USER', 'default')
+            agent = _os.environ.get('OPENVIKING_AGENT', 'hermes')
+            client = _VikingClient(
+                endpoint, api_key,
+                account=account, user=user, agent=agent,
+            )
+            client.post(f'/api/v1/sessions/{session_id}/commit')
+            logger.info(
+                'OpenViking fallback commit succeeded for session %s',
+                session_id,
+            )
+        except Exception as e:
+            logger.debug(
+                'OpenViking fallback commit failed for session %s: %s',
+                session_id, e,
+            )
+
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
 
@@ -3441,6 +3477,13 @@ class GatewayRunner:
                             _cached_agent = self._running_agents.get(key)
                         if _cached_agent and _cached_agent is not _AGENT_PENDING_SENTINEL:
                             self._cleanup_agent_resources(_cached_agent)
+                        elif not _cached_agent or _cached_agent is _AGENT_PENDING_SENTINEL:
+                            # No cached agent — the AIAgent was already evicted
+                            # or never created.  If OpenViking is configured and
+                            # turns may have been synced, perform a direct
+                            # fallback commit so memories are not silently lost
+                            # (#19831).
+                            self._openviking_fallback_commit(entry.session_id)
                         # Drop the cache entry so the AIAgent (and its LLM
                         # clients, tool schemas, memory provider refs) can
                         # be garbage-collected.  Otherwise the cache grows

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -243,3 +243,154 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
         f"on_session_finalize was not fired during idle expiry; "
         f"got session_ids={session_ids} (regression of #14981)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for OpenViking fallback commit on idle expiry (#19831)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_openviking_fallback_commit_on_no_agent(mock_invoke_hook, monkeypatch):
+    """When no cached agent exists at expiry time, _openviking_fallback_commit fires.
+
+    Regression test for #19831: OpenViking sessions left uncommitted when
+    the AIAgent is evicted before the idle-expiry watcher runs.
+    """
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:9999")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._running = True
+    runner._agent_cache = {}
+    runner._agent_cache_lock = __import__("threading").Lock()
+    runner._running_agents = {}
+
+    session_key = "agent:main:telegram:dm:99"
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-orphan",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    expired_entry.expiry_finalized = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    fallback_calls = []
+    runner._openviking_fallback_commit = lambda sid: fallback_calls.append(sid)
+
+    _orig_sleep = __import__("asyncio").sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    def _hook_and_stop(*a, **kw):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = _hook_and_stop
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    assert "sess-orphan" in fallback_calls, (
+        f"_openviking_fallback_commit was not called for orphaned session; "
+        f"got {fallback_calls} (regression of #19831)"
+    )
+    assert expired_entry.expiry_finalized is True
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_openviking_fallback_not_called_when_agent_cached(mock_invoke_hook, monkeypatch):
+    """When a cached agent exists, the normal cleanup path runs — no fallback."""
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:9999")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._running = True
+    runner._running_agents = {}
+
+    mock_agent = MagicMock()
+    session_key = "agent:main:telegram:dm:100"
+    runner._agent_cache = {session_key: (mock_agent, None)}
+    runner._agent_cache_lock = __import__("threading").Lock()
+
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-cached",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    expired_entry.expiry_finalized = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    fallback_calls = []
+    runner._openviking_fallback_commit = lambda sid: fallback_calls.append(sid)
+
+    _orig_sleep = __import__("asyncio").sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    def _hook_and_stop(*a, **kw):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = _hook_and_stop
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    assert fallback_calls == [], (
+        f"Fallback commit should not fire when agent is cached; got {fallback_calls}"
+    )
+    # Normal cleanup should have been called instead
+    runner._cleanup_agent_resources.assert_called_once()


### PR DESCRIPTION
## Summary

When the session expiry watcher fires but the `AIAgent` has already been evicted from the cache, the normal cleanup path (`shutdown_memory_provider` → `on_session_end`) cannot run. If OpenViking is configured and turns were synced during the session, this leaves the OpenViking session uncommitted — memories are never extracted.

## Problem

The idle-expiry watcher in `gateway/run.py` looks up the cached/running agent to call `_cleanup_agent_resources()`. When the agent is gone (evicted by cache cap enforcement, process lifecycle, etc.), the cleanup is silently skipped. For OpenViking users, this means:

- `message_count > 0`, `pending_tokens > 0`  
- `commit_count == 0`, `memories_extracted.total == 0`
- Session marked `expiry_finalized=True` despite never being committed

## Fix

Add `_openviking_fallback_commit()` to `GatewayRunner` that directly calls the OpenViking `/api/v1/sessions/{session_id}/commit` endpoint using environment variable configuration when no cached agent exists. The method is a no-op when `OPENVIKING_ENDPOINT` is not set.

In `_session_expiry_watcher`, the fallback fires in the `elif` branch where `_cached_agent` is `None` or the pending sentinel.

## Scope

- `gateway/run.py`: new `_openviking_fallback_commit()` method + call site in expiry watcher
- `tests/gateway/test_session_boundary_hooks.py`: 2 new regression tests

## Testing

```
pytest tests/gateway/test_session_boundary_hooks.py -v
# 8 passed (6 existing + 2 new)
```

Closes #19831