### PR TITLE
fix(agent): guard extra_content against plain dict to prevent model_dump crash

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6958,7 +6958,9 @@ class AIAgent:
                         if extra is None and hasattr(tc_delta, "model_extra"):
                             extra = (tc_delta.model_extra or {}).get("extra_content")
                         if extra is not None:
-                            if hasattr(extra, "model_dump"):
+                            if isinstance(extra, dict):
+                                pass  # already serializable
+                            elif hasattr(extra, "model_dump"):
                                 extra = extra.model_dump()
                             entry["extra_content"] = extra
                         # Fire once per tool when the full name is available
@@ -8807,7 +8809,9 @@ class AIAgent:
                 # thinking models reject the request with a 400 error.
                 extra = getattr(tool_call, "extra_content", None)
                 if extra is not None:
-                    if hasattr(extra, "model_dump"):
+                    if isinstance(extra, dict):
+                        pass  # already serializable
+                    elif hasattr(extra, "model_dump"):
                         extra = extra.model_dump()
                     tc_dict["extra_content"] = extra
                 tool_calls.append(tc_dict)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1486,6 +1486,19 @@ class TestBuildAssistantMessage:
             "google": {"thought_signature": "abc123"}
         }
 
+    def test_tool_call_extra_content_dict_passthrough(self, agent):
+        """When extra_content is already a plain dict, it must pass through
+        without calling model_dump() (fixes #19968 — MiniMax streaming crash)."""
+        tc = _mock_tool_call(
+            name="search", arguments='{"q":"test"}', call_id="c_dict"
+        )
+        tc.extra_content = {"minimax": {"trace_id": "abc"}}
+        msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        result = agent._build_assistant_message(msg, "tool_calls")
+        assert result["tool_calls"][0]["extra_content"] == {
+            "minimax": {"trace_id": "abc"}
+        }
+
     def test_tool_call_without_extra_content(self, agent):
         """Standard tool calls (no thinking model) should not have extra_content."""
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c3")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -237,6 +237,55 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_call_extra_content_dict_passthrough(self, mock_close, mock_create):
+        """When extra_content is already a plain dict (not a Pydantic model),
+        it must pass through without calling model_dump() (fixes #19968)."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_minimax",
+                    name="search",
+                    model_extra={
+                        "extra_content": {
+                            "minimax": {"trace_id": "mm-abc"}
+                        }
+                    },
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"q": "test"}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert tc[0].extra_content == {
+            "minimax": {"trace_id": "mm-abc"}
+        }
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_mixed_content_and_tool_calls(self, mock_close, mock_create):
         """Stream with both text and tool calls accumulates both."""
         from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

Fix `AttributeError: 'dict' object has no attribute 'model_dump'` crash when providers (e.g. MiniMax) return `extra_content` as a plain `dict` instead of a Pydantic `BaseModel`.


### Root Cause

Two code paths in `run_agent.py` use this pattern to serialize `extra_content`:

```python
if hasattr(extra, "model_dump"):
    extra = extra.model_dump()
```

When `extra` is a Pydantic model, `model_dump()` returns a serializable dict — correct. But when a provider returns `extra_content` as a plain `dict`, `hasattr(dict_obj, "model_dump")` can pass (e.g. if the dict has a `"model_dump"` key, or the object is a dict-like subclass), and the subsequent `.model_dump()` call raises `AttributeError`.

A third code path (reasoning_details at line ~8745) already has `isinstance(d, dict)` as the first check, so it was unaffected.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A