### PR TITLE
test(gateway): isolate foreground run tests from systemd refresh

### DIFF
--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -15,6 +15,17 @@ def _install_fake_gateway_run(monkeypatch, start_gateway):
     monkeypatch.setitem(sys.modules, "gateway.run", module)
 
 
+def _disable_service_refresh(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(
+        gateway,
+        "refresh_systemd_unit_if_needed",
+        lambda system=False: pytest.fail(
+            "foreground gateway tests must not refresh service units"
+        ),
+    )
+
+
 def test_run_gateway_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):
     calls = []
 
@@ -26,6 +37,7 @@ def test_run_gateway_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):
         raise KeyboardInterrupt
 
     _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    _disable_service_refresh(monkeypatch)
     monkeypatch.setattr(gateway.asyncio, "run", fake_asyncio_run)
 
     gateway.run_gateway()
@@ -44,6 +56,7 @@ def test_run_gateway_exits_nonzero_when_start_gateway_reports_failure(monkeypatc
         return object()
 
     _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    _disable_service_refresh(monkeypatch)
     monkeypatch.setattr(gateway.asyncio, "run", lambda coro: False)
 
     with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
## What does this PR do?

Prevents the foreground gateway unit tests from entering the real systemd service-refresh path.

`run_gateway()` refreshes the user systemd unit on startup when systemd is available. The foreground gateway tests mock the gateway runner, but they did not mock that pre-start service refresh. In a local pytest run, the per-test `HERMES_HOME` fixture can then be written into the developer's real user service file before the mocked runner returns.

This keeps those tests scoped to foreground run/exit behavior by forcing the no-systemd branch and installing a fail-fast stub for `refresh_systemd_unit_if_needed()`.

## Related Issue

No GitHub issue found. This came from a local full-suite run where a foreground gateway test rewrote the live user service with a pytest temp `HERMES_HOME`.

Checked these related open PRs and they do not cover this pytest isolation issue:

- #14450
- #14684
- #17170

Also searched open PRs for:

- `test_gateway refresh_systemd_unit_if_needed HERMES_HOME`
- `pytest HERMES_HOME systemd service`
- `run_gateway service refresh`

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a small test helper in `tests/hermes_cli/test_gateway.py` to disable service-manager refresh behavior for foreground gateway tests.
- Applied it to the two `run_gateway()` foreground exit tests that only need to verify gateway runner/exit behavior.
- Added a fail-fast guard so these tests fail loudly if they ever try to refresh real service units again.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_gateway.py`
2. Confirm the local gateway service still points at the real Hermes home after the test run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL with targeted Python test coverage

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

` scripts/run_tests.sh tests/hermes_cli/test_gateway.py ` passed:

`23 passed in 3.21s`

After the targeted test run, the local user gateway service remained active/running and its `HERMES_HOME` remained pointed at the real Hermes home instead of a pytest temp directory.
