### PR TITLE
fix(cli): enforce python 3.10+ requirement in doctor check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -204,8 +204,6 @@ def run_doctor(args):
     elif py_version >= (3, 10):
         check_ok(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}")
         check_warn("Python 3.11+ recommended for RL Training tools (tinker requires >= 3.11)")
-    elif py_version >= (3, 8):
-        check_warn(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}", "(3.10+ recommended)")
     else:
         check_fail(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}", "(3.10+ required)")
         issues.append("Upgrade Python to 3.10+")


### PR DESCRIPTION
## Summary
`hermes doctor` reported Python 3.8/3.9 as a soft warning ("3.10+ recommended") in hermes_cli/doctor.py:207, even though the surrounding branch declares 3.10+ required. Users on unsupported Pythons saw a passing check instead of a failure with an actionable issue.

## Fix
Drop the `elif py_version >= (3, 8)` branch so anything below 3.10 falls through to the existing `check_fail` path, which reports the version as failing and appends "Upgrade Python to 3.10+" to issues.

## Tests
`pytest tests/ -v` was not run since the change is a single conditional in a CLI diagnostics path with no associated tests.
