### PR TITLE
fix(mcp): retry stale pipe transport failures

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -46,6 +46,17 @@ def test_is_session_expired_detects_session_not_found():
     assert _is_session_expired_error(RuntimeError("Unknown session: abc123")) is True
 
 
+def test_is_session_expired_detects_stale_pipe_and_closed_transport_variants():
+    """Stdio/AnyIO stale-pipe failures usually surface as closed-resource
+    or broken-pipe text, not an HTTP session-expired JSON-RPC error."""
+    from tools.mcp_tool import _is_session_expired_error
+    assert _is_session_expired_error(RuntimeError("ClosedResourceError")) is True
+    assert _is_session_expired_error(RuntimeError("closed resource in MCP child")) is True
+    assert _is_session_expired_error(RuntimeError("transport is closed")) is True
+    assert _is_session_expired_error(RuntimeError("Broken pipe while writing request")) is True
+    assert _is_session_expired_error(RuntimeError("End of file from MCP server")) is True
+
+
 def test_is_session_expired_is_case_insensitive():
     """Match uses lower-cased comparison so servers that emit the
     message in different cases (SDK formatter quirks) still trigger."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1611,6 +1611,12 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "session expired",
     "session not found",
     "unknown session",
+    "closedresourceerror",
+    "closed resource",
+    "transport is closed",
+    "connection closed",
+    "broken pipe",
+    "end of file",
 )
 
 


### PR DESCRIPTION
## Summary
- Treat closed-resource, closed-transport, broken-pipe, and EOF MCP failures as stale session equivalents.
- Reuse the existing session-expired reconnect/retry-once path instead of adding a new recovery path.
- Add regression coverage for stale-pipe marker variants.

## Test plan
- python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool_session_expired.py
- python -m pytest tests/tools/test_mcp_tool_session_expired.py -q -o addopts=
- selected secret scan over touched files

## Safety
- Minimal additive marker change only.
- No behavior removal, no credential reads, no provider/routing changes.