### PR TITLE
fix: prefer cron platform home delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -236,6 +236,17 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         }
 
     platform_name = deliver_value
+    platform_key = platform_name.lower()
+
+    if platform_key in _KNOWN_DELIVERY_PLATFORMS:
+        chat_id = _get_home_target_chat_id(platform_name)
+        if chat_id:
+            return {
+                "platform": platform_name,
+                "chat_id": chat_id,
+                "thread_id": _get_home_target_thread_id(platform_name),
+            }
+
     if origin and origin.get("platform") == platform_name:
         return {
             "platform": platform_name,
@@ -243,17 +254,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             "thread_id": origin.get("thread_id"),
         }
 
-    if platform_name.lower() not in _KNOWN_DELIVERY_PLATFORMS:
-        return None
-    chat_id = _get_home_target_chat_id(platform_name)
-    if not chat_id:
-        return None
-
-    return {
-        "platform": platform_name,
-        "chat_id": chat_id,
-        "thread_id": _get_home_target_thread_id(platform_name),
-    }
+    return None
 
 
 def _normalize_deliver_value(deliver) -> str:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -246,7 +246,63 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
-    def test_bare_platform_uses_matching_origin_chat(self):
+    def test_origin_delivery_ignores_configured_home_when_origin_present(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-2002")
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL_THREAD_ID", "home-topic")
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "thread_id": "17585",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "-1001",
+            "thread_id": "17585",
+        }
+
+    def test_bare_platform_prefers_configured_home_over_same_platform_origin(self, monkeypatch):
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "C_HOME")
+        monkeypatch.delenv("SLACK_HOME_CHANNEL_THREAD_ID", raising=False)
+        job = {
+            "deliver": "slack",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C_ORIGIN",
+                "thread_id": "1777931946.284039",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "slack",
+            "chat_id": "C_HOME",
+            "thread_id": None,
+        }
+
+    def test_bare_platform_prefers_home_thread_over_origin_thread(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "parent-42")
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL_THREAD_ID", "topic-7")
+        job = {
+            "deliver": "discord",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "origin-parent",
+                "thread_id": "origin-thread",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "discord",
+            "chat_id": "parent-42",
+            "thread_id": "topic-7",
+        }
+
+    def test_bare_platform_falls_back_to_matching_origin_when_no_home_configured(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL_THREAD_ID", raising=False)
         job = {
             "deliver": "telegram",
             "origin": {
@@ -260,6 +316,22 @@ class TestResolveDeliveryTarget:
             "platform": "telegram",
             "chat_id": "-1001",
             "thread_id": "17585",
+        }
+
+    def test_bare_dynamic_platform_falls_back_to_matching_origin(self):
+        job = {
+            "deliver": "customchat",
+            "origin": {
+                "platform": "customchat",
+                "chat_id": "room-1",
+                "thread_id": "thread-2",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "customchat",
+            "chat_id": "room-1",
+            "thread_id": "thread-2",
         }
 
     def test_bare_platform_falls_back_to_home_channel(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Make bare cron platform delivery values (for example `deliver="slack"`) prefer the configured platform home target when one is available.
- Keep `deliver="origin"` as the explicit way to deliver back to the source chat/thread.
- Preserve fallback to same-platform origin when no home target is configured, including dynamic/plugin platforms.

## Why
A cron job created from a Slack thread with `deliver="slack"` currently resolves to the originating Slack thread before checking `SLACK_HOME_CHANNEL`. This makes reminders easy to bury in old threads even when a Slack home channel is configured. With this change, the semantics are clearer:

- `origin` = exact source chat/thread
- bare platform name = configured platform home when available
- explicit `platform:target` = explicit target

## Tests
- `python -m pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q -o 'addopts='`
- `python -m pytest tests/cron/test_scheduler.py -q -o 'addopts=' -n 0`
