### PR TITLE
fix(backup): fail gracefully on invalid quick snapshot manifests

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -573,8 +574,7 @@ def create_quick_snapshot(
         "total_size": sum(manifest.values()),
         "files": manifest,
     }
-    with open(snap_dir / "manifest.json", "w") as f:
-        json.dump(meta, f, indent=2)
+    atomic_json_write(snap_dir / "manifest.json", meta)
 
     # Auto-prune
     _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP)
@@ -629,8 +629,17 @@ def restore_quick_snapshot(
     if not manifest_path.exists():
         return False
 
-    with open(manifest_path) as f:
-        meta = json.load(f)
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            meta = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error(
+            "Failed to restore quick snapshot %s: invalid manifest %s (%s)",
+            snapshot_id,
+            manifest_path,
+            exc,
+        )
+        return False
 
     restored = 0
     for rel in meta.get("files", {}):

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1177,6 +1177,15 @@ class TestQuickSnapshot:
         from hermes_cli.backup import restore_quick_snapshot
         assert restore_quick_snapshot("nonexistent", hermes_home=hermes_home) is False
 
+    def test_restore_invalid_manifest_returns_false(self, hermes_home):
+        from hermes_cli.backup import restore_quick_snapshot
+
+        snap_dir = hermes_home / "state-snapshots" / "broken-snap"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "manifest.json").write_text("{bad json", encoding="utf-8")
+
+        assert restore_quick_snapshot("broken-snap", hermes_home=hermes_home) is False
+
     def test_auto_prune(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot, list_quick_snapshots, _QUICK_DEFAULT_KEEP
         for i in range(_QUICK_DEFAULT_KEEP + 5):


### PR DESCRIPTION
## Summary

This fixes a crash path in quick snapshot restore when `manifest.json` is invalid or partially written.

The change does two things:

- writes quick snapshot manifests atomically using `atomic_json_write`
- makes `restore_quick_snapshot()` fail gracefully and return `False` when the manifest is corrupt instead of raising `JSONDecodeError`

A regression test was added for the corrupt-manifest case.

## Why

Before this change, a broken `state-snapshots/<id>/manifest.json` could crash restore outright. That makes snapshot recovery brittle in exactly the failure mode snapshots are supposed to help with.

This keeps the behavior fail-closed and consistent with the existing nonexistent-snapshot path.

## Tests

Passed:

```powershell
uv run pytest tests/hermes_cli/test_backup.py -k "restore_nonexistent or restore_invalid_manifest_returns_"

2 passed in 5.58s
