### PR TITLE
fix: stabilize SearXNG and Groq provider setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ export*
 __pycache__/model_tools.cpython-310.pyc
 __pycache__/web_tools.cpython-310.pyc
 logs/
+*.log
 data/
 .pytest_cache/
 tmp/

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -357,6 +357,16 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
+def groq_default_headers() -> Dict[str, str]:
+    """Headers used for api.groq.com OpenAI-compatible requests.
+
+    Some VPS egress paths get Cloudflare 403/1010 from Groq when the request
+    carries the openai-python default user agent.  A normal app User-Agent is
+    enough to pass the real completions and vision endpoints.
+    """
+    return {"User-Agent": f"HermesAgent/{_HERMES_VERSION}"}
+
+
 def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
 
@@ -1166,6 +1176,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
+            elif base_url_host_matches(base_url, "api.groq.com"):
+                extra["default_headers"] = groq_default_headers()
             _client = OpenAI(api_key=api_key, base_url=base_url, **extra)
             _client = _maybe_wrap_anthropic(_client, model, api_key, raw_base_url)
             return _client, model
@@ -1193,6 +1205,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
+        elif base_url_host_matches(base_url, "api.groq.com"):
+            extra["default_headers"] = groq_default_headers()
         _client = OpenAI(api_key=api_key, base_url=base_url, **extra)
         _client = _maybe_wrap_anthropic(_client, model, api_key, raw_base_url)
         return _client, model
@@ -1975,6 +1989,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+    elif base_url_host_matches(sync_base_url, "api.groq.com"):
+        async_kwargs["default_headers"] = groq_default_headers()
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -2202,6 +2218,8 @@ def resolve_provider_client(
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
                 )
+            elif base_url_host_matches(custom_base, "api.groq.com"):
+                extra["default_headers"] = groq_default_headers()
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -2267,6 +2285,8 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                if base_url_host_matches(openai_base, "api.groq.com"):
+                    _extra2["default_headers"] = groq_default_headers()
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")
@@ -2289,6 +2309,8 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                        if base_url_host_matches(_fallback_base, "api.groq.com"):
+                            _fb_extra["default_headers"] = groq_default_headers()
                         client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))
