### PR TITLE
Avoid persisting inline image data

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,7 @@ from typing import Dict, Optional, Any, List, Union
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from hermes_cli.config import cfg_get
+from persistence_sanitizer import summarize_for_log
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -6071,7 +6072,7 @@ class GatewayRunner:
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        _msg_preview = (event.text or "")[:80].replace("\n", " ")
+        _msg_preview = summarize_for_log(event.text or "", limit=80)
         logger.info(
             "inbound message: platform=%s user=%s chat=%s msg=%r",
             _platform_name, source.user_name or source.user_id or "unknown",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -19,6 +19,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
+from persistence_sanitizer import sanitize_message_for_persistence
+
 logger = logging.getLogger(__name__)
 
 
@@ -1255,6 +1257,7 @@ class SessionStore:
                      via its own _flush_messages_to_session_db(), preventing
                      the duplicate-write bug (#860).
         """
+        message = sanitize_message_for_persistence(message)
         # Write to SQLite (unless the agent already handled it)
         if self._db and not skip_db:
             try:
@@ -1297,6 +1300,7 @@ class SessionStore:
         transcript_path = self.get_transcript_path(session_id)
         with open(transcript_path, "w", encoding="utf-8") as f:
             for msg in messages:
+                msg = sanitize_message_for_persistence(msg)
                 f.write(json.dumps(msg, ensure_ascii=False) + "\n")
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
+from persistence_sanitizer import sanitize_for_persistence
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -1197,6 +1198,7 @@ class SessionDB:
         sentinel-prefixed JSON string for lists/dicts. Paired with
         :meth:`_decode_content` on read.
         """
+        content = sanitize_for_persistence(content)
         if content is None or isinstance(content, (str, bytes, int, float)):
             return content
         try:
@@ -1243,18 +1245,18 @@ class SessionDB:
         """
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
-            json.dumps(reasoning_details)
+            json.dumps(sanitize_for_persistence(reasoning_details))
             if reasoning_details else None
         )
         codex_items_json = (
-            json.dumps(codex_reasoning_items)
+            json.dumps(sanitize_for_persistence(codex_reasoning_items))
             if codex_reasoning_items else None
         )
         codex_message_items_json = (
-            json.dumps(codex_message_items)
+            json.dumps(sanitize_for_persistence(codex_message_items))
             if codex_message_items else None
         )
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        tool_calls_json = json.dumps(sanitize_for_persistence(tool_calls)) if tool_calls else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
@@ -1338,15 +1340,15 @@ class SessionDB:
                 )
 
                 reasoning_details_json = (
-                    json.dumps(reasoning_details) if reasoning_details else None
+                    json.dumps(sanitize_for_persistence(reasoning_details)) if reasoning_details else None
                 )
                 codex_items_json = (
-                    json.dumps(codex_reasoning_items) if codex_reasoning_items else None
+                    json.dumps(sanitize_for_persistence(codex_reasoning_items)) if codex_reasoning_items else None
                 )
                 codex_message_items_json = (
-                    json.dumps(codex_message_items) if codex_message_items else None
+                    json.dumps(sanitize_for_persistence(codex_message_items)) if codex_message_items else None
                 )
-                tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+                tool_calls_json = json.dumps(sanitize_for_persistence(tool_calls)) if tool_calls else None
 
                 conn.execute(
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -2627,4 +2629,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/persistence_sanitizer.py
+++ b/persistence_sanitizer.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
+import json
 import re
 from typing import Any, Dict
 
 _DATA_IMAGE_URL_RE = re.compile(
     r"^data:(image/[a-zA-Z0-9.+-]+);base64,(?P<data>[A-Za-z0-9+/=\s]+)$"
+)
+_DATA_IMAGE_URL_ANY_RE = re.compile(
+    r"data:(image/[a-zA-Z0-9.+-]+);base64,[A-Za-z0-9+/=]+"
 )
 
 
@@ -48,8 +52,11 @@ def sanitize_for_persistence(value: Any) -> Any:
     add tens of megabytes to resume context, FTS, and downstream memory sync.
     """
     if isinstance(value, str):
-        if value.startswith("data:image/"):
-            return _image_persistence_placeholder(value)
+        if "data:image/" in value:
+            return _DATA_IMAGE_URL_ANY_RE.sub(
+                lambda match: _image_persistence_placeholder(match.group(0)),
+                value,
+            )
         return value
 
     if isinstance(value, list):
@@ -89,3 +96,19 @@ def sanitize_message_for_persistence(message: Dict[str, Any]) -> Dict[str, Any]:
         if key in sanitized:
             sanitized[key] = sanitize_for_persistence(sanitized[key])
     return sanitized
+
+
+def summarize_for_log(value: Any, *, limit: int = 160) -> str:
+    """Return a compact one-line preview that never includes inline image bytes."""
+    sanitized = sanitize_for_persistence(value)
+    if isinstance(sanitized, str):
+        preview = sanitized
+    else:
+        try:
+            preview = json.dumps(sanitized, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            preview = str(sanitized)
+    preview = " ".join(preview.split())
+    if len(preview) > limit:
+        return f"{preview[: max(0, limit - 1)]}…"
+    return preview

--- a/persistence_sanitizer.py
+++ b/persistence_sanitizer.py
@@ -1,0 +1,91 @@
+"""Helpers for keeping persisted transcripts compact and model-safe."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import re
+from typing import Any, Dict
+
+_DATA_IMAGE_URL_RE = re.compile(
+    r"^data:(image/[a-zA-Z0-9.+-]+);base64,(?P<data>[A-Za-z0-9+/=\s]+)$"
+)
+
+
+def _image_persistence_placeholder(data_url: str) -> str:
+    """Return metadata for an inline image without persisting raw image bytes."""
+    match = _DATA_IMAGE_URL_RE.match(data_url)
+    if not match:
+        digest = hashlib.sha256(data_url.encode("utf-8", errors="ignore")).hexdigest()
+        return (
+            "[Inline data URL omitted from persistent transcript: "
+            f"sha256={digest[:16]}. Raw base64 was not stored.]"
+        )
+
+    mime_type = match.group(1)
+    encoded = "".join(match.group("data").split())
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+        byte_count = len(raw)
+        digest = hashlib.sha256(raw).hexdigest()
+    except (binascii.Error, ValueError):
+        byte_count = int(len(encoded) * 0.75)
+        digest = hashlib.sha256(encoded.encode("ascii", errors="ignore")).hexdigest()
+
+    return (
+        "[Image omitted from persistent transcript: "
+        f"{mime_type}, {byte_count} bytes, sha256={digest[:16]}. "
+        "Raw base64 was not stored.]"
+    )
+
+
+def sanitize_for_persistence(value: Any) -> Any:
+    """Remove inline image bytes before writing session history.
+
+    Runtime model requests may need data:image URLs, but persisted JSON/JSONL
+    and SQLite rows should store only metadata. Otherwise one screenshot can
+    add tens of megabytes to resume context, FTS, and downstream memory sync.
+    """
+    if isinstance(value, str):
+        if value.startswith("data:image/"):
+            return _image_persistence_placeholder(value)
+        return value
+
+    if isinstance(value, list):
+        return [sanitize_for_persistence(item) for item in value]
+
+    if isinstance(value, dict):
+        # OpenAI chat-completions multimodal shape:
+        # {"type": "image_url", "image_url": {"url": "data:image/..."}}
+        if value.get("type") == "image_url":
+            image_url = value.get("image_url")
+            if isinstance(image_url, dict) and isinstance(image_url.get("url"), str):
+                url = image_url["url"]
+                if url.startswith("data:image/"):
+                    return {"type": "text", "text": _image_persistence_placeholder(url)}
+
+        # Responses-style shapes commonly use input_image/image_url strings.
+        if value.get("type") in {"input_image", "image"}:
+            image_url = value.get("image_url") or value.get("url")
+            if isinstance(image_url, str) and image_url.startswith("data:image/"):
+                return {"type": "input_text", "text": _image_persistence_placeholder(image_url)}
+
+        return {key: sanitize_for_persistence(item) for key, item in value.items()}
+
+    return value
+
+
+def sanitize_message_for_persistence(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Sanitize all structured message fields before persistence."""
+    sanitized = dict(message)
+    for key in (
+        "content",
+        "tool_calls",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+    ):
+        if key in sanitized:
+            sanitized[key] = sanitize_for_persistence(sanitized[key])
+    return sanitized

--- a/run_agent.py
+++ b/run_agent.py
@@ -58,6 +58,7 @@ from datetime import datetime
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from persistence_sanitizer import sanitize_message_for_persistence
 
 
 _OPENAI_CLS_CACHE: Optional[type] = None
@@ -4303,7 +4304,7 @@ class AIAgent:
                 if msg.get("role") == "assistant" and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])
-                cleaned.append(msg)
+                cleaned.append(sanitize_message_for_persistence(msg))
 
             # Guard: never overwrite a larger session log with fewer messages.
             # This protects against data loss when --resume loads a session whose

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -473,6 +473,53 @@ class TestSessionStoreRewriteTranscript:
         reloaded = store.load_transcript(session_id)
         assert reloaded == []
 
+    def test_append_sanitizes_inline_image_jsonl(self, store):
+        session_id = "test_session_image_append"
+        data_url = "data:image/png;base64,SGVsbG8="
+        store.append_to_transcript(
+            session_id,
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            },
+        )
+
+        raw = store.get_transcript_path(session_id).read_text(encoding="utf-8")
+        assert data_url not in raw
+        assert "Image omitted from persistent transcript" in raw
+
+        reloaded = store.load_transcript(session_id)
+        assert reloaded[0]["content"][1]["type"] == "text"
+        assert "Raw base64 was not stored" in reloaded[0]["content"][1]["text"]
+
+    def test_rewrite_sanitizes_inline_image_jsonl(self, store):
+        session_id = "test_session_image_rewrite"
+        data_url = "data:image/jpeg;base64,SGVsbG8="
+
+        store.rewrite_transcript(
+            session_id,
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe this"},
+                        {"type": "input_image", "image_url": data_url},
+                    ],
+                }
+            ],
+        )
+
+        raw = store.get_transcript_path(session_id).read_text(encoding="utf-8")
+        assert data_url not in raw
+        assert "Image omitted from persistent transcript" in raw
+
+        reloaded = store.load_transcript(session_id)
+        assert reloaded[0]["content"][1]["type"] == "input_text"
+        assert "image/jpeg" in reloaded[0]["content"][1]["text"]
+
 
 class TestLoadTranscriptCorruptLines:
     """Regression: corrupt JSONL lines (e.g. from mid-write crash) must be

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 from hermes_state import SessionDB
+from persistence_sanitizer import summarize_for_log
 
 
 @pytest.fixture()
@@ -317,6 +318,22 @@ class TestMessageStorage:
         assert "Image omitted from persistent transcript" in msg["content"]
         assert "image/jpeg" in msg["content"]
         assert data_url not in msg["content"]
+
+    def test_embedded_image_data_url_is_not_persisted_or_logged(self, db):
+        """Text containing an inline data URL must not keep raw image bytes."""
+        db.create_session(session_id="s1", source="cli")
+        data_url = "data:image/png;base64,SGVsbG8="
+        content = f"Screenshot payload: {data_url}"
+
+        db.append_message("s1", role="user", content=content)
+
+        msg = db.get_messages("s1")[0]
+        assert data_url not in msg["content"]
+        assert "Image omitted from persistent transcript" in msg["content"]
+
+        preview = summarize_for_log(content)
+        assert data_url not in preview
+        assert "Image omitted from persistent transcript" in preview
 
     def test_get_messages_as_conversation(self, db):
         db.create_session(session_id="s1", source="cli")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -223,26 +223,39 @@ class TestMessageStorage:
         TUI (issue #17522).
         """
         db.create_session(session_id="s1", source="cli")
