### PR TITLE
feat(transport): plumb reasoning_effort to NVIDIA NIM

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -308,7 +308,20 @@ class ChatCompletionsTransport(ProviderTransport):
         # Thinking, GPT-OSS 120B, Qwen3-thinking, Nemotron 3) gate their
         # `<think>` chain on this field; without it `reasoning_content` is null.
         # Non-reasoning models on NIM ignore the field gracefully.
-        # NIM accepts: low / medium / high / max. Hermes' "xhigh" maps to "max".
+        #
+        # NIM's accepted vocabulary is per-model (verified empirically against
+        # integrate.api.nvidia.com on 2026-05-04):
+        #   - DeepSeek V4 Pro/Flash: low / medium / high / max
+        #   - Nemotron 3 Super/Nano: low / medium / high   (rejects max with
+        #     400 literal_error)
+        #   - Other NIM-hosted models: assume low / medium / high to match
+        #     the conservative subset; promote when more provider data lands.
+        #
+        # Effort mapping:
+        #   Hermes 'low'/'medium'/'high'  → forwarded as-is
+        #   Hermes 'xhigh'/'max'          → 'max' on DeepSeek V4 only;
+        #                                   capped to 'high' elsewhere to
+        #                                   avoid the 400 from NIM.
         if is_nvidia_nim:
             _nvidia_thinking_off = bool(
                 reasoning_config
@@ -317,12 +330,14 @@ class ChatCompletionsTransport(ProviderTransport):
             )
             if not _nvidia_thinking_off:
                 _nvidia_effort = "high"
+                _model_lower = (model or "").lower()
+                _supports_max_on_nim = "deepseek-v4" in _model_lower
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in ("low", "medium", "high", "max"):
+                    if _e in ("low", "medium", "high"):
                         _nvidia_effort = _e
-                    elif _e == "xhigh":
-                        _nvidia_effort = "max"
+                    elif _e in ("xhigh", "max"):
+                        _nvidia_effort = "max" if _supports_max_on_nim else "high"
                 api_kwargs["reasoning_effort"] = _nvidia_effort
 
         # Tencent TokenHub: top-level reasoning_effort (unless thinking disabled)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -303,6 +303,28 @@ class ChatCompletionsTransport(ProviderTransport):
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
+        # NVIDIA NIM: top-level reasoning_effort (unless thinking disabled).
+        # NIM-hosted reasoning model families (DeepSeek V4 Pro/Flash, Kimi K2
+        # Thinking, GPT-OSS 120B, Qwen3-thinking, Nemotron 3) gate their
+        # `<think>` chain on this field; without it `reasoning_content` is null.
+        # Non-reasoning models on NIM ignore the field gracefully.
+        # NIM accepts: low / medium / high / max. Hermes' "xhigh" maps to "max".
+        if is_nvidia_nim:
+            _nvidia_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _nvidia_thinking_off:
+                _nvidia_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("low", "medium", "high", "max"):
+                        _nvidia_effort = _e
+                    elif _e == "xhigh":
+                        _nvidia_effort = "max"
+                api_kwargs["reasoning_effort"] = _nvidia_effort
+
         # Tencent TokenHub: top-level reasoning_effort (unless thinking disabled)
         if is_tokenhub:
             _tokenhub_thinking_off = bool(

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -473,8 +473,8 @@ class TestChatCompletionsNvidiaNimReasoning:
         assert kw["reasoning_effort"] == "high"
 
     def test_nvidia_nim_reasoning_effort_explicit_levels(self, transport):
-        """Each documented effort level is forwarded as-is."""
-        for effort in ("low", "medium", "high", "max"):
+        """low/medium/high are accepted by every reasoning model on NIM."""
+        for effort in ("low", "medium", "high"):
             kw = transport.build_kwargs(
                 model="deepseek-ai/deepseek-v4-flash",
                 messages=[{"role": "user", "content": "Hi"}],
@@ -484,16 +484,59 @@ class TestChatCompletionsNvidiaNimReasoning:
             )
             assert kw["reasoning_effort"] == effort, f"effort={effort}"
 
-    def test_nvidia_nim_xhigh_maps_to_max(self, transport):
-        """Hermes' 'xhigh' rung maps to NIM's 'max' (NIM doesn't accept 'xhigh')."""
-        kw = transport.build_kwargs(
+    def test_nvidia_nim_max_passes_through_for_deepseek_v4(self, transport):
+        """DeepSeek V4 Pro/Flash on NIM accept 'max'; forward as-is."""
+        for model in (
+            "deepseek-ai/deepseek-v4-flash",
+            "deepseek-ai/deepseek-v4-pro",
+        ):
+            kw = transport.build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "Hi"}],
+                is_nvidia_nim=True,
+                reasoning_config={"effort": "max"},
+                max_tokens_param_fn=lambda n: {"max_tokens": n},
+            )
+            assert kw["reasoning_effort"] == "max", f"model={model}"
+
+    def test_nvidia_nim_max_caps_to_high_for_nemotron(self, transport):
+        """Nemotron 3 on NIM rejects 'max' with a 400 literal_error.
+        Cap the value to 'high' to keep the request valid.
+        """
+        for model in (
+            "nvidia/nemotron-3-super-120b-a12b",
+            "nvidia/nemotron-3-nano-30b-a3b",
+        ):
+            kw = transport.build_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "Hi"}],
+                is_nvidia_nim=True,
+                reasoning_config={"effort": "max"},
+                max_tokens_param_fn=lambda n: {"max_tokens": n},
+            )
+            assert kw["reasoning_effort"] == "high", f"model={model}"
+
+    def test_nvidia_nim_xhigh_maps_to_max_only_for_v4(self, transport):
+        """Hermes' 'xhigh' rung — promoted to 'max' for V4, capped to 'high' elsewhere.
+        NIM never accepts 'xhigh' itself.
+        """
+        kw_v4 = transport.build_kwargs(
             model="deepseek-ai/deepseek-v4-flash",
             messages=[{"role": "user", "content": "Hi"}],
             is_nvidia_nim=True,
             reasoning_config={"effort": "xhigh"},
             max_tokens_param_fn=lambda n: {"max_tokens": n},
         )
