### PR TITLE
fix: harden voice key and custom provider parsing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1841,6 +1841,21 @@ def _looks_like_slash_command(text: str) -> bool:
     return "/" not in first_word[1:]
 
 
+def _resolve_voice_record_key(record_key: object) -> tuple[str, str]:
+    """Normalize ``voice.record_key`` into prompt_toolkit and display formats.
+
+    Empty, non-string, or whitespace-only values fall back to ``ctrl+b`` so a
+    hand-edited config like ``record_key: ""`` cannot crash CLI startup.
+    """
+    raw_key = record_key if isinstance(record_key, str) else ""
+    raw_key = raw_key.strip() or "ctrl+b"
+    prompt_toolkit_key = raw_key.lower().replace("ctrl+", "c-").replace("alt+", "a-")
+    display_key = raw_key
+    if "ctrl+" in raw_key.lower():
+        display_key = raw_key.replace("ctrl+", "Ctrl+").upper()
+    return prompt_toolkit_key, display_key
+
+
 # ============================================================================
 # Skill Slash Commands — dynamic commands generated from installed skills
 # ============================================================================
@@ -8492,11 +8507,11 @@ class HermesCLI:
         tts_status = " (TTS enabled)" if self._voice_tts else ""
         try:
             from hermes_cli.config import load_config
-            _raw_ptt = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _ptt_key = _raw_ptt.lower().replace("ctrl+", "c-").replace("alt+", "a-")
+            _ptt_key, _ptt_display = _resolve_voice_record_key(
+                load_config().get("voice", {}).get("record_key", "ctrl+b")
+            )
         except Exception:
-            _ptt_key = "c-b"
-        _ptt_display = _ptt_key.replace("c-", "Ctrl+").upper()
+            _ptt_key, _ptt_display = ("c-b", "CTRL+B")
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
@@ -8563,7 +8578,7 @@ class HermesCLI:
         _cprint(f"  TTS:       {'ON' if self._voice_tts else 'OFF'}")
         _cprint(f"  Recording: {'YES' if self._voice_recording else 'no'}")
         _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-        _display_key = _raw_key.replace("ctrl+", "Ctrl+").upper() if "ctrl+" in _raw_key.lower() else _raw_key
+        _, _display_key = _resolve_voice_record_key(_raw_key)
         _cprint(f"  Record key: {_display_key}")
         _cprint(f"\n  {_BOLD}Requirements:{_RST}")
         for line in reqs["details"].split("\n"):
@@ -10461,8 +10476,9 @@ class HermesCLI:
         # Config uses "ctrl+b" format; prompt_toolkit expects "c-b" format.
         try:
             from hermes_cli.config import load_config
