### PR TITLE
fix(gateway): tolerate stale utils during session import

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -64,7 +64,17 @@ from .whatsapp_identity import (
     canonical_whatsapp_identifier,
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
-from utils import atomic_replace
+try:
+    from utils import atomic_replace
+except ImportError:
+    # Long-lived embedding processes can keep an older top-level ``utils``
+    # module in sys.modules across Hermes updates. Keep gateway startup alive
+    # when that stale module lacks the newer helper.
+    def atomic_replace(tmp_path, target):
+        target_str = str(target)
+        real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
+        os.replace(str(tmp_path), real_path)
+        return real_path
 
 
 @dataclass

--- a/tests/gateway/test_session_stale_utils.py
+++ b/tests/gateway/test_session_stale_utils.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def test_gateway_session_imports_with_stale_utils_without_atomic_replace(
+    monkeypatch, tmp_path: Path
+) -> None:
+    stale_utils = types.ModuleType("utils")
+    monkeypatch.setitem(sys.modules, "utils", stale_utils)
+    monkeypatch.delitem(sys.modules, "gateway", raising=False)
+    monkeypatch.delitem(sys.modules, "gateway.session", raising=False)
+
+    session = importlib.import_module("gateway.session")
+
+    target = tmp_path / "sessions.json"
+    target.write_text("old", encoding="utf-8")
+    link = tmp_path / "sessions-link.json"
+    link.symlink_to(target)
+    tmp = tmp_path / ".sessions.tmp"
+    tmp.write_text("new", encoding="utf-8")
+
+    replaced_path = session.atomic_replace(tmp, link)
+
+    assert Path(replaced_path) == target
+    assert link.is_symlink()
+    assert target.read_text(encoding="utf-8") == "new"


### PR DESCRIPTION
## Summary
- add a narrow fallback for `gateway.session` when a long-lived embedding process has a stale top-level `utils` module without `atomic_replace`
- preserve the same symlink-aware atomic replace behavior used by the shared helper
- add a regression test that imports `gateway.session` with a fake stale `utils` module

Closes #5232.

## Verification
- `scripts/run_tests.sh tests/gateway/test_session_stale_utils.py`
- `scripts/run_tests.sh tests/gateway/test_session_stale_utils.py tests/gateway/test_session_reset_notify.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_session_dm_thread_seeding.py`
- `git diff --check`