### PR TITLE
fix(cli): run dashboard PTY spawn off the event loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2885,6 +2885,7 @@ async def get_models_analytics(days: int = 30):
 
 import re
 import asyncio
+import functools
 
 from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError
 
@@ -3011,21 +3012,34 @@ async def pty_ws(ws: WebSocket) -> None:
     await ws.accept()
 
     # --- spawn PTY ------------------------------------------------------
+    # Both _resolve_chat_argv (which may shell out to `npm install`/`npm run
+    # build` on first run) and PtyBridge.spawn (which forks a child) are
+    # synchronous and can take seconds. Running them inline starves the
+    # event loop, which on uvicorn + websockets prevents the WS upgrade
+    # from being flushed and the browser sees the handshake hang.
     resume = ws.query_params.get("resume") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
+    loop = asyncio.get_running_loop()
+
     try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        argv, cwd, env = await loop.run_in_executor(
+            None,
+            functools.partial(
+                _resolve_chat_argv, resume=resume, sidecar_url=sidecar_url
+            ),
+        )
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
 
-
     try:
-        bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
+        bridge = await loop.run_in_executor(
+            None, functools.partial(PtyBridge.spawn, argv, cwd=cwd, env=env)
+        )
     except PtyUnavailableError as exc:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
@@ -3034,8 +3048,6 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
-
-    loop = asyncio.get_running_loop()
 
     # --- reader task: PTY master → WebSocket ----------------------------
     async def pump_pty_to_ws() -> None:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2213,3 +2213,42 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+    def test_argv_resolve_and_spawn_run_off_event_loop(self, monkeypatch):
+        """Regression: _resolve_chat_argv (which can shell out to
+        ``npm install`` / ``npm run build``) and PtyBridge.spawn (which
+        forks a child) must not run on the event loop thread.  Running
+        them inline starves uvicorn's websockets task and the browser
+        sees the WS upgrade hang — the symptom in the FastAPI 0.136
+        regression report."""
+        import asyncio
+
+        captured: dict = {}
+
+        def _site() -> str:
+            try:
+                asyncio.get_running_loop()
+                return "on_event_loop"
+            except RuntimeError:
+                return "off_event_loop"
+
+        def fake_resolve(resume=None, sidecar_url=None):
+            captured["resolve"] = _site()
+            return (["/bin/cat"], None, None)
+
+        real_spawn = self.ws_module.PtyBridge.spawn
+
+        def fake_spawn(cls, *args, **kwargs):
+            captured["spawn"] = _site()
+            return real_spawn(*args, **kwargs)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", fake_resolve)
+        monkeypatch.setattr(
+            self.ws_module.PtyBridge, "spawn", classmethod(fake_spawn)
+        )
+
+        with self.client.websocket_connect(self._url()):
+            pass
+
+        assert captured.get("resolve") == "off_event_loop"
+        assert captured.get("spawn") == "off_event_loop"


### PR DESCRIPTION
Run `_resolve_chat_argv` and `PtyBridge.spawn` in a thread executor so the dashboard `/api/pty` WebSocket handshake doesn't hang on FastAPI 0.136.

## What changed and why
- `hermes_cli/web_server.py`: `/api/pty` now invokes `_resolve_chat_argv` and `PtyBridge.spawn` via `loop.run_in_executor`. Both are synchronous and can take seconds (`_resolve_chat_argv` may shell out to `npm install` / `npm run build`; `PtyBridge.spawn` forks a child). Running them inline starved uvicorn's websockets task so the HTTP 101 upgrade was never flushed and the browser saw the handshake hang. Errors raised from these calls (`SystemExit`, `PtyUnavailableError`, `FileNotFoundError`, `OSError`) still surface to the client as before.
- `tests/hermes_cli/test_web_server.py`: added `test_argv_resolve_and_spawn_run_off_event_loop`, which monkeypatches `_resolve_chat_argv` and `PtyBridge.spawn` to record whether `asyncio.get_running_loop()` succeeds inside them. With the fix both run on a worker thread; without it they'd run on the loop thread (verified by reverting the fix locally — the new test fails as expected).

## How to test
- `pytest tests/hermes_cli/test_web_server.py -q -k Pty`
- Manual: `hermes dashboard --tui`, open the dashboard's Chat tab, confirm the xterm.js terminal connects without the WebSocket handshake timing out.

## What platforms tested on
- macOS on darwin-arm64 (local) — full `tests/hermes_cli/test_web_server.py` (138 passed) and the targeted `Pty` subset (20 passed).

Fixes #19914

<!-- autocontrib:worker-id=issue-new-b47427ee kind=pr-open -->