### PR TITLE
fix(agent): keep Nous GPT-5 on chat completions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3006,6 +3006,10 @@ class AIAgent:
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
+        # Nous serves GPT-5.x models via its OpenAI-compatible chat
+        # completions endpoint; its /v1/responses endpoint returns 404.
+        if normalized_provider == "nous":
+            return False
         if normalized_provider == "copilot":
             try:
                 from hermes_cli.models import _should_use_copilot_responses_api

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3631,8 +3631,8 @@ class TestMaxTokensParam:
         assert result == {"max_completion_tokens": 4096}
 
 
-class TestAzureOpenAIRouting:
-    """Verify Azure OpenAI endpoints stay on chat_completions for gpt-5.x."""
+class TestGpt5ApiModeRouting:
+    """Verify provider-specific GPT-5 API-mode routing."""
 
     def test_azure_gpt5_stays_on_chat_completions(self, agent):
         """Azure serves gpt-5.x on /chat/completions — must not upgrade to codex_responses."""
@@ -3670,6 +3670,25 @@ class TestAzureOpenAIRouting:
         ):
             agent.api_mode = "codex_responses"
         assert agent.api_mode == "codex_responses"
+
+    def test_nous_gpt5_stays_on_chat_completions(self, agent):
+        """Nous serves gpt-5.x on /chat/completions — must not upgrade to codex_responses."""
+        agent.provider = "nous"
+        agent.base_url = "https://inference-api.nousresearch.com/v1"
+        agent.api_mode = "chat_completions"
+        agent.model = "openai/gpt-5.5"
+        if (
+            agent.api_mode == "chat_completions"
+            and not agent._is_azure_openai_url()
+            and (
+                agent._is_direct_openai_url()
+                or agent._provider_model_requires_responses_api(
+                    agent.model, provider=agent.provider,
+                )
+            )
+        ):
+            agent.api_mode = "codex_responses"
+        assert agent.api_mode == "chat_completions"
 
     def test_is_azure_openai_url_detection(self, agent):
         assert agent._is_azure_openai_url("https://foo.openai.azure.com/openai/v1") is True


### PR DESCRIPTION
## What does this PR do?

GPT-5 inference through Nous as provider has been broken since 96cc55605 (Apr 14th).

Fixes a provider-routing bug where `openai/gpt-5.5` through the `nous` provider is incorrectly upgraded to the Responses API transport (`codex_responses`) when Hermes auto-detects API mode. This affects both primary Nous configuration and fallback activation; the fallback path is the concrete repro that surfaced the issue.

The Nous inference API serves `openai/gpt-5.5` successfully through the standard OpenAI-compatible chat completions endpoint:

```text
POST https://inference-api.nousresearch.com/v1/chat/completions -> 200 OK
```

but it does not serve the Responses API endpoint:

```text
POST https://inference-api.nousresearch.com/v1/responses -> 404 Not Found
```

Before this fix, Hermes' generic `gpt-5*` detection could choose `codex_responses` for `provider == "nous"` in both the primary initialization path and `_try_activate_fallback()`. That made a valid Nous GPT-5.5 model fail with repeated `HTTP 404: 404 Not Found` errors; in the fallback case Hermes then falls through to the next fallback provider.

This PR keeps GPT-5.x models routed through Nous on `chat_completions`, while preserving the existing Responses API behavior for direct OpenAI/Codex-style providers.

## Related Issue

Drafted an issue and can cut it, but this is a pretty small/targeted change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - Update `AIAgent._provider_model_requires_responses_api()` so `provider == "nous"` does not fall through to the generic `gpt-5*` Responses API rule.
  - This prevents Nous primary or fallback targets like `openai/gpt-5.5` from being sent to `/v1/responses`, which the Nous inference API returns as `404 Not Found`.
- `tests/run_agent/test_run_agent.py`
  - Add regression coverage that `openai/gpt-5.5` through Nous stays on `chat_completions`.
  - Preserve coverage that direct OpenAI/Codex GPT-5.x routing still uses `codex_responses`.

Implementation note: keep this PR narrowly scoped. The verified live-API bug is for `provider == "nous"`; do not broaden the exception to other providers unless they are explicitly tested and intended.

## How to Test

### 1. Direct endpoint probe against Nous

Using a Hermes-resolved Nous runtime credential, verify the same model against both endpoints:

```text
chat_completions_status=200
chat_completions_body_prefix={"id":"gen-...","object":"chat.completion","created":...,"model":"openai/gpt-5.5-20260423","provider":"OpenAI",...
responses_status=404
responses_body_prefix=404 Not Found
```