-            _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _voice_key = _raw_key.lower().replace("ctrl+", "c-").replace("alt+", "a-")
+            _voice_key, _ = _resolve_voice_record_key(
+                load_config().get("voice", {}).get("record_key", "ctrl+b")
+            )
         except Exception:
             _voice_key = "c-b"
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2522,7 +2522,7 @@ def _normalize_custom_provider_entry(
     if "api_key_env" in entry and "key_env" not in entry:
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+        "name", "id", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
@@ -2563,7 +2563,7 @@ def _normalize_custom_provider_entry(
         return None
 
     name = ""
-    raw_name = entry.get("name")
+    raw_name = entry.get("name") or entry.get("id")
     if isinstance(raw_name, str) and raw_name.strip():
         name = raw_name.strip()
     elif provider_key.strip():
@@ -2600,13 +2600,32 @@ def _normalize_custom_provider_entry(
     if isinstance(models, dict) and models:
         normalized["models"] = models
     elif isinstance(models, list) and models:
-        # Hand-edited configs (and older Hermes versions) write ``models`` as
-        # a plain list of model ids. Preserve them by converting to the dict
-        # shape downstream code expects; otherwise normalize silently drops
-        # the list and /model shows the provider with (0) models.
-        normalized["models"] = {
-            str(m): {} for m in models if isinstance(m, str) and m.strip()
-        }
+        # Hand-edited configs (and older Hermes versions) may write ``models`` as
+        # either a plain list of model ids or a list of per-model dicts. Preserve
+        # both forms by converting to the dict shape downstream code expects;
+        # otherwise normalize silently drops metadata and /model shows the
+        # provider with (0) models or loses context_length overrides.
+        models_dict: Dict[str, Any] = {}
+        for model_entry in models:
+            if isinstance(model_entry, str) and model_entry.strip():
+                models_dict[model_entry.strip()] = {}
+                continue
+            if not isinstance(model_entry, dict):
+                continue
+            model_id = (
+                model_entry.get("id")
+                or model_entry.get("name")
+                or model_entry.get("model")
+            )
+            if not isinstance(model_id, str) or not model_id.strip():
+                continue
+            models_dict[model_id.strip()] = {
+                key: value
+                for key, value in model_entry.items()
+                if key not in {"id", "name", "model"}
+            }
+        if models_dict:
+            normalized["models"] = models_dict
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/tests/cli/test_voice_record_key_config.py
+++ b/tests/cli/test_voice_record_key_config.py
@@ -1,0 +1,17 @@
+from cli import _resolve_voice_record_key
+
+
+def test_empty_record_key_falls_back_to_default():
+    prompt_toolkit_key, display_key = _resolve_voice_record_key("")
+
+    assert prompt_toolkit_key == "c-b"
+    assert display_key == "CTRL+B"
+
+
+def test_whitespace_or_non_string_record_key_falls_back_to_default():
+    assert _resolve_voice_record_key("   ") == ("c-b", "CTRL+B")
+    assert _resolve_voice_record_key(None) == ("c-b", "CTRL+B")
+
+
+def test_alt_binding_is_preserved():
+    assert _resolve_voice_record_key("alt+r") == ("a-r", "alt+r")

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -142,6 +142,28 @@ class TestGetCustomProviderContextLength:
             == 400_000
         )
 
+    def test_config_normalization_supports_id_and_model_dict_lists(self):
+        """Config-path lookups must honor normalized id/list-of-dicts entries."""
+        config = {
+            "custom_providers": [
+                {
+                    "id": "manifest",
+                    "base_url": "https://example.invalid/v1",
+                    "models": [
+                        {"id": "auto", "context_length": 200_000},
+                    ],
+                }
+            ]
+        }
+        assert (
+            get_custom_provider_context_length(
+                "auto",
+                "https://example.invalid/v1",
+                config=config,
+            )
+            == 200_000
+        )
+
 
 class TestGetModelContextLengthHonorsOverride:
     """agent.model_metadata.get_model_context_length must honor the

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -183,6 +183,36 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["models"] == {"valid": {}, "also-valid": {}}
 
+    def test_id_field_can_name_provider(self):
+        """Legacy/hand-edited entries may use ``id`` instead of ``name``."""
+        entry = {
+            "id": "manifest",
+            "base_url": "https://api.example.com/v1",
+            "models": ["auto"],
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["name"] == "manifest"
+
+    def test_models_list_of_dicts_preserves_metadata(self):
+        """List-of-dicts model entries must retain per-model metadata."""
+        entry = {
+            "name": "manifest",
+            "base_url": "https://api.example.com/v1",
+            "models": [
+                {"id": "auto", "context_length": 200000},
+                {"name": "fast", "context_length": 64000, "mode": "cheap"},
+                {"model": "fallback", "context_length": 128000},
+            ],
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["models"] == {
+            "auto": {"context_length": 200000},
+            "fast": {"context_length": 64000, "mode": "cheap"},
+            "fallback": {"context_length": 128000},
+        }
+
     def test_models_empty_list_omitted(self):
         """Empty list (falsy) should not produce a models key."""
         entry = {


### PR DESCRIPTION
## Summary
This PR fixes two config/model-selection regressions reported in upstream issues:

1. `voice.record_key: ""` no longer crashes CLI startup.
   - Empty, whitespace-only, or non-string values now normalize back to the safe default `ctrl+b`.
   - The same normalization path is reused for startup messaging, `/voice` status output, and prompt_toolkit keybinding registration.

2. `custom_providers` normalization now preserves more real-world config shapes.
   - `id` is accepted as a provider-name alias alongside `name`.
   - `models` can be expressed as either `list[str]` or `list[dict]`.
   - Per-model metadata such as `context_length` is retained so downstream context resolution does not silently fall back.

## Tests
- [x] `scripts/run_tests.sh tests/cli/test_voice_record_key_config.py tests/hermes_cli/test_provider_config_validation.py tests/hermes_cli/test_custom_provider_context_length.py`

## Related Issues
- Fixes #19915
- Fixes #19857

## Notes
- Scope is intentionally limited to regression hardening and normalization behavior.
- No provider-routing logic changes are included in this PR.
