### PR TITLE
fix(tui): prevent status model label shaping glitch

### DIFF
--- a/ui-tui/src/__tests__/shapeSafeStatusText.test.ts
+++ b/ui-tui/src/__tests__/shapeSafeStatusText.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  breakTerminalShapingRuns,
+  statusTextAnsi,
+  stripStatusAnsi,
+  truncateStatusText
+} from '../components/shapeSafeStatusText.js'
+
+describe('shape-safe status text', () => {
+  it('keeps the Gemini model label visibly unchanged while breaking the terminal shaping run', () => {
+    const label = 'gemini 3.1 pro preview high'
+    const ansi = statusTextAnsi(label, '#cc9b1f')
+
+    expect(stripStatusAnsi(ansi)).toBe(label)
+    expect(ansi).toContain('gemin\x1b[25mi')
+  })
+
+  it('only inserts the shaping boundary for standalone Gemini labels', () => {
+    expect(breakTerminalShapingRuns('minimax/minimax-m2.5')).toBe('minimax/minimax-m2.5')
+    expect(breakTerminalShapingRuns('gemini 3.1')).toBe('gemin\x1b[25mi 3.1')
+    expect(breakTerminalShapingRuns('Gemini 3.1')).toBe('Gemin\x1b[25mi 3.1')
+  })
+
+  it('truncates by terminal display width before adding ANSI', () => {
+    expect(truncateStatusText('gemini 3.1 pro', 10)).toBe('gemini 3.…')
+    expect(stripStatusAnsi(statusTextAnsi(truncateStatusText('gemini 3.1 pro', 10), '#cc9b1f'))).toBe('gemini 3.…')
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,4 +1,4 @@
-import { Box, type ScrollBoxHandle, Text } from '@hermes/ink'
+import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { type ReactNode, type RefObject, useEffect, useMemo, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
@@ -16,6 +16,7 @@ import { fmtK } from '../lib/text.js'
 import { useViewportSnapshot } from '../lib/viewportStore.js'
 import type { Theme } from '../theme.js'
 import type { Msg, Usage } from '../types.js'
+import { ShapeSafeStatusText, truncateStatusText } from './shapeSafeStatusText.js'
 
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
@@ -236,6 +237,46 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+const statusModelAvailableWidth = ({
+  bgCount,
+  bar,
+  busy,
+  ctxLabel,
+  leftWidth,
+  pct,
+  sessionStartedAt,
+  showCost,
+  status,
+  usage,
+  voiceLabel
+}: {
+  bgCount: number
+  bar: string
+  busy: boolean
+  ctxLabel: string
+  leftWidth: number
+  pct: number | undefined
+  sessionStartedAt?: null | number
+  showCost: boolean
+  status: string
+  usage: Usage
+  voiceLabel?: string
+}) => {
+  const fixed = [
+    '─ ',
+    busy ? 'running…' : status,
+    ' │ ',
+    ctxLabel ? ` │ ${ctxLabel}` : '',
+    bar ? ` │ [${bar}] ${pct != null ? `${pct}%` : ''}` : '',
+    sessionStartedAt ? ` │ ${fmtDuration(Date.now() - sessionStartedAt)}` : '',
+    voiceLabel ? ` │ ${voiceLabel}` : '',
+    bgCount > 0 ? ` │ ${bgCount} bg` : '',
+    showCost && typeof usage.cost_usd === 'number' ? ` │ $${usage.cost_usd.toFixed(4)}` : ''
+  ].join('')
+
+  return Math.max(1, leftWidth - stringWidth(fixed))
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -289,47 +330,62 @@ export function StatusRule({
 
   const bar = usage.context_max ? ctxBar(pct) : ''
   const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
+  const modelText = modelLabel(model, modelReasoningEffort, modelFast)
+  const modelAvailableWidth = statusModelAvailableWidth({
+    bgCount,
+    bar,
+    busy,
+    ctxLabel,
+    leftWidth,
+    pct,
+    sessionStartedAt,
+    showCost,
+    status,
+    usage,
+    voiceLabel
+  })
+  const renderedModelText = truncateStatusText(modelText, modelAvailableWidth)
 
   return (
     <Box height={1}>
       <Box flexShrink={1} width={leftWidth}>
-        <Text color={t.color.border} wrap="truncate-end">
-          {'─ '}
-          {busy ? (
-            <FaceTicker color={statusColor} startedAt={turnStartedAt} />
-          ) : (
-            <Text color={statusColor}>{status}</Text>
-          )}
-          <Text color={t.color.muted}> │ {modelLabel(model, modelReasoningEffort, modelFast)}</Text>
-          {ctxLabel ? <Text color={t.color.muted}> │ {ctxLabel}</Text> : null}
-          {bar ? (
-            <Text color={t.color.muted}>
-              {' │ '}
-              <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
-            </Text>
-          ) : null}
-          {sessionStartedAt ? (
-            <Text color={t.color.muted}>
-              {' │ '}
-              <SessionDuration startedAt={sessionStartedAt} />
-            </Text>
-          ) : null}
-          <SpawnHud t={t} />
-          {voiceLabel ? (
-            <Text
-              color={
-                voiceLabel.startsWith('●') ? t.color.error : voiceLabel.startsWith('◉') ? t.color.warn : t.color.muted
-              }
-            >
-              {' │ '}
-              {voiceLabel}
-            </Text>
-          ) : null}
-          {bgCount > 0 ? <Text color={t.color.muted}> │ {bgCount} bg</Text> : null}
-          {showCost && typeof usage.cost_usd === 'number' ? (
-            <Text color={t.color.muted}> │ ${usage.cost_usd.toFixed(4)}</Text>
-          ) : null}
-        </Text>
+        <Text color={t.color.border}>─ </Text>
+        {busy ? (
+          <FaceTicker color={statusColor} startedAt={turnStartedAt} />
+        ) : (
+          <Text color={statusColor}>{status}</Text>
+        )}
+        <Text color={t.color.muted}> │ </Text>
+        <ShapeSafeStatusText color={t.color.muted} text={renderedModelText} />
+        {ctxLabel ? <Text color={t.color.muted}> │ {ctxLabel}</Text> : null}
+        {bar ? (
+          <>
+            <Text color={t.color.muted}> │ </Text>
+            <Text color={barColor}>[{bar}]</Text>
+            <Text color={barColor}>{pct != null ? ` ${pct}%` : ''}</Text>
+          </>
+        ) : null}
+        {sessionStartedAt ? (
+          <Text color={t.color.muted}>
+            {' │ '}
+            <SessionDuration startedAt={sessionStartedAt} />
+          </Text>
+        ) : null}
+        <SpawnHud t={t} />
+        {voiceLabel ? (
+          <Text
+            color={
+              voiceLabel.startsWith('●') ? t.color.error : voiceLabel.startsWith('◉') ? t.color.warn : t.color.muted
+            }
+          >
+            {' │ '}
+            {voiceLabel}
+          </Text>
+        ) : null}
+        {bgCount > 0 ? <Text color={t.color.muted}> │ {bgCount} bg</Text> : null}
+        {showCost && typeof usage.cost_usd === 'number' ? (
+          <Text color={t.color.muted}> │ ${usage.cost_usd.toFixed(4)}</Text>
+        ) : null}
       </Box>
 
       <Text color={t.color.border}> ─ </Text>

--- a/ui-tui/src/components/shapeSafeStatusText.tsx
+++ b/ui-tui/src/components/shapeSafeStatusText.tsx
@@ -1,0 +1,69 @@
+import { RawAnsi, stringWidth } from '@hermes/ink'
+
+// Some terminal/font stacks shape `gemini` such that the `n` disappears
+// visually in the compact status bar. SGR 25 ("blink off") is a visible
+// no-op for Hermes, but it creates a terminal style boundary that prevents
+// that shaping run while preserving the visible label and copied text.
+const SHAPING_BOUNDARY = '\x1b[25m'
+
+export const stripStatusAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/g, '')
+
+export const truncateStatusText = (text: string, maxWidth: number) => {
+  if (stringWidth(text) <= maxWidth) {
+    return text
+  }
+
+  if (maxWidth <= 1) {
+    return '…'
+  }
+
+  let out = ''
+
+  for (const char of text) {
+    const next = `${out}${char}`
+
+    if (stringWidth(`${next}…`) > maxWidth) {
+      break
+    }
+
+    out = next
+  }
+
+  return `${out}…`
+}
+
+const ansiForeground = (color: string) => {
+  const hex = /^#?([0-9a-f]{6})$/i.exec(color)
+
+  if (hex) {
+    const value = parseInt(hex[1]!, 16)
+    const red = (value >> 16) & 0xff
+    const green = (value >> 8) & 0xff
+    const blue = value & 0xff
+
+    return `\x1b[38;2;${red};${green};${blue}m`
+  }
+
+  const rgb = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/i.exec(color)
+
+  if (rgb) {
+    return `\x1b[38;2;${rgb[1]};${rgb[2]};${rgb[3]}m`
+  }
+
+  const indexed = /^ansi256\((\d+)\)$/i.exec(color)
+
+  if (indexed) {
+    return `\x1b[38;5;${indexed[1]}m`
+  }
+
+  return ''
+}
+
+export const breakTerminalShapingRuns = (text: string) => text.replace(/\bgemin(?=i\b)/gi, `$&${SHAPING_BOUNDARY}`)
+
+export const statusTextAnsi = (text: string, color: string) =>
+  `${ansiForeground(color)}${breakTerminalShapingRuns(text)}\x1b[39m`
+
+export function ShapeSafeStatusText({ color, text }: { color: string; text: string }) {
+  return <RawAnsi lines={[statusTextAnsi(text, color)]} width={stringWidth(text)} />
+}

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -101,6 +101,10 @@ declare module '@hermes/ink' {
     readonly url: string
   }>
   export const NoSelect: React.ComponentType<any>
+  export const RawAnsi: React.ComponentType<{
+    readonly lines: string[]
+    readonly width: number
+  }>
   export const ScrollBox: React.ComponentType<any>
   export const Text: React.ComponentType<any>
   export const TextInput: React.ComponentType<any>


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI status-bar rendering glitch where some terminal/font stacks can visually drop the `n` in the Gemini model family label, making the status bar look like `gemi i 3.1...` even though Hermes resolved the model correctly.

The TUI now renders the model status segment through a small `ShapeSafeStatusText` component. It preserves the visible label and copied plain text, but inserts a harmless SGR 25 (`blink off`) boundary inside standalone `gemini` labels so terminals do not shape the problematic run as a single glyph sequence.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `ShapeSafeStatusText` for compact TUI status labels that need terminal-shaping-safe rendering.
- Updated the TUI status bar model segment to use explicit width-aware truncation and the shape-safe renderer.
- Added `RawAnsi` to the local `@hermes/ink` type shim used by the TUI build config.
- Added tests covering visible text preservation, Gemini-only shaping boundaries, and width-aware truncation.

## How to Test

1. Configure a Gemini model such as `google/gemini-3.1-pro-preview`.
2. Start `hermes --tui` in a terminal/font stack affected by the shaping issue.
3. Confirm the bottom status bar shows `gemini 3.1 pro preview high` instead of dropping the `n`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL terminal environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted TUI checks passed:

- `cd ui-tui && npm run type-check`
- `cd ui-tui && npm test` — 57 files / 609 tests
- `cd ui-tui && npm run build`

Full Python suite:

- `scripts/run_tests.sh`
- Result: failed
- Summary: `44 failed, 19666 passed, 51 skipped, 221 warnings in 647.26s (0:10:47)`

The full-suite failures are outside this PR's TUI files. The local full-suite run also reproduced the existing gateway-service test isolation issue: `tests/hermes_cli/test_gateway.py::test_run_gateway_exits_nonzero` rewrote the live user gateway unit's `HERMES_HOME`. The local service was restored after the run and verified back on the real Hermes home.
