### PR TITLE
fix(terminal): recover from deleted cwd instead of crashing all sessions

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -358,6 +358,19 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # Validate that self.cwd still exists.  When subagents share a single
+        # LocalEnvironment and one cd's into a temp dir that gets deleted,
+        # subprocess.Popen raises FileNotFoundError for ALL subsequent calls.
+        # The shell script from _wrap_command already does `cd -- <path>` so
+        # Popen's cwd just needs to be a valid launch directory for bash.
+        popen_cwd = self.cwd
+        if not os.path.isdir(popen_cwd):
+            # Reset self.cwd to a safe fallback so future calls don't
+            # keep hitting the same stale path.
+            fallback = os.path.expanduser("~") if os.path.isdir(os.path.expanduser("~")) else "/"
+            self.cwd = fallback
+            popen_cwd = fallback
+
         proc = subprocess.Popen(
             args,
             text=True,
@@ -368,7 +381,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            cwd=self.cwd,
+            cwd=popen_cwd,
         )
         if not _IS_WINDOWS:
             try:
@@ -456,8 +469,14 @@ class LocalEnvironment(BaseEnvironment):
         try:
             with open(self._cwd_file) as f:
                 cwd_path = f.read().strip()
-            if cwd_path:
+            if cwd_path and os.path.isdir(cwd_path):
                 self.cwd = cwd_path
+            elif cwd_path and not os.path.isdir(cwd_path):
+                # The recorded cwd no longer exists (temp dir deleted by
+                # another process).  Reset to a safe fallback so subsequent
+                # commands don't loop on exit-126 from a stale cd target.
+                fallback = os.path.expanduser("~") if os.path.isdir(os.path.expanduser("~")) else "/"
+                self.cwd = fallback
         except (OSError, FileNotFoundError):
             pass
 


### PR DESCRIPTION
## Problem

When multiple gateway sessions share a single `LocalEnvironment` (the default — all subagents map to `"default"` task_id), a subagent that `cd`'s into a temp directory poisons `self.cwd` for ALL sessions if that directory is later deleted.

`subprocess.Popen(cwd='/tmp/deleted_dir')` raises `FileNotFoundError` at the Python level — before bash even starts — making terminal and file tools **completely unusable** across all concurrent sessions until gateway restart.

The retry logic (3 retries with exponential backoff) just retries the same broken Popen call, making it worse by delaying the error response.

### Reproduction scenario (from a user's debug report):
1. Gateway running with Telegram, spawning `delegate_task` subagents
2. Subagent cd's into `/tmp/dr3_4_a1_46hd1m5g` (a temp sandbox)
3. Temp dir deleted by script cleanup
4. ALL sessions get: `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/dr3_4_a1_46hd1m5g'`
5. Every terminal/file operation fails with 3 retries each — gateway is bricked

## Fix

Two changes in `tools/environments/local.py`:

### 1. `_run_bash()` — validate cwd before Popen
Before passing `cwd` to `subprocess.Popen`, check `os.path.isdir(self.cwd)`. If the directory no longer exists, reset `self.cwd` to user's home (or `/`) as a safe fallback. The shell-level `cd -- <path>` in `_wrap_command` handles the logical directory switch — Popen's cwd just needs to be a valid launch point for bash.

### 2. `_update_cwd()` — don't restore stale paths from cwd file
After a command runs, `_update_cwd()` reads the cwd tracking file. If the recorded path no longer exists on disk, reset to fallback instead of re-setting `self.cwd` to the stale path. This prevents the exit-126 loop where every command fails because the stale path keeps getting re-read from the file.

## Recovery behavior

After the fix:
- **First command** after deletion: returns exit 126 with clear `No such file or directory` message (model can understand and adapt)
- **All subsequent commands**: succeed from home directory (self-healing)
- **No Python crash**, no retry storms, no gateway bricking

## Test plan

E2E verified:
```python
env = LocalEnvironment(cwd=temp_dir, timeout=30)
env.execute('echo hello')  # works
shutil.rmtree(temp_dir)    # simulate cleanup
env.execute('echo test')   # rc=126, no crash, cwd resets to ~
env.execute('echo ok')     # rc=0, recovered
```

Existing test suite: 50 passed (test_base_environment + test_local_env_blocklist + test_terminal_tool), 973 passed in full tools/ suite (2 pre-existing failures unrelated to this change).