### PR TITLE
fix(gateway): deduplicate BlueBubbles inbound messages by GUID + content hash

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -9,11 +9,14 @@ downloading from PR #4588 (YuhangLin).
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
+import time
 import uuid
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -55,6 +58,11 @@ _TAPBACK_REMOVED = {
 
 # Webhook event types that carry user messages
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+
+# BlueBubbles can dispatch requests for the same message ~500-900ms apart, 
+# particularly when SIP is disabled. De-duplciation tracks by (guid, text_hash)
+# to avoid sending the same message multiple times.
+_MAX_DEDUP_CACHE = 1000
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -129,6 +137,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
+        self._seen_keys: OrderedDict[tuple, None] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -741,6 +750,27 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return None
 
     # ------------------------------------------------------------------
+    # Inbound message dedup (BlueBubbles fires each message twice)
+    # ------------------------------------------------------------------
+
+    def _check_dedup(self, guid: Optional[str], text: str) -> bool:
+        """Return True if *(guid, text_hash)* has already been processed.
+
+        Uses a bounded OrderedDict so memory stays flat during long sessions.
+        """
+        if not guid:
+            return False
+        text_hash = hashlib.md5(text.encode("utf-8")).hexdigest()
+        key = (guid, text_hash)
+        if key in self._seen_keys:
+            logger.debug("[bluebubbles] ignoring duplicate message %s", guid)
+            return True
+        self._seen_keys[key] = None
+        if len(self._seen_keys) > _MAX_DEDUP_CACHE:
+            self._seen_keys.popitem(last=False)
+        return False
+
+    # ------------------------------------------------------------------
     # Webhook handling
     # ------------------------------------------------------------------
 
@@ -900,6 +930,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+
+        message_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        if message_guid and self._check_dedup(message_guid, text):
+            return web.Response(text="ok")
+
         source = self.build_source(
             chat_id=session_chat_id,
             chat_name=chat_identifier or sender,
@@ -913,11 +952,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_guid,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -686,3 +686,41 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesDedup:
+    def test_first_message_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._check_dedup("guid-1", "hello") is False
+
+    def test_duplicate_guid_and_text_is_deduped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._check_dedup("guid-1", "hello")
+        assert adapter._check_dedup("guid-1", "hello") is True
+
+    def test_same_guid_different_text_is_not_deduped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._check_dedup("guid-1", "hello")
+        assert adapter._check_dedup("guid-1", "world") is False
+
+    def test_different_guid_same_text_is_not_deduped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._check_dedup("guid-1", "hello")
+        assert adapter._check_dedup("guid-2", "hello") is False
+
+    def test_empty_guid_is_not_deduped(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._check_dedup(None, "hello") is False
+        assert adapter._check_dedup("", "hello") is False
+
+    def test_cache_evicts_oldest_entries(self, monkeypatch):
+        from gateway.platforms.bluebubbles import _MAX_DEDUP_CACHE
+        adapter = _make_adapter(monkeypatch)
+        for i in range(_MAX_DEDUP_CACHE + 5):
+            adapter._check_dedup(f"guid-{i}", f"text-{i}")
+        assert len(adapter._seen_keys) == _MAX_DEDUP_CACHE
+        # Oldest entries should have been evicted (re-processing returns False)
+        assert adapter._check_dedup("guid-0", "text-0") is False
+        assert adapter._check_dedup("guid-4", "text-4") is False
+        # Newest entries should still be present (re-processing returns True)
+        assert adapter._check_dedup(f"guid-{_MAX_DEDUP_CACHE + 4}", f"text-{_MAX_DEDUP_CACHE + 4}") is True


### PR DESCRIPTION
## What does this PR do?

After disabling [SIP in BlueBubbles](https://docs.bluebubbles.app/private-api/installation), which Hermes requires [in order to access the Private API](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/bluebubbles#private-api), I began getting two independent responses for any given message (see screenshot below). 

Digging through the BlueBubbles logs and Hermes integration, I discovered it's due to BlueBubbles dispatching webhook requests after both the incoming new message as well as the "read" event:

```
[2026-05-04 18:39:19.396][info] [BlueBubblesServer] New Message from +*******1111, "new message"
[2026-05-04 18:39:19.398][debug] [WebhookService] Dispatching event to webhook: ...

[2026-05-04 18:39:20.201][info] [BlueBubblesServer] Read message from [+*******1111]: ["new message"]
[2026-05-04 18:39:20.202][debug] [WebhookService] Dispatching event to webhook: ...
```

The first fires from the private API (phone helper) on immediate detection. The second fires ~800ms later when the Mac Messages DB sync confirms the message. Both carry the same guid and dateCreated — the second is simply a read-receipt-triggered re-dispatch.

The fix adds a bounded OrderedDict cache of (guid, text_hash) pairs that suppresses the duplicate webhook before it reaches the agent loop. The cache is size-bounded (max 1000). I considered making eviction time-bound, but doing so by size is simpler and fully deterministic.

## Related Issue

I consider this to be a small slice for the feature discussed here. 

https://github.com/NousResearch/hermes-agent/issues/8513

This PR solely focuses on deduplicating message requests, which will arguably remain a concern even after a more mature feature is fleshed out.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/platforms/bluebubbles.py
- tests/gateway/test_bluebubbles.py

## How to Test

1. Send an iMessage to the Hermes BlueBubbles integration.
2. Verify only one response is produced (not two).
3. Check ~/.hermes/logs/gateway.log — confirm only one inbound message: platform=bluebubbles entry per message.
4. Check the BlueBubbles server log (~/Library/Logs/bluebubbles-server/main.log) — confirm two dispatches still arrive, but only one is processed by Hermes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots

Example of receiving duplicate messages:
<img width="1046" height="1420" alt="CleanShot 2026-05-04 at 19 27 45@2x" src="https://github.com/user-attachments/assets/c0ceb547-3a91-4bcc-ad25-78f240223bf1" />