### PR TITLE
feat(cli): highlight submitted user messages

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2073,6 +2073,22 @@ class HermesCLI:
             _ump_last_lines = 2
         self.user_message_preview_first_lines = max(1, _ump_first_lines)
         self.user_message_preview_last_lines = max(0, _ump_last_lines)
+        self.user_message_preview_boxed = bool(_ump.get("boxed", True))
+        self.user_message_preview_box_style = str(_ump.get("box_style", "round") or "round").strip().lower()
+        if self.user_message_preview_box_style not in {"ascii", "double", "heavy", "round", "square"}:
+            self.user_message_preview_box_style = "round"
+        self.user_message_preview_accent_color = str(_ump.get("accent_color", "#B084FF") or "#B084FF").strip()
+        self.user_message_preview_text_color = str(_ump.get("text_color", "#F2EAFE") or "#F2EAFE").strip()
+        try:
+            _ump_margin_top = int(_ump.get("margin_top", 2))
+        except (TypeError, ValueError):
+            _ump_margin_top = 2
+        try:
+            _ump_margin_bottom = int(_ump.get("margin_bottom", 2))
+        except (TypeError, ValueError):
+            _ump_margin_bottom = 2
+        self.user_message_preview_margin_top = max(0, _ump_margin_top)
+        self.user_message_preview_margin_bottom = max(0, _ump_margin_bottom)
 
         # Streaming display state
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
@@ -2945,9 +2961,10 @@ class HermesCLI:
 
     def _format_submitted_user_message_preview(self, user_input: str) -> str:
         """Format the submitted user-message scrollback preview."""
+        accent = getattr(self, "user_message_preview_accent_color", _accent_hex())
         lines = user_input.split("\n")
         if len(lines) <= 1:
-            return f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]"
+            return f"[bold {accent}]●[/] [bold]{_escape(user_input)}[/]"
 
         first_lines = int(getattr(self, "user_message_preview_first_lines", 2))
         last_lines = int(getattr(self, "user_message_preview_last_lines", 2))
@@ -2964,7 +2981,7 @@ class HermesCLI:
             tail = []
 
         preview_lines = [
-            f"[bold {_accent_hex()}]●[/] [bold]{_escape(head[0])}[/]"
+            f"[bold {accent}]●[/] [bold]{_escape(head[0])}[/]"
         ]
         preview_lines.extend(f"[bold]{_escape(line)}[/]" for line in head[1:])
 
@@ -2996,12 +3013,36 @@ class HermesCLI:
 
     def _print_user_message_preview(self, user_input: str) -> None:
         """Render a user message using the normal chat scrollback style."""
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        chat_console = ChatConsole()
+        for _ in range(max(0, int(getattr(self, "user_message_preview_margin_top", 0)))):
+            chat_console.print("")
         text = str(user_input or "")
-        if "\n" in text:
-            ChatConsole().print(self._format_submitted_user_message_preview(text))
+        preview = self._format_submitted_user_message_preview(text)
+        accent = getattr(self, "user_message_preview_accent_color", "#B084FF")
+        text_color = getattr(self, "user_message_preview_text_color", "#F2EAFE")
+        if getattr(self, "user_message_preview_boxed", True):
+            box_styles = {
+                "ascii": rich_box.ASCII,
+                "double": rich_box.DOUBLE,
+                "heavy": rich_box.HEAVY,
+                "round": rich_box.ROUNDED,
+                "square": rich_box.SQUARE,
+            }
+            box_style = box_styles.get(getattr(self, "user_message_preview_box_style", "round"), rich_box.ROUNDED)
+            chat_console.print(Panel(
+                _RichText.from_markup(preview, style=text_color),
+                title=f"[bold {accent}]You[/]",
+                title_align="left",
+                border_style=accent,
+                style=text_color,
+                box=box_style,
+                padding=(0, 1),
+            ))
         else:
