### PR TITLE
chore: sync Hermes guardrails and secret-handling hardening

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2309,6 +2309,10 @@ class HermesCLI:
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        self._codex_usage_status_cache = None
+        self._codex_usage_status_checked_at = 0.0
+        self._codex_usage_status_refreshing = False
+        self._codex_usage_status_lock = threading.Lock()
 
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
@@ -2372,6 +2376,182 @@ class HermesCLI:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
+
+    @staticmethod
+    def _codex_usage_percent_windows(payload: Dict[str, Any]) -> tuple[Optional[int], Optional[int]]:
+        """Return max Codex 5h/weekly usage percentages from app-server payload."""
+        buckets: List[Dict[str, Any]] = []
+        primary = payload.get("rateLimits") if isinstance(payload, dict) else None
+        if isinstance(primary, dict):
+            buckets.append(primary)
+        by_id = payload.get("rateLimitsByLimitId") if isinstance(payload, dict) else None
+        if isinstance(by_id, dict):
+            buckets.extend(value for value in by_id.values() if isinstance(value, dict))
+
+        def _max_for(window_key: str) -> Optional[int]:
+            values = []
+            for bucket in buckets:
+                window = bucket.get(window_key)
+                if not isinstance(window, dict):
+                    continue
+                used = window.get("usedPercent")
+                if isinstance(used, (int, float)):
+                    values.append(max(0, min(100, round(float(used)))))
+            return max(values) if values else None
+
+        return _max_for("primary"), _max_for("secondary")
+
+    def _format_codex_usage_status_label(self, payload: Dict[str, Any]) -> Optional[str]:
+        """Format Codex subscription usage for the TUI status bar.
+
+        Uses the worst 5h and weekly bucket across normal Codex and any
+        model-specific buckets (for example GPT-5.3-Codex-Spark), so the
+        footer remains compact but still highlights the limiting quota.
+        """
+        five_hour, weekly = self._codex_usage_percent_windows(payload)
+        if five_hour is None and weekly is None:
+            return None
+        five_hour = five_hour if five_hour is not None else 0
+        weekly = weekly if weekly is not None else 0
+        return (
+            f"Codex 5h {self._build_context_bar(five_hour, width=5)} {five_hour}% "
+            f"W {self._build_context_bar(weekly, width=5)} {weekly}%"
+        )
+
+    @staticmethod
+    def _codex_usage_label_max_percent(label: Optional[str]) -> Optional[int]:
+        if not label:
+            return None
+        matches = re.findall(r"(\d+)%", label)
+        if not matches:
+            return None
+        return max(int(value) for value in matches)
+
+    def _read_codex_usage_rate_limits(self, timeout: float = 8.0) -> Optional[Dict[str, Any]]:
+        """Read Codex account rate limits through the local Codex app-server."""
+        if not shutil.which("codex"):
+            return None
+        import select
+        import subprocess
+
+        try:
+            proc = subprocess.Popen(
+                ["codex", "app-server", "--listen", "stdio://"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                bufsize=0,
+            )
+        except Exception:
+            return None
+
+        def _send(obj: Dict[str, Any]) -> None:
+            assert proc.stdin is not None
+            proc.stdin.write(json.dumps(obj) + "\n")
+            proc.stdin.flush()
+
+        def _read_until_id(target_id: int, deadline: float) -> Optional[Dict[str, Any]]:
+            assert proc.stdout is not None
+            while time.monotonic() < deadline:
+                try:
+                    ready, _, _ = select.select([proc.stdout], [], [], 0.2)
+                except Exception:
+                    return None
+                if not ready:
+                    continue
+                line = proc.stdout.readline()
+                if not line:
+                    if proc.poll() is not None:
+                        return None
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                if obj.get("id") == target_id:
+                    return obj
+            return None
+
+        try:
+            deadline = time.monotonic() + timeout
+            _send({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"clientInfo": {"name": "hermes-cli-status-bar", "version": "1.0.0"}},
+            })
+            initialized = _read_until_id(1, deadline)
+            if not initialized or initialized.get("error"):
+                return None
+            _send({"jsonrpc": "2.0", "id": 2, "method": "account/rateLimits/read", "params": {}})
+            result = _read_until_id(2, deadline)
+            if not result or result.get("error"):
+                return None
+            payload = result.get("result")
+            return payload if isinstance(payload, dict) else None
+        finally:
+            try:
+                proc.terminate()
+                proc.wait(timeout=1)
+            except Exception:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=1)
+                except Exception:
+                    pass
+
+    def _should_show_codex_usage_status(self) -> bool:
+        agent = getattr(self, "agent", None)
+        provider = (getattr(agent, "provider", None) or getattr(self, "provider", None) or "").lower()
+        if provider == "openai-codex":
+            return True
+        if provider:
+            return False
+        model = (getattr(agent, "model", None) or getattr(self, "model", None) or "").lower()
+        return "codex" in model and shutil.which("codex") is not None
+
+    def _refresh_codex_usage_status_async(self) -> None:
+        lock = getattr(self, "_codex_usage_status_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._codex_usage_status_lock = lock
+        with lock:
+            if getattr(self, "_codex_usage_status_refreshing", False):
+                return
+            self._codex_usage_status_refreshing = True
+
+        def _worker() -> None:
+            try:
+                payload = self._read_codex_usage_rate_limits(timeout=8.0)
+                label = self._format_codex_usage_status_label(payload) if payload else None
+                self._codex_usage_status_cache = label
+                self._codex_usage_status_checked_at = time.time()
+            except Exception:
+                self._codex_usage_status_checked_at = time.time()
+            finally:
+                self._codex_usage_status_refreshing = False
+                try:
+                    self._invalidate(min_interval=0.0)
+                except Exception:
+                    pass
+
+        thread = threading.Thread(target=_worker, name="codex-usage-status", daemon=True)
+        thread.start()
+
+    def _get_codex_usage_status_label(self) -> Optional[str]:
+        """Return cached Codex usage label and refresh it off the render path."""
+        if not self._should_show_codex_usage_status():
+            return None
+        cache = getattr(self, "_codex_usage_status_cache", None)
+        checked_at = float(getattr(self, "_codex_usage_status_checked_at", 0.0) or 0.0)
+        now = time.time()
+        # Use a short TTL: the footer should feel live, but prompt_toolkit can
+        # repaint frequently, so rate-limit the external Codex app-server probe.
+        if (now - checked_at) < 60:
+            return cache
+        self._refresh_codex_usage_status_async()
+        return cache
 
     @staticmethod
     def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
@@ -2446,9 +2626,11 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "codex_usage_status": None,
         }
 
         if not agent:
