### PR TITLE
fix(hermes-state): quote colon-delimited fts5 literals

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1621,13 +1621,30 @@ class SessionDB:
         sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
         sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
 
-        # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
-        # quotes.  FTS5's tokenizer splits on dots and hyphens, turning
-        # ``chat-send`` into ``chat AND send`` and ``P2.2`` into ``p2 AND 2``.
-        # Quoting preserves phrase semantics.  A single pass avoids the
-        # double-quoting bug that would occur if dotted, hyphenated and underscored
-        # patterns were applied sequentially (e.g. ``my-app.config``).
-        sanitized = re.sub(r"\b(\w+(?:[._-]\w+)+)\b", r'"\1"', sanitized)
+        # Step 5: Wrap unquoted literal-like tokens that contain punctuation
+        # FTS5 would otherwise tokenize or interpret as syntax.
+        #
+        # Examples:
+        # - ``chat-send`` would become ``chat AND send``
+        # - ``P2.2`` would become ``p2 AND 2``
+        # - ``path:config.yaml`` / ``C:\Users\demo`` would be parsed as
+        #   column filters (``no such column``) instead of literal terms
+        #
+        # A token-based pass avoids the double-quoting bug that would occur
+        # if dotted, hyphenated, underscored, or path-like patterns were
+        # applied sequentially (e.g. ``my-app.config``).
+        def _quote_literal_token(token: str) -> str:
+            if not token:
+                return token
+            if token.upper() in ("AND", "OR", "NOT"):
+                return token
+            if token.startswith("\x00Q") and token.endswith("\x00"):
+                return token
+            if any(ch in token for ch in (".", "_", "-", ":", "/", "\\")) and re.search(r"\w", token):
+                return f'"{token}"'
+            return token
+
+        sanitized = " ".join(_quote_literal_token(token) for token in sanitized.split())
 
         # Step 6: Restore preserved quoted phrases
         for i, quoted in enumerate(_quoted_parts):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -665,6 +665,29 @@ class TestFTS5Search:
         assert isinstance(results2, list)
         assert len(results2) >= 1
 
+    def test_search_colon_and_windows_path_terms_as_literals(self, db):
+        """Colon-delimited and Windows-style path queries must search literal content.
+
+        FTS5 treats ``:`` as a column filter operator, so raw queries like
+        ``path:config.yaml`` or ``C:\\Users\\demo`` raise ``no such column``.
+        search_messages() catches the exception and silently returns [], which
+        makes valid session search queries look like misses.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            role="user",
+            content="Inspect path:config.yaml under C:\\Users\\demo\\project",
+        )
+
+        colon_results = db.search_messages("path:config.yaml")
+        assert len(colon_results) == 1
+        assert colon_results[0]["session_id"] == "s1"
+
+        windows_results = db.search_messages(r"C:\Users\demo\project")
+        assert len(windows_results) == 1
+        assert windows_results[0]["session_id"] == "s1"
+
     def test_search_quoted_phrase_preserved(self, db):
         """User-provided quoted phrases should be preserved for exact matching."""
         db.create_session(session_id="s1", source="cli")
@@ -752,6 +775,15 @@ class TestFTS5Search:
         # Mixed dots and hyphens — single pass avoids double-quoting
         assert s('my-app.config') == '"my-app.config"'
         assert s('my-app.config.ts') == '"my-app.config.ts"'
+
+    def test_sanitize_fts5_quotes_colon_and_windows_path_terms(self):
+        """Colon-delimited and Windows-style path terms should be treated literally."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+
+        assert s('path:config.yaml') == '"path:config.yaml"'
+        assert s('foo:bar') == '"foo:bar"'
+        assert s(r'C:\Users\demo') == r'"C:\Users\demo"'
 
     def test_sanitize_fts5_quotes_underscored_terms(self):
         """Underscored terms should be wrapped in quotes for exact matching.


### PR DESCRIPTION
## Summary

Fixes an FTS5 search bug in `SessionDB.search_messages()` where colon-delimited literals and Windows-style paths were misparsed as FTS5 column filters instead of searched as plain text.

Queries like `path:config.yaml` and `C:\Users\demo\project` could trigger `no such column` inside SQLite FTS5. `search_messages()` caught that `OperationalError` and returned `[]`, so valid searches silently looked like misses.

## Problem

Hermes recently hardened FTS5 query sanitization for quotes, hyphens, dots, underscores, and boolean operators, but `:` remained untreated.

That left a real edge case:

- `path:config.yaml` was sanitized into `path:"config.yaml"`, which FTS5 interpreted as a column filter on a non-existent `path` column.
- `C:\Users\demo` was interpreted as a column filter on `C`.
- The resulting `sqlite3.OperationalError` was swallowed by `search_messages()`, so users saw empty results instead of matches.

This is especially user-visible on Windows and in any workflow that searches config-style tokens, paths, or log fragments containing `:`.

## Fix

Updated `_sanitize_fts5_query()` in `hermes_state.py` to quote literal-like tokens containing punctuation that FTS5 would otherwise tokenize or interpret as syntax, including:

- `.`
- `_`
- `-`
- `:`
- `/`
- `\`

The implementation uses a single token-based pass so we preserve existing behavior for:

- quoted phrases
- boolean operators
- hyphenated/dotted/underscored terms

and avoid double-quoting mixed forms like `my-app.config.ts`.

## Tests

Added regression coverage in `tests/test_hermes_state.py` for:

- literal search of `path:config.yaml`
- literal search of `C:\Users\demo\project`
- sanitizer output for colon-delimited tokens and Windows paths

## Validation

Ran:

```bash
scripts/run_tests.sh tests/test_hermes_state.py -k 'colon_and_windows_path'
scripts/run_tests.sh tests/test_hermes_state.py -k 'FTS5Search'


Results:

targeted regression tests: passed
broader FTS5 search suite: passed