-        assert kw["reasoning_effort"] == "max"
+        assert kw_v4["reasoning_effort"] == "max"
+
+        kw_nemo = transport.build_kwargs(
+            model="nvidia/nemotron-3-super-120b-a12b",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"effort": "xhigh"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw_nemo["reasoning_effort"] == "high"
 
     def test_nvidia_nim_thinking_disabled_omits_field(self, transport):
         """`enabled: False` opts out of thinking — no reasoning_effort emitted."""

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -454,6 +454,83 @@ class TestChatCompletionsKimi:
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
 
+class TestChatCompletionsNvidiaNimReasoning:
+    """NVIDIA NIM reasoning_effort plumbing for thinking-capable model families.
+
+    NIM-hosted models (DeepSeek V4 Pro/Flash, Kimi K2 Thinking, GPT-OSS 120B,
+    Qwen3-thinking, Nemotron 3) gate their `<think>` chain on top-level
+    `reasoning_effort`. Without it, `reasoning_content` is null on the response.
+    """
+
+    def test_nvidia_nim_reasoning_effort_default_high(self, transport):
+        """No explicit effort → default 'high' (NIM's documented sweet spot)."""
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_nvidia_nim_reasoning_effort_explicit_levels(self, transport):
+        """Each documented effort level is forwarded as-is."""
+        for effort in ("low", "medium", "high", "max"):
+            kw = transport.build_kwargs(
+                model="deepseek-ai/deepseek-v4-flash",
+                messages=[{"role": "user", "content": "Hi"}],
+                is_nvidia_nim=True,
+                reasoning_config={"effort": effort},
+                max_tokens_param_fn=lambda n: {"max_tokens": n},
+            )
+            assert kw["reasoning_effort"] == effort, f"effort={effort}"
+
+    def test_nvidia_nim_xhigh_maps_to_max(self, transport):
+        """Hermes' 'xhigh' rung maps to NIM's 'max' (NIM doesn't accept 'xhigh')."""
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"effort": "xhigh"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "max"
+
+    def test_nvidia_nim_thinking_disabled_omits_field(self, transport):
+        """`enabled: False` opts out of thinking — no reasoning_effort emitted."""
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"enabled": False, "effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "reasoning_effort" not in kw
+
+    def test_nvidia_nim_unknown_effort_falls_back_to_default(self, transport):
+        """Garbage effort value → defaults to 'high' rather than crashing."""
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"effort": "unknown-value"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_non_nvidia_route_unaffected(self, transport):
+        """Other routes (no is_nvidia_nim flag) don't get the field auto-injected."""
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            reasoning_config={"effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # Without is_nvidia_nim=True, the NVIDIA branch shouldn't fire.
+        # (Kimi/TokenHub/LM Studio paths might still inject it, but those flags
+        # are off here too — so the field stays out.)
+        assert "reasoning_effort" not in kw
+
+
 class TestChatCompletionsLmStudioReasoning:
     """LM Studio publishes per-model reasoning ``allowed_options``. When the
     user requests an effort the model can't honor (e.g. ``high`` on a


### PR DESCRIPTION
## Summary

NVIDIA NIM hosts reasoning-capable model families (DeepSeek V4 Pro/Flash, Kimi K2 Thinking, GPT-OSS 120B, Qwen3-thinking variants, Nemotron 3) that activate thinking mode via the **top-level `reasoning_effort`** request field. Hermes already detects `is_nvidia_nim` and uses it for `max_tokens` defaulting and `extra_body` assembly, but the `reasoning_effort` plumbing was never added — so every NIM-hosted reasoning model is silently stuck in Non-think mode.

This PR adds an `is_nvidia_nim` branch in `chat_completions.build_kwargs()` that mirrors the existing Kimi block. After this change, configuring `agent.reasoning_effort: high` actually reaches NIM, `reasoning_content` populates, and `display.show_reasoning: true` finally renders thinking blocks for these models.

Closes #19883.

## NIM `reasoning_effort` contract (verified empirically)

Verified against `https://integrate.api.nvidia.com/v1/chat/completions` with `deepseek-ai/deepseek-v4-flash`:

| Request                                  | `reasoning_content`         |
|------------------------------------------|-----------------------------|
| (no field)                               | `null`                      |
| `reasoning_effort: "high"`               | populated                   |
| `reasoning_effort: "max"`                | populated                   |
| `extra_body: {thinking: {type:"max"}}`   | `null` (NIM doesn't accept) |

NIM accepts: `low`, `medium`, `high`, `max`. The nested `extra_body.thinking` toggle that DeepSeek's native API uses is **not** translated by NIM — only the top-level `reasoning_effort` works on this route.

## Hermes → NIM effort mapping

Same vocabulary translation as #14958's DeepSeek-native mapping, applied here for the NIM route:

| Hermes `reasoning_effort` | → NIM `reasoning_effort` |
|---------------------------|--------------------------|
| `low`                     | `low`                    |
| `medium`                  | `medium`                 |
| `high`                    | `high`                   |
| `xhigh`                   | `max`                    |
| `max`                     | `max`                    |
| _(thinking disabled)_     | _omitted_                |

## Changes

- `agent/transports/chat_completions.py` — new `is_nvidia_nim` reasoning_effort branch immediately after the existing `is_kimi` block, structurally identical for easy review (+22 lines).
- `tests/agent/transports/test_chat_completions.py` — new `TestChatCompletionsNvidiaNimReasoning` covering default `high`, explicit effort levels, `xhigh → max` mapping, `enabled: False` opt-out, unknown-value fallback, and no-op for non-NIM routes (+77 lines).

## Test plan

- [x] `pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsNvidiaNimReasoning -v` — 6/6 pass
- [x] `pytest tests/agent/transports/test_chat_completions.py` (full file, 67 tests) — all pass; existing Kimi/TokenHub/LM-Studio/etc. paths unaffected
- [x] End-to-end smoke test with `deepseek-v4-flash` on NIM — `reasoning_content` populates, Hermes' Reasoning block renders
- [x] Confirmed `extra_body.thinking` does NOT work on NIM (sanity check that the top-level `reasoning_effort` is the correct lever)

## Related

- #14958 — `feat(deepseek): plumb reasoning_effort and thinking toggle to V4 API` (covers the DeepSeek native API, complementary to this PR which covers the NIM hosting route)
- #11243 — Same gap requested for Mistral AI's `api.mistral.ai/v1`
- #18742 — Related symptom: Kimi K2.5 via aggregators with no max_tokens/reasoning_effort
