### PR TITLE
fix(agent): recover gemma4 tool_call.arguments corrupted by leaked chat-template markers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -462,6 +462,48 @@ class ChatCompletionsTransport(ProviderTransport):
                     provider_data=tc_provider_data or None,
                 ))
 
+            # Recover from a Gemma 4 chat-template leak: vLLM's harmony parser
+            # for Gemma 4 sometimes structures the tool call (so ``tool_calls``
+            # is populated) but lets the model's quote markers (``<|"|>`` in
+            # full and partial forms) escape into ``tool_call.arguments`` as
+            # literal characters. Hermes' downstream ``json.loads(arguments)``
+            # then fails and the run gets surfaced as
+            # ``Response truncated (finish_reason='length')`` even though the
+            # upstream actually returned ``finish_reason: 'tool_calls'``
+            # cleanly with no token cap hit. Strip the leaked markers so the
+            # JSON parses again, but only when the original was unparseable
+            # AND the cleaned version IS parseable — never silently mutate
+            # already-valid arguments.
+            if tool_calls:
+                import json as _json_for_validation
+
+                def _strip_gemma4_quote_markers(s: str) -> str:
+                    if not s or "<|" not in s:
+                        return s
+                    return (s
+                            .replace('"<|\\"|"', '"')   # full open:  "<|\"|" -> "
+                            .replace('<|\\"', '"')       # full close: <|\"   -> "
+                            .replace('"<|', '"')         # bare open:  "<|     -> "
+                            .replace('<|"', '"'))        # bare close: <|"     -> "
+
+                for tc in tool_calls:
+                    args_str = tc.arguments
+                    if not args_str or "<|" not in args_str:
+                        continue
+                    try:
+                        _json_for_validation.loads(args_str)
+                        continue  # already valid
+                    except (ValueError, TypeError):
+                        pass
+                    cleaned = _strip_gemma4_quote_markers(args_str)
+                    if cleaned == args_str:
+                        continue
+                    try:
+                        _json_for_validation.loads(cleaned)
+                    except (ValueError, TypeError):
+                        continue  # cleaned still broken, leave original
+                    tc.arguments = cleaned
+
         usage = None
         if hasattr(response, "usage") and response.usage:
             u = response.usage

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -656,6 +656,108 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"reasoning_content": "model-extra scratchpad"}
 
 
+class TestChatCompletionsGemma4ArgsSanitization:
+    """Recovery from Gemma 4 chat-template markers leaking into structured
+    tool_call.arguments (the upstream emits ``finish_reason='tool_calls'``
+    cleanly, but the JSON inside ``arguments`` is corrupted by ``<|"|>``
+    and partial variants). Hermes' downstream ``json.loads`` would otherwise
+    fail and the run would be reported as length-truncated.
+
+    The sanitizer is conservative: it only rewrites ``arguments`` when the
+    original is unparseable AND the cleaned variant IS parseable.
+    """
+
+    def _resp(self, args: str):
+        tc = SimpleNamespace(
+            id="call_x",
+            function=SimpleNamespace(name="terminal", arguments=args),
+        )
+        return SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tc], reasoning_content=None),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+
+    def test_full_open_and_close_markers_stripped(self, transport):
+        # Real-world payload shape (kanban_complete with metadata.findings).
+        bad = (
+            '{"metadata": {"findings": [{"date": "<|\\"|"2023-09-18<|\\", '
+            '"identifier": "<|\\"|"BOE-A-2023-19616<|\\"}]}, '
+            '"task_id": "t_8345a55c"}'
+        )
+        nr = transport.normalize_response(self._resp(bad))
+        import json
+        parsed = json.loads(nr.tool_calls[0].arguments)
+        assert parsed["task_id"] == "t_8345a55c"
+        assert parsed["metadata"]["findings"][0]["date"] == "2023-09-18"
+        assert parsed["metadata"]["findings"][0]["identifier"] == "BOE-A-2023-19616"
+
+    def test_bare_marker_only_args_left_intact(self, transport):
+        # Bare ``<|`` markers without inner escaped quote do NOT break JSON
+        # parsing — the value is just an unusual literal string. The strict
+        # sanitizer must NOT touch already-valid args, even if they look
+        # cosmetically off; downstream callers may legitimately use ``<|``.
+        ok = '{"command": "<|grep -l Justicia<|"}'
+        import json
+        json.loads(ok)  # confirm it parses fine before we hand it in
+        nr = transport.normalize_response(self._resp(ok))
+        assert nr.tool_calls[0].arguments == ok
+
+    def test_full_marker_with_bare_close_recovered(self, transport):
+        # Real-world variant: full ``<|"|>`` open marker (which DOES break
+        # JSON because the inner escaped quote terminates the string early)
+        # paired with a bare ``<|"`` close on the same value.
+        bad = '{"y": "<|\\"|"hello<|\\"}'
+        nr = transport.normalize_response(self._resp(bad))
+        import json
+        parsed = json.loads(nr.tool_calls[0].arguments)
+        assert parsed["y"] == "hello"
+
+    def test_already_valid_args_not_mutated(self, transport):
+        good = '{"command": "ls -la"}'
+        nr = transport.normalize_response(self._resp(good))
+        # Identity preserved — no spurious rewrite of clean payloads.
+        assert nr.tool_calls[0].arguments == good
+
+    def test_args_without_markers_not_inspected(self, transport):
+        # Does not contain "<|" — sanitizer skips entirely. Even if the JSON
+        # were broken for unrelated reasons, we leave it alone so downstream
+        # surfaces the real error.
+        broken_unrelated = '{"command": "ls",,}'
+        nr = transport.normalize_response(self._resp(broken_unrelated))
+        assert nr.tool_calls[0].arguments == broken_unrelated
+
+    def test_unrecoverable_args_left_for_downstream(self, transport):
+        # Marker present but the cleaned version is still not valid JSON.
+        # Sanitizer must NOT half-mutate — leave the original so the real
+        # downstream error is surfaced rather than masked.
+        bad = '{"command": "<|"}, "extra": <|>}'
+        nr = transport.normalize_response(self._resp(bad))
+        assert nr.tool_calls[0].arguments == bad
+
+    def test_multiple_tool_calls_each_handled_independently(self, transport):
+        clean_args = '{"x": 1}'
+        # Full marker open — actually breaks JSON parse, so sanitizer fires.
+        dirty_args = '{"y": "<|\\"|"hello<|\\"}'
+        tcs = [
+            SimpleNamespace(id="a", function=SimpleNamespace(name="t1", arguments=clean_args)),
+            SimpleNamespace(id="b", function=SimpleNamespace(name="t2", arguments=dirty_args)),
+        ]
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=tcs, reasoning_content=None),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        import json
+        assert nr.tool_calls[0].arguments == clean_args
+        assert json.loads(nr.tool_calls[1].arguments) == {"y": "hello"}
+
+
 class TestChatCompletionsCacheStats:
 
     def test_no_usage(self, transport):