### 2. Reproduce failure before the fix

Force Hermes to activate a Nous fallback whose model is `openai/gpt-5.5`:

```python
from run_agent import AIAgent

agent = AIAgent(
    provider='nous',
    model='definitely/not-a-real-model-for-fallback-probe',
    fallback_model=[{
        'provider': 'nous',
        'model': 'openai/gpt-5.5',
        'base_url': 'https://inference-api.nousresearch.com/v1',
    }],
    max_iterations=1,
    enabled_toolsets=[],
    skip_context_files=True,
    skip_memory=True,
    quiet_mode=True,
)

print(agent.chat('Reply exactly: OK'))
```

Before the fix, this fails after switching to the fallback:

```text
🔄 Primary model failed — switching to fallback: openai/gpt-5.5 via nous
⚠️  API call failed (attempt 1/3): NotFoundError [HTTP 404]
   🔌 Provider: nous  Model: openai/gpt-5.5
   🌐 Endpoint: https://inference-api.nousresearch.com/v1/
   📝 Error: HTTP 404: 404 Not Found
...
❌ API failed after 3 retries — HTTP 404: 404 Not Found
```

### 3. Verify success after the fix

Run the same forced fallback probe after applying the fix:

```text
⚠️ Non-retryable error (HTTP 404) — trying fallback...
🔄 Primary model failed — switching to fallback: openai/gpt-5.5 via nous
RESULT_START
OK
RESULT_END
```

### 4. TDD / regression test run

The regression test was added first on a clean branch from `origin/main` and was observed failing before the production fix:

```bash
/home/ordinal/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/run_agent/test_run_agent.py::TestGpt5ApiModeRouting::test_nous_gpt5_stays_on_chat_completions \
  -q -o 'addopts='
```

Red result:

```text
E       AssertionError: assert 'codex_responses' == 'chat_completions'
```

After the fix:

```bash
/home/ordinal/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/run_agent/test_run_agent.py \
  -q -o 'addopts='
```

Green result after rebasing on current `origin/main` (`0ce1b9fe2`):

```text
....                                                                     [100%]
315 passed in 48.98s
```

### 5. Routing probe after the fix

After rebasing, the branch returns `False` for the Nous GPT-5.5 Responses-API check and leaves the selected API mode on chat completions:

```text
requires_responses False
selected_api_mode chat_completions
```

The direct live endpoint probe still shows the same endpoint split:

```text
chat 200 {"id":"gen-...","object":"chat.completion",..."model":"openai/gpt-5.5-20260423",...}
responses 404 404 Not Found
```

### 6. Syntax check

```bash
/home/ordinal/.hermes/hermes-agent/venv/bin/python -m py_compile run_agent.py
```

Result: passed.

### 7. Full suite status

There are significant unrelated test failures on main. All of the existing and new tests in `tests/run_agent/test_run_agent.py` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - Commit: `a53e91b fix(agent): keep Nous GPT-5 fallback on chat completions`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - No exact duplicate found via GitHub API searches for Nous + GPT-5.5 + fallback + 404 / Responses API.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - Clean branch: `fix/nous-gpt5-fallback-chat-completions`
  - Worktree: `/tmp/hermes-agent-nous-gpt55-fallback-pr`
  - Diff contains only `run_agent.py` and `tests/run_agent/test_run_agent.py`.
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Full suite was not rerun after this rebase; an earlier full-suite attempt failed on unrelated local/environment failures listed in the test plan above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - Added `TestGpt5ApiModeRouting.test_nous_gpt5_stays_on_chat_completions`.
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Python 3.11.14, Hermes Agent v0.12.0 (2026.4.30), branch based on current `origin/main` at `0ce1b9fe2` with PR commit `a53e91b`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: small provider-routing bug fix; no user-facing config change.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture/workflow change.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - This is provider/API-mode selection logic only and should be platform-independent.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool schema or tool behavior changes.

## Screenshots / Logs

Before fix:

```text
🔄 Primary model failed — switching to fallback: openai/gpt-5.5 via nous
⚠️  API call failed (attempt 1/3): NotFoundError [HTTP 404]
   🔌 Provider: nous  Model: openai/gpt-5.5
   🌐 Endpoint: https://inference-api.nousresearch.com/v1/
   📝 Error: HTTP 404: 404 Not Found
   📋 Details: 404 Not Found
```

Direct Nous endpoint probe:

```text
chat_completions_status=200
responses_status=404
```

After fix:

```text
🔄 Primary model failed — switching to fallback: openai/gpt-5.5 via nous
RESULT_START
OK
RESULT_END
```
