### PR TITLE
fix(discord): scan all attachments for type; don't stop at first unrecognized

### DIFF
--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -9,6 +9,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -111,7 +112,7 @@ def adapter(monkeypatch):
 def make_attachment(
     *,
     filename: str,
-    content_type: str,
+    content_type: Optional[str],
     size: int = 1024,
     url: str = "https://cdn.discordapp.com/attachments/fake/file",
 ) -> SimpleNamespace:


### PR DESCRIPTION
Salvage of #15816 onto current main.

## Summary
The `msg_type` detection loop in `DiscordAdapter._handle_message()` unconditionally `break`ed after the first attachment that had any `content_type` string, even if that type was unrecognised (e.g. `application/octet-stream`). An unsupported first attachment caused subsequent image/audio/video attachments to be missed entirely. Only break when a recognised type is found. Fixes #15701.

## Validation
Manual review of diff.

Original PR: #15816