### PR TITLE
fix(gateway): handle non-numeric WECOM_CALLBACK_PORT env value

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1406,6 +1406,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.WECOM_CALLBACK not in config.platforms:
             config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
         config.platforms[Platform.WECOM_CALLBACK].enabled = True
+        try:
+            wecom_callback_port = int(os.getenv("WECOM_CALLBACK_PORT", "8645"))
+        except ValueError:
+            wecom_callback_port = 8645
         config.platforms[Platform.WECOM_CALLBACK].extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
@@ -1413,7 +1417,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "token": os.getenv("WECOM_CALLBACK_TOKEN", ""),
             "encoding_aes_key": os.getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
             "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
-            "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
+            "port": wecom_callback_port,
         })
 
     # Weixin (personal WeChat via iLink Bot API)


### PR DESCRIPTION
## Summary
A non-numeric `WECOM_CALLBACK_PORT` env value caused `int(...)` at gateway/config.py:1383 to raise `ValueError` from inside the `extra.update` dict literal, aborting gateway config loading entirely.

## Fix
Parse `WECOM_CALLBACK_PORT` before building the extra dict, wrapped in `try/except ValueError` that falls back to the default `8645`. The parsed value is then assigned to port so a bad env var no longer crashes config loading.

## Tests
Verified manually by setting `WECOM_CALLBACK_PORT=notaport` with WeCom callback enabled. The config now loads cleanly with port `8645` instead of raising.
