### PR TITLE
fix(gateway): detect launchd service for restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7706,9 +7706,13 @@ class GatewayRunner:
         # When running under a service manager (systemd/launchd), use the
         # service restart path: exit with code 75 so the service manager
         # restarts us.  The detached subprocess approach (setsid + bash)
-        # doesn't work under systemd because KillMode=mixed kills all
-        # processes in the cgroup, including the detached helper.
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # doesn't work under service supervision: systemd's KillMode=mixed
+        # kills all processes in the cgroup, and launchd with
+        # KeepAlive.SuccessfulExit=false will not restart a clean exit.
+        _under_service = bool(
+            os.environ.get("INVOCATION_ID")  # systemd sets this
+            or os.environ.get("XPC_SERVICE_NAME") == "ai.hermes.gateway"  # launchd
+        )
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -15,9 +15,10 @@ from tests.gateway.restart_test_helpers import make_restart_runner, make_restart
 
 @pytest.mark.asyncio
 async def test_restart_command_while_busy_requests_drain_without_interrupt(monkeypatch):
-    # Ensure INVOCATION_ID is NOT set — systemd sets this in service mode,
-    # which changes the restart call signature.
+    # Ensure service-manager env vars are NOT set — they change the restart
+    # call signature.
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     event = MessageEvent(
@@ -35,6 +36,29 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
     assert result == "⏳ Draining 1 active agent(s) before restart..."
     running_agent.interrupt.assert_not_called()
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_under_launchd_uses_service_restart(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m-launchd",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    result = await runner._handle_message(event)
+
+    assert result == "⏳ Draining 1 active agent(s) before restart..."
+    running_agent.interrupt.assert_not_called()
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Detects launchd-managed Hermes gateways when handling `/restart` from the gateway. launchd sets `XPC_SERVICE_NAME=ai.hermes.gateway`, not `INVOCATION_ID`, so the previous check only recognized systemd. On macOS this could send `/restart` down the detached restart path, exit cleanly, and leave launchd configured with `KeepAlive SuccessfulExit=false` without a respawn.

The fix treats `XPC_SERVICE_NAME == "ai.hermes.gateway"` as service-managed and uses the existing service restart path (`detached=False`, `via_service=True`).

## Related Issue

Related to #11932 and the broader launchd restart reliability work, but this is a separate `/restart` service-detection path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Include launchd's `XPC_SERVICE_NAME=ai.hermes.gateway` in the service-manager detection used by `/restart`.
  - Clarify the service-supervision comment for both systemd and launchd behavior.
- `tests/gateway/test_restart_drain.py`
  - Clear `XPC_SERVICE_NAME` in the non-service restart test.
  - Add launchd coverage verifying `/restart` calls `request_restart(detached=False, via_service=True)`.

## How to Test

1. Run the targeted restart-drain test file:
   ```bash
   python -m pytest tests/gateway/test_restart_drain.py -o 'addopts=' -q
   ```
2. Confirm the launchd regression test passes:
   - `test_restart_command_under_launchd_uses_service_restart`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -m pytest tests/gateway/test_restart_drain.py -o 'addopts=' -q
...............                                                          [100%]
15 passed in 1.46s
```
