### PR TITLE
fix: handle multimodal content in TUI resume

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1408,28 +1408,71 @@ class SessionDB:
         return result
 
     def resolve_resume_session_id(self, session_id: str) -> str:
-        """Redirect a resume target to the descendant session that holds the messages.
+        """Redirect a resume target to the live descendant that should be resumed.
 
         Context compression ends the current session and forks a new child session
-        (linked via ``parent_session_id``). The flush cursor is reset, so the
-        child is where new messages actually land — the parent ends up with
-        ``message_count = 0`` rows unless messages had already been flushed to
-        it before compression. See #15000.
+        (linked via ``parent_session_id``). The continuation is the live chat,
+        even when the compressed parent already has older messages. Resuming the
+        parent would drop the user back into a stale pre-compression slice of the
+        conversation.
 
-        This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the first descendant in the chain that has at least one message
-        row. If the original session already has messages, or no descendant
-        has any, the original ``session_id`` is returned unchanged.
-
-        The chain is always walked via the child whose ``started_at`` is
-        latest; that matches the single-chain shape that compression creates.
-        A depth cap (32) guards against accidental loops in malformed data.
+        Prefer the latest valid compression continuation that contains messages.
+        If there is no compression continuation, preserve the historical fallback
+        for empty-head chains by walking to the first descendant with messages.
         """
         if not session_id:
             return session_id
 
         with self._lock:
-            # If this session already has messages, nothing to redirect.
+            try:
+                root_row = self._conn.execute(
+                    "SELECT end_reason FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
+            except Exception:
+                root_row = None
+            root_end_reason = root_row["end_reason"] if root_row is not None else None
+
+            # Some historical TUI compression chains have an intermediate
+            # continuation whose end_reason was later overwritten by shutdown,
+            # even though its children are still the same logical conversation.
+            # If the requested root was compressed, keep walking the descendant
+            # chain and return the deepest message-bearing continuation instead
+            # of stopping at the first child with messages.
+            if root_end_reason == "compression":
+                current = session_id
+                candidate = session_id
+                seen = {current}
+                for _ in range(100):
+                    try:
+                        child_row = self._conn.execute(
+                            "SELECT id FROM sessions "
+                            "WHERE parent_session_id = ? "
+                            "ORDER BY started_at DESC, id DESC LIMIT 1",
+                            (current,),
+                        ).fetchone()
+                    except Exception:
+                        break
+                    if child_row is None:
+                        break
+                    child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
+                    if not child_id or child_id in seen:
+                        break
+                    seen.add(child_id)
+                    try:
+                        msg_row = self._conn.execute(
+                            "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
+                            (child_id,),
+                        ).fetchone()
+                    except Exception:
+                        msg_row = None
+                    if msg_row is not None:
+                        candidate = child_id
+                    current = child_id
+                if candidate != session_id:
+                    return candidate
+
+            # Non-compression session with its own messages is already resumable.
             try:
                 row = self._conn.execute(
                     "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
@@ -1440,8 +1483,8 @@ class SessionDB:
             if row is not None:
                 return session_id
 
-            # Walk descendants: at each step, pick the most-recently-started
-                # child session; stop once we find one with messages.
+            # Legacy fallback: walk descendants from an empty head and pick the
+            # most-recently-started child at each step until one has messages.
             current = session_id
             seen = {current}
             for _ in range(32):

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -50,10 +50,38 @@ def test_redirects_from_empty_head_to_descendant_with_messages(db):
     assert db.resolve_resume_session_id("head") == "bulk"
 
 
-def test_returns_self_when_session_has_messages(db):
+def test_returns_self_when_non_compression_session_has_messages(db):
     _make_chain(db, [("root", None), ("child", "root")])
     db.append_message("root", role="user", content="hi")
+    db.append_message("child", role="user", content="child from unrelated fork")
     assert db.resolve_resume_session_id("root") == "root"
+
+
+def test_redirects_compressed_parent_with_messages_to_live_tip(db):
+    _make_chain(db, [("root", None), ("child", "root")])
+    db.append_message("root", role="user", content="old pre-compression context")
+    db.end_session("root", "compression")
+    # Make the child a valid compression continuation, created after root ended.
+    ended_at = db.get_session("root")["ended_at"]
+    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (ended_at + 1, "child"))
+    db._conn.commit()
+    db.append_message("child", role="user", content="latest post-compression context")
+    assert db.resolve_resume_session_id("root") == "child"
+
+
+def test_redirects_historical_compression_chain_past_shutdown_overwrite(db):
+    _make_chain(db, [("root", None), ("child", "root"), ("grandchild", "child")])
+    db.append_message("root", role="user", content="old root context")
+    db.end_session("root", "compression")
+    ended_at = db.get_session("root")["ended_at"]
+    db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (ended_at + 1, "child"))
+    db._conn.commit()
+    db.append_message("child", role="user", content="middle context")
+    db.end_session("child", "tui_shutdown")
+    # Older TUI chains can still point later compression children at this row
+    # even after shutdown overwrote the intermediate end_reason.
+    db.append_message("grandchild", role="user", content="latest context")
+    assert db.resolve_resume_session_id("root") == "grandchild"
 
 
 def test_returns_self_when_no_descendant_has_messages(db):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -81,6 +81,30 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_history_to_messages_handles_multimodal_list_content():
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is this?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                },
+            ],
+        },
+        {"role": "assistant", "content": "A screenshot."},
+    ]
+
+    messages = server._history_to_messages(history)
+
+    assert messages == [
+        {"role": "user", "text": "What is this?\n[image]"},
+        {"role": "assistant", "text": "A screenshot."},
+    ]
+    assert "base64" not in messages[0]["text"]
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1909,6 +1909,30 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     return text or "What do you see in this image?"
 
 
+def _message_content_text(content) -> str:
+    """Return a compact text preview for stored OpenAI-style content.
+
+    Older multimodal sessions can contain list-based message content like
+    [{"type": "text", ...}, {"type": "image_url", ...}].  TUI resume only
+    needs display text, so never stringify embedded base64 image URLs.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text)
+            elif part.get("type") == "image_url":
+                parts.append("[image]")
+        return "\n".join(parts)
+    return str(content or "")
+
+
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -1919,6 +1943,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         role = m.get("role")
         if role not in ("user", "assistant", "tool", "system"):
             continue
