### PR TITLE
fix(plugins): deregister stale plugin tools on forced rediscovery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -624,6 +624,20 @@ class PluginManager:
         if self._discovered and not force:
             return
         if force:
+            try:
+                from tools.registry import registry
+            except Exception:
+                registry = None
+            if registry is not None:
+                for tool_name in list(self._plugin_tool_names):
+                    try:
+                        registry.deregister(tool_name)
+                    except Exception:
+                        logger.debug(
+                            "Failed to deregister stale plugin tool during rediscovery: %s",
+                            tool_name,
+                            exc_info=True,
+                        )
             self._plugins.clear()
             self._hooks.clear()
             self._plugin_tool_names.clear()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -572,6 +572,47 @@ class TestPluginContext:
         from tools.registry import registry
         assert "plugin_echo" in registry._tools
 
+    def test_force_rediscovery_deregisters_disabled_plugin_tools(self, tmp_path, monkeypatch):
+        """Forced rediscovery must remove stale tool registrations for disabled plugins."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "reload_plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "reload_plugin"}))
+        (plugin_dir / "__init__.py").write_text(
+            'def register(ctx):\n'
+            '    ctx.register_tool(\n'
+            '        name="reload_plugin_tool",\n'
+            '        toolset="plugin_reload_plugin",\n'
+            '        schema={"name": "reload_plugin_tool", "description": "Reload", "parameters": {"type": "object", "properties": {}}},\n'
+            '        handler=lambda args, **kw: "ok",\n'
+            '    )\n'
+        )
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["reload_plugin"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from tools.registry import registry
+
+        registry.deregister("reload_plugin_tool")
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "reload_plugin_tool" in registry._tools
+        assert "reload_plugin_tool" in mgr._plugin_tool_names
+
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": []}})
+        )
+        mgr.discover_and_load(force=True)
+
+        assert registry.get_entry("reload_plugin_tool") is None
+        assert "reload_plugin_tool" not in mgr._plugin_tool_names
+        assert "reload_plugin" in mgr._plugins
+        assert not mgr._plugins["reload_plugin"].enabled
+
 
 # ── TestPluginToolVisibility ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fix forced plugin rediscovery so plugin-provided tools are removed from the global tool registry when a plugin is disabled and `discover_and_load(force=True)` runs.

Before this change, the plugin manager cleared its own internal state on forced rediscovery, but previously registered plugin tools could remain in `tools.registry`. That left a stale state where a plugin appeared disabled while its tool was still registered and potentially visible/callable.

## What changed

- Deregister previously tracked plugin tools from `tools.registry` before clearing plugin manager state during forced rediscovery.
- Add a regression test covering the disable-and-reload flow.

## Reproduction

1. Enable a plugin that registers a tool.
2. Load plugins so the tool is added to the global registry.
3. Remove the plugin from `plugins.enabled`.
4. Call `discover_and_load(force=True)`.

### Before
The plugin manager no longer tracked the tool, but the tool still existed in the global registry.

### After
The tool is removed from the global registry during forced rediscovery, so plugin state and tool registry state stay consistent.

## Testing

Ran:

```bash
uv run --extra dev pytest tests/hermes_cli/test_plugins.py -k force_rediscovery_deregisters_disabled_plugin_tools

Passed:

force_rediscovery_deregisters_disabled_plugin_tools