### PR TITLE
feat(cli): add CrofAI as built-in provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -233,6 +233,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "crofai": "glm-4.7-flash",
 }
 
 # Vision-specific model overrides for direct providers.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -64,6 +64,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "tencent", "tokenhub", "tencent-cloud", "tencentmaas",
     "arcee-ai", "arceeai",
     "gmi-cloud", "gmicloud",
+    "crofai", "crof", "crof-ai", "crof.ai",
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal",
@@ -314,6 +315,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
     "api.gmi-serving.com": "gmi",
+    "crof.ai": "crofai",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",
 }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -255,6 +255,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GMI_API_KEY",),
         base_url_env_var="GMI_BASE_URL",
     ),
+    "crofai": ProviderConfig(
+        id="crofai",
+        name="CrofAI",
+        auth_type="api_key",
+        inference_base_url="https://crof.ai/v1",
+        api_key_env_vars=("CROFAI_API_KEY",),
+        base_url_env_var="CROFAI_BASE_URL",
+    ),
     "minimax": ProviderConfig(
         id="minimax",
         name="MiniMax",
@@ -1171,6 +1179,7 @@ def resolve_provider(
         "step": "stepfun", "stepfun-coding-plan": "stepfun",
         "arcee-ai": "arcee", "arceeai": "arcee",
         "gmi-cloud": "gmi", "gmicloud": "gmi",
+        "crof": "crofai", "crof-ai": "crofai", "crof.ai": "crofai",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1515,6 +1515,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "CROFAI_API_KEY": {
+        "description": "CrofAI API key",
+        "prompt": "CrofAI API key",
+        "url": "https://crof.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "CROFAI_BASE_URL": {
+        "description": "CrofAI base URL override",
+        "prompt": "CrofAI base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "MINIMAX_API_KEY": {
         "description": "MiniMax API key (international)",
         "prompt": "MiniMax API key",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1881,6 +1881,7 @@ def select_provider_and_model(args=None):
         "xiaomi",
         "arcee",
         "gmi",
+        "crofai",
         "nvidia",
         "ollama-cloud",
         "tencent-tokenhub",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -102,6 +102,7 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "qwen-oauth",
     "xiaomi",
     "arcee",
+    "crofai",
     "ollama-cloud",
     "custom",
 })

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -338,6 +338,23 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
     ],
+    # CrofAI — OpenAI-compatible aggregator at https://crof.ai/v1.
+    # The /v1/models endpoint is preferred at runtime via provider_model_ids();
+    # this static list is the offline / pre-auth fallback shown in `hermes model`.
+    "crofai": [
+        "kimi-k2.6-precision",
+        "kimi-k2.5",
+        "kimi-k2.5-lightning",
+        "glm-5.1",
+        "glm-5.1-precision",
+        "glm-5",
+        "glm-4.7",
+        "glm-4.7-flash",
+        "gemma-4-31b-it",
+        "minimax-m2.5",
+        "qwen3.5-397b-a17b",
+        "deepseek-v3.2",
+    ],
     "opencode-zen": [
         "kimi-k2.5",
         "gpt-5.4-pro",
@@ -798,6 +815,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("ollama-cloud",   "Ollama Cloud",             "Ollama Cloud (cloud-hosted open models — ollama.com)"),
     ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models — direct API)"),
     ProviderEntry("gmi",            "GMI Cloud",                "GMI Cloud (multi-model direct API)"),
+    ProviderEntry("crofai",         "CrofAI",                   "CrofAI (Kimi, GLM, Gemma, MiniMax, Qwen, DeepSeek — OpenAI-compatible aggregator at crof.ai)"),
     ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
