### PR TITLE
fix(tui): complete absolute paths as paths

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { completionRequestForInput } from '../hooks/useCompletion.js'
+
+describe('completionRequestForInput', () => {
+  it('routes real slash commands to slash completion', () => {
+    expect(completionRequestForInput('/help')).toMatchObject({
+      method: 'complete.slash',
+      params: { text: '/help' },
+      replaceFrom: 1
+    })
+  })
+
+  it('does not route absolute paths through slash completion', () => {
+    expect(
+      completionRequestForInput('/home/d/Desktop/agenda/CrimsonRed/.hermes/plans/2026-05-04-HANDOFF-NEXT.md')
+    ).toMatchObject({
+      method: 'complete.path',
+      params: { word: '/home/d/Desktop/agenda/CrimsonRed/.hermes/plans/2026-05-04-HANDOFF-NEXT.md' },
+      replaceFrom: 0
+    })
+  })
+
+  it('keeps path completion for trailing absolute path tokens', () => {
+    expect(completionRequestForInput('read /home/d/Desktop/file.md')).toMatchObject({
+      method: 'complete.path',
+      params: { word: '/home/d/Desktop/file.md' },
+      replaceFrom: 5
+    })
+  })
+
+  it('leaves plain text alone', () => {
+    expect(completionRequestForInput('hello there')).toBeNull()
+  })
+})

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -1,11 +1,42 @@
 import { useEffect, useRef, useState } from 'react'
 
 import type { CompletionItem } from '../app/interfaces.js'
