### PR TITLE
fix(tui): drop empty submissions left over after stripping leaked terminal bytes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3365,6 +3365,23 @@ def _estimate_tui_input_height(
     return min(max(visual_lines, 1), max(1, int(max_height or 1)))
 
 
+def _is_empty_after_terminal_noise_strip(text: object, has_attachments: bool) -> bool:
+    """Return True when a queued submission is effectively empty.
+
+    Used after the bracketed-paste / CPR / mouse-report stripping pass to
+    decide whether to drop a submission that originated entirely from
+    leaked terminal control bytes (e.g. a SIGWINCH-driven CPR storm on
+    WSL2 + Windows Terminal — see issue #19767).  When ``has_attachments``
+    is True the message is preserved even if the textual portion is
+    blank, because the user explicitly attached an image.
+    """
+    if has_attachments:
+        return False
+    if not isinstance(text, str):
+        return not text
+    return not text.strip()
+
+
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
@@ -15211,7 +15228,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         user_input, _had_mouse_reports = _strip_leaked_terminal_responses_with_meta(user_input)
                         if _had_mouse_reports:
                             self._recover_terminal_input_modes(reason="mouse reports leaked into submitted input")
-                    
+
+                    # Drop submissions that collapse to empty after stripping leaked
+                    # terminal control sequences (CPR responses, SGR mouse reports,
+                    # bracketed-paste wrappers).  On WSL2 + Windows Terminal, dragging
+                    # the window to resize triggers a SIGWINCH storm: prompt_toolkit
+                    # queries cursor position via DSR and the terminal floods responses
+                    # back into the input buffer; SGR mouse reports ending in ``M``
+                    # can also be parsed as Ctrl+M (= Enter), submitting a buffer
+                    # whose only content was the leaked bytes.  Without this guard
+                    # the empty payload reaches _print_user_message_preview and
+                    # renders a divider + bullet with no text — a stream of which
+                    # is what users perceive as "TUI auto-generates empty conversation
+                    # records on resize" (issue #19767).
+                    if _is_empty_after_terminal_noise_strip(user_input, bool(submit_images)):
+                        continue
+
                     # Check for commands — but detect dragged/pasted file paths first.
                     # See _detect_file_drop() for details.
                     _file_drop = _detect_file_drop(user_input) if isinstance(user_input, str) else None

--- a/tests/cli/test_cli_resize_empty_record.py
+++ b/tests/cli/test_cli_resize_empty_record.py
@@ -1,0 +1,146 @@
+"""Regression test for issue #19767 — resize-driven empty conversation records.
+
+On WSL2 + Windows Terminal, dragging the window to resize triggers a SIGWINCH
+storm.  prompt_toolkit queries cursor position via DSR (``ESC[6n``) and the
+terminal floods CPR replies back into stdin.  Under these storms the response
+bytes occasionally land in the input buffer as literal text, and SGR mouse
+reports ending in ``M`` can be parsed as Ctrl+M (= Enter) — submitting a
+buffer whose sole content was the leaked sequence.
+
+Existing strip helpers (`_strip_leaked_bracketed_paste_wrappers`,
+`_strip_leaked_terminal_responses_with_meta`) already clean those bytes from
+the submission; the bug was that ``process_loop`` did not re-check whether
+the submission was empty *after* stripping, so the empty payload reached
+``_print_user_message_preview`` and rendered a divider + bullet with no
+text.  Each resize event produced one such ghost record — a dozen+ in a
+single drag.
+
+This file pins down the guard that drops post-strip-empty submissions while
+preserving image-only attachments.
+"""
+
+from cli import (
+    _is_empty_after_terminal_noise_strip,
+    _strip_leaked_bracketed_paste_wrappers,
+    _strip_leaked_terminal_responses,
+)
+
+
+class TestEmptyAfterTerminalNoiseStrip:
+    """Pure-function guard called from process_loop after stripping."""
+
+    def test_real_user_text_is_preserved(self):
+        assert _is_empty_after_terminal_noise_strip("hello", False) is False
+
+    def test_truly_empty_string_is_dropped(self):
+        assert _is_empty_after_terminal_noise_strip("", False) is True
+
+    def test_whitespace_only_string_is_dropped(self):
+        assert _is_empty_after_terminal_noise_strip("   \n\t  ", False) is True
+
+    def test_attachments_keep_blank_payload_alive(self):
+        # User explicitly attached an image with no caption — must submit.
+        assert _is_empty_after_terminal_noise_strip("", True) is False
+        assert _is_empty_after_terminal_noise_strip("   ", True) is False
+
+    def test_non_string_falsy_payload_is_dropped(self):
+        assert _is_empty_after_terminal_noise_strip(None, False) is True
+
+    def test_non_string_truthy_payload_is_preserved(self):
+        # Defensive: list/dict payload should not be dropped by this guard.
+        assert _is_empty_after_terminal_noise_strip(["x"], False) is False
+
+
+class TestResizeStormCollapsesToEmpty:
+    """Real leaked sequences must collapse to empty after the strip pass —
+    verifying that the post-strip guard above will fire on them.
+    """
+
+    @staticmethod
+    def _strip(text: str) -> str:
+        # Apply the same two-step strip pipeline process_loop runs.
+        text = _strip_leaked_bracketed_paste_wrappers(text)
+        text = _strip_leaked_terminal_responses(text)
+        return text
+
+    def test_pure_cpr_response_collapses_to_empty(self):
+        leaked = "\x1b[24;80R"
+        cleaned = self._strip(leaked)
+        assert _is_empty_after_terminal_noise_strip(cleaned, False) is True
+
+    def test_repeated_cpr_storm_collapses_to_empty(self):
+        # A SIGWINCH burst on WSL2 can deliver several CPR replies back-to-back.
+        leaked = "\x1b[24;80R\x1b[24;80R\x1b[25;80R\x1b[26;80R"
+        cleaned = self._strip(leaked)
+        assert _is_empty_after_terminal_noise_strip(cleaned, False) is True
+
+    def test_sgr_mouse_report_collapses_to_empty(self):
+        # The trailing ``M`` is the byte the parser can mistake for Enter.
+        leaked = "\x1b[<65;1;49M"
+        cleaned = self._strip(leaked)
+        assert _is_empty_after_terminal_noise_strip(cleaned, False) is True
+
+    def test_visible_form_cpr_collapses_to_empty(self):
+        leaked = "^[[24;80R"
+        cleaned = self._strip(leaked)
+        assert _is_empty_after_terminal_noise_strip(cleaned, False) is True
+
+    def test_bracketed_paste_wrapper_only_collapses_to_empty(self):
+        leaked = "\x1b[200~\x1b[201~"
+        cleaned = self._strip(leaked)
+        assert _is_empty_after_terminal_noise_strip(cleaned, False) is True
+
+    def test_real_text_between_leaked_sequences_survives(self):
+        # Sanity: if the user actually typed something amidst the leak, keep it.
+        leaked = "\x1b[24;80Rhi\x1b[<65;1;49M"
+        cleaned = self._strip(leaked)
+        assert cleaned == "hi"
+        assert _is_empty_after_terminal_noise_strip(cleaned, False) is False
+
+
+class TestProcessLoopGuardIntegration:
+    """Verify that the process_loop call site has the ``continue`` guard
+    between the terminal-noise strip pass and ``_print_user_message_preview``.
+
+    Teknium's review (#19983): the helper-only tests above exercise
+    ``_is_empty_after_terminal_noise_strip`` in isolation and would pass
+    even if the ``continue`` guard at the process_loop call site were
+    deleted.  This test inspects the actual ``process_loop`` source to
+    confirm the guard is wired in at the boundary.
+    """
+
+    def test_continue_guard_exists_after_strip_in_process_loop(self):
+        import inspect
+        import cli as cli_mod
+
+        # process_loop is a nested function inside a CLI class method.
+        # Read the full cli.py source and locate the process_loop body
+        # by its def line, then check the ordering within that region.
+        full_source = inspect.getsource(cli_mod)
+        loop_start = full_source.find("def process_loop():")
+        assert loop_start > 0, "process_loop() definition not found in cli.py"
+
+        # Grab a generous window after the def line — the guard is near
+        # the bottom of the loop body (after input collection + stripping).
+        region = full_source[loop_start:loop_start + 20000]
+
+        strip_idx = region.find("_strip_leaked_terminal_responses_with_meta")
+        guard_idx = region.find("_is_empty_after_terminal_noise_strip")
+        continue_idx = region.find("continue", guard_idx if guard_idx > 0 else 0)
+        preview_idx = region.find("_print_user_message_preview")
+
+        assert strip_idx > 0, "strip call not found in process_loop region"
+        assert guard_idx > strip_idx, "empty-check guard must come after strip"
+        assert continue_idx > guard_idx, "continue must follow the empty-check guard"
+        # No executable _print_user_message_preview call may sit between the
+        # strip and the guard — that gap is where sanitized-empty submissions
+        # must be dropped before reaching the preview/chat path.  We check
+        # for the call pattern (not just the name, which appears in comments).
+        gap = region[strip_idx:guard_idx]
+        # A real call looks like "self._print_user_message_preview(" or
+        # "_print_user_message_preview(" — not just the name in a comment.
+        import re
+        call_matches = re.findall(r"_print_user_message_preview\s*\(", gap)
+        assert not call_matches, (
+            "_print_user_message_preview() call must not appear between strip and guard"
+        )


### PR DESCRIPTION
## What does this PR do?

Addresses #19767. WSL2 + Windows Terminal: dragging the window triggers a SIGWINCH storm where prompt_toolkit's DSR (cursor-position) queries and SGR mouse reports leak into stdin. The trailing `M` of mouse-report sequences parses as Ctrl+M (= Enter), which submits a buffer containing only the leaked bytes — one ghost record per leaked sequence, accumulating to the dozen-plus empty conversation records the reporter screenshots show.

The existing strip helpers (`_strip_leaked_bracketed_paste_wrappers`, `_strip_leaked_terminal_responses_with_meta`) already clean those bytes from the submitted buffer, but `process_loop` did not re-check emptiness afterward, so the empty payload reached `_print_user_message_preview` and rendered a divider + bullet with no text.

This PR adds the missing post-strip emptiness guard at the existing chokepoint. The fix is a defensive net at the last common point before the preview prints, so it covers any leak path that collapses to empty after stripping — not just the SGR-mouse-as-Ctrl+M mechanism.

## Related Issue

Addresses #19767

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` — add `_is_empty_after_terminal_noise_strip(text, has_attachments)` helper (17 lines) + a guard call in `process_loop` immediately after the existing strip pass (2 lines + comment). `has_attachments` is honored so image-only submissions still pass through.
- `tests/cli/test_cli_resize_empty_record.py` — new regression file:
  - `TestEmptyAfterTerminalNoiseStrip` (6 cases) — pure-function guard semantics: real text preserved, empty/whitespace dropped, `has_attachments=True` keeps blank-text payloads alive, non-string inputs handled.
  - `TestResizeStormCollapsesToEmpty` (6 cases) — drives real leaked CPR / SGR-mouse / bracketed-paste sequences through the same two-step strip pipeline `process_loop` runs, asserts the guard fires; one positive case proves real text wedged between leaked bytes survives.

## How to Test

1. Run `pytest tests/cli/test_cli_resize_empty_record.py -q` → 12 new tests pass.
2. Adjacent regression check: `pytest tests/cli/test_cli_force_redraw.py tests/cli/test_cli_terminal_response_sanitizer.py tests/cli/test_cli_bracketed_paste_sanitizer.py -q` → 32 pre-existing pass.
3. Without the source fix, the new test errors at import (the helper doesn't exist) — true regression test.
4. Manual reproduction (WSL2 + Windows Terminal): start `hermes`, drag the terminal window to resize. Before this PR: dozens of empty bullet records; after: window resizes silently with no transcript change.

**Caveat**: WSL2-only bug, could not reproduce locally. Diagnosis inferred from prior maintainer comment naming the SGR-mouse-as-Ctrl+M leak path and from reading the existing leak-strip code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64 (cannot test WSL2 directly; defensive net at chokepoint)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/cli/test_cli_resize_empty_record.py -q
12 passed

pytest tests/cli/test_cli_force_redraw.py tests/cli/test_cli_terminal_response_sanitizer.py tests/cli/test_cli_bracketed_paste_sanitizer.py -q
32 passed (pre-existing)
```
