### PR TITLE
fix: wrap c-S-c keybinding in try/except for prompt_toolkit compat

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,20 +10484,23 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
+        try:
+            @kb.add('c-S-c')  # Ctrl+Shift+C
+            def handle_ctrl_shift_c(event):
+                """Copy text to clipboard (terminal-native).
 
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
+                This is a no-op at the application level. Terminal emulators
+                handle the actual copy operation when Ctrl+Shift+C is pressed.
+                This binding prevents Hermes from intercepting the keystroke
+                as an interrupt signal.
 
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
+                On macOS the standard copy shortcut is Cmd+C (no Hermes binding
+                needed). On Linux/Windows Ctrl+Shift+C is the conventional
+                terminal copy shortcut.
+                """
+                return  # No-op — let the terminal perform native copy
+        except (ValueError, KeyError):
+            pass  # prompt_toolkit < 3.x does not support ControlShift+letter
 
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):


### PR DESCRIPTION
## Problem

The `@kb.add("c-S-c")` keybinding (Ctrl+Shift+C) raises `ValueError` on startup with prompt_toolkit 3.0.x because `ControlShift+letter` combinations are not valid `Keys` values.

```
Error: Invalid key: c-S-c
```

## Fix

Wrap the decorator in a `try/except (ValueError, KeyError)` so the binding is silently skipped on versions that don't support it. Once prompt_toolkit adds `ControlShift+letter` support, the binding will automatically start working.

## Notes

- The binding is a no-op (copy is handled natively by the terminal emulator)
- No functional change on supported versions
- Tested on prompt_toolkit 3.0.52