### PR TITLE
feat(gateway/discord): route slash-invoked turn replies as ephemeral followups

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -530,6 +530,26 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # Slash-invoked turns: chat_id → active discord.Interaction whose
+        # followup webhook should carry the agent's replies as ephemeral
+        # messages. Registered in _run_simple_slash before the agent runs and
+        # cleared in finally; send() consults this map so /approve, /retry,
+        # tool-progress bubbles, etc. land as ephemeral followups visible only
+        # to the invoker instead of public channel posts.
+        self._slash_followup_interactions: Dict[str, Any] = {}
+
+    def _register_slash_followup(self, chat_id: str, interaction: Any) -> None:
+        """Register *interaction* as the ephemeral-followup target for *chat_id*."""
+        self._slash_followup_interactions[chat_id] = interaction
+
+    def _clear_slash_followup(self, chat_id: str, interaction: Any) -> None:
+        """Drop the registration for *chat_id* iff it still points at *interaction*.
+
+        The identity check guards against clearing a registration that was
+        overwritten by a concurrent slash invocation in the same channel.
+        """
+        if self._slash_followup_interactions.get(chat_id) is interaction:
+            self._slash_followup_interactions.pop(chat_id, None)
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1138,6 +1158,43 @@ class DiscordAdapter(BasePlatformAdapter):
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+            # Slash-invoked turns: route replies through the deferred
+            # interaction's followup webhook as ephemeral so /approve, /deny,
+            # /retry, tool-progress bubbles, etc. stay visible only to the
+            # invoker. Skip when reply_to is requested (followup webhooks
+            # don't accept reply references) and on forum parents (handled
+            # below by _send_to_forum). Falls back to a normal channel.send
+            # if the interaction's 15-minute followup window has expired.
+            slash_interaction = (
+                self._slash_followup_interactions.get(chat_id)
+                if not reply_to
+                else None
+            )
+            if slash_interaction is not None:
+                try:
+                    followup_ids: list[str] = []
+                    for chunk in chunks:
+                        sent = await slash_interaction.followup.send(
+                            content=chunk,
+                            ephemeral=True,
+                        )
+                        sent_id = getattr(sent, "id", None)
+                        if sent_id is not None:
+                            followup_ids.append(str(sent_id))
+                    return SendResult(
+                        success=True,
+                        message_id=followup_ids[0] if followup_ids else None,
+                        raw_response={"message_ids": followup_ids, "ephemeral": True},
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "[%s] Slash followup send failed (%s); "
+                        "falling back to channel.send",
+                        self.name, e,
+                    )
+                    self._clear_slash_followup(chat_id, slash_interaction)
+                    # Fall through to normal channel.send path below.
 
             message_ids = []
             reference = None
@@ -2554,7 +2611,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
         await interaction.response.defer(ephemeral=True)
         event = self._build_slash_event(interaction, command_text)
-        await self.handle_message(event)
+        chat_id = str(interaction.channel_id)
+        self._register_slash_followup(chat_id, interaction)
+        try:
+            await self.handle_message(event)
+        finally:
+            self._clear_slash_followup(chat_id, interaction)
         try:
             if followup_msg:
                 await interaction.edit_original_response(content=followup_msg)
@@ -4343,7 +4405,7 @@ if DISCORD_AVAILABLE:
                     self.session_key, self.confirm_id, choice,
                 )
                 if result_text:
