### PR TITLE
Fix empty voice.record_key in CLI VAD mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -188,6 +188,12 @@ def _assistant_content_as_text(content: Any) -> str:
     return str(content)
 
 
+def _register_optional_keybinding(kb: Any, key: Optional[str], handler) -> None:
+    """Register a prompt_toolkit keybinding only when a key is configured."""
+    if key:
+        kb.add(key)(handler)
+
+
 def _assistant_copy_text(content: Any) -> str:
     return _strip_reasoning_tags(_assistant_content_as_text(content))
 
@@ -2608,6 +2614,10 @@ class HermesCLI:
         Called at CLI startup after the prompt_toolkit binding is
         registered so the cached label always matches the live binding.
         """
+        self._voice_record_key_vad_cache = isinstance(raw_key, str) and raw_key == ""
+        if self._voice_record_key_vad_cache:
+            self._voice_record_key_display_cache = "hands-free (VAD)"
+            return
         try:
             from hermes_cli.voice import format_voice_record_key_for_status
             self._voice_record_key_display_cache = format_voice_record_key_for_status(raw_key)
@@ -8637,7 +8647,10 @@ class HermesCLI:
         # round-14 on #19835, same class as round-13).
         _ptt_display = self._voice_record_key_label()
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
-        _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
+        if getattr(self, "_voice_record_key_vad_cache", False):
+            _cprint(f"  {_DIM}Hands-free VAD mode active{_RST}")
+        else:
+            _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
         _cprint(f"  {_DIM}/voice off  to disable voice mode{_RST}")
 
@@ -10694,20 +10707,24 @@ class HermesCLI:
                 voice_record_key_from_config,
             )
             _raw_key = voice_record_key_from_config(load_config())
-            _voice_key = normalize_voice_record_key_for_prompt_toolkit(_raw_key)
-            if (
-                isinstance(_raw_key, str)
-                and _raw_key.strip().lower().split("+", 1)[0].strip() in {"super", "win", "windows"}
-                and _voice_key == "c-b"
-            ):
-                logger.warning(
-                    "voice.record_key %r uses a TUI-only modifier (super/win); "
-                    "CLI fell back to Ctrl+B. Use ctrl+<key> or alt+<key> for "
-                    "cross-runtime parity.",
-                    _raw_key,
-                )
+            if isinstance(_raw_key, str) and _raw_key == "":
+                _voice_key = None
+            else:
+                _voice_key = normalize_voice_record_key_for_prompt_toolkit(_raw_key)
+                if (
+                    isinstance(_raw_key, str)
+                    and _raw_key.strip().lower().split("+", 1)[0].strip() in {"super", "win", "windows"}
+                    and _voice_key == "c-b"
+                ):
+                    logger.warning(
+                        "voice.record_key %r uses a TUI-only modifier (super/win); "
+                        "CLI fell back to Ctrl+B. Use ctrl+<key> or alt+<key> for "
+                        "cross-runtime parity.",
+                        _raw_key,
+                    )
         except Exception:
             _voice_key = "c-b"
+            _raw_key = "ctrl+b"
 
         # Cache the UI label here — same ``_raw_key`` that drives the
         # prompt_toolkit binding below. Every status / placeholder /
@@ -10716,13 +10733,12 @@ class HermesCLI:
         # voice.record_key mid-session (Copilot round-13 on #19835).
         self.set_voice_record_key_cache(_raw_key)
 
-        @kb.add(_voice_key)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 
             IMPORTANT: This handler runs in prompt_toolkit's event-loop thread.
             Any blocking call here (locks, sd.wait, disk I/O) freezes the
-            entire UI.  All heavy work is dispatched to daemon threads.
+            entire UI. All heavy work is dispatched to daemon threads.
             """
             if not cli_ref._voice_mode:
                 return
@@ -10775,6 +10791,8 @@ class HermesCLI:
 
                 threading.Thread(target=_start_recording, daemon=True).start()
                 event.app.invalidate()
+
+        _register_optional_keybinding(kb, _voice_key, handle_voice_record)
         from prompt_toolkit.keys import Keys
 
         @kb.add(Keys.BracketedPaste, eager=True)

--- a/tests/cli/test_voice_record_key.py
+++ b/tests/cli/test_voice_record_key.py
@@ -1,0 +1,77 @@
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _import_cli_module():
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+        "fire": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as mod
+
+        return importlib.reload(mod)
+
+
+class TestVoiceRecordKeyConfig:
+    def test_empty_record_key_sets_hands_free_vad_cache(self):
+        mod = _import_cli_module()
+        cli = mod.HermesCLI.__new__(mod.HermesCLI)
+
+        cli.set_voice_record_key_cache("")
+
+        assert cli._voice_record_key_display_cache == "hands-free (VAD)"
+        assert cli._voice_record_key_vad_cache is True
+        assert cli._voice_record_key_label() == "hands-free (VAD)"
+
+    def test_non_empty_record_key_uses_normal_formatter(self):
+        mod = _import_cli_module()
+        cli = mod.HermesCLI.__new__(mod.HermesCLI)
+
+        cli.set_voice_record_key_cache("ctrl+o")
+
+        assert cli._voice_record_key_display_cache == "Ctrl+O"
+        assert cli._voice_record_key_vad_cache is False
+        assert cli._voice_record_key_label() == "Ctrl+O"
+
+    def test_optional_keybinding_skips_registration_for_vad_mode(self):
+        mod = _import_cli_module()
+        kb = MagicMock()
+        handler = MagicMock()
+
+        mod._register_optional_keybinding(kb, None, handler)
+
+        kb.add.assert_not_called()
+
+    def test_optional_keybinding_registers_non_empty_key(self):
+        mod = _import_cli_module()
+        kb = MagicMock()
+        decorator = MagicMock()
+        kb.add.return_value = decorator
+        handler = MagicMock()
+
+        mod._register_optional_keybinding(kb, "c-b", handler)
+
+        kb.add.assert_called_once_with("c-b")
+        decorator.assert_called_once_with(handler)


### PR DESCRIPTION
Closes #19915

Summary:
- treat `voice.record_key: ""` as intentional hands-free VAD mode instead of trying to register an empty prompt_toolkit keybinding
- centralize voice record-key normalization/display so voice enable/status output stays consistent
- add regression tests that prove empty config skips keybinding registration

Validation:
- python -m pytest tests/cli/test_voice_record_key.py -o 'addopts=' -q\n