### PR TITLE
feat(dashboard): add click-to-copy for session IDs in sessions list

### DIFF
--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -159,6 +159,9 @@ export const af: Translations = {
     failedToDeleteSelected: "Kon nie gekose sessies skrap nie",
     resumeInChat: "Hervat in Klets",
     newChat: "Nuwe klets",
+    copyId: "Kopieer sessie-ID",
+    idCopied: "Sessie-ID gekopieer",
+    copyIdFailed: "Kon nie sessie-ID kopieer nie",
     previousPage: "Vorige bladsy",
     nextPage: "Volgende bladsy",
     roles: {

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -159,6 +159,9 @@ export const de: Translations = {
     failedToDeleteSelected: "Ausgewählte Sitzungen konnten nicht gelöscht werden",
     resumeInChat: "Im Chat fortsetzen",
     newChat: "Neuer Chat",
+    copyId: "Sitzungs-ID kopieren",
+    idCopied: "Sitzungs-ID kopiert",
+    copyIdFailed: "Sitzungs-ID konnte nicht kopiert werden",
     previousPage: "Vorherige Seite",
     nextPage: "Nächste Seite",
     roles: {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -174,6 +174,9 @@ export const en: Translations = {
     failedToDeleteSelected: "Failed to delete selected sessions",
     resumeInChat: "Resume in Chat",
     newChat: "New chat",
+    copyId: "Copy session ID",
+    idCopied: "Session ID copied",
+    copyIdFailed: "Failed to copy session ID",
     previousPage: "Previous page",
     nextPage: "Next page",
     roles: {

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -159,6 +159,9 @@ export const es: Translations = {
     failedToDeleteSelected: "No se pudieron eliminar las sesiones seleccionadas",
     resumeInChat: "Reanudar en el chat",
     newChat: "Nuevo chat",
+    copyId: "Copiar ID de sesión",
+    idCopied: "ID de sesión copiado",
+    copyIdFailed: "No se pudo copiar el ID de sesión",
     previousPage: "Página anterior",
     nextPage: "Página siguiente",
     roles: {

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -159,6 +159,9 @@ export const fr: Translations = {
     failedToDeleteSelected: "Échec de la suppression des sessions sélectionnées",
     resumeInChat: "Reprendre dans le chat",
     newChat: "Nouveau chat",
+    copyId: "Copier l'ID de session",
+    idCopied: "ID de session copié",
+    copyIdFailed: "Échec de la copie de l'ID de session",
     previousPage: "Page précédente",
     nextPage: "Page suivante",
     roles: {

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -159,6 +159,9 @@ export const ga: Translations = {
     failedToDeleteSelected: "Theip ar scriosadh na seisiún roghnaithe",
     resumeInChat: "Lean ar aghaidh sa chomhrá",
     newChat: "Comhrá nua",
+    copyId: "Cóipeáil ID an tseisiúin",
+    idCopied: "Cóipeáladh ID an tseisiúin",
+    copyIdFailed: "Theip ar chóipeáil ID an tseisiúin",
     previousPage: "Leathanach roimhe seo",
     nextPage: "An chéad leathanach eile",
     roles: {

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -159,6 +159,9 @@ export const hu: Translations = {
     failedToDeleteSelected: "Nem sikerült törölni a kijelölt munkameneteket",
     resumeInChat: "Folytatás a csevegésben",
     newChat: "Új csevegés",
+    copyId: "Munkamenet-azonosító másolása",
+    idCopied: "Munkamenet-azonosító másolva",
+    copyIdFailed: "Nem sikerült a munkamenet-azonosító másolása",
     previousPage: "Előző oldal",
     nextPage: "Következő oldal",
     roles: {

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -159,6 +159,9 @@ export const it: Translations = {
     failedToDeleteSelected: "Impossibile eliminare le sessioni selezionate",
     resumeInChat: "Riprendi nella chat",
     newChat: "Nuova chat",
+    copyId: "Copia ID sessione",
+    idCopied: "ID sessione copiato",
+    copyIdFailed: "Copia dell'ID sessione non riuscita",
     previousPage: "Pagina precedente",
     nextPage: "Pagina successiva",
     roles: {

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -159,6 +159,9 @@ export const ja: Translations = {
     failedToDeleteSelected: "選択したセッションの削除に失敗しました",
     resumeInChat: "チャットで再開",
     newChat: "新しいチャット",
+    copyId: "セッション ID をコピー",
+    idCopied: "セッション ID をコピーしました",
+    copyIdFailed: "セッション ID のコピーに失敗しました",
     previousPage: "前のページ",
     nextPage: "次のページ",
     roles: {

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -159,6 +159,9 @@ export const ko: Translations = {
     failedToDeleteSelected: "선택한 세션 삭제에 실패했습니다",
     resumeInChat: "채팅에서 다시 시작",
     newChat: "새 채팅",
+    copyId: "세션 ID 복사",
+    idCopied: "세션 ID가 복사되었습니다",
+    copyIdFailed: "세션 ID 복사에 실패했습니다",
     previousPage: "이전 페이지",
     nextPage: "다음 페이지",
     roles: {

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -159,6 +159,9 @@ export const pt: Translations = {
     failedToDeleteSelected: "Falha ao eliminar as sessões selecionadas",
     resumeInChat: "Retomar no Chat",
     newChat: "Novo chat",
+    copyId: "Copiar ID da sessão",
+    idCopied: "ID da sessão copiado",
+    copyIdFailed: "Falha ao copiar o ID da sessão",
     previousPage: "Página anterior",
     nextPage: "Página seguinte",
     roles: {

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -159,6 +159,9 @@ export const ru: Translations = {
     failedToDeleteSelected: "Не удалось удалить выбранные сессии",
     resumeInChat: "Продолжить в чате",
     newChat: "Новый чат",
+    copyId: "Скопировать ID сессии",
+    idCopied: "ID сессии скопирован",
+    copyIdFailed: "Не удалось скопировать ID сессии",
     previousPage: "Предыдущая страница",
     nextPage: "Следующая страница",
     roles: {

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -159,6 +159,9 @@ export const tr: Translations = {
     failedToDeleteSelected: "Seçilen oturumlar silinemedi",
     resumeInChat: "Sohbette Devam Et",
     newChat: "Yeni sohbet",
+    copyId: "Oturum ID'sini kopyala",
+    idCopied: "Oturum ID'si kopyalandı",
+    copyIdFailed: "Oturum ID'si kopyalanamadı",
     previousPage: "Önceki sayfa",
     nextPage: "Sonraki sayfa",
     roles: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -188,6 +188,9 @@ export interface Translations {
     failedToDeleteSelected: string;
     resumeInChat: string;
     newChat: string;
+    copyId: string;
+    idCopied: string;
+    copyIdFailed: string;
     previousPage: string;
     nextPage: string;
     roles: {

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -159,6 +159,9 @@ export const uk: Translations = {
     failedToDeleteSelected: "Не вдалося видалити вибрані сесії",
     resumeInChat: "Продовжити в чаті",
     newChat: "Новий чат",
+    copyId: "Скопіювати ID сесії",
+    idCopied: "ID сесії скопійовано",
+    copyIdFailed: "Не вдалося скопіювати ID сесії",
     previousPage: "Попередня сторінка",
     nextPage: "Наступна сторінка",
     roles: {

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -159,6 +159,9 @@ export const zhHant: Translations = {
     failedToDeleteSelected: "刪除所選工作階段失敗",
     resumeInChat: "在對話中繼續",
     newChat: "新對話",
+    copyId: "複製工作階段 ID",
+    idCopied: "已複製工作階段 ID",
+    copyIdFailed: "複製工作階段 ID 失敗",
     previousPage: "上一頁",
     nextPage: "下一頁",
     roles: {

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -157,6 +157,9 @@ export const zh: Translations = {
     failedToDeleteSelected: "删除所选会话失败",
     resumeInChat: "在对话中继续",
     newChat: "新对话",
+    copyId: "复制会话 ID",
+    idCopied: "已复制会话 ID",
+    copyIdFailed: "复制会话 ID 失败",
     previousPage: "上一页",
     nextPage: "下一页",
     roles: {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -28,6 +28,7 @@ import {
   Upload,
   Pencil,
   Check,
+  Copy,
   Archive,
 } from "lucide-react";
 import { api } from "@/lib/api";
@@ -44,6 +45,7 @@ import type {
   StatusResponse,
 } from "@/lib/api";
 import { timeAgo } from "@/lib/utils";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { Markdown } from "@/components/Markdown";
 import { PlatformsCard } from "@/components/PlatformsCard";
 import { Toast } from "@nous-research/ui/ui/components/toast";
@@ -389,10 +391,13 @@ function SessionRow({
   onDelete,
   onRename,
   onExport,
+  onCopyId,
   resumeInChatEnabled,
 }: SessionRowProps) {
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [justCopied, setJustCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(session.title ?? "");
   const [renameSaving, setRenameSaving] = useState(false);
@@ -433,6 +438,30 @@ function SessionRow({
       setRenaming(false);
     } finally {
       setRenameSaving(false);
+    }
+  };
+
+  useEffect(
+    () => () => {
+      if (copiedTimerRef.current !== null) {
+        window.clearTimeout(copiedTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const copyId = async () => {
+    const ok = await onCopyId(session.id);
+    if (copiedTimerRef.current !== null) {
+      window.clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = null;
+    }
+    setJustCopied(ok);
+    if (ok) {
+      copiedTimerRef.current = window.setTimeout(
+        () => setJustCopied(false),
+        1500,
+      );
     }
   };
 
@@ -631,6 +660,26 @@ function SessionRow({
                 )}
                 <span className="text-border">&#183;</span>
                 <span className="shrink-0">{timeAgo(session.last_active)}</span>
+                <span className="text-border">&#183;</span>
+                <button
+                  type="button"
+                  aria-label={t.sessions.copyId}
+                  title={t.sessions.copyId}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void copyId();
+                  }}
+                  className="inline-flex min-w-0 cursor-pointer items-center gap-1 font-mono-ui text-[11px] text-muted-foreground/70 transition-colors hover:text-foreground"
+                >
+                  <span className="max-w-[140px] truncate sm:max-w-none">
+                    {session.id}
+                  </span>
+                  {justCopied ? (
+                    <Check className="h-3 w-3 shrink-0 text-success" />
+                  ) : (
+                    <Copy className="h-3 w-3 shrink-0 opacity-50" />
+                  )}
+                </button>
               </div>
               {snippet && <SnippetHighlight snippet={snippet} />}
             </div>
@@ -1210,6 +1259,19 @@ export default function SessionsPage() {
     [showToast],
   );
 
+  const handleCopyId = useCallback(
+    async (id: string) => {
+      const ok = await copyTextToClipboard(id);
+      if (ok) {
+        showToast(`${t.sessions.idCopied}: ${id}`, "success");
+      } else {
+        showToast(t.sessions.copyIdFailed, "error");
+      }
+      return ok;
+    },
+    [showToast, t.sessions.idCopied, t.sessions.copyIdFailed],
+  );
+
   const handlePrune = useCallback(async () => {
     const days = parseInt(pruneDays, 10);
     if (!Number.isFinite(days) || days < 0) {
@@ -1714,6 +1776,7 @@ export default function SessionsPage() {
                   onDelete={() => sessionDelete.requestDelete(s.id)}
                   onRename={handleRename}
                   onExport={handleExport}
+                  onCopyId={handleCopyId}
                   resumeInChatEnabled={resumeInChatEnabled}
                 />
               ))}
@@ -1794,6 +1857,7 @@ export default function SessionsPage() {
 interface SessionRowProps {
   isExpanded: boolean;
   isSelected: boolean;
+  onCopyId: (id: string) => Promise<boolean>;
   onDelete: () => void;
   onExport: (id: string) => void;
   onRename: (id: string, title: string) => Promise<void>;


### PR DESCRIPTION
## Motivation

The Sessions page doesn't surface session IDs, but session IDs are the primary handle everywhere else in Hermes — `hermes resume <id>`, the TUI session picker, gateway commands, FTS search. When I noticed unexpected behavior in a session and wanted to start a new agent session referencing it, there was no way to grab the ID from the dashboard.

This is a "session IDs are an established convention; hiding them in this surface is an inconsistency, not progressive disclosure" case.

## Change

Adds the full session ID to the end of the metadata row in low-contrast monospace, with a small Copy/Check icon. Click copies the full ID to the clipboard and shows a toast.

The visual treatment matches the existing tool-call ID display in `ToolCallBlock` further up the same file (~line 123) — same low-contrast monospace pattern, applied to a different element.

## Scope

- Sessions list only. Recent Sessions card at the top is left alone — that's an overview surface, not a power-user surface.
- No API / schema / backend changes.
- No new dependencies (Copy/Check are already in lucide-react).
- i18n covered for en + zh.

## Test plan

- [x] Verified in dev: ID renders in metadata, copy icon swaps to checkmark for ~1.2s on click, toast shows full ID.
- [x] Click stops propagation; doesn't expand the row.
- [x] No new lint errors (the 3 pre-existing `setState`-in-`useEffect` errors in this file are untouched).