### PR TITLE
fix: remove invalid Ctrl+Shift+C keybinding

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,20 +10484,10 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
-
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
-
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
+        # Do not bind Ctrl+Shift+C here. prompt_toolkit does not support a
+        # portable key name for that chord (e.g. 'c-S-c' raises
+        # ValueError: Invalid key), and terminal emulators handle copy before
+        # the application sees it anyway.
 
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):

--- a/tests/cli/test_cli_keybindings.py
+++ b/tests/cli/test_cli_keybindings.py
@@ -1,0 +1,56 @@
+"""Regression tests for CLI prompt_toolkit key binding declarations."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from prompt_toolkit.key_binding import KeyBindings
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _literal_kb_add_sequences(path: Path) -> list[tuple[int, tuple[str, ...]]]:
+    tree = ast.parse(path.read_text())
+    sequences: list[tuple[int, tuple[str, ...]]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr == "add"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "kb"
+        ):
+            continue
+        keys: list[str] = []
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                keys.append(arg.value)
+            else:
+                break
+        else:
+            if keys:
+                sequences.append((node.lineno, tuple(keys)))
+    return sequences
+
+
+def test_cli_keybindings_are_valid_prompt_toolkit_keys():
+    """Invalid key names break `hermes` startup before the input prompt appears."""
+    sequences = _literal_kb_add_sequences(REPO_ROOT / "cli.py")
+    assert sequences
+
+    for lineno, sequence in sequences:
+        kb = KeyBindings()
+        try:
+            decorator = kb.add(*sequence)
+        except Exception as exc:  # pragma: no cover - assertion path includes details
+            raise AssertionError(
+                f"Invalid prompt_toolkit key binding at cli.py:{lineno}: {sequence!r}"
+            ) from exc
+
+        @decorator
+        def _handler(event):  # pragma: no cover - never executed
+            return None


### PR DESCRIPTION
## Summary
- Remove the `@kb.add('c-S-c')` prompt_toolkit binding that raises `ValueError: Invalid key: c-S-c` during CLI startup.
- Leave Ctrl+Shift+C/Cmd+C handling to terminal emulators.
- Add regression coverage that validates literal CLI keybinding declarations against prompt_toolkit.

## Test Plan
- [x] `python -m pytest tests/cli/test_cli_keybindings.py tests/cli/test_cli_extension_hooks.py -q`
- [x] `hermes --version`
- [x] `hermes chat -q 'pingとだけ返して' --quiet`
- [x] Interactive `hermes` launch in tmux
