### PR TITLE
fix(gateway): bound per-adapter disconnect timeout to prevent shutdown hang

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -49,6 +49,7 @@ from hermes_cli.config import cfg_get
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 
@@ -1502,13 +1503,25 @@ class GatewayRunner:
 
         Must tolerate partial-init state and never raise, since callers
         use it inside error-handling blocks.
+
+        A per-adapter timeout prevents wedged websockets (e.g. Feishu /
+        Lark on flaky networks) from blocking the entire shutdown
+        sequence.  See #19937.
         """
+        timeout = _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+        platform_label = platform.value if platform is not None else "adapter"
         try:
-            await adapter.disconnect()
+            await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "⚠ %s disconnect timed out after %.0fs — abandoning",
+                platform_label,
+                timeout,
+            )
         except Exception as e:
             logger.debug(
                 "Defensive %s disconnect after failed connect raised: %s",
-                platform.value if platform is not None else "adapter",
+                platform_label,
                 e,
             )
 
@@ -4266,8 +4279,17 @@ class GatewayRunner:
                 except Exception as e:
                     logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
                 try:
-                    await adapter.disconnect()
+                    await asyncio.wait_for(
+                        adapter.disconnect(),
+                        timeout=_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT,
+                    )
                     logger.info("✓ %s disconnected", platform.value)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "⚠ %s disconnect timed out after %.0fs — abandoning",
+                        platform.value,
+                        _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT,
+                    )
                 except Exception as e:
                     logger.error("✗ %s disconnect error: %s", platform.value, e)
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2056,7 +2056,17 @@ def systemd_stop(system: bool = False):
             write_planned_stop_marker(pid)
     except Exception:
         pass
-    _run_systemctl(["stop", get_service_name()], system=system, check=True, timeout=90)
+    try:
+        _run_systemctl(["stop", get_service_name()], system=system, check=True, timeout=90)
+    except subprocess.TimeoutExpired:
+        scope = _service_scope_label(system)
+        print(
+            f"⚠ {scope.capitalize()} service is still shutting down after 90s.\n"
+            f"  The gateway is draining active sessions — this can take a while\n"
+            f"  if adapters have slow websocket closes. Check status with:\n"
+            f"    hermes gateway status"
+        )
+        return
     print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
 
 

--- a/tests/gateway/test_safe_adapter_disconnect.py
+++ b/tests/gateway/test_safe_adapter_disconnect.py
@@ -10,7 +10,8 @@ The fix: gateway/run.py wraps each adapter connect() with a safety-net
 call to _safe_adapter_disconnect() in the failure branches.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -57,3 +58,70 @@ async def test_safe_disconnect_handles_none_platform(bare_runner):
     await bare_runner._safe_adapter_disconnect(adapter, None)
 
     adapter.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_disconnect_abandons_on_timeout(bare_runner, monkeypatch):
+    """A wedged adapter disconnect must be abandoned after the per-adapter
+    timeout instead of blocking the entire shutdown (#19937)."""
+
+    async def _hang_forever():
+        await asyncio.sleep(3600)  # simulate a stuck websocket
+
+    adapter = MagicMock()
+    adapter.disconnect = _hang_forever
+
+    # Patch the timeout to 0.05s so the test is fast
+    monkeypatch.setattr(
+        "gateway.run._ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT", 0.05
+    )
+
+    # Must NOT raise and must complete quickly
+    await bare_runner._safe_adapter_disconnect(adapter, Platform.FEISHU)
+
+    # If we get here, the timeout worked — no exception propagated
+
+
+@pytest.mark.asyncio
+async def test_stop_disconnect_abandons_wedged_adapter(monkeypatch):
+    """In the stop() method, a wedged adapter must be abandoned after the
+    per-adapter timeout so other adapters still get disconnected (#19937)."""
+    from tests.gateway.restart_test_helpers import make_restart_runner
+
+    runner, telegram_adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01  # force quick drain timeout
+
+    call_order = []
+    disconnect_timeout = 0.05
+
+    # Override telegram adapter disconnect to track call
+    async def _normal_disconnect():
+        call_order.append("telegram_disconnect")
+
+    telegram_adapter.disconnect = _normal_disconnect
+
+    # Create a second (feishu) adapter that hangs
+    async def _hang_forever():
+        call_order.append("feishu_disconnect_start")
+        await asyncio.sleep(3600)
+
+    feishu_adapter = AsyncMock()
+    feishu_adapter.disconnect = _hang_forever
+    feishu_adapter.cancel_background_tasks = AsyncMock()
+
+    runner.adapters[Platform.FEISHU] = feishu_adapter
+
+    # Patch the timeout constant
+    monkeypatch.setattr(
+        "gateway.run._ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT", disconnect_timeout
+    )
+
+    with (patch("gateway.status.remove_pid_file"),
+          patch("gateway.status.write_runtime_status"),
+          patch("agent.auxiliary_client.shutdown_cached_clients")):
+        await runner.stop()
+
+    # The wedged feishu adapter's disconnect should have started
+    assert "feishu_disconnect_start" in call_order
+    # The normal telegram adapter should have completed
+    assert "telegram_disconnect" in call_order


### PR DESCRIPTION
## What does this PR do?

Bound per-adapter disconnect with a 5-second timeout to prevent wedged websockets (Feishu/Lark/Weixin on WSL with flaky networking) from blocking the entire gateway shutdown sequence.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A