### PR TITLE
fix(docs): register cron-script-only guide in sidebar

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -168,6 +168,7 @@ const sidebars: SidebarsConfig = {
         'guides/use-voice-mode-with-hermes',
         'guides/build-a-hermes-plugin',
         'guides/automate-with-cron',
+        'guides/cron-script-only',
         'guides/automation-templates',
         'guides/cron-troubleshooting',
         'guides/work-with-skills',


### PR DESCRIPTION
## Summary

Fixes the broken sidebar on [`/docs/guides/cron-script-only`](https://hermes-agent.nousresearch.com/docs/guides/cron-script-only).

PR #19709 added the guide file but never added the entry to `website/sidebars.ts`, which is explicitly enumerated (not autogenerated). Two consequences:

1. The guide didn't show up in the left-nav "Guides & Tutorials" list — users could only reach it via cross-links from other pages.
2. Landing on the guide page directly made the sidebar disappear entirely (Docusaurus renders orphaned docs without their parent sidebar).

## Change

Added `'guides/cron-script-only'` to the `Guides & Tutorials` category in `sidebars.ts`, slotted next to `'guides/automate-with-cron'` so related cron content stays grouped.

## Verification

Ran `npm run build` locally:

- No orphan-doc warnings
- No broken links
- Guide page builds with its sidebar intact
- Cross-links from other guides / feature-reference pages still resolve

No content changes. Docs only.

Related: #19709, #19871
