### PR TITLE
fix: remove invalid Ctrl+Shift+C keybinding

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,20 +10484,10 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
-
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
-
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
+        # Do not bind Ctrl+Shift+C here. prompt_toolkit does not support a
+        # portable key name for that chord (e.g. 'c-S-c' raises
+        # ValueError: Invalid key), and terminal emulators handle copy before
+        # the application sees it anyway.
 
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):

--- a/tests/cli/test_invalid_keybindings.py
+++ b/tests/cli/test_invalid_keybindings.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+from prompt_toolkit.key_binding import KeyBindings
+
+
+@pytest.mark.parametrize("key", ["c-S-c"])
+def test_prompt_toolkit_rejects_non_portable_key_names(key):
+    kb = KeyBindings()
+
+    with pytest.raises(Exception, match="Invalid key"):
+        kb.add(key)(lambda event: None)
+
+
+def test_cli_does_not_register_invalid_ctrl_shift_c_binding():
+    source = Path(__file__).resolve().parents[2] / "cli.py"
+
+    assert "@kb.add('c-S-c')" not in source.read_text()


### PR DESCRIPTION
## Summary
- Remove the `@kb.add('c-S-c')` prompt_toolkit binding that raises `ValueError: Invalid key: c-S-c` during CLI startup.
- Leave Ctrl+Shift+C/Cmd+C handling to terminal emulators.
- Add regression coverage to prevent reintroducing the invalid key name.

## Test Plan
- [x] `python -m pytest tests/cli/test_invalid_keybindings.py -q`
- [x] `python -m pytest tests/cli/test_invalid_keybindings.py tests/cli/test_cli_extension_hooks.py -q`
- [x] `hermes --version`
- [x] `hermes chat -q 'pingとだけ返して' --quiet`
- [x] Interactive `hermes` launch in tmux
