### PR TITLE
fix(cli): guard c-S-c key binding with try/except to prevent startup crash

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,20 +10484,19 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
+        try:
+            @kb.add('c-S-c')  # Ctrl+Shift+C — no-op, let terminal handle native copy
+            def handle_ctrl_shift_c(event):
+                """No-op: let the terminal handle Ctrl+Shift+C natively.
 
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
-
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
+                Wrapped in try/except because prompt_toolkit raises ValueError
+                ("Invalid key: c-S-c") on platforms where this key spec is not
+                recognised.  The binding is best-effort; if registration fails,
+                startup continues normally.
+                """
+                return
+        except ValueError:
+            pass  # prompt_toolkit on this platform/version doesn't support c-S-c
 
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):


### PR DESCRIPTION
## What does this PR do?

PR #19884 added `@kb.add('c-S-c')` unconditionally. `prompt_toolkit` raises `ValueError("Invalid key: c-S-c")` during `HermesCLI.__init__` on platforms where this key spec is not recognised — the process exits before reaching the prompt loop.

Reported on **macOS** (#19894) and **Linux** (#19896) immediately after #19884 landed.

**Root cause:** `prompt_toolkit.key_binding.KeyBindings.add()` calls `_parse_key('c-S-c')` which raises `ValueError: Invalid key: c-S-c` on the current platform/version. The exception propagates through `HermesCLI.__init__` and aborts startup.

**Fix:** Wrap the `@kb.add('c-S-c')` registration in `try/except ValueError`. Where the spec is accepted the binding is registered normally as a no-op; where it fails, startup continues cleanly and Ctrl+Shift+C falls through to the terminal's native handler.

Verified locally:
```python
from prompt_toolkit.key_binding import KeyBindings
kb = KeyBindings()
try:
    @kb.add('c-S-c')
    def f(e): pass
except ValueError as ex:
    print(ex)  # "Invalid key: c-S-c"
```

## Related Issue

Fixes #19894 (macOS crash)
Fixes #19896 (Linux crash)

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `cli.py`: wrap `@kb.add('c-S-c')` in `try/except ValueError` (+13/-14)

## How to Test

On affected macOS or Linux: run `hermes`. Before this fix: `Error: Invalid key: c-S-c` and immediate exit. After: clean startup.

## Checklist
### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest run (no tests added — interactive TUI binding, not unit-testable)
- [x] Platform: macOS + Linux (regression from #19884, same day)

### Documentation & Housekeeping
- [x] Docs — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — fixes both macOS (#19894) and Linux (#19896)
- [x] Tool descriptions — N/A