### PR TITLE
fix(codex): copy headers from _custom_headers (SDK >= 1.x) not _default_headers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1455,9 +1455,17 @@ class AIAgent:
                     }
                     if _provider_timeout is not None:
                         client_kwargs["timeout"] = _provider_timeout
-                    # Preserve any default_headers the router set
-                    if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-                        client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    # Preserve any default_headers the router set.
+                    # OpenAI SDK >= 1.x stores user-supplied default_headers in
+                    # _custom_headers (not _default_headers), so without the
+                    # _custom_headers branch the codex_cloudflare_headers
+                    # (originator, ChatGPT-Account-ID, codex_cli_rs UA) silently
+                    # drop here and the Codex backend rejects every model with a
+                    # "not supported when using Codex with a ChatGPT account" 400.
+                    _routed_headers = getattr(_routed_client, '_custom_headers', None) \
+                        or getattr(_routed_client, '_default_headers', None)
+                    if _routed_headers:
+                        client_kwargs["default_headers"] = dict(_routed_headers)
                 else:
                     # When the user explicitly chose a non-OpenRouter provider
                     # but no credentials were found, fail fast with a clear
@@ -1501,8 +1509,10 @@ class AIAgent:
                                 }
                                 if _provider_timeout is not None:
                                     client_kwargs["timeout"] = _provider_timeout
-                                if hasattr(_fb_client, "_default_headers") and _fb_client._default_headers:
-                                    client_kwargs["default_headers"] = dict(_fb_client._default_headers)
+                                _fb_headers = getattr(_fb_client, "_custom_headers", None) \
+                                    or getattr(_fb_client, "_default_headers", None)
+                                if _fb_headers:
+                                    client_kwargs["default_headers"] = dict(_fb_headers)
                                 _fb_resolved = True
                                 break
                         if not _fb_resolved:


### PR DESCRIPTION
## Summary

PR #12664 wires `_codex_cloudflare_headers` into `resolve_provider_client`'s `raw_codex` branch so the returned `OpenAI` client carries `originator: codex_cli_rs`, the codex_cli_rs-shaped `User-Agent`, and `ChatGPT-Account-ID` — the headers Cloudflare expects on the Codex backend. ✓

`run_agent.AIAgent.__init__` then tries to copy those headers into the new client's `client_kwargs` via:

```python
if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
    client_kwargs["default_headers"] = dict(_routed_client._default_headers)
```

But OpenAI Python SDK 1.x+ stores user-supplied `default_headers=` under `_custom_headers`, not `_default_headers`. Verified live with `openai==2.32.0`:

```python
>>> from openai import OpenAI
>>> c = OpenAI(api_key="x", default_headers={"A": "b"})
>>> getattr(c, "_default_headers", "<missing>")
'<missing>'
>>> c._custom_headers
{'A': 'b'}
```

So the lookup misses, the headers silently drop, and the request goes out with only `Authorization` + `Content-Type`. The Codex backend can't determine the plan and rejects every model:

```
{"detail":"The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account."}
```

A sibling code path in the same file at line 7662 already uses `_custom_headers` correctly — so this is just a transcription mismatch in two call sites.

## Fix

Two-line replacement at `run_agent.py:1459` (the openai-codex hand-off) and `:1504` (the fallback path). Read `_custom_headers` first, fall back to `_default_headers` to stay compatible with older SDK versions.

## Verification

Before:
```
$ hermes --provider openai-codex -m gpt-5.5 -z "Reply with only the word PONG."
[no output, request rejected with 400 model-not-supported]
```

After (same machine, same OAuth, same prompt):
```
$ hermes --provider openai-codex -m gpt-5.5 -z "Reply with only the word PONG."
PONG
```

Request_dump shows the headers are now on the wire after the patch.

Closes #19981