-                    await interaction.followup.send(result_text)
+                    await interaction.followup.send(result_text, ephemeral=True)
                 logger.info(
                     "Discord button resolved slash-confirm for session %s "
                     "(choice=%s, user=%s)",

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -386,3 +386,171 @@ async def test_forum_post_file_creation_failure():
 
     assert result.success is False
     assert "missing perms" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Slash-followup ephemeral routing — replies to slash-invoked turns are sent
+# as ephemeral followups on the registered interaction so /approve, /retry,
+# tool-progress bubbles, etc. don't post publicly to the channel.
+# ---------------------------------------------------------------------------
+
+
+def _make_slash_interaction(*, message_id=4242):
+    """Build a stand-in discord.Interaction whose followup.send returns a msg."""
+    sent = SimpleNamespace(id=message_id)
+    interaction = SimpleNamespace(
+        followup=SimpleNamespace(send=AsyncMock(return_value=sent)),
+    )
+    return interaction, sent
+
+
+@pytest.mark.asyncio
+async def test_send_routes_through_followup_when_slash_interaction_registered():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    interaction, sent = _make_slash_interaction(message_id=7777)
+    adapter._register_slash_followup("123", interaction)
+
+    result = await adapter.send("123", "tool result")
+
+    assert result.success is True
+    assert result.message_id == "7777"
+    assert (result.raw_response or {}).get("ephemeral") is True
+    interaction.followup.send.assert_awaited_once_with(
+        content="tool result", ephemeral=True,
+    )
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_followup_sends_each_chunk_when_message_splits():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.MAX_MESSAGE_LENGTH = 20
+
+    channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    counter = {"n": 0}
+
+    async def fake_followup_send(*, content, ephemeral):
+        counter["n"] += 1
+        return SimpleNamespace(id=10 + counter["n"])
+
+    interaction = SimpleNamespace(
+        followup=SimpleNamespace(send=AsyncMock(side_effect=fake_followup_send)),
+    )
+    adapter._register_slash_followup("999", interaction)
+
+    result = await adapter.send("999", "A" * 50)
+
+    assert result.success is True
+    assert result.message_id == "11"
+    assert interaction.followup.send.await_count >= 2
+    assert all(
+        call.kwargs.get("ephemeral") is True
+        for call in interaction.followup.send.await_args_list
+    )
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_falls_back_to_channel_when_followup_window_expired():
+    """Discord enforces a 15-minute followup TTL on interactions. When the
+    followup webhook rejects the send, drop the registration and fall back
+    to a normal channel.send so a long-running agent turn still delivers."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    channel_msg = SimpleNamespace(id=2024)
+    channel = SimpleNamespace(send=AsyncMock(return_value=channel_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    interaction = SimpleNamespace(
+        followup=SimpleNamespace(
+            send=AsyncMock(side_effect=RuntimeError("Unknown Webhook (10015)")),
+        ),
+    )
+    adapter._register_slash_followup("555", interaction)
+
+    result = await adapter.send("555", "late reply")
+
+    assert result.success is True
+    assert result.message_id == "2024"
+    interaction.followup.send.assert_awaited_once()
+    channel.send.assert_awaited_once()
+    # Registration was dropped after the failure so subsequent sends skip
+    # the followup path entirely.
+    assert "555" not in adapter._slash_followup_interactions
+
+
+@pytest.mark.asyncio
+async def test_send_uses_channel_when_no_slash_registered():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    sent_msg = SimpleNamespace(id=3030)
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("888", "hello")
+
+    assert result.success is True
+    assert result.message_id == "3030"
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_skips_followup_when_reply_to_set():
+    """Followup webhooks don't accept reply references. When the caller asks
+    for a reply, prefer channel.send so the reply chain is preserved even
+    if a slash interaction is registered for the channel."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=object()))
+    sent_msg = SimpleNamespace(id=4040)
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(return_value=ref_msg),
+        send=AsyncMock(return_value=sent_msg),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    interaction, _ = _make_slash_interaction()
+    adapter._register_slash_followup("777", interaction)
+
+    result = await adapter.send("777", "thread reply", reply_to="99")
+
+    assert result.success is True
+    assert result.message_id == "4040"
+    interaction.followup.send.assert_not_called()
+    channel.send.assert_awaited_once()
+
+
+def test_clear_slash_followup_only_clears_matching_interaction():
+    """_clear_slash_followup must not drop a registration that was overwritten
+    by a concurrent slash invocation in the same channel."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    interaction_a = SimpleNamespace(name="a")
+    interaction_b = SimpleNamespace(name="b")
+
+    adapter._register_slash_followup("c1", interaction_a)
+    # A second slash invocation in the same channel overwrites the first.
+    adapter._register_slash_followup("c1", interaction_b)
+    # First handler finishes and tries to clear — must be a no-op.
+    adapter._clear_slash_followup("c1", interaction_a)
+    assert adapter._slash_followup_interactions["c1"] is interaction_b
+    # Second handler clears its own registration successfully.
+    adapter._clear_slash_followup("c1", interaction_b)
+    assert "c1" not in adapter._slash_followup_interactions


### PR DESCRIPTION
## Summary

Slash commands in Discord (`/approve`, `/deny`, `/retry`, `/background`, `/queue`, `/steer`, etc.) defer their response as ephemeral, but any agent reply or tool-progress bubble emitted during the turn was sent via a regular `channel.send()` — public to everyone in the channel. This clutters busy channels and, for `/approve` / `/deny`, leaks command-decision state to non-invokers.

This PR routes those mid-turn replies through the deferred interaction's followup webhook with `ephemeral=True`, so they're visible only to the user who fired the slash command.

### Changes

- `DiscordAdapter.__init__`: add `_slash_followup_interactions: Dict[str, Interaction]` registry plus `_register_slash_followup` / `_clear_slash_followup` helpers (the clear helper does an identity check so concurrent slash invocations in the same channel don't clobber each other).
- `_run_simple_slash`: register the interaction before `handle_message`, clear in a `finally` block — so every slash command that runs through this helper gets ephemeral followups for its turn.
- `DiscordAdapter.send`: when an interaction is registered for `chat_id`, route each chunk through `interaction.followup.send(content=…, ephemeral=True)`. Falls back to `channel.send` cleanly when:
  - the followup webhook raises (e.g. Discord's 15-minute interaction TTL has elapsed) — the registration is dropped so subsequent sends don't keep retrying;
  - `reply_to` is set (followup webhooks don't accept reply references).
  - The forum-channel branch above is unaffected and still routes through `_send_to_forum`.
- `SlashConfirmView._resolve`: the one remaining non-ephemeral `interaction.followup.send(result_text)` (used by `/reload-mcp` confirmation) now passes `ephemeral=True` so the result text doesn't post publicly either.

### Why

- **Privacy / safety**: `/approve` and `/deny` previously surfaced their result as a public channel message; the approver's decision and any returned status text was visible to everyone in the channel.
- **Channel hygiene**: tool-progress bubbles ("🔍 web_search …", "✏️ write_file …") are useful real-time feedback for the invoker, but on a busy server they're noise for everyone else. Now they're visible only to the user who triggered the turn.
- Builds on the existing `interaction.response.defer(ephemeral=True)` pattern in `_run_simple_slash` — the deferred placeholder was already ephemeral; this completes the picture for the rest of the turn.

## How to test

1. Run a Discord bot configured against `gateway/platforms/discord.py`.
2. In a server channel, fire `/retry`, `/undo`, `/queue some prompt`, or `/background some prompt`. Observe that the bot's reply (and any tool-progress bubbles) only appear to you, not to the rest of the channel.
3. Trigger a slash-confirm flow (`/reload-mcp`) and click a button — the resolution text is ephemeral.
4. Trigger an interaction that takes >15 minutes (e.g. a long `/background` task) — replies should fall back to `channel.send` automatically once the followup window expires.
5. Regular `@mention` messages and DMs are unaffected (no interaction registered → normal `channel.send`).

Automated tests added in `tests/gateway/test_discord_send.py`:

- `test_send_routes_through_followup_when_slash_interaction_registered`
- `test_send_followup_sends_each_chunk_when_message_splits`
- `test_send_falls_back_to_channel_when_followup_window_expired`
- `test_send_uses_channel_when_no_slash_registered`
- `test_send_skips_followup_when_reply_to_set`
- `test_clear_slash_followup_only_clears_matching_interaction`

```bash
scripts/run_tests.sh tests/gateway/test_discord_send.py
```

## Platforms tested

- macOS (Darwin 25.3.0) — full `tests/gateway/test_discord_send.py` (21 passed) and broader `tests/gateway/` sweep (4569 passed; the 15 unrelated pre-existing failures in dingtalk/feishu/teams/whatsapp E2E suites also fail on `main` without this patch).
- Live Discord bot manual smoke: not run yet; reviewers with a test bot can validate the slash-invoked flow above.

## Test plan
- [ ] Maintainer dry-run on a test Discord bot to confirm `/approve`, `/retry`, and tool-progress bubbles are ephemeral.
- [ ] Maintainer review of fallback behavior when the 15-min interaction TTL elapses (current handling: drop registration + `channel.send`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)