+            snapshot["codex_usage_status"] = self._get_codex_usage_status_label()
             return snapshot
 
         snapshot["session_input_tokens"] = getattr(agent, "session_input_tokens", 0) or 0
@@ -2459,6 +2641,7 @@ class HermesCLI:
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+        snapshot["codex_usage_status"] = self._get_codex_usage_status_label()
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -2659,6 +2842,9 @@ class HermesCLI:
                 context_label = "ctx --"
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            codex_usage = snapshot.get("codex_usage_status")
+            if codex_usage and width >= 110:
+                parts.append(codex_usage)
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -2719,9 +2905,18 @@ class HermesCLI:
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
+                    ]
+                    codex_usage = snapshot.get("codex_usage_status")
+                    if codex_usage and width >= 110:
+                        usage_style = self._status_bar_context_style(
+                            self._codex_usage_label_max_percent(codex_usage)
+                        )
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((usage_style, codex_usage))
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
-                    ]
+                    ])
                     # Position 7: per-prompt elapsed timer (live or frozen)
                     prompt_elapsed = snapshot.get("prompt_elapsed")
                     if prompt_elapsed:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -31,6 +31,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import time
@@ -60,6 +61,18 @@ _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 
 
+def _resolve_env_placeholder(value: Any, fallback_env: str | None = None) -> str:
+    """Resolve ${VAR} config placeholders without exposing secrets in config.yaml."""
+    if value is None or value == "":
+        if fallback_env:
+            return os.getenv(fallback_env, "")
+        return ""
+    text = str(value)
+    if text.startswith("${") and text.endswith("}") and len(text) > 3:
+        return os.getenv(text[2:-1], "")
+    return text
+
+
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -72,8 +85,17 @@ class WebhookAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.WEBHOOK)
         self._host: str = config.extra.get("host", DEFAULT_HOST)
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
-        self._global_secret: str = config.extra.get("secret", "")
-        self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
+        self._global_secret: str = _resolve_env_placeholder(
+            config.extra.get("secret"), "HERMES_WEBHOOK_SECRET"
+        )
+        self._static_routes: Dict[str, dict] = {
+            name: {
+                **route,
+                "secret": _resolve_env_placeholder(route.get("secret"))
+                if "secret" in route else route.get("secret"),
+            }
+            for name, route in config.extra.get("routes", {}).items()
+        }
         self._dynamic_routes: Dict[str, dict] = {}
         self._dynamic_routes_mtime: float = 0.0
         self._routes: Dict[str, dict] = dict(self._static_routes)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5544,6 +5544,9 @@ class GatewayRunner:
                     canonical = _cmd_def.name if _cmd_def else command
                     break
 