+import { looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { CompletionResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
 
 const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
+
+export function completionRequestForInput(
+  input: string
+):
+  | { method: 'complete.path'; params: { word: string }; replaceFrom: number }
+  | { method: 'complete.slash'; params: { text: string }; replaceFrom: number }
+  | null {
+  const isSlashCommand = looksLikeSlashCommand(input)
+  const pathWord = isSlashCommand ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
+
+  if (!isSlashCommand && !pathWord) {
+    return null
+  }
+
+  // `/model` / `/provider` use the two-step ModelPicker (real curated IDs).
+  // Slash completion here only showed short aliases + vendor/family meta.
+  if (isSlashCommand && /^\/(?:model|provider)(?:\s|$)/.test(input)) {
+    return null
+  }
+
+  if (isSlashCommand) {
+    return { method: 'complete.slash', params: { text: input }, replaceFrom: 1 }
+  }
+
+  return {
+    method: 'complete.path',
+    params: { word: pathWord! },
+    replaceFrom: input.length - pathWord!.length
+  }
+}
 
 export function useCompletion(input: string, blocked: boolean, gw: GatewayClient) {
   const [completions, setCompletions] = useState<CompletionItem[]>([])
@@ -33,35 +64,19 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
 
     ref.current = input
 
-    const isSlash = input.startsWith('/')
-    const pathWord = isSlash ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
-
-    if (!isSlash && !pathWord) {
+    const request = completionRequestForInput(input)
+    if (!request) {
       clear()
 
       return
     }
-
-    // `/model` / `/provider` use the two-step ModelPicker (real curated IDs).
-    // Slash completion here only showed short aliases + vendor/family meta.
-    if (isSlash && /^\/(?:model|provider)(?:\s|$)/.test(input)) {
-      clear()
-
-      return
-    }
-
-    const pathReplace = input.length - (pathWord?.length ?? 0)
 
     const t = setTimeout(() => {
       if (ref.current !== input) {
         return
       }
 
-      const req = isSlash
-        ? gw.request<CompletionResponse>('complete.slash', { text: input })
-        : gw.request<CompletionResponse>('complete.path', { word: pathWord })
-
-      req
+      gw.request<CompletionResponse>(request.method, request.params)
         .then(raw => {
           if (ref.current !== input) {
             return
@@ -71,7 +86,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
 
           setCompletions(r?.items ?? [])
           setCompIdx(0)
-          setCompReplace(isSlash ? (r?.replace_from ?? 1) : pathReplace)
+          setCompReplace(request.method === 'complete.slash' ? (r?.replace_from ?? 1) : request.replaceFrom)
         })
         .catch((e: unknown) => {
           if (ref.current !== input) {
@@ -86,7 +101,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
             }
           ])
           setCompIdx(0)
-          setCompReplace(isSlash ? 1 : pathReplace)
+          setCompReplace(request.replaceFrom)
         })
     }, 60)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI completion routing bug where text beginning with an absolute path, such as `/home/d/Desktop/file.md`, could enter the slash-command completion path because completion checked only `input.startsWith("/")`.

The submit path already has a stricter slash-command shape check, so this makes completion use the same distinction: real slash commands still use `complete.slash`, while absolute paths use `complete.path`.

## Related Issue

No GitHub issue found. This came from a Discord support report where an absolute path typed at the start of the TUI prompt appeared to be eaten unless the user prefixed it with a space.

Searched for existing PRs/issues with:
- `prompt starting with / eaten`
- `absolute path slash command eaten`
- `looksLikeSlashCommand useCompletion`
- `complete.slash absolute path`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `ui-tui/src/hooks/useCompletion.ts` so completion uses `looksLikeSlashCommand()` instead of treating every leading `/` as a slash command.
- Added `completionRequestForInput()` to keep the completion routing decision testable.
- Added `ui-tui/src/__tests__/useCompletion.test.ts` covering slash commands, absolute-path-leading prompts, trailing absolute path tokens, and plain text.

## How to Test

1. `cd ui-tui && npm run type-check`
2. `cd ui-tui && npm test -- --run src/__tests__/useCompletion.test.ts src/__tests__/useComposerState.test.ts`
3. In the TUI, type an absolute path like `/home/d/Desktop/agenda/CrimsonRed/.hermes/plans/2026-05-04-HANDOFF-NEXT.md` and press Enter. It should be treated as prompt text/path input, not as a slash command.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL with focused TUI type-check, focused Vitest coverage, and full Python suite attempt through `scripts/run_tests.sh -n 4`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`cd ui-tui && npm run type-check` passed.

`cd ui-tui && npm test -- --run src/__tests__/useCompletion.test.ts src/__tests__/useComposerState.test.ts` passed: 2 files, 13 tests.

`scripts/run_tests.sh -n 4` failed:

`51 failed, 19611 passed, 51 skipped, 222 warnings in 596.24s (0:09:56)`

The full-suite failures are outside the files changed by this PR.

<details>
<summary>Full-suite failure list</summary>

```text
FAILED tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once
FAILED tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny
FAILED tests/cron/test_cron_script.py::TestBuildJobPromptWithScript::test_script_empty_output_noted
FAILED tests/agent/test_auxiliary_client.py::TestGetTextAuxiliaryClient::test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api
FAILED tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml
FAILED tests/agent/test_bedrock_1m_context.py::TestBedrockContext1MBeta::test_build_anthropic_kwargs_includes_1m_for_bedrock_fastmode
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_intermediate_send_stays_streaming
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_done_fires_only_when_reply_to_is_set
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_fires_done
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_false_tracks_sibling
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_next_send_auto_closes_sibling_streaming_cards
FAILED tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured
FAILED tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none
FAILED tests/gateway/test_api_server.py::TestAdapterInit::test_default_config
FAILED tests/gateway/test_discord_free_response.py::test_discord_free_channel_skips_auto_thread
FAILED tests/agent/test_curator.py::test_state_atomic_write_no_tmp_leftovers
FAILED tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_run_gateway_refreshes_outdated_unit_on_boot
FAILED tests/hermes_cli/test_model_validation.py::TestValidateCodexAutoCorrection::test_very_different_name_falls_to_suggestions
FAILED tests/gateway/test_teams.py::TestTeamsSend::test_send_typing
FAILED tests/hermes_cli/test_backup.py::TestPreUpdateBackup::test_rotation_keeps_only_n
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_restarts_profile_manual_gateways
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_profile_manual_gateway_falls_back_to_sigterm
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestServicePidExclusion::test_update_kills_manual_pid_but_not_service_pid
FAILED tests/hermes_cli/test_update_yes_flag.py::TestUpdateYesConfigMigration::test_no_yes_flag_still_prompts_in_tty
FAILED tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_refreshes_repo_and_tui_node_dependencies
FAILED tests/run_agent/test_concurrent_interrupt.py::test_concurrent_interrupt_cancels_pending
FAILED tests/hermes_cli/test_update_yes_flag.py::TestUpdateYesStashRestore::test_yes_restores_stash_without_prompting
FAILED tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted
FAILED tests/test_tui_gateway_server.py::test_session_create_drops_pending_title_on_valueerror
FAILED tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_dir_empty
FAILED tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_only_unrelated_browsers
FAILED tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_path_not_a_dir
FAILED tests/tools/test_browser_chromium_check.py::TestCheckBrowserRequirementsChromium::test_local_mode_missing_chromium_returns_false
FAILED tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_local_mode_missing_chromium_returns_error_immediately
FAILED tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_docker_hint_mentions_image_pull
FAILED tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_non_docker_hint_mentions_agent_browser_install
FAILED tests/tools/test_credential_pool_env_fallback.py::TestCredentialPoolSeedsFromDotEnv::test_os_environ_still_wins_over_dotenv
FAILED tests/tools/test_daytona_environment.py::TestExecute::test_custom_cwd_in_command_wrapper
FAILED tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_nous_provider_resolves_nous_credentials
FAILED tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_uses_runtime_model_when_config_model_missing
FAILED tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolves_full_credentials
FAILED tests/tools/test_delegate.py::TestDelegateHeartbeat::test_heartbeat_still_trips_idle_stale_when_no_tool
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_installs_tui_dependencies
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_materializes_local_tui_ink_package
FAILED tests/tools/test_skill_provenance.py::test_default_origin_is_foreground
FAILED tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears
FAILED tests/tools/test_vercel_sandbox_environment.py::TestExecute::test_execute_runs_command_from_workspace_root_and_updates_cwd
FAILED tests/tui_gateway/test_goal_command.py::test_goal_bare_shows_status_when_none_set
FAILED tests/tui_gateway/test_goal_command.py::test_goal_whitespace_only_shows_status
FAILED tests/tui_gateway/test_goal_command.py::test_goal_status_alias_shows_status
```

</details>
