### PR TITLE
fix(agent): attempt native vision when caps unknown but slug looks vision-shaped

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -186,6 +186,32 @@ def _lookup_supports_vision(
     return bool(caps.supports_vision)
 
 
+_VISION_SLUG_FRAGMENTS = (
+    "vision",
+    "visual",
+    "vl",
+    "omni",
+    "multimodal",
+)
+
+_VISION_SLUG_SUFFIXES = (
+    "-vl",
+    "_vl",
+    ".vl",
+)
+
+
+def _looks_like_vision_model(model: str) -> bool:
+    """Heuristically identify vision-capable models absent from models.dev."""
+    slug = (model or "").strip().lower()
+    if not slug:
+        return False
+    tail = slug.rsplit("/", 1)[-1]
+    if any(fragment in tail for fragment in _VISION_SLUG_FRAGMENTS):
+        return True
+    return tail.endswith(_VISION_SLUG_SUFFIXES)
+
+
 def decide_image_input_mode(
     provider: str,
     model: str,
@@ -215,6 +241,8 @@ def decide_image_input_mode(
 
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
+        return "native"
+    if supports is None and _looks_like_vision_model(model):
         return "native"
     return "text"
 
@@ -388,4 +416,5 @@ def build_native_content_parts(
 __all__ = [
     "decide_image_input_mode",
     "build_native_content_parts",
+    "_looks_like_vision_model",
 ]

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -14,6 +14,7 @@ from agent.image_routing import (
     _explicit_aux_vision_override,
     _lookup_supports_vision,
     _supports_vision_override,
+    _looks_like_vision_model,
     build_native_content_parts,
     decide_image_input_mode,
 )
@@ -67,6 +68,26 @@ class TestExplicitAuxVisionOverride:
     def test_base_url_set_is_explicit(self):
         cfg = {"auxiliary": {"vision": {"provider": "auto", "base_url": "http://localhost:11434"}}}
         assert _explicit_aux_vision_override(cfg) is True
+
+
+class TestLooksLikeVisionModel:
+    @pytest.mark.parametrize("model", [
+        "mimo-v2-omni",
+        "qwen2.5-vl-72b-instruct",
+        "claude-3-vision-preview",
+        "vendor/model-visual",
+    ])
+    def test_recognises_vision_slugs(self, model):
+        assert _looks_like_vision_model(model) is True
+
+    @pytest.mark.parametrize("model", [
+        "gpt-4o-mini",
+        "claude-3-haiku",
+        "deepseek-chat",
+        "",
+    ])
+    def test_rejects_non_vision_slugs(self, model):
+        assert _looks_like_vision_model(model) is False
 
 
 # ─── decide_image_input_mode ─────────────────────────────────────────────────
@@ -298,6 +319,20 @@ def _png_bytes() -> bytes:
     return base64.b64decode(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABpfZFQAAAAABJRU5ErkJggg=="
     )
+
+
+    @pytest.mark.parametrize("model", [
+        "mimo-v2-omni",
+        "qwen2.5-vl-72b-instruct",
+        "claude-3-vision-preview",
+    ])
+    def test_auto_with_unknown_vision_shaped_slug_falls_back_to_native(self, model, monkeypatch):
+        monkeypatch.setattr("agent.image_routing._lookup_supports_vision", lambda provider, model, cfg=None: None)
+        assert decide_image_input_mode("custom", model, {}) == "native"
+
+    def test_auto_known_non_vision_still_text_even_if_slug_looks_visiony(self, monkeypatch):
+        monkeypatch.setattr("agent.image_routing._lookup_supports_vision", lambda provider, model, cfg=None: False)
+        assert decide_image_input_mode("custom", "fake-vision-model", {}) == "text"
 
 
 class TestBuildNativeContentParts:


### PR DESCRIPTION
## What does this PR do?

Image routing previously relied on explicit capability metadata and could skip native vision for models whose slugs clearly indicate vision support but whose capabilities are unknown. This PR adds a narrow slug heuristic for vision-shaped model names while preserving explicit capability overrides, MIME handling, and path-hint behavior.

## Related Issue

Fixes #19287

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a conservative vision-shaped model slug heuristic in `agent/image_routing.py`.
- Preserve explicit capability decisions and existing image-routing fallbacks.
- Add focused regression tests for native-vision selection and preserved negative cases.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/agent/test_image_routing.py -q`
3. Expected result: 65 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/agent/test_image_routing.py -q` — 65 passed
```