@@ -835,6 +853,9 @@ _PROVIDER_ALIASES = {
     "arceeai": "arcee",
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+    "crof": "crofai",
+    "crof-ai": "crofai",
+    "crof.ai": "crofai",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "minimax-portal": "minimax-oauth",
@@ -1991,6 +2012,19 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             from hermes_cli.auth import resolve_api_key_provider_credentials
 
             creds = resolve_api_key_provider_credentials("gmi")
+            api_key = str(creds.get("api_key") or "").strip()
+            base_url = str(creds.get("base_url") or "").strip()
+            if api_key and base_url:
+                live = fetch_api_models(api_key, base_url)
+                if live:
+                    return live
+        except Exception:
+            pass
+    if normalized == "crofai":
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+
+            creds = resolve_api_key_provider_credentials("crofai")
             api_key = str(creds.get("api_key") or "").strip()
             base_url = str(creds.get("base_url") or "").strip()
             if api_key and base_url:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -185,6 +185,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "crofai": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("CROFAI_API_KEY",),
+        base_url_override="https://crof.ai/v1",
+        base_url_env_var="CROFAI_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="OLLAMA_BASE_URL",
@@ -333,6 +340,11 @@ ALIASES: Dict[str, str] = {
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
 
+    # crofai
+    "crof": "crofai",
+    "crof-ai": "crofai",
+    "crof.ai": "crofai",
+
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
@@ -356,6 +368,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
+    "crofai": "CrofAI",
     "tencent-tokenhub": "Tencent TokenHub",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",

--- a/tests/hermes_cli/test_crofai_provider.py
+++ b/tests/hermes_cli/test_crofai_provider.py
@@ -1,0 +1,237 @@
+"""Tests for CrofAI provider support — standard direct API provider."""
+
+import types
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+_OTHER_PROVIDER_KEYS = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "DASHSCOPE_API_KEY",
+    "XAI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY", "AI_GATEWAY_API_KEY",
+    "KILOCODE_API_KEY", "HF_TOKEN", "GLM_API_KEY", "ZAI_API_KEY",
+    "XIAOMI_API_KEY", "TOKENHUB_API_KEY", "ARCEEAI_API_KEY",
+    "GMI_API_KEY", "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+)
+
+
+# =============================================================================
+# Provider Registry
+# =============================================================================
+
+
+class TestCrofAIProviderRegistry:
+    def test_registered(self):
+        assert "crofai" in PROVIDER_REGISTRY
+
+    def test_name(self):
+        assert PROVIDER_REGISTRY["crofai"].name == "CrofAI"
+
+    def test_auth_type(self):
+        assert PROVIDER_REGISTRY["crofai"].auth_type == "api_key"
+
+    def test_inference_base_url(self):
+        assert PROVIDER_REGISTRY["crofai"].inference_base_url == "https://crof.ai/v1"
+
+    def test_api_key_env_vars(self):
+        assert PROVIDER_REGISTRY["crofai"].api_key_env_vars == ("CROFAI_API_KEY",)
+
+    def test_base_url_env_var(self):
+        assert PROVIDER_REGISTRY["crofai"].base_url_env_var == "CROFAI_BASE_URL"
+
+
+# =============================================================================
+# Aliases
+# =============================================================================
+
+
+class TestCrofAIAliases:
+    @pytest.mark.parametrize("alias", ["crofai", "crof", "crof-ai", "crof.ai"])
+    def test_alias_resolves(self, alias, monkeypatch):
+        for key in _OTHER_PROVIDER_KEYS + ("OPENROUTER_API_KEY",):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("CROFAI_API_KEY", "crof-test-12345")
+        assert resolve_provider(alias) == "crofai"
+
+    def test_normalize_provider_models_py(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("crof") == "crofai"
+        assert normalize_provider("crof-ai") == "crofai"
+        assert normalize_provider("crof.ai") == "crofai"
+
+    def test_normalize_provider_providers_py(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("crof") == "crofai"
+        assert normalize_provider("crof-ai") == "crofai"
+        assert normalize_provider("crof.ai") == "crofai"
+
+
+# =============================================================================
+# Credentials
+# =============================================================================
+
+
+class TestCrofAICredentials:
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("CROFAI_API_KEY", "crof-test")
+        status = get_api_key_provider_status("crofai")
+        assert status["configured"]
+
+    def test_status_not_configured(self, monkeypatch):
+        monkeypatch.delenv("CROFAI_API_KEY", raising=False)
+        status = get_api_key_provider_status("crofai")
+        assert not status["configured"]
+
+    def test_openrouter_key_does_not_make_crofai_configured(self, monkeypatch):
+        """OpenRouter users should NOT see CrofAI as configured."""
+        monkeypatch.delenv("CROFAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        status = get_api_key_provider_status("crofai")
+        assert not status["configured"]
+
+    def test_resolve_credentials(self, monkeypatch):
+        monkeypatch.setenv("CROFAI_API_KEY", "crof-direct-key")
+        monkeypatch.delenv("CROFAI_BASE_URL", raising=False)
+        creds = resolve_api_key_provider_credentials("crofai")
+        assert creds["api_key"] == "crof-direct-key"
+        assert creds["base_url"] == "https://crof.ai/v1"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("CROFAI_API_KEY", "crof-x")
+        monkeypatch.setenv("CROFAI_BASE_URL", "https://custom.crof.example/v1")
+        creds = resolve_api_key_provider_credentials("crofai")
+        assert creds["base_url"] == "https://custom.crof.example/v1"
+
+
+# =============================================================================
+# Model catalog
+# =============================================================================
+
+
+class TestCrofAIModelCatalog:
+    def test_static_model_list(self):
+        """CrofAI has a static _PROVIDER_MODELS catalog entry. Specific model
+        names change with releases and don't belong in tests — assert the
+        relationship (catalog populated, model IDs look like simple slugs)
+        instead of snapshotting names. See AGENTS.md change-detector rule.
+        """
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "crofai" in _PROVIDER_MODELS
+        models = _PROVIDER_MODELS["crofai"]
+        assert len(models) >= 1
+        # Invariant: CrofAI catalog ships bare model slugs (no provider/ prefix).
+        for m in models:
+            assert "/" not in m, (
+                f"CrofAI catalog model {m!r} unexpectedly contains '/'; "
+                "the API returns bare model IDs (e.g. 'kimi-k2.5')."
+            )
+
+    def test_canonical_provider_entry(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert "crofai" in slugs
+
+
+# =============================================================================
+# Live /v1/models fetch path — fetch is best-effort; static fallback is the
+# contract this test guards.
+# =============================================================================
+
+
+class TestCrofAILiveModelsFallback:
+    def test_provider_model_ids_falls_back_to_static_when_unauthenticated(self, monkeypatch):
+        from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
+
+        for key in _OTHER_PROVIDER_KEYS + ("CROFAI_API_KEY", "OPENROUTER_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+        ids = provider_model_ids("crofai")
+        assert ids == _PROVIDER_MODELS["crofai"]
+
+
+# =============================================================================
+# Model normalization
+# =============================================================================
+
+
+class TestCrofAINormalization:
+    def test_in_matching_prefix_strip_set(self):
+        from hermes_cli.model_normalize import _MATCHING_PREFIX_STRIP_PROVIDERS
+        assert "crofai" in _MATCHING_PREFIX_STRIP_PROVIDERS
+
+    def test_strips_prefix(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        assert normalize_model_for_provider("crofai/kimi-k2.5", "crofai") == "kimi-k2.5"
+
+    def test_bare_name_unchanged(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        assert normalize_model_for_provider("kimi-k2.5", "crofai") == "kimi-k2.5"
+
+
+# =============================================================================
+# URL mapping
+# =============================================================================
+
+
+class TestCrofAIURLMapping:
+    def test_url_to_provider(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("crof.ai") == "crofai"
+
+    def test_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "crofai" in _PROVIDER_PREFIXES
+        assert "crof" in _PROVIDER_PREFIXES
+        assert "crof-ai" in _PROVIDER_PREFIXES
+
+    def test_trajectory_compressor_detects_crofai(self):
+        import trajectory_compressor as tc
+        comp = tc.TrajectoryCompressor.__new__(tc.TrajectoryCompressor)
+        comp.config = types.SimpleNamespace(base_url="https://crof.ai/v1")
+        assert comp._detect_provider() == "crofai"
+
+
+# =============================================================================
+# providers.py overlay + label
+# =============================================================================
+
+
+class TestCrofAIProvidersModule:
+    def test_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "crofai" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["crofai"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.base_url_env_var == "CROFAI_BASE_URL"
+        assert overlay.is_aggregator
+
+    def test_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["crofai"] == "CrofAI"
+
+
+# =============================================================================
+# Auxiliary client — cheapest/fastest model in the catalog
+# =============================================================================
+
+
+class TestCrofAIAuxiliary:
+    def test_aux_model_is_in_catalog(self):
+        """The auxiliary default must be a model CrofAI actually serves; if a
+        future change retires the chosen aux, this test catches the dangling
+        reference instead of failing at first vision/compression call.
+        """
+        from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        aux = _API_KEY_PROVIDER_AUX_MODELS.get("crofai")
+        assert aux, "CrofAI should have an auxiliary-model default"
+        assert aux in _PROVIDER_MODELS["crofai"]

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -454,6 +454,8 @@ class TrajectoryCompressor:
             return "kimi-coding"
         if base_url_host_matches(url, "arcee.ai"):
             return "arcee"
+        if base_url_host_matches(url, "crof.ai"):
+            return "crofai"
         if base_url_host_matches(url, "minimaxi.com"):
             return "minimax-cn"
         if base_url_host_matches(url, "minimax.io"):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -40,6 +40,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `CROFAI_API_KEY` | CrofAI API key — OpenAI-compatible aggregator for Kimi, GLM, Gemma, MiniMax, Qwen, DeepSeek ([crof.ai](https://crof.ai/)) |
+| `CROFAI_BASE_URL` | Override CrofAI base URL (default: `https://crof.ai/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
## Summary

Adds [CrofAI](https://crof.ai) as a built-in OpenAI-compatible provider. CrofAI exposes Kimi, GLM, Gemma, MiniMax, Qwen, and DeepSeek through a single Bearer-token API at `https://crof.ai/v1`, so plumbing it through Hermes' standard provider checklist gives users one-line access via:

```bash
export CROFAI_API_KEY=...
hermes chat --provider crofai --model glm-5.1 -q \"Hello\"
```

…or interactively through `hermes model` / `hermes setup` (which auto-discover from `CANONICAL_PROVIDERS`).

## Changes (follows `website/docs/developer-guide/adding-providers.md`)

| File | Change |
|------|--------|
| `hermes_cli/auth.py` | `PROVIDER_REGISTRY` entry + aliases (`crof`, `crof-ai`, `crof.ai`) |
| `hermes_cli/models.py` | `_PROVIDER_MODELS` (12-model catalog fallback), `CANONICAL_PROVIDERS`, `_PROVIDER_ALIASES`, **live `/v1/models` fetch branch** in `provider_model_ids()` so new CrofAI models surface in `hermes model` without a Hermes release |
| `hermes_cli/main.py` | included in the dispatch list that routes through `_model_flow_api_key_provider()` (same pattern as `deepseek` / `xai` / `arcee` / `gmi`) |
| `hermes_cli/providers.py` | `HermesOverlay` (`openai_chat`, `is_aggregator=True`) + label override |
| `hermes_cli/model_normalize.py` | added to `_MATCHING_PREFIX_STRIP_PROVIDERS` so config entries like `crofai/kimi-k2.5` strip cleanly |
| `hermes_cli/config.py` | `CROFAI_API_KEY` + `CROFAI_BASE_URL` env-var metadata |
| `agent/auxiliary_client.py` | `glm-4.7-flash` as the cheap/fast aux default |
| `agent/model_metadata.py` | `_URL_TO_PROVIDER[\"crof.ai\"]` + `_PROVIDER_PREFIXES` aliases |
| `trajectory_compressor.py` | base-URL host detection for `crof.ai` |
| `website/docs/reference/environment-variables.md` | user-facing env-var rows |
| `tests/hermes_cli/test_crofai_provider.py` | 29 new invariant tests |

`hermes_cli/runtime_provider.py` needs no change — OpenAI-compatible providers fall through to the auto-detect `else` branch and pick up `base_url` directly from `PROVIDER_REGISTRY` (same as `deepseek` / `arcee` / `gmi`).

## Catalog

Static fallback (used only when `/v1/models` is unreachable; the live fetch is preferred):

```text
kimi-k2.6-precision   kimi-k2.5             kimi-k2.5-lightning
glm-5.1               glm-5.1-precision     glm-5
glm-4.7               glm-4.7-flash         gemma-4-31b-it
minimax-m2.5          qwen3.5-397b-a17b     deepseek-v3.2
```

Existing substring entries in `DEFAULT_CONTEXT_LENGTHS` already cover every catalog model (`glm` → 202752, `kimi` → 262144, `gemma-4-31b` → 256000, `minimax` → 204800, `qwen` → 131072, `deepseek` → 128000), so no additions there. Live `/v1/models` returns precise per-model metadata when the user is authenticated.

## Tests added (`tests/hermes_cli/test_crofai_provider.py`, 29 tests)

Modelled on `test_arcee_provider.py`. Covers:

- Provider registry (id, name, auth_type, base URL, env vars)
- Alias resolution (`crof`, `crof-ai`, `crof.ai` → `crofai` via both `auth.py` and `models.py` and `providers.py`)
- Credential resolution (env-var, `OPENROUTER_API_KEY` doesn't false-positive, custom base URL override)
- Catalog **shape** (catalog populated, model IDs are bare slugs without `/`) — explicitly NOT a snapshot of the 12 names so model releases don't break CI
- Live-fetch fallback (without `CROFAI_API_KEY`, `provider_model_ids(\"crofai\")` returns the static list)
- Model-prefix normalization
- URL → provider mapping (`crof.ai`)
- Trajectory compressor base-URL detection
- HermesOverlay (transport, env var, aggregator flag)
- Display label
- Aux model is in catalog (catches a future retirement of the chosen aux)

Verification:

```bash
$ scripts/run_tests.sh tests/hermes_cli/test_crofai_provider.py
============================== 29 passed in 1.43s ==============================

$ scripts/run_tests.sh \\
    tests/hermes_cli/test_arcee_provider.py \\
    tests/hermes_cli/test_gmi_provider.py \\
    tests/hermes_cli/test_xiaomi_provider.py \\
    tests/hermes_cli/test_tencent_tokenhub_provider.py \\
    tests/hermes_cli/test_api_key_providers.py \\
    tests/hermes_cli/test_model_catalog.py \\
    tests/hermes_cli/test_models_dev_preferred_merge.py \\
    tests/hermes_cli/test_user_providers_model_switch.py \\
    tests/hermes_cli/test_overlay_slug_resolution.py \\
    tests/hermes_cli/test_crofai_provider.py
============================== 416 passed in 24.32s ============================
```

## Platforms tested

- macOS (Darwin 25.3.0) — full provider-touching test suite (416 passed). Live smoke against the actual CrofAI endpoint not run; reviewers with a key can sanity-check `hermes chat --provider crofai --model glm-5.1 -q \"Hello\"`.

## Test plan
- [ ] Maintainer smoke test with a CrofAI key against `hermes chat --provider crofai --model glm-5.1`
- [ ] `hermes model` interactive picker shows CrofAI in the list and walks through key entry
- [ ] `hermes setup` walks the user through `CROFAI_API_KEY` entry when CrofAI is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)