### PR TITLE
fix(model_tools): log plugin hook exceptions instead of silently swallowing them

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -730,8 +730,8 @@ def handle_function_call(
                     session_id=session_id or "",
                     tool_call_id=tool_call_id or "",
                 )
-            except Exception:
-                pass
+            except Exception as _hook_err:
+                logger.debug("pre_tool_call hook error: %s", _hook_err)
 
             if block_message is not None:
                 return json.dumps({"error": block_message}, ensure_ascii=False)
@@ -782,8 +782,8 @@ def handle_function_call(
                 tool_call_id=tool_call_id or "",
                 duration_ms=duration_ms,
             )
-        except Exception:
-            pass
+        except Exception as _hook_err:
+            logger.debug("post_tool_call hook error: %s", _hook_err)
 
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by
@@ -807,8 +807,8 @@ def handle_function_call(
                 if isinstance(hook_result, str):
                     result = hook_result
                     break
-        except Exception:
-            pass
+        except Exception as _hook_err:
+            logger.debug("transform_tool_result hook error: %s", _hook_err)
 
         return result
 


### PR DESCRIPTION
## What does this PR do?
Three plugin hook call sites in `handle_function_call()` used bare `except Exception: pass`, silently discarding any exception raised by the hook system. This makes it impossible to diagnose plugin failures without attaching a debugger.

## Type of Change
- [x] Bug fix

## Changes Made
- `pre_tool_call` hook: `except Exception: pass` → `except Exception as _hook_err: logger.debug(...)`
- `post_tool_call` hook: same pattern
- `transform_tool_result` hook: same pattern

Note: `notify_other_tool_call` (file_tools import guard) is intentionally left as `pass` — its comment explains the module may not be loaded yet.

## How to Test
1. Install a plugin that raises an exception in any of the three hooks
2. Before: exception silently swallowed, no trace in logs
3. After: debug log entry appears with exception details

## Checklist
- [x] Follows existing code style
- [x] No secrets or sensitive data
- [x] Minimal, focused change