### PR TITLE
fix(gateway): mark WeCom and QQBot missing-credential errors as non-retryable

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -234,7 +234,7 @@ class QQAdapter(BasePlatformAdapter):
             return False
         if not self._app_id or not self._client_secret:
             message = "QQ startup failed: QQ_APP_ID and QQ_CLIENT_SECRET are required"
-            self._set_fatal_error("qq_missing_credentials", message, retryable=True)
+            self._set_fatal_error("qq_missing_credentials", message, retryable=False)
             logger.warning("[%s] %s", self._log_tag, message)
             return False
 

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -202,7 +202,7 @@ class WeComAdapter(BasePlatformAdapter):
             return False
         if not self._bot_id or not self._secret:
             message = "WeCom startup failed: WECOM_BOT_ID and WECOM_SECRET are required"
-            self._set_fatal_error("wecom_missing_credentials", message, retryable=True)
+            self._set_fatal_error("wecom_missing_credentials", message, retryable=False)
             logger.warning("[%s] %s", self.name, message)
             return False
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -193,6 +193,28 @@ class TestVoiceAttachmentSSRFProtection:
 
 
 # ---------------------------------------------------------------------------
+# QQAdapter.connect() — credential validation
+# ---------------------------------------------------------------------------
+
+class TestQQConnect:
+    @pytest.mark.asyncio
+    async def test_missing_credentials_is_non_retryable(self):
+        import gateway.platforms.qqbot.adapter as qqbot_module
+        from gateway.platforms.qqbot import QQAdapter
+
+        with mock.patch.object(qqbot_module, "AIOHTTP_AVAILABLE", True), \
+             mock.patch.object(qqbot_module, "HTTPX_AVAILABLE", True):
+            adapter = QQAdapter(_make_config())  # no app_id / client_secret
+
+            connected = await adapter.connect()
+
+        assert connected is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "qq_missing_credentials"
+        assert adapter.fatal_error_retryable is False
+
+
+# ---------------------------------------------------------------------------
 # WebSocket proxy handling
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -91,6 +91,7 @@ class TestWeComConnect:
         assert adapter.has_fatal_error is True
         assert adapter.fatal_error_code == "wecom_missing_credentials"
         assert "WECOM_BOT_ID" in (adapter.fatal_error_message or "")
+        assert adapter.fatal_error_retryable is False
 
     @pytest.mark.asyncio
     async def test_connect_records_handshake_failure_details(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`WeComAdapter.connect()` and `QQAdapter.connect()` call `_set_fatal_error()` with `retryable=True` when `WECOM_BOT_ID`/`WECOM_SECRET` or `QQ_APP_ID`/`QQ_CLIENT_SECRET` are not configured. `gateway/run.py` queues adapters with `fatal_error_retryable=True` for background reconnection every 30 seconds. A missing credential is a configuration error that will never resolve on its own — the reconnect watcher spins indefinitely while the gateway status shows `"retrying"` instead of `"fatal"`, obscuring the real problem.

`gateway/platforms/sms.py` (merged today in #19745) and `gateway/platforms/weixin.py` already mark the same class of config error as `retryable=False`. This PR brings WeCom and QQBot into parity.

**Root cause:** `wecom.py` line 205 and `qqbot/adapter.py` line 237 pass `retryable=True` to `_set_fatal_error()` for credential-missing checks.

**Fix:** flip `retryable=False` on both credential checks. One-line change per adapter, symmetric across both platform branches. No behavior change when credentials are present.

## Related Issue

Fixes #19890

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `gateway/platforms/wecom.py`: `retryable=True` → `retryable=False` for `wecom_missing_credentials` (+1/-1)
- `gateway/platforms/qqbot/adapter.py`: `retryable=True` → `retryable=False` for `qq_missing_credentials` (+1/-1)
- `tests/gateway/test_wecom.py`: add `assert adapter.fatal_error_retryable is False` to existing missing-credentials test
- `tests/gateway/test_qqbot.py`: add `TestQQConnect.test_missing_credentials_is_non_retryable`

## How to Test

```bash
python3.11 -m pytest tests/gateway/test_wecom.py::TestWeComConnect::test_connect_records_missing_credentials tests/gateway/test_qqbot.py::TestQQConnect::test_missing_credentials_is_non_retryable -v
```

## Checklist
### Code
- [x] Contributing Guide okundu
- [x] Conventional Commits
- [x] Duplicate PR yok
- [x] Sadece bu fix
- [x] pytest çalıştırıldı
- [x] Test eklendi
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs güncellendi — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A