### PR TITLE
fix(model_tools): log discord dynamic schema exceptions instead of silently discarding

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -425,7 +425,8 @@ def _compute_tool_definitions(
                 from tools import discord_tool as _dt
                 schema_fn = getattr(_dt, _discord_schema_fns[discord_tool_name])
                 dynamic = schema_fn()
-            except Exception:
+            except Exception as _schema_err:
+                logger.debug("Discord dynamic schema error for %s: %s", discord_tool_name, _schema_err)
                 dynamic = None
             if dynamic is None:
                 filtered_tools = [


### PR DESCRIPTION
## What does this PR do?
When building the tool list, `get_tool_definitions()` fetches dynamic schemas for Discord tools via `schema_fn()`. If this call raises (e.g. import error, missing attribute, API failure), the exception was silently swallowed with `except Exception: pass` and `dynamic` was set to `None`, causing the tool to be silently removed from the list with no diagnostic output.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `logger.debug()` to log the exception and `discord_tool_name` before falling back to `dynamic = None`

## How to Test
1. Break the discord schema function (e.g. make it raise)
2. Before: silent failure, tool disappears from list
3. After: debug log shows which tool and what error

## Checklist
- [x] Follows existing code style
- [x] No secrets or sensitive data
- [x] Minimal, focused change