+        data_url = "data:image/png;base64,iVBORw0KGgo="
         content = [
             {"type": "text", "text": "describe this screenshot"},
             {
                 "type": "image_url",
-                "image_url": {"url": "data:image/png;base64,iVBORw0KG..."},
+                "image_url": {"url": data_url},
             },
         ]
 
         # Write must not raise
         db.append_message("s1", role="user", content=content)
 
-        # get_messages decodes back to the original list
         msgs = db.get_messages("s1")
         assert len(msgs) == 1
-        assert msgs[0]["content"] == content
+        assert msgs[0]["content"][0] == content[0]
+        image_part = msgs[0]["content"][1]
+        assert image_part["type"] == "text"
+        assert "Image omitted from persistent transcript" in image_part["text"]
+        assert "image/png" in image_part["text"]
+        assert "Raw base64 was not stored" in image_part["text"]
+        assert data_url not in str(msgs[0]["content"])
 
-        # get_messages_as_conversation decodes back to the original list
         conv = db.get_messages_as_conversation("s1")
         assert len(conv) == 1
-        assert conv[0] == {"role": "user", "content": content}
+        assert conv[0]["role"] == "user"
+        assert data_url not in str(conv[0]["content"])
+
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT content FROM messages WHERE session_id = ?", ("s1",)
+            ).fetchone()
+        assert data_url not in row["content"]
+        assert "Image omitted from persistent transcript" in row["content"]
 
     def test_dict_content_round_trip(self, db):
         """Dict-shaped content (e.g. provider wrappers) also round-trips."""
