### PR TITLE
fix: prefer active provider for anthropic sonnet switches

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1611,18 +1611,33 @@ def detect_provider_for_model(
     Returns ``None`` when no confident match is found.
 
     Priority:
-    0. Bare provider name → switch to that provider's default model
-    1. Direct provider static catalog match
-    2. OpenRouter catalog match
+    0. Prefer the current provider when the input can be normalized into one
+       of its native model IDs
+    1. Bare provider name → switch to that provider's default model
+    2. Direct provider static catalog match
+    3. OpenRouter catalog match
     """
     name = (model_name or "").strip()
     if not name:
         return None
 
+    current_keys = _provider_keys(current_provider)
+
+    from hermes_cli.model_normalize import normalize_model_for_provider
+
+    normalized_current = normalize_model_for_provider(name, current_provider)
+
+    if normalized_current:
+        normalized_lower = normalized_current.lower()
+        if _model_in_provider_catalog(normalized_lower, current_keys):
+            if normalized_lower == name.lower():
+                return None
+            return (normalize_provider(current_provider), normalized_current)
+
     static_match = detect_static_provider_for_model(name, current_provider)
     if static_match:
         return static_match
-    if _model_in_provider_catalog(name.lower(), _provider_keys(current_provider)):
+    if _model_in_provider_catalog(name.lower(), current_keys):
         return None
 
     # --- Step 2: check OpenRouter catalog ---

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -267,6 +267,26 @@ class TestDetectProviderForModel:
         assert result[0] == "anthropic"
         assert result[1].startswith("claude-sonnet")
 
+    def test_current_provider_prefers_native_model_for_aggregator_slug(self):
+        """Anthropic should keep the switch local when given an OpenRouter-style slug."""
+        with patch(
+            "hermes_cli.models.fetch_openrouter_models",
+            side_effect=AssertionError("network lookup should not run"),
+        ):
+            result = detect_provider_for_model(
+                "anthropic/claude-sonnet-4.6", "anthropic"
+            )
+        assert result == ("anthropic", "claude-sonnet-4-6")
+
+    def test_current_provider_prefers_native_model_for_dotted_claude_name(self):
+        """Anthropic should normalize dotted Claude ids before considering OpenRouter."""
+        with patch(
+            "hermes_cli.models.fetch_openrouter_models",
+            side_effect=AssertionError("network lookup should not run"),
+        ):
+            result = detect_provider_for_model("claude-sonnet-4.6", "anthropic")
+        assert result == ("anthropic", "claude-sonnet-4-6")
+
     def test_openrouter_slug_match(self):
         """Models in the OpenRouter catalog should be found."""
         with patch("hermes_cli.models.fetch_openrouter_models", return_value=LIVE_OPENROUTER_MODELS):


### PR DESCRIPTION
## Summary
Fixes #19858 by preferring the active provider when a requested model can be normalized into one of that provider's native model IDs.

Before this change, ambiguous Claude Sonnet inputs such as `claude-sonnet-4.6` or `anthropic/claude-sonnet-4.6` could fall through to generic provider detection and get remapped to an aggregator catalog entry instead of staying on the already-active Anthropic provider.

## What changed
- normalize the requested model against the current provider before cross-provider detection
- if the normalized ID already belongs to the current provider catalog, keep the provider unchanged and reuse the native ID
- add regression coverage for both:
  - `anthropic/claude-sonnet-4.6` while already on `anthropic`
  - `claude-sonnet-4.6` while already on `anthropic`

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_models.py tests/hermes_cli/test_model_switch_variant_tags.py`
- direct reproduction check:
  - `detect_provider_for_model('anthropic/claude-sonnet-4.6', 'anthropic')`
  - `detect_provider_for_model('claude-sonnet-4.6', 'anthropic')`
  - both now resolve to `('anthropic', 'claude-sonnet-4-6')`

## Notes
This keeps the existing fallback behavior for true cross-provider switches, but stops same-provider Claude inputs from being hijacked by later OpenRouter-style detection.