+        content_text = _message_content_text(m.get("content"))
         if role == "assistant" and m.get("tool_calls"):
             for tc in m["tool_calls"]:
                 fn = tc.get("function", {})
@@ -1929,7 +1954,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-            if not (m.get("content") or "").strip():
+            if not content_text.strip():
                 continue
         if role == "tool":
             tc_id = m.get("tool_call_id", "")
@@ -1940,9 +1965,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                 {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
             )
             continue
-        if not (m.get("content") or "").strip():
+        if not content_text.strip():
             continue
-        messages.append({"role": role, "text": m.get("content") or ""})
+        messages.append({"role": role, "text": content_text})
 
     return messages
 


### PR DESCRIPTION
## Summary
- Prevent TUI resume from crashing when stored message content is a multimodal list instead of a string.
- Render text parts normally and image parts as `[image]` for resume history.
- Avoid dumping embedded base64 image payloads into the TUI transcript.
- Add a regression test for multimodal list content.


## Details
The bug happens when resuming older TUI sessions that contain multimodal user messages, for example a pasted screenshot. Those messages can be stored in OpenAI-style list form:

```json
[{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "..."}}]
```

The TUI resume path converts stored history into display messages, but it assumed every message `content` was a string and called `.strip()` directly. For list-based multimodal content this crashes with:

```text
'list' object has no attribute 'strip'
```

This PR keeps the resume display path string-safe by normalizing stored content before checking/rendering it:
- string content is rendered unchanged
- text parts from multimodal lists are extracted
- image parts are represented as `[image]`
- embedded image/base64 payloads are not rendered into the TUI transcript

This is intentionally display-only; it doesn’t attempt to replay or rehydrate the original image attachment into the active model context. The goal is to make historical multimodal sessions resumable again without crashing.

## Test plan
- [x] `./.venv/bin/python -m pytest tests/test_tui_gateway_server.py -k 'history_to_messages_handles_multimodal_list_content' -o 'addopts=' -q`
- [x] `./.venv/bin/python -m pytest tests/test_tui_gateway_server.py -o 'addopts=' -q` (2 unrelated pre-existing failures on clean `main`: `test_session_create_drops_pending_title_on_valueerror`, `test_browser_manage_connect_default_local_reports_launch_hint`)
- [x] Stashed this branch's changes and reran the full file on clean `main`; the same 2 failures remained, confirming they are not introduced by this change.

## Update: compressed-session resume continuation
- Also fixes resuming compressed TUI sessions into stale pre-compression context.
- `SessionDB.resolve_resume_session_id()` now treats compressed roots as logical conversations and walks to the deepest message-bearing continuation, including historical chains where an intermediate continuation was later ended with `tui_shutdown`.
- Adds regression coverage for compressed parents that already have old messages and for historical continuation chains.

Additional validation:
- [x] `./.venv/bin/python -m pytest tests/hermes_state/test_resolve_resume_session_id.py tests/gateway/test_resume_command.py -q -o 'addopts='` (20 passed)

