### PR TITLE
fix(model_metadata): lowercase default context length keys for matching

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1416,7 +1416,7 @@ def get_model_context_length(
     for default_model, length in sorted(
         DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
     ):
-        if default_model in model_lower:
+        if default_model.lower() in model_lower:
             return length
 
     # 9. Query local server as last resort


### PR DESCRIPTION
## Summary

In `agent/model_metadata.py:1419`, the fallback lookup in `get_model_context_length` compared `DEFAULT_CONTEXT_LENGTHS` keys directly against `model_lower`. Any entry containing uppercase characters (e.g. `Qwen/...`, `MiniMaxAI/...`, `XiaomiMiMo/...`, `zai-org/...`) could never match, so those models silently fell through to the local-server query instead of returning their known context length.

## Fix

Lowercase the key before the substring check so mixed-case entries match against the already-lowercased model name. The dict itself is left untouched to keep the keys readable.

## Tests
Spot-checked `get_model_context_length` against a few of the affected model strings to confirm they now return the expected length instead of falling through.
