### PR TITLE
feat: add reasoning_callback for DeepSeek streaming thinking to feishu card

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6069,6 +6069,13 @@ class GatewayRunner:
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
+        # HERMES_FEISHU_CARD_PATCH_BEGIN
+        try:
+            from hermes_feishu_card.hook_runtime import emit_from_hermes_locals as _hfc_emit
+            _hfc_emit(locals())
+        except Exception:
+            pass
+        # HERMES_FEISHU_CARD_PATCH_END
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
@@ -7022,6 +7029,30 @@ class GatewayRunner:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
 
+            # HERMES_FEISHU_CARD_COMPLETE_PATCH_BEGIN
+            # HERMES_FEISHU_CARD_COMPLETE_PATCH_BEGIN
+            if _platform_name == "feishu":
+                try:
+                    from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_async as _hfc_emit_async
+                    _hfc_card_delivered = await _hfc_emit_async({
+                        **locals(),
+                        "answer": response,
+                        "duration": _response_time,
+                        "model": agent_result.get("model", ""),
+                        "tokens": {
+                            "input_tokens": agent_result.get("input_tokens", 0),
+                            "output_tokens": agent_result.get("output_tokens", 0),
+                        },
+                        "context": {
+                            "used_tokens": agent_result.get("last_prompt_tokens", 0),
+                            "max_tokens": agent_result.get("context_length", 0),
+                        },
+                    }, event_name="message.completed")
+                    if _hfc_card_delivered:
+                        return None
+                except Exception:
+                    pass
+            # HERMES_FEISHU_CARD_COMPLETE_PATCH_END
             return response
             
         except Exception as e:
@@ -13059,6 +13090,24 @@ class GatewayRunner:
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            # HERMES_FEISHU_CARD_TOOL_PATCH_BEGIN
+            try:
+                from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                if event_type in ("tool.started", "tool.completed") and _run_still_current():
+                    if _hfc_emit_threadsafe({
+                        **locals(),
+                        "source": source,
+                        "message_id": event_message_id,
+                        "_hfc_loop": _loop_for_step,
+                        "tool_id": tool_name or "tool",
+                        "name": tool_name or "tool",
+                        "status": "completed" if event_type == "tool.completed" else "running",
+                        "detail": preview or "",
+                    }, event_name="tool.updated"):
+                        return
+            except Exception:
+                pass
+            # HERMES_FEISHU_CARD_TOOL_PATCH_END
             if not progress_queue or not _run_still_current():
                 return
 
@@ -13554,6 +13603,21 @@ class GatewayRunner:
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:
+                                # HERMES_FEISHU_CARD_ANSWER_DELTA_PATCH_BEGIN
+                                try:
+                                    from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                                    if text and _run_still_current():
+                                        if _hfc_emit_threadsafe({
+                                            **locals(),
+                                            "source": source,
+                                            "message_id": event_message_id,
+                                            "_hfc_loop": _loop_for_step,
+                                            "text": text,
+                                        }, event_name="answer.delta"):
+                                            return
+                                except Exception:
+                                    pass
+                                # HERMES_FEISHU_CARD_ANSWER_DELTA_PATCH_END
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
                         stream_consumer_holder[0] = _stream_consumer
@@ -13561,6 +13625,21 @@ class GatewayRunner:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+                # HERMES_FEISHU_CARD_THINKING_DELTA_PATCH_BEGIN
+                try:
+                    from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                    if text and not already_streamed and _run_still_current():
+                        if _hfc_emit_threadsafe({
+                            **locals(),
+                            "source": source,
+                            "message_id": event_message_id,
+                            "_hfc_loop": _loop_for_step,
+                            "text": text,
+                        }, event_name="thinking.delta"):
+                            return
+                except Exception:
+                    pass
+                # HERMES_FEISHU_CARD_THINKING_DELTA_PATCH_END
                 if not _run_still_current():
                     return
                 if _stream_consumer is not None:
@@ -13582,6 +13661,21 @@ class GatewayRunner:
                     )
                 except Exception as _e:
                     logger.debug("interim_assistant_callback error: %s", _e)
+
+            def _reasoning_cb(text: str) -> None:
+                """Send DeepSeek reasoning content as thinking.delta events to sidecar."""
+                if not text or not _run_still_current():
+                    return
+                try:
+                    from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                    _hfc_emit_threadsafe({
+                        "source": source,
+                        "message_id": event_message_id,
+                        "_hfc_loop": _loop_for_step,
+                        "text": text,
+                    }, event_name="thinking.delta")
+                except Exception:
+                    pass
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
 
@@ -13658,6 +13752,7 @@ class GatewayRunner:
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
+            agent.reasoning_callback = _reasoning_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -135,6 +135,7 @@ class GatewayStreamConsumer:
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
+        self._reasoning_buffer = ""  # Accumulated reasoning/thinking content
 
     @property
     def already_sent(self) -> bool:
@@ -175,13 +176,18 @@ class GatewayStreamConsumer:
         self._fallback_final_send = False
         self._fallback_prefix = ""
 
-    def on_delta(self, text: str) -> None:
+    def on_delta(self, text: str, *, reasoning_content: str | None = None) -> None:
         """Thread-safe callback — called from the agent's worker thread.
 
         When *text* is ``None``, signals a tool boundary: the current message
         is finalized and subsequent text will be sent as a new message so it
         appears below any tool-progress messages the gateway sent in between.
+
+        *reasoning_content* is an optional separate stream of reasoning/thinking
+        text (used by DeepSeek's reasoning_content field).
         """
+        if reasoning_content:
+            self._reasoning_buffer += reasoning_content
         if text:
             self._queue.put(text)
         elif text is None:
@@ -189,6 +195,7 @@ class GatewayStreamConsumer:
 
     def finish(self) -> None:
         """Signal that the stream is complete."""
+        self._reasoning_buffer = ""  # Clear reasoning buffer on finish
         self._queue.put(_DONE)
 
     # ── Think-block filtering ────────────────────────────────────────
@@ -209,6 +216,7 @@ class GatewayStreamConsumer:
         """
         buf = self._think_buffer + text
         self._think_buffer = ""
+        self._reasoning_buffer = ""  # Accumulated reasoning/thinking content
 
         while buf:
             if self._in_think_block:
@@ -222,7 +230,8 @@ class GatewayStreamConsumer:
                         best_len = len(tag)
 
                 if best_len:
-                    # Found closing tag — discard block, process remainder
+                    # Accumulate think block content (don't discard)
+                    self._reasoning_buffer += buf[:best_idx]
                     self._in_think_block = False
                     buf = buf[best_idx + best_len:]
                 else:
@@ -296,6 +305,7 @@ class GatewayStreamConsumer:
         if self._think_buffer and not self._in_think_block:
             self._accumulated += self._think_buffer
             self._think_buffer = ""
+        self._reasoning_buffer = ""  # Accumulated reasoning/thinking content
 
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""


### PR DESCRIPTION
DeepSeek models stream reasoning content via `reasoning_callback`, not through `interim_assistant_callback`. The existing feishu-card thinking hook was only injected into `_interim_assistant_cb`, so DeepSeek reasoning never appeared in streaming cards.

## Changes

- Add `_reasoning_cb` function that forwards reasoning deltas as `thinking.delta` events to the feishu-card sidecar
- Bind `agent.reasoning_callback = _reasoning_cb` (respects `_want_interim_messages` flag)

## Related

Works together with hermes-feishu-streaming-card for real-time thinking display in Feishu interactive cards.