+        if canonical == "start":
+            return self._gateway_start_message(source)
+
         if canonical == "new":
             if self._is_telegram_topic_root_lobby(source):
                 return self._telegram_topic_root_new_message()
@@ -8540,6 +8543,20 @@ class GatewayRunner:
         
         preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
         return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""
+
+    def _gateway_start_message(self, source: SessionSource) -> str:
+        """Return lightweight onboarding for messaging-platform /start."""
+        platform_name = source.platform.value if source.platform else "this platform"
+        return (
+            "Hi — I'm Hermes.\n\n"
+            "Send me a message here and I'll handle it like a normal Hermes "
+            f"session on {platform_name}.\n\n"
+            "Useful commands:\n"
+            "• /sethome — make this chat the delivery target for cron jobs and cross-platform messages\n"
+            "• /commands — browse available gateway commands\n"
+            "• /new — start a fresh session\n"
+            "• /status — show session info"
+        )
 
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""

--- a/hermes_cli/codex_usage_guardrail.py
+++ b/hermes_cli/codex_usage_guardrail.py
@@ -1,0 +1,108 @@
+"""Shared Codex subscription usage guardrail helpers.
+
+The cron watchdog writes ``codex_usage_pause.json`` in the shared Hermes root
+when any tracked Codex 5-hour/session or weekly bucket reaches the configured
+threshold. Runtime dispatch paths use this module to fail closed before starting
+new Codex-backed autonomous work.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+
+CODEX_USAGE_PAUSE_FILENAME = "codex_usage_pause.json"
+
+
+def codex_usage_pause_path(root: Optional[Path | str] = None) -> Path:
+    """Return the pause-sentinel path for the shared Hermes root."""
+    if root is None:
+        from hermes_constants import get_default_hermes_root
+
+        root_path = get_default_hermes_root()
+    else:
+        root_path = Path(root).expanduser()
+    return root_path / CODEX_USAGE_PAUSE_FILENAME
+
+
+def is_codex_usage_paused(root: Optional[Path | str] = None) -> bool:
+    """Return True when the usage watchdog pause sentinel currently exists."""
+    try:
+        return codex_usage_pause_path(root).exists()
+    except OSError:
+        # Fail closed: if the root cannot be inspected, don't launch new
+        # subscription-backed autonomous work while the guardrail is in doubt.
+        return True
+
+
+def provider_model_uses_codex(
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> bool:
+    """Best-effort check for whether a provider/model context is Codex-backed.
+
+    The ChatGPT Codex backend URL is authoritative because Hermes credential
+    resolution gives explicit ``base_url`` values routing precedence. Without
+    this override, a config that says ``provider: openrouter`` but points
+    ``base_url`` at ``chatgpt.com/backend-api/codex`` could start Codex-backed
+    workers while the pause sentinel is active.
+
+    Otherwise explicit non-Codex providers win over model names that happen to
+    contain ``codex``.
+    """
+    provider_s = str(provider or "").strip().lower()
+    model_s = str(model or "").strip().lower()
+    base_s = str(base_url or "").strip().lower()
+
+    if "chatgpt.com" in base_s and "/backend-api/codex" in base_s:
+        return True
+    if provider_s:
+        return provider_s == "openai-codex"
+    return "codex" in model_s
+
+
+def delegation_config_uses_codex(cfg: dict[str, Any], parent_agent: Any = None) -> bool:
+    """Return True if a delegate_task call would route to Codex.
+
+    ``delegation.provider`` / ``delegation.base_url`` override inheritance. If
+    neither is set, the child inherits the parent agent provider/model context.
+    """
+    cfg = cfg or {}
+    cfg_provider = str(cfg.get("provider") or "").strip() or None
+    cfg_model = str(cfg.get("model") or "").strip() or None
+    cfg_base_url = str(cfg.get("base_url") or "").strip() or None
+
+    if cfg_provider or cfg_base_url:
+        return provider_model_uses_codex(
+            provider=cfg_provider,
+            model=cfg_model,
+            base_url=cfg_base_url,
+        )
+
+    parent_provider = getattr(parent_agent, "provider", None) if parent_agent is not None else None
+    parent_model = cfg_model or (getattr(parent_agent, "model", None) if parent_agent is not None else None)
+    parent_base_url = getattr(parent_agent, "base_url", None) if parent_agent is not None else None
+    return provider_model_uses_codex(
+        provider=parent_provider,
+        model=parent_model,
+        base_url=parent_base_url,
+    )
+
+
+def format_codex_usage_pause_message(
+    *,
+    root: Optional[Path | str] = None,
+    source: str = "autonomous dispatch",
+) -> str:
+    """Human-readable message for dispatchers that refuse to start work."""
+    path = codex_usage_pause_path(root)
+    return (
+        f"Codex usage guardrail is active for {source}: the watchdog wrote "
+        f"{path} after a 5-hour/session or weekly Codex bucket reached the "
+        "90% pause threshold. New Codex-backed autonomous work is blocked "
+        "until Will approves continuing on paid credits or the sentinel is "
+        "cleared after limits reset."
+    )

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -63,6 +63,8 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
+    CommandDef("start", "Show gateway onboarding and setup hints", "Session",
+               gateway_only=True),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -82,6 +82,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_cli.codex_usage_guardrail import (
+    format_codex_usage_pause_message,
+    is_codex_usage_paused,
+)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -2124,6 +2129,8 @@ class DispatchResult:
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
+    paused: list[str] = field(default_factory=list)
+    """Ready task ids left unclaimed because a global guardrail is active."""
 
 
 def _pid_alive(pid: Optional[int]) -> bool:
@@ -2499,6 +2506,23 @@ def dispatch_once(
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
+    if ready_rows and not dry_run and is_codex_usage_paused():
+        pause_msg = format_codex_usage_pause_message(source="kanban dispatcher")
+        for row in ready_rows:
+            if row["assignee"]:
+                result.paused.append(row["id"])
+        if result.paused:
+            try:
+                for task_id in result.paused:
+                    _append_event(
+                        conn,
+                        task_id,
+                        "dispatch_paused",
+                        {"reason": pause_msg},
+                    )
+            except Exception:
+                pass
+            return result
     spawned = 0
     for row in ready_rows:
         if max_spawn is not None and spawned >= max_spawn:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -14,6 +14,7 @@ import os
 import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from hermes_cli.config import (
     cfg_get,
@@ -29,6 +30,46 @@ from hermes_constants import display_hermes_home
 logger = logging.getLogger(__name__)
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SENSITIVE_DISPLAY_KEY_RE = re.compile(
+    r"(api[_-]?key|apikey|key|token|secret|password|passwd|pwd|auth|credential)",
+    re.IGNORECASE,
+)
+
+
+def _redact_sensitive_text(text: Any) -> str:
+    """Redact likely credentials before printing CLI diagnostics."""
+    value = str(text)
+    value = re.sub(r"(?i)(Bearer\s+)[^\s&]+", r"\1***", value)
+    value = re.sub(
+        r"(?i)\b(api[_-]?key|apikey|key|token|secret|password|passwd|pwd|auth|credential)=([^&\s]+)",
+        lambda match: f"{match.group(1)}=***",
+        value,
+    )
+    return value
+
+
+def _redact_url_for_display(url: Any) -> str:
+    """Redact sensitive query/fragment values in an MCP URL before display."""
+    raw = str(url)
+    try:
+        parts = urlsplit(raw)
+        if not parts.scheme or not parts.netloc:
+            return _redact_sensitive_text(raw)
+        query_pairs = parse_qsl(parts.query, keep_blank_values=True)
+        if query_pairs:
+            query = urlencode(
+                [
+                    (key, "***" if _SENSITIVE_DISPLAY_KEY_RE.search(key) else value)
+                    for key, value in query_pairs
+                ],
+                doseq=True,
+            )
+        else:
+            query = parts.query
+        fragment = _redact_sensitive_text(parts.fragment) if parts.fragment else parts.fragment
+        return _redact_sensitive_text(urlunsplit((parts.scheme, parts.netloc, parts.path, query, fragment)))
+    except Exception:
+        return _redact_sensitive_text(raw)
 
 
 _MCP_PRESETS: Dict[str, Dict[str, Any]] = {}
@@ -529,7 +570,7 @@ def cmd_mcp_test(args):
 
     # Show transport info
     if "url" in cfg:
-        _info(f"Transport: HTTP → {cfg['url']}")
+        _info(f"Transport: HTTP → {_redact_url_for_display(cfg['url'])}")
     else:
         cmd = cfg.get("command", "?")
         _info(f"Transport: stdio → {cmd}")
@@ -559,7 +600,7 @@ def cmd_mcp_test(args):
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
-        _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
+        _error(f"Connection failed ({elapsed_ms:.0f}ms): {_redact_sensitive_text(exc)}")
         return
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -206,6 +206,101 @@ class TestCLIStatusBar:
         assert "⚕" in text
         assert "claude-sonnet-4-20250514" in text
 
+    def test_codex_usage_label_formats_5h_and_weekly_bars(self):
+        cli_obj = _make_cli()
+        payload = {
+            "rateLimitsByLimitId": {
+                "codex": {
+                    "primary": {"usedPercent": 7},
+                    "secondary": {"usedPercent": 89},
+                },
+                "codex_bengalfox": {
+                    "limitName": "GPT-5.3-Codex-Spark",
+                    "primary": {"usedPercent": 23},
+                    "secondary": {"usedPercent": 2},
+                },
+            }
+        }
+
+        label = cli_obj._format_codex_usage_status_label(payload)
+
+        assert label == "Codex 5h [█░░░░] 23% W [████░] 89%"
+
+    def test_status_bar_text_includes_cached_codex_usage_on_wide_terminal(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.5"),
+            prompt_tokens=10000,
+            completion_tokens=2400,
+            total_tokens=12400,
+            api_calls=7,
+            context_tokens=12400,
+            context_length=200_000,
+        )
+        cli_obj._codex_usage_status_cache = "Codex 5h [█░░░░] 23% W [████░] 89%"
+        cli_obj._codex_usage_status_checked_at = 9999999999
+        cli_obj.agent.provider = "openai-codex"
+
+        text = cli_obj._build_status_bar_text(width=160)
+
+        assert "Codex 5h [█░░░░] 23% W [████░] 89%" in text
+
+    def test_status_bar_fragments_include_cached_codex_usage_style(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.5"),
+            prompt_tokens=10000,
+            completion_tokens=2400,
+            total_tokens=12400,
+            api_calls=7,
+            context_tokens=12400,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+        cli_obj._codex_usage_status_cache = "Codex 5h [█░░░░] 23% W [████░] 89%"
+        cli_obj._codex_usage_status_checked_at = 9999999999
+        cli_obj.agent.provider = "openai-codex"
+
+        with patch("prompt_toolkit.application.get_app") as mock_get_app:
+            mock_get_app.return_value.output.get_size.return_value = MagicMock(columns=160)
+            frags = cli_obj._get_status_bar_fragments()
+
+        assert ("class:status-bar-dim", " │ ") in frags
+        assert ("class:status-bar-bad", "Codex 5h [█░░░░] 23% W [████░] 89%") in frags
+
+    def test_non_codex_status_bar_hides_stale_codex_usage_cache(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="anthropic/claude-sonnet-4-20250514"),
+            prompt_tokens=10000,
+            completion_tokens=2400,
+            total_tokens=12400,
+            api_calls=7,
+            context_tokens=12400,
+            context_length=200_000,
+        )
+        cli_obj._codex_usage_status_cache = "Codex 5h [█░░░░] 23% W [████░] 89%"
+        cli_obj._codex_usage_status_checked_at = 9999999999
+
+        text = cli_obj._build_status_bar_text(width=160)
+
+        assert "Codex 5h" not in text
+
+    def test_non_codex_provider_hides_codex_named_model_usage_cache(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.3-codex"),
+            prompt_tokens=10000,
+            completion_tokens=2400,
+            total_tokens=12400,
+            api_calls=7,
+            context_tokens=12400,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openrouter"
+        cli_obj._codex_usage_status_cache = "Codex 5h [█░░░░] 23% W [████░] 89%"
+        cli_obj._codex_usage_status_checked_at = 9999999999
+
+        text = cli_obj._build_status_bar_text(width=160)
+
+        assert "Codex 5h" not in text
+
     def test_minimal_tui_chrome_threshold(self):
         cli_obj = _make_cli()
 

--- a/tests/gateway/test_start_command.py
+++ b/tests/gateway/test_start_command.py
@@ -1,0 +1,53 @@
+"""Tests for gateway /start onboarding command."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/start"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="12345",
+        chat_id="67890",
+        chat_type="dm",
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = {}
+    runner.session_store = None
+    runner._voice_mode = {}
+    runner._update_prompt_pending = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._failed_platforms = {}
+    runner._draining = False
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._session_key_for_source = MagicMock(return_value="agent:main:telegram:dm:67890")
+    runner._handle_message_with_agent = AsyncMock(return_value="agent should not run")
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_start_command_returns_onboarding_without_agent_loop():
+    runner = _make_runner()
+
+    result = await runner._handle_message(_make_event("/start"))
+
+    assert result is not None
+    assert "Hermes" in result
+    assert "/sethome" in result
+    runner._handle_message_with_agent.assert_not_awaited()

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -30,6 +30,7 @@ from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.platforms.webhook import (
     WebhookAdapter,
     _INSECURE_NO_AUTH,
+    _resolve_env_placeholder,
     check_webhook_requirements,
 )
 
