### PR TITLE
fix(cli): remove invalid 'c-S-c' keybinding that crashes prompt_toolkit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10484,21 +10484,6 @@ class HermesCLI:
                     self._should_exit = True
                     event.app.exit()
 
-        @kb.add('c-S-c')  # Ctrl+Shift+C
-        def handle_ctrl_shift_c(event):
-            """Copy text to clipboard (terminal-native).
-
-            This is a no-op at the application level. Terminal emulators
-            handle the actual copy operation when Ctrl+Shift+C is pressed.
-            This binding prevents Hermes from intercepting the keystroke
-            as an interrupt signal.
-
-            On macOS the standard copy shortcut is Cmd+C (no Hermes binding
-            needed). On Linux/Windows Ctrl+Shift+C is the conventional
-            terminal copy shortcut.
-            """
-            return  # No-op — let the terminal perform native copy
-
         @kb.add('c-q')  # Ctrl+Q
         def handle_ctrl_q(event):
             """Alternative interrupt/exit shortcut (Ctrl+Q).


### PR DESCRIPTION
## Summary

Remove the invalid `@kb.add('c-S-c')` keybinding registration at `cli.py:10487` that causes `hermes` and `hermes chat` to crash on startup with:

```
Error: Invalid key: c-S-c
```

## Root Cause

`prompt_toolkit` does not support Shift modifiers (`S-`) in keybinding strings. The `c-S-c` syntax is not recognized, causing an immediate crash before the CLI can render.

## Fix

Removed the 14-line `handle_ctrl_shift_c` handler (decorator + docstring + no-op `return`). The handler was intentionally a no-op — its purpose was to prevent Hermes from intercepting Ctrl+Shift+C as an interrupt, but terminal emulators handle this keystroke at the OS level before it reaches the application, so the binding was unnecessary.

## Testing

- Verified `c-S-c` no longer appears anywhere in `cli.py`
- Ran CLI test suite (`pytest tests/ -k cli`): 2180 passed, pre-existing failures unrelated to this change
- No other keybindings affected

## Checklist

- [x] Scope: 1 file (`cli.py`), 15 lines removed
- [x] No new dependencies
- [x] No breaking changes

Closes #19903