### PR TITLE
fix(web): force light color-scheme on docs iframe

### DIFF
--- a/web/src/pages/DocsPage.tsx
+++ b/web/src/pages/DocsPage.tsx
@@ -50,7 +50,15 @@ export default function DocsPage() {
         className={cn(
           "min-h-0 w-full min-w-0 flex-1",
           "rounded-sm border border-current/20",
-          "bg-background",
+          // Docusaurus paints over a transparent <html> / <body> and
+          // relies on the browser's canvas color (light by default) to
+          // fill the viewport. Inheriting the dashboard's dark color
+          // scheme makes that canvas dark, so the docs body text — which
+          // is tuned for a light canvas — becomes near-invisible. Force a
+          // light color scheme + white background on the iframe element so
+          // the docs render cleanly regardless of the active dashboard
+          // theme or the user's prefers-color-scheme.
+          "[color-scheme:light] bg-white",
         )}
         sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
         referrerPolicy="no-referrer-when-downgrade"


### PR DESCRIPTION
## What does this PR do?

The Documentation tab embeds the public Hermes Agent docs site (https://hermes-agent.nousresearch.com/docs/) via an `<iframe>`. On any system where the browser's `prefers-color-scheme` resolves to dark — the default on macOS with system dark mode, and increasingly common on Linux and Windows too — the docs body text in the dashboard renders nearly invisible against its own background. **This affects every built-in dashboard theme**, not just custom ones.

The cause is a mismatch between Docusaurus's rendering model and the dashboard's:

- Docusaurus's `<html>` and `<body>` are intentionally transparent (`background: rgba(0,0,0,0)`); the actual page background comes from the browser's *Canvas* color (the `Canvas` system color).
- Inside our iframe, the iframe element had `bg-background` (the dashboard's dark canvas) AND inherited the dashboard's dark color-scheme. The browser therefore set the iframe's Canvas to a dark value, which Docusaurus's transparent `<body>` exposed — and the docs site's body text (tuned for a light Canvas) became near-illegible.

The fix is one className change on the iframe in `web/src/pages/DocsPage.tsx`:

- Drop `bg-background` (which made the iframe element's bg the dashboard's dark canvas).
- Add `[color-scheme:light]` — the spec-blessed way to override the inherited color-scheme for iframe content; works cross-origin without `postMessage` or sandbox changes.
- Add `bg-white` — belt-and-suspenders fallback covering the brief paint window before content loads.

## Related Issue

No existing issue/PR — searched `iframe`, `DocsPage`, `documentation contrast`, and `color-scheme docs` across both PRs and issues, all states.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/pages/DocsPage.tsx`: replaced `bg-background` className on the `<iframe>` with `[color-scheme:light] bg-white`, plus an explanatory comment.

## How to Test

1. Set your OS to dark mode (or open Chrome DevTools → Rendering → Emulate CSS media feature `prefers-color-scheme: dark`).
2. `hermes dashboard` — open the dashboard.
3. Navigate to the **Documentation** tab.
4. **Before this PR**: the docs body text (`Hermes Agent` headline, `What is Hermes Agent?` body) is dark gray on dark gray and nearly invisible. The Docusaurus sidebar and header still render correctly because they have their own opaque white backgrounds.
5. **After this PR**: the docs render with full contrast on a white Canvas, identical to opening the docs site in a fresh tab.
6. Bonus check: cycle the dashboard themes via the theme switcher — docs remain readable across all themes (the fix is theme-agnostic).
7. Bonus check: toggle the docs site's own theme via its half-moon header button — Docusaurus's dark-mode opaque backgrounds still cover the white Canvas, so docs dark mode still works.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(web):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` — N/A (TypeScript-only change in the dashboard frontend; no Python tests touched)
- [x] I've added tests for my changes — N/A (CSS-only visual fix; the dashboard has no visual-regression test suite, and the change is mechanically a single className swap)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Chrome

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `color-scheme` is CSS Color Adjustment Module Level 1, supported in all evergreen browsers across all platforms
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Repro on `Readable Warm` theme (a custom theme), but the bug reproduces on every built-in dark dashboard theme — the dashboard's dark `color-scheme` cascades into the iframe regardless of which theme is active.

**Before** — `bg-background` on the iframe + inherited dark color-scheme. Docs sidebar/header render fine (their elements are opaque), but the docs main pane's body text is near-invisible because Docusaurus's transparent `<body>` exposes the dark Canvas:

<img width="1469" height="949" alt="image" src="https://github.com/user-attachments/assets/7b130a0b-4dd8-42f1-85ab-c5313a6f44a1" />

**After** — `[color-scheme:light] bg-white` on the iframe. Identical to opening the docs site in a fresh tab:

<img width="1469" height="949" alt="image" src="https://github.com/user-attachments/assets/0230514a-7c43-4734-bcbb-211b5cb41a23" />