-            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(text)}[/]")
+            chat_console.print(f"[{accent}]{'─' * 40}[/]")
+            chat_console.print(preview)
+        for _ in range(max(0, int(getattr(self, "user_message_preview_margin_bottom", 0)))):
+            chat_console.print("")
 
     def _stream_reasoning_delta(self, text: str) -> None:
         """Stream reasoning/thinking tokens into a dim box above the response.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -787,6 +787,12 @@ DEFAULT_CONFIG = {
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,
+            "boxed": True,
+            "box_style": "round",  # round, square, double, heavy, ascii
+            "accent_color": "#B084FF",
+            "text_color": "#F2EAFE",
+            "margin_top": 2,
+            "margin_bottom": 2,
         },
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
@@ -4463,7 +4469,10 @@ def show_config():
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)
-    print(f"  User preview: first {ump_first} line(s), last {ump_last} line(s)")
+    ump_box = 'boxed' if ump.get('boxed', True) else 'line'
+    ump_box_style = ump.get('box_style', 'round')
+    ump_accent = ump.get('accent_color', '#B084FF')
+    print(f"  User preview: first {ump_first} line(s), last {ump_last} line(s), {ump_box}/{ump_box_style}, {ump_accent}")
 
     # Terminal
     print()

--- a/tests/cli/test_cli_user_message_preview.py
+++ b/tests/cli/test_cli_user_message_preview.py
@@ -20,7 +20,16 @@ def _make_cli(user_message_preview=None):
         "display": {
             "compact": False,
             "tool_progress": "all",
-            "user_message_preview": user_message_preview or {"first_lines": 2, "last_lines": 2},
+            "user_message_preview": user_message_preview or {
+                "first_lines": 2,
+                "last_lines": 2,
+                "boxed": True,
+                "box_style": "round",
+                "accent_color": "#B084FF",
+                "text_color": "#F2EAFE",
+                "margin_top": 2,
+                "margin_bottom": 2,
+            },
         },
         "agent": {},
         "terminal": {"env_type": "local"},
@@ -90,3 +99,21 @@ class TestSubmittedUserMessagePreview:
         assert "line3" in rendered
         assert "line4" in rendered
         assert "(+1 more line)" in rendered
+
+    def test_default_preview_uses_purple_box_anchor_and_spacing(self):
+        cli = _make_cli()
+
+        assert cli.user_message_preview_boxed is True
+        assert cli.user_message_preview_box_style == "round"
+        assert cli.user_message_preview_accent_color == "#B084FF"
+        assert cli.user_message_preview_text_color == "#F2EAFE"
+        assert cli.user_message_preview_margin_top == 2
+        assert cli.user_message_preview_margin_bottom == 2
+
+        rendered = cli._format_submitted_user_message_preview("hello")
+        assert "#B084FF" in rendered
+
+    def test_preview_box_style_falls_back_to_round(self):
+        cli = _make_cli({"first_lines": 2, "last_lines": 2, "box_style": "unknown"})
+
+        assert cli.user_message_preview_box_style == "round"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -657,3 +657,12 @@ class TestUserMessagePreviewConfig:
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]
         assert preview["first_lines"] == 2
         assert preview["last_lines"] == 2
+
+    def test_default_config_preview_box_uses_purple_anchor(self):
+        preview = DEFAULT_CONFIG["display"]["user_message_preview"]
+        assert preview["boxed"] is True
+        assert preview["box_style"] == "round"
+        assert preview["accent_color"] == "#B084FF"
+        assert preview["text_color"] == "#F2EAFE"
+        assert preview["margin_top"] == 2
+        assert preview["margin_bottom"] == 2


### PR DESCRIPTION
## Summary
- Highlight submitted user messages in the CLI with a boxed preview.
- Use a purple accent by default so user prompts stand apart from the default Hermes yellow theme.
- Add configurable preview styling for box shape, accent/text color, and vertical spacing.
- Keep the existing first/last-line preview behavior for long pasted or multi-line prompts.

## Why
In long terminal sessions, it can be hard to visually find the exact prompt that triggered a response. This makes submitted user prompts act as a clear visual anchor in scrollback without changing the underlying message, prompt, or session history.

## Config
This adds these `display.user_message_preview` options:

```yaml
display:
  user_message_preview:
    boxed: true
    box_style: round   # round, square, double, heavy, ascii
    accent_color: "#B084FF"
    text_color: "#F2EAFE"
    margin_top: 2
    margin_bottom: 2
```

`box_style` also gives users a lightweight way to choose line weight/shape preferences, e.g. `heavy` or `double` for stronger borders.

## Follow-up UX idea
If this direction feels right, a follow-up could expose these preferences through an interactive CLI/TUI setting picker, for example:
- choose accent color from presets or a custom hex value
- choose box style/line weight: round, square, double, heavy, ascii
- choose vertical spacing around submitted prompts
- preview the selected style live before saving

## Test Plan
- `/Users/seongqkim/developer/tools/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/cli/test_cli_user_message_preview.py tests/hermes_cli/test_config.py -q`
- `/Users/seongqkim/developer/tools/hermes-agent/.venv/bin/python -m py_compile cli.py hermes_cli/config.py`
- `git diff --check`