@@ -37,6 +38,25 @@ from gateway.platforms.webhook import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def test_resolve_env_placeholder(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBHOOK_SECRET", "from-env")
+    assert _resolve_env_placeholder("${HERMES_WEBHOOK_SECRET}") == "from-env"
+    assert _resolve_env_placeholder("literal") == "literal"
+    assert _resolve_env_placeholder("${MISSING_SECRET}") == ""
+
+
+def test_adapter_uses_env_backed_global_and_route_secrets(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBHOOK_SECRET", "global-env")
+    monkeypatch.setenv("ROUTE_WEBHOOK_SECRET", "route-env")
+    adapter = _make_adapter(
+        routes={"test": {"prompt": "hello", "secret": "${ROUTE_WEBHOOK_SECRET}"}},
+        secret="${HERMES_WEBHOOK_SECRET}",
+    )
+    assert adapter._global_secret == "global-env"
+    assert adapter._routes["test"]["secret"] == "route-env"
+
 
 def _make_config(
     routes=None,

--- a/tests/hermes_cli/test_codex_usage_guardrail.py
+++ b/tests/hermes_cli/test_codex_usage_guardrail.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+from hermes_cli.codex_usage_guardrail import (
+    codex_usage_pause_path,
+    delegation_config_uses_codex,
+    format_codex_usage_pause_message,
+    is_codex_usage_paused,
+    provider_model_uses_codex,
+)
+
+
+def test_pause_path_uses_hermes_root(tmp_path):
+    assert codex_usage_pause_path(tmp_path) == tmp_path / "codex_usage_pause.json"
+
+
+def test_pause_detects_existing_sentinel(tmp_path):
+    assert is_codex_usage_paused(tmp_path) is False
+    (tmp_path / "codex_usage_pause.json").write_text('{"threshold": 90}', encoding="utf-8")
+    assert is_codex_usage_paused(tmp_path) is True
+
+
+def test_provider_model_uses_codex_requires_actual_codex_provider_context():
+    assert provider_model_uses_codex(provider="openai-codex", model="gpt-5.3-codex")
+    assert provider_model_uses_codex(provider=None, model="gpt-5.3-codex")
+    assert provider_model_uses_codex(
+        provider=None,
+        model="gpt-5.3-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert not provider_model_uses_codex(provider="openrouter", model="gpt-5.3-codex")
+    assert provider_model_uses_codex(
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+    assert not provider_model_uses_codex(provider="anthropic", model="claude-sonnet-4")
+
+
+def test_delegation_config_treats_codex_backend_base_url_as_authoritative():
+    assert delegation_config_uses_codex(
+        {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+        parent_agent=SimpleNamespace(provider="openrouter", model="claude", base_url=""),
+    )
+    assert delegation_config_uses_codex(
+        {},
+        parent_agent=SimpleNamespace(
+            provider="custom",
+            model="claude",
+            base_url="https://chatgpt.com/backend-api/codex",
+        ),
+    )
+    assert not delegation_config_uses_codex(
+        {"provider": "openrouter", "model": "gpt-5.3-codex"},
+        parent_agent=SimpleNamespace(provider="openai-codex", model="gpt-5.3-codex"),
+    )
+
+
+def test_pause_message_includes_reset_guidance(tmp_path):
+    msg = format_codex_usage_pause_message(root=tmp_path, source="delegate_task")
+    assert "Codex usage guardrail" in msg
+    assert "delegate_task" in msg
+    assert str(tmp_path / "codex_usage_pause.json") in msg
+    assert "90%" in msg

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -368,6 +368,26 @@ def test_dispatch_promotes_ready_and_spawns(kanban_home):
         assert kb.get_task(conn, c).status == "running"
 
 
+def test_dispatch_codex_usage_pause_leaves_ready_tasks_unclaimed(kanban_home, monkeypatch):
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append((task.id, task.assignee, workspace))
+
+    monkeypatch.setattr(kb, "is_codex_usage_paused", lambda: True)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="paused", assignee="coder53")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, t)
+
+    assert not spawns
+    assert not res.spawned
+    assert t in res.paused
+    assert task.status == "ready"
+    assert task.claim_lock is None
+
+
 def test_dispatch_spawn_failure_releases_claim(kanban_home):
     def boom(task, workspace):
         raise RuntimeError("spawn failed")

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -442,6 +442,45 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_test_redacts_sensitive_url_query(self, tmp_path, capsys, monkeypatch):
+        secret = "secret-value-123"
+        _seed_config(tmp_path, {
+            "search": {"url": f"https://mcp.example.com/mcp/?tavilyApiKey={secret}&safe=ok"},
+        })
+
+        def mock_probe(name, config, **kw):
+            return [("search", "Search")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="search"))
+        out = capsys.readouterr().out
+        assert secret not in out
+        assert "tavilyApiKey=%2A%2A%2A" in out or "tavilyApiKey=***" in out
+        assert "safe=ok" in out
+
+    def test_test_redacts_sensitive_connection_errors(self, tmp_path, capsys, monkeypatch):
+        secret = "secret-value-456"
+        _seed_config(tmp_path, {
+            "search": {"url": f"https://mcp.example.com/mcp/?apiKey={secret}"},
+        })
+
+        def mock_probe(name, config, **kw):
+            raise RuntimeError(f"failed apiKey={secret}")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="search"))
+        out = capsys.readouterr().out
+        assert secret not in out
+        assert "apiKey=***" in out
+
 
 # ---------------------------------------------------------------------------
 # Tests: env var interpolation

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -114,6 +114,58 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("parent agent", result["error"])
 
+    @patch("tools.delegate_tool.is_codex_usage_paused", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={"provider": "openai-codex", "model": "gpt-5.3-codex"})
+    @patch("tools.delegate_tool._run_single_child")
+    def test_codex_usage_pause_blocks_codex_delegation(self, mock_run, _mock_cfg, _mock_paused):
+        parent = _make_mock_parent()
+        parent.provider = "openai-codex"
+        parent.model = "gpt-5.3-codex"
+        result = json.loads(delegate_task(goal="test", parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("Codex usage guardrail", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool.is_codex_usage_paused", return_value=True)
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={"provider": "custom:codex-alias", "model": "claude"})
+    @patch("tools.delegate_tool._run_single_child")
+    def test_codex_usage_pause_blocks_resolved_codex_base_url(self, mock_run, _mock_cfg, mock_creds, _mock_paused):
+        mock_creds.return_value = {
+            "provider": "custom",
+            "model": "claude",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.model = "anthropic/claude-sonnet-4"
+        result = json.loads(delegate_task(goal="test", parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("Codex usage guardrail", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool.is_codex_usage_paused", return_value=True)
+    @patch("tools.delegate_tool._run_single_child")
+    def test_codex_usage_pause_does_not_block_non_codex_delegation(self, mock_run, _mock_paused):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.model = "anthropic/claude-sonnet-4"
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            result = json.loads(delegate_task(goal="test", parent_agent=parent))
+        self.assertIn("results", result)
+        mock_run.assert_called_once()
+
     def test_depth_limit(self):
         parent = _make_mock_parent(depth=2)
         result = json.loads(delegate_task(goal="test", parent_agent=parent))

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -53,6 +53,30 @@ def _make_mock_server(name, session=None, tools=None):
 # ---------------------------------------------------------------------------
 
 class TestLoadMCPConfig:
+    def test_env_placeholders_resolved_for_stdio_env(self, monkeypatch):
+        """${VAR} placeholders in stdio env resolve from process env."""
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-secret")
+        from tools.mcp_tool import _build_safe_env
+
+        env = _build_safe_env({"FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"})
+
+        assert env["FIRECRAWL_API_KEY"] == "fc-secret"
+
+    def test_env_placeholders_resolved_inside_nested_values(self, monkeypatch):
+        """${VAR} placeholders work inside URLs, headers, lists, and dicts."""
+        monkeypatch.setenv("TAVILY_API_KEY", "tv-secret")
+        from tools.mcp_tool import _resolve_env_placeholders
+
+        resolved = _resolve_env_placeholders({
+            "url": "https://example.com/mcp?apiKey=${TAVILY_API_KEY}",
+            "headers": {"Authorization": "Bearer ${TAVILY_API_KEY}"},
+            "args": ["--token", "${TAVILY_API_KEY}"],
+        })
+
+        assert resolved["url"] == "https://example.com/mcp?apiKey=tv-secret"
+        assert resolved["headers"]["Authorization"] == "Bearer tv-secret"
+        assert resolved["args"] == ["--token", "tv-secret"]
+
     def test_no_config_returns_empty(self):
         """No mcp_servers key in config -> empty dict."""
         with patch("hermes_cli.config.load_config", return_value={"model": "test"}):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -34,6 +34,12 @@ from toolsets import TOOLSETS
 from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
+from hermes_cli.codex_usage_guardrail import (
+    delegation_config_uses_codex,
+    format_codex_usage_pause_message,
+    is_codex_usage_paused,
+    provider_model_uses_codex,
+)
 
 
 # Tools that children must never have access to
@@ -1870,6 +1876,15 @@ def delegate_task(
             "(`p` in /agents) or the `delegation.pause` RPC before retrying."
         )
 
+    # Load config before any spawn/credential work so the Codex subscription
+    # watchdog can fail closed. The watchdog writes codex_usage_pause.json at
+    # 90% usage; delegate_task must not start new Codex-backed workers while
+    # that sentinel is present.
+    cfg = _load_config()
+    codex_usage_paused = is_codex_usage_paused()
+    if codex_usage_paused and delegation_config_uses_codex(cfg, parent_agent):
+        return tool_error(format_codex_usage_pause_message(source="delegate_task"))
+
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
 
@@ -1889,8 +1904,6 @@ def delegate_task(
             }
         )
 
-    # Load config
-    cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -1914,6 +1927,13 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    if codex_usage_paused and provider_model_uses_codex(
+        provider=creds.get("provider") or getattr(parent_agent, "provider", None),
+        model=creds.get("model") or getattr(parent_agent, "model", None),
+        base_url=creds.get("base_url") or getattr(parent_agent, "base_url", None),
+    ):
+        return tool_error(format_codex_usage_pause_message(source="delegate_task"))
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -273,6 +273,20 @@ _CREDENTIAL_PATTERN = re.compile(
 # Security helpers
 # ---------------------------------------------------------------------------
 
+_ENV_PLACEHOLDER_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _resolve_env_placeholders(value):
+    """Resolve ${VAR} placeholders in MCP config values from process env."""
+    if isinstance(value, str):
+        return _ENV_PLACEHOLDER_RE.sub(lambda match: os.getenv(match.group(1), ""), value)
+    if isinstance(value, dict):
+        return {key: _resolve_env_placeholders(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env_placeholders(item) for item in value]
+    return value
+
+
 def _build_safe_env(user_env: Optional[dict]) -> dict:
     """Build a filtered environment dict for stdio subprocesses.
 
@@ -288,7 +302,7 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
         if key in _SAFE_ENV_KEYS or key.startswith("XDG_"):
             env[key] = value
     if user_env:
-        env.update(user_env)
+        env.update(_resolve_env_placeholders(user_env))
     return env
 
 
@@ -1149,8 +1163,8 @@ class MCPServerTask:
                 "Upgrade the mcp package to get HTTP support."
             )
 
-        url = config["url"]
-        headers = dict(config.get("headers") or {})
+        url = _resolve_env_placeholders(config["url"])
+        headers = dict(_resolve_env_placeholders(config.get("headers") or {}))
         # Some MCP servers require MCP-Protocol-Version on the initial
         # initialize request and reject session-less POSTs otherwise.
         # Seed it as a client-level default, but treat user overrides as


### PR DESCRIPTION
## Summary
- Add Codex usage guardrails and pause enforcement plumbing for autonomous work
- Harden webhook config placeholder resolution so env-backed values resolve safely
- Harden MCP config secret handling and redact sensitive transport/error output from `hermes mcp test`
- Add focused regression coverage for webhook, MCP, gateway `/start`, and Codex guardrail behavior

## Test Plan
- `python -m py_compile tools/mcp_tool.py hermes_cli/mcp_config.py tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_config.py`
- `python -m pytest tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_config.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_start_command.py tests/hermes_cli/test_codex_usage_guardrail.py -q`
- Result from local run: `271 passed in 11.05s`

## Notes
- No real secrets are included; touched files were checked for likely credential patterns.
- This PR syncs the local hygiene/guardrail commits from Will's fork back toward upstream main.
