### PR TITLE
fix(cli): remove invalid ctrl-shift-c keybinding

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,21 +10484,6 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
-
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
-
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
-
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):
             """Alternative interrupt/exit shortcut (Ctrl+Q).

--- a/tests/cli/test_cli_keybindings.py
+++ b/tests/cli/test_cli_keybindings.py
@@ -1,0 +1,51 @@
+import ast
+from pathlib import Path
+
+from prompt_toolkit.key_binding import KeyBindings
+
+
+def _literal_kb_add_sequences(source: str) -> list[tuple[str, ...]]:
+    tree = ast.parse(source)
+    sequences: list[tuple[str, ...]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            func = decorator.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "add"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "kb"
+            ):
+                continue
+
+            keys = tuple(
+                arg.value
+                for arg in decorator.args
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+            )
+            if keys:
+                sequences.append(keys)
+
+    return sequences
+
+
+def test_cli_literal_prompt_toolkit_keybindings_are_valid():
+    source = Path("cli.py").read_text(encoding="utf-8")
+    sequences = _literal_kb_add_sequences(source)
+
+    assert sequences
+
+    invalid: list[tuple[tuple[str, ...], str]] = []
+    for keys in sequences:
+        kb = KeyBindings()
+        try:
+            kb.add(*keys)(lambda event: None)
+        except Exception as exc:  # pragma: no cover - assertion reports details
+            invalid.append((keys, str(exc)))
+
+    assert invalid == []


### PR DESCRIPTION
## What does this PR do?

Removes the `@kb.add('c-S-c')` prompt_toolkit binding that crashes Hermes startup with `Error: Invalid key: c-S-c`.

The handler was a no-op intended to let terminals handle Ctrl+Shift+C. Because prompt_toolkit rejects that key spec on affected installs, registering it aborts CLI startup before the prompt opens. Removing it preserves terminal-native copy behavior and avoids registering an invalid key.

This is an alternative to #19895. That PR keeps the binding behind `try/except`; this PR removes the no-op binding entirely and adds a regression test that validates literal CLI keybindings against prompt_toolkit.

## Related Issue

Fixes #19894
Fixes #19896
Fixes #19903

Related: #19895
Regression introduced by #19884

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: removed the invalid no-op `c-S-c` binding.
- `tests/cli/test_cli_keybindings.py`: added a regression test that parses literal `@kb.add(...)` decorators in `cli.py` and verifies prompt_toolkit can register them.

## How to Test

1. On an affected checkout, run `hermes`; before this fix it exits during startup with `Error: Invalid key: c-S-c`.
2. Run `.venv/bin/python -m py_compile cli.py`.
3. Run `scripts/run_tests.sh tests/cli/test_cli_keybindings.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run locally:

```text
.venv/bin/python -m py_compile cli.py
scripts/run_tests.sh tests/cli/test_cli_keybindings.py -q

1 passed in 2.96s
```