### PR TITLE
fix(image_gen): drop unsupported tool_choice from openai-codex request

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -307,11 +307,15 @@ def _build_responses_payload(
             "background": "opaque",
             "partial_images": 1,
         }],
-        "tool_choice": {
-            "type": "allowed_tools",
-            "mode": "required",
-            "tools": [{"type": "image_generation"}],
-        },
+        # No ``tool_choice`` is sent: the chatgpt.com/backend-api/codex backend
+        # rejects every shape we have for forcing the hosted ``image_generation``
+        # tool. ``{"type": "allowed_tools", "mode": "required", "tools": [{"type":
+        # "image_generation"}]}`` (and the simpler ``{"type": "image_generation"}``
+        # form) both 400 with ``Tool choice 'image_generation' not found in 'tools'
+        # parameter`` — the backend looks up tool_choice as a *function* name and
+        # never recognizes hosted-tool entries. Letting the host model decide is
+        # the only shape Codex currently accepts; the ``instructions`` above are
+        # what nudge it toward the tool. See issue #19505.
         "stream": True,
     }
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -149,9 +149,10 @@ class TestGenerate:
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"
         assert captured["input"][0]["content"][0]["type"] == "input_text"
-        assert captured["tool_choice"]["type"] == "allowed_tools"
-        assert captured["tool_choice"]["mode"] == "required"
-        assert captured["tool_choice"]["tools"] == [{"type": "image_generation"}]
+        # Regression for #19505: the Codex backend 400s on every tool_choice
+        # shape we have for the hosted ``image_generation`` tool, so the
+        # provider must omit tool_choice entirely and rely on instructions.
+        assert "tool_choice" not in captured
 
         tool = captured["tools"][0]
         assert tool["type"] == "image_generation"


### PR DESCRIPTION
## What does this PR do?

Addresses the **stage-1 400** documented in #19505: the Codex backend rejects every `tool_choice` shape for the hosted `image_generation` tool with `400 invalid_request_error: Tool choice 'image_generation' not found in 'tools' parameter`. The backend resolves `tool_choice` as a *function-tool name* and never recognizes hosted-tool entries like `image_generation`.

The bundled plugin sent `tool_choice={"type": "allowed_tools", "mode": "required", "tools": [{"type": "image_generation"}]}` alongside `tools=[{"type": "image_generation", ...}]`. Removing the `tool_choice` block is the only request shape Codex currently accepts; the existing `instructions` already nudge the host model toward the tool, so steering doesn't regress.

**Stage-2 not addressed here.** The reporter notes that even after the 400 is gone, the host model `gpt-5.4` still doesn't always invoke the tool (no `image_generation_call` events emitted, Hermes then fails with `error_type: empty_response`). That appears to need backend-side investigation of whether Codex actually honors hosted `image_generation` from the chat surface; the reporter has already exhausted obvious request-shape variants (`auto`, omission, `partial_images=0`). I left `Fixes` off the issue ref deliberately so the issue stays open for the empty-response work.

## Related Issue

Addresses #19505 (stage-1 only)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py` — remove the broken `tool_choice` block from the `client.responses.stream(...)` call; add a short comment explaining why (hosted-tool name rejected as function-tool name by the Codex backend).
- `tests/plugins/image_gen/test_openai_codex_provider.py` — flip the `test_codex_stream_request_shape` assertion to lock in `"tool_choice" not in captured`. Verified the test fails without the source change (stash → run → restore round-trip).

## How to Test

1. Run `pytest tests/plugins/image_gen/ -q` → 61 passed.
2. Reproduction (requires a Codex OAuth credential; see issue for full env):
   - On `main`: `hermes -q "generate an image of a cat"` with `image_gen.provider: openai-codex` → HTTP 400 `Tool choice 'image_generation' not found in 'tools' parameter`.
   - On this branch: same command → request succeeds; if `gpt-5.4` then chooses to invoke `image_generation`, image is returned. (Empty-response stage-2 path remains; see #19505 for ongoing diagnosis.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/plugins/image_gen/ -q
# 61 passed
```
