### PR TITLE
fix(qqbot): reconnect on missed heartbeat ACK

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -187,6 +187,8 @@ class QQAdapter(BasePlatformAdapter):
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
+        self._heartbeat_ack_pending = False
+        self._last_heartbeat_sent_at: Optional[float] = None
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
@@ -393,6 +395,8 @@ class QQAdapter(BasePlatformAdapter):
         if self._ws and not self._ws.closed:
             await self._ws.close()
         self._ws = None
+        self._heartbeat_ack_pending = False
+        self._last_heartbeat_sent_at = None
         if self._session and not self._session.closed:
             await self._session.close()
         self._session = None
@@ -625,8 +629,29 @@ class QQAdapter(BasePlatformAdapter):
                 if not self._ws or self._ws.closed:
                     continue
                 try:
+                    if self._heartbeat_ack_pending:
+                        elapsed = (
+                            time.monotonic() - self._last_heartbeat_sent_at
+                            if self._last_heartbeat_sent_at is not None
+                            else self._heartbeat_interval
+                        )
+                        logger.warning(
+                            "[%s] Heartbeat ACK timeout after %.1fs; closing WebSocket to reconnect",
+                            self._log_tag,
+                            elapsed,
+                        )
+                        await self._ws.close(
+                            code=aiohttp.WSCloseCode.GOING_AWAY,
+                            message=b"heartbeat ACK timeout",
+                        )
+                        self._heartbeat_ack_pending = False
+                        self._last_heartbeat_sent_at = None
+                        continue
                     # d should be the latest sequence number received, or null
                     await self._ws.send_json({"op": 1, "d": self._last_seq})
+                    self._heartbeat_ack_pending = True
+                    self._last_heartbeat_sent_at = time.monotonic()
+                    logger.debug("[%s] Heartbeat sent (seq=%s)", self._log_tag, self._last_seq)
                 except Exception as exc:
                     logger.debug("[%s] Heartbeat failed: %s", self._log_tag, exc)
         except asyncio.CancelledError:
@@ -743,6 +768,14 @@ class QQAdapter(BasePlatformAdapter):
                 self._create_task(self._send_resume())
             else:
                 self._create_task(self._send_identify())
+            return
+
+        # op 11 = Heartbeat ACK. If this stops arriving, the heartbeat loop
+        # closes the socket so the existing reconnect path can recover.
+        if op == 11:
+            self._heartbeat_ack_pending = False
+            self._last_heartbeat_sent_at = None
+            logger.debug("[%s] Heartbeat ACK received", self._log_tag)
             return
 
         # op 0 = Dispatch

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -433,13 +433,61 @@ class TestDispatchPayload:
 
     def test_op11_heartbeat_ack(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._heartbeat_ack_pending = True
+        adapter._last_heartbeat_sent_at = 123.0
         # Should not raise
         adapter._dispatch_payload({"op": 11, "t": "HEARTBEAT_ACK", "s": 42})
+        assert adapter._heartbeat_ack_pending is False
+        assert adapter._last_heartbeat_sent_at is None
 
     def test_seq_tracking(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter._dispatch_payload({"op": 0, "t": "READY", "s": 100, "d": {}})
         assert adapter._last_seq == 100
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_closes_ws_when_ack_missing(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._heartbeat_interval = 0.001
+        adapter._last_seq = 42
+        adapter._running = True
+
+        class FakeWS:
+            closed = False
+
+            def __init__(self):
+                self.sent = []
+                self.close_calls = []
+
+            async def send_json(self, payload):
+                self.sent.append(payload)
+
+            async def close(self, **kwargs):
+                self.close_calls.append(kwargs)
+                self.closed = True
+
+        ws = FakeWS()
+        adapter._ws = ws
+
+        task = asyncio.create_task(adapter._heartbeat_loop())
+        try:
+            for _ in range(50):
+                if ws.close_calls:
+                    break
+                await asyncio.sleep(0.001)
+        finally:
+            adapter._running = False
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert ws.sent == [{"op": 1, "d": 42}]
+        assert ws.close_calls
+        assert ws.close_calls[0]["message"] == b"heartbeat ACK timeout"
+        assert adapter._heartbeat_ack_pending is False
+        assert adapter._last_heartbeat_sent_at is None
 
     def test_seq_increments(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")


### PR DESCRIPTION
## Summary

Fixes #19648.

QQ Bot already sends gateway heartbeats, but it did not track whether the gateway returned opcode 11 heartbeat ACKs. If the WebSocket stopped acknowledging heartbeats while the process stayed alive, the listener could remain blocked waiting for frames and systemd would still see the gateway as running.

This PR adds a small ACK watchdog to the existing heartbeat loop:

- mark a heartbeat ACK as pending after sending opcode 1 with the latest sequence number
- clear the pending state when opcode 11 arrives
- if the next heartbeat tick sees the previous ACK still pending, close the WebSocket so the existing reconnect path recovers the session
- reset ACK state when opening/cleaning up WebSocket resources

## Scope

Kept intentionally narrow to the QQ Bot adapter and its existing unit tests. No protocol rewrite, watchdog daemon, or systemd integration is added here.

## Verification

```bash
scripts/run_tests.sh tests/gateway/test_qqbot.py
# 73 passed
```

I also ran `git diff --check` successfully. `python -m ruff check ...` was not available in this local environment (`No module named ruff`).