### PR TITLE
fix(cli): remove invalid 'c-S-c' key binding crashing TUI on startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,21 +10484,6 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
-
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
-
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
-
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):
             """Alternative interrupt/exit shortcut (Ctrl+Q).


### PR DESCRIPTION
## Summary

- `@kb.add('c-S-c')` (added in 645a2f4) raises `Invalid key: c-S-c` from prompt_toolkit immediately after the welcome banner, making the TUI unusable on startup.
- Terminals do not deliver Ctrl+Shift+C as a key combination distinct from Ctrl+C — the shift modifier is not transmitted for control-letter sequences in standard xterm/VT encodings — so prompt_toolkit rejects the key name.
- The handler was a documented no-op anyway. Its sole purpose was preventing Hermes from intercepting native terminal copy, which already works without any binding because the terminal handles Ctrl+Shift+C before the application sees it.

Removing the binding restores TUI startup with no behavioral change to copy/paste.

## Reproduction

```
$ hermes
... banner renders ...
Welcome to Hermes Agent! Type your message or /help for commands.
Error: Invalid key: c-S-c
```

## Test plan

- [x] `hermes` starts cleanly past the welcome banner with the patch applied
- [x] Native terminal copy (Ctrl+Shift+C on Linux/Windows, Cmd+C on macOS) still works — was already terminal-handled
- [x] `python -m py_compile cli.py` clean