### PR TITLE
fix(copilot-acp): honor limit when line is unset or <= 1

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -602,10 +602,12 @@ class CopilotACPClient:
                 content = path.read_text() if path.exists() else ""
                 line = params.get("line")
                 limit = params.get("limit")
-                if isinstance(line, int) and line > 1:
+                has_line = isinstance(line, int) and line > 1
+                has_limit = isinstance(limit, int) and limit > 0
+                if has_line or has_limit:
                     lines = content.splitlines(keepends=True)
-                    start = line - 1
-                    end = start + limit if isinstance(limit, int) and limit > 0 else None
+                    start = line - 1 if has_line else 0
+                    end = start + limit if has_limit else None
                     content = "".join(lines[start:end])
                 if content:
                     content = redact_sensitive_text(content, force=True)


### PR DESCRIPTION
## Summary

In `agent/copilot_acp_client.py:608`, the read path only sliced the file when `line > 1`, so passing `limit` without `line` (or with `line <= 1`) silently returned the entire file. Callers asking for a bounded read got the whole thing instead.

## Fix

Compute `has_line` and `has_limit` separately and enter the slicing branch when either is set. `start` falls back to 0 when no line is given, and `end` is `start + limit` whenever a positive limit is provided.

## Tests

Manually exercised the read path with `limit` only, `line` only, both, and neither, and confirmed the returned content matches the requested window in each case. 