### PR TITLE
feat(cli): add /voice vad command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8548,7 +8548,7 @@ class HermesCLI:
             self._voice_tts_done.set()
 
     def _handle_voice_command(self, command: str):
-        """Handle /voice [on|off|tts|status] command."""
+        """Handle /voice [on|off|tts|status|vad] command."""
         parts = command.strip().split(maxsplit=1)
         subcommand = parts[1].lower().strip() if len(parts) > 1 else ""
 
@@ -8560,6 +8560,8 @@ class HermesCLI:
             self._toggle_voice_tts()
         elif subcommand == "status":
             self._show_voice_status()
+        elif subcommand == "vad":
+            self._enable_voice_vad()
         elif subcommand == "":
             # Toggle
             if self._voice_mode:
@@ -8568,7 +8570,7 @@ class HermesCLI:
                 self._enable_voice_mode()
         else:
             _cprint(f"Unknown voice subcommand: {subcommand}")
-            _cprint("Usage: /voice [on|off|tts|status]")
+            _cprint("Usage: /voice [on|off|tts|status|vad]")
 
     def _voice_beeps_enabled(self) -> bool:
         """Return whether CLI voice mode should play record start/stop beeps."""
@@ -8640,6 +8642,49 @@ class HermesCLI:
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
         _cprint(f"  {_DIM}/voice off  to disable voice mode{_RST}")
