### PR TITLE
fix(plugins): honor documented transform hook kwargs

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -797,6 +797,7 @@ def handle_function_call(
                 "transform_tool_result",
                 tool_name=function_name,
                 args=function_args,
+                arguments=function_args,
                 result=result,
                 task_id=task_id or "",
                 session_id=session_id or "",

--- a/tests/test_transform_tool_result_hook.py
+++ b/tests/test_transform_tool_result_hook.py
@@ -101,10 +101,26 @@ def test_hook_receives_expected_kwargs(monkeypatch):
     assert out == '{"ok": true}'
     assert captured["tool_name"] == "my_tool"
     assert captured["args"] == {"a": 1, "b": "x"}
+    assert captured["arguments"] == {"a": 1, "b": "x"}
     assert captured["result"] == '{"ok": true}'
     assert captured["task_id"] == "t1"
     assert captured["session_id"] == "s1"
     assert captured["tool_call_id"] == "tc1"
+
+
+def test_hook_accepts_documented_arguments_kwarg(monkeypatch):
+    out = _run_handle_function_call(
+        monkeypatch,
+        tool_name="my_tool",
+        tool_args={"a": 1},
+        dispatch_result='{"ok": true}',
+        invoke_hook=lambda hook_name, **kwargs: (
+            [f'ARGS={kwargs["arguments"]["a"]}']
+            if hook_name == "transform_tool_result"
+            else []
+        ),
+    )
+    assert out == "ARGS=1"
 
 
 def test_hook_exception_falls_back_to_original(monkeypatch):

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -133,6 +133,26 @@ def test_terminal_output_transform_still_runs_strip_and_redact(monkeypatch, tmp_
     assert "***" in result["output"]
 
 
+def test_terminal_output_transform_hook_receives_documented_cwd(monkeypatch, tmp_path):
+    captured = {}
+
+    def _hook(hook_name, **kwargs):
+        if hook_name == "transform_terminal_output":
+            captured.update(kwargs)
+        return []
+
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=_hook,
+        command="pwd",
+    )
+
+    assert result["output"] == "plain output"
+    assert captured["cwd"] == str(tmp_path)
+
+
 def test_terminal_output_transform_hook_exception_falls_back(monkeypatch, tmp_path):
     def _raise(*_args, **_kwargs):
         raise RuntimeError("boom")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2052,6 +2052,7 @@ def terminal_tool(
                     command=command,
                     output=output,
                     returncode=returncode,
+                    cwd=workdir or cwd,
                     task_id=effective_task_id or "",
                     env_type=env_type,
                 )


### PR DESCRIPTION
## What does this PR do?

Aligns the plugin transform hook payloads with the
documented contract.

Two documented hook kwargs were missing or mismatched
in the runtime payload:

- `transform_tool_result` docs describe an `arguments`
  kwarg, but the runtime only passed `args`
- `transform_terminal_output` docs describe a `cwd`
  kwarg, but the runtime did not pass it at all

Because hook invocation is fail-open, plugins written
against the documented signatures could silently no-op
after raising `TypeError` on missing kwargs.

This change keeps backward compatibility while fixing
the documented API:

- `transform_tool_result` now passes both `args` and
  `arguments`
- `transform_terminal_output` now passes `cwd`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds
      functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `model_tools.py` so
  `transform_tool_result` hooks receive `arguments`
  in addition to the existing `args`
- Updated `tools/terminal_tool.py` so
  `transform_terminal_output` hooks receive `cwd`
- Added regression coverage in:
  - `tests/test_transform_tool_result_hook.py`
  - `tests/tools/test_terminal_output_transform_hook.py`

## How to Test

1. Run:

   `.venv\Scripts\python.exe -m pytest
   tests/test_transform_tool_result_hook.py
   tests/tools/test_terminal_output_transform_hook.py
   -q`

2. Verify the transform hook tests pass.

3. Optionally verify that plugins using explicit
   `arguments` or `cwd` keyword-only callback
   parameters now work without falling back silently.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
      (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this
      isn't a duplicate
- [x] My PR contains only changes related to this
      fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes


### Documentation & Housekeeping

- [x] I've updated relevant documentation
      (`README`, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I
      added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`
      if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact
      (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I
      changed tool behavior — or N/A

## Screenshots / Logs

```text
.venv\Scripts\python.exe -m pytest \
  tests/test_transform_tool_result_hook.py \
  tests/tools/test_terminal_output_transform_hook.py -q

bringing up nodes...
bringing up nodes...
....................
20 passed, 20 warnings in 5.09s