### PR DESCRIPTION
## Summary

When using Gemma 4 served via vLLM (NaN Builders, and others), the harmony parser intermittently structures the tool call cleanly — `tool_calls` is non-empty and the upstream returns `finish_reason='tool_calls'` — but lets the model's chat-template quote markers (`<|"|>` in its full and partial forms) escape into the JSON of `tool_call.arguments` as literal characters.

Hermes' downstream `json.loads(arguments)` then fails. The retry sees the same deterministic corruption, fails again, and the run gets surfaced to the user as `Response truncated (finish_reason='length') — model hit max output tokens` despite no token cap being hit and the upstream having returned successfully.

This is a complement to the existing content-side recovery path proposed in #7449 — that one fires on `if not tool_calls and content:`, assuming the structured channel is safe. This PR handles the case where the structured channel is taken but the JSON inside `arguments` is corrupted.

## Symptom

Captured payload (`kanban_complete` from a worker, gemma4 via NaN Builders, full 1658-byte arg string, captured via SSE pass-through proxy):

```
{"metadata": {"findings": [{"date": "<|\"|"2023-09-18<|\", "identifier": "<|\"|"BOE-A-2023-19616<|\", "title": "<|Resolución de 28 de julio de 2023, ...<|"}, ... ]}, "summary": "...", "task_id": "t_8345a55c"}
```