+
+    def _voice_silence_duration(self) -> float:
+        """Return configured silence auto-stop duration in seconds."""
+        try:
+            from hermes_cli.config import load_config
+            _cfg = load_config().get("voice")
+            voice_cfg = _cfg if isinstance(_cfg, dict) else {}
+            duration = voice_cfg.get("silence_duration", 3.0)
+            if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+                return float(duration)
+        except Exception:
+            pass
+        return 3.0
+
+    def _start_voice_vad_recording_async(self) -> None:
+        def _start_vad():
+            try:
+                self._voice_start_recording()
+                if hasattr(self, '_app') and self._app:
+                    self._app.invalidate()
+            except Exception as e:
+                _cprint(f"\n{_DIM}VAD recording failed: {e}{_RST}")
+
+        threading.Thread(target=_start_vad, daemon=True).start()
+
+    def _enable_voice_vad(self):
+        """Enable hands-free VAD mode and start listening immediately."""
+        if self._voice_mode and self._voice_continuous and self._voice_recording:
+            _cprint(f"{_DIM}VAD mode is already active.{_RST}")
+            return
+
+        if not self._voice_mode:
+            self._enable_voice_mode()
+            if not self._voice_mode:
+                return
+
+        with self._voice_lock:
+            self._voice_continuous = True
+
+        _cprint(f"\n{_ACCENT}Voice VAD mode enabled - listening...{_RST}")
+        _cprint(f"  {_DIM}Speak to start recording. Auto-stops on {self._voice_silence_duration()}s silence.{_RST}")
+        _cprint(f"  {_DIM}/voice off to disable voice mode{_RST}")
+        self._start_voice_vad_recording_async()
 
     def _disable_voice_mode(self):
         """Disable voice mode, cancel any active recording, and stop TTS."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -141,7 +141,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[kaomoji|emoji|unicode|ascii]",
                subcommands=("kaomoji", "emoji", "unicode", "ascii")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
-               args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+               args_hint="[on|off|tts|status|vad]", subcommands=("on", "off", "tts", "status", "vad")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -138,6 +138,7 @@ class TestVoiceCommandParsing:
             ("/voice off", "off"),
             ("/voice tts", "tts"),
             ("/voice status", "status"),
+            ("/voice vad", "vad"),
             ("/voice", ""),
             ("/voice  ON  ", "on"),
         ]
@@ -809,6 +810,7 @@ class TestHandleVoiceCommandReal:
         cli._disable_voice_mode = MagicMock()
         cli._toggle_voice_tts = MagicMock()
         cli._show_voice_status = MagicMock()
+        cli._enable_voice_vad = MagicMock()
         return cli
 
     @patch("cli._cprint")
@@ -836,6 +838,12 @@ class TestHandleVoiceCommandReal:
         cli._show_voice_status.assert_called_once()
 
     @patch("cli._cprint")
+    def test_vad_calls_enable_vad(self, _cp):
+        cli = self._cli()
+        cli._handle_voice_command("/voice vad")
+        cli._enable_voice_vad.assert_called_once()
+
+    @patch("cli._cprint")
     def test_toggle_off_when_enabled(self, _cp):
         cli = self._cli()
         cli._voice_mode = True
@@ -858,6 +866,64 @@ class TestHandleVoiceCommandReal:
         # Should print usage via _cprint
         assert any("Unknown" in str(c) or "unknown" in str(c)
                     for c in mock_cp.call_args_list)
+
+
+class TestEnableVoiceVadReal:
+    """Tests the CLI hands-free VAD slash command behavior."""
+
+    @patch("cli._cprint")
+    def test_enables_voice_mode_then_starts_vad(self, _cp):
+        cli = _make_voice_cli()
+        cli._enable_voice_mode = MagicMock(side_effect=lambda: setattr(cli, "_voice_mode", True))
+        cli._start_voice_vad_recording_async = MagicMock()
+
+        cli._enable_voice_vad()
+
+        cli._enable_voice_mode.assert_called_once()
+        assert cli._voice_continuous is True
+        cli._start_voice_vad_recording_async.assert_called_once()
+
+    @patch("cli._cprint")
+    def test_does_not_start_when_voice_requirements_fail(self, _cp):
+        cli = _make_voice_cli()
+        cli._enable_voice_mode = MagicMock()
+        cli._start_voice_vad_recording_async = MagicMock()
+
+        cli._enable_voice_vad()
+
+        assert cli._voice_continuous is False
+        cli._start_voice_vad_recording_async.assert_not_called()
+
+    @patch("cli._cprint")
+    def test_existing_voice_mode_switches_to_continuous(self, _cp):
+        cli = _make_voice_cli(_voice_mode=True)
+        cli._enable_voice_mode = MagicMock()
+        cli._start_voice_vad_recording_async = MagicMock()
+
+        cli._enable_voice_vad()
+
+        cli._enable_voice_mode.assert_not_called()
+        assert cli._voice_continuous is True
+        cli._start_voice_vad_recording_async.assert_called_once()
+
+    @patch("cli._cprint")
+    def test_already_active_vad_is_noop(self, _cp):
+        cli = _make_voice_cli(_voice_mode=True, _voice_continuous=True, _voice_recording=True)
+        cli._start_voice_vad_recording_async = MagicMock()
+
+        cli._enable_voice_vad()
+
+        cli._start_voice_vad_recording_async.assert_not_called()
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"silence_duration": 1.25}})
+    def test_silence_duration_reads_numeric_config(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_silence_duration() == 1.25
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {"silence_duration": True}})
+    def test_silence_duration_ignores_bool_config(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_silence_duration() == 3.0
 
 
 class TestEnableVoiceModeReal:


### PR DESCRIPTION
## Summary
- add `/voice vad` to the classic CLI voice command handler
- enable voice mode if needed, switch continuous VAD on, and start the first recording asynchronously
- update the central slash command registry so help/autocomplete advertises `vad`

## Scope
This intentionally stays in the classic CLI voice path. It does not change gateway voice-channel behavior or the existing `/voice on|off|tts|status` flows.

Fixes #19927

## Verification
- `scripts/run_tests.sh tests/tools/test_voice_cli_integration.py tests/hermes_cli/test_commands.py` -> 233 passed, 4 warnings
- `git diff --check` -> passed
- `python -m ruff check cli.py tests/tools/test_voice_cli_integration.py` -> unavailable locally (`No module named ruff`)
