### PR TITLE
fix(terminal): guard background process spawn against deleted cwd

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,7 +41,7 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _sanitize_subprocess_env
+from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -480,7 +480,7 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
-            cwd=cwd or os.getcwd(),
+            cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
 


### PR DESCRIPTION
## Summary

Follow-up to #19928. The foreground terminal path (`_run_bash`) was fixed to recover from a deleted cwd, but the background process spawn path in `process_registry.py` had the same vulnerability.

## The Bug

`spawn_local()` passes `session.cwd` directly to `subprocess.Popen(cwd=...)` and `PtyProcess.spawn(cwd=...)`. If the cwd was deleted (same scenario as #17558), background process creation fails with `FileNotFoundError`.

This is less severe than the foreground wedge (it's a one-shot failure rather than a permanent brick), but still causes unnecessary errors.

## The Fix

Apply `_resolve_safe_cwd()` (the helper from #19928) at session creation time:

```python
cwd=_resolve_safe_cwd(cwd or os.getcwd()),
```

This single change protects both the PTY path (line 499) and the Popen path (line 541) since they both use `session.cwd`.

## Test Plan

- `tests/tools/test_process_registry.py`: 47 passed
- `tests/tools/test_local_env_cwd_recovery.py`: 9 passed  
- Adjacent suite (terminal, base_environment, local_env_blocklist): 59 passed
- Compile check: OK