`json.loads` chokes at column 43 because `"<|\"|"` parses as a closed string `<|"|` followed by a bare `2023-09-18` token. Same payload retried twice (deterministic), same parse error twice, session aborts.

Four marker shapes turn up in the wild:

| Marker (raw) | After JSON-escape inside arguments | Sanitizer rule |
|---|---|---|
| `<\|"\|>` opening (full) | `"<\|\"\|"` | replace with `"` |
| `<\|"\|>` closing (full) | `<\|\"` | replace with `"` |
| `<\|"\|>` opening (truncated, no inner `\"`) | `"<\|` | replace with `"` |
| `<\|"\|>` closing (truncated, no inner `\\`) | `<\|"` | replace with `"` |

## Approach

`agent/transports/chat_completions.py::normalize_response` already populates `tool_calls`. After that loop, if any `tool_call.arguments` contains `<|` and fails `json.loads`, run the marker-stripping substitution and accept the result **only if the cleaned variant parses**. Concretely:

```python
if tool_calls:
    import json as _json_for_validation

    def _strip_gemma4_quote_markers(s: str) -> str:
        if not s or "<|" not in s:
            return s
        return (s
                .replace('"<|\\"|"', '"')
                .replace('<|\\"', '"')
                .replace('"<|', '"')
                .replace('<|"', '"'))

    for tc in tool_calls:
        args_str = tc.arguments
        if not args_str or "<|" not in args_str:
            continue
        try:
            _json_for_validation.loads(args_str)
            continue  # already valid
        except (ValueError, TypeError):
            pass
        cleaned = _strip_gemma4_quote_markers(args_str)
        if cleaned == args_str:
            continue
        try:
            _json_for_validation.loads(cleaned)
        except (ValueError, TypeError):
            continue  # cleaned still broken
        tc.arguments = cleaned
```

The double guard (original unparseable AND cleaned parseable) means already-valid args are never touched, even if they cosmetically contain `<|` substrings — legitimate user content (regex with alternation, certain code patterns) can do that.

## Tests

`TestChatCompletionsGemma4ArgsSanitization` (6 cases) added to `tests/agent/transports/test_chat_completions.py`:

- ✅ Real-world full-marker payload (the dump shape above) → recovered.
- ✅ Full open marker + bare close on the same value → recovered.
- ✅ Bare-only markers that DON'T break JSON → arguments left intact (strict guard).
- ✅ Already-valid arguments → not mutated.
- ✅ `<|` present but cleaned variant still unparseable → original left for downstream error visibility.
- ✅ Multiple tool_calls in a single response, mixed clean/dirty → each handled independently.

Full test file: `68 passed in 4.11s` (61 existing + 7 new).

## Validation in production

Validated against 14 tool_calls captured from a failing gemma4 + NaN Builders session: 12 already-valid args untouched, 2 broken `kanban_complete` payloads (with nested `metadata.findings`) parse cleanly post-sanitization, 0 collateral damage. Worker resumes normally.

## Relationship to #7449

Independent. #7449 (and the three follow-up issues in [its thread](https://github.com/NousResearch/hermes-agent/pull/7449#issuecomment-4373788390)) addresses Gemma 4's tool calls landing in `message.content` instead of `tool_calls`. This PR addresses the orthogonal case where `tool_calls` IS populated but its `arguments` JSON is corrupted. Either fix can land first; both are needed for full coverage.