### PR TITLE
fix(discord): log exception when reading HTTP error body fails

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -92,8 +92,8 @@ def _discord_request(
         error_body = ""
         try:
             error_body = e.read().decode("utf-8", errors="replace")
-        except Exception:
-            pass
+        except Exception as _decode_err:
+            logger.debug("Failed to read Discord error body: %s", _decode_err)
         raise DiscordAPIError(e.code, error_body) from e
 
 


### PR DESCRIPTION
## What does this PR do?
When `_discord_request()` receives an HTTP error, it attempts to read the response body for a detailed error message. If `e.read().decode()` raises an exception (e.g. connection reset, encoding error), it was silently swallowed with `except Exception: pass`, leaving `error_body` empty with no indication of what went wrong.

## Type of Change
- [x] Bug fix

## Changes Made
- Replace `except Exception: pass` with `except Exception as _decode_err: logger.debug(...)` so failures are at least visible in debug logs

## How to Test
1. Simulate a Discord HTTP error where the response body read fails (e.g. mock `e.read()` to raise an exception)
2. Before: exception silently swallowed
3. After: debug log entry appears with the exception details

## Checklist
- [x] Follows existing code style
- [x] No secrets or sensitive data
- [x] Minimal, focused change