### PR TITLE
fix(kanban-dashboard): tone down completed-run metadata panel

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1698,8 +1698,11 @@
             ? h("div", { className: "hermes-kanban-run-error" }, r.error)
             : null,
           r.metadata
-            ? h("code", { className: "hermes-kanban-run-meta" },
-                JSON.stringify(r.metadata))
+            ? h("div", { className: "hermes-kanban-run-meta-block" },
+                h("div", { className: "hermes-kanban-run-meta-label" }, "Metadata"),
+                h("code", { className: "hermes-kanban-run-meta" },
+                  JSON.stringify(r.metadata, null, 2)),
+              )
             : null,
         );
       }),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -783,15 +783,37 @@
   padding: 0.15rem 0 0;
   font-family: var(--font-mono, ui-monospace, monospace);
 }
+/* Run metadata is a secondary detail panel. Render it as a clearly-labeled
+ * sub-block with a thin left rule, capped height, and muted treatment so
+ * a verbose JSON blob (e.g. changed_files + URLs from a writer task) does
+ * not visually swamp the parent run row or get mistaken for a crash dump.
+ * See issue #19548. */
+.hermes-kanban-run-meta-block {
+  margin-top: 0.4rem;
+  padding: 0.25rem 0.5rem;
+  border-left: 2px solid var(--color-border);
+  background: transparent;
+}
+.hermes-kanban-run-meta-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted-foreground);
+  padding-bottom: 0.15rem;
+}
 .hermes-kanban-run-meta {
   display: block;
+  max-height: 8.5rem;
+  overflow: auto;
   font-size: 0.72rem;
   line-height: 1.5;
-  padding: 0.15rem 0 0;
+  padding: 0;
   color: var(--color-muted-foreground);
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, ui-monospace, monospace);
+  background: transparent;
 }
 
 /* -------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1072,3 +1072,51 @@ def test_home_channels_empty_when_no_homes_configured(client, monkeypatch):
     r = client.get("/api/plugins/kanban/home-channels")
     assert r.status_code == 200
     assert r.json()["home_channels"] == []
+
+
+# ---------------------------------------------------------------------------
+# Built-asset regressions for the dashboard's run-history rendering
+# (issue #19548 — completed-run metadata used to render as a large pale box
+# that read like a crash dump). The plugin ships built-only, so we lock in
+# the rendered shape with static assertions on dist/index.js + dist/style.css.
+# ---------------------------------------------------------------------------
+
+
+def _dashboard_dist_path(name: str) -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    p = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / name
+    assert p.exists(), f"dashboard asset missing: {p}"
+    return p
+
+
+def test_run_metadata_pretty_printed_with_label():
+    """Run-history metadata is pretty-printed JSON inside a labeled sub-block."""
+    js = _dashboard_dist_path("index.js").read_text(encoding="utf-8")
+    # Pretty-printed JSON (indent=2) so a writer task's changed_files +
+    # URLs blob doesn't render as one wall-of-text monoline.
+    assert "JSON.stringify(r.metadata, null, 2)" in js
+    # Explicit label so the panel reads as auxiliary detail, not a crash dump.
+    assert '"hermes-kanban-run-meta-label"' in js
+    assert ">Metadata<" in js or '"Metadata"' in js
+    # Wrapped in the labelled meta block container.
+    assert '"hermes-kanban-run-meta-block"' in js
+
+
+def test_run_metadata_secondary_styling():
+    """Metadata block is capped, transparent, and visually secondary."""
+    css = _dashboard_dist_path("style.css").read_text(encoding="utf-8")
+    # The label class exists with muted-foreground treatment.
+    assert ".hermes-kanban-run-meta-label" in css
+    # Container styling: thin left rule, no opaque highlighted fill that
+    # could be mistaken for an error/warning panel.
+    assert ".hermes-kanban-run-meta-block" in css
+    block_start = css.index(".hermes-kanban-run-meta-block")
+    block_decl = css[block_start : block_start + 400]
+    assert "background: transparent" in block_decl
+    assert "border-left" in block_decl
+    # Cap meta height so verbose JSON doesn't sprawl across the run row.
+    meta_start = css.index(".hermes-kanban-run-meta {")
+    meta_decl = css[meta_start : meta_start + 400]
+    assert "max-height" in meta_decl
+    assert "overflow: auto" in meta_decl
+    assert "color: var(--color-muted-foreground)" in meta_decl


### PR DESCRIPTION
## What does this PR do?

Closes #19548. Completed-run metadata in the Kanban task drawer rendered as a wall-of-monoline JSON inside a bare `<code class="hermes-kanban-run-meta">` on the run container's pale `--color-foreground 3%` tinted background. With monospace + `white-space: pre-wrap`, a writer-task payload (`changed_files`, URLs, artifact details) wrapped into a tall code-ish block that filled the parent `.hermes-kanban-run` container — visually identical to the destructive-tinted crash/timeout/blocked panels.

This PR restyles only — no interactivity changes. Native `<details>` expand/collapse would be a follow-up that needs UX agreement on default state.

- Wraps the payload in a labeled `Metadata` sub-block with a thin border-left rule so it reads as a secondary detail.
- Pretty-prints the JSON (`indent=2`) so the structure is scannable instead of one long line.
- Caps the rendered block at `max-height: 8.5rem` with internal scroll so it doesn't dominate the run summary.
- Drops the inherited tinted background on the metadata block (transparent) so completed runs no longer mimic the warning-tinted state.

## Related Issue

Closes #19548

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/kanban/dashboard/dist/index.js` (+5 / -2) — wrap the existing metadata `<code>` in a labeled sub-block; switch to `JSON.stringify(r.metadata, null, 2)`.
- `plugins/kanban/dashboard/dist/style.css` (+23 / -1) — add `.hermes-kanban-run-meta-block`, `.hermes-kanban-run-meta-label` rules; cap `.hermes-kanban-run-meta` at `max-height: 8.5rem; overflow: auto`; transparent backgrounds on both.
- `tests/plugins/test_kanban_dashboard_plugin.py` (+48 / -0) — add two static-asset regression tests:
  - `test_run_metadata_pretty_printed_with_label` — asserts the label text and `JSON.stringify(..., null, 2)` shape exist in the bundled `dist/index.js`.
  - `test_run_metadata_secondary_styling` — asserts the new CSS classes + `max-height` + transparent-background rules exist in `dist/style.css`.

## How to Test

1. Run `pytest tests/plugins/test_kanban_dashboard_plugin.py -q` → 55 passed.
2. Open the Kanban dashboard, find a completed task with non-trivial metadata (e.g. a writer task with `changed_files`), expand its run history. The metadata panel now shows a `Metadata` label, pretty-printed JSON, scrolls internally past 8.5rem, and no longer reads as a warning panel.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/plugins/test_kanban_dashboard_plugin.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (visual-only change in built dashboard plugin)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (CSS/JS in browser-rendered dashboard)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A