### PR TITLE
fix(gateway): prefer configured provider for model aliases

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -998,6 +998,46 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_gateway_model_state(config: dict | None = None) -> tuple[str, str, str]:
+    """Read current model/provider/base_url from config.yaml for gateway commands.
+
+    The canonical config shape stores these values under ``model:``, but older
+    configs and migration docs may still use a string-valued ``model`` plus
+    root-level ``provider``/``base_url``.  Match the interactive CLI fallback
+    behavior so provider-aware operations such as ``/model sonnet`` resolve
+    aliases against the provider the user actually configured.
+    """
+    cfg = config if config is not None else _load_gateway_config()
+    current_model = ""
+    current_provider = "openrouter"
+    current_base_url = ""
+    has_nested_provider = False
+
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, str):
+        current_model = model_cfg
+    elif isinstance(model_cfg, dict):
+        current_model = model_cfg.get("default") or model_cfg.get("model") or ""
+        nested_provider = model_cfg.get("provider")
+        if nested_provider:
+            current_provider = nested_provider
+            has_nested_provider = True
+        current_base_url = model_cfg.get("base_url") or ""
+
+    if not current_provider:
+        current_provider = "openrouter"
+    if not has_nested_provider:
+        root_provider = cfg.get("provider")
+        if root_provider:
+            current_provider = root_provider
+    if not current_base_url:
+        root_base_url = cfg.get("base_url")
+        if root_base_url:
+            current_base_url = root_base_url
+
+    return current_model, current_provider, current_base_url
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -7881,11 +7921,9 @@ class GatewayRunner:
         try:
             cfg = _load_gateway_config()
             if cfg:
-                model_cfg = cfg.get("model", {})
-                if isinstance(model_cfg, dict):
-                    current_model = model_cfg.get("default", "")
-                    current_provider = model_cfg.get("provider", current_provider)
-                    current_base_url = model_cfg.get("base_url", "")
+                current_model, current_provider, current_base_url = (
+                    _resolve_gateway_model_state(cfg)
+                )
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -1,5 +1,7 @@
 """Regression tests for gateway /model support of config.yaml custom_providers."""
 
+from types import SimpleNamespace
+
 import yaml
 import pytest
 
@@ -61,3 +63,55 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_uses_root_provider_with_string_model(tmp_path, monkeypatch):
+    """Legacy config shape must still drive provider-aware alias resolution.
+
+    BlueBubbles/gateway users can have a string-valued ``model`` plus a
+    root-level ``provider``.  The gateway ``/model`` command should pass that
+    provider into the shared switcher so ambiguous aliases like ``sonnet`` are
+    resolved on Anthropic instead of the OpenRouter default.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": "claude-opus-4-6",
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    seen = {}
+
+    def fake_switch_model(**kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(
+            success=True,
+            new_model="claude-sonnet-4-6",
+            target_provider="anthropic",
+            api_key="",
+            base_url="https://api.anthropic.com",
+            api_mode="anthropic_messages",
+            provider_label="Anthropic",
+            model_info=None,
+            warning_message="",
+        )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+
+    result = await _make_runner()._handle_model_command(_make_event("/model sonnet"))
+
+    assert seen["raw_input"] == "sonnet"
+    assert seen["current_model"] == "claude-opus-4-6"
+    assert seen["current_provider"] == "anthropic"
+    assert seen["current_base_url"] == "https://api.anthropic.com"
+    assert "Model switched to `claude-sonnet-4-6`" in result


### PR DESCRIPTION
## Summary
- make gateway `/model` read legacy root-level `provider`/`base_url` when `model` is a string
- align gateway provider fallback with the interactive CLI so ambiguous aliases resolve against the configured provider
- add regression coverage for `/model sonnet` with string model + root Anthropic provider config

Fixes #19858

## Validation
- `python3 -m py_compile gateway/run.py tests/gateway/test_model_command_custom_providers.py`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_model_command_custom_providers.py -q -n 4` → 2 passed

## Note
- `scripts/run_tests.sh tests/gateway/test_model_command_custom_providers.py -q` could not start locally because the shared venv lacks `pip` while the wrapper attempted to install `pytest-split`.