@@ -271,9 +284,10 @@ class TestMessageStorage:
         """`replace_messages` (used by /retry, /undo, /compress) must also
         handle list content without crashing."""
         db.create_session(session_id="s1", source="cli")
+        data_url = "data:image/png;base64,AAA"
         content = [
             {"type": "text", "text": "look at this"},
-            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+            {"type": "image_url", "image_url": {"url": data_url}},
         ]
 
         db.replace_messages(
@@ -286,8 +300,23 @@ class TestMessageStorage:
 
         msgs = db.get_messages("s1")
         assert len(msgs) == 2
-        assert msgs[0]["content"] == content
+        assert msgs[0]["content"][0] == content[0]
+        assert msgs[0]["content"][1]["type"] == "text"
+        assert "Image omitted from persistent transcript" in msgs[0]["content"][1]["text"]
+        assert data_url not in str(msgs[0]["content"])
         assert msgs[1]["content"] == "I see a screenshot."
+
+    def test_scalar_image_data_url_is_not_persisted(self, db):
+        """Bare data URLs are replaced with metadata before storage."""
+        db.create_session(session_id="s1", source="cli")
+        data_url = "data:image/jpeg;base64,SGVsbG8="
+
+        db.append_message("s1", role="user", content=data_url)
+
+        msg = db.get_messages("s1")[0]
+        assert "Image omitted from persistent transcript" in msg["content"]
+        assert "image/jpeg" in msg["content"]
+        assert data_url not in msg["content"]
 
     def test_get_messages_as_conversation(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -2909,4 +2938,3 @@ class TestFTS5ToolCallMigration:
             assert version == 11
         finally:
             session_db.close()
-


### PR DESCRIPTION
## Summary
- sanitize inline `data:image/...;base64,...` payloads before writing Hermes session logs, gateway transcripts, and state DB rows
- preserve compact metadata placeholders with MIME type, byte count, and SHA-256 prefix instead of raw image bytes
- cover chat-completions image parts, responses-style image parts, recursive nested persistence fields, and embedded data URLs inside scalar log strings

## Why
Inline image payloads can be very large. Persisting them in session JSON/JSONL, state history, or logs can bloat later context reconstruction and cause aggressive compaction even when the model only needs the interpreted image output after the original turn.

This keeps current-turn multimodal behavior unchanged; the sanitizer only applies at persistence/logging boundaries.

## Tests
- `/tmp/hermes-image-sanitize-py312/bin/python -m pytest tests/test_hermes_state.py tests/gateway/test_session.py -q`
- `/tmp/hermes-image-sanitize-py312/bin/python -m py_compile persistence_sanitizer.py hermes_state.py run_agent.py gateway/session.py gateway/run.py tests/test_hermes_state.py tests/gateway/test_session.py`
