### PR TITLE
fix(file_tools): log config exception in _get_max_read_chars instead of silently swallowing

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -53,8 +53,8 @@ def _get_max_read_chars() -> int:
         if isinstance(val, (int, float)) and val > 0:
             _max_read_chars_cached = int(val)
             return _max_read_chars_cached
-    except Exception:
-        pass
+    except Exception as _cfg_err:
+        logger.debug("Failed to load file_read_max_chars config: %s", _cfg_err)
     _max_read_chars_cached = _DEFAULT_MAX_READ_CHARS
     return _max_read_chars_cached
 


### PR DESCRIPTION
## What does this PR do?
`_get_max_read_chars()` loads the `file_read_max_chars` config value at runtime. If `load_config()` or the value access raises (e.g. malformed config, import error), the exception was silently swallowed with `except Exception: pass`, falling back to the default with no diagnostic output.

## Type of Change
- [x] Bug fix

## Changes Made
- Replace `except Exception: pass` with `except Exception as _cfg_err: logger.debug(...)` so config load failures are visible in debug logs

## How to Test
1. Corrupt the config or mock `load_config()` to raise
2. Before: silent fallback to default, no log
3. After: debug log shows the exception

## Checklist
- [x] Follows existing code style
- [x] No secrets or sensitive data
- [x] Minimal, focused change