@@ -2390,6 +2412,8 @@ def resolve_provider_client(
             headers.update(copilot_request_headers(
                 is_agent_turn=True, is_vision=is_vision
             ))
+        elif base_url_host_matches(base_url, "api.groq.com"):
+            headers.update(groq_default_headers())
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1433,6 +1433,9 @@ class AIAgent:
                     from hermes_cli.models import copilot_default_headers
 
                     client_kwargs["default_headers"] = copilot_default_headers()
+                elif base_url_host_matches(effective_base, "api.groq.com"):
+                    from agent.auxiliary_client import groq_default_headers
+                    client_kwargs["default_headers"] = groq_default_headers()
                 elif base_url_host_matches(effective_base, "api.kimi.com"):
                     client_kwargs["default_headers"] = {
                         "User-Agent": "claude-code/0.1.0",
@@ -6229,6 +6232,9 @@ class AIAgent:
             from hermes_cli.models import copilot_default_headers
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
+        elif base_url_host_matches(base_url, "api.groq.com"):
+            from agent.auxiliary_client import groq_default_headers
+            self._client_kwargs["default_headers"] = groq_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
             self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
         elif base_url_host_matches(base_url, "portal.qwen.ai"):

--- a/tests/agent/test_groq_cloudflare_headers.py
+++ b/tests/agent/test_groq_cloudflare_headers.py
@@ -1,0 +1,70 @@
+"""Regression guard: Groq Cloudflare 403/1010 mitigation headers."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def test_groq_default_headers_use_hermes_user_agent():
+    from agent.auxiliary_client import groq_default_headers
+
+    headers = groq_default_headers()
+    assert headers == {"User-Agent": headers["User-Agent"]}
+    assert headers["User-Agent"].startswith("HermesAgent/")
+    assert "openai-python" not in headers["User-Agent"].lower()
+
+
+def test_primary_client_wires_groq_headers():
+    from run_agent import AIAgent
+
+    with patch("run_agent.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        AIAgent(
+            api_key="gsk-test",
+            base_url="https://api.groq.com/openai/v1",
+            provider="custom",
+            model="llama-3.3-70b-versatile",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        headers = mock_openai.call_args.kwargs.get("default_headers") or {}
+        assert headers.get("User-Agent", "").startswith("HermesAgent/")
+
+
+def test_apply_client_headers_wires_groq_headers():
+    from run_agent import AIAgent
+
+    with patch("run_agent.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        agent = AIAgent(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+            provider="custom",
+            model="gpt-4o-mini",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._apply_client_headers_for_base_url("https://api.groq.com/openai/v1")
+        headers = agent._client_kwargs.get("default_headers") or {}
+        assert headers.get("User-Agent", "").startswith("HermesAgent/")
+
+
+def test_transcription_groq_client_wires_headers(monkeypatch, tmp_path):
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    monkeypatch.setattr("tools.transcription_tools._HAS_OPENAI", True)
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"RIFFxxxxWAVEfmt ")
+
+    with patch("openai.OpenAI") as mock_openai:
+        client = MagicMock()
+        client.audio.transcriptions.create.return_value = "hello"
+        mock_openai.return_value = client
+
+        from tools.transcription_tools import _transcribe_groq
+
+        result = _transcribe_groq(str(audio_path), "whisper-large-v3-turbo")
+
+    assert result["success"] is True
+    headers = mock_openai.call_args.kwargs.get("default_headers") or {}
+    assert headers.get("User-Agent", "").startswith("HermesAgent/")

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -324,6 +324,25 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "Tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_searxng(self):
+        """web.backend=searxng in config → 'searxng'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            assert _get_backend() == "searxng"
+
+    def test_config_searxng_case_insensitive(self):
+        """web.backend=SearXNG (mixed case) → 'searxng'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "SearXNG"}):
+            assert _get_backend() == "searxng"
+
+    def test_config_searxng_overrides_env_keys(self):
+        """web.backend=searxng in config → 'searxng' even if Firecrawl key set."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_backend() == "searxng"
+
     # ── Fallback (no web.backend in config) ───────────────────────────
 
     def test_fallback_parallel_only_key(self):
@@ -619,6 +638,19 @@ class TestCheckWebApiKey:
                 with patch.dict(os.environ, {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"}, clear=False):
                     from tools.web_tools import check_web_api_key
                     assert check_web_api_key() is True
+
+    def test_searxng_without_url_returns_false(self):
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
+    def test_searxng_with_url_returns_true(self):
+        with patch("tools.web_tools._load_web_config", return_value={
+            "backend": "searxng",
+            "searxng_url": "http://127.0.0.1:8888",
+        }):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
 
 
 def test_web_requires_env_includes_exa_key():

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -555,7 +555,14 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
-        client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
+        from agent.auxiliary_client import groq_default_headers
+        client = OpenAI(
+            api_key=api_key,
+            base_url=GROQ_BASE_URL,
+            timeout=30,
+            max_retries=0,
+            default_headers=groq_default_headers(),
+        )
         try:
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,7 +126,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -155,6 +155,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "searxng":
+        return bool(_get_searxng_url())
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -359,6 +361,41 @@ def _normalize_tavily_search_results(response: dict) -> dict:
             "position": i + 1,
         })
     return {"success": True, "data": {"web": web_results}}
+
+
+# ─── SearXNG Client ──────────────────────────────────────────────────────────
+
+def _get_searxng_url() -> str:
+    """Return configured SearXNG base URL without trailing slash."""
+    url = (_load_web_config().get("searxng_url") or os.getenv("SEARXNG_URL", "")).strip()
+    return url.rstrip("/")
+
+
+def _normalize_searxng_search_results(response: dict, limit: int) -> dict:
+    """Normalize SearXNG JSON results to the standard web search format."""
+    web_results = []
+    for i, result in enumerate(response.get("results", [])[:limit]):
+        web_results.append({
+            "title": result.get("title", ""),
+            "url": result.get("url", ""),
+            "description": result.get("content", ""),
+            "position": i + 1,
+        })
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _searxng_search(query: str, limit: int) -> dict:
+    """Search a configured SearXNG instance."""
+    base_url = _get_searxng_url()
+    if not base_url:
+        raise ValueError("SearXNG backend selected but web.searxng_url is not configured")
+    response = httpx.get(
+        f"{base_url}/search",
+        params={"q": query, "format": "json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return _normalize_searxng_search_results(response.json(), limit)
 
 
 def _normalize_tavily_documents(response: dict, fallback_url: str = "") -> List[Dict[str, Any]]:
@@ -1156,6 +1193,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "include_images": False,
             })
             response_data = _normalize_tavily_search_results(raw)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "searxng":
+            logger.info("SearXNG search: '%s' (limit: %d)", query, limit)
+            response_data = _searxng_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
@@ -1967,7 +2014,7 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng"):
         return _is_backend_available(configured)
     return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
 


### PR DESCRIPTION
## Summary
- honor configured SearXNG web backend so self-hosted search does not fall through to unavailable paid providers
- add Groq default User-Agent headers across main, auxiliary/vision, named provider, rotation, and STT OpenAI-compatible clients to avoid Cloudflare 403/1010 blocks from VPS environments
- ignore generated *.log files

## Test Plan
- python -m pytest tests/agent/test_groq_cloudflare_headers.py tests/tools/test_web_searxng_backend.py -q
- real Groq text completion via hermes chat --provider groq
- real Groq vision call with public image URL